### PR TITLE
perf: use jemalloc as the default allocator only on release mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
  "sulk-interface",
  "sulk-sema",
  "sulk-tester",
+ "tikv-jemallocator",
  "tracing-error",
  "tracing-subscriber",
  "vergen",
@@ -2397,6 +2398,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/sulk/Cargo.toml
+++ b/crates/sulk/Cargo.toml
@@ -36,14 +36,13 @@ tracing-subscriber = { workspace = true, features = [
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
-# TODO: slows tests by 2x
-# tikv-jemallocator = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 sulk-tester.workspace = true
 
 [features]
-# default = ["jemalloc"]
+default = ["jemalloc"]
 nightly = [
     "sulk-config/nightly",
     "sulk-data-structures/nightly",
@@ -51,7 +50,7 @@ nightly = [
     "sulk-sema/nightly",
     "sulk-tester/nightly",
 ]
-# jemalloc = ["dep:tikv-jemallocator"]
+jemalloc = ["dep:tikv-jemallocator"]
 
 [[test]]
 name = "tests"

--- a/crates/sulk/src/main.rs
+++ b/crates/sulk/src/main.rs
@@ -30,13 +30,14 @@ pub mod sigsegv_handler {
 #[cfg(test)]
 use sulk_tester as _;
 
-// TODO: slows tests by 2x
-/*
 // We use jemalloc for performance reasons.
+#[cfg(not(debug_assertions))]
 #[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-*/
+
+#[cfg(debug_assertions)]
+use tikv_jemallocator as _;
 
 fn main() -> ExitCode {
     sigsegv_handler::install();


### PR DESCRIPTION
We spawn too many compilers that have a very short runtime for jemalloc to be worth it in tests (20% to 2x+ slowdown depending on platform etc). This is likely due to initialization + destruction times heavily outweighing any benefit on allocations:
![image](https://github.com/paradigmxyz/sulk/assets/57450786/f1886ee7-0393-488a-b1f8-1d687c44e3ad)

But manual testing shows that it does provide significant benefits (20%+ speedups) on real world loads.