### PR TITLE
feat: implement const evaluation for array lengths

### DIFF
--- a/crates/ast/src/ast/lit.rs
+++ b/crates/ast/src/ast/lit.rs
@@ -40,6 +40,20 @@ pub enum LitKind {
     Err(ErrorGuaranteed),
 }
 
+impl LitKind {
+    /// Returns the description of this literal kind.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Str(kind, _) => kind.description(),
+            Self::Number(_) => "number",
+            Self::Rational(_) => "rational",
+            Self::Address(_) => "address",
+            Self::Bool(_) => "boolean",
+            Self::Err(_) => "<error>",
+        }
+    }
+}
+
 /// A single UTF-8 string literal. Only used in import paths and statements, not expressions.
 #[derive(Clone, Debug)]
 pub struct StrLit {
@@ -58,6 +72,17 @@ pub enum StrKind {
     Unicode,
     /// A hex string literal.
     Hex,
+}
+
+impl StrKind {
+    /// Returns the description of this string kind.
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Str => "string",
+            Self::Unicode => "unicode string",
+            Self::Hex => "hex string",
+        }
+    }
 }
 
 /// A number sub-denomination.

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -1,0 +1,242 @@
+use crate::{hir, ty::Gcx};
+use alloy_primitives::U256;
+use solar_ast::ast::LitKind;
+use solar_interface::{diagnostics::ErrorGuaranteed, Span};
+use std::fmt;
+
+const RECURSION_LIMIT: usize = 64;
+
+// TODO: `convertType` for truncating and extending correctly: https://github.com/ethereum/solidity/blob/de1a017ccb935d149ed6bcbdb730d89883f8ce02/libsolidity/analysis/ConstantEvaluator.cpp#L234
+
+/// Evaluates simple constants.
+pub struct ConstantEvaluator<'gcx> {
+    pub gcx: Gcx<'gcx>,
+    depth: usize,
+}
+
+type EvalResult<'gcx> = Result<IntScalar, EvalError>;
+
+impl<'gcx> ConstantEvaluator<'gcx> {
+    pub fn new(gcx: Gcx<'gcx>) -> Self {
+        Self { gcx, depth: 0 }
+    }
+
+    pub fn eval(&mut self, expr: &hir::Expr<'_>) -> Result<IntScalar, ErrorGuaranteed> {
+        self.eval_expr(expr).map_err(|err| match err.kind {
+            EE::AlreadyEmitted(guar) => guar,
+            _ => {
+                let msg = "evaluation of constant value failed";
+                self.gcx.dcx().err(msg).span(expr.span).span_note(err.span, err.kind.msg()).emit()
+            }
+        })
+    }
+
+    fn eval_expr(&mut self, expr: &hir::Expr<'_>) -> EvalResult<'gcx> {
+        self.depth += 1;
+        if self.depth > RECURSION_LIMIT {
+            return Err(EE::RecursionLimitReached.spanned(expr.span));
+        }
+        let mut res = self.eval_expr_inner(expr);
+        if let Err(e) = &mut res {
+            if e.span.is_dummy() {
+                e.span = expr.span;
+            }
+        }
+        self.depth -= 1;
+        res
+    }
+
+    fn eval_expr_inner(&mut self, expr: &hir::Expr<'_>) -> EvalResult<'gcx> {
+        let expr = expr.peel_parens();
+        match expr.kind {
+            // hir::ExprKind::Array(_) => todo!(),
+            // hir::ExprKind::Assign(_, _, _) => todo!(),
+            hir::ExprKind::Binary(l, bin_op, r) => {
+                let l = self.eval_expr(l)?;
+                let r = self.eval_expr(r)?;
+                l.binop(&r, bin_op.kind).map_err(Into::into)
+            }
+            // hir::ExprKind::Call(_, _) => todo!(),
+            // hir::ExprKind::CallOptions(_, _) => todo!(),
+            // hir::ExprKind::Delete(_) => todo!(),
+            hir::ExprKind::Ident(&[hir::Res::Item(hir::ItemId::Variable(v))]) => {
+                let v = self.gcx.hir.variable(v);
+                if v.mutability != Some(hir::VarMut::Constant) {
+                    return Err(EE::NonConstantVar.into());
+                }
+                self.eval_expr(v.initializer.expect("constant variable has no initializer"))
+            }
+            // hir::ExprKind::Index(_, _) => todo!(),
+            // hir::ExprKind::Slice(_, _, _) => todo!(),
+            hir::ExprKind::Lit(lit) => self.eval_lit(lit),
+            // hir::ExprKind::Member(_, ident) => todo!(),
+            // hir::ExprKind::New(_) => todo!(),
+            // hir::ExprKind::Payable(_) => todo!(),
+            hir::ExprKind::Ternary(cond, t, f) => {
+                let cond = self.eval_expr(cond)?;
+                Ok(if cond.to_bool() { self.eval_expr(t)? } else { self.eval_expr(f)? })
+            }
+            // hir::ExprKind::Tuple(_) => todo!(),
+            // hir::ExprKind::TypeCall(_) => todo!(),
+            // hir::ExprKind::Type(_) => todo!(),
+            hir::ExprKind::Unary(un_op, v) => {
+                let v = self.eval_expr(v)?;
+                v.unop(un_op.kind).map_err(Into::into)
+            }
+            hir::ExprKind::Err(guar) => Err(EE::AlreadyEmitted(guar).into()),
+            _ => Err(EE::UnsupportedExpr.into()),
+        }
+    }
+
+    fn eval_lit(&mut self, lit: &hir::Lit) -> EvalResult<'gcx> {
+        match lit.kind {
+            // LitKind::Str(str_kind, arc) => todo!(),
+            LitKind::Number(ref big_int) => {
+                let (_, bytes) = big_int.to_bytes_be();
+                if bytes.len() > 32 {
+                    return Err(EE::IntTooBig.into());
+                }
+                Ok(IntScalar::from_be_bytes(&bytes))
+            }
+            // LitKind::Rational(ratio) => todo!(),
+            LitKind::Address(address) => Ok(IntScalar::from_be_bytes(address.as_slice())),
+            LitKind::Bool(bool) => Ok(IntScalar::from_be_bytes(&[bool as u8])),
+            LitKind::Err(guar) => Err(EE::AlreadyEmitted(guar).into()),
+            _ => Err(EE::UnsupportedLiteral.into()),
+        }
+    }
+}
+
+pub struct IntScalar {
+    pub data: U256,
+}
+
+impl IntScalar {
+    pub fn new(data: U256) -> Self {
+        Self { data }
+    }
+
+    /// Creates a new integer value from a boolean.
+    pub fn from_bool(value: bool) -> Self {
+        Self { data: U256::from(value as u8) }
+    }
+
+    /// Creates a new integer value from big-endian bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bytes` is empty or has a length greater than 32.
+    pub fn from_be_bytes(bytes: &[u8]) -> Self {
+        Self { data: U256::from_be_slice(bytes) }
+    }
+
+    /// Converts the integer value to a boolean.
+    pub fn to_bool(&self) -> bool {
+        !self.data.is_zero()
+    }
+
+    /// Applies the given unary operation to this value.
+    pub fn unop(&self, op: hir::UnOpKind) -> Result<Self, EE> {
+        Ok(match op {
+            hir::UnOpKind::PreInc
+            | hir::UnOpKind::PreDec
+            | hir::UnOpKind::PostInc
+            | hir::UnOpKind::PostDec => return Err(EE::UnsupportedUnaryOp),
+            hir::UnOpKind::Not | hir::UnOpKind::BitNot => Self::new(!self.data),
+            hir::UnOpKind::Neg => Self::new(self.data.wrapping_neg()),
+        })
+    }
+
+    /// Applies the given binary operation to this value.
+    pub fn binop(&self, r: &Self, op: hir::BinOpKind) -> Result<Self, EE> {
+        let l = self;
+        Ok(match op {
+            hir::BinOpKind::Lt => Self::from_bool(l.data < r.data),
+            hir::BinOpKind::Le => Self::from_bool(l.data <= r.data),
+            hir::BinOpKind::Gt => Self::from_bool(l.data > r.data),
+            hir::BinOpKind::Ge => Self::from_bool(l.data >= r.data),
+            hir::BinOpKind::Eq => Self::from_bool(l.data == r.data),
+            hir::BinOpKind::Ne => Self::from_bool(l.data != r.data),
+            hir::BinOpKind::Or | hir::BinOpKind::BitOr => Self::new(l.data | r.data),
+            hir::BinOpKind::And | hir::BinOpKind::BitAnd => Self::new(l.data & r.data),
+            hir::BinOpKind::BitXor => Self::new(l.data ^ r.data),
+            hir::BinOpKind::Shr => {
+                Self::new(l.data.wrapping_shr(r.data.try_into().unwrap_or(usize::MAX)))
+            }
+            hir::BinOpKind::Shl => {
+                Self::new(l.data.wrapping_shl(r.data.try_into().unwrap_or(usize::MAX)))
+            }
+            hir::BinOpKind::Sar => {
+                Self::new(l.data.arithmetic_shr(r.data.try_into().unwrap_or(usize::MAX)))
+            }
+            hir::BinOpKind::Add => {
+                Self::new(l.data.checked_add(r.data).ok_or(EE::ArithmeticOverflow)?)
+            }
+            hir::BinOpKind::Sub => {
+                Self::new(l.data.checked_sub(r.data).ok_or(EE::ArithmeticOverflow)?)
+            }
+            hir::BinOpKind::Pow => {
+                Self::new(l.data.checked_pow(r.data).ok_or(EE::ArithmeticOverflow)?)
+            }
+            hir::BinOpKind::Mul => {
+                Self::new(l.data.checked_mul(r.data).ok_or(EE::ArithmeticOverflow)?)
+            }
+            hir::BinOpKind::Div => Self::new(l.data.checked_div(r.data).ok_or(EE::DivisionByZero)?),
+            hir::BinOpKind::Rem => Self::new(l.data.checked_rem(r.data).ok_or(EE::DivisionByZero)?),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum EvalErrorKind {
+    RecursionLimitReached,
+    ArithmeticOverflow,
+    IntTooBig,
+    DivisionByZero,
+    UnsupportedLiteral,
+    UnsupportedUnaryOp,
+    UnsupportedExpr,
+    NonConstantVar,
+    AlreadyEmitted(ErrorGuaranteed),
+}
+use EvalErrorKind as EE;
+
+impl EvalErrorKind {
+    pub fn spanned(self, span: Span) -> EvalError {
+        EvalError { kind: self, span }
+    }
+
+    fn msg(&self) -> &'static str {
+        match self {
+            Self::RecursionLimitReached => "recursion limit reached",
+            Self::ArithmeticOverflow => "arithmetic overflow",
+            Self::IntTooBig => "integer value is too big",
+            Self::DivisionByZero => "division by zero",
+            Self::UnsupportedLiteral => "unsupported literal",
+            Self::UnsupportedUnaryOp => "unsupported unary operation",
+            Self::UnsupportedExpr => "unsupported expression",
+            Self::NonConstantVar => "only constant variables are allowed",
+            Self::AlreadyEmitted(_) => "error already emitted",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EvalError {
+    pub span: Span,
+    pub kind: EvalErrorKind,
+}
+
+impl From<EE> for EvalError {
+    fn from(value: EE) -> Self {
+        Self { kind: value, span: Span::DUMMY }
+    }
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.kind.msg().fmt(f)
+    }
+}
+
+impl std::error::Error for EvalError {}

--- a/crates/sema/src/hir.rs
+++ b/crates/sema/src/hir.rs
@@ -869,6 +869,17 @@ pub struct Expr<'hir> {
     pub span: Span,
 }
 
+impl Expr<'_> {
+    /// Peels off unnecessary parentheses from the expression.
+    pub fn peel_parens(&self) -> &Self {
+        let mut expr = self;
+        while let ExprKind::Tuple([Some(inner)]) = &expr.kind {
+            expr = inner;
+        }
+        expr
+    }
+}
+
 /// A kind of expression.
 #[derive(Debug)]
 pub enum ExprKind<'hir> {

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -29,6 +29,7 @@ mod parse;
 pub use parse::{ParsedSource, ParsedSources, ParsingContext};
 
 pub mod builtins;
+pub mod eval;
 pub mod hir;
 pub mod ty;
 

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1,5 +1,6 @@
 use super::Gcx;
 use crate::{builtins::Builtin, hir};
+use alloy_primitives::U256;
 use solar_ast::ast::{DataLocation, ElementaryType, StateMutability, TypeSize, Visibility};
 use solar_data_structures::{map::FxHashSet, smallvec::SmallVec, Interned};
 use solar_interface::diagnostics::ErrorGuaranteed;
@@ -182,7 +183,7 @@ pub enum TyKind<'gcx> {
     DynArray(Ty<'gcx>),
 
     /// Fixed-size array: `T[N]`.
-    Array(Ty<'gcx>, u64),
+    Array(Ty<'gcx>, U256),
 
     /// Tuple: `(T1, T2, ...)`.
     Tuple(&'gcx [Ty<'gcx>]),

--- a/crates/solar/src/main.rs
+++ b/crates/solar/src/main.rs
@@ -158,7 +158,9 @@ fn run_compiler_with(args: Args, f: impl FnOnce(&Compiler) -> Result + Send) -> 
         sess.stop_after = args.stop_after;
         sess.dump = args.unstable.dump.clone();
         sess.jobs = NonZeroUsize::new(jobs).unwrap();
-        if args.input.iter().all(|arg| arg.extension() == Some("yul".as_ref())) {
+        if !args.input.is_empty()
+            && args.input.iter().all(|arg| arg.extension() == Some("yul".as_ref()))
+        {
             sess.language = solar_config::Language::Yul;
         }
 

--- a/tests/ui/typeck/eval.sol
+++ b/tests/ui/typeck/eval.sol
@@ -1,0 +1,32 @@
+uint constant x = (69 + (((420))));
+
+uint constant rec1 = rec1;
+uint constant rec2 = rec1;
+
+uint constant bigLiteral = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+uint constant tooBigLiteral = 115792089237316195423570985008687907853269984665640564039457584007913129639936;
+
+contract C {
+    uint constant zero = x - x;
+
+    uint[bigLiteral] public big;
+    uint[bigLiteral + 1] public tooBig1; //~ ERROR: evaluation of constant value failed
+    uint[tooBigLiteral] public tooBig2; //~ ERROR: evaluation of constant value failed
+
+    uint public stateVar = 69;
+
+    function a(uint[x / 0] memory) public {} //~ ERROR: evaluation of constant value failed
+    function b(uint[x] memory) public {}
+    function c(uint[x * 2] memory) public {}
+    function d(uint[0 - 1] memory) public {} //~ ERROR: evaluation of constant value failed
+    function e(uint[rec1] memory) public {} //~ ERROR: evaluation of constant value failed
+    function f(uint[rec2] memory) public {} //~ ERROR: evaluation of constant value failed
+
+    function g(uint[0] memory) public {} //~ ERROR: array length must be greater than zero
+    function h(uint[zero] memory) public {} //~ ERROR: array length must be greater than zero
+
+    function i(uint[block.timestamp] memory) public {} //~ ERROR: evaluation of constant value failed
+    function j(uint["lol"] memory) public {} //~ ERROR: evaluation of constant value failed
+    function k(uint[--x] memory) public {} //~ ERROR: evaluation of constant value failed
+    function l(uint[stateVar] memory) public {} //~ ERROR: evaluation of constant value failed
+}

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -1,0 +1,108 @@
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function a(uint[x / 0] memory) public {}
+   |                     ^^^^^
+   |                     ----- note: division by zero
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function d(uint[0 - 1] memory) public {}
+   |                     ^^^^^
+   |                     ----- note: arithmetic overflow
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant rec1 = rec1;
+   |                      ---- note: recursion limit reached
+LL | uint constant rec2 = rec1;
+...
+LL |     function d(uint[0 - 1] memory) public {}
+LL |     function e(uint[rec1] memory) public {}
+   |                     ^^^^
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant rec1 = rec1;
+   |                      ---- note: recursion limit reached
+LL | uint constant rec2 = rec1;
+...
+LL |     function e(uint[rec1] memory) public {}
+LL |     function f(uint[rec2] memory) public {}
+   |                     ^^^^
+   |
+
+error: array length must be greater than zero
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function g(uint[0] memory) public {}
+   |                     ^
+   |
+
+error: array length must be greater than zero
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function h(uint[zero] memory) public {}
+   |                     ^^^^
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function i(uint[block.timestamp] memory) public {}
+   |                     ^^^^^^^^^^^^^^^
+   |                     --------------- note: unsupported expression
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function j(uint["lol"] memory) public {}
+   |                     ^^^^^
+   |                     ----- note: unsupported literal
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function k(uint[--x] memory) public {}
+   |                     ^^^
+   |                     --- note: unsupported unary operation
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function l(uint[stateVar] memory) public {}
+   |                     ^^^^^^^^
+   |                     -------- note: only constant variables are allowed
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     uint[bigLiteral + 1] public tooBig1;
+   |          ^^^^^^^^^^^^^^
+   |          -------------- note: arithmetic overflow
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant tooBigLiteral = 115792089237316195423570985008687907853269984665640564039457584007913129639936;
+   |                               ------------------------------------------------------------------------------ note: integer value is too big
+LL | 
+...
+LL |     uint[bigLiteral + 1] public tooBig1;
+LL |     uint[tooBigLiteral] public tooBig2;
+   |          ^^^^^^^^^^^^^
+   |
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
This is bare-bones since it has to run before type checking, so it only evaluates literals and arithmetic operations.

Equivalent of [`ConstantEvaluator` in solc]( https://github.com/ethereum/solidity/blob/de1a017ccb935d149ed6bcbdb730d89883f8ce02/libsolidity/analysis/ConstantEvaluator.cpp).