### PR TITLE
chore: remove `Captures<'_>`

### DIFF
--- a/crates/data-structures/src/captures.rs
+++ b/crates/data-structures/src/captures.rs
@@ -1,8 +1,0 @@
-/// "Signaling" trait used in impl trait to tag lifetimes that you may
-/// need to capture but don't really need for other reasons.
-/// Basically a workaround; see [this comment] for details.
-///
-/// [this comment]: https://github.com/rust-lang/rust/issues/34511#issuecomment-373423999
-pub trait Captures<'a> {}
-
-impl<T: ?Sized> Captures<'_> for T {}

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -25,9 +25,6 @@ pub use bump_ext::BumpExt;
 mod collect;
 pub use collect::CollectAndApply;
 
-mod captures;
-pub use captures::Captures;
-
 mod never;
 pub use never::Never;
 


### PR DESCRIPTION
`use<..>` was stabilized in Rust 1.82 so we don't need this anymore

https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#precise-capturing-use-syntax