### PR TITLE
chore: rename --error-format rich-json to rustc-json

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -96,10 +96,13 @@ impl Args {
 #[derive(Clone, Debug, Default, clap::ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum ErrorFormat {
+    /// Human-readable output.
     #[default]
     Human,
+    /// Solc-like JSON output.
     Json,
-    RichJson,
+    /// Rustc-like JSON output.
+    RustcJson,
 }
 
 /// A single import map, AKA remapping: `map=path`.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -117,11 +117,11 @@ fn run_compiler_with(args: Args, f: impl FnOnce(&Compiler) -> Result + Send) -> 
                     .ui_testing(ui_testing);
                 Box::new(human)
             }
-            cli::ErrorFormat::Json | cli::ErrorFormat::RichJson => {
+            cli::ErrorFormat::Json | cli::ErrorFormat::RustcJson => {
                 let writer = Box::new(std::io::BufWriter::new(std::io::stderr()));
                 let json = JsonEmitter::new(writer, source_map.clone())
                     .pretty(args.pretty_json_err)
-                    .rustc_like(matches!(args.error_format, cli::ErrorFormat::RichJson))
+                    .rustc_like(matches!(args.error_format, cli::ErrorFormat::RustcJson))
                     .ui_testing(ui_testing);
                 Box::new(json)
             }

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -76,7 +76,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             program: cmd.into(),
             args: {
                 let mut args =
-                    vec!["-j1", "--error-format=rich-json", "-Zui-testing", "-Zparse-yul"];
+                    vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"];
                 if mode.is_solc() {
                     args.push("--stop-after=parsing");
                 }


### PR DESCRIPTION
Don't know why I called it rich in the first place tbh