### PR TITLE
fix: correct getters with struct return types

### DIFF
--- a/crates/ast/src/ast/item.rs
+++ b/crates/ast/src/ast/item.rs
@@ -410,7 +410,7 @@ pub struct FunctionHeader<'ast> {
 }
 
 /// A kind of function.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, EnumIs)]
 pub enum FunctionKind {
     /// `constructor`
     Constructor,
@@ -450,16 +450,6 @@ impl FunctionKind {
     /// Returns `true` if the function is an ordinary function.
     pub fn is_ordinary(&self) -> bool {
         matches!(self, Self::Function)
-    }
-
-    /// Returns `true` if the function is a constructor.
-    pub fn is_constructor(&self) -> bool {
-        matches!(self, Self::Constructor)
-    }
-
-    /// Returns `true` if the function is a modifier.
-    pub fn is_modifier(&self) -> bool {
-        matches!(self, Self::Modifier)
     }
 }
 

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -819,6 +819,7 @@ symbols! {
     // nice to have.
     Symbols {
         X,
+        __tmp_struct,
         abi,
         abicoder,
         assert,

--- a/crates/sema/src/ast_lowering/lower.rs
+++ b/crates/sema/src/ast_lowering/lower.rs
@@ -104,8 +104,15 @@ impl<'ast> super::LoweringContext<'_, 'ast, '_> {
                     }
                     hir::ItemId::Function(id)
                 }
-                ast::ItemKind::Variable(_)
-                | ast::ItemKind::Struct(_)
+                ast::ItemKind::Variable(_) => {
+                    let hir::ItemId::Variable(id) = self.lower_item(item) else { unreachable!() };
+                    items.push(hir::ItemId::Variable(id));
+                    if let Some(getter) = self.hir.variable(id).getter {
+                        items.push(getter.into());
+                    }
+                    continue;
+                }
+                ast::ItemKind::Struct(_)
                 | ast::ItemKind::Enum(_)
                 | ast::ItemKind::Udvt(_)
                 | ast::ItemKind::Error(_)

--- a/tests/ui/abi/getters.sol
+++ b/tests/ui/abi/getters.sol
@@ -1,0 +1,40 @@
+//@ignore-host: windows
+//@compile-flags: --emit=abi,hashes --pretty-json
+
+contract C {
+    int public simple;
+    int[] public array;
+    mapping(int k => bool v) public map;
+    mapping(int k => bool[] v) public mapOfArrays;
+    mapping(int k => bool v)[] public arrayOfMaps;
+
+    struct One {
+        int x;
+    }
+    One public simpleOne;
+    One[] public arrayOne;
+    mapping(string k => One v) public mapOne;
+    mapping(int k => One[] v) public mapOfArraysOne;
+    mapping(int k => One v)[] public arrayOfMapsOne;
+
+    struct Two {
+        int x;
+        bool y;
+    }
+    Two public simpleTwo;
+    Two[] public arrayTwo;
+    mapping(string k => Two v) public mapTwo;
+    mapping(int k => Two[] v) public mapOfArraysTwo;
+    mapping(int k => Two v)[] public arrayOfMapsTwo;
+    
+    struct RecMap {
+        int x;
+        mapping(int kn => Two[] vn) y;
+        bool z;
+    }
+    RecMap public simpleRecMap;
+    RecMap[] public arrayRecMap;
+    mapping(string k => RecMap v) public mapRecMap;
+    mapping(int k => RecMap[] v) public mapOfArraysRecMap;
+    mapping(int k => RecMap v)[] public arrayOfMapsRecMap;
+}

--- a/tests/ui/abi/getters.stdout
+++ b/tests/ui/abi/getters.stdout
@@ -1,0 +1,477 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/abi/getters.sol:C": {
+      "abi": [
+        {
+          "type": "function",
+          "name": "simple",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "array",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "map",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "v",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapOfArrays",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "index1",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "v",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayOfMaps",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "v",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "simpleOne",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayOne",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapOne",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapOfArraysOne",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "index1",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayOfMapsOne",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "simpleTwo",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "y",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayTwo",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "y",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapTwo",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "y",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapOfArraysTwo",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "index1",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "y",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayOfMapsTwo",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "y",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "simpleRecMap",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "z",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayRecMap",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "z",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapRecMap",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "string",
+              "internalType": "string"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "z",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "mapOfArraysRecMap",
+          "inputs": [
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "index1",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "z",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "arrayOfMapsRecMap",
+          "inputs": [
+            {
+              "name": "index0",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "k",
+              "type": "int256",
+              "internalType": "int256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "x",
+              "type": "int256",
+              "internalType": "int256"
+            },
+            {
+              "name": "z",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "stateMutability": "view"
+        }
+      ],
+      "hashes": {
+        "array(uint256)": "38d94193",
+        "arrayOfMaps(uint256,int256)": "25a0fe0c",
+        "arrayOfMapsOne(uint256,int256)": "f1c794f0",
+        "arrayOfMapsRecMap(uint256,int256)": "62adfa5e",
+        "arrayOfMapsTwo(uint256,int256)": "d0a7fde9",
+        "arrayOne(uint256)": "4d472626",
+        "arrayRecMap(uint256)": "4ec7956c",
+        "arrayTwo(uint256)": "c04d1634",
+        "map(int256)": "51bd3a41",
+        "mapOfArrays(int256,uint256)": "4f5b6558",
+        "mapOfArraysOne(int256,uint256)": "cb6caba9",
+        "mapOfArraysRecMap(int256,uint256)": "dcc98b71",
+        "mapOfArraysTwo(int256,uint256)": "d918e586",
+        "mapOne(string)": "22fd05a9",
+        "mapRecMap(string)": "84729686",
+        "mapTwo(string)": "60437563",
+        "simple()": "df201a46",
+        "simpleOne()": "3fab5226",
+        "simpleRecMap()": "5e8874bb",
+        "simpleTwo()": "8980a582"
+      }
+    }
+  },
+  "version": "VERSION"
+}

--- a/tests/ui/resolve/getters_complex.sol
+++ b/tests/ui/resolve/getters_complex.sol
@@ -1,0 +1,22 @@
+contract Complex {
+    struct A {
+        B b;
+    }
+
+    struct B {
+        uint256[] arr;
+    }
+
+    mapping(uint256 => A) public mapA;
+
+    function pushValueA(uint256 idx, uint256 val) public {
+        mapA[idx].b.arr.push(val);
+    }
+
+    // TODO: Internal or recursive type is not allowed for public state variables.
+    mapping(uint256 => B) public mapB;
+
+    function pushValueB(uint256 idx, uint256 val) public {
+        mapB[idx].arr.push(val);
+    }
+}

--- a/tests/ui/typeck/eval.sol
+++ b/tests/ui/typeck/eval.sol
@@ -13,7 +13,8 @@ contract C {
     uint[bigLiteral + 1] public tooBig1; //~ ERROR: evaluation of constant value failed
     uint[tooBigLiteral] public tooBig2; //~ ERROR: evaluation of constant value failed
 
-    uint public stateVar = 69;
+    uint private stateVar = 69;
+    uint public stateVarPublic = 420;
 
     function a(uint[x / 0] memory) public {} //~ ERROR: evaluation of constant value failed
     function b(uint[x] memory) public {}
@@ -29,4 +30,5 @@ contract C {
     function j(uint["lol"] memory) public {} //~ ERROR: evaluation of constant value failed
     function k(uint[--x] memory) public {} //~ ERROR: evaluation of constant value failed
     function l(uint[stateVar] memory) public {} //~ ERROR: evaluation of constant value failed
+    function l(uint[stateVarPublic] memory) public {} //~ ERROR: evaluation of constant value failed
 }

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -87,6 +87,14 @@ LL |     function l(uint[stateVar] memory) public {}
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
+LL |     function l(uint[stateVarPublic] memory) public {}
+   |                     ^^^^^^^^^^^^^^
+   |                     -------------- note: unsupported expression
+   |
+
+error: evaluation of constant value failed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
 LL |     uint[bigLiteral + 1] public tooBig1;
    |          ^^^^^^^^^^^^^^
    |          -------------- note: arithmetic overflow
@@ -104,5 +112,5 @@ LL |     uint[tooBigLiteral] public tooBig2;
    |          ^^^^^^^^^^^^^
    |
 
-error: aborting due to 12 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Getter functions have a flattened return type when it would've been a struct. Also append the getters to the contract items to fix name resolution for them.