### PR TITLE
fix: allow `Symbol::DUMMY.to_string()`

### DIFF
--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -186,7 +186,7 @@ impl Default for Symbol {
 
 impl Symbol {
     /// A dummy symbol.
-    pub const DUMMY: Self = Self(BaseIndex32::MAX);
+    pub const DUMMY: Self = kw::Empty;
 
     const fn new(n: u32) -> Self {
         Self(BaseIndex32::new(n))
@@ -492,6 +492,9 @@ symbols! {
     // When modifying this, also update all the `is_keyword` functions in this file.
     // Modified from the `TOKEN_LIST` macro in Solc: https://github.com/ethereum/solidity/blob/194b114664c7daebc2ff68af3c573272f5d28913/liblangutil/Token.h#L67
     Keywords {
+        // Special symbols used internally.
+        Empty:       "",
+
         Abstract:    "abstract",
         Anonymous:   "anonymous",
         As:          "as",
@@ -886,5 +889,20 @@ mod tests {
         assert_eq!(i.intern("cat"), Symbol::new(1));
         // dog is still at zero
         assert_eq!(i.intern("dog"), Symbol::new(0));
+    }
+
+    #[test]
+    fn defaults() {
+        assert_eq!(Symbol::DUMMY, Symbol::new(0));
+        assert_eq!(Symbol::DUMMY, Symbol::default());
+        assert_eq!(Ident::DUMMY, Ident::new(Symbol::DUMMY, Span::DUMMY));
+        assert_eq!(Ident::DUMMY, Ident::default());
+
+        crate::enter(|| {
+            assert_eq!(Symbol::DUMMY.as_str(), "");
+            assert_eq!(Symbol::DUMMY.to_string(), "");
+            assert_eq!(Ident::DUMMY.as_str(), "");
+            assert_eq!(Ident::DUMMY.to_string(), "");
+        });
     }
 }

--- a/crates/sema/src/ty/abi.rs
+++ b/crates/sema/src/ty/abi.rs
@@ -54,7 +54,7 @@ impl<'gcx> Gcx<'gcx> {
     fn function_abi(self, id: hir::FunctionId) -> json::Function {
         let f = self.hir.function(id);
         json::Function {
-            name: f.name.map(|id| id.to_string()).unwrap_or_default(),
+            name: f.name.unwrap_or_default().to_string(),
             inputs: f.parameters.iter().map(|&p| self.var_param_abi(p)).collect(),
             outputs: f.returns.iter().map(|&p| self.var_param_abi(p)).collect(),
             state_mutability: json_state_mutability(f.state_mutability),
@@ -81,7 +81,7 @@ impl<'gcx> Gcx<'gcx> {
     fn var_param_abi(self, id: hir::VariableId) -> json::Param {
         let v = self.hir.variable(id);
         let ty = self.type_of_item(id.into());
-        self.param_abi(ty, v.name.map(|id| id.to_string()).unwrap_or_default())
+        self.param_abi(ty, v.name.unwrap_or_default().to_string())
     }
 
     fn param_abi(self, ty: Ty<'gcx>, name: String) -> json::Param {


### PR DESCRIPTION
Shouldn't expose invalid symbols since `as_str` is implemented with the assumption that its input is always valid.