### PR TITLE
fix: inherit fallback/receive

### DIFF
--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -34,7 +34,7 @@ pub struct HumanEmitter {
     renderer: Renderer,
 }
 
-// SAFETY: `real_writer` always points to the `dyn Writer` in `writer`.
+// SAFETY: `real_writer` always points to the `Writer` in `writer`.
 unsafe impl Send for HumanEmitter {}
 
 impl Emitter for HumanEmitter {
@@ -71,7 +71,6 @@ impl HumanEmitter {
         Self {
             writer_type_id,
             real_writer: &mut *real_writer,
-            // NOTE: Intentionally erases the `+ Send` bound, see `writer` above.
             writer: AutoStream::new(real_writer, color),
             source_map: None,
             renderer: DEFAULT_RENDERER,

--- a/crates/sema/src/ast_lowering/mod.rs
+++ b/crates/sema/src/ast_lowering/mod.rs
@@ -38,6 +38,7 @@ pub(crate) fn lower<'sess, 'hir>(
     lcx.collect_contract_declarations();
     lcx.resolve_base_contracts();
     lcx.linearize_contracts();
+    lcx.assign_constructors();
 
     // Resolve declarations and top-level symbols, and finish lowering to HIR.
     lcx.resolve_symbols();

--- a/tests/ui/abi/basic.stdout
+++ b/tests/ui/abi/basic.stdout
@@ -554,6 +554,10 @@
           "anonymous": false
         },
         {
+          "type": "fallback",
+          "stateMutability": "nonpayable"
+        },
+        {
           "type": "function",
           "name": "f1",
           "inputs": [],
@@ -868,6 +872,10 @@
             }
           ],
           "stateMutability": "nonpayable"
+        },
+        {
+          "type": "receive",
+          "stateMutability": "payable"
         }
       ],
       "hashes": {

--- a/tests/ui/abi/contract_special_functions.sol
+++ b/tests/ui/abi/contract_special_functions.sol
@@ -1,0 +1,18 @@
+//@ignore-host: windows
+//@compile-flags: --emit=abi,hashes --pretty-json
+
+contract C {
+    constructor() {}
+    fallback() external {}
+}
+
+contract D is C {
+    constructor() payable {}
+    receive() external payable {}
+}
+
+// Inherits `C.fallback`, but not the constructor.
+contract E is C {}
+
+// Inherits `C.fallback` and `D.receive`, but not any of the constructors.
+contract F is D {}

--- a/tests/ui/abi/contract_special_functions.stdout
+++ b/tests/ui/abi/contract_special_functions.stdout
@@ -1,0 +1,59 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/abi/contract_special_functions.sol:C": {
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "fallback",
+          "stateMutability": "nonpayable"
+        }
+      ],
+      "hashes": {}
+    },
+    "ROOT/tests/ui/abi/contract_special_functions.sol:D": {
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "fallback",
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "receive",
+          "stateMutability": "payable"
+        }
+      ],
+      "hashes": {}
+    },
+    "ROOT/tests/ui/abi/contract_special_functions.sol:E": {
+      "abi": [
+        {
+          "type": "fallback",
+          "stateMutability": "nonpayable"
+        }
+      ],
+      "hashes": {}
+    },
+    "ROOT/tests/ui/abi/contract_special_functions.sol:F": {
+      "abi": [
+        {
+          "type": "fallback",
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "receive",
+          "stateMutability": "payable"
+        }
+      ],
+      "hashes": {}
+    }
+  },
+  "version": "VERSION"
+}

--- a/tests/ui/resolve/contract_special_functions.sol
+++ b/tests/ui/resolve/contract_special_functions.sol
@@ -1,0 +1,24 @@
+contract C {
+    constructor() {}
+    constructor() {} //~ ERROR: constructor function already declared
+
+    fallback() external {}
+    fallback() external {} //~ ERROR: fallback function already declared
+
+    receive() external payable {}
+    receive() external payable {} //~ ERROR: receive function already declared
+}
+
+contract D {
+    constructor() {}
+    constructor() {} //~ ERROR: constructor function already declared
+    constructor() {} //~ ERROR: constructor function already declared
+
+    fallback() external {}
+    fallback() external {} //~ ERROR: fallback function already declared
+    fallback() external {} //~ ERROR: fallback function already declared
+
+    receive() external payable {}
+    receive() external payable {} //~ ERROR: receive function already declared
+    receive() external payable {} //~ ERROR: receive function already declared
+}

--- a/tests/ui/resolve/contract_special_functions.stderr
+++ b/tests/ui/resolve/contract_special_functions.stderr
@@ -1,0 +1,86 @@
+error: constructor function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     constructor() {}
+   |     ---------------- note: previous declaration here
+LL |     constructor() {}
+   |     ^^^^^^^^^^^^^^^^
+   |
+
+error: fallback function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     fallback() external {}
+   |     ---------------------- note: previous declaration here
+LL |     fallback() external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: receive function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     receive() external payable {}
+   |     ----------------------------- note: previous declaration here
+LL |     receive() external payable {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: constructor function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     constructor() {}
+   |     ---------------- note: previous declaration here
+LL |     constructor() {}
+   |     ^^^^^^^^^^^^^^^^
+   |
+
+error: constructor function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     constructor() {}
+   |     ---------------- note: previous declaration here
+LL |     constructor() {}
+LL |     constructor() {}
+   |     ^^^^^^^^^^^^^^^^
+   |
+
+error: fallback function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     fallback() external {}
+   |     ---------------------- note: previous declaration here
+LL |     fallback() external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: fallback function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     fallback() external {}
+   |     ---------------------- note: previous declaration here
+LL |     fallback() external {}
+LL |     fallback() external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: receive function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     receive() external payable {}
+   |     ----------------------------- note: previous declaration here
+LL |     receive() external payable {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: receive function already declared
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
+LL |     receive() external payable {}
+   |     ----------------------------- note: previous declaration here
+LL |     receive() external payable {}
+LL |     receive() external payable {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: aborting due to 9 previous errors
+


### PR DESCRIPTION
`fallback` and `receive` are inherited like normal functions, but `constructor` isn't.