### PR TITLE
Add syntax test pragma solidity

### DIFF
--- a/tests/ui/parser/pragma_unknown.sol
+++ b/tests/ui/parser/pragma_unknown.sol
@@ -10,4 +10,4 @@ pragma amogus 69;
 pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
 //~^ ERROR: unknown pragma
 pragma amogus 0.8.15;
-//~^ ERROR: unknown pragma
+//~^ ERROR: only `solidity` is supported as a version pragma

--- a/tests/ui/parser/pragma_unknown.sol
+++ b/tests/ui/parser/pragma_unknown.sol
@@ -9,3 +9,5 @@ pragma amogus 69;
 //~^ ERROR: unknown pragma
 pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
 //~^ ERROR: unknown pragma
+pragma amogus 0.8.15;
+//~^ ERROR: unknown pragma

--- a/tests/ui/parser/pragma_unknown.stderr
+++ b/tests/ui/parser/pragma_unknown.stderr
@@ -33,5 +33,12 @@ LL | pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 
-error: aborting due to 5 previous errors
+error: only `solidity` is supported as a version pragma
+  --> ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
+   |
+LL | pragma amogus 0.8.15;
+   |        ^^^^^^
+   |
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
This PR adds a syntax unit test to check the case where the pragma has a version but not the `solidity` pragma.