### PR TITLE
AST validate that a contract does not have a function with contract name

### DIFF
--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -120,10 +120,8 @@ impl<'ast> Visit<'ast> for AstValidator<'_> {
                 if let Some(func_name) = header.name {
                     if func_name.as_str() == contract_name {
                         self.dcx()
-                            .err(
-                                "Functions are not allowed to have the same name as the contract.
-        If you intend this to be a constructor, use \"constructor(...) { ... }\" to define it.",
-                            )
+                            .err("functions are not allowed to have the same name as the contract")
+                            .note("if you intend this to be a constructor, use \"constructor(...) { ... }\" to define it")
                             .span(func_name.span)
                             .emit();
                     }

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -123,7 +123,10 @@ impl<'ast> Visit<'ast> for AstValidator<'_> {
         self.walk_stmt(stmt)
     }
 
-    fn visit_item_contract(&mut self, contract: &'ast ast::ItemContract<'ast>) {
+    fn visit_item_contract(
+        &mut self,
+        contract: &'ast ast::ItemContract<'ast>,
+    ) -> ControlFlow<Self::BreakValue> {
         let ast::ItemContract { kind: _, name, bases: _, body } = contract;
         let contract_name = name.as_str();
 
@@ -143,7 +146,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_> {
             }
         }
 
-        self.walk_item_contract(contract);
+        self.walk_item_contract(contract)
     }
 
     // Intentionally override unused default implementations to reduce bloat.

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -138,7 +138,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_> {
                     if func_name.as_str() == contract_name {
                         self.dcx()
                             .err("functions are not allowed to have the same name as the contract")
-                            .note("if you intend this to be a constructor, use \"constructor(...) { ... }\" to define it")
+                            .note("if you intend this to be a constructor, use `constructor(...) { ... }` to define it")
                             .span(func_name.span)
                             .emit();
                     }

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -127,20 +127,20 @@ impl<'ast> Visit<'ast> for AstValidator<'_> {
         &mut self,
         contract: &'ast ast::ItemContract<'ast>,
     ) -> ControlFlow<Self::BreakValue> {
-        let ast::ItemContract { kind: _, name, bases: _, body } = contract;
-        let contract_name = name.as_str();
+        let ast::ItemContract { kind: _, name: _, bases: _, body } = contract;
 
         for item in body.iter() {
-            if let ast::ItemKind::Function(ast::ItemFunction { kind: _, header, body: _ }) =
-                &item.kind
+            if let ast::ItemKind::Function(ast::ItemFunction { kind, header, body: _ }) = &item.kind
             {
-                if let Some(func_name) = header.name {
-                    if func_name == contract.name {
-                        self.dcx()
+                if *kind == ast::FunctionKind::Function {
+                    if let Some(func_name) = header.name {
+                        if func_name == contract.name {
+                            self.dcx()
                             .err("functions are not allowed to have the same name as the contract")
                             .note("if you intend this to be a constructor, use `constructor(...) { ... }` to define it")
                             .span(func_name.span)
                             .emit();
+                        }
                     }
                 }
             }

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -135,7 +135,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_> {
                 &item.kind
             {
                 if let Some(func_name) = header.name {
-                    if func_name.as_str() == contract_name {
+                    if func_name == contract.name {
                         self.dcx()
                             .err("functions are not allowed to have the same name as the contract")
                             .note("if you intend this to be a constructor, use `constructor(...) { ... }` to define it")

--- a/tests/ui/parser/contract_function_shared_name.sol
+++ b/tests/ui/parser/contract_function_shared_name.sol
@@ -1,5 +1,5 @@
 contract C {
-    function C() public {} //~ ERROR: Functions are not allowed to have the same name as the contract.
+    function C() public {} //~ ERROR: functions are not allowed to have the same name as the contract
 
     function c() public {}
 }

--- a/tests/ui/parser/contract_function_shared_name.sol
+++ b/tests/ui/parser/contract_function_shared_name.sol
@@ -1,0 +1,3 @@
+contract C {
+    function C() public {} //~ ERROR: Functions are not allowed to have the same name as the contract.
+}

--- a/tests/ui/parser/contract_function_shared_name.sol
+++ b/tests/ui/parser/contract_function_shared_name.sol
@@ -1,3 +1,5 @@
 contract C {
     function C() public {} //~ ERROR: Functions are not allowed to have the same name as the contract.
+
+    function c() public {}
 }

--- a/tests/ui/parser/contract_function_shared_name.stderr
+++ b/tests/ui/parser/contract_function_shared_name.stderr
@@ -1,10 +1,10 @@
-error: Functions are not allowed to have the same name as the contract.
-        If you intend this to be a constructor, use "constructor(...) { ... }" to define it.
+error: functions are not allowed to have the same name as the contract
   --> ROOT/tests/ui/parser/contract_function_shared_name.sol:LL:CC
    |
 LL |     function C() public {}
    |              ^
    |
+   = note: if you intend this to be a constructor, use "constructor(...) { ... }" to define it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/contract_function_shared_name.stderr
+++ b/tests/ui/parser/contract_function_shared_name.stderr
@@ -1,0 +1,10 @@
+error: Functions are not allowed to have the same name as the contract.
+        If you intend this to be a constructor, use "constructor(...) { ... }" to define it.
+  --> ROOT/tests/ui/parser/contract_function_shared_name.sol:LL:CC
+   |
+LL |     function C() public {}
+   |              ^
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/contract_function_shared_name.stderr
+++ b/tests/ui/parser/contract_function_shared_name.stderr
@@ -4,7 +4,7 @@ error: functions are not allowed to have the same name as the contract
 LL |     function C() public {}
    |              ^
    |
-   = note: if you intend this to be a constructor, use "constructor(...) { ... }" to define it
+   = note: if you intend this to be a constructor, use `constructor(...) { ... }` to define it
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This PR adds an AST validation check similar to [this](https://github.com/ethereum/solidity/blob/df01dcc7b759f53ba45811979d3286562eab7846/libsolidity/analysis/SyntaxChecker.cpp#L385) which verifies that a function does not have the same name as the contract.

Note, eventually this can be merged into a specific AST contract level checker.