### PR TITLE
Initial AST validation for using-for

### DIFF
--- a/tests/ui/parser/using.sol
+++ b/tests/ui/parser/using.sol
@@ -1,0 +1,13 @@
+using {f} for * global; //~ ERROR: Can only globally attach functions to specific types
+//~^ ERROR: The type has to be specified explicitly at file level (cannot use '*')
+function f(uint) pure {}
+
+contract C {
+    using {f} for uint global; //~ ERROR: 'global' can only be used at file level
+}
+function f(uint) pure {}
+
+interface I2 {
+    using L for int; //~ ERROR: The 'using for' directive is not allowed inside interfaces
+    function g() external;
+}

--- a/tests/ui/parser/using.stderr
+++ b/tests/ui/parser/using.stderr
@@ -1,0 +1,30 @@
+error: The type has to be specified explicitly at file level (cannot use '*')
+  --> ROOT/tests/ui/parser/using.sol:LL:CC
+   |
+LL | using {f} for * global;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: Can only globally attach functions to specific types
+  --> ROOT/tests/ui/parser/using.sol:LL:CC
+   |
+LL | using {f} for * global;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: 'global' can only be used at file level
+  --> ROOT/tests/ui/parser/using.sol:LL:CC
+   |
+LL |     using {f} for uint global;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: The 'using for' directive is not allowed inside interfaces
+  --> ROOT/tests/ui/parser/using.sol:LL:CC
+   |
+LL |     using L for int;
+   |     ^^^^^^^^^^^^^^^^
+   |
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This PR adds the initial AST validation for the `using` statement. This PR only has tests for the 3 parsing scenarios while the Solidity repo has [dozens of them](https://github.com/ethereum/solidity/tree/b0d991bd4b3bc2d48d40029c3303f67f604d7cc5/test/libsolidity/syntaxTests/using). I was wondering how do you want to approach that on `solar`. Should I create sub-directories like they do? Merge them on the same file? Should I copy/paste the whole syntax e2e tests from Solidity? Is it enough with basic tests and we do not need as many as Solidity has?