### PR TITLE
fix: install rayon pool in Session::enter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,6 @@ dependencies = [
  "clap",
  "const_format",
  "libc",
- "rayon",
  "solar-config",
  "solar-interface",
  "solar-sema",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,7 +27,6 @@ alloy-primitives.workspace = true
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive"] }
 const_format = { workspace = true, features = ["rust_1_64"] }
-rayon.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -102,65 +102,64 @@ impl Compiler {
 }
 
 fn run_compiler_with(args: Args, f: impl FnOnce(&Compiler) -> Result + Send) -> Result {
-    utils::run_in_thread_pool_with_globals(args.threads, |jobs| {
-        let ui_testing = args.unstable.ui_testing;
-        let source_map = Arc::new(SourceMap::empty());
-        let emitter: Box<DynEmitter> = match args.error_format {
-            cli::ErrorFormat::Human => {
-                let color = match args.color {
-                    clap::ColorChoice::Always => solar_interface::ColorChoice::Always,
-                    clap::ColorChoice::Auto => solar_interface::ColorChoice::Auto,
-                    clap::ColorChoice::Never => solar_interface::ColorChoice::Never,
-                };
-                let human = HumanEmitter::stderr(color)
-                    .source_map(Some(source_map.clone()))
-                    .ui_testing(ui_testing);
-                Box::new(human)
-            }
-            cli::ErrorFormat::Json | cli::ErrorFormat::RustcJson => {
-                let writer = Box::new(std::io::BufWriter::new(std::io::stderr()));
-                let json = JsonEmitter::new(writer, source_map.clone())
-                    .pretty(args.pretty_json_err)
-                    .rustc_like(matches!(args.error_format, cli::ErrorFormat::RustcJson))
-                    .ui_testing(ui_testing);
-                Box::new(json)
-            }
-        };
-        let dcx = DiagCtxt::new(emitter).set_flags(|flags| {
-            flags.deduplicate_diagnostics &= !ui_testing;
-            flags.track_diagnostics &= !ui_testing;
-            flags.track_diagnostics |= args.unstable.track_diagnostics;
-        });
-
-        let mut sess = Session::new(dcx, source_map);
-        sess.evm_version = args.evm_version;
-        sess.language = args.language;
-        sess.stop_after = args.stop_after;
-        sess.dump = args.unstable.dump.clone();
-        sess.jobs = NonZeroUsize::new(jobs).unwrap();
-        if !args.input.is_empty()
-            && args.input.iter().all(|arg| arg.extension() == Some("yul".as_ref()))
-        {
-            sess.language = solar_config::Language::Yul;
+    let ui_testing = args.unstable.ui_testing;
+    let source_map = Arc::new(SourceMap::empty());
+    let emitter: Box<DynEmitter> = match args.error_format {
+        cli::ErrorFormat::Human => {
+            let color = match args.color {
+                clap::ColorChoice::Always => solar_interface::ColorChoice::Always,
+                clap::ColorChoice::Auto => solar_interface::ColorChoice::Auto,
+                clap::ColorChoice::Never => solar_interface::ColorChoice::Never,
+            };
+            let human = HumanEmitter::stderr(color)
+                .source_map(Some(source_map.clone()))
+                .ui_testing(ui_testing);
+            Box::new(human)
         }
-        sess.emit = {
-            let mut set = BTreeSet::default();
-            for &emit in &args.emit {
-                if !set.insert(emit) {
-                    let msg = format!("cannot specify `--emit {emit}` twice");
-                    return Err(sess.dcx.err(msg).emit());
-                }
-            }
-            set
-        };
-        sess.out_dir = args.out_dir.clone();
-        sess.pretty_json = args.pretty_json;
+        cli::ErrorFormat::Json | cli::ErrorFormat::RustcJson => {
+            let writer = Box::new(std::io::BufWriter::new(std::io::stderr()));
+            let json = JsonEmitter::new(writer, source_map.clone())
+                .pretty(args.pretty_json_err)
+                .rustc_like(matches!(args.error_format, cli::ErrorFormat::RustcJson))
+                .ui_testing(ui_testing);
+            Box::new(json)
+        }
+    };
+    let dcx = DiagCtxt::new(emitter).set_flags(|flags| {
+        flags.deduplicate_diagnostics &= !ui_testing;
+        flags.track_diagnostics &= !ui_testing;
+        flags.track_diagnostics |= args.unstable.track_diagnostics;
+    });
 
-        let compiler = Compiler { sess, args };
-        compiler.sess.enter(|| {
-            let mut r = f(&compiler);
-            r = compiler.finish_diagnostics().and(r);
-            r
-        })
+    let mut sess = Session::new(dcx, source_map);
+    sess.evm_version = args.evm_version;
+    sess.language = args.language;
+    sess.stop_after = args.stop_after;
+    sess.dump = args.unstable.dump.clone();
+    sess.jobs = NonZeroUsize::new(args.threads)
+        .unwrap_or_else(|| std::thread::available_parallelism().unwrap_or(NonZeroUsize::MIN));
+    if !args.input.is_empty()
+        && args.input.iter().all(|arg| arg.extension() == Some("yul".as_ref()))
+    {
+        sess.language = solar_config::Language::Yul;
+    }
+    sess.emit = {
+        let mut set = BTreeSet::default();
+        for &emit in &args.emit {
+            if !set.insert(emit) {
+                let msg = format!("cannot specify `--emit {emit}` twice");
+                return Err(sess.dcx.err(msg).emit());
+            }
+        }
+        set
+    };
+    sess.out_dir = args.out_dir.clone();
+    sess.pretty_json = args.pretty_json;
+
+    let compiler = Compiler { sess, args };
+    compiler.sess.enter(|| {
+        let mut r = f(&compiler);
+        r = compiler.finish_diagnostics().and(r);
+        r
     })
 }

--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -171,17 +171,23 @@ impl DiagCtxt {
         }
     }
 
+    /// Returns the emitted diagnostics. Can be empty.
+    ///
+    /// Returns `None` if the underlying emitter is not a human buffer emitter created with
+    /// [`with_buffer_emitter`](Self::with_buffer_emitter).
+    pub fn emitted_diagnostics(&self) -> Option<EmittedDiagnostics> {
+        let inner = self.inner.lock();
+        Some(EmittedDiagnostics(inner.emitter.local_buffer()?.to_string()))
+    }
+
     /// Returns `Err` with the printed diagnostics if any errors have been emitted.
     ///
     /// Returns `None` if the underlying emitter is not a human buffer emitter created with
     /// [`with_buffer_emitter`](Self::with_buffer_emitter).
-    pub fn emitted_diagnostics(&self) -> Option<Result<(), EmittedDiagnostics>> {
+    pub fn emitted_errors(&self) -> Option<Result<(), EmittedDiagnostics>> {
         let inner = self.inner.lock();
-        Some(if inner.has_errors() {
-            Err(EmittedDiagnostics(inner.emitter.local_buffer()?.to_string()))
-        } else {
-            Ok(())
-        })
+        let buffer = inner.emitter.local_buffer()?;
+        Some(if inner.has_errors() { Err(EmittedDiagnostics(buffer.to_string())) } else { Ok(()) })
     }
 
     /// Emits a diagnostic if any warnings or errors have been emitted.

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -41,6 +41,13 @@ impl fmt::Display for EmittedDiagnostics {
 
 impl std::error::Error for EmittedDiagnostics {}
 
+impl EmittedDiagnostics {
+    /// Returns `true` if no diagnostics have been emitted.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 /// Useful type to use with [`Result`] indicate that an error has already been reported to the user,
 /// so no need to continue checking.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/interface/src/globals.rs
+++ b/crates/interface/src/globals.rs
@@ -44,10 +44,9 @@ impl SessionGlobals {
 
     /// Insert `source_map` into the session globals for the duration of the closure's execution.
     pub fn with_source_map<R>(source_map: Arc<SourceMap>, f: impl FnOnce() -> R) -> R {
-        Self::with(|g| *g.source_map.lock() = Some(source_map));
-
+        let prev = Self::with(|g| g.source_map.lock().replace(source_map));
         let _clear = defer(|| {
-            Self::with(|g| g.source_map.lock().take());
+            Self::with(|g| *g.source_map.lock() = prev);
         });
         f()
     }

--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -67,7 +67,10 @@ macro_rules! pluralize {
 /// Creates new session globals on the current thread if they doesn't exist already and then
 /// executes the given closure.
 ///
-/// Prefer [`Session::enter`] to this function if possible to also set the source map.
+/// Prefer [`Session::enter`] to this function if possible to also set the source map and thread
+/// pool.
+///
+/// Using this instead of [`Session::enter`] may cause unexpected panics.
 #[inline]
 pub fn enter<R>(f: impl FnOnce() -> R) -> R {
     SessionGlobals::with_or_default(|_| f())

--- a/crates/interface/src/session.rs
+++ b/crates/interface/src/session.rs
@@ -134,13 +134,22 @@ impl Session {
         SessionBuilder::default()
     }
 
+    /// Returns the emitted diagnostics. Can be empty.
+    ///
+    /// Returns `None` if the underlying emitter is not a human buffer emitter created with
+    /// [`with_buffer_emitter`](SessionBuilder::with_buffer_emitter).
+    #[inline]
+    pub fn emitted_diagnostics(&self) -> Option<EmittedDiagnostics> {
+        self.dcx.emitted_diagnostics()
+    }
+
     /// Returns `Err` with the printed diagnostics if any errors have been emitted.
     ///
     /// Returns `None` if the underlying emitter is not a human buffer emitter created with
     /// [`with_buffer_emitter`](SessionBuilder::with_buffer_emitter).
     #[inline]
-    pub fn emitted_diagnostics(&self) -> Option<Result<(), EmittedDiagnostics>> {
-        self.dcx.emitted_diagnostics()
+    pub fn emitted_errors(&self) -> Option<Result<(), EmittedDiagnostics>> {
+        self.dcx.emitted_errors()
     }
 
     /// Returns a reference to the source map.
@@ -164,7 +173,7 @@ impl Session {
     /// Returns `true` if parallelism is not enabled.
     #[inline]
     pub fn is_sequential(&self) -> bool {
-        self.jobs.get() == 1
+        self.jobs == NonZeroUsize::MIN
     }
 
     /// Returns `true` if parallelism is enabled.
@@ -221,21 +230,65 @@ impl Session {
         solar_data_structures::sync::scope(self.is_parallel(), op)
     }
 
-    /// Sets up session globals on the current thread if they doesn't exist already and then
+    /// Sets up the thread pool and session globals if they doesn't exist already and then
     /// executes the given closure.
     ///
     /// This also calls [`SessionGlobals::with_source_map`].
     #[inline]
-    pub fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
-        SessionGlobals::with_or_default(|_| {
-            SessionGlobals::with_source_map(self.clone_source_map(), f)
+    pub fn enter<R: Send>(&self, f: impl FnOnce() -> R + Send) -> R {
+        SessionGlobals::with_or_default(|session_globals| {
+            SessionGlobals::with_source_map(self.clone_source_map(), || {
+                run_in_thread_pool_with_globals(self.jobs.get(), session_globals, f)
+            })
         })
     }
+}
+
+/// Runs the given closure in a thread pool with the given number of threads.
+fn run_in_thread_pool_with_globals<R: Send>(
+    threads: usize,
+    session_globals: &SessionGlobals,
+    f: impl FnOnce() -> R + Send,
+) -> R {
+    // Avoid panicking below if this is a recursive call.
+    if rayon::current_thread_index().is_some() {
+        return f();
+    }
+
+    let mut builder =
+        rayon::ThreadPoolBuilder::new().thread_name(|i| format!("solar-{i}")).num_threads(threads);
+    // We still want to use a rayon thread pool with 1 thread so that `ParallelIterator`s don't
+    // install and run in the default global thread pool.
+    if threads == 1 {
+        builder = builder.use_current_thread();
+    }
+    builder
+        .build_scoped(
+            // Initialize each new worker thread when created.
+            move |thread| session_globals.set(|| thread.run()),
+            // Run `f` on the first thread in the thread pool.
+            move |pool| pool.install(f),
+        )
+        .unwrap()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn use_globals() {
+        SessionGlobals::with(|_globals| {});
+
+        let s = "hello";
+        let sym = crate::Symbol::intern(s);
+        assert_eq!(sym.as_str(), s);
+
+        let span = crate::Span::new(crate::BytePos(0), crate::BytePos(1));
+        let s = format!("{span:?}");
+        assert!(!s.contains("Span("), "{s}");
+        let s = format!("{span:#?}");
+        assert!(!s.contains("Span("), "{s}");
+    }
 
     #[test]
     #[should_panic = "diagnostics context not set"]
@@ -274,10 +327,29 @@ mod tests {
 
     #[test]
     fn local() {
+        let sess = Session::builder().with_stderr_emitter().build();
+        assert!(sess.emitted_diagnostics().is_none());
+        assert!(sess.emitted_errors().is_none());
+
         let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
         sess.dcx.err("test").emit();
-        let err = sess.dcx.emitted_diagnostics().unwrap().unwrap_err();
+        let err = sess.dcx.emitted_errors().unwrap().unwrap_err();
         let err = Box::new(err) as Box<dyn std::error::Error>;
         assert!(err.to_string().contains("error: test"), "{err:?}");
+    }
+
+    #[test]
+    fn enter() {
+        let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        sess.enter(use_globals);
+        assert!(sess.dcx.emitted_diagnostics().unwrap().is_empty());
+        assert!(sess.dcx.emitted_errors().unwrap().is_ok());
+        sess.enter(|| {
+            use_globals();
+            sess.enter(use_globals);
+            use_globals();
+        });
+        assert!(sess.dcx.emitted_diagnostics().unwrap().is_empty());
+        assert!(sess.dcx.emitted_errors().unwrap().is_ok());
     }
 }

--- a/crates/interface/src/span.rs
+++ b/crates/interface/src/span.rs
@@ -36,10 +36,12 @@ impl fmt::Debug for Span {
         }
 
         if SessionGlobals::is_set() {
-            SessionGlobals::with(|g| {
-                if let Some(source_map) = &*g.source_map.lock() {
+            SessionGlobals::with(|g: &SessionGlobals| {
+                let sm = g.source_map.lock();
+                if let Some(source_map) = &*sm {
                     f.write_str(&source_map.span_to_diagnostic_string(*self))
                 } else {
+                    drop(sm);
                     fallback(*self, f)
                 }
             })

--- a/examples/src/parser.rs
+++ b/examples/src/parser.rs
@@ -26,5 +26,6 @@ fn main() -> Result<(), EmittedDiagnostics> {
     });
 
     // Return the emitted diagnostics as a `Result<(), _>`.
-    sess.emitted_diagnostics().unwrap()
+    // If any errors were emitted, this returns `Err(_)`, otherwise `Ok(())`.
+    sess.emitted_errors().unwrap()
 }


### PR DESCRIPTION
Install the rayon pool together with session globals in Session::enter instead of in CLI only; this enables library users to use `sema` and any other `rayon` usage

cc @ferranbt https://t.me/paradigm_solar/100