### PR TITLE
refactor!: re-export ast::* internal module

### DIFF
--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -9,6 +9,8 @@
 pub use bumpalo;
 pub use solar_interface as interface;
 
-pub mod ast;
+mod ast;
+pub use ast::*;
+
 pub mod token;
 pub mod visit;

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Modified from Rust's [`rustc_lexer`](https://github.com/rust-lang/rust/blob/45749b21b7fd836f6c4f11dd40376f7c83e2791b/compiler/rustc_lexer/src/lib.rs).
 
-use solar_ast::ast::Base;
+use solar_ast::Base;
 use std::str::Chars;
 
 pub mod token;

--- a/crates/parse/src/lexer/cursor/token.rs
+++ b/crates/parse/src/lexer/cursor/token.rs
@@ -1,6 +1,6 @@
 //! Raw, low-level tokens. Created using [`Cursor`](crate::Cursor).
 
-use solar_ast::ast::Base;
+use solar_ast::Base;
 
 /// A raw token.
 ///

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -1,8 +1,8 @@
 //! Solidity and Yul lexer.
 
 use solar_ast::{
-    ast::Base,
     token::{BinOpToken, CommentKind, Delimiter, Token, TokenKind, TokenLitKind},
+    Base,
 };
 use solar_interface::{
     diagnostics::DiagCtxt, source_map::SourceFile, sym, BytePos, Pos, Session, Span, Symbol,

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -18,7 +18,7 @@ pub use parser::Parser;
 
 // Convenience re-exports.
 pub use bumpalo;
-pub use solar_ast::{ast, token};
+pub use solar_ast::{self as ast, token};
 pub use solar_interface as interface;
 
 /// Parser error type.

--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -1,5 +1,5 @@
 use crate::{PResult, Parser};
-use solar_ast::{ast::*, token::*};
+use solar_ast::{token::*, *};
 use solar_interface::kw;
 
 impl<'sess, 'ast> Parser<'sess, 'ast> {

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -1,7 +1,7 @@
 use super::{ExpectedToken, SeqSep};
 use crate::{PResult, Parser};
 use itertools::Itertools;
-use solar_ast::{ast::*, token::*};
+use solar_ast::{token::*, *};
 use solar_interface::{error_code, kw, sym, Ident, Span};
 use std::num::IntErrorKind;
 

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -3,7 +3,7 @@ use alloy_primitives::Address;
 use num_bigint::BigInt;
 use num_rational::BigRational;
 use num_traits::Num;
-use solar_ast::{ast::*, token::*};
+use solar_ast::{token::*, *};
 use solar_interface::{diagnostics::ErrorGuaranteed, kw, Symbol};
 use std::{borrow::Cow, fmt};
 

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -1,8 +1,9 @@
 use crate::{Lexer, PErr, PResult};
 use smallvec::SmallVec;
 use solar_ast::{
-    ast::{self, AstPath, Box, DocComment, DocComments, PathSlice},
+    self as ast,
     token::{Delimiter, Token, TokenKind},
+    AstPath, Box, DocComment, DocComments, PathSlice,
 };
 use solar_data_structures::BumpExt;
 use solar_interface::{

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -1,7 +1,7 @@
 use super::item::VarFlags;
 use crate::{parser::SeqSep, PResult, Parser};
 use smallvec::SmallVec;
-use solar_ast::{ast::*, token::*};
+use solar_ast::{token::*, *};
 use solar_data_structures::BumpExt;
 use solar_interface::{kw, sym, Ident, Span};
 

--- a/crates/parse/src/parser/ty.rs
+++ b/crates/parse/src/parser/ty.rs
@@ -1,6 +1,6 @@
 use super::item::FunctionFlags;
 use crate::{PResult, Parser};
-use solar_ast::{ast::*, token::*};
+use solar_ast::{token::*, *};
 use solar_interface::kw;
 use std::{fmt, ops::RangeInclusive};
 

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -1,10 +1,7 @@
 use super::SeqSep;
 use crate::{PResult, Parser};
 use smallvec::SmallVec;
-use solar_ast::{
-    ast::{yul::*, AstPath, Box, DocComments, LitKind, PathSlice, StrKind, StrLit},
-    token::*,
-};
+use solar_ast::{token::*, yul::*, AstPath, Box, DocComments, LitKind, PathSlice, StrKind, StrLit};
 use solar_interface::{error_code, kw, sym, Ident};
 
 impl<'sess, 'ast> Parser<'sess, 'ast> {

--- a/crates/sema/src/ast_lowering/lower.rs
+++ b/crates/sema/src/ast_lowering/lower.rs
@@ -2,7 +2,7 @@ use crate::{
     hir::{self, ContractId, SourceId},
     ParsedSource,
 };
-use solar_ast::ast;
+use solar_ast as ast;
 use solar_data_structures::{index::IndexVec, smallvec::SmallVec};
 
 impl<'ast> super::LoweringContext<'_, 'ast, '_> {

--- a/crates/sema/src/ast_lowering/mod.rs
+++ b/crates/sema/src/ast_lowering/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     hir::{self, Hir},
     ParsedSources,
 };
-use solar_ast::ast;
+use solar_ast as ast;
 use solar_data_structures::{
     index::{Idx, IndexVec},
     map::FxHashMap,

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1,5 +1,5 @@
 use crate::{builtins::Builtin, hir, ParsedSources};
-use solar_ast::ast;
+use solar_ast as ast;
 use solar_data_structures::{
     index::{Idx, IndexVec},
     map::{FxIndexMap, IndexEntry},

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -3,7 +3,7 @@ use crate::{
     hir,
     ty::{Gcx, Ty, TyFnPtr, TyKind},
 };
-use solar_ast::ast::{DataLocation, ElementaryType, StateMutability as SM};
+use solar_ast::{DataLocation, ElementaryType, StateMutability as SM};
 use solar_data_structures::BumpExt;
 use solar_interface::{kw, sym, Symbol};
 

--- a/crates/sema/src/builtins/mod.rs
+++ b/crates/sema/src/builtins/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     hir,
     ty::{Gcx, Ty},
 };
-use solar_ast::ast::StateMutability as SM;
+use solar_ast::StateMutability as SM;
 use solar_interface::{kw, sym, Span, Symbol};
 
 pub(crate) mod members;

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -1,6 +1,6 @@
 use crate::{hir, ty::Gcx};
 use alloy_primitives::U256;
-use solar_ast::ast::LitKind;
+use solar_ast::LitKind;
 use solar_interface::{diagnostics::ErrorGuaranteed, Span};
 use std::fmt;
 

--- a/crates/sema/src/hir.rs
+++ b/crates/sema/src/hir.rs
@@ -3,7 +3,7 @@
 use crate::builtins::Builtin;
 use derive_more::derive::From;
 use rayon::prelude::*;
-use solar_ast::ast;
+use solar_ast as ast;
 use solar_data_structures::{
     index::{Idx, IndexVec},
     newtype_index, BumpExt,

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -18,7 +18,7 @@ use ty::Gcx;
 // Convenience re-exports.
 pub use ::thread_local;
 pub use bumpalo;
-pub use solar_ast::ast;
+pub use solar_ast as ast;
 pub use solar_interface as interface;
 
 mod ast_lowering;

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -1,6 +1,6 @@
 use crate::hir::SourceId;
 use rayon::prelude::*;
-use solar_ast::ast;
+use solar_ast as ast;
 use solar_data_structures::{
     index::{Idx, IndexVec},
     map::FxHashSet,

--- a/crates/sema/src/stats.rs
+++ b/crates/sema/src/stats.rs
@@ -1,13 +1,9 @@
-use std::ops::ControlFlow;
-
-use solar_ast::{
-    ast::{self, yul, ItemId},
-    visit::Visit,
-};
+use solar_ast::{self as ast, visit::Visit, yul, ItemId};
 use solar_data_structures::{
     map::{FxHashMap, FxHashSet},
     Never,
 };
+use std::ops::ControlFlow;
 
 struct NodeStats {
     count: usize,

--- a/crates/sema/src/ty/abi.rs
+++ b/crates/sema/src/ty/abi.rs
@@ -1,7 +1,7 @@
 use super::{Gcx, Ty, TyKind};
 use crate::hir;
 use alloy_json_abi as json;
-use solar_ast::ast::ElementaryType;
+use solar_ast::ElementaryType;
 use std::{fmt, ops::ControlFlow};
 
 impl<'gcx> Gcx<'gcx> {

--- a/crates/sema/src/ty/common.rs
+++ b/crates/sema/src/ty/common.rs
@@ -1,5 +1,5 @@
 use super::{Interner, Ty, TyFlags, TyKind};
-use solar_ast::ast::{DataLocation, ElementaryType, TypeSize};
+use solar_ast::{DataLocation, ElementaryType, TypeSize};
 
 /// Pre-interned types.
 pub struct CommonTypes<'gcx> {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_primitives::{keccak256, Selector, B256};
 use either::Either;
-use solar_ast::ast::{DataLocation, StateMutability, TypeSize, Visibility};
+use solar_ast::{DataLocation, StateMutability, TypeSize, Visibility};
 use solar_data_structures::{
     fmt_from_fn,
     map::{FxBuildHasher, FxHashMap, FxHashSet},

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1,7 +1,7 @@
 use super::{Gcx, Recursiveness};
 use crate::{builtins::Builtin, hir};
 use alloy_primitives::U256;
-use solar_ast::ast::{DataLocation, ElementaryType, StateMutability, TypeSize, Visibility};
+use solar_ast::{DataLocation, ElementaryType, StateMutability, TypeSize, Visibility};
 use solar_data_structures::Interned;
 use solar_interface::diagnostics::ErrorGuaranteed;
 use std::{borrow::Borrow, fmt, hash::Hash, ops::ControlFlow};

--- a/examples/src/parser.rs
+++ b/examples/src/parser.rs
@@ -1,5 +1,5 @@
 use solar::{
-    ast::ast,
+    ast,
     interface::{diagnostics::EmittedDiagnostics, Session},
     parse::Parser,
 };


### PR DESCRIPTION
Before: `use solar_ast::{ast::Item, visit::Visitor};`, `use solar_parse::ast::Item;` (visitor not available)

After: `use solar_ast::{Item, visit::Visitor};`, `use solar_parse::ast::{Item, visit::Visitor};` (identical + other modules are available)