### PR TITLE
refactor: split Ty printers

### DIFF
--- a/crates/ast/src/ast/ty.rs
+++ b/crates/ast/src/ast/ty.rs
@@ -131,6 +131,16 @@ impl fmt::Debug for ElementaryType {
     }
 }
 
+impl fmt::Display for ElementaryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.write_abi_str(f)?;
+        if let Self::Address(true) = self {
+            f.write_str(" payable")?;
+        }
+        Ok(())
+    }
+}
+
 impl ElementaryType {
     /// Returns the Solidity ABI representation of the type as a string.
     pub fn to_abi_str(self) -> Cow<'static, str> {
@@ -148,14 +158,14 @@ impl ElementaryType {
     }
 
     /// Writes the Solidity ABI representation of the type to a formatter.
-    pub fn write_abi_str(self, f: &mut impl fmt::Write) -> fmt::Result {
+    pub fn write_abi_str<W: fmt::Write + ?Sized>(self, f: &mut W) -> fmt::Result {
         f.write_str(match self {
             Self::Address(_) => "address",
             Self::Bool => "bool",
             Self::String => "string",
             Self::Bytes => "bytes",
-            Self::Fixed(_size, _fixed) => "fixed",
-            Self::UFixed(_size, _fixed) => "ufixed",
+            Self::Fixed(m, n) => return write!(f, "fixed{}x{}", m.bits(), n.get()),
+            Self::UFixed(m, n) => return write!(f, "ufixed{}x{}", m.bits(), n.get()),
             Self::Int(size) => return write!(f, "int{}", size.bits()),
             Self::UInt(size) => return write!(f, "uint{}", size.bits()),
             Self::FixedBytes(size) => return write!(f, "bytes{}", size.bytes()),

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -95,7 +95,7 @@ impl<'sess> ParsingContext<'sess> {
     /// Sources are not guaranteed to be in any particular order, as they may be parsed in parallel.
     #[instrument(level = "debug", skip_all)]
     pub fn parse<'ast>(mut self, arenas: &'ast ThreadLocal<ast::Arena>) -> ParsedSources<'ast> {
-        // SAFETY: The `'static` lifetime on `self.sources` is a lie since none of the values are
+        // SAFETY: The `'static` lifetime on `self.sources` is a lie since none of the asts are
         // populated, so this is safe.
         let sources: ParsedSources<'static> = std::mem::take(&mut self.sources);
         let mut sources: ParsedSources<'ast> =

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -217,10 +217,7 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::Meta(ty) => ty.visit(f),
 
             TyKind::Error(list, _) | TyKind::Event(list, _) | TyKind::Tuple(list) => {
-                for ty in list {
-                    ty.visit(f)?;
-                }
-                ControlFlow::Continue(())
+                list.iter().copied().try_for_each(f)
             }
 
             TyKind::Mapping(k, v) => {


### PR DESCRIPTION
Currently they are in the same struct but re-use none of eachother's implementations.