### PR TITLE
fix: exclude arrays from mapping getter returns

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -491,7 +491,7 @@ impl super::LoweringContext<'_, '_, '_> {
             let s = self.hir.strukt(s_id);
             for &field_id in s.fields.iter() {
                 let field = self.hir.variable(field_id);
-                if !matches!(field.ty.kind, hir::TypeKind::Mapping(_)) {
+                if !matches!(field.ty.kind, hir::TypeKind::Mapping(_) | hir::TypeKind::Array(_)) {
                     push_return(self, field.ty.clone(), field.name);
                 }
             }

--- a/tests/ui/abi/mapping_getters.sol
+++ b/tests/ui/abi/mapping_getters.sol
@@ -1,0 +1,16 @@
+//@ignore-host: windows
+//@compile-flags: --emit=abi,hashes --pretty-json
+
+contract C {
+    struct Data {
+        uint a;
+        bytes3 b;
+        uint[3] c;
+        uint[] d;
+        bytes e;
+    }
+    mapping(uint => mapping(bool => Data[])) public data1;
+    mapping(uint => mapping(bool => Data)) public data2;
+    
+    mapping(bool => mapping(address => uint256[])[])[][] public nestedMapArray;
+}

--- a/tests/ui/abi/mapping_getters.stdout
+++ b/tests/ui/abi/mapping_getters.stdout
@@ -34,16 +34,6 @@
               "internalType": "bytes3"
             },
             {
-              "name": "c",
-              "type": "uint256[3]",
-              "internalType": "uint256[3]"
-            },
-            {
-              "name": "d",
-              "type": "uint256[]",
-              "internalType": "uint256[]"
-            },
-            {
               "name": "e",
               "type": "bytes",
               "internalType": "bytes"
@@ -76,16 +66,6 @@
               "name": "b",
               "type": "bytes3",
               "internalType": "bytes3"
-            },
-            {
-              "name": "c",
-              "type": "uint256[3]",
-              "internalType": "uint256[3]"
-            },
-            {
-              "name": "d",
-              "type": "uint256[]",
-              "internalType": "uint256[]"
             },
             {
               "name": "e",

--- a/tests/ui/abi/mapping_getters.stdout
+++ b/tests/ui/abi/mapping_getters.stdout
@@ -1,0 +1,151 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/abi/mapping_getters.sol:C": {
+      "abi": [
+        {
+          "type": "function",
+          "name": "data1",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "a",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "b",
+              "type": "bytes3",
+              "internalType": "bytes3"
+            },
+            {
+              "name": "c",
+              "type": "uint256[3]",
+              "internalType": "uint256[3]"
+            },
+            {
+              "name": "d",
+              "type": "uint256[]",
+              "internalType": "uint256[]"
+            },
+            {
+              "name": "e",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "data2",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "a",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "b",
+              "type": "bytes3",
+              "internalType": "bytes3"
+            },
+            {
+              "name": "c",
+              "type": "uint256[3]",
+              "internalType": "uint256[3]"
+            },
+            {
+              "name": "d",
+              "type": "uint256[]",
+              "internalType": "uint256[]"
+            },
+            {
+              "name": "e",
+              "type": "bytes",
+              "internalType": "bytes"
+            }
+          ],
+          "stateMutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "nestedMapArray",
+          "inputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool"
+            },
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            },
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address"
+            },
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        }
+      ],
+      "hashes": {
+        "data1(uint256,bool,uint256)": "0a42c96e",
+        "data2(uint256,bool)": "23a808ad",
+        "nestedMapArray(uint256,uint256,bool,uint256,address,uint256)": "5d46ce82"
+      }
+    }
+  },
+  "version": "VERSION"
+}


### PR DESCRIPTION
Ref https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L2887-L2891