### PR TITLE
feat: syntax checker for functions with modifiers

### DIFF
--- a/crates/ast/src/ast/item.rs
+++ b/crates/ast/src/ast/item.rs
@@ -390,6 +390,13 @@ pub struct ItemFunction<'ast> {
     pub body: Option<Block<'ast>>,
 }
 
+impl ItemFunction<'_> {
+    /// Returns `true` if the function is implemented
+    pub fn is_implemented(&self) -> bool {
+        self.body.is_some()
+    }
+}
+
 /// A function header: `function helloWorld() external pure returns(string memory)`.
 #[derive(Debug, Default)]
 pub struct FunctionHeader<'ast> {

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -211,6 +211,17 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
                     }
                 }
             }
+            if contract.kind.is_interface() && !func.header.modifiers.is_empty() {
+                self.dcx()
+                    .err("functions in interfaces cannot have modifiers")
+                    .span(self.span)
+                    .emit();
+            } else if !func.is_implemented() && !func.header.modifiers.is_empty() {
+                self.dcx()
+                    .err("functions without implementation cannot have modifiers")
+                    .span(self.span)
+                    .emit();
+            }
         }
 
         if func.header.visibility.is_none() {

--- a/tests/ui/resolve/func_modifiers.sol
+++ b/tests/ui/resolve/func_modifiers.sol
@@ -1,0 +1,15 @@
+abstract contract A {
+    modifier x() {
+        _;
+    }
+
+    function updateState() external virtual x; //~ERROR: functions without implementation cannot have modifiers
+}
+
+interface B {
+    modifier x() {
+        _;
+    }
+
+    function j() external x; //~ERROR: functions in interfaces cannot have modifiers
+}

--- a/tests/ui/resolve/func_modifiers.stderr
+++ b/tests/ui/resolve/func_modifiers.stderr
@@ -1,0 +1,16 @@
+error: functions without implementation cannot have modifiers
+  --> ROOT/tests/ui/resolve/func_modifiers.sol:LL:CC
+   |
+LL |     function updateState() external virtual x;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: functions in interfaces cannot have modifiers
+  --> ROOT/tests/ui/resolve/func_modifiers.sol:LL:CC
+   |
+LL |     function j() external x;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Implemented the following lines from syntax checker 

https://github.com/ethereum/solidity/blob/a62a455039120da834fd5faac2e0db8fc222c10d/libsolidity/analysis/SyntaxChecker.cpp#L474C1-L479C1