### PR TITLE
fix: correctly resolve try/catch scopes

### DIFF
--- a/crates/ast/src/ast/stmt.rs
+++ b/crates/ast/src/ast/stmt.rs
@@ -95,19 +95,20 @@ pub struct StmtAssembly<'ast> {
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.tryStatement>
 #[derive(Debug)]
 pub struct StmtTry<'ast> {
+    /// The call expression.
     pub expr: Box<'ast, Expr<'ast>>,
-    pub returns: ParameterList<'ast>,
-    /// The try block.
-    pub block: Block<'ast>,
-    /// The list of catch clauses. Cannot be parsed empty.
-    pub catch: Box<'ast, [CatchClause<'ast>]>,
+    /// The list of clauses. Never empty.
+    pub clauses: Box<'ast, [TryCatchClause<'ast>]>,
 }
 
-/// A catch clause: `catch (...) { ... }`.
+/// Clause of a try/catch block: `returns/catch (...) { ... }`.
+///
+/// Includes both the successful case and the unsuccessful cases.
+/// Names are only allowed for unsuccessful cases.
 ///
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.catchClause>
 #[derive(Debug)]
-pub struct CatchClause<'ast> {
+pub struct TryCatchClause<'ast> {
     pub name: Option<Ident>,
     pub args: ParameterList<'ast>,
     pub block: Block<'ast>,

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -345,18 +345,16 @@ declare_visitors! {
         }
 
         fn visit_stmt_try(&mut self, try_: &'ast #mut StmtTry<'ast>) -> ControlFlow<Self::BreakValue> {
-            let StmtTry { expr, returns, block, catch } = try_;
+            let StmtTry { expr, clauses } = try_;
             self.visit_expr #_mut(expr)?;
-            self.visit_parameter_list #_mut(returns)?;
-            self.visit_block #_mut(block)?;
-            for catch in catch.iter #_mut() {
-                self.visit_catch_clause #_mut(catch)?;
+            for catch in clauses.iter #_mut() {
+                self.visit_try_catch_clause #_mut(catch)?;
             }
             ControlFlow::Continue(())
         }
 
-        fn visit_catch_clause(&mut self, catch: &'ast #mut CatchClause<'ast>) -> ControlFlow<Self::BreakValue> {
-            let CatchClause { name, args, block } = catch;
+        fn visit_try_catch_clause(&mut self, catch: &'ast #mut TryCatchClause<'ast>) -> ControlFlow<Self::BreakValue> {
+            let TryCatchClause { name, args, block } = catch;
             if let Some(name) = name {
                 self.visit_ident #_mut(name)?;
             }

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -991,19 +991,22 @@ pub enum StmtKind<'hir> {
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.tryStatement>
 #[derive(Debug)]
 pub struct StmtTry<'hir> {
+    /// The call expression.
     pub expr: Expr<'hir>,
-    pub returns: &'hir [VariableId],
-    /// The try block.
-    pub block: Block<'hir>,
-    /// The list of catch clauses. Never empty.
-    pub catch: &'hir [CatchClause<'hir>],
+    /// The list of clauses. Never empty.
+    ///
+    /// The first item is always the `returns` clause.
+    pub clauses: &'hir [TryCatchClause<'hir>],
 }
 
-/// A catch clause: `catch (...) { ... }`.
+/// Clause of a try/catch block: `returns/catch (...) { ... }`.
+///
+/// Includes both the successful case and the unsuccessful cases.
+/// Names are only allowed for unsuccessful cases.
 ///
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.catchClause>
 #[derive(Debug)]
-pub struct CatchClause<'hir> {
+pub struct TryCatchClause<'hir> {
     pub name: Option<Ident>,
     pub args: &'hir [VariableId],
     pub block: Block<'hir>,

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -161,17 +161,11 @@ pub trait Visit<'hir> {
             }
             StmtKind::Try(try_) => {
                 self.visit_expr(&try_.expr);
-                for &var in try_.returns {
-                    self.visit_nested_var(var)?;
-                }
-                for stmt in try_.block {
-                    self.visit_stmt(stmt)?;
-                }
-                for catch in try_.catch {
-                    for &var in catch.args {
+                for clause in try_.clauses {
+                    for &var in clause.args {
                         self.visit_nested_var(var)?;
                     }
-                    for stmt in catch.block {
+                    for stmt in clause.block {
                         self.visit_stmt(stmt)?;
                     }
                 }

--- a/crates/sema/src/stats.rs
+++ b/crates/sema/src/stats.rs
@@ -381,11 +381,11 @@ impl<'ast> Visit<'ast> for StatCollector {
         self.walk_stmt_try(try_)
     }
 
-    fn visit_catch_clause(
+    fn visit_try_catch_clause(
         &mut self,
-        catch: &'ast ast::CatchClause<'ast>,
+        catch: &'ast ast::TryCatchClause<'ast>,
     ) -> ControlFlow<Self::BreakValue> {
-        self.record("CatchClause", None, catch);
+        self.record("TryCatchClause", None, catch);
         self.visit_parameter_list(&catch.args)?;
         self.visit_block(&catch.block)?;
         // Don't visit name field since it isn't boxed

--- a/tests/ui/resolve/try_scopes.sol
+++ b/tests/ui/resolve/try_scopes.sol
@@ -1,0 +1,13 @@
+// https://github.com/paradigmxyz/solar/issues/196
+contract C {
+    function g(bool x) public returns (uint a, uint b) {}
+
+    function f(bool b) public {
+        try this.g(b) returns (uint a, uint b) {
+            a = 1;
+            b = 2;
+        } catch Error(string memory s) {
+            revert(s);
+        }
+    }
+}


### PR DESCRIPTION
Also tweaks the representation by grouping both the successful and unsuccessful clauses in the same array.

Fixes #196.