### PR TITLE
fix: variable getter functions are external

### DIFF
--- a/crates/sema/src/ast_lowering/lower.rs
+++ b/crates/sema/src/ast_lowering/lower.rs
@@ -319,7 +319,7 @@ fn generate_partial_getter(hir: &mut hir::Hir<'_>, id: hir::VariableId) -> hir::
         span,
         name,
         kind: ast::FunctionKind::Function,
-        visibility: ast::Visibility::Public,
+        visibility: ast::Visibility::External,
         state_mutability: ast::StateMutability::View,
         modifiers: &[],
         marked_virtual: false,


### PR DESCRIPTION
https://github.com/ethereum/solidity/blob/a1506a38a8d683992477c76b00715eb70dbf94b2/libsolidity/ast/Types.cpp#L2866