### PR TITLE
feat(sema): implement function pointer member resolution

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -136,8 +136,13 @@ pub(crate) fn contract(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_>
 }
 
 fn function<'gcx>(gcx: Gcx<'gcx>, f: &'gcx TyFnPtr<'gcx>) -> MemberListOwned<'gcx> {
-    let _ = (gcx, f);
-    todo!()
+    // Function pointers in Solidity have the following members:
+    // - selector: returns the function selector as bytes4
+    // - address: returns the contract address where the function is located
+    vec![
+        Member::of_builtin(gcx, Builtin::FunctionSelector),
+        Member::of_builtin(gcx, Builtin::FunctionAddress),
+    ]
 }
 
 fn reference<'gcx>(


### PR DESCRIPTION
- Add implementation for function pointer member resolution
- Add support for .selector and .address members
- Remove todo!() macro in members.rs
- Improve type system completeness for function pointers

This change completes the implementation of function pointer type  members in the Solidity type system, allowing proper resolution  of .selector (returns bytes4) and .address (returns address) members  when working with function pointers.

Part of the type system improvements.