### PR TITLE
chore: fix incorrect Solidity/Yul keyword check

### DIFF
--- a/scripts/is_kw.sh
+++ b/scripts/is_kw.sh
@@ -223,10 +223,10 @@ for kw in "${kws[@]}"; do
 
     [ "$n" -eq 1 ] && printf "%s\n" "$r"
 
-    if [[ $code -gt 0 ]]; then
-        result="yes"
-    else
+    if [[ $code -eq 0 ]]; then
         result="no"
+    else
+        result="yes"
     fi
     printf "%-${align}s %s\n" "$kw:" "$result"
 done


### PR DESCRIPTION
The script incorrectly determines whether a word is a Solidity or Yul keyword. If `solc` throws an error, that means the word **is** a keyword (since it can't be used as an identifier). However, the current logic does the opposite:  

#### **Before (incorrect logic)**  
```bash
if [[ $code -gt 0 ]]; then
    result="yes"
else
    result="no"
fi
```
#### **After (fixed logic)**  
```bash
if [[ $code -eq 0 ]]; then
    result="no"
else
    result="yes"
fi
```
This fix ensures that the script properly identifies reserved keywords.