### PR TITLE
fix: unsound transmute

### DIFF
--- a/crates/sema/src/builtins/mod.rs
+++ b/crates/sema/src/builtins/mod.rs
@@ -29,6 +29,7 @@ fn declarations(builtins: impl IntoIterator<Item = Builtin>) -> Declarations {
 macro_rules! declare_builtins {
     (|$gcx:ident| $($(#[$variant_attr:meta])* $variant_name:ident => $sym:ident::$name:ident => $ty:expr;)*) => {
         /// A compiler builtin.
+        #[repr(u8)]
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
         pub enum Builtin {
             $(

--- a/crates/sema/src/builtins/mod.rs
+++ b/crates/sema/src/builtins/mod.rs
@@ -271,6 +271,16 @@ impl Builtin {
             assert!(std::mem::size_of::<Self>() == 1);
         };
         if i < Self::COUNT {
+            // SAFETY:
+            //
+            // `Self` is a field-less, `repr(u8)` enum and therefore guaranteed
+            // to have the same size and alignment as `u8`.
+            //
+            // This branch ensures `i < Self::COUNT` where `Self::COUNT` is the
+            // number of variants in `Self`. The discriminants of `Self` are
+            // contiguous because no variant specifies a custom discriminant
+            // with `Variant = value`. This ensures that `i as u8` is a valid
+            // inhabitant of type `Self`.
             Some(unsafe { std::mem::transmute::<u8, Self>(i as u8) })
         } else {
             None


### PR DESCRIPTION
The following use of `std::mem::transmute` in `Builtin::from_index` was previously unsound, as there are few layout [guarantees](https://doc.rust-lang.org/reference/type-layout.html#r-layout.repr.rust.layout) made for `repr(Rust)` types. This `transmute` relies on the assumption that an enum has the same alignment as the smallest integer type that can hold all its variants, but `repr(Rust)` enums make no such guarantee.

https://github.com/paradigmxyz/solar/blob/27f20c504cacf59c19c902dc925ff85e49bb1c37/crates/sema/src/builtins/mod.rs#L266-L277

This is fixed by tagging the `Builtin` enum `repr(u8)`, which provides the [guarantees](https://doc.rust-lang.org/reference/type-layout.html#primitive-representation-of-field-less-enums) needed here. I have also added a safety comment explaining the remaining assumptions (e.g. the enum is field-less).