### PR TITLE
fix(parser)!: glob imports require an alias

### DIFF
--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -69,9 +69,7 @@ declare_visitors! {
                     }
                 }
                 ImportItems::Glob(alias) => {
-                    if let Some(alias) = alias {
-                        self.visit_ident #_mut(alias)?;
-                    }
+                    self.visit_ident #_mut(alias)?;
                 }
             }
             ControlFlow::Continue(())

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -555,7 +555,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             // { x as y, ... } from ""
             let list = self.parse_delim_comma_seq(Delimiter::Brace, false, |this| {
                 let name = this.parse_ident()?;
-                let alias = this.parse_as_alias()?;
+                let alias = this.parse_as_alias_opt()?;
                 Ok((name, alias))
             })?;
             self.expect_keyword(sym::from)?;
@@ -564,7 +564,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         } else {
             // "" as alias
             path = self.parse_str_lit()?;
-            let alias = self.parse_as_alias()?;
+            let alias = self.parse_as_alias_opt()?;
             ImportItems::Plain(alias)
         };
         if path.value.as_str().is_empty() {
@@ -575,13 +575,19 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         Ok(ImportDirective { path, items })
     }
 
-    /// Parses an `as` alias identifier.
-    fn parse_as_alias(&mut self) -> PResult<'sess, Option<Ident>> {
+    /// Parses an optional `as` alias identifier.
+    fn parse_as_alias_opt(&mut self) -> PResult<'sess, Option<Ident>> {
         if self.eat_keyword(kw::As) {
             self.parse_ident().map(Some)
         } else {
             Ok(None)
         }
+    }
+
+    /// Parses an `as` alias identifier.
+    fn parse_as_alias(&mut self) -> PResult<'sess, Ident> {
+        self.expect_keyword(kw::As)?;
+        self.parse_ident()
     }
 
     /// Parses a using directive.

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -52,8 +52,8 @@ impl super::LoweringContext<'_, '_, '_> {
                     (&mut self.resolver.source_scopes[source_id], None)
                 };
                 match import.items {
-                    ast::ImportItems::Plain(alias) | ast::ImportItems::Glob(alias) => {
-                        if let Some(alias) = alias {
+                    ast::ImportItems::Plain(_) | ast::ImportItems::Glob(_) => {
+                        if let Some(alias) = import.items.source_alias() {
                             let _ = source_scope.declare_res(
                                 self.sess,
                                 &self.hir,

--- a/tests/ui/resolve/import_glob_conflicts.sol
+++ b/tests/ui/resolve/import_glob_conflicts.sol
@@ -1,2 +1,2 @@
 import "./auxiliary/udvt.sol";
-import * from "./auxiliary/udvt2.sol"; //~ ERROR: already declared
+import "./auxiliary/udvt2.sol"; //~ ERROR: already declared

--- a/tests/ui/resolve/import_glob_conflicts.stderr
+++ b/tests/ui/resolve/import_glob_conflicts.stderr
@@ -3,8 +3,8 @@ error: identifier `MyUdvt` already declared
    |
 LL | import "./auxiliary/udvt.sol";
    | ------------------------------ note: previous declaration imported here
-LL | import * from "./auxiliary/udvt2.sol";
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | import "./auxiliary/udvt2.sol";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: ROOT/tests/ui/resolve/auxiliary/udvt.sol:LL:CC
    |


### PR DESCRIPTION
`import * from "x";` is not accepted as an alternative to `import "x";`.

https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.importDirective