### PR TITLE
fix(parser): don't panic when parsing hex rationals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/interface/src/source_map/mod.rs
+++ b/crates/interface/src/source_map/mod.rs
@@ -282,6 +282,7 @@ impl SourceMap {
     ///
     /// This index is guaranteed to be valid for the lifetime of this `SourceMap`.
     pub fn lookup_source_file_idx(&self, pos: BytePos) -> usize {
+        assert!(!self.files().is_empty(), "attempted to lookup source file in empty `SourceMap`");
         self.files().partition_point(|x| x.start_pos <= pos) - 1
     }
 

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -5,7 +5,7 @@ use solar_ast::{
     Base,
 };
 use solar_interface::{
-    diagnostics::DiagCtxt, source_map::SourceFile, sym, BytePos, Session, Span, Symbol,
+    diagnostics::DiagCtxt, source_map::SourceFile, BytePos, Session, Span, Symbol,
 };
 
 mod cursor;
@@ -309,8 +309,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                     (TokenLitKind::Err(guar), self.symbol_from_to(start, end))
                 } else {
                     let kind = if unicode { TokenLitKind::UnicodeStr } else { TokenLitKind::Str };
-                    let prefix_len = if unicode { 7 } else { 0 }; // `unicode`
-                    self.cook_quoted(kind, start, end, prefix_len)
+                    self.cook_quoted(kind, start, end)
                 }
             }
             RawLiteralKind::HexStr { terminated } => {
@@ -319,15 +318,14 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                     let guar = self.dcx().err("unterminated hex string").span(span).emit();
                     (TokenLitKind::Err(guar), self.symbol_from_to(start, end))
                 } else {
-                    let prefix_len = 3; // `hex`
-                    self.cook_quoted(TokenLitKind::HexStr, start, end, prefix_len)
+                    self.cook_quoted(TokenLitKind::HexStr, start, end)
                 }
             }
             RawLiteralKind::Int { base, empty_int } => {
                 if empty_int {
                     let span = self.new_span(start, end);
                     self.dcx().err("no valid digits found for number").span(span).emit();
-                    (TokenLitKind::Integer, sym::integer(0))
+                    (TokenLitKind::Integer, self.symbol_from_to(start, end))
                 } else {
                     if matches!(base, Base::Binary | Base::Octal) {
                         let start = start + 2;
@@ -374,12 +372,11 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
         kind: TokenLitKind,
         start: BytePos,
         end: BytePos,
-        prefix_len: u32,
     ) -> (TokenLitKind, Symbol) {
-        let mode = match kind {
-            TokenLitKind::Str => unescape::Mode::Str,
-            TokenLitKind::UnicodeStr => unescape::Mode::UnicodeStr,
-            TokenLitKind::HexStr => unescape::Mode::HexStr,
+        let (mode, prefix_len) = match kind {
+            TokenLitKind::Str => (unescape::Mode::Str, 0),
+            TokenLitKind::UnicodeStr => (unescape::Mode::UnicodeStr, 7),
+            TokenLitKind::HexStr => (unescape::Mode::HexStr, 3),
             _ => unreachable!(),
         };
 
@@ -489,19 +486,25 @@ mod tests {
 
     type Expected<'a> = &'a [(Range<usize>, TokenKind)];
 
-    fn check(src: &str, expected: Expected<'_>) {
-        let sess = Session::builder().with_test_emitter().build();
+    fn check(src: &str, should_fail: bool, expected: Expected<'_>) {
+        let sess = Session::builder().with_silent_emitter(None).build();
         let tokens: Vec<_> = Lexer::new(&sess, src)
             .filter(|t| !t.is_comment())
             .map(|t| (t.span.lo().to_usize()..t.span.hi().to_usize(), t.kind))
             .collect();
-        sess.dcx.has_errors().unwrap();
+        assert_eq!(sess.dcx.has_errors().is_err(), should_fail, "{src:?}");
         assert_eq!(tokens, expected, "{src:?}");
     }
 
     fn checks(tests: &[(&str, Expected<'_>)]) {
         for &(src, expected) in tests {
-            check(src, expected);
+            check(src, false, expected);
+        }
+    }
+
+    fn checks_full(tests: &[(&str, bool, Expected<'_>)]) {
+        for &(src, should_fail, expected) in tests {
+            check(src, should_fail, expected);
         }
     }
 
@@ -547,7 +550,6 @@ mod tests {
                 //
                 ("0", &[(0..1, lit(Integer, "0"))]),
                 ("0a", &[(0..1, lit(Integer, "0")), (1..2, id("a"))]),
-                ("0xa", &[(0..3, lit(Integer, "0xa"))]),
                 ("0.e1", &[(0..1, lit(Integer, "0")), (1..2, Dot), (2..4, id("e1"))]),
                 (
                     "0.e-1",
@@ -566,6 +568,15 @@ mod tests {
                 ("0.0e-1", &[(0..6, lit(Rational, "0.0e-1"))]),
                 ("0e1", &[(0..3, lit(Rational, "0e1"))]),
                 ("0e1.", &[(0..3, lit(Rational, "0e1")), (3..4, Dot)]),
+            ]);
+
+            checks_full(&[
+                ("0b0", true, &[(0..3, lit(Integer, "0b0"))]),
+                ("0B0", false, &[(0..1, lit(Integer, "0")), (1..3, id("B0"))]),
+                ("0o0", true, &[(0..3, lit(Integer, "0o0"))]),
+                ("0O0", false, &[(0..1, lit(Integer, "0")), (1..3, id("O0"))]),
+                ("0xa", false, &[(0..3, lit(Integer, "0xa"))]),
+                ("0Xa", false, &[(0..1, lit(Integer, "0")), (1..3, id("Xa"))]),
             ]);
         });
     }

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -119,8 +119,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             Err(e @ ParseInteger(_)) => panic!("failed to parse integer literal {symbol:?}: {e}"),
             // Should never happen.
             Err(
-                e @ (EmptyRational | EmptyExponent | ParseRational(_) | ParseExponent(_)
-                | RationalTooLarge | ExponentTooLarge),
+                e @ (InvalidRational | EmptyRational | EmptyExponent | ParseRational(_)
+                | ParseExponent(_) | RationalTooLarge | ExponentTooLarge),
             ) => panic!("this error shouldn't happen for normal integer literals: {e}"),
         }
     }
@@ -135,7 +135,9 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 e @ (EmptyRational | RationalTooLarge | ExponentTooLarge | IntegerLeadingZeros),
             ) => Err(self.dcx().err(e.to_string())),
             // User error, but already emitted.
-            Err(EmptyExponent) => Ok(LitKind::Err(ErrorGuaranteed::new_unchecked())),
+            Err(InvalidRational | EmptyExponent) => {
+                Ok(LitKind::Err(ErrorGuaranteed::new_unchecked()))
+            }
             // Lexer internal error.
             Err(e @ (ParseExponent(_) | ParseInteger(_) | ParseRational(_) | EmptyInteger)) => {
                 panic!("failed to parse rational literal {symbol:?}: {e}")
@@ -175,6 +177,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
 #[derive(Debug, PartialEq, Eq)]
 enum LitError {
+    InvalidRational,
+
     EmptyInteger,
     EmptyRational,
     EmptyExponent,
@@ -191,6 +195,7 @@ enum LitError {
 impl fmt::Display for LitError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidRational => write!(f, "invalid rational literal"),
             Self::EmptyInteger => write!(f, "empty integer"),
             Self::EmptyRational => write!(f, "empty rational"),
             Self::EmptyExponent => write!(f, "empty exponent"),
@@ -251,6 +256,11 @@ fn parse_rational(symbol: Symbol) -> Result<LitKind, LitError> {
     let s = &strip_underscores(&symbol)[..];
     debug_assert!(!s.is_empty());
 
+    if matches!(s.get(..2), Some("0b" | "0o" | "0x")) {
+        return Err(LitError::InvalidRational);
+    }
+
+    // Split the string into integer, rational, and exponent parts.
     let (mut int, rat, exp) = match (s.find('.'), s.find(['e', 'E'])) {
         // X
         (None, None) => (s, None, None),
@@ -266,7 +276,9 @@ fn parse_rational(symbol: Symbol) -> Result<LitKind, LitError> {
         }
         // X.YeZ
         (Some(dot), Some(exp)) => {
-            debug_assert!(exp > dot);
+            if exp < dot {
+                return Err(LitError::InvalidRational);
+            }
             let (int, rest) = split_at_exclusive(s, dot);
             let (rat, exp) = split_at_exclusive(rest, exp - dot - 1);
             (int, Some(rat), Some(exp))
@@ -339,10 +351,7 @@ fn parse_rational(symbol: Symbol) -> Result<LitKind, LitError> {
 
 #[track_caller]
 fn split_at_exclusive(s: &str, idx: usize) -> (&str, &str) {
-    if !s.is_char_boundary(idx) || !s.is_char_boundary(idx + 1) {
-        panic!();
-    }
-    unsafe { (s.get_unchecked(..idx), s.get_unchecked(idx + 1..)) }
+    (&s[..idx], &s[idx + 1..])
 }
 
 #[inline]
@@ -368,11 +377,11 @@ mod tests {
 
     // Run through the lexer to get the same input that the parser gets.
     #[track_caller]
-    fn lex_literal(src: &str) -> Symbol {
-        let sess = Session::builder().with_test_emitter().build();
+    fn lex_literal(src: &str, should_fail: bool) -> Symbol {
+        let sess = Session::builder().with_silent_emitter(None).build();
         let tokens = Lexer::new(&sess, src).into_tokens();
-        sess.dcx.has_errors().unwrap();
-        assert_eq!(tokens.len(), 1, "expected exactly 1 token {tokens:?}");
+        assert_eq!(tokens.len(), 1, "expected exactly 1 token: {tokens:?}");
+        assert_eq!(sess.dcx.has_errors().is_err(), should_fail, "{src:?} -> {tokens:?}");
         tokens[0].lit().expect("not a literal").symbol
     }
 
@@ -382,7 +391,7 @@ mod tests {
 
         #[track_caller]
         fn check_int(src: &str, expected: Result<&str, LitError>) {
-            let symbol = lex_literal(src);
+            let symbol = lex_literal(src, false);
             let res = match parse_integer(symbol) {
                 Ok(LitKind::Number(n)) => Ok(n),
                 Ok(x) => panic!("not a number: {x:?} ({src:?})"),
@@ -397,7 +406,7 @@ mod tests {
 
         #[track_caller]
         fn check_address(src: &str, expected: Result<Address, &str>) {
-            let symbol = lex_literal(src);
+            let symbol = lex_literal(src, false);
             match expected {
                 Ok(address) => match parse_integer(symbol) {
                     Ok(LitKind::Address(a)) => assert_eq!(a, address, "{src:?}"),
@@ -483,8 +492,8 @@ mod tests {
         use LitError::*;
 
         #[track_caller]
-        fn check_int(src: &str, expected: Result<&str, LitError>) {
-            let symbol = lex_literal(src);
+        fn check_int_full(src: &str, should_fail_lexing: bool, expected: Result<&str, LitError>) {
+            let symbol = lex_literal(src, should_fail_lexing);
             let res = match parse_rational(symbol) {
                 Ok(LitKind::Number(r)) => Ok(r),
                 Ok(x) => panic!("not a number: {x:?} ({src:?})"),
@@ -498,8 +507,13 @@ mod tests {
         }
 
         #[track_caller]
+        fn check_int(src: &str, expected: Result<&str, LitError>) {
+            check_int_full(src, false, expected);
+        }
+
+        #[track_caller]
         fn check_rat(src: &str, expected: Result<&str, LitError>) {
-            let symbol = lex_literal(src);
+            let symbol = lex_literal(src, false);
             let res = match parse_rational(symbol) {
                 Ok(LitKind::Rational(r)) => Ok(r),
                 Ok(x) => panic!("not a number: {x:?} ({src:?})"),
@@ -567,6 +581,33 @@ mod tests {
             check_int("1.00e-0", Ok("1"));
             check_int("1.0e-00", Ok("1"));
             check_int("1.00e-00", Ok("1"));
+
+            check_int_full("0b", true, Err(InvalidRational));
+            check_int_full("0b0", true, Err(InvalidRational));
+            check_int_full("0b01", true, Err(InvalidRational));
+            check_int_full("0b01.0", true, Err(InvalidRational));
+            check_int_full("0b01.0e1", true, Err(InvalidRational));
+            check_int_full("0b0e", true, Err(InvalidRational));
+            // check_int_full("0b0e.0", true, Err(InvalidRational));
+            // check_int_full("0b0e.0e1", true, Err(InvalidRational));
+
+            check_int_full("0o", true, Err(InvalidRational));
+            check_int_full("0o0", true, Err(InvalidRational));
+            check_int_full("0o01", true, Err(InvalidRational));
+            check_int_full("0o01.0", true, Err(InvalidRational));
+            check_int_full("0o01.0e1", true, Err(InvalidRational));
+            check_int_full("0o0e", true, Err(InvalidRational));
+            // check_int_full("0o0e.0", true, Err(InvalidRational));
+            // check_int_full("0o0e.0e1", true, Err(InvalidRational));
+
+            check_int_full("0x", true, Err(InvalidRational));
+            check_int_full("0x0", false, Err(InvalidRational));
+            check_int_full("0x01", false, Err(InvalidRational));
+            check_int_full("0x01.0", true, Err(InvalidRational));
+            check_int_full("0x01.0e1", true, Err(InvalidRational));
+            check_int_full("0x0e", false, Err(InvalidRational));
+            check_int_full("0x0e.0", true, Err(InvalidRational));
+            check_int_full("0x0e.0e1", true, Err(InvalidRational));
 
             check_int("1e1", Ok("10"));
             check_int("1.0e1", Ok("10"));


### PR DESCRIPTION
Currently we reject hex rational literals in the lexer, but they are passed on to the parser which then panics.

Fixes https://github.com/foundry-rs/foundry/issues/10287.