### PR TITLE
fix(parser)!: remove RawTokenKind::UnknownPrefix

### DIFF
--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -218,12 +218,7 @@ impl<'a> Cursor<'a> {
 
         // Start is already eaten, eat the rest of identifier.
         self.eat_while(is_id_continue);
-        // Known prefixes must have been handled earlier.
-        // So if we see a prefix here, it is definitely an unknown prefix.
-        match self.first() {
-            '"' | '\'' => RawTokenKind::UnknownPrefix,
-            _ => RawTokenKind::Ident,
-        }
+        RawTokenKind::Ident
     }
 
     fn number(&mut self, first_digit: char) -> RawLiteralKind {

--- a/crates/parse/src/lexer/cursor/tests.rs
+++ b/crates/parse/src/lexer/cursor/tests.rs
@@ -106,10 +106,10 @@ fn hex_str() {
             RawToken { kind: Whitespace, len: 1 }
             RawToken { kind: Literal { kind: HexStr { terminated: true } }, len: 7 }
             RawToken { kind: Whitespace, len: 1 }
-            RawToken { kind: UnknownPrefix, len: 1 }
+            RawToken { kind: Ident, len: 1 }
             RawToken { kind: Literal { kind: Str { terminated: true, unicode: false } }, len: 3 }
             RawToken { kind: Whitespace, len: 1 }
-            RawToken { kind: UnknownPrefix, len: 2 }
+            RawToken { kind: Ident, len: 2 }
             RawToken { kind: Literal { kind: Str { terminated: false, unicode: false } }, len: 2 }
         "#]],
     );
@@ -124,10 +124,10 @@ fn unicode_str() {
             RawToken { kind: Whitespace, len: 1 }
             RawToken { kind: Literal { kind: Str { terminated: true, unicode: true } }, len: 11 }
             RawToken { kind: Whitespace, len: 1 }
-            RawToken { kind: UnknownPrefix, len: 1 }
+            RawToken { kind: Ident, len: 1 }
             RawToken { kind: Literal { kind: Str { terminated: true, unicode: false } }, len: 3 }
             RawToken { kind: Whitespace, len: 1 }
-            RawToken { kind: UnknownPrefix, len: 3 }
+            RawToken { kind: Ident, len: 3 }
             RawToken { kind: Literal { kind: Str { terminated: false, unicode: false } }, len: 2 }
         "#]],
     );

--- a/crates/parse/src/lexer/cursor/token.rs
+++ b/crates/parse/src/lexer/cursor/token.rs
@@ -47,12 +47,6 @@ pub enum RawTokenKind {
     /// At this step, keywords are also considered identifiers.
     Ident,
 
-    /// An unknown prefix, like `foo'`, `foo"`.
-    ///
-    /// Note that only the prefix (`foo`) is included in the token, not the separator (which is
-    /// lexed as its own distinct token).
-    UnknownPrefix,
-
     /// Examples: `123`, `0x123`, `hex"123"`. Note that `_` is an invalid
     /// suffix, but may be present here on string and float literals. Users of
     /// this type will need to check for and reject that case.

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -169,11 +169,6 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                     let sym = self.symbol_from(start);
                     TokenKind::Ident(sym)
                 }
-                RawTokenKind::UnknownPrefix => {
-                    self.report_unknown_prefix(start);
-                    let sym = self.symbol_from(start);
-                    TokenKind::Ident(sym)
-                }
                 RawTokenKind::Literal { kind } => {
                     let (kind, symbol) = self.cook_literal(start, self.pos, kind);
                     TokenKind::Literal(kind, symbol)
@@ -441,12 +436,6 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
     /// Slice of the source text spanning from `start` until the end.
     fn str_from_to_end(&self, start: BytePos) -> &'src str {
         &self.src[self.src_index(start)..]
-    }
-
-    fn report_unknown_prefix(&self, start: BytePos) {
-        let prefix = self.str_from_to(start, self.pos);
-        let msg = format!("literal prefix {prefix} is unknown");
-        self.dcx().err(msg).span(self.new_span(start, self.pos)).emit();
     }
 }
 

--- a/tests/ui/parser/no_unknown_prefix.sol
+++ b/tests/ui/parser/no_unknown_prefix.sol
@@ -1,0 +1,7 @@
+//@compile-flags: --stop-after parsing
+
+// This used to fail with an "unknown string prefix" error.
+
+import"does_not_exist";
+import {a}from"does_not_exist";
+import {b} from"does_not_exist";


### PR DESCRIPTION
Identifiers are allowed to be attached to string literals.

~~Based on https://github.com/paradigmxyz/solar/pull/259.~~