### PR TITLE
feat(sema): add validation for assembly memory-safe flags

### DIFF
--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -215,6 +215,33 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
                         .emit();
                 }
             }
+            ast::StmtKind::Assembly(assembly) => {
+                let mut memory_safe_found = false;
+
+                // Check for multiple memory-safe flags
+                for flag in assembly.flags.iter() {
+                    if flag.value.to_string() == "memory-safe" {
+                        if memory_safe_found {
+                            self.dcx()
+                                .err("Inline assembly marked memory-safe multiple times.")
+                                .span(stmt.span)
+                                .emit();
+                            break;
+                        }
+                        memory_safe_found = true;
+
+                        // TODO: Add annotation to Assembly block to indicate that it is memory-safe
+                    }
+                    // TODO: Add warning for unknown flags
+                    // else {
+                    //     // Warning for unknown flags
+                    //     self.dcx()
+                    //         .warn(format!("Unknown inline assembly flag: \"{}\"", flag.value))
+                    //         .span(flag.span)
+                    //         .emit();
+                    // }
+                }
+            }
             _ => {}
         }
 

--- a/tests/ui/typeck/assembly_flags.sol
+++ b/tests/ui/typeck/assembly_flags.sol
@@ -1,0 +1,16 @@
+contract C {
+    function a() public {
+        assembly ("memory-safe", "memory-safe") { //~ ERROR: Inline assembly marked memory-safe multiple times
+            let y := 7
+        }
+        
+        // TODO: Add warning for unknown flags
+        // assembly ("unknown-flag") {
+        //     let y := 8
+        // }
+        
+        assembly ("memory-safe") {
+            let y := 9
+        }
+    }
+}

--- a/tests/ui/typeck/assembly_flags.stderr
+++ b/tests/ui/typeck/assembly_flags.stderr
@@ -1,0 +1,11 @@
+error: Inline assembly marked memory-safe multiple times.
+  --> ROOT/tests/ui/typeck/assembly_flags.sol:LL:CC
+   |
+LL | /         assembly ("memory-safe", "memory-safe") {
+LL | |             let y := 7
+LL | |         }
+   | |_________^
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## Description
This PR adds validation for assembly flags, specifically checking for multiple "memory-safe" flags in inline assembly blocks. When multiple memory-safe flags are found, an error is reported to match the behavior in the Solidity compiler.

This is towards #29.

## Implementation Details
- Added flag validation in the AST validator's `visit_stmt` method for assembly statements
- Tracks when a memory-safe flag is found and reports an error if duplicate flags are detected
- Includes TODOs for future enhancements:
  - Adding warnings for unknown flags
  - Adding annotations to assembly blocks to indicate memory-safe status

## Testing
Added a test file at `tests/ui/typeck/assembly_flags.sol` to verify the error is reported correctly.

## Related Issues
Implements part of the Solidity syntax checking for inline assembly as described in the Solidity codebase's `SyntaxChecker::visit(InlineAssembly const& _inlineAssembly)` function.

## Future Work
Future PRs will:
- Implement warnings for unknown flags
- Add assembly annotations to maintain memory-safe status for later compiler phases