### PR TITLE
feat: pretty printing utilities

### DIFF
--- a/crates/ast/src/ast/item.rs
+++ b/crates/ast/src/ast/item.rs
@@ -344,6 +344,14 @@ impl UserDefinableOperator {
             Self::Ne => Either::Right(BinOpKind::Ne),
         }
     }
+
+    /// Returns the string representation of the operator.
+    pub const fn to_str(self) -> &'static str {
+        match self.to_op() {
+            Either::Left(unop) => unop.to_str(),
+            Either::Right(binop) => binop.to_str(),
+        }
+    }
 }
 
 /// A contract, abstract contract, interface, or library definition:

--- a/crates/ast/src/ast/mod.rs
+++ b/crates/ast/src/ast/mod.rs
@@ -4,6 +4,7 @@ use solar_data_structures::{index::IndexSlice, newtype_index, BumpExt};
 use std::fmt;
 
 pub use crate::token::CommentKind;
+pub use either::{self, Either};
 pub use solar_interface::{Ident, Span, Symbol};
 
 mod expr;

--- a/crates/interface/src/span.rs
+++ b/crates/interface/src/span.rs
@@ -204,12 +204,16 @@ impl Span {
     }
 
     /// Joins all the spans in the given iterator using [`to`](Self::to).
+    ///
+    /// Returns [`DUMMY`](Self::DUMMY) if the iterator is empty.
     #[inline]
     pub fn join_many(spans: impl IntoIterator<Item = Self>) -> Self {
         spans.into_iter().reduce(Self::to).unwrap_or_default()
     }
 
     /// Joins the first and last span in the given iterator.
+    ///
+    /// Returns [`DUMMY`](Self::DUMMY) if the iterator is empty.
     #[inline]
     pub fn join_first_last(
         spans: impl IntoIterator<Item = Self, IntoIter: DoubleEndedIterator>,


### PR DESCRIPTION
- re-export `either` in ast as it's used in the public API
- UserDefinableOperator::to_str
- impl fmt::Display for Lit
- improve fmt::Debug for LitKind::Str
- treat literal parse errors as non fatal using the LitKind::Err variant