### PR TITLE
feat(ast)!: store concatenated string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,7 +2625,6 @@ version = "0.1.2"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
- "derive_more 2.0.1",
  "either",
  "num-bigint",
  "num-rational",

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -26,7 +26,6 @@ solar-macros.workspace = true
 
 alloy-primitives.workspace = true
 bumpalo = { workspace = true, features = ["std", "boxed"] }
-derive_more.workspace = true
 either.workspace = true
 semver.workspace = true
 num-bigint.workspace = true

--- a/crates/ast/src/ast/expr.rs
+++ b/crates/ast/src/ast/expr.rs
@@ -61,6 +61,9 @@ pub enum ExprKind<'ast> {
     Index(Box<'ast, Expr<'ast>>, IndexKind<'ast>),
 
     /// A literal: `hex"1234"`, `5.6 ether`.
+    ///
+    /// Note that the `SubDenomination` is only present for numeric literals, and it's already
+    /// applied to `Lit`'s value. It is only present for error reporting/formatting purposes.
     Lit(&'ast mut Lit, Option<SubDenomination>),
 
     /// Access of a named member: `obj.k`.

--- a/crates/ast/src/ast/lit.rs
+++ b/crates/ast/src/ast/lit.rs
@@ -4,15 +4,23 @@ use std::{fmt, sync::Arc};
 
 /// A literal: `hex"1234"`, `5.6 ether`.
 ///
+/// Note that multiple string literals of the same kind are concatenated together to form a single
+/// `Lit` (see [`LitKind::Str`]), thus the `span` will be the span of the entire literal, and
+/// the `symbol` will be the concatenated string.
+///
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.literal>
 #[derive(Clone, Debug)]
 pub struct Lit {
-    /// The span of the literal.
+    /// The concatenated span of the literal.
     pub span: Span,
-    /// The original literal as written in the source code.
+    /// The original contents of the literal as written in the source code, excluding any quotes.
+    ///
+    /// If this is a concatenated string literal, this will contain only the **first string
+    /// literal's contents**. For all the other string literals, see the `extra` field in
+    /// [`LitKind::Str`].
     pub symbol: Symbol,
     /// The "semantic" representation of the literal lowered from the original tokens.
-    /// Strings are unescaped, hexadecimal forms are eliminated, etc.
+    /// Strings are unescaped and concatenated, hexadecimal forms are eliminated, etc.
     pub kind: LitKind,
 }
 
@@ -20,9 +28,9 @@ impl fmt::Display for Lit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { ref kind, symbol, span: _ } = *self;
         match kind {
-            LitKind::Str(StrKind::Str, _) => write!(f, "\"{symbol}\""),
-            LitKind::Str(StrKind::Unicode, _) => write!(f, "unicode\"{symbol}\""),
-            LitKind::Str(StrKind::Hex, _) => write!(f, "hex\"{symbol}\""),
+            LitKind::Str(StrKind::Str, ..) => write!(f, "\"{symbol}\""),
+            LitKind::Str(StrKind::Unicode, ..) => write!(f, "unicode\"{symbol}\""),
+            LitKind::Str(StrKind::Hex, ..) => write!(f, "hex\"{symbol}\""),
             LitKind::Number(_)
             | LitKind::Rational(_)
             | LitKind::Err(_)
@@ -32,16 +40,45 @@ impl fmt::Display for Lit {
     }
 }
 
+impl Lit {
+    /// Returns the span of the first string literal in this literal.
+    pub fn first_span(&self) -> Span {
+        if let LitKind::Str(kind, _, extra) = &self.kind {
+            if !extra.is_empty() {
+                let str_len = kind.prefix().len() + 1 + self.symbol.as_str().len() + 1;
+                return self.span.with_hi(self.span.lo() + str_len as u32);
+            }
+        }
+        self.span
+    }
+
+    /// Returns an iterator over all the literals that were concatenated to form this literal.
+    pub fn literals(&self) -> impl Iterator<Item = (Span, Symbol)> + '_ {
+        let extra = if let LitKind::Str(_, _, extra) = &self.kind { extra.as_slice() } else { &[] };
+        std::iter::once((self.first_span(), self.symbol)).chain(extra.iter().copied())
+    }
+}
+
 /// A kind of literal.
-#[derive(Clone, derive_more::Debug)]
+#[derive(Clone)]
 pub enum LitKind {
     /// A string, unicode string, or hex string literal. Contains the kind and the unescaped
     /// contents of the string.
     ///
     /// Note that even if this is a string or unicode string literal, invalid UTF-8 sequences
     /// are allowed, and as such this cannot be a `str` or `Symbol`.
-    #[debug("Str({:?}, {})", _0, debug_str_literal(_1))]
-    Str(StrKind, Arc<[u8]>),
+    ///
+    /// The `Vec<(Span, Symbol)>` contains the extra string literals of the same kind that were
+    /// concatenated together to form this literal. For example, `"foo" "bar"` would be parsed
+    /// as: ```ignore (illustrative-debug-format)
+    /// # #![rustfmt::skip]
+    /// Lit {
+    ///     span: 0..11,
+    ///     symbol: "foo",
+    ///     kind: Str(Str, "foobar", [(6..11, "bar")]),
+    /// }
+    /// ```
+    Str(StrKind, Arc<[u8]>, Vec<(Span, Symbol)>),
     /// A decimal or hexadecimal number literal.
     Number(num_bigint::BigInt),
     /// A rational number literal.
@@ -57,22 +94,35 @@ pub enum LitKind {
     Err(ErrorGuaranteed),
 }
 
-#[allow(dead_code)] // False positive somehow. Used in `LitKind::Str` above.
-fn debug_str_literal(value: &[u8]) -> impl fmt::Display + '_ {
-    solar_data_structures::fmt::from_fn(move |f| {
-        if let Ok(utf8) = std::str::from_utf8(value) {
-            fmt::Debug::fmt(utf8, f)
-        } else {
-            f.write_str(&alloy_primitives::hex::encode_prefixed(value))
+impl fmt::Debug for LitKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LitKind::Str(kind, value, extra) => {
+                write!(f, "{kind:?}(")?;
+                if let Ok(utf8) = std::str::from_utf8(value) {
+                    write!(f, "{utf8:?}")?;
+                } else {
+                    f.write_str(&alloy_primitives::hex::encode_prefixed(value))?;
+                }
+                if !extra.is_empty() {
+                    write!(f, ", {extra:?}")?;
+                }
+                f.write_str(")")
+            }
+            LitKind::Number(value) => write!(f, "Number({value:?})"),
+            LitKind::Rational(value) => write!(f, "Rational({value:?})"),
+            LitKind::Address(value) => write!(f, "Address({value:?})"),
+            LitKind::Bool(value) => write!(f, "Bool({value:?})"),
+            LitKind::Err(_) => write!(f, "Err"),
         }
-    })
+    }
 }
 
 impl LitKind {
     /// Returns the description of this literal kind.
     pub fn description(&self) -> &'static str {
         match self {
-            Self::Str(kind, _) => kind.description(),
+            Self::Str(kind, ..) => kind.description(),
             Self::Number(_) => "number",
             Self::Rational(_) => "rational",
             Self::Address(_) => "address",
@@ -109,6 +159,26 @@ impl StrKind {
             Self::Str => "string",
             Self::Unicode => "unicode string",
             Self::Hex => "hex string",
+        }
+    }
+
+    /// Returns the prefix as a string. Empty if `Str`.
+    #[doc(alias = "to_str")]
+    pub fn prefix(self) -> &'static str {
+        match self {
+            Self::Str => "",
+            Self::Unicode => "unicode",
+            Self::Hex => "hex",
+        }
+    }
+
+    /// Returns the prefix as a symbol. Empty if `Str`.
+    #[doc(alias = "to_symbol")]
+    pub fn prefix_symbol(self) -> Symbol {
+        match self {
+            Self::Str => kw::Empty,
+            Self::Unicode => kw::Unicode,
+            Self::Hex => kw::Hex,
         }
     }
 }
@@ -300,11 +370,30 @@ impl Base {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solar_interface::{enter, BytePos};
 
     #[test]
     fn literal_fmt() {
-        let lit = LitKind::Str(StrKind::Str, Arc::from(b"hello world" as &[u8]));
-        assert_eq!(lit.description(), "string");
-        assert_eq!(format!("{lit:?}"), "Str(Str, \"hello world\")");
+        enter(|| {
+            let lit = LitKind::Str(StrKind::Str, Arc::from(b"hello world" as &[u8]), vec![]);
+            assert_eq!(lit.description(), "string");
+            assert_eq!(format!("{lit:?}"), "Str(\"hello world\")");
+
+            let lit = LitKind::Str(StrKind::Str, Arc::from(b"hello\0world" as &[u8]), vec![]);
+            assert_eq!(lit.description(), "string");
+            assert_eq!(format!("{lit:?}"), "Str(\"hello\\0world\")");
+
+            let lit = LitKind::Str(StrKind::Str, Arc::from(&[255u8][..]), vec![]);
+            assert_eq!(lit.description(), "string");
+            assert_eq!(format!("{lit:?}"), "Str(0xff)");
+
+            let lit = LitKind::Str(
+                StrKind::Str,
+                Arc::from(b"hello world" as &[u8]),
+                vec![(Span::new(BytePos(69), BytePos(420)), Symbol::intern("world"))],
+            );
+            assert_eq!(lit.description(), "string");
+            assert_eq!(format!("{lit:?}"), "Str(\"hello world\", [(Span(69..420), \"world\")])");
+        })
     }
 }

--- a/crates/ast/src/ast/lit.rs
+++ b/crates/ast/src/ast/lit.rs
@@ -69,13 +69,14 @@ pub enum LitKind {
     /// are allowed, and as such this cannot be a `str` or `Symbol`.
     ///
     /// The `Vec<(Span, Symbol)>` contains the extra string literals of the same kind that were
-    /// concatenated together to form this literal. For example, `"foo" "bar"` would be parsed
-    /// as: ```ignore (illustrative-debug-format)
+    /// concatenated together to form this literal.
+    /// For example, `"foo" "bar"` would be parsed as:
+    /// ```ignore (illustrative-debug-format)
     /// # #![rustfmt::skip]
     /// Lit {
     ///     span: 0..11,
     ///     symbol: "foo",
-    ///     kind: Str(Str, "foobar", [(6..11, "bar")]),
+    ///     kind: Str("foobar", [(6..11, "bar")]),
     /// }
     /// ```
     Str(StrKind, Arc<[u8]>, Vec<(Span, Symbol)>),
@@ -97,7 +98,7 @@ pub enum LitKind {
 impl fmt::Debug for LitKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LitKind::Str(kind, value, extra) => {
+            Self::Str(kind, value, extra) => {
                 write!(f, "{kind:?}(")?;
                 if let Ok(utf8) = std::str::from_utf8(value) {
                     write!(f, "{utf8:?}")?;
@@ -109,11 +110,11 @@ impl fmt::Debug for LitKind {
                 }
                 f.write_str(")")
             }
-            LitKind::Number(value) => write!(f, "Number({value:?})"),
-            LitKind::Rational(value) => write!(f, "Rational({value:?})"),
-            LitKind::Address(value) => write!(f, "Address({value:?})"),
-            LitKind::Bool(value) => write!(f, "Bool({value:?})"),
-            LitKind::Err(_) => write!(f, "Err"),
+            Self::Number(value) => write!(f, "Number({value:?})"),
+            Self::Rational(value) => write!(f, "Rational({value:?})"),
+            Self::Address(value) => write!(f, "Address({value:?})"),
+            Self::Bool(value) => write!(f, "Bool({value:?})"),
+            Self::Err(_) => write!(f, "Err"),
         }
     }
 }

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -158,10 +158,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         };
 
         let mut value = unescape::parse_string_literal(lit.symbol.as_str(), mode);
+        let mut extra = vec![];
         while let Some(TokenLit { symbol, kind }) = self.token.lit() {
             if kind != lit.kind {
                 break;
             }
+            extra.push((self.token.span, lit.symbol));
             value
                 .to_mut()
                 .extend_from_slice(&unescape::parse_string_literal(symbol.as_str(), mode));
@@ -174,7 +176,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             TokenLitKind::HexStr => StrKind::Hex,
             _ => unreachable!(),
         };
-        Ok(LitKind::Str(kind, value.into()))
+        Ok(LitKind::Str(kind, value.into(), extra))
     }
 }
 

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -72,7 +72,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         self.expect_keyword(sym::data)?;
         let name = self.parse_str_lit()?;
         let data = self.parse_lit()?;
-        if !matches!(data.kind, LitKind::Str(StrKind::Str | StrKind::Hex, _)) {
+        if !matches!(data.kind, LitKind::Str(StrKind::Str | StrKind::Hex, ..)) {
             let msg = "only string and hex string literals are allowed in `data` segments";
             return Err(self.dcx().err(msg).span(data.span));
         }

--- a/crates/sema/src/ty/abi.rs
+++ b/crates/sema/src/ty/abi.rs
@@ -245,7 +245,7 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
 ///
 /// This is mainly used in the `internalType` field of the ABI.
 ///
-/// Example: https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L2352-L2358
+/// Example: <https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L2352-L2358>
 struct TySolcPrinter<'gcx, W> {
     gcx: Gcx<'gcx>,
     buf: W,


### PR DESCRIPTION
Currently multiple string literals of the same kind get concatenated in the parser, without leaving trace in the AST.

Add an extra field to `LitKind::Str` that stores any extra literals that were concatenated into the current literal.