### PR TITLE
chore: add update=none to submodules

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Checkout submodules
+        run: git submodule update --checkout
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -45,6 +47,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Checkout submodules
+        run: git submodule update --checkout
       - name: Install Valgrind
         run: sudo apt update && sudo apt install valgrind
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Checkout submodules
+        run: git submodule update --checkout
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -52,8 +54,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: dtolnay/rust-toolchain@nightly
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
@@ -67,8 +67,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: dtolnay/rust-toolchain@clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -85,8 +83,6 @@ jobs:
       pages: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,4 @@
 	url = https://github.com/ethereum/solidity.git
 	shallow = true
 	fetchRecurseSubmodules = false
+	update = none # Makes `cargo` not clone the submodule: https://github.com/rust-lang/cargo/issues/4247#issuecomment-1149178736

--- a/benches/README.md
+++ b/benches/README.md
@@ -2,7 +2,7 @@
 
 Simple benchmarks across different Solidity parser implementations.
 
-Requires cloning submodules: `git submodule update --init --recursive`.
+Requires cloning submodules: `git submodule update --init --checkout`.
 
 Run with:
 

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -28,14 +28,14 @@ pub fn get_srcs() -> &'static [Source] {
 }
 
 fn include_source(path: &'static str) -> Source {
-    source_from_path(
-        path,
-        std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
-            .unwrap_or_else(|e| {
-                panic!("failed to read {path}: {e}; you may need to initialize submodules")
-            })
-            .leak(),
-    )
+    let source = match std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(path)) {
+        Ok(source) => source,
+        Err(e) => panic!(
+            "failed to read {path}: {e};\n\
+             you may need to initialize submodules: `git submodule update --init --checkout`"
+        ),
+    };
+    source_from_path(path, source.leak())
 }
 
 fn source_from_path(path: &'static str, src: &'static str) -> Source {

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -75,7 +75,8 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
     let tests_root = root.join(path);
     assert!(
         tests_root.exists(),
-        "tests root directory does not exist: {path}; you may need to initialize submodules"
+        "tests root directory does not exist: {path};\n\
+         you may need to initialize submodules: `git submodule update --init --checkout`"
     );
 
     let mut config = ui_test::Config {


### PR DESCRIPTION
Cargo will recursively fetch submodules in `cargo install`, `[dependencies] git = ""`... unless `update=none` is specified.

See: https://github.com/rust-lang/cargo/issues/4247#issuecomment-1149178736