### PR TITLE
perf: add and default to using mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1668,15 @@ dependencies = [
  "nom",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2657,6 +2676,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "libc",
+ "mimalloc",
  "solar-config",
  "solar-interface",
  "solar-sema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,6 @@ scoped-tls = "1.0"
 semver = "1.0"
 smallvec = { version = "1", features = ["const_generics", "union"] }
 thread_local = "1.1"
-tikv-jemallocator = "0.6"
 typed-arena = "2.0"
 unicode-width = "0.2"
 vergen = "8"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,13 +33,15 @@ tracing-subscriber = { workspace = true, optional = true, features = [
 tracing-chrome = { version = "0.7", optional = true }
 tracing-tracy = { version = "0.11", optional = true, features = ["demangle"] }
 
+mimalloc = { version = "0.1", optional = true }
+
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
-tikv-jemallocator = { workspace = true, optional = true }
+tikv-jemallocator = { version = "0.6", optional = true }
 
 [features]
-default = ["jemalloc", "tracing"]
+default = ["mimalloc", "tracing"]
 # Nightly-only features for faster/smaller builds.
 nightly = [
     "solar-config/nightly",
@@ -48,12 +50,17 @@ nightly = [
 ]
 # Faster but less portable algorithm implementations, such as Keccak-256.
 asm = ["alloy-primitives/asm-keccak", "solar-config/asm"]
-# Faster but less portable allocator.
+# Faster but possibly less portable allocators.
 jemalloc = ["dep:tikv-jemallocator", "solar-config/jemalloc"]
+mimalloc = ["dep:mimalloc", "solar-config/mimalloc"]
 
 # Debugging and profiling.
 tracing = ["dep:tracing-subscriber", "solar-config/tracing"]
 tracing-off = ["tracing/release_max_level_off", "solar-config/tracing-off"]
-tracing-chrome = ["tracing", "dep:tracing-chrome", "solar-config/tracing-chrome"]
+tracing-chrome = [
+    "tracing",
+    "dep:tracing-chrome",
+    "solar-config/tracing-chrome",
+]
 tracy = ["tracing", "dep:tracing-tracy", "solar-config/tracy"]
 tracy-allocator = ["tracing", "tracy", "solar-config/tracy-allocator"]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -42,6 +42,7 @@ serde = ["dep:serde"]
 # solar-cli features, only used by build.rs to include in the version string.
 asm = []
 jemalloc = []
+mimalloc = []
 tracing = []
 tracing-off = []
 tracing-chrome = []

--- a/crates/solar/Cargo.toml
+++ b/crates/solar/Cargo.toml
@@ -63,6 +63,7 @@ nightly = [
 asm = ["solar-cli?/asm", "alloy-primitives/asm-keccak"]
 # Faster but less portable allocator.
 jemalloc = ["solar-cli?/jemalloc"]
+mimalloc = ["solar-cli?/mimalloc"]
 
 # Debugging and profiling.
 tracing = ["solar-cli?/tracing"]

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -20,7 +20,7 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-da
 # Build only the required packages, and individually
 precise-builds = true
 # Features to pass to cargo build
-features = ["cli", "asm", "jemalloc"]
+features = ["cli", "asm", "mimalloc"]
 # Whether dist should create a Github Release or use an existing draft
 create-release = true
 # Which actions to run on pull requests


### PR DESCRIPTION
mimalloc consistently is performing equal to or better than jemalloc, is smaller in binary size, is more portable and is faster to compile