### PR TITLE
perf(lexer): deal with bytes instead of chars in Cursor

### DIFF
--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -361,31 +361,22 @@ impl<'a> Cursor<'a> {
 
     /// Eats characters for a decimal number. Returns `true` if any digits were encountered.
     fn eat_decimal_digits(&mut self) -> bool {
-        let mut has_digits = false;
-        loop {
-            match self.first() {
-                b'_' => {
-                    self.bump();
-                }
-                b'0'..=b'9' => {
-                    has_digits = true;
-                    self.bump();
-                }
-                _ => break,
-            }
-        }
-        has_digits
+        self.eat_digits(|x| x.is_ascii_digit())
     }
 
     /// Eats characters for a hexadecimal number. Returns `true` if any digits were encountered.
     fn eat_hexadecimal_digits(&mut self) -> bool {
+        self.eat_digits(|x| x.is_ascii_hexdigit())
+    }
+
+    fn eat_digits(&mut self, mut is_digit: impl FnMut(u8) -> bool) -> bool {
         let mut has_digits = false;
         loop {
             match self.first() {
                 b'_' => {
                     self.bump();
                 }
-                b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F' => {
+                c if is_digit(c) => {
                     has_digits = true;
                     self.bump();
                 }

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -10,7 +10,7 @@ use solar_interface::{
 
 mod cursor;
 use cursor::token::{RawLiteralKind, RawToken, RawTokenKind};
-pub use cursor::{is_id_continue, is_id_start, is_ident, is_whitespace, token, Cursor};
+pub use cursor::*;
 
 pub mod unescape;
 


### PR DESCRIPTION
We still use `Chars` internally to handle UTF-8 correctly, but everywhere else we use `u8` instead of `char`.

Improves `Cursor` performance by 10-30%.