### PR TITLE
fix(parser): named call arguments are allowed to be empty

### DIFF
--- a/crates/ast/src/ast/expr.rs
+++ b/crates/ast/src/ast/expr.rs
@@ -4,6 +4,8 @@ use solar_interface::{Ident, Span};
 use std::fmt;
 
 /// A list of named arguments: `{a: "1", b: 2}`.
+///
+/// Present in [`CallArgsKind::Named`] and [`ExprKind::CallOptions`].
 pub type NamedArgList<'ast> = Box<'ast, [NamedArg<'ast>]>;
 
 /// An expression.

--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -156,7 +156,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 }
 
                 // expr{args}
-                let args = self.parse_named_args()?;
+                let args = self.parse_named_args(false)?;
                 ExprKind::CallOptions(expr, args)
             } else {
                 break;
@@ -226,7 +226,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     fn parse_call_args_kind(&mut self) -> PResult<'sess, CallArgsKind<'ast>> {
         if self.look_ahead(1).kind == TokenKind::OpenDelim(Delimiter::Brace) {
             self.expect(TokenKind::OpenDelim(Delimiter::Parenthesis))?;
-            let args = self.parse_named_args().map(CallArgsKind::Named)?;
+            let args = self.parse_named_args(true).map(CallArgsKind::Named)?;
             self.expect(TokenKind::CloseDelim(Delimiter::Parenthesis))?;
             Ok(args)
         } else {
@@ -261,8 +261,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
     /// Parses a list of named arguments: `{a: b, c: d, ...}`
     #[track_caller]
-    fn parse_named_args(&mut self) -> PResult<'sess, NamedArgList<'ast>> {
-        self.parse_delim_comma_seq(Delimiter::Brace, false, Self::parse_named_arg)
+    fn parse_named_args(&mut self, allow_empty: bool) -> PResult<'sess, NamedArgList<'ast>> {
+        self.parse_delim_comma_seq(Delimiter::Brace, allow_empty, Self::parse_named_arg)
     }
 
     /// Parses a single named argument: `a: b`.

--- a/tests/ui/parser/empty_call_args.sol
+++ b/tests/ui/parser/empty_call_args.sol
@@ -1,0 +1,9 @@
+function f() {
+    f;
+    f ();
+    f ({ });
+
+    revert;
+    revert ();
+    revert ({ });
+}

--- a/tests/ui/parser/empty_call_opts.sol
+++ b/tests/ui/parser/empty_call_opts.sol
@@ -1,0 +1,4 @@
+function f() {
+    f{gas:69}();
+    f{}(); //~ ERROR: expected one of
+}

--- a/tests/ui/parser/empty_call_opts.stderr
+++ b/tests/ui/parser/empty_call_opts.stderr
@@ -1,0 +1,9 @@
+error: expected one of `(`, `.`, `;`, `?`, or `[`, found `{`
+  --> ROOT/tests/ui/parser/empty_call_opts.sol:LL:CC
+   |
+LL |     f{}();
+   |      ^ expected one of `(`, `.`, `;`, `?`, or `[`
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Call argument list: https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.callArgumentList
Expression: https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.expression

`expression {}` is not allowed to be empty (call options), but `call({})` (call argument list) is.