### PR TITLE
feat: literal checks

### DIFF
--- a/tests/ui/resolve/address_checksums.sol
+++ b/tests/ui/resolve/address_checksums.sol
@@ -1,0 +1,7 @@
+contract C {
+    // Not OK
+    address public a = 0xb71cb1A7ab0B6Bc6c07f5A3Ef2EA36757968A121; //~ ERROR: invalid checksum
+
+    // OK
+    address public b = 0xB71cb1A7ab0B6Bc6c07f5A3Ef2EA36757968A121;
+}

--- a/tests/ui/resolve/address_checksums.stderr
+++ b/tests/ui/resolve/address_checksums.stderr
@@ -1,0 +1,11 @@
+error: invalid checksummed address
+  --> ROOT/tests/ui/resolve/address_checksums.sol:LL:CC
+   |
+LL |     address public a = 0xb71cb1A7ab0B6Bc6c07f5A3Ef2EA36757968A121;
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: correct checksummed address: "0xB71cb1A7ab0B6Bc6c07f5A3Ef2EA36757968A121"
+   = note: if this is not used as an address, please prepend "00"
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/resolve/denominations.sol
+++ b/tests/ui/resolve/denominations.sol
@@ -1,0 +1,12 @@
+contract C {
+    uint256 public a = 0x123 ether; //~ ERROR: cannot be used with unit denominations
+    uint256 public b = 0x123 days; //~ ERROR: cannot be used with unit denominations
+    uint256 public h = 1 years; //~ ERROR: unit denomination is deprecated
+
+    // OK
+    uint256 public i = 1 seconds;
+    uint256 public j = 1 minutes;
+    uint256 public k = 1 hours;
+    uint256 public l = 1 days;
+    uint256 public m = 1 weeks;
+}

--- a/tests/ui/resolve/denominations.stderr
+++ b/tests/ui/resolve/denominations.stderr
@@ -1,0 +1,25 @@
+error: hexadecimal numbers cannot be used with unit denominations
+  --> ROOT/tests/ui/resolve/denominations.sol:LL:CC
+   |
+LL |     uint256 public a = 0x123 ether;
+   |                        ^^^^^
+   |
+   = help: you can use an expression of the form "0x1234 * 1 days" instead
+
+error: hexadecimal numbers cannot be used with unit denominations
+  --> ROOT/tests/ui/resolve/denominations.sol:LL:CC
+   |
+LL |     uint256 public b = 0x123 days;
+   |                        ^^^^^
+   |
+   = help: you can use an expression of the form "0x1234 * 1 days" instead
+
+error: using "years" as a unit denomination is deprecated
+  --> ROOT/tests/ui/resolve/denominations.sol:LL:CC
+   |
+LL |     uint256 public h = 1 years;
+   |                        ^
+   |
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Implements literal checks from solc

These checks are not implemented because I don't really know if they are relevant:

- Seems like a weird check? Or at least something for typeck https://github.com/ethereum/solidity/blob/9c0098b221556e4df56c892d7280bfb5b7e10c0d/libsolidity/analysis/TypeChecker.cpp#L3740-L3745
- I assume we already have this handled https://github.com/ethereum/solidity/blob/9c0098b221556e4df56c892d7280bfb5b7e10c0d/libsolidity/analysis/TypeChecker.cpp#L3781-L3782

Closes #284 