### PR TITLE
feat: `--no-warnings`

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -132,6 +132,7 @@ fn run_compiler_with(opts: Opts, f: impl FnOnce(&Compiler) -> Result + Send) -> 
         flags.deduplicate_diagnostics &= !ui_testing;
         flags.track_diagnostics &= !ui_testing;
         flags.track_diagnostics |= opts.unstable.track_diagnostics;
+        flags.can_emit_warnings |= !opts.no_warnings;
     });
 
     let mut sess = Session::builder().dcx(dcx).source_map(source_map).opts(opts).build();

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -87,6 +87,9 @@ pub struct Opts {
         arg(help_heading = "Display options", long, value_enum, default_value_t)
     )]
     pub error_format: ErrorFormat,
+    /// Whether to disable warnings.
+    #[cfg_attr(feature = "clap", arg(help_heading = "Display options", long))]
+    pub no_warnings: bool,
 
     /// Unstable flags. WARNING: these are completely unstable, and may change at any time.
     ///


### PR DESCRIPTION
Adds a flag to disable emitting warning diagnostics.

In the future, we should consider following rustc's format with flags `-A` and `-D` to allow and deny
warnings, respectively. In `rustc`, `-Awarnings` is equivalent to `--no-warnings`.

Additionally, `-Dwarnings` would treat warnings
as errors.

Ref #170 since it is blocked because we currently don't support disabling warnings