### PR TITLE
feat: typecheck for external type clashes

### DIFF
--- a/tests/ui/typeck/external_type_clashes.sol
+++ b/tests/ui/typeck/external_type_clashes.sol
@@ -1,0 +1,65 @@
+contract A {
+    struct S0 {
+        address a;
+    }
+    struct S1 {
+        uint256 a;
+        S0 s;
+    }
+    struct S2 {
+        uint256 b;
+        S0 s;
+    }
+
+    S2 public b;
+
+    function f(S1 memory a) external {}
+
+    function f(S2 memory a) external {}
+    //~^ ERROR: function overload clash during conversion to external types for arguments
+}
+
+contract C {
+    enum a {
+        X
+    }
+
+    function f(a) public {}
+    //~^ ERROR: function overload clash during conversion to external types for arguments
+}
+
+contract D is C {
+    function f(uint8 a) public {}
+}
+
+contract E {
+    function f(address) external pure {}
+
+    function f(address payable) external pure {}
+    //~^ ERROR: function overload clash during conversion to external types for arguments
+
+    function c(address) public pure {}
+
+    function c(address payable) public pure {}
+    //~^ ERROR: function overload clash during conversion to external types for arguments
+}
+
+type MyAddress is address;
+
+interface I {}
+
+contract F {
+    function f(MyAddress a) external {}
+
+    function f(address a) external {}
+    //~^ ERROR: function overload clash during conversion to external types for arguments
+}
+
+contract G {
+    function g(MyAddress a) external {}
+    //~^ ERROR: function overload clash during conversion to external types for arguments
+}
+
+contract H is G {
+    function g(I a) external {}
+}

--- a/tests/ui/typeck/external_type_clashes.stderr
+++ b/tests/ui/typeck/external_type_clashes.stderr
@@ -1,0 +1,44 @@
+error[9914]: function overload clash during conversion to external types for arguments
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function f(S2 memory a) external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error[9914]: function overload clash during conversion to external types for arguments
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function f(a) public {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error[9914]: function overload clash during conversion to external types for arguments
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function f(address payable) external pure {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error[9914]: function overload clash during conversion to external types for arguments
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function c(address payable) public pure {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error[9914]: function overload clash during conversion to external types for arguments
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function f(address a) external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error[9914]: function overload clash during conversion to external types for arguments
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function g(MyAddress a) external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
implement `checkExternalTypeClashes` in an effort for #303 

[solc reference](https://github.com/ethereum/solidity/blob/d42f92bd68d76db01b0dc17477cd4c7716059d93/libsolidity/analysis/ContractLevelChecker.cpp#L430-L465), includes all relevant ui tests present in solc in one test file

notes:
- we don't use `gcx.hir.functions` method instead of `gcx.hir.contract_item_ids` since we want to include inherited methods
- unlike the solc implementation: 
  - we don't run the pre-processing on external variables since their external is already populated & covered in the functions branch
  - we omit libraries since they produce external methods & it's methods are implicitly omitted in the `if(functionType->interfaceFunctionType())` [branch](https://github.com/ethereum/solidity/blob/d42f92bd68d76db01b0dc17477cd4c7716059d93/libsolidity/analysis/ContractLevelChecker.cpp#L440)