### PR TITLE
docs: delete hyperlink to pull_request_template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,10 +281,8 @@ Refs: #453, #154
 ### Opening the Pull Request
 
 From within GitHub, opening a new Pull Request will present you with a
-[template] that should be filled out. Please try to do your best at filling out
+template that should be filled out. Please try to do your best at filling out
 the details, but feel free to skip parts if you're not sure what to put.
-
-[template]: .github/PULL_REQUEST_TEMPLATE.md
 
 ### Discuss and update
 


### PR DESCRIPTION
we don't have PULL_REQUEST_TEMPLATE.md so i think we need to delete this hyperlink like we have it [HERE](https://github.com/paradigmxyz/reth/blob/main/CONTRIBUTING.md?plain=1#L152)