### PR TITLE
perf(lexer): add eat_until

### DIFF
--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -189,6 +189,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
+    #[inline(never)]
     fn line_comment(&mut self) -> RawTokenKind {
         debug_assert!(self.prev() == b'/' && self.first() == b'/');
         self.bump();
@@ -483,7 +484,7 @@ impl<'a> Cursor<'a> {
     }
 
     /// Eats symbols until `ch` is found or until the end of file is reached.
-    #[inline(never)]
+    #[inline]
     fn eat_until(&mut self, ch: u8) {
         let b = self.as_str().as_bytes();
         self.ignore_bytes(memchr::memchr(ch, b).unwrap_or(b.len()));

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -482,7 +482,7 @@ impl<'a> Cursor<'a> {
     }
 
     /// Eats symbols until `ch` is found or until the end of file is reached.
-    #[inline(never)]
+    #[inline]
     fn eat_until(&mut self, ch: u8) {
         let b = self.as_str().as_bytes();
         self.ignore_bytes(memchr::memchr(ch, b).unwrap_or(b.len()));

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -478,7 +478,8 @@ impl<'a> Cursor<'a> {
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
     fn ignore_bytes(&mut self, n: usize) {
-        self.chars = self.chars.as_str()[n..].chars();
+        debug_assert!(n <= self.as_str().len());
+        self.chars = unsafe { self.as_str().get_unchecked(n..) }.chars();
     }
 
     /// Eats symbols until `ch` is found or until the end of file is reached.

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -483,14 +483,10 @@ impl<'a> Cursor<'a> {
     }
 
     /// Eats symbols until `ch` is found or until the end of file is reached.
-    #[inline]
+    #[inline(never)]
     fn eat_until(&mut self, ch: u8) {
-        #[inline(never)]
-        fn memchr_outline(ch: u8, b: &[u8]) -> usize {
-            memchr::memchr(ch, b).unwrap_or(b.len())
-        }
         let b = self.as_str().as_bytes();
-        self.ignore_bytes(memchr_outline(ch, b));
+        self.ignore_bytes(memchr::memchr(ch, b).unwrap_or(b.len()));
     }
 
     /// Eats symbols while predicate returns true or until the end of file is reached.

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -485,8 +485,12 @@ impl<'a> Cursor<'a> {
     /// Eats symbols until `ch` is found or until the end of file is reached.
     #[inline]
     fn eat_until(&mut self, ch: u8) {
+        #[inline(never)]
+        fn memchr_outline(ch: u8, b: &[u8]) -> usize {
+            memchr::memchr(ch, b).unwrap_or(b.len())
+        }
         let b = self.as_str().as_bytes();
-        self.ignore_bytes(memchr::memchr(ch, b).unwrap_or(b.len()));
+        self.ignore_bytes(memchr_outline(ch, b));
     }
 
     /// Eats symbols while predicate returns true or until the end of file is reached.

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -185,10 +185,6 @@ impl<'a> Cursor<'a> {
                 RawTokenKind::Literal { kind }
             }
 
-            // Identifier starting with an emoji. Only lexed for graceful error recovery.
-            // c if !c.is_ascii() && unic_emoji_char::is_emoji(c) => {
-            //     self.fake_ident_or_unknown_prefix()
-            // }
             _ => RawTokenKind::Unknown,
         }
     }
@@ -200,7 +196,7 @@ impl<'a> Cursor<'a> {
         // `////` (more than 3 slashes) is not considered a doc comment.
         let is_doc = matches!(self.first(), b'/' if self.second() != b'/');
 
-        self.eat_while(|c| c != b'\n');
+        self.eat_until(b'\n');
         RawTokenKind::LineComment { is_doc }
     }
 
@@ -483,6 +479,13 @@ impl<'a> Cursor<'a> {
     #[cfg_attr(debug_assertions, track_caller)]
     fn ignore_bytes(&mut self, n: usize) {
         self.chars = self.chars.as_str()[n..].chars();
+    }
+
+    /// Eats symbols until `ch` is found or until the end of file is reached.
+    #[inline(never)]
+    fn eat_until(&mut self, ch: u8) {
+        let b = self.as_str().as_bytes();
+        self.ignore_bytes(memchr::memchr(ch, b).unwrap_or(b.len()));
     }
 
     /// Eats symbols while predicate returns true or until the end of file is reached.


### PR DESCRIPTION
Cursor performance:
- `inline(never)` on `eat_until`: -7% to +21%
- nothing: -15% to +15%
- `inline(never)` on `line_comment`: -1% to +26%

Not entirely sure why inlining even just the few instructions that call out to memchr can have such a huge impact on overall performance of `Cursor`, even when memchr isn't even called.