### PR TITLE
fix(sema): don't warn 3628 if no interface functions

### DIFF
--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -64,7 +64,10 @@ fn check_payable_fallback_without_receive(gcx: Gcx<'_>, contract_id: hir::Contra
 
     if let Some(fallback) = contract.fallback {
         let fallback = gcx.hir.function(fallback);
-        if fallback.state_mutability.is_payable() && contract.receive.is_none() {
+        if fallback.state_mutability.is_payable()
+            && contract.receive.is_none()
+            && !gcx.interface_functions(contract_id).is_empty()
+        {
             gcx.dcx()
                 .warn("contract has a payable fallback function, but no receive ether function")
                 .span(contract.name.span)

--- a/tests/ui/parser/payable_fallback_without_receive.sol
+++ b/tests/ui/parser/payable_fallback_without_receive.sol
@@ -1,6 +1,13 @@
 contract P1 {
     //~^ WARN: contract has a payable fallback function, but no receive ether function
     fallback() external payable {}
+
+    function f() external {}
+}
+
+// OK, no interface functions.
+contract P11 {
+    fallback() external payable {}
 }
 
 contract P2 is P1 {

--- a/tests/ui/parser/payable_fallback_without_receive.stderr
+++ b/tests/ui/parser/payable_fallback_without_receive.stderr
@@ -13,7 +13,7 @@ warning[3628]: contract has a payable fallback function, but no receive ether fu
    |
 LL |     fallback() external payable {}
    |     -------- help: consider changing `fallback` to `receive`
-LL | }
+LL |
 ...
 LL |
 LL | contract P4 is P1 {}


### PR DESCRIPTION
Conditions mismatch https://github.com/ethereum/solidity/blob/d6a396eed7c60322ec22039b77b8ed1bc79be35b/libsolidity/analysis/ContractLevelChecker.cpp#L583