### PR TITLE
Perf: Use hyrbid of bytes and chars in advance_token

### DIFF
--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -422,7 +422,12 @@ impl<'a> Cursor<'a> {
     #[doc(hidden)]
     #[inline]
     fn peek_byte(&self, index: usize) -> u8 {
-        self.as_str().as_bytes().get(index).copied().unwrap_or(EOF)
+        let bytes = self.as_str().as_bytes();
+        if index < bytes.len() {
+            unsafe { *bytes.get_unchecked(index) }
+        } else {
+            EOF
+        }
     }
 
     /// Checks if there is nothing more to consume.

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -421,7 +421,12 @@ impl<'a> Cursor<'a> {
     #[doc(hidden)]
     #[inline]
     fn peek_byte(&self, index: usize) -> u8 {
-        self.as_str().as_bytes().get(index).copied().unwrap_or(EOF)
+        let bytes = r.as_str().as_bytes();
+        if index < bytes.len() {
+            unsafe { *bytes.get_unchecked(index) }
+        } else {
+            EOF
+        }
     }
 
     /// Checks if there is nothing more to consume.

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -421,7 +421,7 @@ impl<'a> Cursor<'a> {
     #[doc(hidden)]
     #[inline]
     fn peek_byte(&self, index: usize) -> u8 {
-        let bytes = r.as_str().as_bytes();
+        let bytes = self.as_str().as_bytes();
         if index < bytes.len() {
             unsafe { *bytes.get_unchecked(index) }
         } else {

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -710,7 +710,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             if !sep.trailing_sep_allowed && trailing {
                 let msg = format!("trailing `{sep_kind}` separator is not allowed");
                 self.dcx().err(msg).span(self.prev_token.span).emit();
-            } 
+            }
         }
 
         Ok((self.alloc_smallvec(v), recovered))

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -710,7 +710,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             if !sep.trailing_sep_allowed && trailing {
                 let msg = format!("trailing `{sep_kind}` separator is not allowed");
                 self.dcx().err(msg).span(self.prev_token.span).emit();
-            }
+            } 
         }
 
         Ok((self.alloc_smallvec(v), recovered))


### PR DESCRIPTION
Fast Path for ASCII and normal CHAR path for non ASCII

elimiante bound checks in peek_byte(major perf effect tbh)

From LLVM-MCA, post peek_byte changes:

Iterations:        100
Instructions:      24400
Total Cycles:      18359
Total uOps:        29500

Dispatch Width:    4
uOps Per Cycle:    1.61
IPC:               1.33
Block RThroughput: 85.0
And pre peek_byte changes:

Iterations:        100
Instructions:      27500
Total Cycles:      20017
Total uOps:        32700

Dispatch Width:    4
uOps Per Cycle:    1.63
IPC:               1.37
Block RThroughput: 95.0
Did benchmark the changes and there was an increase(only on seaport) 