### PR TITLE
fix(parser): allow EVM builtins to be present in yul paths

### DIFF
--- a/tests/ui/parser/yul_kws_err.sol
+++ b/tests/ui/parser/yul_kws_err.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f() external {
+        assembly {
+            number := 0
+            //~^ ERROR: expected identifier, found Yul EVM builtin keyword `number`
+            number, number := some_call()
+            //~^ ERROR: expected identifier, found Yul EVM builtin keyword `number`
+            //~| ERROR: expected identifier, found Yul EVM builtin keyword `number`
+            let number := 0
+            //~^ ERROR: expected identifier, found Yul EVM builtin keyword `number`
+        }
+    }
+}

--- a/tests/ui/parser/yul_kws_err.stderr
+++ b/tests/ui/parser/yul_kws_err.stderr
@@ -1,0 +1,30 @@
+error: expected identifier, found Yul EVM builtin keyword `number`
+  --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
+   |
+LL |             number := 0
+   |             ^^^^^^
+   |
+
+error: expected identifier, found Yul EVM builtin keyword `number`
+  --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
+   |
+LL |             number, number := some_call()
+   |             ^^^^^^
+   |
+
+error: expected identifier, found Yul EVM builtin keyword `number`
+  --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
+   |
+LL |             number, number := some_call()
+   |                     ^^^^^^
+   |
+
+error: expected identifier, found Yul EVM builtin keyword `number`
+  --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
+   |
+LL |             let number := 0
+   |                 ^^^^^^
+   |
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/parser/yul_kws_ok.sol
+++ b/tests/ui/parser/yul_kws_ok.sol
@@ -1,0 +1,16 @@
+contract C {
+    uint number;
+    function f() external {
+        assembly {
+            number.slot := 69
+            number.slot, number.slot := some_call()
+
+            number.number := 69
+            number.number, number.number := some_call()
+
+            sstore(number.slot, 1)
+
+            pop(number())
+        }
+    }
+}


### PR DESCRIPTION
The `yul-path` rules don't match the solc implementation because in their implementation a path is just a longer identifier: https://github.com/ethereum/solidity/issues/16054