### PR TITLE
fix: windows eol lexing

### DIFF
--- a/crates/parse/src/lexer/cursor/tests.rs
+++ b/crates/parse/src/lexer/cursor/tests.rs
@@ -210,3 +210,14 @@ RawToken { kind: Whitespace, len: 1 }
 "#]],
     );
 }
+
+#[test]
+fn windows_line_ending() {
+    check(
+        "/// doc line\r\n",
+        str![[r#"
+RawToken { kind: LineComment { is_doc: true }, len: 12 }
+RawToken { kind: Whitespace, len: 2 }
+"#]],
+    );
+}


### PR DESCRIPTION
Windows, unlike other OS, uses CRLF (`\r\n`) as end-of-line delimiter. As the lexer relies on the end-of-line when handling `//`/`///` single line comments, this creates a cross-platform inconsistent behavior (the final `\r` ends up included in the comment parsed, see  #315 ).

This PR adds a test for this hedge case and a suggested fix (reusing memchr ability to match 2 different bytes in a given haystack)