### PR TITLE
feat: add span visitor debug tool

### DIFF
--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -12,5 +12,6 @@ pub use solar_interface as interface;
 mod ast;
 pub use ast::*;
 
+pub mod span_visitor;
 pub mod token;
 pub mod visit;

--- a/crates/ast/src/span_visitor.rs
+++ b/crates/ast/src/span_visitor.rs
@@ -1,0 +1,33 @@
+//! Span visitor that emits diagnostics for each span in the AST.
+
+use crate::visit::Visit;
+use solar_interface::{Session, Span};
+use std::ops::ControlFlow;
+
+/// A visitor that emits a diagnostic for each span it encounters.
+pub struct SpanVisitor<'sess> {
+    sess: &'sess Session,
+    count: usize,
+}
+
+impl<'sess> SpanVisitor<'sess> {
+    /// Creates a new span visitor.
+    pub fn new(sess: &'sess Session) -> Self {
+        Self { sess, count: 0 }
+    }
+
+    /// Returns the number of spans visited.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+impl<'ast, 'sess> Visit<'ast> for SpanVisitor<'sess> {
+    type BreakValue = ();
+
+    fn visit_span(&mut self, span: &'ast Span) -> ControlFlow<Self::BreakValue> {
+        self.count += 1;
+        self.sess.dcx.note(format!("visiting span #{}", self.count)).span(*span).emit();
+        ControlFlow::Continue(())
+    }
+}

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -169,6 +169,10 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub ast_stats: bool,
 
+    /// Run the span visitor after parsing.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub span_visitor: bool,
+
     /// Print help.
     #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Help))]
     pub help: (),

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -107,6 +107,16 @@ pub(crate) fn parse_and_lower<'hir, 'sess: 'hir>(
         }
     }
 
+    if sess.opts.unstable.span_visitor {
+        use ast::span_visitor::SpanVisitor;
+        use ast::visit::Visit;
+        for source in sources.asts() {
+            let mut visitor = SpanVisitor::new(sess);
+            let _ = visitor.visit_source_unit(source);
+            debug!(spans_visited = visitor.count(), "span visitor completed");
+        }
+    }
+
     if sess.opts.language.is_yul() || sess.stop_after(CompilerStage::Parsed) {
         return Ok(None);
     }

--- a/tests/ui/parser/span_visitor.sol
+++ b/tests/ui/parser/span_visitor.sol
@@ -1,0 +1,9 @@
+//@compile-flags: -Zspan-visitor
+
+contract SpanVisitorTest {
+    uint256 x;
+    
+    function foo() public {
+        x = 42;
+    }
+}

--- a/tests/ui/parser/span_visitor.stderr
+++ b/tests/ui/parser/span_visitor.stderr
@@ -1,0 +1,131 @@
+note: visiting span #1
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL | / contract SpanVisitorTest {
+LL | |     uint256 x;
+...  |
+LL | |     }
+LL | | }
+   | |_-
+   |
+
+note: visiting span #2
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL | contract SpanVisitorTest {
+   |          ---------------
+   |
+
+note: visiting span #3
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |     uint256 x;
+   |     ----------
+   |
+
+note: visiting span #4
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |     uint256 x;
+   |     ----------
+   |
+
+note: visiting span #5
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |     uint256 x;
+   |     -------
+   |
+
+note: visiting span #6
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |     uint256 x;
+   |             -
+   |
+
+note: visiting span #7
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL | /     function foo() public {
+LL | |         x = 42;
+LL | |     }
+   | |_____-
+   |
+
+note: visiting span #8
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |     function foo() public {
+   |     ---------------------
+   |
+
+note: visiting span #9
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |     function foo() public {
+   |              ---
+   |
+
+note: visiting span #10
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |       function foo() public {
+   |  ___________________________-
+LL | |         x = 42;
+LL | |     }
+   | |_____-
+   |
+
+note: visiting span #11
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |         x = 42;
+   |         -------
+   |
+
+note: visiting span #12
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |         x = 42;
+   |         ------
+   |
+
+note: visiting span #13
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |         x = 42;
+   |         -
+   |
+
+note: visiting span #14
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |         x = 42;
+   |         -
+   |
+
+note: visiting span #15
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |         x = 42;
+   |             --
+   |
+
+note: visiting span #16
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |         x = 42;
+   |             --
+   |
+
+note: visiting span #17
+  --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
+   |
+LL |       function foo() public {
+   |  ___________________________-
+LL | |         x = 42;
+LL | |     }
+   | |_____-
+   |
+


### PR DESCRIPTION
Adds a -Z span-visitor flag that emits diagnostics for each span in the AST. Useful for debugging AST traversal.