### PR TITLE
chore: add span to `TryCatchClause`

### DIFF
--- a/crates/ast/src/ast/stmt.rs
+++ b/crates/ast/src/ast/stmt.rs
@@ -129,10 +129,13 @@ pub struct StmtTry<'ast> {
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.catchClause>
 #[derive(Debug)]
 pub struct TryCatchClause<'ast> {
-    pub name: Option<Ident>,
-    pub args: ParameterList<'ast>,
-    pub block: Block<'ast>,
     /// The span of the entire clause, from the `returns` and `catch`
     /// keywords, to the closing brace of the block.
     pub span: Span,
+    /// The catch clause name: `Error`, `Panic`, or custom.
+    pub name: Option<Ident>,
+    /// The parameter list for the clause.
+    pub args: ParameterList<'ast>,
+    /// A block of statements
+    pub block: Block<'ast>,
 }

--- a/crates/ast/src/ast/stmt.rs
+++ b/crates/ast/src/ast/stmt.rs
@@ -132,6 +132,7 @@ pub struct TryCatchClause<'ast> {
     pub name: Option<Ident>,
     pub args: ParameterList<'ast>,
     pub block: Block<'ast>,
-    /// The span of the clause, including the `{` and `}`.
+    /// The span of the entire clause, from the `returns` and `catch`
+    /// keywords, to the closing brace of the block.
     pub span: Span,
 }

--- a/crates/ast/src/ast/stmt.rs
+++ b/crates/ast/src/ast/stmt.rs
@@ -132,4 +132,6 @@ pub struct TryCatchClause<'ast> {
     pub name: Option<Ident>,
     pub args: ParameterList<'ast>,
     pub block: Block<'ast>,
+    /// The span of the clause, including the `{` and `}`.
+    pub span: Span,
 }

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -360,7 +360,7 @@ declare_visitors! {
         }
 
         fn visit_try_catch_clause(&mut self, catch: &'ast #mut TryCatchClause<'ast>) -> ControlFlow<Self::BreakValue> {
-            let TryCatchClause { name, args, block } = catch;
+            let TryCatchClause { name, args, block, .. } = catch;
             if let Some(name) = name {
                 self.visit_ident #_mut(name)?;
             }

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -360,7 +360,8 @@ declare_visitors! {
         }
 
         fn visit_try_catch_clause(&mut self, catch: &'ast #mut TryCatchClause<'ast>) -> ControlFlow<Self::BreakValue> {
-            let TryCatchClause { name, args, block, .. } = catch;
+            let TryCatchClause { span, name, args, block } = catch;
+            self.visit_span #_mut(span)?;
             if let Some(name) = name {
                 self.visit_ident #_mut(name)?;
             }

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -135,7 +135,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let expr = self.parse_expr()?;
         let mut clauses = SmallVec::<[_; 4]>::new();
 
-        let lo = self.token.span;
+        let mut lo = self.token.span;
         let returns = if self.eat_keyword(kw::Returns) {
             self.parse_parameter_list(false, VarFlags::FUNCTION)?
         } else {
@@ -145,9 +145,9 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let span = lo.to(self.prev_token.span);
         clauses.push(TryCatchClause { name: None, args: returns, block, span });
 
+        lo = self.token.span;
         self.expect_keyword(kw::Catch)?;
         loop {
-            let lo = self.token.span;
             let name = self.parse_ident_opt()?;
             let args = if self.check(TokenKind::OpenDelim(Delimiter::Parenthesis)) {
                 self.parse_parameter_list(false, VarFlags::FUNCTION)?
@@ -157,6 +157,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             let block = self.parse_block()?;
             let span = lo.to(self.prev_token.span);
             clauses.push(TryCatchClause { name, args, block, span });
+            lo = self.token.span;
             if !self.eat_keyword(kw::Catch) {
                 break;
             }

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -780,9 +780,10 @@ impl<'sess, 'hir, 'a> ResolveContext<'sess, 'hir, 'a> {
 
     fn lower_try_catch_clause(
         &mut self,
-        &ast::TryCatchClause { name, ref args, ref block, .. }: &ast::TryCatchClause<'_>,
+        &ast::TryCatchClause { span, name, ref args, ref block }: &ast::TryCatchClause<'_>,
     ) -> hir::TryCatchClause<'hir> {
         self.in_scope(|this| hir::TryCatchClause {
+            span,
             name,
             args: this.lower_variables(args, hir::VarKind::TryCatch),
             block: this.lower_block(block),

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -780,7 +780,7 @@ impl<'sess, 'hir, 'a> ResolveContext<'sess, 'hir, 'a> {
 
     fn lower_try_catch_clause(
         &mut self,
-        &ast::TryCatchClause { name, ref args, ref block }: &ast::TryCatchClause<'_>,
+        &ast::TryCatchClause { name, ref args, ref block, .. }: &ast::TryCatchClause<'_>,
     ) -> hir::TryCatchClause<'hir> {
         self.in_scope(|this| hir::TryCatchClause {
             name,

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1028,8 +1028,14 @@ pub struct StmtTry<'hir> {
 /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.catchClause>
 #[derive(Debug)]
 pub struct TryCatchClause<'hir> {
+    /// The span of the entire clause, from the `returns` and `catch`
+    /// keywords, to the closing brace of the block.
+    pub span: Span,
+    /// The catch clause name: `Error`, `Panic`, or custom.
     pub name: Option<Ident>,
+    /// The parameter list for the clause.
     pub args: &'hir [VariableId],
+    /// A block of statements
     pub block: Block<'hir>,
 }
 


### PR DESCRIPTION
necessary for the formatter to properly handle comments such as `comment9`, which are placed after a closing brace `}` and the keyword `catch`:
```solidity
// comment7
try unknown.empty() {
    // comment8
    unknown.doSomething();
} /* comment9 */ catch /* comment10 */ Error(string memory) {
    unknown.handleError();
} catch /* comment11 */ Panic(uint256) {
    unknown.handleError();
}
```