### PR TITLE
feat: flatten diag msg with style

### DIFF
--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -189,7 +189,7 @@ impl HumanEmitter {
             .children
             .iter()
             .filter(|sub| sub.span.is_dummy())
-            .map(OwnedMessage::from_subdiagnostic)
+            .map(|sub| OwnedMessage::from_subdiagnostic(sub, self.supports_color()))
             .collect();
 
         let snippet = title
@@ -282,8 +282,12 @@ impl OwnedMessage {
         Self { id: diag.id(), label: diag.label().into_owned(), level: to_as_level(diag.level) }
     }
 
-    fn from_subdiagnostic(sub: &SubDiagnostic) -> Self {
-        Self { id: None, label: sub.label().into_owned(), level: to_as_level(sub.level) }
+    fn from_subdiagnostic(sub: &SubDiagnostic, supports_color: bool) -> Self {
+        Self {
+            id: None,
+            label: sub.label_with_style(supports_color).into_owned(),
+            level: to_as_level(sub.level),
+        }
     }
 
     fn as_ref(&self) -> Message<'_> {


### PR DESCRIPTION
i was working on improved lints that would show code diffs, and i realized that despite using `fn highlighted_note`, the `fn flatten_messages` would remove the style.

so this PR aims to enhance `fn flatten_messages` to optionally preserve styles while flattening (depending on whether the emitter supports styles or not).

i added a new `fn label_with_style()` to try to avoid breaking API changes for solar users, but not sure if may have missed something. @DaniPopes please lmk if the approach looks good or if we should do it differently.