### PR TITLE
Refactor: Optimize Lexer Error Handling and Add Test for Invalid Characters

### DIFF
--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -265,11 +265,11 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                         err = err.help(help);
                     }
                     if repeats > 0 {
-                        let note = match repeats {
-                            1 => "once more".to_string(),
-                            _ => format!("{repeats} more times"),
+                        err = if repeats == 1 {
+                            err.note("character repeats once more")
+                        } else {
+                            err.note(format!("character repeats {repeats} more times"))
                         };
-                        err = err.note(format!("character repeats {note}"));
                     }
                     err.emit();
 
@@ -686,4 +686,5 @@ mod tests {
             ("- -", &[(0..1, BinOp(Minus)), (2..3, BinOp(Minus))]),
         ]);
     }
+
 }

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -687,4 +687,24 @@ mod tests {
         ]);
     }
 
+    #[test]
+    fn repeated_invalid_characters() {
+        solar_interface::SessionGlobals::new().set(|| {
+            // Test single invalid character, should fail with 1 error
+            check("valid∞", true, &[(0..5, id("valid"))]);
+
+            // Test repeated invalid characters, should fail with 1 error (not 5)
+            // The swallow_next_invalid logic should prevent error spam
+            check("valid∞∞∞∞∞", true, &[(0..5, id("valid"))]);
+
+            // Test different invalid characters, should fail with multiple errors
+            check("valid∞†", true, &[(0..5, id("valid"))]);
+
+            // Test non-breaking space handling
+            check("valid\u{00a0}more", true, &[(0..5, id("valid")), (7..11, id("more"))]);
+
+            // Test mixed valid/invalid sequences
+            check("a∞b†c", true, &[(0..1, id("a")), (4..5, id("b")), (8..9, id("c"))]);
+        });
+    }
 }


### PR DESCRIPTION
This pr adds a reduces string allocation and adds a test case for repeated_invalid_characters 

This should be a perf but the repeats branch is never touched on any of my testcase(Picked from solars), what it does is reduce string allocation