### PR TITLE
chore(benches): extract Session initialization to its own benchmark

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -8,7 +8,7 @@ Run with:
 
 ```bash
 # Criterion
-cargo criterion -p solar-bench --bench criterion -- --quiet --format terse |& tee benches/criterion.out
+cargo bench -p solar-bench --bench criterion -- --quiet --format terse parser |& tee benches/criterion.out
 uv --project benches/analyze run benches/analyze/main.py benches/README.md < benches/criterion.out
 
 # iai - requires `valgrind` and `iai-callgrind-runner`

--- a/benches/benches/criterion.rs
+++ b/benches/benches/criterion.rs
@@ -1,6 +1,34 @@
 use criterion::{Criterion, criterion_group, criterion_main};
-use solar_bench::{PARSERS, Source, get_srcs};
-use std::time::Duration;
+use solar_bench::{PARSERS, Source, get_src, get_srcs};
+use std::{hint::black_box, time::Duration};
+
+fn micro_benches(c: &mut Criterion) {
+    let mut g = make_group(c, "micro");
+
+    g.bench_function("session/new", |b| {
+        b.iter(|| solar_parse::interface::Session::builder().with_stderr_emitter().build());
+    });
+    g.bench_function("session/enter", |b| {
+        let sess =
+            &black_box(solar_parse::interface::Session::builder().with_stderr_emitter().build());
+        b.iter(|| sess.enter(|| black_box(sess)));
+    });
+
+    g.bench_function("source_map/new_source_file", |b| {
+        let source = black_box(get_src("Optimism"));
+        b.iter_batched_ref(
+            solar_parse::interface::SourceMap::default,
+            |sm| {
+                sm.new_source_file(
+                    solar_parse::interface::source_map::FileName::Real(source.path.into()),
+                    source.src,
+                )
+                .unwrap()
+            },
+            criterion::BatchSize::PerIteration,
+        )
+    });
+}
 
 fn parser_benches(c: &mut Criterion) {
     for s in get_srcs() {
@@ -8,11 +36,7 @@ fn parser_benches(c: &mut Criterion) {
     }
     eprintln!();
 
-    let mut g = c.benchmark_group("parser");
-    g.warm_up_time(Duration::from_secs(3));
-    g.measurement_time(Duration::from_secs(10));
-    g.sample_size(10);
-    g.noise_threshold(0.05);
+    let mut g = make_group(c, "parser");
 
     solar_parse::interface::enter(|| {
         for &Source { name: sname, path: _, src } in get_srcs() {
@@ -31,10 +55,11 @@ fn parser_benches(c: &mut Criterion) {
                         format!("{sname}/{pname}/{id}")
                     }
                 };
+                let setup = &mut *parser.setup(src);
                 if parser.can_lex() {
-                    g.bench_function(mk_id("lex"), |b| b.iter(|| parser.lex(src)));
+                    g.bench_function(mk_id("lex"), |b| b.iter(|| parser.lex(src, setup)));
                 }
-                g.bench_function(mk_id("parse"), |b| b.iter(|| parser.parse(src)));
+                g.bench_function(mk_id("parse"), |b| b.iter(|| parser.parse(src, setup)));
             }
             eprintln!();
         }
@@ -43,5 +68,17 @@ fn parser_benches(c: &mut Criterion) {
     g.finish();
 }
 
-criterion_group!(benches, parser_benches);
+fn make_group<'a>(
+    c: &'a mut Criterion,
+    name: &str,
+) -> criterion::BenchmarkGroup<'a, criterion::measurement::WallTime> {
+    let mut g = c.benchmark_group(name);
+    g.warm_up_time(Duration::from_secs(3));
+    g.measurement_time(Duration::from_secs(10));
+    g.sample_size(10);
+    g.noise_threshold(0.05);
+    g
+}
+
+criterion_group!(benches, micro_benches, parser_benches);
 criterion_main!(benches);

--- a/benches/benches/iai.rs
+++ b/benches/benches/iai.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 
 use iai_callgrind::{library_benchmark, library_benchmark_group};
-use solar_bench::{Parser, Slang, Solang, Solar, Source, get_srcs};
+use solar_bench::{Parser, Slang, Solang, Solar, Source, get_src};
 use std::hint::black_box;
 
 #[library_benchmark]
@@ -106,19 +106,16 @@ mk_groups!(
 #[inline]
 fn run_lex(name: &str, parser: &dyn Parser) {
     assert!(parser.can_lex(), "{} can't lex", parser.name());
-    let Source { name: _, path: _, src } = get_source(name);
-    solar_parse::interface::enter(|| parser.lex(black_box(src)))
+    let Source { name: _, path: _, src } = get_src(name);
+    let setup = &mut *parser.setup(src);
+    parser.lex(black_box(src), setup)
 }
 
 #[inline]
 fn run_parse(name: &str, parser: &dyn Parser) {
-    let Source { name: _, path: _, src } = get_source(name);
-    solar_parse::interface::enter(|| parser.parse(black_box(src)))
-}
-
-#[inline]
-fn get_source(name: &str) -> &'static Source {
-    get_srcs().iter().find(|s| s.name == name).unwrap()
+    let Source { name: _, path: _, src } = get_src(name);
+    let setup = &mut *parser.setup(src);
+    parser.parse(black_box(src), setup)
 }
 
 // use lex_::lex;

--- a/benches/criterion.out
+++ b/benches/criterion.out
@@ -9,7 +9,7 @@ Vm: 1763 LoC, 91405 bytes
 safeconsole: 13248 LoC, 397898 bytes
 Seaport: 19935 LoC, 770547 bytes
 Solady: 31047 LoC, 1381235 bytes
-Optimism: 124413 LoC, 5383876 bytes
+Optimism: 124413 LoC, 5383882 bytes
 
 Benchmarking parser/empty/solc/parse
 Benchmarking parser/empty/solc/parse: Warming up for 3.0000 s


### PR DESCRIPTION
Removing `Session` initialization from the parser benchmarks, since it's a one-time initialization just like `enter` currently. This is changed in https://github.com/paradigmxyz/solar/pull/379, so making these changes here to remove noise from that PR.