### PR TITLE
feat: visit_override when walking fn

### DIFF
--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -224,7 +224,7 @@ declare_visitors! {
                 state_mutability,
                 modifiers,
                 virtual_: _,
-                override_: _,
+                override_,
                 returns,
             } = header;
             self.visit_span #_mut(span)?;
@@ -246,6 +246,9 @@ declare_visitors! {
             if let Some(returns) = returns {
                 self.visit_parameter_list #_mut(returns)?;
             }
+            if let Some(override_) = override_ {
+                self.visit_override #_mut(override_)?;
+            }
             ControlFlow::Continue(())
         }
 
@@ -253,6 +256,15 @@ declare_visitors! {
             let Modifier { name, arguments } = modifier;
             self.visit_path #_mut(name)?;
             self.visit_call_args #_mut(arguments)?;
+            ControlFlow::Continue(())
+        }
+
+        fn visit_override(&mut self, override_: &'ast #mut Override<'ast>) -> ControlFlow<Self::BreakValue> {
+            let Override { span, paths } = override_;
+            self.visit_span #_mut(span)?;
+            for path in paths.iter #_mut() {
+                self.visit_path #_mut(path)?;
+            }
             ControlFlow::Continue(())
         }
 


### PR DESCRIPTION
## Motivation

implement missing fn for the `ast::Visitor` trait, to ensure that all paths (including those in `override`) are walked when using `fn visit_path`

would fix https://github.com/foundry-rs/foundry/issues/11019 without requiring any code changes 

## Implementation

added a new `fn visit_override` to the `Visitor` trait and updated `fn visit_function_header` to call it.

@DaniPopes should we replicate the same for the hir visitor?