### PR TITLE
chore: spanned data location + subdenomination

### DIFF
--- a/crates/ast/src/ast/expr.rs
+++ b/crates/ast/src/ast/expr.rs
@@ -1,6 +1,6 @@
 use super::{Box, Lit, SubDenomination, Type};
 use either::Either;
-use solar_interface::{Ident, Span};
+use solar_interface::{Ident, Span, Spanned};
 use std::fmt;
 
 /// A list of named arguments: `{a: "1", b: 2}`.
@@ -66,7 +66,7 @@ pub enum ExprKind<'ast> {
     ///
     /// Note that the `SubDenomination` is only present for numeric literals, and it's already
     /// applied to `Lit`'s value. It is only present for error reporting/formatting purposes.
-    Lit(&'ast mut Lit, Option<SubDenomination>),
+    Lit(&'ast mut Lit, Option<Spanned<SubDenomination>>),
 
     /// Access of a named member: `obj.k`.
     Member(Box<'ast, Expr<'ast>>, Ident),

--- a/crates/ast/src/ast/item.rs
+++ b/crates/ast/src/ast/item.rs
@@ -684,7 +684,7 @@ pub struct VariableDefinition<'ast> {
     pub ty: Type<'ast>,
     pub visibility: Option<Visibility>,
     pub mutability: Option<VarMut>,
-    pub data_location: Option<DataLocation>,
+    pub data_location: Option<Spanned<DataLocation>>,
     pub override_: Option<Override<'ast>>,
     pub indexed: bool,
     pub name: Option<Ident>,

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -22,7 +22,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Returns None if no subdenomination was parsed or if the literal is not a number or rational.
     pub fn parse_lit_with_subdenomination(
         &mut self,
-    ) -> PResult<'sess, (&'ast mut Lit, Option<SubDenomination>)> {
+    ) -> PResult<'sess, (&'ast mut Lit, Option<Spanned<SubDenomination>>)> {
         let lit = self.parse_lit()?;
         let mut sub = self.parse_subdenomination();
         if let opt @ Some(_) = &mut sub {
@@ -47,12 +47,13 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     }
 
     /// Parses a subdenomination.
-    pub fn parse_subdenomination(&mut self) -> Option<SubDenomination> {
+    pub fn parse_subdenomination(&mut self) -> Option<Spanned<SubDenomination>> {
+        let lo = self.token.span;
         let sub = self.subdenomination();
         if sub.is_some() {
             self.bump();
         }
-        sub
+        sub.map(|data| Spanned { span: lo.to(self.prev_token.span), data })
     }
 
     fn subdenomination(&self) -> Option<SubDenomination> {

--- a/crates/sema/src/ast_lowering/lower.rs
+++ b/crates/sema/src/ast_lowering/lower.rs
@@ -281,7 +281,7 @@ pub(super) fn lower_variable_partial(
         name,
         visibility,
         mutability,
-        data_location,
+        data_location: data_location.map(|loc| *loc),
         override_: override_.is_some(),
         overrides: &[],
         indexed,

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -437,7 +437,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
         let ast::Expr { kind, .. } = expr;
         if let ast::ExprKind::Lit(lit, subdenomination) = kind {
             self.check_underscores_in_number_literals(lit);
-            self.check_subdenominations_for_number_literals(lit, subdenomination);
+            self.check_subdenominations_for_number_literals(lit, &subdenomination.map(|sub| *sub));
             self.check_address_checksums(lit);
         }
         self.walk_expr(expr)

--- a/tests/ui/stats/ast.stderr
+++ b/tests/ui/stats/ast.stderr
@@ -4,23 +4,23 @@ ast-stats ----------------------------------------------------------------
 ast-stats SourceUnit                16 ( 0.7%)             1            16
 ast-stats Ident                     36 ( 1.5%)             3            12
 ast-stats PragmaDirective           40 ( 1.7%)             1            40
-ast-stats Block                     48 ( 2.1%)             2            24
+ast-stats Block                     48 ( 2.0%)             2            24
 ast-stats ItemContract              64 ( 2.7%)             1            64
-ast-stats VariableDefinition        88 ( 3.8%)             1            88
+ast-stats VariableDefinition       104 ( 4.4%)             1           104
 ast-stats DocComments              112 ( 4.8%)             7            16
 ast-stats Span                     112 ( 4.8%)            14             8
 ast-stats Stmt                     176 ( 7.5%)             2            88
 ast-stats - Expr                   176 ( 7.5%)             2
-ast-stats Expr                     240 (10.3%)             5            48
-ast-stats - Assign                  48 ( 2.1%)             1
-ast-stats - Unary                   48 ( 2.1%)             1
-ast-stats - Ident                  144 ( 6.2%)             3
-ast-stats ItemFunction             368 (15.7%)             2           184
-ast-stats Item                   1_040 (44.4%)             5           208
-ast-stats - Contract               208 ( 8.9%)             1
-ast-stats - Pragma                 208 ( 8.9%)             1
-ast-stats - Variable               208 ( 8.9%)             1
-ast-stats - Function               416 (17.8%)             2
+ast-stats Expr                     240 (10.2%)             5            48
+ast-stats - Assign                  48 ( 2.0%)             1
+ast-stats - Unary                   48 ( 2.0%)             1
+ast-stats - Ident                  144 ( 6.1%)             3
+ast-stats ItemFunction             368 (15.6%)             2           184
+ast-stats Item                   1_040 (44.1%)             5           208
+ast-stats - Contract               208 ( 8.8%)             1
+ast-stats - Pragma                 208 ( 8.8%)             1
+ast-stats - Variable               208 ( 8.8%)             1
+ast-stats - Function               416 (17.7%)             2
 ast-stats ----------------------------------------------------------------
-ast-stats Total                  2_340
+ast-stats Total                  2_356
 ast-stats


### PR DESCRIPTION
# Motivation

these spans are required by the formatter to print comments between the data location and the subdomain keywords:

```solidity
uint256[] /* comment1 */ memory /* comment2 */ sample3; // comment3

value = someVeryVeryVeryLongVariableNameForTheMultiplierForEtherValue
    * 1 /* comment1 */ ether; // comment2
```