### PR TITLE
feat: support `cargo binstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can find a more detailed list in the [pinned GitHub issue](https://github.co
   - [x] Lexing
   - [x] Parsing
   - [ ] Semantic analysis
-    - [x] Symbol resolution 
+    - [x] Symbol resolution
     - [ ] Type checker
     - [ ] Static analysis
 - [ ] Middle-end

--- a/crates/solar/Cargo.toml
+++ b/crates/solar/Cargo.toml
@@ -12,6 +12,10 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/v{version}/solar-{target}{archive-suffix}"
+bin-dir = "solar-{target}/{bin}{binary-ext}"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
Adds some metadata to support [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall). Currently it is not supported because the crate is named `solar-compiler`, but the binary and binary directory are named `solar`.

Equivalent `cargo binstall` line:

```sh
cargo binstall solar-compiler --bin-dir "solar-{target}/{bin}{binary-ext}" \ 
  --pkg-url "{repo}/releases/download/v{version}/solar-{target}{archive-suffix}"
```