### PR TITLE
fix: error on dummy instead of empty args

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -433,7 +433,10 @@ impl<'hir> super::LoweringContext<'_, '_, 'hir> {
                     .position(|&l| l == base_id)
                     .expect("base contract not found");
 
-                if is_ctor && base.args.is_empty() {
+                if is_ctor && base.args.is_dummy() {
+                    // bad: `contract is C` ... `constructor() C`
+                    //  ok: `contract is C` ... `constructor() C()`
+                    // So we use `is_dummy` here instead of `is_empty`.
                     self.sess
                         .dcx
                         .err("modifier-style base constructor call without arguments")

--- a/tests/ui/resolve/base_constructor.sol
+++ b/tests/ui/resolve/base_constructor.sol
@@ -1,26 +1,38 @@
-abstract contract C {
-    constructor(uint, bool) {}
+abstract contract NoArgs {
+    uint256 private a;
+    constructor() {
+        a = 0;
+    }
+}
+abstract contract WithArgs {
+    uint256 private a;
+    constructor(uint256 b) {
+        a = b;
+    }
 }
 
-abstract contract D is C {}
+abstract contract D is NoArgs {}
 
-abstract contract E is C {
+abstract contract E is NoArgs {
     constructor() {}
 }
 
-abstract contract F is C {
-    constructor() C {} //~ERROR: modifier-style base constructor call without arguments
+abstract contract F is NoArgs {
+    constructor() NoArgs {} //~ERROR: modifier-style base constructor call without arguments
+}
+abstract contract FF is NoArgs {
+    constructor() NoArgs() {} // OK
 }
 
-contract J is C(1337, false) { //~HELP: previous declaration
-    constructor() C(1337, false) {} //~ERROR: base constructor arguments given twice
+contract J is WithArgs(1337) { //~HELP: previous declaration
+    constructor() WithArgs(1337) {} //~ERROR: base constructor arguments given twice
 }
 
-contract G is C {
-    constructor(uint x) C(x, false) {}
+contract G is WithArgs {
+    constructor(uint x) WithArgs(x) {}
 }
 
 // ok
-contract K is C(1337, false) {
+contract K is WithArgs(1337) {
     constructor() {}
 }

--- a/tests/ui/resolve/base_constructor.stderr
+++ b/tests/ui/resolve/base_constructor.stderr
@@ -1,16 +1,16 @@
 error: modifier-style base constructor call without arguments
   --> ROOT/tests/ui/resolve/base_constructor.sol:LL:CC
    |
-LL |     constructor() C {}
-   |                   ^
+LL |     constructor() NoArgs {}
+   |                   ^^^^^^
    |
 
 error: base constructor arguments given twice
   --> ROOT/tests/ui/resolve/base_constructor.sol:LL:CC
    |
-LL | contract J is C(1337, false) {
+LL | contract J is WithArgs(1337) {
    |               -------------- help: previous declaration
-LL |     constructor() C(1337, false) {}
+LL |     constructor() WithArgs(1337) {}
    |                   ^^^^^^^^^^^^^^
    |
 


### PR DESCRIPTION
solc fails on *no parens* (`args.is_dummy()`) instead of *empty arguments* which includes both `C` and `C()`.