### PR TITLE
chore: downgrade some debug spans to trace

### DIFF
--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -9,7 +9,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         self.parse_expr_with(None)
     }
 
-    #[instrument(name = "parse_expr", level = "debug", skip_all)]
+    #[instrument(name = "parse_expr", level = "trace", skip_all)]
     pub(super) fn parse_expr_with(
         &mut self,
         with: Option<Box<'ast, Expr<'ast>>>,

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, fmt};
 
 impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Parses a literal.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub fn parse_lit(&mut self) -> PResult<'sess, &'ast mut Lit> {
         self.parse_spanned(Self::parse_lit_inner)
             .map(|(span, (symbol, kind))| self.arena.literals.alloc(Lit { span, symbol, kind }))

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -7,7 +7,7 @@ use solar_interface::{Ident, Span, kw, sym};
 
 impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Parses a statement.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub fn parse_stmt(&mut self) -> PResult<'sess, Stmt<'ast>> {
         let docs = self.parse_doc_comments();
         self.parse_spanned(Self::parse_stmt_kind).map(|(span, kind)| Stmt { docs, kind, span })

--- a/crates/parse/src/parser/ty.rs
+++ b/crates/parse/src/parser/ty.rs
@@ -6,7 +6,7 @@ use std::{fmt, ops::RangeInclusive};
 
 impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Parses a type.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     pub fn parse_type(&mut self) -> PResult<'sess, Type<'ast>> {
         let mut ty = self
             .parse_spanned(Self::parse_basic_ty_kind)

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -787,7 +787,7 @@ impl<'sess, 'hir, 'a> ResolveContext<'sess, 'hir, 'a> {
         self.arena.alloc(self.lower_stmt_full(stmt))
     }
 
-    #[instrument(name = "lower_stmt", level = "debug", skip_all)]
+    #[instrument(name = "lower_stmt", level = "trace", skip_all)]
     fn lower_stmt_full(&mut self, stmt: &ast::Stmt<'_>) -> hir::Stmt<'hir> {
         let kind = match &stmt.kind {
             ast::StmtKind::DeclSingle(var) => {
@@ -1028,7 +1028,7 @@ impl<'sess, 'hir, 'a> ResolveContext<'sess, 'hir, 'a> {
             .alloc_slice_fill_iter(exprs.into_iter().map(|e| self.lower_expr_full(e.as_ref())))
     }
 
-    #[instrument(name = "lower_expr", level = "debug", skip_all)]
+    #[instrument(name = "lower_expr", level = "trace", skip_all)]
     fn lower_expr_full(&mut self, expr: &ast::Expr<'_>) -> hir::Expr<'hir> {
         let kind = match &expr.kind {
             ast::ExprKind::Array(exprs) => hir::ExprKind::Array(self.lower_exprs(&**exprs)),
@@ -1131,7 +1131,7 @@ impl<'sess, 'hir, 'a> ResolveContext<'sess, 'hir, 'a> {
         hir::CallArgs { kind, span: args.span }
     }
 
-    #[instrument(name = "lower_stmt", level = "debug", skip_all)]
+    #[instrument(name = "lower_type", level = "trace", skip_all)]
     fn lower_type(&mut self, ty: &ast::Type<'_>) -> hir::Type<'hir> {
         let kind = match &ty.kind {
             ast::TypeKind::Elementary(ty) => hir::TypeKind::Elementary(*ty),


### PR DESCRIPTION
Downgrade `parse_*` and `lower_*` spans that are very verbose.