### PR TITLE
fix(ast): visit array size

### DIFF
--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -184,8 +184,11 @@ declare_visitors! {
             match kind {
                 TypeKind::Elementary(_) => {}
                 TypeKind::Array(array) => {
-                    let TypeArray { element, size: _ } = &#mut **array;
+                    let TypeArray { element, size } = &#mut **array;
                     self.visit_ty #_mut(element)?;
+                    if let Some(size) = size {
+                        self.visit_expr #_mut(size)?;
+                    }
                 }
                 TypeKind::Function(function) => {
                     let TypeFunction { parameters, visibility: _, state_mutability: _, returns } = &#mut **function;


### PR DESCRIPTION
## Motivation

A bug report for ⁠`forge-lint` revealed that the AST visitor was not traversing array size exprs. This means that any issues within those expressions aren't caught.
- https://github.com/foundry-rs/foundry/issues/11392

## Solution 
ensure array size expres are visited