### PR TITLE
chore: make all features reachable from meta crate

### DIFF
--- a/crates/sema/Cargo.toml
+++ b/crates/sema/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 solar-ast.workspace = true
 solar-data-structures.workspace = true
-solar-interface.workspace = true
+solar-interface = { workspace = true, features = ["json"] }
 solar-macros.workspace = true
 solar-parse.workspace = true
 

--- a/crates/solar/Cargo.toml
+++ b/crates/solar/Cargo.toml
@@ -52,7 +52,7 @@ solar-tester.workspace = true
 [features]
 default = ["cli", "solar-cli?/default"]
 # Enable the CLI and binary.
-cli = ["dep:solar-cli"]
+cli = ["dep:solar-cli", "clap"]
 # Nightly-only features for faster/smaller builds.
 nightly = [
     "solar-cli?/nightly",
@@ -68,6 +68,9 @@ asm = ["solar-cli?/asm", "alloy-primitives/asm-keccak"]
 # Faster but less portable allocator.
 jemalloc = ["solar-cli?/jemalloc"]
 mimalloc = ["solar-cli?/mimalloc"]
+
+# Clap support.
+clap = ["solar-config/clap"]
 
 # Debugging and profiling.
 tracing = ["solar-cli?/tracing"]


### PR DESCRIPTION
"json" is implied in sema due to ABI support, "clap" is re-exported.