### PR TITLE
feat(diagnostics): track notes + expose notes/warn counts

### DIFF
--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -334,7 +334,7 @@ impl DiagCtxtInner {
                 self.deduplicated_err_count += 1;
             } else if diagnostic.level == Level::Warning {
                 self.deduplicated_warn_count += 1;
-            } else if matches!(diagnostic.level, Level::Note | Level::OnceNote) {
+            } else if diagnostic.is_note() {
                 self.deduplicated_note_count += 1;
             }
         }
@@ -345,7 +345,7 @@ impl DiagCtxtInner {
         } else {
             if diagnostic.level == Level::Warning {
                 self.bump_warn_count();
-            } else if matches!(diagnostic.level, Level::Note | Level::OnceNote) {
+            } else if diagnostic.is_note() {
                 self.bump_note_count();
             }
             // Don't bump any counters for `Help`, `OnceHelp`, or `Allow`

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -229,6 +229,23 @@ impl Level {
         }
     }
 
+    /// Returns `true` if this level is a note.
+    #[inline]
+    pub fn is_note(self) -> bool {
+        match self {
+            Self::Note | Self::OnceNote => true,
+
+            Self::Bug
+            | Self::Fatal
+            | Self::Error
+            | Self::FailureNote
+            | Self::Warning
+            | Self::Help
+            | Self::OnceHelp
+            | Self::Allow => false,
+        }
+    }
+
     /// Returns the style of this level.
     #[inline]
     pub const fn style(self) -> anstyle::Style {
@@ -382,6 +399,12 @@ impl Diag {
     #[inline]
     pub fn is_error(&self) -> bool {
         self.level.is_error()
+    }
+
+    /// Returns `true` if this diagnostic is a note.
+    #[inline]
+    pub fn is_note(&self) -> bool {
+        self.level.is_note()
     }
 
     /// Formats the diagnostic messages into a single string.


### PR DESCRIPTION
## Motivation
there is a request for the linter to return exit code 1 when lints are emitted (useful for CI). Additionally, some people may only want this behavior for warnings, but not for notes

 - https://github.com/foundry-rs/foundry/issues/11393

## Solution

track warnings and notes in separate counters + expose them via public methods