### PR TITLE
chore!(data-structures): remove aliases in sync re-exports

### DIFF
--- a/crates/data-structures/src/sync.rs
+++ b/crates/data-structures/src/sync.rs
@@ -1,7 +1,6 @@
 pub use parking_lot::{
-    MappedMutexGuard as MappedLockGuard, MappedRwLockReadGuard as MappedReadGuard,
-    MappedRwLockWriteGuard as MappedWriteGuard, Mutex as Lock, RwLock,
-    RwLockReadGuard as ReadGuard, RwLockWriteGuard as WriteGuard,
+    MappedMutexGuard, MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, RwLock,
+    RwLockReadGuard, RwLockWriteGuard,
 };
 
 /// Executes the given expressions in parallel.

--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{Result, SourceMap};
 use anstream::ColorChoice;
-use solar_data_structures::{map::FxHashSet, sync::Lock};
+use solar_data_structures::{map::FxHashSet, sync::Mutex};
 use std::{borrow::Cow, hash::BuildHasher, num::NonZeroUsize, sync::Arc};
 
 /// Flags that control the behaviour of a [`DiagCtxt`].
@@ -36,7 +36,7 @@ impl Default for DiagCtxtFlags {
 /// Certain errors (fatal, bug, unimpl) may cause immediate exit,
 /// others log errors for later reporting.
 pub struct DiagCtxt {
-    inner: Lock<DiagCtxtInner>,
+    inner: Mutex<DiagCtxtInner>,
 }
 
 struct DiagCtxtInner {
@@ -63,7 +63,7 @@ impl DiagCtxt {
     /// Creates a new `DiagCtxt` with the given diagnostics emitter.
     pub fn new(emitter: Box<DynEmitter>) -> Self {
         Self {
-            inner: Lock::new(DiagCtxtInner {
+            inner: Mutex::new(DiagCtxtInner {
                 emitter,
                 flags: DiagCtxtFlags::default(),
                 err_count: 0,

--- a/crates/interface/src/source_map/mod.rs
+++ b/crates/interface/src/source_map/mod.rs
@@ -5,7 +5,7 @@ use once_map::OnceMap;
 use solar_data_structures::{
     fmt,
     map::FxBuildHasher,
-    sync::{ReadGuard, RwLock},
+    sync::{RwLock, RwLockReadGuard},
 };
 use std::{
     io::{self, Read},
@@ -280,7 +280,7 @@ impl SourceMap {
 
     /// Returns a read guard to the source files in the source map.
     pub fn files(&self) -> impl std::ops::Deref<Target = [Arc<SourceFile>]> + '_ {
-        ReadGuard::map(self.source_files.read(), |f| f.as_slice())
+        RwLockReadGuard::map(self.source_files.read(), |f| f.as_slice())
     }
 
     pub fn source_file_by_file_name(&self, filename: &FileName) -> Option<Arc<SourceFile>> {

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -4,7 +4,7 @@ use solar_ast::{self as ast, Span};
 use solar_data_structures::{
     index::{Idx, IndexVec},
     map::FxHashSet,
-    sync::Lock,
+    sync::Mutex,
 };
 use solar_interface::{
     Result, Session,
@@ -197,7 +197,7 @@ impl<'gcx> ParsingContext<'gcx> {
         sources: &mut Sources<'ast>,
         arenas: &'ast ThreadLocal<ast::Arena>,
     ) {
-        let lock = Lock::new(std::mem::take(sources));
+        let lock = Mutex::new(std::mem::take(sources));
         rayon::scope(|scope| {
             let sources = &*lock.lock();
             for (id, source) in sources.iter_enumerated() {
@@ -213,7 +213,7 @@ impl<'gcx> ParsingContext<'gcx> {
 
     fn spawn_parse_job<'ast, 'scope>(
         &'scope self,
-        lock: &'scope Lock<Sources<'ast>>,
+        lock: &'scope Mutex<Sources<'ast>>,
         id: SourceId,
         file: Arc<SourceFile>,
         arenas: &'ast ThreadLocal<ast::Arena>,
@@ -225,7 +225,7 @@ impl<'gcx> ParsingContext<'gcx> {
     #[instrument(level = "debug", skip_all)]
     fn parse_job<'ast, 'scope>(
         &'scope self,
-        lock: &'scope Lock<Sources<'ast>>,
+        lock: &'scope Mutex<Sources<'ast>>,
         id: SourceId,
         file: Arc<SourceFile>,
         arenas: &'ast ThreadLocal<ast::Arena>,


### PR DESCRIPTION
No reason to alias them