### PR TITLE
perf(interface): cache thread pool inside of session

### DIFF
--- a/crates/interface/src/session.rs
+++ b/crates/interface/src/session.rs
@@ -344,11 +344,10 @@ impl Session {
         solar_data_structures::sync::scope(self.is_parallel(), op)
     }
 
-    /// Sets up a thread pool and the session globals in the current thread, then executes the given
-    /// closure.
+    /// Sets up the session globals and executes the given closure in the thread pool.
     ///
-    /// The globals are stored in this [`Session`] itself, meaning multiple consecutive calls to
-    /// [`enter`](Self::enter) will share the same globals.
+    /// The thread pool and globals are stored in this [`Session`] itself, meaning multiple
+    /// consecutive calls to [`enter`](Self::enter) will share the same globals and resources.
     #[track_caller]
     pub fn enter<R: Send>(&self, f: impl FnOnce() -> R + Send) -> R {
         if in_rayon() {
@@ -367,7 +366,7 @@ impl Session {
         self.enter_sequential(|| self.thread_pool().install(f))
     }
 
-    /// Sets up the session globals in the current thread, then executes the given closure.
+    /// Sets up the session globals and executes the given closure in the current thread.
     ///
     /// Note that this does not set up the rayon thread pool. This is only useful when parsing
     /// sequentially, like manually using `Parser`. Otherwise, it might cause panics later on if a

--- a/crates/sema/src/compiler.rs
+++ b/crates/sema/src/compiler.rs
@@ -89,6 +89,8 @@ impl Compiler {
     }
 
     /// Enters the compiler context.
+    ///
+    /// See [`Session::enter`](Session::enter) for more details.
     pub fn enter<T: Send>(&self, f: impl FnOnce(&CompilerRef<'_>) -> T + Send) -> T {
         self.0.sess.enter(|| f(CompilerRef::new(&self.0)))
     }
@@ -97,6 +99,8 @@ impl Compiler {
     ///
     /// This is currently only necessary when parsing sources and lowering the ASTs.
     /// All accesses after can make use of `gcx`, passed by immutable reference.
+    ///
+    /// See [`Session::enter`](Session::enter) for more details.
     pub fn enter_mut<T: Send>(&mut self, f: impl FnOnce(&mut CompilerRef<'_>) -> T + Send) -> T {
         // SAFETY: `sess` is not modified.
         let sess = unsafe { trustme::decouple_lt(&self.0.sess) };


### PR DESCRIPTION
Thankfully `ThreadPoolBuilder::build_scoped` can be entirely re-implemented by ourselves, using `Arc` + `spawn` instead of `std::thread::scope`, avoiding having to create a new thread pool every time `enter` is called.