### PR TITLE
chore(deps): bump vergen to 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537c317ddf588aab15c695bf92cf55dec159b93221c074180ca3e0e5a94da415"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5abbf2d4a4c6896197c9de13d6d7cb7eff438c63dacde1dde980569cb00248"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +867,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1218,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1349,12 @@ checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "impl-codec"
@@ -1951,6 +2029,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,7 +2705,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.2",
- "vergen",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -3289,16 +3377,41 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vergen"
-version = "8.3.2"
+version = "10.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+checksum = "01dfb229dfa86c675981eb5fc6ebd6d325df14ea43cfe8a6c076d952b8ae2400"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "cfg-if",
- "regex",
+ "bon",
  "rustversion",
  "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "2.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b67fcab8e25b04483d5934948e4c12ee36fe321d5aad5955624647e4c635e"
+dependencies = [
+ "anyhow",
+ "bon",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "1.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edcbfdaf11023965be978b8648607767c013b8e9f9a92079cabda635be7bf2b"
+dependencies = [
+ "anyhow",
+ "bon",
+ "getset",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,6 @@ smallvec = { version = "1", features = ["const_generics", "union"] }
 thread_local = "1.1"
 typed-arena = "2.0"
 unicode-width = "0.2"
-vergen = "8"
+vergen = { package = "vergen-gitcl", version = "2.0.0-beta.1" }
 
 [patch.crates-io]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -18,9 +18,8 @@ workspace = true
 [build-dependencies]
 vergen = { workspace = true, optional = true, features = [
     "build",
-    "git",
-    "gitcl",
     "cargo",
+    "emit_and_set",
 ] }
 
 [dependencies]

--- a/crates/config/build.rs
+++ b/crates/config/build.rs
@@ -1,16 +1,15 @@
 #[cfg(feature = "version")]
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::env;
 
-    vergen::EmitBuilder::builder()
-        .git_describe(false, true, None)
-        .git_dirty(true)
-        .git_sha(false)
-        .build_timestamp()
-        .cargo_features()
-        .cargo_target_triple()
-        .emit_and_set()
-        .unwrap();
+    let cargo = vergen::Cargo::builder().features(true).target_triple(true).build();
+    let build = vergen::Build::builder().build_timestamp(true).build();
+    let git = vergen::Gitcl::builder().describe(false, true, None).dirty(true).sha(false).build();
+    vergen::Emitter::new()
+        .add_instructions(&cargo)?
+        .add_instructions(&build)?
+        .add_instructions(&git)?
+        .emit_and_set()?;
 
     let sha = env::var("VERGEN_GIT_SHA").unwrap();
     let sha_short = &sha[..7];
@@ -59,6 +58,8 @@ fn main() {
     for (i, line) in long_version.lines().enumerate() {
         println!("cargo:rustc-env=LONG_VERSION{i}={line}");
     }
+
+    Ok(())
 }
 
 #[cfg(not(feature = "version"))]


### PR DESCRIPTION
This actually reduces build time dependencies by removing `cargo_metadata`, even if it does add a bunch of proc macros.