### PR TITLE
feat: bump to annotate-snippets 0.12, diagnostic tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
  "anstyle",
+ "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0b4cc914c1b0d47acea9b7abc1deffde6430c7c417ff2e7ceb77b80f137739"
+dependencies = [
+ "anstyle",
  "memchr",
  "unicode-width 0.2.1",
 ]
@@ -2644,7 +2654,7 @@ dependencies = [
 name = "solar-interface"
 version = "0.1.6"
 dependencies = [
- "annotate-snippets",
+ "annotate-snippets 0.12.0",
  "anstream",
  "anstyle",
  "derive_more",
@@ -3196,7 +3206,7 @@ version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b56a6897cc4bb6f8daf1939b0b39cd9645856997f46f4d0b3e3cb7122dfe9251"
 dependencies = [
- "annotate-snippets",
+ "annotate-snippets 0.11.5",
  "anyhow",
  "bstr",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ clap_builder = "4.4"
 # diagnostics
 anstream = "0.6.18"
 anstyle = "1.0"
-annotate-snippets = { version = "0.11.5", features = ["simd"] }
+annotate-snippets = { version = "0.12", features = ["simd"] }
 
 # serde
 serde = "1.0"

--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -158,23 +158,24 @@ impl HumanEmitter {
 
     /// Formats the given `diagnostic` into a [`Message`] suitable for use with the renderer.
     fn snippet<R>(&mut self, diagnostic: &Diag, f: impl FnOnce(&mut Self, Report<'_>) -> R) -> R {
-        // Current format (annotate-snippets 0.10.0) (comments in <...>):
+        // Current format (annotate-snippets 0.12.0) (comments in <...>):
         /*
         title.level[title.id]: title.label
-           --> snippets[0].origin
+           --> snippets[0].path:ll:cc
             |
-         LL | snippets[0].source[ann[0].range] <ann = snippets[0].annotations>
-            | ^^^^^^^^^^^^^^^^ ann[0].level: ann[0].label <type is skipped for error, warning>
+         LL | snippets[0].source[ann[0].range] <ann = snippets[0].annotations; these are diag.span_label()s>
+            | ^^^^^^^^^^^^^^^^ ann[0].label <primary>
          LL | snippets[0].source[ann[1].range]
-            | ---------------- ann[1].level: ann[1].label
+            | ---------------- ann[1].label <secondary>
             |
-           ::: snippets[1].origin
+           ::: snippets[1].path:ll:cc
             |
         etc...
             |
             = footer[0].level: footer[0].label
             = footer[1].level: footer[1].label
             = ...
+        <other groups for subdiagnostics, same as above without footers>
         */
 
         let sm = self.source_map.as_deref();

--- a/crates/interface/src/diagnostics/emitter/rustc.rs
+++ b/crates/interface/src/diagnostics/emitter/rustc.rs
@@ -344,22 +344,6 @@ impl FileWithAnnotatedLines {
         }
         output
     }
-
-    pub(crate) fn add_lines(&mut self, lines: impl IntoIterator<Item = Line>) {
-        debug_assert!(self.lines.is_sorted(), "file lines should be sorted");
-        for line in lines {
-            match self.lines.binary_search_by_key(&line.line_index, |l| l.line_index) {
-                Ok(i) => {
-                    self.lines[i].annotations.extend(line.annotations);
-                    self.lines[i].annotations.sort();
-                }
-                Err(i) => {
-                    self.lines.insert(i, line);
-                }
-            }
-        }
-        debug_assert!(self.lines.is_sorted(), "file lines should still be sorted");
-    }
 }
 
 fn num_overlap(

--- a/crates/interface/src/diagnostics/emitter/rustc.rs
+++ b/crates/interface/src/diagnostics/emitter/rustc.rs
@@ -330,7 +330,7 @@ impl FileWithAnnotatedLines {
                     add_annotation_to_file(&mut output, Arc::clone(&file), line, ann.as_line());
                 }
                 let line_end = ann.line_end - 1;
-                let end_is_empty = file.get_line(line_end - 1).is_some_and(|s| !filter(&s));
+                let end_is_empty = file.get_line(line_end - 1).is_some_and(|s| !filter(s));
                 if middle < line_end && !end_is_empty {
                     add_annotation_to_file(&mut output, Arc::clone(&file), line_end, ann.as_line());
                 }

--- a/crates/interface/src/diagnostics/emitter/rustc.rs
+++ b/crates/interface/src/diagnostics/emitter/rustc.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     SourceMap,
-    diagnostics::{Level, MultiSpan, SpanLabel},
+    diagnostics::{MultiSpan, SpanLabel},
     source_map::{Loc, SourceFile},
 };
 use std::{
@@ -14,14 +14,6 @@ use std::{
 pub(crate) struct Line {
     pub(crate) line_index: usize,
     pub(crate) annotations: Vec<Annotation>,
-}
-
-impl Line {
-    pub(crate) fn set_level(&mut self, level: Level) {
-        for ann in &mut self.annotations {
-            ann.level = Some(level);
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Default)]
@@ -87,7 +79,6 @@ impl MultilineAnnotation {
             is_primary: self.is_primary,
             label: None,
             annotation_type: AnnotationType::MultilineStart(self.depth),
-            level: None,
         }
     }
 
@@ -103,7 +94,6 @@ impl MultilineAnnotation {
             is_primary: self.is_primary,
             label: self.label.clone(),
             annotation_type: AnnotationType::MultilineEnd(self.depth),
-            level: None,
         }
     }
 
@@ -114,7 +104,6 @@ impl MultilineAnnotation {
             is_primary: self.is_primary,
             label: None,
             annotation_type: AnnotationType::MultilineLine(self.depth),
-            level: None,
         }
     }
 }
@@ -165,8 +154,6 @@ pub(crate) struct Annotation {
     /// Is this a single line, multiline or multiline span minimized down to a
     /// smaller span.
     pub(crate) annotation_type: AnnotationType,
-
-    pub(crate) level: Option<Level>,
 }
 
 #[derive(Debug)]
@@ -255,7 +242,6 @@ impl FileWithAnnotatedLines {
                     is_primary,
                     label,
                     annotation_type: AnnotationType::Singleline,
-                    level: None,
                 };
                 add_annotation_to_file(&mut output, lo.file, lo.line, ann);
             };
@@ -312,19 +298,41 @@ impl FileWithAnnotatedLines {
                 //  | |      |
                 //  | |______foo
                 //  |        baz
-                add_annotation_to_file(&mut output, file.clone(), ann.line_start, ann.as_start());
+                add_annotation_to_file(
+                    &mut output,
+                    Arc::clone(&file),
+                    ann.line_start,
+                    ann.as_start(),
+                );
                 // 4 is the minimum vertical length of a multiline span when presented: two lines
                 // of code and two lines of underline. This is not true for the special case where
                 // the beginning doesn't have an underline, but the current logic seems to be
                 // working correctly.
                 let middle = min(ann.line_start + 4, ann.line_end);
-                for line in ann.line_start + 1..middle {
+                // We'll show up to 4 lines past the beginning of the multispan start.
+                // We will *not* include the tail of lines that are only whitespace, a comment or
+                // a bare delimiter.
+                let filter = |s: &str| {
+                    let s = s.trim();
+                    // Consider comments as empty, but don't consider docstrings to be empty.
+                    !(s.starts_with("//") && !(s.starts_with("///") || s.starts_with("//!")))
+                        // Consider lines with nothing but whitespace, a single delimiter as empty.
+                        && !["", "{", "}", "(", ")", "[", "]"].contains(&s)
+                };
+                let until = (ann.line_start..middle)
+                    .rev()
+                    .filter_map(|line| file.get_line(line - 1).map(|s| (line + 1, s)))
+                    .find(|(_, s)| filter(s))
+                    .map(|(line, _)| line)
+                    .unwrap_or(ann.line_start);
+                for line in ann.line_start + 1..until {
                     // Every `|` that joins the beginning of the span (`___^`) to the end (`|__^`).
-                    add_annotation_to_file(&mut output, file.clone(), line, ann.as_line());
+                    add_annotation_to_file(&mut output, Arc::clone(&file), line, ann.as_line());
                 }
                 let line_end = ann.line_end - 1;
-                if middle < line_end {
-                    add_annotation_to_file(&mut output, file.clone(), line_end, ann.as_line());
+                let end_is_empty = file.get_line(line_end - 1).is_some_and(|s| !filter(&s));
+                if middle < line_end && !end_is_empty {
+                    add_annotation_to_file(&mut output, Arc::clone(&file), line_end, ann.as_line());
                 }
             } else {
                 end_ann.annotation_type = AnnotationType::Singleline;
@@ -335,12 +343,6 @@ impl FileWithAnnotatedLines {
             file_vec.multiline_depth = max_depth;
         }
         output
-    }
-
-    pub(crate) fn set_level(&mut self, level: Level) {
-        for line in &mut self.lines {
-            line.set_level(level);
-        }
     }
 
     pub(crate) fn add_lines(&mut self, lines: impl IntoIterator<Item = Line>) {

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -337,7 +337,7 @@ pub struct SubDiagnostic {
 impl SubDiagnostic {
     /// Formats the diagnostic messages into a single string.
     pub fn label(&self) -> Cow<'_, str> {
-        flatten_messages(&self.messages, false, self.level)
+        self.label_with_style(false)
     }
 
     /// Formats the diagnostic messages into a single string with ANSI color codes if applicable.
@@ -434,16 +434,18 @@ impl Diag {
     }
 
     /// Fields used for `PartialEq` and `Hash` implementations.
-    fn keys(&self) -> impl PartialEq + std::hash::Hash + '_ {
+    fn keys(&self) -> impl PartialEq + std::hash::Hash {
         (
             &self.level,
             &self.messages,
-            // self.args().collect(),
             &self.code,
             &self.span,
-            // &self.suggestions,
-            // (if self.is_lint { None } else { Some(&self.children) }),
             &self.children,
+            // &self.suggestions,
+            // self.args().collect(),
+            // omit self.sort_span
+            // &self.is_lint,
+            // omit self.created_at
         )
     }
 }
@@ -624,8 +626,8 @@ fn flatten_messages(messages: &[(DiagMsg, Style)], with_style: bool, level: Leve
 }
 
 fn write_fmt(output: &mut String, msg: &DiagMsg, style: &Style, level: Level) {
-    let ansi_style = style.to_color_spec(level);
-    write!(output, "{}{}{}", ansi_style.render(), msg.as_str(), ansi_style.render_reset()).unwrap();
+    let style = style.to_color_spec(level);
+    let _ = write!(output, "{style}{}{style:#}", msg.as_str());
 }
 
 #[cfg(test)]

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -268,7 +268,9 @@ impl Level {
         // https://github.com/rust-lang/rust/blob/99472c7049783605444ab888a97059d0cce93a12/compiler/rustc_errors/src/lib.rs#L1768
         match self {
             Self::Bug | Self::Fatal | Self::Error => Some(AnsiColor::BrightRed),
-            Self::Warning => Some(AnsiColor::BrightYellow),
+            Self::Warning => {
+                Some(if cfg!(windows) { AnsiColor::BrightYellow } else { AnsiColor::Yellow })
+            }
             Self::Note | Self::OnceNote => Some(AnsiColor::BrightGreen),
             Self::Help | Self::OnceHelp => Some(AnsiColor::BrightCyan),
             Self::FailureNote | Self::Allow => None,

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -224,7 +224,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     self.dcx()
                         .err(msg)
                         .span(span)
-                        .span_note(prev.span, "previous definition")
+                        .span_label(prev.span, "previous definition")
                         .emit();
                 } else {
                     let mut v = Some(visibility);
@@ -243,7 +243,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     self.dcx()
                         .err(msg)
                         .span(span)
-                        .span_note(prev.span, "previous definition")
+                        .span_label(prev.span, "previous definition")
                         .emit();
                 } else {
                     let mut sm = Some(state_mutability);
@@ -263,7 +263,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     self.dcx().err(msg).span(span).emit();
                 } else if let Some(prev) = header.virtual_ {
                     let msg = "virtual already specified";
-                    self.dcx().err(msg).span(span).span_note(prev, "previous definition").emit();
+                    self.dcx().err(msg).span(span).span_label(prev, "previous definition").emit();
                 } else {
                     header.virtual_ = Some(span);
                 }
@@ -278,7 +278,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     self.dcx()
                         .err(msg)
                         .span(span)
-                        .span_note(prev.span, "previous definition")
+                        .span_label(prev.span, "previous definition")
                         .emit();
                 } else {
                     header.override_ = Some(o);
@@ -366,7 +366,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     self.dcx()
                         .err(msg)
                         .span(span(new_bases))
-                        .span_note(span(prev), "previous definition")
+                        .span_label(span(prev), "previous definition")
                         .emit();
                 } else if !new_bases.is_empty() {
                     bases = Some(new_bases);
@@ -378,7 +378,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     self.dcx()
                         .err(msg)
                         .span(new_layout.span)
-                        .span_note(prev.span, "previous definition")
+                        .span_label(prev.span, "previous definition")
                         .emit();
                 } else {
                     layout = Some(new_layout);

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -91,10 +91,10 @@ impl<'gcx> ConstantEvaluator<'gcx> {
             // hir::ExprKind::Member(_, _) => unimplemented!(),
             // hir::ExprKind::New(_) => unimplemented!(),
             // hir::ExprKind::Payable(_) => unimplemented!(),
-            hir::ExprKind::Ternary(cond, t, f) => {
-                let cond = self.try_eval(cond)?;
-                Ok(if cond.to_bool() { self.try_eval(t)? } else { self.try_eval(f)? })
-            }
+            // hir::ExprKind::Ternary(cond, t, f) => {
+            //     let cond = self.try_eval(cond)?;
+            //     Ok(if cond.to_bool() { self.try_eval(t)? } else { self.try_eval(f)? })
+            // }
             // hir::ExprKind::Tuple(_) => unimplemented!(),
             // hir::ExprKind::TypeCall(_) => unimplemented!(),
             // hir::ExprKind::Type(_) => unimplemented!(),

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -205,7 +205,7 @@ impl IntScalar {
             | hir::BinOpKind::Eq
             | hir::BinOpKind::Ne
             | hir::BinOpKind::Or
-            | hir::BinOpKind::And => return Err(EE::UnsupportedBinaryOp.into()),
+            | hir::BinOpKind::And => return Err(EE::UnsupportedBinaryOp),
         })
     }
 }

--- a/tests/ui/lexer/string_escapes_crlf.stderr
+++ b/tests/ui/lexer/string_escapes_crlf.stderr
@@ -3,98 +3,97 @@ error: invalid hex digit
    |
 LL | bytes constant s = hex"\
    |                        ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
 LL | bytes constant s = hex"\
    |                         ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL | bytes constant s = hex"\
-   |                         ^
-   |
+LL |   bytes constant s = hex"\
+   |  _________________________^
+LL | | ";
+   | |_^
 
 error: cannot skip multiple lines with `\`
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL |
-   | ^
-   |
+LL | /
+LL | | ";
+   | |_^
 
 error: cannot skip multiple lines with `\`
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL |
-   | ^
-   |
+LL | /
+LL | | ";
+   | |_^
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
 LL | bytes constant s = hex"\
    |                        ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
 LL | bytes constant s = hex"\
    |                         ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL | bytes constant s = hex"\
-   |                         ^
-   |
-
-error: invalid hex digit
-  --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   |
-LL | ...
-   |^
-   |
+LL |   bytes constant s = hex"\
+   |  _________________________^
+LL | |
+   | |_^
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
 LL |
    | ^
+
+error: invalid hex digit
+  --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
+LL | /
+LL | | ";
+   | |_^
 
 error: unescaped newline
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL | string constant s = "
-   |                      ^
-   |
+LL |   string constant s = "
+   |  ______________________^
+LL | | ";
+   | |_^
 
 error: unescaped newline
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL | string constant s = unicode"
-   |                             ^
-   |
+LL |   string constant s = unicode"
+   |  _____________________________^
+LL | | ";
+   | |_^
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
 LL | bytes constant s = hex"
    |                        ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    |
-LL | bytes constant s = hex"
-   |                        ^
-   |
+LL |   bytes constant s = hex"
+   |  ________________________^
+LL | | ";
+   | |_^
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/lexer/string_escapes_lf.stderr
+++ b/tests/ui/lexer/string_escapes_lf.stderr
@@ -3,70 +3,73 @@ error: invalid hex digit
    |
 LL | bytes constant s = hex"\
    |                        ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL | bytes constant s = hex"\
-   |                         ^
-   |
+LL |   bytes constant s = hex"\
+   |  _________________________^
+LL | | ";
+   | |_^
 
 error: cannot skip multiple lines with `\`
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL |
-   | ^
-   |
+LL | /
+LL | | ";
+   | |_^
 
 error: cannot skip multiple lines with `\`
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL |
-   | ^
-   |
+LL | /
+LL | | ";
+   | |_^
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
 LL | bytes constant s = hex"\
    |                        ^
-   |
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL | bytes constant s = hex"\
-   |                         ^
-   |
+LL |   bytes constant s = hex"\
+   |  _________________________^
+LL | |
+   | |_^
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL |
-   | ^
-   |
+LL | /
+LL | | ";
+   | |_^
 
 error: unescaped newline
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL | string constant s = "
-   |                      ^
-   |
+LL |   string constant s = "
+   |  ______________________^
+LL | | ";
+   | |_^
 
 error: unescaped newline
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL | string constant s = unicode"
-   |                             ^
-   |
+LL |   string constant s = unicode"
+   |  _____________________________^
+LL | | ";
+   | |_^
 
 error: invalid hex digit
   --> ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    |
-LL | bytes constant s = hex"
-   |                        ^
-   |
+LL |   bytes constant s = hex"
+   |  ________________________^
+LL | | ";
+   | |_^
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/lexer/unterminated_hex_string.stderr
+++ b/tests/ui/lexer/unterminated_hex_string.stderr
@@ -5,7 +5,6 @@ LL | / hex"
 LL | |
 LL | |
    | |_________________________________^
-   |
 
 error: expected global item (pragma, import directive, contract, interface, library, struct, enum, constant, function, modifier, or error definition), found `<error>`
   --> ROOT/tests/ui/lexer/unterminated_hex_string.sol:LL:CC

--- a/tests/ui/lexer/unterminated_string.stderr
+++ b/tests/ui/lexer/unterminated_string.stderr
@@ -5,7 +5,6 @@ LL | / "
 LL | |
 LL | |
    | |_________________________________^
-   |
 
 error: expected global item (pragma, import directive, contract, interface, library, struct, enum, constant, function, modifier, or error definition), found `<error>`
   --> ROOT/tests/ui/lexer/unterminated_string.sol:LL:CC

--- a/tests/ui/lexer/unterminated_unicode_string.stderr
+++ b/tests/ui/lexer/unterminated_unicode_string.stderr
@@ -5,7 +5,6 @@ LL | / unicode"
 LL | |
 LL | |
    | |_________________________________^
-   |
 
 error: expected global item (pragma, import directive, contract, interface, library, struct, enum, constant, function, modifier, or error definition), found `<error>`
   --> ROOT/tests/ui/lexer/unterminated_unicode_string.sol:LL:CC

--- a/tests/ui/parser/already_specified.sol
+++ b/tests/ui/parser/already_specified.sol
@@ -1,0 +1,33 @@
+contract C
+    is A
+    is B //~ ERROR: base contracts already specified
+    layout at 0
+    layout at 1 //~ ERROR: storage layout already specified
+{
+    function f()
+    public
+    private //~ ERROR: visibility already specified
+
+    view
+    pure //~ ERROR: state mutability already specified
+
+    virtual
+    virtual //~ ERROR: virtual already specified
+
+    override
+    override //~ ERROR: override already specified
+    {}
+
+    uint
+    public
+    private //~ ERROR: visibility already specified
+
+    constant
+    immutable //~ ERROR: mutability already specified
+
+    virtual //~ ERROR: `virtual` is not allowed here
+
+    override
+    override //~ ERROR: override already specified
+    x = 0;
+}

--- a/tests/ui/parser/already_specified.stderr
+++ b/tests/ui/parser/already_specified.stderr
@@ -1,0 +1,74 @@
+error: base contracts already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     is A
+   |        - previous definition
+LL |     is B
+   |        ^
+
+error: storage layout already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     layout at 0
+   |     ----------- previous definition
+LL |     layout at 1
+   |     ^^^^^^^^^^^
+
+error: visibility already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     public
+   |     ------ previous definition
+LL |     private
+   |     ^^^^^^^
+
+error: state mutability already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     view
+   |     ---- previous definition
+LL |     pure
+   |     ^^^^
+
+error: virtual already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     virtual
+   |     ------- previous definition
+LL |     virtual
+   |     ^^^^^^^
+
+error: override already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     override
+   |     -------- previous definition
+LL |     override
+   |     ^^^^^^^^
+
+error: visibility already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     private
+   |     ^^^^^^^
+
+error: mutability already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     immutable
+   |     ^^^^^^^^^
+
+error: `virtual` is not allowed here
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     virtual
+   |     ^^^^^^^
+
+error: override already specified
+  --> ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   |
+LL |     override
+   |     ^^^^^^^^
+
+error: aborting due to 10 previous errors
+

--- a/tests/ui/parser/big_literal.stderr
+++ b/tests/ui/parser/big_literal.stderr
@@ -3,7 +3,6 @@ error: integer part too large
    |
 LL | uint constant tooBigLiteral = 115792089237316195423570985008687907853269984665640564039457584007913129639936;
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/break_continue_outside_loop.stderr
+++ b/tests/ui/parser/break_continue_outside_loop.stderr
@@ -3,56 +3,48 @@ error: `break` outside of a loop
    |
 LL |     break;
    |     ^^^^^^
-   |
 
 error: `continue` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |     continue;
    |     ^^^^^^^^^
-   |
 
 error: `break` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |         break;
    |         ^^^^^^
-   |
 
 error: `continue` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |         continue;
    |         ^^^^^^^^^
-   |
 
 error: `break` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |         break;
    |         ^^^^^^
-   |
 
 error: `continue` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |         continue;
    |         ^^^^^^^^^
-   |
 
 error: `break` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |             break;
    |             ^^^^^^
-   |
 
 error: `continue` outside of a loop
   --> ROOT/tests/ui/parser/break_continue_outside_loop.sol:LL:CC
    |
 LL |             continue;
    |             ^^^^^^^^^
-   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/empty_call_opts.stderr
+++ b/tests/ui/parser/empty_call_opts.stderr
@@ -3,7 +3,6 @@ error: expected one of `(`, `.`, `;`, `?`, or `[`, found `{`
    |
 LL |     f{}();
    |      ^ expected one of `(`, `.`, `;`, `?`, or `[`
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/escaped_import.stderr
+++ b/tests/ui/parser/escaped_import.stderr
@@ -3,7 +3,6 @@ error: unknown character escape
    |
 LL | import "\?";
    |          ^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/multiline_error.stderr
+++ b/tests/ui/parser/multiline_error.stderr
@@ -2,13 +2,10 @@ error: expected one of `(`, `.`, `;`, `?`, `[`, or `{`, found keyword `new`
   --> ROOT/tests/ui/parser/multiline_error.sol:LL:CC
    |
 LL |         new string[](3)
-   |                        ^ expected one of `(`, `.`, `;`, `?`, `[`, or `{`
-LL |      
-LL |  
-LL |
+   |                        - expected one of `(`, `.`, `;`, `?`, `[`, or `{`
+...
 LL |         new string[](4)
    |         ^^^ unexpected token
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/non_existant_import.stderr
+++ b/tests/ui/parser/non_existant_import.stderr
@@ -3,7 +3,6 @@ error: file doesnotexist not found
    |
 LL | import "doesnotexist";
    |        ^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/non_utf8_import.stderr
+++ b/tests/ui/parser/non_utf8_import.stderr
@@ -3,7 +3,6 @@ error: couldn't read ROOT/tests/ui/parser/auxiliary/non_utf8.sol: stream did not
    |
 LL | import "./auxiliary/non_utf8.sol";
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/old_fallback.stderr
+++ b/tests/ui/parser/old_fallback.stderr
@@ -10,10 +10,9 @@ error: expected one of `(`, `.`, `;`, `?`, `[`, `payable`, `pure`, `view`, or `{
   --> ROOT/tests/ui/parser/old_fallback.sol:LL:CC
    |
 LL |         uint
-   |             ^ expected one of 9 possible tokens
+   |             - expected one of 9 possible tokens
 LL |     }
    |     ^ unexpected token
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/payable_fallback_without_receive.stderr
+++ b/tests/ui/parser/payable_fallback_without_receive.stderr
@@ -2,21 +2,17 @@ warning[3628]: contract has a payable fallback function, but no receive ether fu
   --> ROOT/tests/ui/parser/payable_fallback_without_receive.sol:LL:CC
    |
 LL | contract P1 {
-   |          --
+   |          ^^
 LL |
 LL |     fallback() external payable {}
-   |     -------- help: consider changing `fallback` to `receive`
-   |
+   |     -------- consider changing `fallback` to `receive`
 
 warning[3628]: contract has a payable fallback function, but no receive ether function
   --> ROOT/tests/ui/parser/payable_fallback_without_receive.sol:LL:CC
    |
 LL |     fallback() external payable {}
-   |     -------- help: consider changing `fallback` to `receive`
-LL |
+   |     -------- consider changing `fallback` to `receive`
 ...
-LL |
 LL | contract P4 is P1 {}
-   |          --
-   |
+   |          ^^
 

--- a/tests/ui/parser/payable_fallback_without_receive.stderr
+++ b/tests/ui/parser/payable_fallback_without_receive.stderr
@@ -3,16 +3,22 @@ warning[3628]: contract has a payable fallback function, but no receive ether fu
    |
 LL | contract P1 {
    |          ^^
-LL |
+   |
+help: consider changing `fallback` to `receive`
+  --> ROOT/tests/ui/parser/payable_fallback_without_receive.sol:LL:CC
+   |
 LL |     fallback() external payable {}
-   |     -------- consider changing `fallback` to `receive`
+   |     ^^^^^^^^
 
 warning[3628]: contract has a payable fallback function, but no receive ether function
   --> ROOT/tests/ui/parser/payable_fallback_without_receive.sol:LL:CC
    |
-LL |     fallback() external payable {}
-   |     -------- consider changing `fallback` to `receive`
-...
 LL | contract P4 is P1 {}
    |          ^^
+   |
+help: consider changing `fallback` to `receive`
+  --> ROOT/tests/ui/parser/payable_fallback_without_receive.sol:LL:CC
+   |
+LL |     fallback() external payable {}
+   |     ^^^^^^^^
 

--- a/tests/ui/parser/pragma_unknown.stderr
+++ b/tests/ui/parser/pragma_unknown.stderr
@@ -3,42 +3,36 @@ error: unknown pragma
    |
 LL | pragma foo bar;
    | ^^^^^^^^^^^^^^^
-   |
 
 error: unknown pragma
   --> ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
    |
 LL | pragma amogus;
    | ^^^^^^^^^^^^^^
-   |
 
 error: unknown pragma
   --> ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
    |
 LL | pragma amogus sus;
    | ^^^^^^^^^^^^^^^^^^
-   |
 
 error: unknown pragma
   --> ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
    |
 LL | pragma amogus 69;
    | ^^^^^^^^^^^^^^^^^
-   |
 
 error: unknown pragma
   --> ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
    |
 LL | pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: only `solidity` is supported as a version pragma
   --> ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
    |
 LL | pragma amogus 0.8.15;
    |        ^^^^^^
-   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/pragma_versions.stderr
+++ b/tests/ui/parser/pragma_versions.stderr
@@ -3,112 +3,96 @@ error: unexpected trailing characters
    |
 LL | pragma solidity xX*x***X*X;
    |                  ^
-   |
 
 error: expected version number
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity xX*x***X*X;
    |                     ^^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity xX*x***X*X;
    |                     ^^
-   |
 
 error: version number too large
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity ^4294967296;
    |                            ^
-   |
 
 error: version number too large
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity ^0.4294967296;
    |                              ^
-   |
 
 error: expected version number
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0.;
    |                   ^
-   |
 
 error: expected version number
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0.0.;
    |                     ^
-   |
 
 error: expected version number
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity .0;
    |                 ^^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity .0;
    |                  ^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 88_;
    |                   ^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 88_e3;
    |                   ^^^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0e1.0;
    |                  ^^
-   |
 
 error: expected version number
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0e1.0;
    |                    ^^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0e1.0;
    |                     ^
-   |
 
 error: unexpected trailing characters
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0.0e1;
    |                    ^^
-   |
 
 error: ranges can only be combined using the || operator
   --> ROOT/tests/ui/parser/pragma_versions.sol:LL:CC
    |
 LL | pragma solidity 0 - 1 0 - 2;
    | ^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/parser/returns_empty_parens.stderr
+++ b/tests/ui/parser/returns_empty_parens.stderr
@@ -3,7 +3,6 @@ error: expected one of `function`, `mapping`, elementary type name, or path, fou
    |
 LL | function f() returns() {}
    |                      ^ expected one of `function`, `mapping`, elementary type name, or path
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/returns_no_parens.stderr
+++ b/tests/ui/parser/returns_no_parens.stderr
@@ -3,7 +3,6 @@ error: expected `(`, found `{`
    |
 LL | function f() returns {}
    |                      ^ expected `(`
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/span_visitor.stderr
+++ b/tests/ui/parser/span_visitor.stderr
@@ -3,46 +3,41 @@ note: span #1
    |
 LL | / contract SpanVisitorTest {
 LL | |     uint256 x;
+LL | |     
+LL | |     function foo() public {
 ...  |
-LL | |     }
 LL | | }
-   | |_-
-   |
+   | |_^
 
 note: span #2
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL | contract SpanVisitorTest {
-   |          ---------------
-   |
+   |          ^^^^^^^^^^^^^^^
 
 note: span #3
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     uint256 x;
-   |     ----------
-   |
+   |     ^^^^^^^^^^
 
 note: span #4
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     uint256 x;
-   |     ----------
-   |
+   |     ^^^^^^^^^^
 
 note: span #5
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     uint256 x;
-   |     -------
-   |
+   |     ^^^^^^^
 
 note: span #6
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     uint256 x;
-   |             -
-   |
+   |             ^
 
 note: span #7
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
@@ -50,96 +45,83 @@ note: span #7
 LL | /     function foo() public {
 LL | |         x = 42;
 LL | |     }
-   | |_____-
-   |
+   | |_____^
 
 note: span #8
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     function foo() public {
-   |     ---------------------
-   |
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
 note: span #9
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     function foo() public {
-   |              ---
-   |
+   |              ^^^
 
 note: span #10
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     function foo() public {
-   |                 --
-   |
+   |                 ^^
 
 note: span #11
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |     function foo() public {
-   |                    ------
-   |
+   |                    ^^^^^^
 
 note: span #12
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |       function foo() public {
-   |  ___________________________-
+   |  ___________________________^
 LL | |         x = 42;
 LL | |     }
-   | |_____-
-   |
+   | |_____^
 
 note: span #13
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |         x = 42;
-   |         -------
-   |
+   |         ^^^^^^^
 
 note: span #14
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |         x = 42;
-   |         ------
-   |
+   |         ^^^^^^
 
 note: span #15
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |         x = 42;
-   |         -
-   |
+   |         ^
 
 note: span #16
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |         x = 42;
-   |         -
-   |
+   |         ^
 
 note: span #17
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |         x = 42;
-   |             --
-   |
+   |             ^^
 
 note: span #18
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |         x = 42;
-   |             --
-   |
+   |             ^^
 
 note: span #19
   --> ROOT/tests/ui/parser/span_visitor.sol:LL:CC
    |
 LL |       function foo() public {
-   |  ___________________________-
+   |  ___________________________^
 LL | |         x = 42;
 LL | |     }
-   | |_____-
-   |
+   | |_____^
 

--- a/tests/ui/parser/trailing_dot.stderr
+++ b/tests/ui/parser/trailing_dot.stderr
@@ -3,7 +3,6 @@ error: empty rational
    |
 LL | uint256 constant a = 2 + 2.;
    |                          ^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/trailing_separators.stderr
+++ b/tests/ui/parser/trailing_separators.stderr
@@ -2,24 +2,21 @@ error: expected `;`, found `}`
   --> ROOT/tests/ui/parser/trailing_separators.sol:LL:CC
    |
 LL |     uint x
-   |           ^ expected `;`
+   |           - expected `;`
 LL | }
    | ^ unexpected token
-   |
 
 error: trailing `,` separator is not allowed
   --> ROOT/tests/ui/parser/trailing_separators.sol:LL:CC
    |
 LL |     V,
    |      ^
-   |
 
 error: trailing `,` separator is not allowed
   --> ROOT/tests/ui/parser/trailing_separators.sol:LL:CC
    |
 LL | function f(E arg,) {
    |                 ^
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/transient.stderr
+++ b/tests/ui/parser/transient.stderr
@@ -3,7 +3,6 @@ error: data location can only be specified for array, struct or mapping types
    |
 LL |     function g(uint256 transient transient) external {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: invalid data location `transient`
   --> ROOT/tests/ui/parser/transient.sol:LL:CC

--- a/tests/ui/parser/using.stderr
+++ b/tests/ui/parser/using.stderr
@@ -3,28 +3,24 @@ error: the type has to be specified explicitly at file level (cannot use `*`)
    |
 LL | using {f} for * global;
    | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: can only globally attach functions to specific types
   --> ROOT/tests/ui/parser/using.sol:LL:CC
    |
 LL | using {f} for * global;
    | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: `global` can only be used at file level
   --> ROOT/tests/ui/parser/using.sol:LL:CC
    |
 LL |     using {f} for uint global;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: the `using for` directive is not allowed inside interfaces
   --> ROOT/tests/ui/parser/using.sol:LL:CC
    |
 LL |     using L for int;
    |     ^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/parser/yul/function_arrow.stderr
+++ b/tests/ui/parser/yul/function_arrow.stderr
@@ -3,7 +3,6 @@ error: expected identifier, found `{`
    |
 LL |     function f() -> {}
    |                     ^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/yul_kws_err.stderr
+++ b/tests/ui/parser/yul_kws_err.stderr
@@ -3,28 +3,24 @@ error: expected identifier, found Yul EVM builtin keyword `number`
    |
 LL |             number := 0
    |             ^^^^^^
-   |
 
 error: expected identifier, found Yul EVM builtin keyword `number`
   --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
    |
 LL |             number, number := some_call()
    |             ^^^^^^
-   |
 
 error: expected identifier, found Yul EVM builtin keyword `number`
   --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
    |
 LL |             number, number := some_call()
    |                     ^^^^^^
-   |
 
 error: expected identifier, found Yul EVM builtin keyword `number`
   --> ROOT/tests/ui/parser/yul_kws_err.sol:LL:CC
    |
 LL |             let number := 0
    |                 ^^^^^^
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/resolve/bad_inheritance.stderr
+++ b/tests/ui/resolve/bad_inheritance.stderr
@@ -3,42 +3,36 @@ error: declaration `does_not_exist` not found in ROOT/tests/ui/resolve/bad_inher
    |
 LL | import {does_not_exist} from "./bad_inheritance.sol";
    |         ^^^^^^^^^^^^^^
-   |
 
 error: contracts cannot inherit from themselves
   --> ROOT/tests/ui/resolve/bad_inheritance.sol:LL:CC
    |
 LL | contract C is C {}
    |               ^
-   |
 
 error: contracts cannot inherit from themselves
   --> ROOT/tests/ui/resolve/bad_inheritance.sol:LL:CC
    |
 LL | contract D is self1.D {}
    |               ^^^^^^^
-   |
 
 error: contracts cannot inherit from themselves
   --> ROOT/tests/ui/resolve/bad_inheritance.sol:LL:CC
    |
 LL | contract E is self2.E {}
    |               ^^^^^^^
-   |
 
 error: expected contract, found namespace
   --> ROOT/tests/ui/resolve/bad_inheritance.sol:LL:CC
    |
 LL | contract F is self1 {}
    |               ^^^^^
-   |
 
 error: expected contract, found namespace
   --> ROOT/tests/ui/resolve/bad_inheritance.sol:LL:CC
    |
 LL | contract G is self2 {}
    |               ^^^^^
-   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/resolve/bad_type_path.stderr
+++ b/tests/ui/resolve/bad_type_path.stderr
@@ -2,40 +2,34 @@ error: identifier `S2` already declared
   --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
    |
 LL | struct S2 {
-   |        -- note: previous declaration declared here
-LL |     uint x;
-LL | }
+   |        -- previous declaration declared here
+...
 LL | struct S2 {
    |        ^^
-   |
 
 error: `S` is a struct, which cannot be indexed in type paths
   --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
    |
 LL |     S.x s2;
    |     ^
-   |
 
 error: `S2` is a struct, which cannot be indexed in type paths
   --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
    |
 LL |     S2.x s4;
    |     ^^
-   |
 
 error: symbol `f` resolved to multiple declarations
   --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
    |
 LL |     f f1;
    |     ^
-   |
 
 error: symbol `f` resolved to multiple declarations
   --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
    |
 LL |     f.x f2;
    |     ^
-   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/bad_type_path.stderr
+++ b/tests/ui/resolve/bad_type_path.stderr
@@ -2,8 +2,11 @@ error: identifier `S2` already declared
   --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
    |
 LL | struct S2 {
-   |        -- previous declaration declared here
-...
+   |        ^^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/bad_type_path.sol:LL:CC
+   |
 LL | struct S2 {
    |        ^^
 

--- a/tests/ui/resolve/base_constructor.stderr
+++ b/tests/ui/resolve/base_constructor.stderr
@@ -3,16 +3,14 @@ error: modifier-style base constructor call without arguments
    |
 LL |     constructor() NoArgs {}
    |                   ^^^^^^
-   |
 
 error: base constructor arguments given twice
   --> ROOT/tests/ui/resolve/base_constructor.sol:LL:CC
    |
 LL | contract J is WithArgs(1337) {
-   |               -------------- help: previous declaration
+   |               -------------- previous declaration
 LL |     constructor() WithArgs(1337) {}
    |                   ^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/base_constructor.stderr
+++ b/tests/ui/resolve/base_constructor.stderr
@@ -7,10 +7,14 @@ LL |     constructor() NoArgs {}
 error: base constructor arguments given twice
   --> ROOT/tests/ui/resolve/base_constructor.sol:LL:CC
    |
-LL | contract J is WithArgs(1337) {
-   |               -------------- previous declaration
 LL |     constructor() WithArgs(1337) {}
    |                   ^^^^^^^^^^^^^^
+   |
+help: previous declaration
+  --> ROOT/tests/ui/resolve/base_constructor.sol:LL:CC
+   |
+LL | contract J is WithArgs(1337) {
+   |               ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/base_scope.stderr
+++ b/tests/ui/resolve/base_scope.stderr
@@ -3,7 +3,6 @@ error: unresolved symbol `x`
    |
 LL | contract D is C(x) {
    |                 ^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/conflicts.stderr
+++ b/tests/ui/resolve/conflicts.stderr
@@ -2,40 +2,34 @@ error: identifier `Er1` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
 LL | error Er1(uint);
-   |       --- note: previous declaration declared here
+   |       --- previous declaration declared here
 LL | error Er1(int);
    |       ^^^
-   |
 
 error: identifier `C` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
 LL | contract C {
-   |          - note: previous declaration declared here
-LL |     // OK
+   |          - previous declaration declared here
 ...
-LL |
 LL | contract C {}
    |          ^
-   |
 
 error: identifier `m` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
 LL |     modifier m(uint) { _; }
-   |              - note: previous declaration declared here
+   |              - previous declaration declared here
 LL |     modifier m(int) { _; }
    |              ^
-   |
 
 error: identifier `Er2` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
 LL |     error Er2(uint);
-   |           --- note: previous declaration declared here
+   |           --- previous declaration declared here
 LL |     error Er2(int);
    |           ^^^
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/resolve/conflicts.stderr
+++ b/tests/ui/resolve/conflicts.stderr
@@ -1,34 +1,49 @@
 error: identifier `Er1` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
-LL | error Er1(uint);
-   |       --- previous declaration declared here
 LL | error Er1(int);
+   |       ^^^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
+   |
+LL | error Er1(uint);
    |       ^^^
 
 error: identifier `C` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
-LL | contract C {
-   |          - previous declaration declared here
-...
 LL | contract C {}
+   |          ^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
+   |
+LL | contract C {
    |          ^
 
 error: identifier `m` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
-LL |     modifier m(uint) { _; }
-   |              - previous declaration declared here
 LL |     modifier m(int) { _; }
+   |              ^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
+   |
+LL |     modifier m(uint) { _; }
    |              ^
 
 error: identifier `Er2` already declared
   --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
    |
-LL |     error Er2(uint);
-   |           --- previous declaration declared here
 LL |     error Er2(int);
+   |           ^^^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/conflicts.sol:LL:CC
+   |
+LL |     error Er2(uint);
    |           ^^^
 
 error: aborting due to 4 previous errors

--- a/tests/ui/resolve/contract_special_functions.stderr
+++ b/tests/ui/resolve/contract_special_functions.stderr
@@ -2,85 +2,76 @@ error: constructor function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     constructor() {}
-   |     ---------------- note: previous declaration here
+   |     ---------------- previous declaration here
 LL |     constructor() {}
    |     ^^^^^^^^^^^^^^^^
-   |
 
 error: fallback function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     fallback() external {}
-   |     ---------------------- note: previous declaration here
+   |     ---------------------- previous declaration here
 LL |     fallback() external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: receive function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- note: previous declaration here
+   |     ----------------------------- previous declaration here
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: constructor function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     constructor() {}
-   |     ---------------- note: previous declaration here
+   |     ---------------- previous declaration here
 LL |     constructor() {}
    |     ^^^^^^^^^^^^^^^^
-   |
 
 error: constructor function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     constructor() {}
-   |     ---------------- note: previous declaration here
+   |     ---------------- previous declaration here
 LL |     constructor() {}
 LL |     constructor() {}
    |     ^^^^^^^^^^^^^^^^
-   |
 
 error: fallback function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     fallback() external {}
-   |     ---------------------- note: previous declaration here
+   |     ---------------------- previous declaration here
 LL |     fallback() external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: fallback function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     fallback() external {}
-   |     ---------------------- note: previous declaration here
+   |     ---------------------- previous declaration here
 LL |     fallback() external {}
 LL |     fallback() external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: receive function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- note: previous declaration here
+   |     ----------------------------- previous declaration here
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: receive function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- note: previous declaration here
+   |     ----------------------------- previous declaration here
 LL |     receive() external payable {}
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/resolve/contract_special_functions.stderr
+++ b/tests/ui/resolve/contract_special_functions.stderr
@@ -2,7 +2,11 @@ error: constructor function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     constructor() {}
-   |     ---------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     constructor() {}
    |     ^^^^^^^^^^^^^^^^
 
@@ -10,7 +14,11 @@ error: fallback function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     fallback() external {}
-   |     ---------------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     fallback() external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -18,7 +26,11 @@ error: receive function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -26,7 +38,11 @@ error: constructor function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     constructor() {}
-   |     ---------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     constructor() {}
    |     ^^^^^^^^^^^^^^^^
 
@@ -34,8 +50,11 @@ error: constructor function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     constructor() {}
-   |     ---------------- previous declaration here
-LL |     constructor() {}
+   |     ^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     constructor() {}
    |     ^^^^^^^^^^^^^^^^
 
@@ -43,7 +62,11 @@ error: fallback function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     fallback() external {}
-   |     ---------------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     fallback() external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -51,8 +74,11 @@ error: fallback function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     fallback() external {}
-   |     ---------------------- previous declaration here
-LL |     fallback() external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     fallback() external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -60,7 +86,11 @@ error: receive function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -68,8 +98,11 @@ error: receive function already declared
   --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- previous declaration here
-LL |     receive() external payable {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/resolve/contract_special_functions.sol:LL:CC
+   |
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/resolve/denominations.stderr
+++ b/tests/ui/resolve/denominations.stderr
@@ -19,7 +19,6 @@ error: using "years" as a unit denomination is deprecated
    |
 LL |     uint256 public h = 1 years;
    |                        ^^^^^^^
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/resolve/func_modifiers.stderr
+++ b/tests/ui/resolve/func_modifiers.stderr
@@ -3,14 +3,12 @@ error: functions without implementation cannot have modifiers
    |
 LL |     function updateState() external virtual x;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: functions in interfaces cannot have modifiers
   --> ROOT/tests/ui/resolve/func_modifiers.sol:LL:CC
    |
 LL |     function j() external x;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/func_ty_named_params.stderr
+++ b/tests/ui/resolve/func_ty_named_params.stderr
@@ -2,15 +2,13 @@ warning[6162]: named function type parameters are deprecated
   --> ROOT/tests/ui/resolve/func_ty_named_params.sol:LL:CC
    |
 LL |         function(uint256) view returns (uint256 j) c;
-   |                                                 -
-   |
+   |                                                 ^
 
 warning[6162]: named function type parameters are deprecated
   --> ROOT/tests/ui/resolve/func_ty_named_params.sol:LL:CC
    |
 LL |         function(uint256 k) view returns (uint256) d;
-   |                          -
-   |
+   |                          ^
 
 error: return parameters in function types may not be named
   --> ROOT/tests/ui/resolve/func_ty_named_params.sol:LL:CC
@@ -18,8 +16,7 @@ error: return parameters in function types may not be named
 LL |         function(uint256) view returns (uint256 j) c;
    |                                         ^^^^^^^^-
    |                                                 |
-   |                                                 help: remove `j`
-   |
+   |                                                 remove `j`
 
 error: aborting due to 1 previous error; 2 warnings emitted
 

--- a/tests/ui/resolve/func_ty_named_params.stderr
+++ b/tests/ui/resolve/func_ty_named_params.stderr
@@ -14,9 +14,13 @@ error: return parameters in function types may not be named
   --> ROOT/tests/ui/resolve/func_ty_named_params.sol:LL:CC
    |
 LL |         function(uint256) view returns (uint256 j) c;
-   |                                         ^^^^^^^^-
-   |                                                 |
-   |                                                 remove `j`
+   |                                         ^^^^^^^^^
+   |
+help: remove `j`
+  --> ROOT/tests/ui/resolve/func_ty_named_params.sol:LL:CC
+   |
+LL |         function(uint256) view returns (uint256 j) c;
+   |                                                 ^
 
 error: aborting due to 1 previous error; 2 warnings emitted
 

--- a/tests/ui/resolve/func_visibility.stderr
+++ b/tests/ui/resolve/func_visibility.stderr
@@ -43,7 +43,6 @@ error: free functions must be implemented
    |
 LL | function xyz();
    | ^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/resolve/getters_complex.stderr
+++ b/tests/ui/resolve/getters_complex.stderr
@@ -4,8 +4,7 @@ error: getter must return at least one value
 LL |     mapping(uint256 => B) public mapB;
    |     ^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^
    |                        |
-   |                        note: the struct has all its members omitted, therefore the getter cannot return any values
-   |
+   |                        the struct has all its members omitted, therefore the getter cannot return any values
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/getters_complex.stderr
+++ b/tests/ui/resolve/getters_complex.stderr
@@ -2,9 +2,13 @@ error: getter must return at least one value
   --> ROOT/tests/ui/resolve/getters_complex.sol:LL:CC
    |
 LL |     mapping(uint256 => B) public mapB;
-   |     ^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^
-   |                        |
-   |                        the struct has all its members omitted, therefore the getter cannot return any values
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the struct has all its members omitted, therefore the getter cannot return any values
+  --> ROOT/tests/ui/resolve/getters_complex.sol:LL:CC
+   |
+LL |     mapping(uint256 => B) public mapB;
+   |                        ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/import_conflicts.stderr
+++ b/tests/ui/resolve/import_conflicts.stderr
@@ -2,12 +2,10 @@ error: identifier `MyUdvt` already declared
   --> ROOT/tests/ui/resolve/import_conflicts.sol:LL:CC
    |
 LL | import {MyUdvt, MyUdvt as MyUdvt} from "./auxiliary/udvt.sol";
-   |         ------ note: previous declaration declared here
-LL | import {MyUdvt as MyUdvt2, MyUdvt as MyUdvt2} from "./auxiliary/udvt.sol";
-LL |
+   |         ------ previous declaration declared here
+...
 LL | import "./auxiliary/udvt.sol" as MyUdvt;
    |                                  ^^^^^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/import_conflicts.stderr
+++ b/tests/ui/resolve/import_conflicts.stderr
@@ -1,11 +1,14 @@
 error: identifier `MyUdvt` already declared
   --> ROOT/tests/ui/resolve/import_conflicts.sol:LL:CC
    |
-LL | import {MyUdvt, MyUdvt as MyUdvt} from "./auxiliary/udvt.sol";
-   |         ------ previous declaration declared here
-...
 LL | import "./auxiliary/udvt.sol" as MyUdvt;
    |                                  ^^^^^^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/import_conflicts.sol:LL:CC
+   |
+LL | import {MyUdvt, MyUdvt as MyUdvt} from "./auxiliary/udvt.sol";
+   |         ^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/import_glob_conflicts.stderr
+++ b/tests/ui/resolve/import_glob_conflicts.stderr
@@ -1,15 +1,19 @@
 error: identifier `MyUdvt` already declared
   --> ROOT/tests/ui/resolve/import_glob_conflicts.sol:LL:CC
    |
-LL | import "./auxiliary/udvt.sol";
-   | ------------------------------ previous declaration imported here
 LL | import "./auxiliary/udvt2.sol";
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-  ::: ROOT/tests/ui/resolve/auxiliary/udvt.sol:LL:CC
+note: previous declaration imported here
+  --> ROOT/tests/ui/resolve/import_glob_conflicts.sol:LL:CC
+   |
+LL | import "./auxiliary/udvt.sol";
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/auxiliary/udvt.sol:LL:CC
    |
 LL | type MyUdvt is uint256;
-   | ----------------------- previous declaration declared here
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/import_glob_conflicts.stderr
+++ b/tests/ui/resolve/import_glob_conflicts.stderr
@@ -2,15 +2,14 @@ error: identifier `MyUdvt` already declared
   --> ROOT/tests/ui/resolve/import_glob_conflicts.sol:LL:CC
    |
 LL | import "./auxiliary/udvt.sol";
-   | ------------------------------ note: previous declaration imported here
+   | ------------------------------ previous declaration imported here
 LL | import "./auxiliary/udvt2.sol";
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
   ::: ROOT/tests/ui/resolve/auxiliary/udvt.sol:LL:CC
    |
 LL | type MyUdvt is uint256;
-   | ----------------------- note: previous declaration declared here
-   |
+   | ----------------------- previous declaration declared here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/inheritance_conflicts.stderr
+++ b/tests/ui/resolve/inheritance_conflicts.stderr
@@ -2,25 +2,19 @@ error: identifier `x` already declared
   --> ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
    |
 LL |     uint public x = 0;
-   |                 - note: previous declaration declared here
-LL | }
-LL |
-LL | contract B is A {
+   |                 - previous declaration declared here
+...
 LL |     uint public x = 1;
    |                 ^
-   |
 
 error: identifier `y` already declared
   --> ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
    |
 LL |     uint public y = 2;
-   |                 - note: previous declaration declared here
-LL | }
-LL |
-LL | contract BB {
+   |                 - previous declaration declared here
+...
 LL |     uint public y = 3;
    |                 ^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/inheritance_conflicts.stderr
+++ b/tests/ui/resolve/inheritance_conflicts.stderr
@@ -1,19 +1,25 @@
 error: identifier `x` already declared
   --> ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
    |
-LL |     uint public x = 0;
-   |                 - previous declaration declared here
-...
 LL |     uint public x = 1;
+   |                 ^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   |
+LL |     uint public x = 0;
    |                 ^
 
 error: identifier `y` already declared
   --> ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
    |
-LL |     uint public y = 2;
-   |                 - previous declaration declared here
-...
 LL |     uint public y = 3;
+   |                 ^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   |
+LL |     uint public y = 2;
    |                 ^
 
 error: aborting due to 2 previous errors

--- a/tests/ui/resolve/library_requirements.stderr
+++ b/tests/ui/resolve/library_requirements.stderr
@@ -3,14 +3,12 @@ error: library is not allowed to inherit
    |
 LL | library B is A {}
    |         ^
-   |
 
 error: library cannot have non-constant state variable
   --> ROOT/tests/ui/resolve/library_requirements.sol:LL:CC
    |
 LL |     uint256 y;
    |     ^^^^^^^^^^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/literals_underscores.stderr
+++ b/tests/ui/resolve/literals_underscores.stderr
@@ -3,7 +3,6 @@ error: empty rational
    |
 LL |     uint F6 = 1._;
    |               ^^^
-   |
 
 error: invalid use of underscores in number literal
   --> ROOT/tests/ui/resolve/literals_underscores.sol:LL:CC

--- a/tests/ui/resolve/loops.stderr
+++ b/tests/ui/resolve/loops.stderr
@@ -3,91 +3,78 @@ error: unresolved symbol `a`
    |
 LL |     while (a == 0) { uint a = 0; }
    |            ^
-   |
 
 error: unresolved symbol `a`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     a;
    |     ^
-   |
 
 error: unresolved symbol `b`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     while (b == 0) { uint b = 0; }
    |            ^
-   |
 
 error: unresolved symbol `b`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     b;
    |     ^
-   |
 
 error: unresolved symbol `c`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     do { uint c; } while (c == 0);
    |                           ^
-   |
 
 error: unresolved symbol `c`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     c;
    |     ^
-   |
 
 error: unresolved symbol `d`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     do { uint d; } while (d == 0);
    |                           ^
-   |
 
 error: unresolved symbol `d`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     d;
    |     ^
-   |
 
 error: unresolved symbol `e`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     for (; false; e++) { uint e; }
    |                   ^
-   |
 
 error: unresolved symbol `e`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     e;
    |     ^
-   |
 
 error: unresolved symbol `f`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     for (; false; f++) { uint f; }
    |                   ^
-   |
 
 error: unresolved symbol `f`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     f;
    |     ^
-   |
 
 error: unresolved symbol `g`
   --> ROOT/tests/ui/resolve/loops.sol:LL:CC
    |
 LL |     g;
    |     ^
-   |
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/resolve/modifier_without_placeholder.stderr
+++ b/tests/ui/resolve/modifier_without_placeholder.stderr
@@ -3,7 +3,6 @@ error: modifier must have a `_;` placeholder statement
    |
 LL |     modifier P() {}
    |              ^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/modifiers.stderr
+++ b/tests/ui/resolve/modifiers.stderr
@@ -3,14 +3,12 @@ error: expected modifier, found function
    |
 LL |     function bad1() public f1_2 {}
    |                            ^^^^
-   |
 
 error: expected modifier, found function
   --> ROOT/tests/ui/resolve/modifiers.sol:LL:CC
    |
 LL |     function bad2() public f1_2() {}
    |                            ^^^^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/placeholder_unchecked.stderr
+++ b/tests/ui/resolve/placeholder_unchecked.stderr
@@ -3,7 +3,6 @@ error: placeholder statements cannot be used inside unchecked blocks
    |
 LL |             _;
    |             ^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/receive_func.stderr
+++ b/tests/ui/resolve/receive_func.stderr
@@ -3,7 +3,6 @@ error: libraries cannot have receive ether functions
    |
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: receive ether function must be payable
   --> ROOT/tests/ui/resolve/receive_func.sol:LL:CC
@@ -18,7 +17,6 @@ error: receive ether function cannot take parameters
    |
 LL |     receive(bool _x) external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/resolve/shadowed_vars.stderr
+++ b/tests/ui/resolve/shadowed_vars.stderr
@@ -2,10 +2,9 @@ error: identifier `x` already declared
   --> ROOT/tests/ui/resolve/shadowed_vars.sol:LL:CC
    |
 LL |     function g(uint x) private
-   |                     - note: previous declaration declared here
+   |                     - previous declaration declared here
 LL |         returns (int x)
    |                      ^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/shadowed_vars.stderr
+++ b/tests/ui/resolve/shadowed_vars.stderr
@@ -1,10 +1,14 @@
 error: identifier `x` already declared
   --> ROOT/tests/ui/resolve/shadowed_vars.sol:LL:CC
    |
-LL |     function g(uint x) private
-   |                     - previous declaration declared here
 LL |         returns (int x)
    |                      ^
+   |
+note: previous declaration declared here
+  --> ROOT/tests/ui/resolve/shadowed_vars.sol:LL:CC
+   |
+LL |     function g(uint x) private
+   |                     ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/super_type.stderr
+++ b/tests/ui/resolve/super_type.stderr
@@ -3,56 +3,48 @@ error: identifier `this` already declared
    |
 LL |     struct this { uint x; }
    |            ^^^^
-   |
 
 error: identifier `super` already declared
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL |     struct super { uint x; }
    |            ^^^^^
-   |
 
 error: unresolved symbol `this`
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL | contract D is this.C {}
    |               ^^^^
-   |
 
 error: unresolved symbol `super`
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL | contract E is super.C {}
    |               ^^^^^
-   |
 
 error: `this` is a builtin, which cannot be indexed in type paths
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL |         this.S1 memory x0;
    |         ^^^^
-   |
 
 error: `super` is a builtin, which cannot be indexed in type paths
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL |         super.S1 memory x1;
    |         ^^^^^
-   |
 
 error: `super` is a builtin, which cannot be indexed in type paths
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL |         super.S2 memory x2;
    |         ^^^^^
-   |
 
 error: `super` is a builtin, which cannot be indexed in type paths
   --> ROOT/tests/ui/resolve/super_type.sol:LL:CC
    |
 LL |         super.super.S2 memory x3;
    |         ^^^^^
-   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/resolve/type_paths.stderr
+++ b/tests/ui/resolve/type_paths.stderr
@@ -3,14 +3,12 @@ error: unresolved symbol `Unknown`
    |
 LL |         self.C.Unknown memory d
    |                ^^^^^^^
-   |
 
 error: unresolved symbol `Unknown`
   --> ROOT/tests/ui/resolve/type_paths.sol:LL:CC
    |
 LL |         self.C.Unknown memory h = self.C.Unknown(3);
    |                ^^^^^^^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/unknown_import.stderr
+++ b/tests/ui/resolve/unknown_import.stderr
@@ -3,21 +3,18 @@ error: file doesnotexist1 not found
    |
 LL | import "doesnotexist1";
    |        ^^^^^^^^^^^^^^^
-   |
 
 error: file doesnotexist2 not found
   --> ROOT/tests/ui/resolve/unknown_import.sol:LL:CC
    |
 LL | import {A} from "doesnotexist2";
    |                 ^^^^^^^^^^^^^^^
-   |
 
 error: file doesnotexist3 not found
   --> ROOT/tests/ui/resolve/unknown_import.sol:LL:CC
    |
 LL | import * as B from "doesnotexist3";
    |                    ^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/contract_vars.stderr
+++ b/tests/ui/typeck/contract_vars.stderr
@@ -3,21 +3,18 @@ error: name has to refer to a valid user-defined type
    |
 LL |     f a;
    |     ^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/contract_vars.sol:LL:CC
    |
 LL |     E1 b;
    |     ^^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/contract_vars.sol:LL:CC
    |
 LL |     E2 c;
    |     ^^
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/duplicate_overloaded_items.stderr
+++ b/tests/ui/typeck/duplicate_overloaded_items.stderr
@@ -4,8 +4,7 @@ error: event with same name and parameter types declared twice
 LL | event E1();
    |       ^^
 LL | event E1();
-   |       -- note: other declaration
-   |
+   |       -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -13,8 +12,7 @@ error: event with same name and parameter types declared twice
 LL | event E2(uint);
    |       ^^
 LL | event E2(uint);
-   |       -- note: other declaration
-   |
+   |       -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -22,8 +20,7 @@ error: event with same name and parameter types declared twice
 LL | event E3(uint);
    |       ^^
 LL | event E3(uint) anonymous;
-   |       -- note: other declaration
-   |
+   |       -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -31,8 +28,7 @@ error: event with same name and parameter types declared twice
 LL | event E4(uint);
    |       ^^
 LL | event E4(uint indexed);
-   |       -- note: other declaration
-   |
+   |       -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -40,8 +36,7 @@ error: function with same name and parameter types declared twice
 LL | function f1() {}
    |          ^^
 LL | function f1() {}
-   |          -- note: other declaration
-   |
+   |          -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -49,10 +44,9 @@ error: function with same name and parameter types declared twice
 LL | function f2() {}
    |          ^^
 LL | function f2() {}
-   |          -- note: other declaration
+   |          -- other declaration
 LL | function f2() {}
-   |          -- note: other declaration
-   |
+   |          -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -60,8 +54,7 @@ error: function with same name and parameter types declared twice
 LL | function f2_2(uint) {}
    |          ^^^^
 LL | function f2_2(uint) {}
-   |          ---- note: other declaration
-   |
+   |          ---- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -69,8 +62,7 @@ error: function with same name and parameter types declared twice
 LL | function f5(int) {}
    |          ^^
 LL | function f5(int) {}
-   |          -- note: other declaration
-   |
+   |          -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -78,8 +70,7 @@ error: function with same name and parameter types declared twice
 LL | function f6(string memory) {}
    |          ^^
 LL | function f6(string calldata) {}
-   |          -- note: other declaration
-   |
+   |          -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -87,8 +78,7 @@ error: event with same name and parameter types declared twice
 LL |     event E1();
    |           ^^
 LL |     event E1();
-   |           -- note: other declaration
-   |
+   |           -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -96,8 +86,7 @@ error: event with same name and parameter types declared twice
 LL |     event E2(uint);
    |           ^^
 LL |     event E2(uint);
-   |           -- note: other declaration
-   |
+   |           -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -105,8 +94,7 @@ error: event with same name and parameter types declared twice
 LL |     event E3(uint);
    |           ^^
 LL |     event E3(uint) anonymous;
-   |           -- note: other declaration
-   |
+   |           -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -114,8 +102,7 @@ error: event with same name and parameter types declared twice
 LL |     event E4(uint);
    |           ^^
 LL |     event E4(uint indexed);
-   |           -- note: other declaration
-   |
+   |           -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -123,8 +110,7 @@ error: function with same name and parameter types declared twice
 LL |     function f1() public {}
    |              ^^
 LL |     function f1() public {}
-   |              -- note: other declaration
-   |
+   |              -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -132,10 +118,9 @@ error: function with same name and parameter types declared twice
 LL |     function f2() public {}
    |              ^^
 LL |     function f2() public {}
-   |              -- note: other declaration
+   |              -- other declaration
 LL |     function f2() public {}
-   |              -- note: other declaration
-   |
+   |              -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -143,10 +128,9 @@ error: function with same name and parameter types declared twice
 LL |     function f22() public {}
    |              ^^^
 LL |     function f22() public {}
-   |              --- note: other declaration
+   |              --- other declaration
 LL |     function f22() public {}
-   |              --- note: other declaration
-   |
+   |              --- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -154,8 +138,7 @@ error: function with same name and parameter types declared twice
 LL |     function f5(int) public {}
    |              ^^
 LL |     function f5(int) public {}
-   |              -- note: other declaration
-   |
+   |              -- other declaration
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
@@ -163,20 +146,16 @@ error: function with same name and parameter types declared twice
 LL |     function f6(string memory) public {}
    |              ^^
 LL |     function f6(string calldata) public {}
-   |              -- note: other declaration
-   |
+   |              -- other declaration
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     event E5();
-   |           -- note: other declaration
-LL | }
-LL |
-LL | contract D is C2 {
+   |           -- other declaration
+...
 LL |     event E5() anonymous;
    |           ^^
-   |
 
 error: aborting due to 19 previous errors
 

--- a/tests/ui/typeck/duplicate_overloaded_items.stderr
+++ b/tests/ui/typeck/duplicate_overloaded_items.stderr
@@ -3,158 +3,242 @@ error: event with same name and parameter types declared twice
    |
 LL | event E1();
    |       ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | event E1();
-   |       -- other declaration
+   |       ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | event E2(uint);
    |       ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | event E2(uint);
-   |       -- other declaration
+   |       ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | event E3(uint);
    |       ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | event E3(uint) anonymous;
-   |       -- other declaration
+   |       ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | event E4(uint);
    |       ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | event E4(uint indexed);
-   |       -- other declaration
+   |       ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | function f1() {}
    |          ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | function f1() {}
-   |          -- other declaration
+   |          ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | function f2() {}
    |          ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | function f2() {}
-   |          -- other declaration
+   |          ^^
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | function f2() {}
-   |          -- other declaration
+   |          ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | function f2_2(uint) {}
    |          ^^^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | function f2_2(uint) {}
-   |          ---- other declaration
+   |          ^^^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | function f5(int) {}
    |          ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | function f5(int) {}
-   |          -- other declaration
+   |          ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL | function f6(string memory) {}
    |          ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL | function f6(string calldata) {}
-   |          -- other declaration
+   |          ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     event E1();
    |           ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     event E1();
-   |           -- other declaration
+   |           ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     event E2(uint);
    |           ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     event E2(uint);
-   |           -- other declaration
+   |           ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     event E3(uint);
    |           ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     event E3(uint) anonymous;
-   |           -- other declaration
+   |           ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     event E4(uint);
    |           ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     event E4(uint indexed);
-   |           -- other declaration
+   |           ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     function f1() public {}
    |              ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f1() public {}
-   |              -- other declaration
+   |              ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     function f2() public {}
    |              ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f2() public {}
-   |              -- other declaration
+   |              ^^
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f2() public {}
-   |              -- other declaration
+   |              ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     function f22() public {}
    |              ^^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f22() public {}
-   |              --- other declaration
+   |              ^^^
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f22() public {}
-   |              --- other declaration
+   |              ^^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     function f5(int) public {}
    |              ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f5(int) public {}
-   |              -- other declaration
+   |              ^^
 
 error: function with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
 LL |     function f6(string memory) public {}
    |              ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
 LL |     function f6(string calldata) public {}
-   |              -- other declaration
+   |              ^^
 
 error: event with same name and parameter types declared twice
   --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
    |
-LL |     event E5();
-   |           -- other declaration
-...
 LL |     event E5() anonymous;
+   |           ^^
+   |
+note: other declaration
+  --> ROOT/tests/ui/typeck/duplicate_overloaded_items.sol:LL:CC
+   |
+LL |     event E5();
    |           ^^
 
 error: aborting due to 19 previous errors

--- a/tests/ui/typeck/duplicate_selectors.stderr
+++ b/tests/ui/typeck/duplicate_selectors.stderr
@@ -1,16 +1,20 @@
 error: function signature hash collision
   --> ROOT/tests/ui/typeck/duplicate_selectors.sol:LL:CC
    |
-LL |     function mintEfficientN2M_001Z5BWH() public {}
-   |     ---------------------------------------------- first function
-...
 LL | contract D is C {
    |          ^
-LL |
-LL |     function BlazingIt4490597615() public {}
-   |     ---------------------------------------- second function
    |
    = note: the function signatures `mintEfficientN2M_001Z5BWH()` and `BlazingIt4490597615()` produce the same 4-byte selector `0x00000000`
+note: first function
+  --> ROOT/tests/ui/typeck/duplicate_selectors.sol:LL:CC
+   |
+LL |     function mintEfficientN2M_001Z5BWH() public {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: second function
+  --> ROOT/tests/ui/typeck/duplicate_selectors.sol:LL:CC
+   |
+LL |     function BlazingIt4490597615() public {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/duplicate_selectors.stderr
+++ b/tests/ui/typeck/duplicate_selectors.stderr
@@ -2,14 +2,13 @@ error: function signature hash collision
   --> ROOT/tests/ui/typeck/duplicate_selectors.sol:LL:CC
    |
 LL |     function mintEfficientN2M_001Z5BWH() public {}
-   |     ---------------------------------------------- note: first function
-LL | }
-LL |
+   |     ---------------------------------------------- first function
+...
 LL | contract D is C {
    |          ^
 LL |
 LL |     function BlazingIt4490597615() public {}
-   |     ---------------------------------------- note: second function
+   |     ---------------------------------------- second function
    |
    = note: the function signatures `mintEfficientN2M_001Z5BWH()` and `BlazingIt4490597615()` produce the same 4-byte selector `0x00000000`
 

--- a/tests/ui/typeck/empty_struct.stderr
+++ b/tests/ui/typeck/empty_struct.stderr
@@ -3,7 +3,6 @@ error: structs must have at least one field
    |
 LL | struct A {}
    |        ^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/enum_variants.stderr
+++ b/tests/ui/typeck/enum_variants.stderr
@@ -3,14 +3,12 @@ error: enum must have at least one variant
    |
 LL |     enum NeedsAtLeastOneVariant { }
    |          ^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: enum cannot have more than 256 variants
   --> ROOT/tests/ui/typeck/enum_variants.sol:LL:CC
    |
 LL |     enum ExceedsMaxVariants {
    |          ^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/eval.sol
+++ b/tests/ui/typeck/eval.sol
@@ -5,6 +5,8 @@ uint constant rec2 = rec1;
 
 uint constant bigLiteral = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
+uint constant fails = 0 / 0;
+
 contract C {
     uint constant zero = x - x;
     uint public constant zeroPublic = x / x - 1;
@@ -12,25 +14,29 @@ contract C {
     uint[zeroPublic + 1] public oneArray;
 
     uint[bigLiteral] public big;
-    uint[bigLiteral + 1] public tooBig1; //~ ERROR: evaluation of constant value failed
+    uint[bigLiteral + 1] public tooBig1; //~ ERROR: failed to evaluate constant: arithmetic overflow
 
     uint private stateVar = 69;
     uint public stateVarPublic = 420;
 
-    function a(uint[x / 0] memory) public {} //~ ERROR: evaluation of constant value failed
+    function early(uint[fails] memory) public {} //~ ERROR: failed to evaluate constant: attempted to divide by zero
+
+    function a(uint[x / 0] memory) public {} //~ ERROR: failed to evaluate constant: attempted to divide by zero
+    function a2(uint[x / zeroPublic] memory) public {} //~ ERROR: failed to evaluate constant: attempted to divide by zero
     function b(uint[x] memory) public {}
     function c(uint[x * 2] memory) public {}
-    function d(uint[0 - 1] memory) public {} //~ ERROR: evaluation of constant value failed
-    function e(uint[rec1] memory) public {} //~ ERROR: evaluation of constant value failed
-    function f(uint[rec2] memory) public {} //~ ERROR: evaluation of constant value failed
+    function d(uint[0 - 1] memory) public {} //~ ERROR: failed to evaluate constant: arithmetic overflow
+    function d2(uint[zeroPublic - 1] memory) public {} //~ ERROR: failed to evaluate constant: arithmetic overflow
+    function e(uint[rec1] memory) public {} //~ ERROR: failed to evaluate constant: recursion limit reached
+    function f(uint[rec2] memory) public {} //~ ERROR: failed to evaluate constant: recursion limit reached
 
     function g(uint[0] memory) public {} //~ ERROR: array length must be greater than zero
     function h(uint[zero] memory) public {} //~ ERROR: array length must be greater than zero
     function h2(uint[zeroPublic] memory) public {} //~ ERROR: array length must be greater than zero
 
-    function i(uint[block.timestamp] memory) public {} //~ ERROR: evaluation of constant value failed
-    function j(uint["lol"] memory) public {} //~ ERROR: evaluation of constant value failed
-    function k(uint[--x] memory) public {} //~ ERROR: evaluation of constant value failed
-    function l(uint[stateVar] memory) public {} //~ ERROR: evaluation of constant value failed
-    function m(uint[stateVarPublic] memory) public {} //~ ERROR: evaluation of constant value failed
+    function i(uint[block.timestamp] memory) public {} //~ ERROR: failed to evaluate constant: unsupported expression
+    function j(uint["lol"] memory) public {} //~ ERROR: failed to evaluate constant: unsupported literal
+    function k(uint[--x] memory) public {} //~ ERROR: failed to evaluate constant: unsupported unary operation
+    function l(uint[stateVar] memory) public {} //~ ERROR: failed to evaluate constant: only constant variables are allowed
+    function m(uint[stateVarPublic] memory) public {} //~ ERROR: failed to evaluate constant: only constant variables are allowed
 }

--- a/tests/ui/typeck/eval.sol
+++ b/tests/ui/typeck/eval.sol
@@ -39,4 +39,6 @@ contract C {
     function k(uint[--x] memory) public {} //~ ERROR: failed to evaluate constant: unsupported unary operation
     function l(uint[stateVar] memory) public {} //~ ERROR: failed to evaluate constant: only constant variables are allowed
     function m(uint[stateVarPublic] memory) public {} //~ ERROR: failed to evaluate constant: only constant variables are allowed
+
+    function tern(uint[(zero > 0) ? 1 : 0] memory) public {} //~ ERROR: failed to evaluate constant: unsupported expression
 }

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -1,50 +1,53 @@
-error: evaluation of constant value failed
+error: failed to evaluate constant: attempted to divide by zero
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant fails = 0 / 0;
+   |                       ----- evaluation of constant value failed here
+...
+LL |     function early(uint[fails] memory) public {}
+   |                         ^^^^^
+
+error: failed to evaluate constant: attempted to divide by zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function a(uint[x / 0] memory) public {}
-   |                     ^^^^^
-   |
-note: division by zero
+   |                     ^^^^^ evaluation of constant value failed here
+
+error: failed to evaluate constant: attempted to divide by zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
-LL |     function a(uint[x / 0] memory) public {}
-   |                     ^^^^^
+LL |     function a2(uint[x / zeroPublic] memory) public {}
+   |                      ^^^^^^^^^^^^^^ evaluation of constant value failed here
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: arithmetic overflow
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function d(uint[0 - 1] memory) public {}
-   |                     ^^^^^
-   |
-note: arithmetic overflow
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     function d(uint[0 - 1] memory) public {}
-   |                     ^^^^^
+   |                     ^^^^^ evaluation of constant value failed here
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: arithmetic overflow
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
+LL |     function d2(uint[zeroPublic - 1] memory) public {}
+   |                      ^^^^^^^^^^^^^^ evaluation of constant value failed here
+
+error: failed to evaluate constant: recursion limit reached
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant rec1 = rec1;
+   |                      ---- evaluation of constant value failed here
+...
 LL |     function e(uint[rec1] memory) public {}
    |                     ^^^^
-   |
-note: recursion limit reached
+
+error: failed to evaluate constant: recursion limit reached
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL | uint constant rec1 = rec1;
-   |                      ^^^^
-
-error: evaluation of constant value failed
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
+   |                      ---- evaluation of constant value failed here
+...
 LL |     function f(uint[rec2] memory) public {}
    |                     ^^^^
-   |
-note: recursion limit reached
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL | uint constant rec1 = rec1;
-   |                      ^^^^
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
@@ -64,65 +67,35 @@ error: array length must be greater than zero
 LL |     function h2(uint[zeroPublic] memory) public {}
    |                      ^^^^^^^^^^
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: unsupported expression
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function i(uint[block.timestamp] memory) public {}
-   |                     ^^^^^^^^^^^^^^^
-   |
-note: unsupported expression
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     function i(uint[block.timestamp] memory) public {}
-   |                     ^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^ evaluation of constant value failed here
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: unsupported literal
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function j(uint["lol"] memory) public {}
-   |                     ^^^^^
-   |
-note: unsupported literal
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     function j(uint["lol"] memory) public {}
-   |                     ^^^^^
+   |                     ^^^^^ evaluation of constant value failed here
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: unsupported unary operation
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function k(uint[--x] memory) public {}
-   |                     ^^^
-   |
-note: unsupported unary operation
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     function k(uint[--x] memory) public {}
-   |                     ^^^
+   |                     ^^^ evaluation of constant value failed here
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: only constant variables are allowed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function l(uint[stateVar] memory) public {}
-   |                     ^^^^^^^^
-   |
-note: only constant variables are allowed
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     function l(uint[stateVar] memory) public {}
-   |                     ^^^^^^^^
+   |                     ^^^^^^^^ evaluation of constant value failed here
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: only constant variables are allowed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function m(uint[stateVarPublic] memory) public {}
-   |                     ^^^^^^^^^^^^^^
-   |
-note: only constant variables are allowed
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     function m(uint[stateVarPublic] memory) public {}
-   |                     ^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^ evaluation of constant value failed here
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
@@ -130,17 +103,11 @@ error: array length must be greater than zero
 LL |     uint[zero] public zeroArray;
    |          ^^^^
 
-error: evaluation of constant value failed
+error: failed to evaluate constant: arithmetic overflow
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     uint[bigLiteral + 1] public tooBig1;
-   |          ^^^^^^^^^^^^^^
-   |
-note: arithmetic overflow
-  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
-   |
-LL |     uint[bigLiteral + 1] public tooBig1;
-   |          ^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^ evaluation of constant value failed here
 
-error: aborting due to 14 previous errors
+error: aborting due to 17 previous errors
 

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -97,6 +97,12 @@ error: failed to evaluate constant: only constant variables are allowed
 LL |     function m(uint[stateVarPublic] memory) public {}
    |                     ^^^^^^^^^^^^^^ evaluation of constant value failed here
 
+error: failed to evaluate constant: unsupported expression
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function tern(uint[(zero > 0) ? 1 : 0] memory) public {}
+   |                        ^^^^^^^^^^^^^^^^^^ evaluation of constant value failed here
+
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
@@ -109,5 +115,5 @@ error: failed to evaluate constant: arithmetic overflow
 LL |     uint[bigLiteral + 1] public tooBig1;
    |          ^^^^^^^^^^^^^^ evaluation of constant value failed here
 
-error: aborting due to 17 previous errors
+error: aborting due to 18 previous errors
 

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -2,125 +2,91 @@ error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function a(uint[x / 0] memory) public {}
-   |                     -----
-   |                     |
-   |                     note: division by zero
-   |
+   |                     ^^^^^ division by zero
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function d(uint[0 - 1] memory) public {}
-   |                     -----
-   |                     |
-   |                     note: arithmetic overflow
-   |
+   |                     ^^^^^ arithmetic overflow
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL | uint constant rec1 = rec1;
-   |                      ---- note: recursion limit reached
-LL | uint constant rec2 = rec1;
+   |                      ---- recursion limit reached
 ...
-LL |     function d(uint[0 - 1] memory) public {}
 LL |     function e(uint[rec1] memory) public {}
    |                     ^^^^
-   |
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL | uint constant rec1 = rec1;
-   |                      ---- note: recursion limit reached
-LL | uint constant rec2 = rec1;
+   |                      ---- recursion limit reached
 ...
-LL |     function e(uint[rec1] memory) public {}
 LL |     function f(uint[rec2] memory) public {}
    |                     ^^^^
-   |
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function g(uint[0] memory) public {}
    |                     ^
-   |
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function h(uint[zero] memory) public {}
    |                     ^^^^
-   |
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function h2(uint[zeroPublic] memory) public {}
    |                      ^^^^^^^^^^
-   |
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function i(uint[block.timestamp] memory) public {}
-   |                     ---------------
-   |                     |
-   |                     note: unsupported expression
-   |
+   |                     ^^^^^^^^^^^^^^^ unsupported expression
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function j(uint["lol"] memory) public {}
-   |                     -----
-   |                     |
-   |                     note: unsupported literal
-   |
+   |                     ^^^^^ unsupported literal
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function k(uint[--x] memory) public {}
-   |                     ---
-   |                     |
-   |                     note: unsupported unary operation
-   |
+   |                     ^^^ unsupported unary operation
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function l(uint[stateVar] memory) public {}
-   |                     --------
-   |                     |
-   |                     note: only constant variables are allowed
-   |
+   |                     ^^^^^^^^ only constant variables are allowed
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function m(uint[stateVarPublic] memory) public {}
-   |                     --------------
-   |                     |
-   |                     note: only constant variables are allowed
-   |
+   |                     ^^^^^^^^^^^^^^ only constant variables are allowed
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     uint[zero] public zeroArray;
    |          ^^^^
-   |
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     uint[bigLiteral + 1] public tooBig1;
-   |          --------------
-   |          |
-   |          note: arithmetic overflow
-   |
+   |          ^^^^^^^^^^^^^^ arithmetic overflow
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -2,31 +2,49 @@ error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function a(uint[x / 0] memory) public {}
-   |                     ^^^^^ division by zero
+   |                     ^^^^^
+   |
+note: division by zero
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function a(uint[x / 0] memory) public {}
+   |                     ^^^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function d(uint[0 - 1] memory) public {}
-   |                     ^^^^^ arithmetic overflow
+   |                     ^^^^^
+   |
+note: arithmetic overflow
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function d(uint[0 - 1] memory) public {}
+   |                     ^^^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
-LL | uint constant rec1 = rec1;
-   |                      ---- recursion limit reached
-...
 LL |     function e(uint[rec1] memory) public {}
    |                     ^^^^
+   |
+note: recursion limit reached
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant rec1 = rec1;
+   |                      ^^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
-LL | uint constant rec1 = rec1;
-   |                      ---- recursion limit reached
-...
 LL |     function f(uint[rec2] memory) public {}
    |                     ^^^^
+   |
+note: recursion limit reached
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL | uint constant rec1 = rec1;
+   |                      ^^^^
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
@@ -50,31 +68,61 @@ error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function i(uint[block.timestamp] memory) public {}
-   |                     ^^^^^^^^^^^^^^^ unsupported expression
+   |                     ^^^^^^^^^^^^^^^
+   |
+note: unsupported expression
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function i(uint[block.timestamp] memory) public {}
+   |                     ^^^^^^^^^^^^^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function j(uint["lol"] memory) public {}
-   |                     ^^^^^ unsupported literal
+   |                     ^^^^^
+   |
+note: unsupported literal
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function j(uint["lol"] memory) public {}
+   |                     ^^^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function k(uint[--x] memory) public {}
-   |                     ^^^ unsupported unary operation
+   |                     ^^^
+   |
+note: unsupported unary operation
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function k(uint[--x] memory) public {}
+   |                     ^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function l(uint[stateVar] memory) public {}
-   |                     ^^^^^^^^ only constant variables are allowed
+   |                     ^^^^^^^^
+   |
+note: only constant variables are allowed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function l(uint[stateVar] memory) public {}
+   |                     ^^^^^^^^
 
 error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     function m(uint[stateVarPublic] memory) public {}
-   |                     ^^^^^^^^^^^^^^ only constant variables are allowed
+   |                     ^^^^^^^^^^^^^^
+   |
+note: only constant variables are allowed
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     function m(uint[stateVarPublic] memory) public {}
+   |                     ^^^^^^^^^^^^^^
 
 error: array length must be greater than zero
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
@@ -86,7 +134,13 @@ error: evaluation of constant value failed
   --> ROOT/tests/ui/typeck/eval.sol:LL:CC
    |
 LL |     uint[bigLiteral + 1] public tooBig1;
-   |          ^^^^^^^^^^^^^^ arithmetic overflow
+   |          ^^^^^^^^^^^^^^
+   |
+note: arithmetic overflow
+  --> ROOT/tests/ui/typeck/eval.sol:LL:CC
+   |
+LL |     uint[bigLiteral + 1] public tooBig1;
+   |          ^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors
 

--- a/tests/ui/typeck/external_type_clashes.stderr
+++ b/tests/ui/typeck/external_type_clashes.stderr
@@ -3,54 +3,72 @@ error[9914]: function overload clash during conversion to external types for arg
    |
 LL |     function f(S1 memory a) external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+   |
+help: other declaration is here
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
 LL |     function f(S2 memory a) external {}
-   |     ----------------------------------- other declaration is here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
-LL |     function f(a) public {}
-   |     ----------------------- other declaration is here
-...
 LL |     function f(uint8 a) public {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: other declaration is here
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function f(a) public {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function c(address) public pure {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+   |
+help: other declaration is here
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
 LL |     function c(address payable) public pure {}
-   |     ------------------------------------------ other declaration is here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function f(address) external pure {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+   |
+help: other declaration is here
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
 LL |     function f(address payable) external pure {}
-   |     -------------------------------------------- other declaration is here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function f(MyAddress a) external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
+   |
+help: other declaration is here
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
 LL |     function f(address a) external {}
-   |     --------------------------------- other declaration is here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
-LL |     function g(MyAddress a) external {}
-   |     ----------------------------------- other declaration is here
-...
 LL |     function g(I a) external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: other declaration is here
+  --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   |
+LL |     function g(MyAddress a) external {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/external_type_clashes.stderr
+++ b/tests/ui/typeck/external_type_clashes.stderr
@@ -3,68 +3,54 @@ error[9914]: function overload clash during conversion to external types for arg
    |
 LL |     function f(S1 memory a) external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |
+...
 LL |     function f(S2 memory a) external {}
-   |     ----------------------------------- help: other declaration is here
-   |
+   |     ----------------------------------- other declaration is here
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function f(a) public {}
-   |     ----------------------- help: other declaration is here
-LL |
+   |     ----------------------- other declaration is here
 ...
-LL | contract D is C {
 LL |     function f(uint8 a) public {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function c(address) public pure {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     
+...
 LL |     function c(address payable) public pure {}
-   |     ------------------------------------------ help: other declaration is here
-   |
+   |     ------------------------------------------ other declaration is here
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function f(address) external pure {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |     
+...
 LL |     function f(address payable) external pure {}
-   |     -------------------------------------------- help: other declaration is here
-   |
+   |     -------------------------------------------- other declaration is here
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function f(MyAddress a) external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |
-LL |
+...
 LL |     function f(address a) external {}
-   |     --------------------------------- help: other declaration is here
-   |
+   |     --------------------------------- other declaration is here
 
 error[9914]: function overload clash during conversion to external types for arguments
   --> ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    |
 LL |     function g(MyAddress a) external {}
-   |     ----------------------------------- help: other declaration is here
-LL |
+   |     ----------------------------------- other declaration is here
 ...
-LL | contract H is G {
 LL |     function g(I a) external {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/function_vars.stderr
+++ b/tests/ui/typeck/function_vars.stderr
@@ -3,21 +3,18 @@ error: name has to refer to a valid user-defined type
    |
 LL |     f a;
    |     ^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/function_vars.sol:LL:CC
    |
 LL |     E1 b;
    |     ^^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/function_vars.sol:LL:CC
    |
 LL |     E2 c;
    |     ^^
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/invalid_placeholder.stderr
+++ b/tests/ui/typeck/invalid_placeholder.stderr
@@ -3,7 +3,6 @@ error: placeholder statements can only be used in modifiers
    |
 LL |       _;
    |       ^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/mapping_structs.stderr
+++ b/tests/ui/typeck/mapping_structs.stderr
@@ -2,17 +2,25 @@ error: getter must return at least one value
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     S public var_2;
-   |     -^^^^^^^^^^^^^^
-   |     |
-   |     the struct has all its members omitted, therefore the getter cannot return any values
+   |     ^^^^^^^^^^^^^^^
+   |
+note: the struct has all its members omitted, therefore the getter cannot return any values
+  --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   |
+LL |     S public var_2;
+   |     ^
 
 error: getter must return at least one value
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     S[] public var_array_2;
-   |     -^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     the struct has all its members omitted, therefore the getter cannot return any values
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the struct has all its members omitted, therefore the getter cannot return any values
+  --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   |
+LL |     S[] public var_array_2;
+   |     ^
 
 error: types containing mappings cannot be parameter or return types of public getter functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC

--- a/tests/ui/typeck/mapping_structs.stderr
+++ b/tests/ui/typeck/mapping_structs.stderr
@@ -4,8 +4,7 @@ error: getter must return at least one value
 LL |     S public var_2;
    |     -^^^^^^^^^^^^^^
    |     |
-   |     note: the struct has all its members omitted, therefore the getter cannot return any values
-   |
+   |     the struct has all its members omitted, therefore the getter cannot return any values
 
 error: getter must return at least one value
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
@@ -13,29 +12,25 @@ error: getter must return at least one value
 LL |     S[] public var_array_2;
    |     -^^^^^^^^^^^^^^^^^^^^^^
    |     |
-   |     note: the struct has all its members omitted, therefore the getter cannot return any values
-   |
+   |     the struct has all its members omitted, therefore the getter cannot return any values
 
 error: types containing mappings cannot be parameter or return types of public getter functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     Nested public var_nested_2;
    |     ^^^^^^
-   |
 
 error: types containing mappings cannot be parameter or return types of public getter functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     Nested[] public var_nested_array_2;
    |     ^^^^^^
-   |
 
 error: types containing mappings cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     function func_1(S memory) public {}
    |                     ^
-   |
 
 error: invalid data location `storage`
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
@@ -50,14 +45,12 @@ error: types containing mappings cannot be parameter or return types of public f
    |
 LL |     function func_2(S storage) public {}
    |                     ^
-   |
 
 error: types containing mappings cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     function func_3() public returns(S memory) {}
    |                                      ^
-   |
 
 error: invalid data location `storage`
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
@@ -72,14 +65,12 @@ error: types containing mappings cannot be parameter or return types of public f
    |
 LL |     function func_4() public returns(S storage) {}
    |                                      ^
-   |
 
 error: types containing mappings cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     function func_nested_1(Nested memory) public {}
    |                            ^^^^^^
-   |
 
 error: invalid data location `storage`
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
@@ -94,14 +85,12 @@ error: types containing mappings cannot be parameter or return types of public f
    |
 LL |     function func_nested_2(Nested storage) public {}
    |                            ^^^^^^
-   |
 
 error: types containing mappings cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
    |
 LL |     function func_nested_3() public returns(Nested memory) {}
    |                                             ^^^^^^
-   |
 
 error: invalid data location `storage`
   --> ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
@@ -116,7 +105,6 @@ error: types containing mappings cannot be parameter or return types of public f
    |
 LL |     function func_nested_4() public returns(Nested storage) {}
    |                                             ^^^^^^
-   |
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/typeck/receive.stderr
+++ b/tests/ui/typeck/receive.stderr
@@ -3,28 +3,24 @@ error: `public` not allowed here; allowed values: external
    |
 LL |     receive() public payable {}
    |               ^^^^^^
-   |
 
 error: `view` not allowed here; allowed values: payable
   --> ROOT/tests/ui/typeck/receive.sol:LL:CC
    |
 LL |     receive() external view {}
    |                        ^^^^
-   |
 
 error: `pure` not allowed here; allowed values: payable
   --> ROOT/tests/ui/typeck/receive.sol:LL:CC
    |
 LL |     receive() external pure {}
    |                        ^^^^
-   |
 
 error: libraries cannot have receive ether functions
   --> ROOT/tests/ui/typeck/receive.sol:LL:CC
    |
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: receive ether function must be payable
   --> ROOT/tests/ui/typeck/receive.sol:LL:CC
@@ -39,7 +35,6 @@ error: receive ether function cannot take parameters
    |
 LL |     receive(uint256 x) external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/receive_a.stderr
+++ b/tests/ui/typeck/receive_a.stderr
@@ -2,10 +2,9 @@ error: receive function already declared
   --> ROOT/tests/ui/typeck/receive_a.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- note: previous declaration here
+   |     ----------------------------- previous declaration here
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/receive_a.stderr
+++ b/tests/ui/typeck/receive_a.stderr
@@ -2,7 +2,11 @@ error: receive function already declared
   --> ROOT/tests/ui/typeck/receive_a.sol:LL:CC
    |
 LL |     receive() external payable {}
-   |     ----------------------------- previous declaration here
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous declaration here
+  --> ROOT/tests/ui/typeck/receive_a.sol:LL:CC
+   |
 LL |     receive() external payable {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/ui/typeck/receive_returns.stderr
+++ b/tests/ui/typeck/receive_returns.stderr
@@ -3,7 +3,6 @@ error: expected one of `;`, `external`, `internal`, `override`, `payable`, `priv
    |
 LL |     receive() external payable returns (uint256) {}
    |                                ^^^^^^^ expected one of 11 possible tokens
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/recursive_function_parameter.stderr
+++ b/tests/ui/typeck/recursive_function_parameter.stderr
@@ -5,7 +5,6 @@ LL | /     struct A {
 LL | |         B b;
 LL | |     }
    | |_____^
-   |
 
 error: recursive struct definition
   --> ROOT/tests/ui/typeck/recursive_function_parameter.sol:LL:CC
@@ -14,21 +13,18 @@ LL | /     struct B {
 LL | |         A a;
 LL | |     }
    | |_____^
-   |
 
 error: recursive types cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/recursive_function_parameter.sol:LL:CC
    |
 LL |     function c1(C memory) public {}
    |                 ^
-   |
 
 error: recursive types cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/recursive_function_parameter.sol:LL:CC
    |
 LL |     function c2() public returns(C memory) {}
    |                                  ^
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/recursive_structs.stderr
+++ b/tests/ui/typeck/recursive_structs.stderr
@@ -7,7 +7,6 @@ LL | |     // TODO: Cache the check so we don't emit the error twice.
 LL | |     A a;
 LL | | }
    | |_^
-   |
 
 error: recursive struct definition
   --> ROOT/tests/ui/typeck/recursive_structs.sol:LL:CC
@@ -18,7 +17,6 @@ LL | |     // TODO: Cache the check so we don't emit the error twice.
 LL | |     A a;
 LL | | }
    | |_^
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/recursive_types.stderr
+++ b/tests/ui/typeck/recursive_types.stderr
@@ -5,7 +5,6 @@ LL | /     struct A {
 LL | |         B b;
 LL | |     }
    | |_____^
-   |
 
 error: recursive struct definition
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
@@ -14,49 +13,42 @@ LL | /     struct B {
 LL | |         A a;
 LL | |     }
    | |_____^
-   |
 
 error: recursive types cannot be parameter or return types of public functions
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
    |
 LL |     function c(C memory) public {}
    |                ^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
    |
 LL |     function d(E1 memory) public {}
    |                ^^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
    |
 LL |     function e(E2 memory) public {}
    |                ^^
-   |
 
 error: the underlying type of UDVTs must be an elementary value type
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
    |
 LL |     type U1 is U1;
    |                ^^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
    |
 LL |     event E1(E2);
    |              ^^
-   |
 
 error: name has to refer to a valid user-defined type
   --> ROOT/tests/ui/typeck/recursive_types.sol:LL:CC
    |
 LL |     event E2(E1);
    |              ^^
-   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/typeck/udvts.stderr
+++ b/tests/ui/typeck/udvts.stderr
@@ -3,35 +3,30 @@ error: the underlying type of UDVTs must be an elementary value type
    |
 LL | type U01 is U01;
    |             ^^^
-   |
 
 error: the underlying type of UDVTs must be an elementary value type
   --> ROOT/tests/ui/typeck/udvts.sol:LL:CC
    |
 LL | type U02 is string;
    |             ^^^^^^
-   |
 
 error: the underlying type of UDVTs must be an elementary value type
   --> ROOT/tests/ui/typeck/udvts.sol:LL:CC
    |
 LL | type U03 is bytes;
    |             ^^^^^
-   |
 
 error: the underlying type of UDVTs must be an elementary value type
   --> ROOT/tests/ui/typeck/udvts.sol:LL:CC
    |
 LL | type U04 is uint[];
    |             ^^^^^^
-   |
 
 error: the underlying type of UDVTs must be an elementary value type
   --> ROOT/tests/ui/typeck/udvts.sol:LL:CC
    |
 LL | type U05 is U06;
    |             ^^^
-   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/typeck/unchecked_block.stderr
+++ b/tests/ui/typeck/unchecked_block.stderr
@@ -3,28 +3,24 @@ error: `unchecked` blocks cannot be nested
    |
 LL |         unchecked {}
    |         ^^^^^^^^^^^^
-   |
 
 error: `unchecked` blocks cannot be nested
   --> ROOT/tests/ui/typeck/unchecked_block.sol:LL:CC
    |
 LL |         unchecked {}
    |         ^^^^^^^^^^^^
-   |
 
 error: `unchecked` blocks cannot be nested
   --> ROOT/tests/ui/typeck/unchecked_block.sol:LL:CC
    |
 LL |             unchecked {}
    |             ^^^^^^^^^^^^
-   |
 
 error: `unchecked` blocks cannot be nested
   --> ROOT/tests/ui/typeck/unchecked_block.sol:LL:CC
    |
 LL |             unchecked {}
    |             ^^^^^^^^^^^^
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/var_loc_contract_fns.stderr
+++ b/tests/ui/typeck/var_loc_contract_fns.stderr
@@ -3,112 +3,96 @@ error: data location can only be specified for array, struct or mapping types
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         uint memory a2,
    |         ^^^^^^^^^^^^^^
-   |
 
 error: data location can only be specified for array, struct or mapping types
   --> ROOT/tests/ui/typeck/var_loc_contract_fns.sol:LL:CC
    |
 LL |         E memory e2,
    |         ^^^^^^^^^^^
-   |
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/typeck/var_loc_file_level.stderr
+++ b/tests/ui/typeck/var_loc_file_level.stderr
@@ -3,28 +3,24 @@ error: data locations are not allowed here
    |
 LL | uint memory constant a0 = 0;
    |      ^^^^^^
-   |
 
 error: data locations are not allowed here
   --> ROOT/tests/ui/typeck/var_loc_file_level.sol:LL:CC
    |
 LL | uint[] memory constant b0 = [];
    |        ^^^^^^
-   |
 
 error: data locations are not allowed here
   --> ROOT/tests/ui/typeck/var_loc_file_level.sol:LL:CC
    |
 LL | S memory constant c0 = S(0);
    |   ^^^^^^
-   |
 
 error: data locations are not allowed here
   --> ROOT/tests/ui/typeck/var_loc_file_level.sol:LL:CC
    |
 LL | S[] memory constant d0 = [];
    |     ^^^^^^
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/var_loc_state.stderr
+++ b/tests/ui/typeck/var_loc_state.stderr
@@ -3,7 +3,6 @@ error: data location can only be specified for array, struct or mapping types
    |
 LL |     uint memory a1 = 0;
    |     ^^^^^^^^^^^^^^^^^^^
-   |
 
 error: invalid data location `memory`
   --> ROOT/tests/ui/typeck/var_loc_state.sol:LL:CC

--- a/tests/ui/typeck/var_mutability.stderr
+++ b/tests/ui/typeck/var_mutability.stderr
@@ -3,112 +3,96 @@ error: only constant variables are allowed at file level
    |
 LL | uint a = 0;
    | ^^^^^^^^^^^
-   |
 
 error: only constant variables are allowed at file level
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL | uint immutable c = 0;
    | ^^^^^^^^^^^^^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint constant b3;
    |              ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint immutable c3;
    |              ^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint constant b4,
    |              ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint immutable c4
    |              ^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint constant b5,
    |              ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint immutable c5
    |              ^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint constant b6,
    |              ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint immutable c6
    |              ^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint constant b7,
    |              ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint immutable c7
    |              ^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint constant b8;
    |              ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |         uint immutable c8;
    |              ^^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |             uint constant b9,
    |                  ^^^^^^^^
-   |
 
 error: mutability is not allowed here
   --> ROOT/tests/ui/typeck/var_mutability.sol:LL:CC
    |
 LL |             uint immutable c9
    |                  ^^^^^^^^^
-   |
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/typeck/var_visibility.stderr
+++ b/tests/ui/typeck/var_visibility.stderr
@@ -3,231 +3,198 @@ error: visibility is not allowed here
    |
 LL | uint constant private b = 0;
    |               ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL | uint constant internal c = 0;
    |               ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL | uint constant public d = 0;
    |               ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL | uint constant external e = 0;
    |               ^^^^^^^^
-   |
 
 error: `external` not allowed here; allowed values: private, internal, public
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |     uint external e2 = 0;
    |          ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint private b3;
    |              ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint internal c3;
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint public d3;
    |              ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint external e3;
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint private b4,
    |              ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint internal c4,
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint public d4,
    |              ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint external e4
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint private b5,
    |              ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint internal c5,
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint public d5,
    |              ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint external e5
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint private b6,
    |              ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint internal c6,
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint public d6,
    |              ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint external e6
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint private b7,
    |              ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint internal c7,
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint public d7,
    |              ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint external e7
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint private b8;
    |              ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint internal c8;
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint public d8;
    |              ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |         uint external e8;
    |              ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |             uint private b9,
    |                  ^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |             uint internal c9,
    |                  ^^^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |             uint public d9,
    |                  ^^^^^^
-   |
 
 error: visibility is not allowed here
   --> ROOT/tests/ui/typeck/var_visibility.sol:LL:CC
    |
 LL |             uint external e9
    |                  ^^^^^^^^
-   |
 
 error: aborting due to 33 previous errors
 


### PR DESCRIPTION
Mainly aligning with rustc: `span_<level>` now is displayed as a separate group, whereas before it had the same effect as `span_label` if in the same file as the main diagnostic.