### PR TITLE
feat: add error format options for human-readable diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ typos
 For details of how to use `typos`, see <https://github.com/crate-ci/typos>.
 
 If the command rejects a word, you should backtick the rejected word if it's code related.
-If not, the rejected word should be inserted into `typos.toml`.
+If not, the  rejected word should be inserted into `typos.toml`. 
 
 ### Tests
 
@@ -182,7 +182,6 @@ example), it is either adding new functionality to Solar or it is fixing
 existing, broken functionality. In both of these cases, the pull request should
 include one or more tests to ensure that Solar does not regress in the future.
 There are a few ways to write tests:
-
 - [unit tests][unit-tests]
 - [documentation tests][documentation-tests]
 - [integration tests][integration-tests]
@@ -344,7 +343,7 @@ Note that only **incremental** improvement is needed to land a PR. This means
 that the PR does not need to be perfect, only better than the status quo. Follow
 up PRs may be opened to continue iterating.
 
-When changes are necessary, _request_ them, do not _demand_ them, and **do not
+When changes are necessary, *request* them, do not *demand* them, and **do not
 assume that the submitter already knows how to add a test or run a benchmark**.
 
 Specific performance optimization techniques, coding styles and conventions
@@ -364,7 +363,7 @@ with the appropriate reason to keep the conversation flow concise and relevant.
 
 ### Be aware of the person behind the code
 
-Be aware that _how_ you communicate requests and reviews in your feedback can
+Be aware that *how* you communicate requests and reviews in your feedback can
 have a significant impact on the success of the Pull Request. Yes, we may land
 a particular change that makes Solar better, but the individual might just not
 want to have anything to do with Solar ever again. The goal is not just having

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ typos
 For details of how to use `typos`, see <https://github.com/crate-ci/typos>.
 
 If the command rejects a word, you should backtick the rejected word if it's code related.
-If not, the  rejected word should be inserted into `typos.toml`. 
+If not, the rejected word should be inserted into `typos.toml`.
 
 ### Tests
 
@@ -182,6 +182,7 @@ example), it is either adding new functionality to Solar or it is fixing
 existing, broken functionality. In both of these cases, the pull request should
 include one or more tests to ensure that Solar does not regress in the future.
 There are a few ways to write tests:
+
 - [unit tests][unit-tests]
 - [documentation tests][documentation-tests]
 - [integration tests][integration-tests]
@@ -343,7 +344,7 @@ Note that only **incremental** improvement is needed to land a PR. This means
 that the PR does not need to be perfect, only better than the status quo. Follow
 up PRs may be opened to continue iterating.
 
-When changes are necessary, *request* them, do not *demand* them, and **do not
+When changes are necessary, _request_ them, do not _demand_ them, and **do not
 assume that the submitter already knows how to add a test or run a benchmark**.
 
 Specific performance optimization techniques, coding styles and conventions
@@ -363,7 +364,7 @@ with the appropriate reason to keep the conversation flow concise and relevant.
 
 ### Be aware of the person behind the code
 
-Be aware that *how* you communicate requests and reviews in your feedback can
+Be aware that _how_ you communicate requests and reviews in your feedback can
 have a significant impact on the success of the Pull Request. Yes, we may land
 a particular change that makes Solar better, but the individual might just not
 want to have anything to do with Solar ever again. The goal is not just having

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -205,6 +205,20 @@ str_enum! {
     }
 }
 
+str_enum! {
+    /// Human-readable error message style.
+    #[derive(Default)]
+    #[strum(serialize_all = "kebab-case")]
+    #[non_exhaustive]
+    pub enum HumanEmitterKind {
+        /// Unicode-style decorations (default).
+        #[default]
+        Unicode,
+        /// Short-style decorations.
+        Short,
+    }
+}
+
 /// A single import remapping: `[context:]prefix=path`.
 #[derive(Clone)]
 pub struct ImportRemapping {

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -1,8 +1,8 @@
 //! Solar CLI arguments.
 
 use crate::{
-    ColorChoice, CompilerOutput, CompilerStage, Dump, ErrorFormat, EvmVersion, ImportRemapping,
-    Language, Threads,
+    ColorChoice, CompilerOutput, CompilerStage, Dump, ErrorFormat, EvmVersion, HumanEmitterKind,
+    ImportRemapping, Language, Threads,
 };
 use std::{num::NonZeroUsize, path::PathBuf};
 
@@ -123,6 +123,18 @@ pub struct Opts {
         arg(help_heading = "Display options", long, value_enum, default_value_t)
     )]
     pub error_format: ErrorFormat,
+    /// Human-readable error message style.
+    #[cfg_attr(
+        feature = "clap",
+        arg(help_heading = "Display options", long, value_enum, default_value_t)
+    )]
+    pub error_format_human: HumanEmitterKind,
+    /// Terminal width for error message formatting.
+    #[cfg_attr(
+        feature = "clap",
+        arg(help_heading = "Display options", long, value_name = "WIDTH")
+    )]
+    pub diagnostic_width: Option<usize>,
     /// Whether to disable warnings.
     #[cfg_attr(feature = "clap", arg(help_heading = "Display options", long))]
     pub no_warnings: bool,

--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -156,7 +156,9 @@ impl DiagCtxt {
             ErrorFormat::Human => {
                 let human = HumanEmitter::stderr(opts.color)
                     .source_map(Some(source_map))
-                    .ui_testing(opts.unstable.ui_testing);
+                    .ui_testing(opts.unstable.ui_testing)
+                    .human_kind(opts.error_format_human)
+                    .terminal_width(opts.diagnostic_width);
                 Box::new(human)
             }
             #[cfg(feature = "json")]
@@ -166,7 +168,9 @@ impl DiagCtxt {
                 let json = crate::diagnostics::JsonEmitter::new(writer, source_map)
                     .pretty(opts.pretty_json_err)
                     .rustc_like(matches!(opts.error_format, ErrorFormat::RustcJson))
-                    .ui_testing(opts.unstable.ui_testing);
+                    .ui_testing(opts.unstable.ui_testing)
+                    .human_kind(opts.error_format_human)
+                    .terminal_width(opts.diagnostic_width);
                 Box::new(json)
             }
             format => unimplemented!("{format:?}"),

--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -8,6 +8,7 @@ use annotate_snippets::{
     Annotation, AnnotationKind, Group, Level as ASLevel, Message, Renderer, Report, Snippet, Title,
 };
 use anstream::{AutoStream, ColorChoice};
+use solar_config::HumanEmitterKind;
 use std::{
     any::Any,
     io::{self, Write},
@@ -132,6 +133,30 @@ impl HumanEmitter {
             std::mem::replace(&mut self.renderer, DEFAULT_RENDERER).anonymized_line_numbers(yes);
     }
 
+    /// Sets the human emitter kind (unicode vs short).
+    pub fn human_kind(mut self, kind: HumanEmitterKind) -> Self {
+        match kind {
+            HumanEmitterKind::Unicode => {
+                // Unicode is the default, no change needed
+                self
+            }
+            HumanEmitterKind::Short => {
+                // Use short message format
+                self.renderer = self.renderer.short_message(true);
+                self
+            }
+            _ => unreachable!("Invalid HumanEmitterKind: {kind:?}"),
+        }
+    }
+
+    /// Sets the terminal width for formatting.
+    pub fn terminal_width(mut self, width: Option<usize>) -> Self {
+        if let Some(w) = width {
+            self.renderer = self.renderer.term_width(w);
+        }
+        self
+    }
+
     /// Downcasts the underlying writer to the specified type.
     fn downcast_writer<T: Any>(&self) -> Option<&T> {
         if self.writer_type_id == std::any::TypeId::of::<T>() {
@@ -231,6 +256,18 @@ impl HumanBufferEmitter {
     /// Sets whether to emit diagnostics in a way that is suitable for UI testing.
     pub fn ui_testing(mut self, yes: bool) -> Self {
         self.inner = self.inner.ui_testing(yes);
+        self
+    }
+
+    /// Sets the human emitter kind (unicode vs short).
+    pub fn human_kind(mut self, kind: HumanEmitterKind) -> Self {
+        self.inner = self.inner.human_kind(kind);
+        self
+    }
+
+    /// Sets the terminal width for formatting.
+    pub fn terminal_width(mut self, width: Option<usize>) -> Self {
+        self.inner = self.inner.terminal_width(width);
         self
     }
 

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anstream::ColorChoice;
 use serde::Serialize;
+use solar_config::HumanEmitterKind;
 use std::{io, sync::Arc};
 
 /// Diagnostic emitter that emits diagnostics as JSON.
@@ -62,6 +63,18 @@ impl JsonEmitter {
     /// Sets whether to emit diagnostics in a way that is suitable for UI testing.
     pub fn ui_testing(mut self, yes: bool) -> Self {
         self.human_emitter = self.human_emitter.ui_testing(yes);
+        self
+    }
+
+    /// Sets the human emitter kind for rendered messages.
+    pub fn human_kind(mut self, kind: HumanEmitterKind) -> Self {
+        self.human_emitter = self.human_emitter.human_kind(kind);
+        self
+    }
+
+    /// Sets the terminal width for formatting.
+    pub fn terminal_width(mut self, width: Option<usize>) -> Self {
+        self.human_emitter = self.human_emitter.terminal_width(width);
         self
     }
 

--- a/testdata/test_error_format.sol
+++ b/testdata/test_error_format.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract TestError {
+    uint256 public number;
+    
+    function test() public {
+        uint256 x = 1;
+        uint256 y = 2;
+        uint256 z = x + y // Missing semicolon - this will cause a syntax error
+    }
+}

--- a/tests/ui/cli/help.long.stdout
+++ b/tests/ui/cli/help.long.stdout
@@ -83,5 +83,14 @@ Display options:
           [default: human]
           [possible values: human, json, rustc-json]
 
+      --error-format-human <ERROR_FORMAT_HUMAN>
+          Human-readable error message style
+          
+          [default: unicode]
+          [possible values: unicode, short]
+
+      --diagnostic-width <WIDTH>
+          Terminal width for error message formatting
+
       --no-warnings
           Whether to disable warnings

--- a/tests/ui/cli/help.short.stdout
+++ b/tests/ui/cli/help.short.stdout
@@ -21,9 +21,19 @@ Input options:
       --allow-paths <ALLOW_PATHS>    Allow a given path for imports
 
 Display options:
-      --color <COLOR>                Coloring [default: auto] [possible values: auto, always, never]
-  -v, --verbose                      Use verbose output
-      --pretty-json                  Pretty-print JSON output
-      --pretty-json-err              Pretty-print error JSON output
-      --error-format <ERROR_FORMAT>  How errors and other messages are produced [default: human] [possible values: human, json, rustc-json]
-      --no-warnings                  Whether to disable warnings
+      --color <COLOR>
+          Coloring [default: auto] [possible values: auto, always, never]
+  -v, --verbose
+          Use verbose output
+      --pretty-json
+          Pretty-print JSON output
+      --pretty-json-err
+          Pretty-print error JSON output
+      --error-format <ERROR_FORMAT>
+          How errors and other messages are produced [default: human] [possible values: human, json, rustc-json]
+      --error-format-human <ERROR_FORMAT_HUMAN>
+          Human-readable error message style [default: unicode] [possible values: unicode, short]
+      --diagnostic-width <WIDTH>
+          Terminal width for error message formatting
+      --no-warnings
+          Whether to disable warnings


### PR DESCRIPTION
## Description

This PR adds command-line options to control error message formatting in Solar.

## Changes

- **`--error-format-human=unicode|short`**: Controls human-readable error message style
  - `unicode` (default): Full detailed format with line numbers and arrows
  - `short`: Compact format with essential error information only
- **`--diagnostic-width=<number>`**: Controls terminal width for error message formatting

## Implementation Details

- Added `HumanEmitterKind` enum with `Unicode` and `Short` variants
- Enhanced `HumanEmitter` with `human_kind()` and `terminal_width()` methods
- Updated `DiagCtxt::from_opts()` to use new options
- Added methods to `HumanBufferEmitter` and `JsonEmitter` for full integration

## Testing

- Verified different formats produce expected output
- Confirmed terminal width truncation works correctly
- All `cargo check` passes successfully
- Help output shows new options correctly

Closes #468 

cc @DaniPopes :)