### PR TITLE
refactor(lexer): Inline token glueing into Cursor

### DIFF
--- a/crates/ast/src/token.rs
+++ b/crates/ast/src/token.rs
@@ -439,59 +439,6 @@ impl TokenKind {
     pub const fn is_comment_or_doc(&self) -> bool {
         matches!(self, Self::Comment(..))
     }
-
-    /// Glues two token kinds together.
-    pub const fn glue(self, other: Self) -> Option<Self> {
-        use BinOpToken::*;
-        use TokenKind::*;
-        Some(match self {
-            Eq => match other {
-                Eq => EqEq,
-                Gt => FatArrow,
-                _ => return None,
-            },
-            Lt => match other {
-                Eq => Le,
-                Lt => BinOp(Shl),
-                Le => BinOpEq(Shl),
-                _ => return None,
-            },
-            Gt => match other {
-                Eq => Ge,
-                Gt => BinOp(Shr),
-                Ge => BinOpEq(Shr),
-                BinOp(Shr) => BinOp(Sar),
-                BinOpEq(Shr) => BinOpEq(Sar),
-                _ => return None,
-            },
-            Not => match other {
-                Eq => Ne,
-                _ => return None,
-            },
-            Colon => match other {
-                Eq => Walrus,
-                _ => return None,
-            },
-            BinOp(op) => match (op, other) {
-                (op, Eq) => BinOpEq(op),
-                (And, BinOp(And)) => AndAnd,
-                (Or, BinOp(Or)) => OrOr,
-                (Minus, Gt) => Arrow,
-                (Shr, Gt) => BinOp(Sar),
-                (Shr, Ge) => BinOpEq(Sar),
-                (Plus, BinOp(Plus)) => PlusPlus,
-                (Minus, BinOp(Minus)) => MinusMinus,
-                (Star, BinOp(Star)) => StarStar,
-                _ => return None,
-            },
-
-            Le | EqEq | Ne | Ge | AndAnd | OrOr | Tilde | Walrus | PlusPlus | MinusMinus
-            | StarStar | BinOpEq(_) | At | Dot | Comma | Semi | Arrow | FatArrow | Question
-            | OpenDelim(_) | CloseDelim(_) | Literal(..) | Ident(_) | Comment(..) | Eof => {
-                return None;
-            }
-        })
-    }
 }
 
 /// A single token.
@@ -763,11 +710,6 @@ impl Token {
     #[inline]
     pub fn description(self) -> Option<TokenDescription> {
         TokenDescription::from_token(self)
-    }
-
-    /// Glues two tokens together.
-    pub fn glue(self, other: Self) -> Option<Self> {
-        self.kind.glue(other.kind).map(|kind| Self::new(kind, self.span.to(other.span)))
     }
 }
 

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -224,20 +224,22 @@ impl<'a> Cursor<'a> {
                     }
                     b'>' => {
                         self.bump();
-                        if self.first() == b'>' {
-                            // >>> or >>>=
-                            self.bump();
-                            if self.first() == b'=' {
+                        match self.first() {
+                            b'>' => {
+                                // >>> or >>>=
                                 self.bump();
-                                RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Sar)
-                            } else {
-                                RawTokenKind::BinOp(solar_ast::token::BinOpToken::Sar)
+                                if self.first() == b'=' {
+                                    self.bump();
+                                    RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Sar)
+                                } else {
+                                    RawTokenKind::BinOp(solar_ast::token::BinOpToken::Sar)
+                                }
                             }
-                        } else if self.first() == b'=' {
-                            self.bump();
-                            RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Shr)
-                        } else {
-                            RawTokenKind::BinOp(solar_ast::token::BinOpToken::Shr)
+                            b'=' => {
+                                self.bump();
+                                RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Shr)
+                            }
+                            _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Shr),
                         }
                     }
                     _ => RawTokenKind::Gt,

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -172,6 +172,8 @@ impl<'a> Cursor<'a> {
             b']' => RawTokenKind::CloseBracket,
             b'~' => RawTokenKind::Tilde,
             b'?' => RawTokenKind::Question,
+
+            // Multi-character tokens.
             b':' => match self.first() {
                 b'=' => {
                     self.bump();

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -141,7 +141,7 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Slash)
                 }
-                _ => RawTokenKind::Slash,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Slash),
             },
 
             // Whitespace sequence.
@@ -260,7 +260,7 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     RawTokenKind::Arrow
                 }
-                _ => RawTokenKind::Minus,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Minus),
             },
             b'&' => match self.first() {
                 b'&' => {
@@ -271,7 +271,7 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::And)
                 }
-                _ => RawTokenKind::And,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::And),
             },
             b'|' => match self.first() {
                 b'|' => {
@@ -282,7 +282,7 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Or)
                 }
-                _ => RawTokenKind::Or,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Or),
             },
             b'+' => match self.first() {
                 b'+' => {
@@ -293,7 +293,7 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Plus)
                 }
-                _ => RawTokenKind::Plus,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Plus),
             },
             b'*' => match self.first() {
                 b'*' => {
@@ -304,21 +304,21 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Star)
                 }
-                _ => RawTokenKind::Star,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Star),
             },
             b'^' => match self.first() {
                 b'=' => {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Caret)
                 }
-                _ => RawTokenKind::Caret,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Caret),
             },
             b'%' => match self.first() {
                 b'=' => {
                     self.bump();
                     RawTokenKind::BinOpEq(solar_ast::token::BinOpToken::Percent)
                 }
-                _ => RawTokenKind::Percent,
+                _ => RawTokenKind::BinOp(solar_ast::token::BinOpToken::Percent),
             },
 
             // String literal.

--- a/crates/parse/src/lexer/cursor/tests.rs
+++ b/crates/parse/src/lexer/cursor/tests.rs
@@ -20,18 +20,18 @@ RawToken { kind: Whitespace, len: 1 }
 RawToken { kind: Ident, len: 2 }
 RawToken { kind: Whitespace, len: 1 }
 RawToken { kind: Ident, len: 4 }
-RawToken { kind: OpenParen, len: 1 }
-RawToken { kind: CloseParen, len: 1 }
+RawToken { kind: OpenDelim(Parenthesis), len: 1 }
+RawToken { kind: CloseDelim(Parenthesis), len: 1 }
 RawToken { kind: Whitespace, len: 1 }
-RawToken { kind: OpenBrace, len: 1 }
+RawToken { kind: OpenDelim(Brace), len: 1 }
 RawToken { kind: Whitespace, len: 1 }
 RawToken { kind: Ident, len: 5 }
-RawToken { kind: OpenParen, len: 1 }
+RawToken { kind: OpenDelim(Parenthesis), len: 1 }
 RawToken { kind: Literal { kind: Str { kind: Str, terminated: true } }, len: 7 }
-RawToken { kind: CloseParen, len: 1 }
+RawToken { kind: CloseDelim(Parenthesis), len: 1 }
 RawToken { kind: Semi, len: 1 }
 RawToken { kind: Whitespace, len: 1 }
-RawToken { kind: CloseBrace, len: 1 }
+RawToken { kind: CloseDelim(Brace), len: 1 }
 RawToken { kind: Whitespace, len: 1 }
 "#]],
     );

--- a/crates/parse/src/lexer/cursor/token.rs
+++ b/crates/parse/src/lexer/cursor/token.rs
@@ -1,6 +1,6 @@
 //! Raw, low-level tokens. Created using [`Cursor`](crate::Cursor).
 
-use solar_ast::{Base, StrKind};
+use solar_ast::{Base, StrKind, token::BinOpToken};
 
 /// A raw token.
 ///
@@ -53,6 +53,36 @@ pub enum RawTokenKind {
     ///
     /// See [`RawLiteralKind`] for more details.
     Literal { kind: RawLiteralKind },
+
+    // Multi-character operator tokens:
+    /// `==`
+    EqEq,
+    /// `<=`
+    Le,
+    /// `>=`
+    Ge,
+    /// `!=`
+    Ne,
+    /// `&&`
+    AndAnd,
+    /// `||`
+    OrOr,
+    /// `:=`
+    Walrus,
+    /// `++`
+    PlusPlus,
+    /// `--`
+    MinusMinus,
+    /// `**`
+    StarStar,
+    /// `->`
+    Arrow,
+    /// `=>`
+    FatArrow,
+    /// Binary operator composed of multiple characters, e.g. `<<`, `>>`, `>>>` ...
+    BinOp(BinOpToken),
+    /// Binary operator with assignment, e.g. `+=`, `*=`, `<<=` ...
+    BinOpEq(BinOpToken),
 
     // One-char tokens:
     /// `;`

--- a/crates/parse/src/lexer/cursor/token.rs
+++ b/crates/parse/src/lexer/cursor/token.rs
@@ -79,7 +79,7 @@ pub enum RawTokenKind {
     Arrow,
     /// `=>`
     FatArrow,
-    /// Binary operator composed of multiple characters, e.g. `<<`, `>>`, `>>>` ...
+    /// Binary operator, e.g. `<<`, `>>`, `>>>` ...
     BinOp(BinOpToken),
     /// Binary operator with assignment, e.g. `+=`, `*=`, `<<=` ...
     BinOpEq(BinOpToken),
@@ -117,22 +117,6 @@ pub enum RawTokenKind {
     Lt,
     /// `>`
     Gt,
-    /// `-`
-    Minus,
-    /// `&`
-    And,
-    /// `|`
-    Or,
-    /// `+`
-    Plus,
-    /// `*`
-    Star,
-    /// `/`
-    Slash,
-    /// `^`
-    Caret,
-    /// `%`
-    Percent,
 
     /// Unknown token, not expected by the lexer, e.g. `№`
     Unknown,

--- a/crates/parse/src/lexer/cursor/token.rs
+++ b/crates/parse/src/lexer/cursor/token.rs
@@ -1,6 +1,9 @@
 //! Raw, low-level tokens. Created using [`Cursor`](crate::Cursor).
 
-use solar_ast::{Base, StrKind, token::BinOpToken};
+use solar_ast::{
+    Base, StrKind,
+    token::{BinOpToken, Delimiter},
+};
 
 /// A raw token.
 ///
@@ -54,19 +57,29 @@ pub enum RawTokenKind {
     /// See [`RawLiteralKind`] for more details.
     Literal { kind: RawLiteralKind },
 
-    // Multi-character operator tokens:
-    /// `==`
-    EqEq,
+    // Expression-operator symbols.
+    /// `=`
+    Eq,
+    /// `<`
+    Lt,
     /// `<=`
     Le,
-    /// `>=`
-    Ge,
+    /// `==`
+    EqEq,
     /// `!=`
     Ne,
+    /// `>=`
+    Ge,
+    /// `>`
+    Gt,
     /// `&&`
     AndAnd,
     /// `||`
     OrOr,
+    /// `!`
+    Not,
+    /// `~`
+    Tilde,
     /// `:=`
     Walrus,
     /// `++`
@@ -75,48 +88,32 @@ pub enum RawTokenKind {
     MinusMinus,
     /// `**`
     StarStar,
+    /// A binary operator token.
+    BinOp(BinOpToken),
+    /// A binary operator token, followed by an equals sign (`=`).
+    BinOpEq(BinOpToken),
+
+    // Structural symbols.
+    /// `@`
+    At,
+    /// `.`
+    Dot,
+    /// `,`
+    Comma,
+    /// `;`
+    Semi,
+    /// `:`
+    Colon,
     /// `->`
     Arrow,
     /// `=>`
     FatArrow,
-    /// Binary operator, e.g. `<<`, `>>`, `>>>` ...
-    BinOp(BinOpToken),
-    /// Binary operator with assignment, e.g. `+=`, `*=`, `<<=` ...
-    BinOpEq(BinOpToken),
-
-    // One-char tokens:
-    /// `;`
-    Semi,
-    /// `,`
-    Comma,
-    /// `.`
-    Dot,
-    /// `(`
-    OpenParen,
-    /// `)`
-    CloseParen,
-    /// `{`
-    OpenBrace,
-    /// `}`
-    CloseBrace,
-    /// `[`
-    OpenBracket,
-    /// `]`
-    CloseBracket,
-    /// `~`
-    Tilde,
     /// `?`
     Question,
-    /// `:`
-    Colon,
-    /// `=`
-    Eq,
-    /// `!`
-    Bang,
-    /// `<`
-    Lt,
-    /// `>`
-    Gt,
+    /// An opening delimiter (e.g., `{`).
+    OpenDelim(Delimiter),
+    /// A closing delimiter (e.g., `}`).
+    CloseDelim(Delimiter),
 
     /// Unknown token, not expected by the lexer, e.g. `№`
     Unknown,

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -39,9 +39,6 @@ pub struct Lexer<'sess, 'src> {
     /// Cursor for getting lexer tokens.
     cursor: Cursor<'src>,
 
-    /// The current token which has not been processed by `next_token` yet.
-    token: Token,
-
     /// When a "unknown start of token: \u{a0}" has already been emitted earlier
     /// in this file, it's safe to treat further occurrences of the non-breaking
     /// space character as whitespace.
@@ -63,17 +60,14 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
 
     /// Creates a new `Lexer` for the given source string and starting position.
     pub fn with_start_pos(sess: &'sess Session, src: &'src str, start_pos: BytePos) -> Self {
-        let mut lexer = Self {
+        Self {
             sess,
             start_pos,
             pos: start_pos,
             src,
             cursor: Cursor::new(src),
-            token: Token::DUMMY,
             nbsp_is_whitespace: false,
-        };
-        lexer.token = lexer.bump();
-        lexer
+        }
     }
 
     /// Returns a reference to the diagnostic context.
@@ -113,11 +107,6 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
 
     /// Returns the next token, advancing the lexer.
     pub fn next_token(&mut self) -> Token {
-        let next_token = self.bump();
-        std::mem::replace(&mut self.token, next_token)
-    }
-
-    fn bump(&mut self) -> Token {
         let mut swallow_next_invalid = 0;
         loop {
             let RawToken { kind: raw_kind, len } = self.cursor.advance_token();

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -2,7 +2,7 @@
 
 use solar_ast::{
     Base, StrKind,
-    token::{BinOpToken, CommentKind, Delimiter, Token, TokenKind, TokenLitKind},
+    token::{CommentKind, Delimiter, Token, TokenKind, TokenLitKind},
 };
 use solar_interface::{
     BytePos, Session, Span, Symbol, diagnostics::DiagCtxt, source_map::SourceFile,
@@ -165,14 +165,6 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 RawTokenKind::Bang => TokenKind::Not,
                 RawTokenKind::Lt => TokenKind::Lt,
                 RawTokenKind::Gt => TokenKind::Gt,
-                RawTokenKind::Minus => TokenKind::BinOp(BinOpToken::Minus),
-                RawTokenKind::And => TokenKind::BinOp(BinOpToken::And),
-                RawTokenKind::Or => TokenKind::BinOp(BinOpToken::Or),
-                RawTokenKind::Plus => TokenKind::BinOp(BinOpToken::Plus),
-                RawTokenKind::Star => TokenKind::BinOp(BinOpToken::Star),
-                RawTokenKind::Slash => TokenKind::BinOp(BinOpToken::Slash),
-                RawTokenKind::Caret => TokenKind::BinOp(BinOpToken::Caret),
-                RawTokenKind::Percent => TokenKind::BinOp(BinOpToken::Percent),
 
                 RawTokenKind::EqEq => TokenKind::EqEq,
                 RawTokenKind::Le => TokenKind::Le,
@@ -417,8 +409,8 @@ fn escaped_char(c: char) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use BinOpToken::*;
     use TokenKind::*;
+    use solar_ast::token::BinOpToken::*;
     use std::ops::Range;
 
     type Expected<'a> = &'a [(Range<usize>, TokenKind)];

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -21,8 +21,7 @@ mod utf8;
 /// Solidity and Yul lexer.
 ///
 /// Converts a [`Cursor`]'s output from simple [`RawTokenKind`]s into rich [`TokenKind`]s, by
-/// converting strings into interned symbols, concatenating tokens together, and running additional
-/// validation.
+/// converting strings into interned symbols, and running additional validation.
 pub struct Lexer<'sess, 'src> {
     /// The parsing context.
     pub(crate) sess: &'sess Session,

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -113,18 +113,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
 
     /// Returns the next token, advancing the lexer.
     pub fn next_token(&mut self) -> Token {
-        let mut next_token;
-        loop {
-            let preceded_by_whitespace;
-            (next_token, preceded_by_whitespace) = self.bump();
-            if preceded_by_whitespace {
-                break;
-            } else if let Some(glued) = self.token.glue(next_token) {
-                self.token = glued;
-            } else {
-                break;
-            }
-        }
+        let (next_token, _) = self.bump();
         std::mem::replace(&mut self.token, next_token)
     }
 
@@ -202,6 +191,21 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 RawTokenKind::Slash => TokenKind::BinOp(BinOpToken::Slash),
                 RawTokenKind::Caret => TokenKind::BinOp(BinOpToken::Caret),
                 RawTokenKind::Percent => TokenKind::BinOp(BinOpToken::Percent),
+
+                RawTokenKind::EqEq => TokenKind::EqEq,
+                RawTokenKind::Le => TokenKind::Le,
+                RawTokenKind::Ge => TokenKind::Ge,
+                RawTokenKind::Ne => TokenKind::Ne,
+                RawTokenKind::AndAnd => TokenKind::AndAnd,
+                RawTokenKind::OrOr => TokenKind::OrOr,
+                RawTokenKind::Walrus => TokenKind::Walrus,
+                RawTokenKind::PlusPlus => TokenKind::PlusPlus,
+                RawTokenKind::MinusMinus => TokenKind::MinusMinus,
+                RawTokenKind::StarStar => TokenKind::StarStar,
+                RawTokenKind::Arrow => TokenKind::Arrow,
+                RawTokenKind::FatArrow => TokenKind::FatArrow,
+                RawTokenKind::BinOp(op) => TokenKind::BinOp(op),
+                RawTokenKind::BinOpEq(op) => TokenKind::BinOpEq(op),
 
                 RawTokenKind::Unknown => {
                     // Don't emit diagnostics for sequences of the same invalid token


### PR DESCRIPTION
- Updated `next_token` method in `Lexer` to directly use the result of `bump()` without attempting to glue tokens.
- Added new raw token kinds for various operators: `EqEq`, `Le`, `Ge`...
- Updated `Cursor` to handle multi-character operator tokens and their corresponding raw token kinds.
- Removed the `glue` methods from `TokenKind` and `Token` impl (no longer needed)

Closes #477 