### PR TITLE
chore: improve 'parsed' debug log

### DIFF
--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -471,7 +471,7 @@ impl DiagCtxtInner {
         match (errors, others.is_empty()) {
             (None, true) => Ok(()),
             (None, false) => {
-                // TODO: Don't emit in tests since it's not handled by `ui_test`.
+                // TODO: Don't emit in tests since it's not handled by `ui_test`: https://github.com/oli-obk/ui_test/issues/324
                 if self.flags.track_diagnostics {
                     let msg = others.join(", ");
                     self.emitter.emit_diagnostic(&mut Diag::new(Level::Warning, msg));

--- a/crates/sema/src/ty/abi.rs
+++ b/crates/sema/src/ty/abi.rs
@@ -41,7 +41,7 @@ impl<'gcx> Gcx<'gcx> {
         for f in self.interface_functions(id) {
             items.push(self.function_abi(f.id).into());
         }
-        // TODO: Does not include referenced items.
+        // TODO: Does not include referenced items: https://github.com/paradigmxyz/solar/issues/305
         // See solc `interfaceEvents` and `interfaceErrors`.
         for item in self.hir.contract_item_ids(id) {
             match item {


### PR DESCRIPTION
Avoid spamming with no-op parse logs and display some more stats.