### PR TITLE
feat(interface): add Session::reconfigure

### DIFF
--- a/crates/interface/src/source_map/file.rs
+++ b/crates/interface/src/source_map/file.rs
@@ -100,9 +100,8 @@ impl FileName {
     /// Displays the filename.
     #[inline]
     pub fn display(&self) -> FileNameDisplay<'_> {
-        let base_path = crate::SessionGlobals::try_with(|g| {
-            g.and_then(|g| g.source_map.base_path.get().cloned())
-        });
+        let base_path =
+            crate::SessionGlobals::try_with(|g| g.and_then(|g| g.source_map.base_path()));
         FileNameDisplay { inner: self, base_path }
     }
 


### PR DESCRIPTION
We need to expose re-configuring the session's internals to library users. Mainly, `SourceMap::base_path` is used to trim diagnostics output paths, but `ui_test` requires that paths be absolute for annotations to work, and there is currently no way to unset the `base_path` after Session instantiation.