### PR TITLE
feat(ast)!: add span to yul switch cases

### DIFF
--- a/crates/ast/src/ast/yul.rs
+++ b/crates/ast/src/ast/yul.rs
@@ -157,8 +157,15 @@ pub enum StmtKind<'ast> {
 #[derive(Debug)]
 pub struct StmtSwitch<'ast> {
     pub selector: Expr<'ast>,
-    pub branches: Box<'ast, [StmtSwitchCase<'ast>]>,
-    pub default_case: Option<Block<'ast>>,
+    /// The cases of the switch statement. Includes the default case in the last position, if any.
+    pub cases: Box<'ast, [StmtSwitchCase<'ast>]>,
+}
+
+impl<'ast> StmtSwitch<'ast> {
+    /// Returns the default case of the switch statement, if any.
+    pub fn default_case(&self) -> Option<&StmtSwitchCase<'ast>> {
+        self.cases.last().filter(|case| case.constant.is_none())
+    }
 }
 
 /// Represents a non-default case of a Yul switch statement.
@@ -166,7 +173,9 @@ pub struct StmtSwitch<'ast> {
 /// See [`StmtSwitch`] for more information.
 #[derive(Debug)]
 pub struct StmtSwitchCase<'ast> {
-    pub constant: Lit<'ast>,
+    pub span: Span,
+    /// The constant of the case, if any. `None` for the default case.
+    pub constant: Option<Lit<'ast>>,
     pub body: Block<'ast>,
 }
 

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -565,20 +565,20 @@ declare_visitors! {
         }
 
         fn visit_yul_stmt_switch(&mut self, switch: &'ast #mut yul::StmtSwitch<'ast>) -> ControlFlow<Self::BreakValue> {
-            let yul::StmtSwitch { selector, branches, default_case } = switch;
+            let yul::StmtSwitch { selector, cases } = switch;
             self.visit_yul_expr #_mut(selector)?;
-            for case in branches.iter #_mut() {
+            for case in cases.iter #_mut() {
                 self.visit_yul_stmt_case #_mut(case)?;
-            }
-            if let Some(case) = default_case {
-                self.visit_yul_block #_mut(case)?;
             }
             ControlFlow::Continue(())
         }
 
         fn visit_yul_stmt_case(&mut self, case: &'ast #mut yul::StmtSwitchCase<'ast>) -> ControlFlow<Self::BreakValue> {
-            let yul::StmtSwitchCase { constant, body } = case;
-            self.visit_lit #_mut(constant)?;
+            let yul::StmtSwitchCase { span, constant, body } = case;
+            self.visit_span #_mut(span)?;
+            if let Some(constant) = constant {
+                self.visit_lit #_mut(constant)?;
+            }
             self.visit_yul_block #_mut(body)?;
             ControlFlow::Continue(())
         }

--- a/crates/sema/src/stats.rs
+++ b/crates/sema/src/stats.rs
@@ -474,11 +474,8 @@ impl<'ast> Visit<'ast> for StatCollector {
     ) -> ControlFlow<Self::BreakValue> {
         self.record("YulStmtSwitch", None, switch);
         // Don't visit selector field since it isn't boxed
-        for case in switch.branches.iter() {
+        for case in switch.cases.iter() {
             self.visit_yul_stmt_case(case)?;
-        }
-        if let Some(case) = &switch.default_case {
-            self.visit_yul_block(case)?;
         }
         ControlFlow::Continue(())
     }

--- a/tests/ui/parser/bad_switch.sol
+++ b/tests/ui/parser/bad_switch.sol
@@ -1,0 +1,8 @@
+function f() {
+    assembly {
+        switch 42 //~ ERROR: `switch` statement has no cases
+
+        switch 42 //~ WARN: `switch` statement has only a default case
+        default {}
+    }
+}

--- a/tests/ui/parser/bad_switch.stderr
+++ b/tests/ui/parser/bad_switch.stderr
@@ -1,0 +1,15 @@
+error: `switch` statement has no cases
+  --> ROOT/tests/ui/parser/bad_switch.sol:LL:CC
+   |
+LL |         switch 42
+   |         ^^^^^^^^^
+
+warning[9592]: `switch` statement has only a default case
+  --> ROOT/tests/ui/parser/bad_switch.sol:LL:CC
+   |
+LL | /         switch 42
+LL | |         default {}
+   | |__________________^
+
+error: aborting due to 1 previous error; 1 warning emitted
+


### PR DESCRIPTION
Also renames to `branches` to `cases`, and moves the default case into the list.