### PR TITLE
refactor(ast): boxed `yul::StmtKind::For` to reduce the size of `yul::Stmt`

### DIFF
--- a/crates/ast/src/ast/mod.rs
+++ b/crates/ast/src/ast/mod.rs
@@ -241,6 +241,6 @@ mod tests {
         assert_size::<yul::StmtKind<'_>>(str!["80"]);
         assert_size::<yul::Stmt<'_>>(str!["104"]);
         assert_size::<yul::Block<'_>>(str!["24"]);
-        assert_size::<yul::YulStmtFor<'_>>(str!["120"]);
+        assert_size::<yul::StmtFor<'_>>(str!["120"]);
     }
 }

--- a/crates/ast/src/ast/mod.rs
+++ b/crates/ast/src/ast/mod.rs
@@ -238,8 +238,9 @@ mod tests {
         assert_size::<yul::ExprKind<'_>>(str!["40"]);
         assert_size::<yul::Expr<'_>>(str!["48"]);
 
-        assert_size::<yul::StmtKind<'_>>(str!["120"]);
-        assert_size::<yul::Stmt<'_>>(str!["144"]);
+        assert_size::<yul::StmtKind<'_>>(str!["80"]);
+        assert_size::<yul::Stmt<'_>>(str!["104"]);
         assert_size::<yul::Block<'_>>(str!["24"]);
+        assert_size::<yul::YulStmtFor<'_>>(str!["120"]);
     }
 }

--- a/crates/ast/src/ast/yul.rs
+++ b/crates/ast/src/ast/yul.rs
@@ -116,7 +116,7 @@ pub enum StmtKind<'ast> {
     /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.yulForStatement>
     ///
     /// Breakdown of parts: <https://docs.soliditylang.org/en/latest/yul.html#loops>
-    For { init: Block<'ast>, cond: Expr<'ast>, step: Block<'ast>, body: Block<'ast> },
+    For(Box<'ast, YulStmtFor<'ast>>),
 
     /// A switch statement: `switch expr case 0 { ... } default { ... }`.
     ///
@@ -139,6 +139,15 @@ pub enum StmtKind<'ast> {
     ///
     /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.yulVariableDeclaration>
     VarDecl(Box<'ast, [Ident]>, Option<Expr<'ast>>),
+}
+
+/// A Yul `for` statement parts.
+#[derive(Debug)]
+pub struct YulStmtFor<'ast> {
+    pub init: Block<'ast>,
+    pub cond: Expr<'ast>,
+    pub step: Block<'ast>,
+    pub body: Block<'ast>,
 }
 
 /// A Yul switch statement can consist of only a default-case or one

--- a/crates/ast/src/ast/yul.rs
+++ b/crates/ast/src/ast/yul.rs
@@ -116,7 +116,7 @@ pub enum StmtKind<'ast> {
     /// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.yulForStatement>
     ///
     /// Breakdown of parts: <https://docs.soliditylang.org/en/latest/yul.html#loops>
-    For(Box<'ast, YulStmtFor<'ast>>),
+    For(Box<'ast, StmtFor<'ast>>),
 
     /// A switch statement: `switch expr case 0 { ... } default { ... }`.
     ///
@@ -141,9 +141,13 @@ pub enum StmtKind<'ast> {
     VarDecl(Box<'ast, [Ident]>, Option<Expr<'ast>>),
 }
 
-/// A Yul `for` statement parts.
+/// A Yul for statement: `for {let i := 0} lt(i,10) {i := add(i,1)} { ... }`.
+///
+/// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.yulForStatement>
+///
+/// Breakdown of parts: <https://docs.soliditylang.org/en/latest/yul.html#loops>
 #[derive(Debug)]
-pub struct YulStmtFor<'ast> {
+pub struct StmtFor<'ast> {
     pub init: Block<'ast>,
     pub cond: Expr<'ast>,
     pub step: Block<'ast>,

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -528,7 +528,8 @@ declare_visitors! {
                     self.visit_yul_expr #_mut(expr)?;
                     self.visit_yul_block #_mut(block)?;
                 }
-                yul::StmtKind::For { init, cond, step, body } => {
+                yul::StmtKind::For(for_) => {
+                    let yul::YulStmtFor { init, cond, step, body } = for_;
                     self.visit_yul_block #_mut(init)?;
                     self.visit_yul_expr #_mut(cond)?;
                     self.visit_yul_block #_mut(step)?;

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -528,8 +528,7 @@ declare_visitors! {
                     self.visit_yul_expr #_mut(expr)?;
                     self.visit_yul_block #_mut(block)?;
                 }
-                yul::StmtKind::For(for_) => {
-                    let yul::YulStmtFor { init, cond, step, body } = for_;
+                yul::StmtKind::For(yul::StmtFor { init, cond, step, body }) => {
                     self.visit_yul_block #_mut(init)?;
                     self.visit_yul_expr #_mut(cond)?;
                     self.visit_yul_block #_mut(step)?;

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -268,7 +268,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let cond = self.parse_yul_expr()?;
         let step = self.parse_yul_block_unchecked()?;
         let body = self.parse_yul_block_unchecked()?;
-        Ok(StmtKind::For { init, cond, step, body })
+        Ok(StmtKind::For(self.alloc(YulStmtFor { init, cond, step, body })))
     }
 
     /// Parses a Yul expression.

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -268,7 +268,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let cond = self.parse_yul_expr()?;
         let step = self.parse_yul_block_unchecked()?;
         let body = self.parse_yul_block_unchecked()?;
-        Ok(StmtKind::For(self.alloc(YulStmtFor { init, cond, step, body })))
+        Ok(StmtKind::For(self.alloc(StmtFor { init, cond, step, body })))
     }
 
     /// Parses a Yul expression.


### PR DESCRIPTION
Closes #499 