### PR TITLE
perf(lexer): use lookup tables for char info

### DIFF
--- a/crates/parse/src/lexer/cursor/char_info.rs
+++ b/crates/parse/src/lexer/cursor/char_info.rs
@@ -31,6 +31,14 @@ pub const fn is_id_continue_byte(c: u8) -> bool {
     classify(c) & ID_CONTINUE != 0
 }
 
+pub(super) const fn is_decimal_digit(c: u8) -> bool {
+    classify(c) & DECIMAL_DIGIT != 0
+}
+
+pub(super) const fn is_hex_digit(c: u8) -> bool {
+    classify(c) & HEX_DIGIT != 0
+}
+
 /// Returns `true` if the given string is a valid Solidity identifier.
 ///
 /// An identifier in Solidity has to start with a letter, a dollar-sign or an underscore and may
@@ -63,14 +71,6 @@ pub const fn is_ident_bytes(s: &[u8]) -> bool {
     }
 
     true
-}
-
-pub(super) const fn is_decimal_digit(c: u8) -> bool {
-    classify(c) & DECIMAL_DIGIT != 0
-}
-
-pub(super) const fn is_hex_digit(c: u8) -> bool {
-    classify(c) & HEX_DIGIT != 0
 }
 
 /// Converts a `char` to a `u8`.

--- a/crates/parse/src/lexer/cursor/char_info.rs
+++ b/crates/parse/src/lexer/cursor/char_info.rs
@@ -115,10 +115,10 @@ const fn classify_impl(c: u8) -> u8 {
     if matches!(c, b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$' | b'0'..=b'9') {
         result |= ID_CONTINUE;
     }
-    if matches!(c, b'0'..=b'9') {
+    if c.is_ascii_digit() {
         result |= DECIMAL_DIGIT;
     }
-    if matches!(c, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F') {
+    if c.is_ascii_hexdigit() {
         result |= HEX_DIGIT;
     }
     result

--- a/crates/parse/src/lexer/cursor/char_info.rs
+++ b/crates/parse/src/lexer/cursor/char_info.rs
@@ -31,10 +31,13 @@ pub const fn is_id_continue_byte(c: u8) -> bool {
     classify(c) & ID_CONTINUE != 0
 }
 
+#[inline]
 pub(super) const fn is_decimal_digit(c: u8) -> bool {
-    classify(c) & DECIMAL_DIGIT != 0
+    // classify(c) & DECIMAL_DIGIT != 0
+    c.is_ascii_digit()
 }
 
+#[inline]
 pub(super) const fn is_hex_digit(c: u8) -> bool {
     classify(c) & HEX_DIGIT != 0
 }

--- a/crates/parse/src/lexer/cursor/char_info.rs
+++ b/crates/parse/src/lexer/cursor/char_info.rs
@@ -1,0 +1,98 @@
+/// Returns `true` if the given character is considered a whitespace.
+#[inline]
+pub const fn is_whitespace(c: char) -> bool {
+    is_whitespace_byte(ch2u8(c))
+}
+/// Returns `true` if the given character is considered a whitespace.
+#[inline]
+pub const fn is_whitespace_byte(c: u8) -> bool {
+    INFO[c as usize] & WHITESPACE != 0
+}
+
+/// Returns `true` if the given character is valid at the start of a Solidity identifier.
+#[inline]
+pub const fn is_id_start(c: char) -> bool {
+    is_id_start_byte(ch2u8(c))
+}
+/// Returns `true` if the given character is valid at the start of a Solidity identifier.
+#[inline]
+pub const fn is_id_start_byte(c: u8) -> bool {
+    INFO[c as usize] & ID_START != 0
+}
+
+/// Returns `true` if the given character is valid in a Solidity identifier.
+#[inline]
+pub const fn is_id_continue(c: char) -> bool {
+    is_id_continue_byte(ch2u8(c))
+}
+/// Returns `true` if the given character is valid in a Solidity identifier.
+#[inline]
+pub const fn is_id_continue_byte(c: u8) -> bool {
+    INFO[c as usize] & ID_CONTINUE != 0
+}
+
+/// Returns `true` if the given string is a valid Solidity identifier.
+///
+/// An identifier in Solidity has to start with a letter, a dollar-sign or an underscore and may
+/// additionally contain numbers after the first symbol.
+///
+/// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityLexer.Identifier>
+#[inline]
+pub const fn is_ident(s: &str) -> bool {
+    is_ident_bytes(s.as_bytes())
+}
+
+/// Returns `true` if the given byte slice is a valid Solidity identifier.
+///
+/// See [`is_ident`] for more details.
+pub const fn is_ident_bytes(s: &[u8]) -> bool {
+    let [first, ref rest @ ..] = *s else {
+        return false;
+    };
+
+    if !is_id_start_byte(first) {
+        return false;
+    }
+
+    let mut i = 0;
+    while i < rest.len() {
+        if !is_id_continue_byte(rest[i]) {
+            return false;
+        }
+        i += 1;
+    }
+
+    true
+}
+
+/// Converts a `char` to a `u8`.
+#[inline(always)]
+const fn ch2u8(c: char) -> u8 {
+    c as u32 as u8
+}
+
+pub(super) const EOF: u8 = b'\0';
+
+const WHITESPACE: u8 = 1 << 0;
+const ID_START: u8 = 1 << 1;
+const ID_CONTINUE: u8 = 1 << 2;
+
+static INFO: [u8; 256] = {
+    let mut table = [0; 256];
+    let mut i = 0;
+    while i < 256 {
+        table[i] = classify(i as u8);
+        i += 1;
+    }
+    table
+};
+
+const fn classify(c: u8) -> u8 {
+    // https://github.com/argotorg/solidity/blob/965166317bbc2b02067eb87f222a2dce9d24e289/liblangutil/Common.h#L20-L46
+    match c {
+        b' ' | b'\t' | b'\n' | b'\r' => WHITESPACE,
+        b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$' => ID_START | ID_CONTINUE,
+        b'0'..=b'9' => ID_CONTINUE,
+        _ => 0,
+    }
+}

--- a/crates/parse/src/lexer/cursor/char_info.rs
+++ b/crates/parse/src/lexer/cursor/char_info.rs
@@ -33,6 +33,7 @@ pub const fn is_id_continue_byte(c: u8) -> bool {
 
 #[inline]
 pub(super) const fn is_decimal_digit(c: u8) -> bool {
+    // `is_ascii_digit` is cheap enough to not benefit from the lookup table.
     // classify(c) & DECIMAL_DIGIT != 0
     c.is_ascii_digit()
 }

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -438,7 +438,7 @@ impl<'a> Cursor<'a> {
 
     /// Eats characters for a hexadecimal number. Returns `true` if any digits were encountered.
     fn eat_hexadecimal_digits(&mut self) -> bool {
-        self.eat_digits(|x| x.is_ascii_hexdigit())
+        self.eat_digits(is_hex_digit)
     }
 
     fn eat_digits(&mut self, mut is_digit: impl FnMut(u8) -> bool) -> bool {

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -13,84 +13,11 @@ use std::sync::OnceLock;
 pub mod token;
 use token::{RawLiteralKind, RawToken, RawTokenKind};
 
+mod char_info;
+pub use char_info::*;
+
 #[cfg(test)]
 mod tests;
-
-/// Returns `true` if the given character is considered a whitespace.
-#[inline]
-pub const fn is_whitespace(c: char) -> bool {
-    is_whitespace_byte(ch2u8(c))
-}
-/// Returns `true` if the given character is considered a whitespace.
-#[inline]
-pub const fn is_whitespace_byte(c: u8) -> bool {
-    matches!(c, b' ' | b'\t' | b'\n' | b'\r')
-}
-
-/// Returns `true` if the given character is valid at the start of a Solidity identifier.
-#[inline]
-pub const fn is_id_start(c: char) -> bool {
-    is_id_start_byte(ch2u8(c))
-}
-/// Returns `true` if the given character is valid at the start of a Solidity identifier.
-#[inline]
-pub const fn is_id_start_byte(c: u8) -> bool {
-    matches!(c, b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$')
-}
-
-/// Returns `true` if the given character is valid in a Solidity identifier.
-#[inline]
-pub const fn is_id_continue(c: char) -> bool {
-    is_id_continue_byte(ch2u8(c))
-}
-/// Returns `true` if the given character is valid in a Solidity identifier.
-#[inline]
-pub const fn is_id_continue_byte(c: u8) -> bool {
-    let is_number = (c >= b'0') & (c <= b'9');
-    is_id_start_byte(c) || is_number
-}
-
-/// Returns `true` if the given string is a valid Solidity identifier.
-///
-/// An identifier in Solidity has to start with a letter, a dollar-sign or an underscore and may
-/// additionally contain numbers after the first symbol.
-///
-/// Reference: <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityLexer.Identifier>
-#[inline]
-pub const fn is_ident(s: &str) -> bool {
-    is_ident_bytes(s.as_bytes())
-}
-
-/// Returns `true` if the given byte slice is a valid Solidity identifier.
-///
-/// See [`is_ident`] for more details.
-pub const fn is_ident_bytes(s: &[u8]) -> bool {
-    let [first, ref rest @ ..] = *s else {
-        return false;
-    };
-
-    if !is_id_start_byte(first) {
-        return false;
-    }
-
-    let mut i = 0;
-    while i < rest.len() {
-        if !is_id_continue_byte(rest[i]) {
-            return false;
-        }
-        i += 1;
-    }
-
-    true
-}
-
-/// Converts a `char` to a `u8`.
-#[inline(always)]
-const fn ch2u8(c: char) -> u8 {
-    c as u32 as u8
-}
-
-const EOF: u8 = b'\0';
 
 /// Peekable iterator over a char sequence.
 ///
@@ -153,7 +80,7 @@ impl<'a> Cursor<'a> {
             // Whitespace sequence.
             c if is_whitespace_byte(c) => self.whitespace(),
 
-            // Identifier (this should be checked after other variant that can start as identifier).
+            // Identifier. This should be checked after other variants that can start as identifier.
             c if is_id_start_byte(c) => self.ident_or_prefixed_literal(c),
 
             // Numeric literal.
@@ -180,6 +107,7 @@ impl<'a> Cursor<'a> {
             b'?' => RawTokenKind::Question,
 
             // Multi-character tokens.
+            // : :=
             b':' => match self.first() {
                 b'=' => {
                     self.bump();
@@ -187,6 +115,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::Colon,
             },
+            // = == =>
             b'=' => match self.first() {
                 b'=' => {
                     self.bump();
@@ -198,6 +127,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::Eq,
             },
+            // ! !=
             b'!' => match self.first() {
                 b'=' => {
                     self.bump();
@@ -205,6 +135,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::Not,
             },
+            // < <= << <<=
             b'<' => match self.first() {
                 b'=' => {
                     self.bump();
@@ -212,7 +143,6 @@ impl<'a> Cursor<'a> {
                 }
                 b'<' => {
                     self.bump();
-                    // Now check for <<= or <<
                     if self.first() == b'=' {
                         self.bump();
                         RawTokenKind::BinOpEq(BinOpToken::Shl)
@@ -222,6 +152,8 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::Lt,
             },
+            // https://github.com/rust-lang/rustfmt/issues/6660
+            // `> >= >> >>= >>> >>>=`
             b'>' => match self.first() {
                 b'=' => {
                     self.bump();
@@ -231,7 +163,6 @@ impl<'a> Cursor<'a> {
                     self.bump();
                     match self.first() {
                         b'>' => {
-                            // >>> or >>>=
                             self.bump();
                             if self.first() == b'=' {
                                 self.bump();
@@ -249,6 +180,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::Gt,
             },
+            // - -- -= ->
             b'-' => match self.first() {
                 b'-' => {
                     self.bump();
@@ -264,6 +196,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::BinOp(BinOpToken::Minus),
             },
+            // & && &=
             b'&' => match self.first() {
                 b'&' => {
                     self.bump();
@@ -275,6 +208,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::BinOp(BinOpToken::And),
             },
+            // | || |=
             b'|' => match self.first() {
                 b'|' => {
                     self.bump();
@@ -286,6 +220,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::BinOp(BinOpToken::Or),
             },
+            // + ++ +=
             b'+' => match self.first() {
                 b'+' => {
                     self.bump();
@@ -297,6 +232,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::BinOp(BinOpToken::Plus),
             },
+            // * ** *=
             b'*' => match self.first() {
                 b'*' => {
                     self.bump();
@@ -308,6 +244,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::BinOp(BinOpToken::Star),
             },
+            // ^ ^=
             b'^' => match self.first() {
                 b'=' => {
                     self.bump();
@@ -315,6 +252,7 @@ impl<'a> Cursor<'a> {
                 }
                 _ => RawTokenKind::BinOp(BinOpToken::Caret),
             },
+            // % %=
             b'%' => match self.first() {
                 b'=' => {
                     self.bump();

--- a/crates/parse/src/lexer/cursor/mod.rs
+++ b/crates/parse/src/lexer/cursor/mod.rs
@@ -433,7 +433,7 @@ impl<'a> Cursor<'a> {
 
     /// Eats characters for a decimal number. Returns `true` if any digits were encountered.
     fn eat_decimal_digits(&mut self) -> bool {
-        self.eat_digits(|x| x.is_ascii_digit())
+        self.eat_digits(is_decimal_digit)
     }
 
     /// Eats characters for a hexadecimal number. Returns `true` if any digits were encountered.


### PR DESCRIPTION
Turns out lookup table is faster due to less instructions and branches, which outweighs the hit from having one in the first place. CC @malik672