### PR TITLE
Enable AVX2+FMA for benchmark builds

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   codspeed:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C target-feature=+avx2,+fma"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -39,6 +41,7 @@ jobs:
     env:
       BASELINE: base
       IAI_CALLGRIND_RUNNER: iai-callgrind-runner
+      RUSTFLAGS: "-C target-feature=+avx2,+fma"
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Fixes #494

Enables modern SIMD features for benchmark builds