### PR TITLE
chore(interface)!: make SessionGlobals private

### DIFF
--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -13,7 +13,7 @@ pub mod diagnostics;
 use diagnostics::ErrorGuaranteed;
 
 mod globals;
-pub use globals::SessionGlobals;
+use globals::SessionGlobals;
 
 mod pos;
 pub use pos::{BytePos, CharPos, RelativeBytePos};


### PR DESCRIPTION
This should not be used directly. There isn't really a reason for it to be public since Session should be used instead.