### PR TITLE
perf(lexer)!: avoid thread locals when we have a Session

### DIFF
--- a/crates/ast/src/ast/item.rs
+++ b/crates/ast/src/ast/item.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::token::Token;
 use either::Either;
-use solar_interface::{Ident, Span, Spanned};
+use solar_interface::{Ident, Span, Spanned, Symbol};
 use std::{
     fmt,
     ops::{Deref, DerefMut},
@@ -230,6 +230,14 @@ pub enum IdentOrStrLit {
 }
 
 impl IdentOrStrLit {
+    /// Returns the value of the identifier or literal.
+    pub fn value(&self) -> Symbol {
+        match self {
+            Self::Ident(ident) => ident.name,
+            Self::StrLit(str_lit) => str_lit.value,
+        }
+    }
+
     /// Returns the string value of the identifier or literal.
     pub fn as_str(&self) -> &str {
         match self {

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -1385,8 +1385,12 @@ mod tests {
     use super::*;
     use solar_interface::{Result, Session, source_map::FileName};
 
+    fn session() -> Session {
+        Session::builder().with_test_emitter().single_threaded().build()
+    }
+
     fn assert_version_matches(tests: &[(&str, &str, bool)]) {
-        let sess = Session::builder().with_test_emitter().build();
+        let sess = session();
         sess.enter(|| -> Result {
             for (i, &(v, req_s, res)) in tests.iter().enumerate() {
                 let name = i.to_string();
@@ -1608,7 +1612,7 @@ mod tests {
         ];
 
         for (idx, src) in test_functions.iter().enumerate() {
-            let sess = Session::builder().with_test_emitter().build();
+            let sess = session();
             sess.enter(|| -> Result {
                 let arena = Arena::new();
                 let mut parser = Parser::from_source_code(
@@ -1703,7 +1707,7 @@ mod tests {
             ),
         ];
 
-        let sess = Session::builder().with_test_emitter().build();
+        let sess = session();
         sess.enter(|| -> Result {
             for (idx, (src, vis, sm, virt, params, returns)) in test_cases.iter().enumerate() {
                 let arena = Arena::new();

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -135,6 +135,7 @@ impl SeqSep {
 impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Creates a new parser.
     pub fn new(sess: &'sess Session, arena: &'ast ast::Arena, tokens: Vec<Token>) -> Self {
+        assert!(sess.is_entered(), "session should be entered before parsing");
         let mut parser = Self {
             sess,
             arena,

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -480,8 +480,8 @@ mod tests {
     #[test]
     fn optional_items_seq() {
         fn check(tests: &[(&str, &[Option<&str>])]) {
-            solar_interface::enter(|| -> Result {
-                let sess = Session::builder().with_test_emitter().build();
+            let sess = Session::builder().with_test_emitter().single_threaded().build();
+            sess.enter_sequential(|| -> Result {
                 for (i, &(s, results)) in tests.iter().enumerate() {
                     let name = i.to_string();
                     let arena = Arena::new();


### PR DESCRIPTION
Ensure that `Session` is entered when we lex/parse, and use it instead of accessing thread locals.

+0% - +3%: https://codspeed.io/paradigmxyz/solar/branches/dani%2Fintern-in