### PR TITLE
perf(parser): pass Token in registers

### DIFF
--- a/crates/ast/src/token.rs
+++ b/crates/ast/src/token.rs
@@ -442,13 +442,63 @@ impl TokenKind {
 }
 
 /// A single token.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// This struct is written in such a way that it can be passed in registers.
+/// The actual representation is [`TokenRepr`], but it should not be accessed directly.
+#[derive(Clone, Copy)]
 pub struct Token {
+    _data: (std::mem::MaybeUninit<u64>, std::mem::MaybeUninit<u64>),
+}
+
+/// Actual representation of [`Token`].
+///
+/// Do not use this struct directly. Use [`Token`] instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TokenRepr {
     /// The kind of the token.
     pub kind: TokenKind,
     /// The full span of the token.
     pub span: Span,
 }
+
+const _: () = {
+    assert!(size_of::<Token>() == size_of::<TokenRepr>());
+    assert!(align_of::<Token>() >= align_of::<TokenRepr>());
+};
+
+impl std::ops::Deref for Token {
+    type Target = TokenRepr;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: transparent wrapper.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl std::ops::DerefMut for Token {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: transparent wrapper.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl fmt::Debug for Token {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl PartialEq for Token {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl Eq for Token {}
 
 impl From<Ident> for Token {
     #[inline]
@@ -467,7 +517,8 @@ impl Token {
     /// Creates a new token.
     #[inline]
     pub const fn new(kind: TokenKind, span: Span) -> Self {
-        Self { kind, span }
+        // SAFETY: transparent wrapper.
+        unsafe { std::mem::transmute(TokenRepr { kind, span }) }
     }
 
     /// Recovers a `Token` from an `Ident`.
@@ -478,7 +529,7 @@ impl Token {
 
     /// Creates a new identifier if the kind is [`TokenKind::Ident`].
     #[inline]
-    pub const fn ident(&self) -> Option<Ident> {
+    pub fn ident(&self) -> Option<Ident> {
         match self.kind {
             TokenKind::Ident(ident) => Some(Ident::new(ident, self.span)),
             _ => None,
@@ -487,7 +538,7 @@ impl Token {
 
     /// Returns the literal if the kind is [`TokenKind::Literal`].
     #[inline]
-    pub const fn lit(&self) -> Option<TokenLit> {
+    pub fn lit(&self) -> Option<TokenLit> {
         match self.kind {
             TokenKind::Literal(kind, symbol) => Some(TokenLit::new(kind, symbol)),
             _ => None,
@@ -496,7 +547,7 @@ impl Token {
 
     /// Returns this token's literal kind, if any.
     #[inline]
-    pub const fn lit_kind(&self) -> Option<TokenLitKind> {
+    pub fn lit_kind(&self) -> Option<TokenLitKind> {
         match self.kind {
             TokenKind::Literal(kind, _) => Some(kind),
             _ => None,
@@ -505,7 +556,7 @@ impl Token {
 
     /// Returns the comment if the kind is [`TokenKind::Comment`], and whether it's a doc-comment.
     #[inline]
-    pub const fn comment(&self) -> Option<(bool, DocComment)> {
+    pub fn comment(&self) -> Option<(bool, DocComment)> {
         match self.kind {
             TokenKind::Comment(is_doc, kind, symbol) => {
                 Some((is_doc, DocComment { span: self.span, kind, symbol }))
@@ -518,7 +569,7 @@ impl Token {
     ///
     /// Does not check that `is_doc` is `true`.
     #[inline]
-    pub const fn doc(&self) -> Option<DocComment> {
+    pub fn doc(&self) -> Option<DocComment> {
         match self.kind {
             TokenKind::Comment(_, kind, symbol) => {
                 Some(DocComment { span: self.span, kind, symbol })
@@ -529,7 +580,7 @@ impl Token {
 
     /// Returns `true` if the token is an operator.
     #[inline]
-    pub const fn is_op(&self) -> bool {
+    pub fn is_op(&self) -> bool {
         self.kind.is_op()
     }
 
@@ -553,7 +604,7 @@ impl Token {
 
     /// Returns `true` if the token is an identifier.
     #[inline]
-    pub const fn is_ident(&self) -> bool {
+    pub fn is_ident(&self) -> bool {
         matches!(self.kind, TokenKind::Ident(_))
     }
 
@@ -645,7 +696,7 @@ impl Token {
 
     /// Returns `true` if the token is an end-of-file marker.
     #[inline]
-    pub const fn is_eof(&self) -> bool {
+    pub fn is_eof(&self) -> bool {
         matches!(self.kind, TokenKind::Eof)
     }
 
@@ -663,13 +714,13 @@ impl Token {
 
     /// Returns `true` if the token is a normal comment (not a doc-comment).
     #[inline]
-    pub const fn is_comment(&self) -> bool {
+    pub fn is_comment(&self) -> bool {
         self.kind.is_comment()
     }
 
     /// Returns `true` if the token is a comment or doc-comment.
     #[inline]
-    pub const fn is_comment_or_doc(&self) -> bool {
+    pub fn is_comment_or_doc(&self) -> bool {
         self.kind.is_comment_or_doc()
     }
 

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -129,7 +129,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     ///
     /// Expects the current token to be a function-like keyword.
     fn parse_function(&mut self) -> PResult<'sess, ItemFunction<'ast>> {
-        let Token { span: lo, kind: TokenKind::Ident(kw) } = self.token else {
+        let TokenRepr { span: lo, kind: TokenKind::Ident(kw) } = *self.token else {
             unreachable!("parse_function called without function-like keyword");
         };
         self.bump(); // kw
@@ -930,7 +930,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         if !self.check_str_lit() {
             return None;
         }
-        let Token { kind: TokenKind::Literal(TokenLitKind::Str, symbol), span } = self.token else {
+        let TokenRepr { kind: TokenKind::Literal(TokenLitKind::Str, symbol), span } = *self.token
+        else {
             unreachable!()
         };
         self.bump();

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -781,7 +781,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Use [`bump`](Self::bump) and [`token`](Self::token) instead.
     #[inline(always)]
     fn next_token(&mut self) -> Token {
-        self.tokens.next().unwrap_or(Token { kind: TokenKind::Eof, span: self.token.span })
+        self.tokens.next().unwrap_or(Token::new(TokenKind::Eof, self.token.span))
     }
 
     /// Returns the token `dist` tokens ahead of the current one.


### PR DESCRIPTION
Even though token is `Copy` and 16 bytes, it won't be passed in 2x8 byte registers but rather on the stack. We can separate the fields of the struct and instead write it as `(u64, u64)` to allow passing `Token` in registers.