### PR TITLE
bench: lowering benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
  "slang_solidity",
  "solang-parser",
  "solar-parse",
+ "solar-sema",
  "tree-sitter",
  "tree-sitter-solidity",
 ]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 
 [dependencies]
 solar-parse.workspace = true
+solar-sema.workspace = true
 
 solang-parser = "=0.3.4"
 


### PR DESCRIPTION
Note that the performance regressions are not real in the sense that the previous benchmarks would allocate on the first benchmark iteration and then just do lookups in the subsequent ones, whereas the benchmarks now get a full new session on each iteration, which means we don't reuse anything from previous iterations.
Closes #520