### PR TITLE
perf: fix branch issue

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 #[allow(unexpected_cfgs)]
-pub const PARSERS: &[&dyn Parser] = if true {
+pub const PARSERS: &[&dyn Parser] = if cfg!(codspeed) {
     // Only benchmark our own code in CI.
     &[&Solar]
 } else {


### PR DESCRIPTION
based on the benchmark in the main branch and function ` parse_simple_stmt_kind` we hit  the second(else)  branch 28,760 times compared to the  first one which we only hit 845 times this pr swaps position of the branches