### PR TITLE
fix(diagnostics): render footer below suggestions

### DIFF
--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -223,7 +223,6 @@ impl HumanEmitter {
 
         // Dummy subdiagnostics go in the main group's footer, non-dummy ones go as separate groups.
         let subs = |d| diagnostic.children.iter().filter(move |sub| sub.span.is_dummy() == d);
-        let footers = subs(true).map(|sub| message_from_subdiagnostic(sub, self.supports_color()));
         let sub_groups = subs(false).map(|sub| {
             let mut g = Group::with_title(title_from_subdiagnostic(sub, self.supports_color()));
             if let Some(sm) = sm {
@@ -231,6 +230,11 @@ impl HumanEmitter {
             }
             g
         });
+
+        let mut footers =
+            subs(true).map(|sub| message_from_subdiagnostic(sub, self.supports_color())).peekable();
+        let footer_group =
+            footers.peek().is_some().then(|| Group::with_level(ASLevel::NOTE).elements(footers));
 
         // Create suggestion groups for non-inline suggestions
         let suggestion_groups = children.iter().flat_map(|suggestion| {
@@ -274,10 +278,11 @@ impl HumanEmitter {
             None
         });
 
-        let main_group = Group::with_title(title).elements(snippets).elements(footers);
+        let main_group = Group::with_title(title).elements(snippets);
         let report = std::iter::once(main_group)
             .chain(sub_groups)
             .chain(suggestion_groups)
+            .chain(footer_group)
             .collect::<Vec<_>>();
         f(self, &report)
     }

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1011,6 +1011,41 @@ help: mutable variables should use mixedCase
     }
 
     #[test]
+    fn test_suggestion_with_footer() {
+        let (var_span, var_sugg) = (Span::new(BytePos(66), BytePos(72)), "myVar");
+        let mut diag = Diag::new(Level::Note, "mutable variables should use mixedCase");
+        diag.span(var_span)
+            .span_suggestion_with_style(
+                var_span,
+                "mutable variables should use mixedCase",
+                var_sugg,
+                Applicability::MachineApplicable,
+                SuggestionStyle::ShowAlways,
+            )
+            .help("some footer help msg that should be displayed at the very bottom");
+
+        assert_eq!(diag.suggestions.len(), 1);
+        assert_eq!(diag.suggestions[0].applicability, Applicability::MachineApplicable);
+        assert_eq!(diag.suggestions[0].style, SuggestionStyle::ShowAlways);
+
+        let expected = r#"note: mutable variables should use mixedCase
+ --> <test.sol>:4:17
+  |
+4 |         uint256 my_var = 0;
+  |                 ^^^^^^
+  |
+help: mutable variables should use mixedCase
+  |
+4 -         uint256 my_var = 0;
+4 +         uint256 myVar = 0;
+  |
+  = help: some footer help msg that should be displayed at the very bottom
+
+"#;
+        assert_eq!(emit_human_diagnostics(diag), expected);
+    }
+
+    #[test]
     fn test_multispan_suggestion() {
         let (pub_span, pub_sugg) = (Span::new(BytePos(36), BytePos(42)), "external".into());
         let (view_span, view_sugg) = (Span::new(BytePos(43), BytePos(47)), "pure".into());


### PR DESCRIPTION
### Motivation

when initially implementing code suggestions i didn't realize that i was printing them after the footers, so we would get this ugly and non-intuitive output:
```
 --> <test.sol>:4:17
  |
4 |         uint256 my_var = 0;
  |                 ^^^^^^
  |
  = help: some footer help msg that should be displayed at the very bottom
help: mutable variables should use mixedCase
  |
4 -         uint256 my_var = 0;
4 +         uint256 myVar = 0;
  |
```

instead, we should print footers at the very bottom
```
 --> <test.sol>:4:17
  |
4 |         uint256 my_var = 0;
  |                 ^^^^^^
  |
help: mutable variables should use mixedCase
  |
4 -         uint256 my_var = 0;
4 +         uint256 myVar = 0;
  |
  = help: some footer help msg that should be displayed at the very bottom
```