### PR TITLE
feat(data-structures): add ThinSlice

### DIFF
--- a/crates/data-structures/src/bump_ext.rs
+++ b/crates/data-structures/src/bump_ext.rs
@@ -1,8 +1,9 @@
+use crate::RawThinSlice;
 use bumpalo::Bump;
 use smallvec::SmallVec;
 
 /// Extension trait for [`Bump`].
-#[allow(clippy::mut_from_ref)] // Arena.
+#[expect(clippy::mut_from_ref)] // Arena.
 pub trait BumpExt {
     /// Returns the number of bytes currently in use.
     fn used_bytes(&self) -> usize;
@@ -41,6 +42,43 @@ pub trait BumpExt {
     /// ownership is moved as well, such as through [`alloc_vec`](Self::alloc_vec) and the other
     /// methods in this trait.
     unsafe fn alloc_slice_unchecked<'a, T>(&'a self, slice: &[T]) -> &'a mut [T];
+
+    // `RawThinSlice` methods
+
+    /// See [`alloc_as_slice`](Self::alloc_as_slice).
+    fn alloc_as_thin_slice<H, T>(&self, header: H, value: T) -> &mut RawThinSlice<H, T>;
+
+    /// See [`alloc_from_iter`](Self::alloc_from_iter).
+    fn alloc_from_iter_thin<H, T>(
+        &self,
+        header: H,
+        iter: impl Iterator<Item = T>,
+    ) -> &mut RawThinSlice<H, T>;
+
+    /// See [`alloc_vec`](Self::alloc_vec).
+    fn alloc_vec_thin<H, T>(&self, header: H, values: Vec<T>) -> &mut RawThinSlice<H, T>;
+
+    /// See [`alloc_smallvec`](Self::alloc_smallvec).
+    fn alloc_smallvec_thin<H, A: smallvec::Array>(
+        &self,
+        header: H,
+        values: SmallVec<A>,
+    ) -> &mut RawThinSlice<H, A::Item>;
+
+    /// See [`alloc_array`](Self::alloc_array).
+    fn alloc_array_thin<H, T, const N: usize>(
+        &self,
+        header: H,
+        values: [T; N],
+    ) -> &mut RawThinSlice<H, T>;
+
+    /// See [`alloc_slice_unchecked`](Self::alloc_slice_unchecked).
+    #[expect(clippy::missing_safety_doc)]
+    unsafe fn alloc_thin_slice_unchecked<'a, H, T>(
+        &'a self,
+        header: H,
+        src: &[T],
+    ) -> &'a mut RawThinSlice<H, T>;
 }
 
 impl BumpExt for Bump {
@@ -99,7 +137,7 @@ impl BumpExt for Bump {
         }
 
         let values = std::mem::ManuallyDrop::new(values);
-        // SAFETY: See `alloc_vec`.
+        // SAFETY: The values are not dropped.
         unsafe { self.alloc_slice_unchecked(values.as_slice()) }
     }
 
@@ -112,6 +150,72 @@ impl BumpExt for Bump {
             std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
             std::slice::from_raw_parts_mut(dst.as_ptr(), src.len())
         }
+    }
+
+    #[inline]
+    fn alloc_as_thin_slice<H, T>(&self, header: H, value: T) -> &mut RawThinSlice<H, T> {
+        let value = std::mem::ManuallyDrop::new(value);
+        unsafe { self.alloc_thin_slice_unchecked(header, std::slice::from_ref(&*value)) }
+    }
+
+    #[inline]
+    fn alloc_from_iter_thin<H, T>(
+        &self,
+        header: H,
+        mut iter: impl Iterator<Item = T>,
+    ) -> &mut RawThinSlice<H, T> {
+        match iter.size_hint() {
+            (min, Some(max)) if min == max => {
+                RawThinSlice::<H, T>::from_arena_with(self, header, min, |_| {
+                    iter.next().expect("Iterator supplied too few elements")
+                })
+            }
+            _ => self.alloc_smallvec_thin(header, SmallVec::<[T; 8]>::from_iter(iter)),
+        }
+    }
+
+    #[inline]
+    fn alloc_vec_thin<H, T>(&self, header: H, mut values: Vec<T>) -> &mut RawThinSlice<H, T> {
+        // SAFETY: The `Vec` is deallocated, but the elements are not dropped.
+        unsafe {
+            let r = self.alloc_thin_slice_unchecked(header, values.as_slice());
+            values.set_len(0);
+            r
+        }
+    }
+
+    #[inline]
+    fn alloc_smallvec_thin<H, A: smallvec::Array>(
+        &self,
+        header: H,
+        mut values: SmallVec<A>,
+    ) -> &mut RawThinSlice<H, A::Item> {
+        // SAFETY: See `alloc_vec_thin`.
+        unsafe {
+            let r = self.alloc_thin_slice_unchecked(header, values.as_slice());
+            values.set_len(0);
+            r
+        }
+    }
+
+    #[inline]
+    fn alloc_array_thin<H, T, const N: usize>(
+        &self,
+        header: H,
+        values: [T; N],
+    ) -> &mut RawThinSlice<H, T> {
+        let values = std::mem::ManuallyDrop::new(values);
+        // SAFETY: The values are not dropped.
+        unsafe { self.alloc_thin_slice_unchecked(header, values.as_slice()) }
+    }
+
+    #[inline]
+    unsafe fn alloc_thin_slice_unchecked<'a, H, T>(
+        &'a self,
+        header: H,
+        src: &[T],
+    ) -> &'a mut RawThinSlice<H, T> {
+        RawThinSlice::from_arena(self, header, src)
     }
 }
 
@@ -150,5 +254,31 @@ mod tests {
         for mut item in other_vec {
             item.defuse();
         }
+    }
+
+    #[test]
+    fn test_alloc_vec_thin() {
+        let bump = Bump::new();
+        let vec = vec![DropBomb::new(1), DropBomb::new(2), DropBomb::new(3)];
+        let other_vec = vec![DropBomb::new(1), DropBomb::new(2), DropBomb::new(3)];
+        let raw_slice = bump.alloc_vec_thin(69usize, vec);
+        assert_eq!(*raw_slice.header(), 69usize);
+        let slice = &mut **raw_slice;
+        assert_eq!(slice, &other_vec[..]);
+        for item in slice {
+            item.defuse();
+        }
+        for mut item in other_vec {
+            item.defuse();
+        }
+    }
+
+    #[test]
+    fn test_alloc_thin_empty() {
+        let bump = Bump::new();
+        let data = Vec::<&'static str>::new();
+        let raw_slice = bump.alloc_vec_thin(69usize, data);
+        assert_eq!(*raw_slice.header(), 69usize);
+        assert!(raw_slice.as_slice().is_empty());
     }
 }

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(feature = "nightly", feature(debug_closure_helpers))]
 #![cfg_attr(feature = "nightly", feature(rustc_attrs))]
 #![cfg_attr(feature = "nightly", feature(likely_unlikely))]
+#![cfg_attr(feature = "nightly", feature(extern_types))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 
 pub mod cycle;
@@ -33,6 +34,9 @@ pub use drop_guard::{DropGuard, defer};
 
 mod interned;
 pub use interned::Interned;
+
+mod thin_slice;
+pub use thin_slice::{RawThinSlice, ThinSlice};
 
 pub use smallvec;
 

--- a/crates/data-structures/src/thin_slice.rs
+++ b/crates/data-structures/src/thin_slice.rs
@@ -1,0 +1,246 @@
+use bumpalo::Bump;
+use std::{alloc::Layout, fmt};
+
+// Modified from [`rustc_middle::ty::List`](https://github.com/rust-lang/rust/blob/a2db9280539229a3b8a084a09886670a57bc7e9c/compiler/rustc_middle/src/ty/list.rs#L15).
+
+/// A thin-pointer slice of `T`.
+///
+/// This is similar to `[T]`, but the length is stored in the slice itself,
+/// rather than in a separate field, making it a single word in size, instead of two.
+pub type ThinSlice<T> = RawThinSlice<(), T>;
+
+/// [`ThinSlice`] with a custom header.
+pub struct RawThinSlice<H, T> {
+    skel: ThinSliceSkeleton<H, T>,
+    _opaque: OpaqueListContents,
+}
+
+#[repr(C)]
+struct ThinSliceSkeleton<H, T> {
+    header: H,
+    len: usize,
+    /// Although this claims to be a zero-length array, in practice `len`
+    /// elements are actually present.
+    data: [T; 0],
+}
+
+#[cfg(not(feature = "nightly"))]
+type OpaqueListContents = ();
+
+#[cfg(feature = "nightly")]
+unsafe extern "C" {
+    type OpaqueListContents;
+}
+
+impl<H, T> RawThinSlice<H, T> {
+    /// Returns a reference to the header.
+    #[inline]
+    pub fn header(&self) -> &H {
+        &self.skel.header
+    }
+
+    /// Returns a mutable reference to the header.
+    #[inline]
+    pub fn header_mut(&mut self) -> &mut H {
+        &mut self.skel.header
+    }
+
+    /// Allocates a list from `arena` and copies the contents of `slice` into it.
+    #[inline]
+    #[expect(clippy::mut_from_ref)] // Arena.
+    pub(super) fn from_arena<'a>(arena: &'a Bump, header: H, slice: &[T]) -> &'a mut Self {
+        let mem = Self::alloc_from_arena(arena, slice.len());
+        // SAFETY: `mem` comes from `alloc_from_arena`.
+        unsafe { Self::init(mem, header, slice) }
+    }
+
+    /// Allocates a list from `arena` and calls `f` for each element.
+    #[inline]
+    #[expect(clippy::mut_from_ref)] // Arena.
+    pub(super) fn from_arena_with(
+        arena: &Bump,
+        header: H,
+        len: usize,
+        f: impl FnMut(usize) -> T,
+    ) -> &mut Self {
+        let mem = Self::alloc_from_arena(arena, len);
+        // SAFETY: `mem` comes from `alloc_from_arena`.
+        unsafe { Self::init_with(mem, header, len, f) }
+    }
+
+    /// Allocates a list from `arena`.
+    #[inline]
+    fn alloc_from_arena(arena: &Bump, len: usize) -> *mut Self {
+        let (layout, _offset) = Layout::new::<ThinSliceSkeleton<H, T>>()
+            .extend(Layout::array::<T>(len).unwrap())
+            .unwrap();
+        arena.alloc_layout(layout).as_ptr() as *mut Self
+    }
+
+    /// Initializes a list by copying the contents of `slice` into it.
+    ///
+    /// # Safety
+    ///
+    /// `mem` must come from `alloc_from_arena`.
+    #[inline]
+    unsafe fn init<'a>(mem: *mut Self, header: H, slice: &[T]) -> &'a mut Self {
+        unsafe {
+            (&raw mut (*mem).skel.header).write(header);
+            (&raw mut (*mem).skel.len).write(slice.len());
+            (&raw mut (*mem).skel.data)
+                .cast::<T>()
+                .copy_from_nonoverlapping(slice.as_ptr(), slice.len());
+            &mut *mem
+        }
+    }
+
+    /// Initializes a list by calling `f` for each element.
+    ///
+    /// # Safety
+    ///
+    /// `mem` must come from `alloc_from_arena`.
+    #[inline]
+    unsafe fn init_with<'a>(
+        mem: *mut Self,
+        header: H,
+        len: usize,
+        mut f: impl FnMut(usize) -> T,
+    ) -> &'a mut Self {
+        unsafe {
+            (&raw mut (*mem).skel.header).write(header);
+            (&raw mut (*mem).skel.len).write(len);
+            for i in 0..len {
+                (&raw mut (*mem).skel.data).cast::<T>().add(i).write(f(i));
+            }
+            &mut *mem
+        }
+    }
+
+    /// Returns the number of elements in the slice.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.skel.len
+    }
+
+    /// Returns `true` if the slice is empty.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.skel.len == 0
+    }
+
+    /// Returns the slice as a slice of `T`.
+    #[inline(always)]
+    pub fn as_slice(&self) -> &[T] {
+        self
+    }
+
+    /// Returns the slice as a mutable slice of `T`.
+    #[inline(always)]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        self
+    }
+}
+
+impl<H, T> std::ops::Deref for RawThinSlice<H, T> {
+    type Target = [T];
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        let data_ptr = (&raw const self.skel.data).cast::<T>();
+        // SAFETY: `data_ptr` has the same provenance as `self` and can therefore
+        // access the `self.skel.len` elements stored at `self.skel.data`.
+        // Note that we specifically don't reborrow `&self.skel.data`, because that
+        // would give us a pointer with provenance over 0 bytes.
+        unsafe { std::slice::from_raw_parts(data_ptr, self.len()) }
+    }
+}
+
+impl<H, T> std::ops::DerefMut for RawThinSlice<H, T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let data_ptr = (&raw mut self.skel.data).cast::<T>();
+        // SAFETY: See `Deref`.
+        unsafe { std::slice::from_raw_parts_mut(data_ptr, self.len()) }
+    }
+}
+
+macro_rules! impl_default {
+    ($header_ty:ty, $header_init:expr) => {
+        impl<T> Default for &RawThinSlice<$header_ty, T> {
+            /// Returns a reference to the (per header unique, static) empty slice.
+            #[inline(always)]
+            fn default() -> Self {
+                #[repr(align(64))]
+                struct MaxAlign;
+
+                static EMPTY: ThinSliceSkeleton<$header_ty, MaxAlign> =
+                    ThinSliceSkeleton { header: $header_init, len: 0, data: [] };
+
+                assert!(align_of::<T>() <= align_of::<MaxAlign>());
+
+                // SAFETY: `EMPTY` is sufficiently aligned to be an empty slice for all
+                // types with `align_of(T) <= align_of(MaxAlign)`, which we checked above.
+                unsafe { &*((&raw const EMPTY) as *const Self) }
+            }
+        }
+    };
+}
+
+impl_default!((), ());
+
+impl<H, T: fmt::Debug> fmt::Debug for RawThinSlice<H, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl<H, T: PartialEq> PartialEq for RawThinSlice<H, T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<H, T: Eq> Eq for RawThinSlice<H, T> {}
+
+impl<H, T: PartialOrd> PartialOrd for RawThinSlice<H, T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_slice().partial_cmp(other.as_slice())
+    }
+}
+
+impl<H, T: Ord> Ord for RawThinSlice<H, T> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl<H, T: std::hash::Hash> std::hash::Hash for RawThinSlice<H, T> {
+    #[inline]
+    fn hash<Hasher: std::hash::Hasher>(&self, state: &mut Hasher) {
+        self.as_slice().hash(state)
+    }
+}
+
+impl<'a, H, T> IntoIterator for &'a RawThinSlice<H, T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, H, T> IntoIterator for &'a mut RawThinSlice<H, T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}


### PR DESCRIPTION
Add ThinSlice, a thin-pointer slice which stores its length before the data.