### PR TITLE
fix: do not break on close paren for struct

### DIFF
--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -657,8 +657,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             first = false;
         }
 
-        while !self.check_noexpect(ket) {
-            if TokenKind::Eof == self.token.kind {
+        while !self.check(ket) {
+            if self.token.kind == TokenKind::Eof {
                 break;
             }
 
@@ -678,7 +678,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                         Err(e) => return Err(e),
                     }
 
-                    if self.check_noexpect(ket) {
+                    if self.check(ket) {
                         trailing = true;
                         break;
                     }

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -659,6 +659,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
         while !self.check(ket) {
             if self.token.kind == TokenKind::Eof {
+                recovered = Recovered::Yes;
                 break;
             }
 

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -657,8 +657,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             first = false;
         }
 
-        while !self.check(ket) {
-            if let TokenKind::CloseDelim(..) | TokenKind::Eof = self.token.kind {
+        while !self.check_noexpect(ket) {
+            if TokenKind::Eof == self.token.kind {
                 break;
             }
 
@@ -678,7 +678,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                         Err(e) => return Err(e),
                     }
 
-                    if self.check(ket) {
+                    if self.check_noexpect(ket) {
                         trailing = true;
                         break;
                     }

--- a/tests/ui/parser/close_delimeter.sol
+++ b/tests/ui/parser/close_delimeter.sol
@@ -1,3 +1,3 @@
 struct X {
-    uint y) //~ ERROR: `;`, found `)`
+    uint y) //~ ERROR: expected one of `;` or `}`, found `)`
 }

--- a/tests/ui/parser/close_delimeter.sol
+++ b/tests/ui/parser/close_delimeter.sol
@@ -1,0 +1,3 @@
+struct X {
+    uint y) //~ ERROR: `;`, found `)`
+}

--- a/tests/ui/parser/close_delimeter.stderr
+++ b/tests/ui/parser/close_delimeter.stderr
@@ -1,8 +1,8 @@
-error: expected `;`, found `)`
+error: expected one of `;` or `}`, found `)`
   --> ROOT/tests/ui/parser/close_delimeter.sol:LL:CC
    |
 LL |     uint y)
-   |           ^ expected `;`
+   |           ^ expected one of `;` or `}`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/close_delimeter.stderr
+++ b/tests/ui/parser/close_delimeter.stderr
@@ -1,0 +1,8 @@
+error: expected `;`, found `)`
+  --> ROOT/tests/ui/parser/close_delimeter.sol:LL:CC
+   |
+LL |     uint y)
+   |           ^ expected `;`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/close_delimeter2.sol
+++ b/tests/ui/parser/close_delimeter2.sol
@@ -1,0 +1,3 @@
+struct X {
+    //~v ERROR: expected one of `;` or `}`, found `<eof>`
+    uint y

--- a/tests/ui/parser/close_delimeter2.stderr
+++ b/tests/ui/parser/close_delimeter2.stderr
@@ -4,11 +4,5 @@ error: expected one of `;` or `}`, found `<eof>`
 LL |     uint y
    |          ^ expected one of `;` or `}`
 
-error: expected `}`, found `<eof>`
-  --> ROOT/tests/ui/parser/close_delimeter2.sol:LL:CC
-   |
-LL |     uint y
-   |          ^ expected `}`
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/parser/close_delimeter2.stderr
+++ b/tests/ui/parser/close_delimeter2.stderr
@@ -1,0 +1,14 @@
+error: expected one of `;` or `}`, found `<eof>`
+  --> ROOT/tests/ui/parser/close_delimeter2.sol:LL:CC
+   |
+LL |     uint y
+   |          ^ expected one of `;` or `}`
+
+error: expected `}`, found `<eof>`
+  --> ROOT/tests/ui/parser/close_delimeter2.sol:LL:CC
+   |
+LL |     uint y
+   |          ^ expected `}`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The while loop in `parse_seq_to_before_tokens ` was exiting early on the close parentheses emitting an error for the missing semi. Since `parse_struct` also `expect`'s semis, it was hitting the panic in `expected_one_of_not_found`. 

`parse_seq_to_end` already `expect`s a close bracket, so it's okay to use `check_noexpect` and prevents the close bracket from appearing in the error message: "ERROR: expected `;` or `}`, found `)`"

Addresses 2nd panic in https://github.com/foundry-rs/foundry/issues/12001