### PR TITLE
feat(sema): implicit integer literal conversions

### DIFF
--- a/tests/ui/typeck/int_literals.sol
+++ b/tests/ui/typeck/int_literals.sol
@@ -1,0 +1,76 @@
+//@compile-flags: -Ztypeck
+
+contract C {
+    function unsigned() public {
+        uint8 a = 0;
+        uint16 b = 0;
+        uint24 c = 0;
+        uint32 d = 0;
+        uint40 e = 0;
+        uint48 f = 0;
+        uint56 g = 0;
+        uint64 h = 0;
+        uint72 i = 0;
+        uint80 j = 0;
+        uint88 k = 0;
+        uint96 l = 0;
+        uint104 m = 0;
+        uint112 n = 0;
+        uint120 o = 0;
+        uint128 p = 0;
+        uint136 q = 0;
+        uint144 r = 0;
+        uint152 s = 0;
+        uint160 t = 0;
+        uint168 u = 0;
+        uint176 v = 0;
+        uint184 w = 0;
+        uint192 x = 0;
+        uint200 y = 0;
+        uint208 z = 0;
+        uint216 aa = 0;
+        uint224 bb = 0;
+        uint232 cc = 0;
+        uint240 dd = 0;
+        uint248 ee = 0;
+        uint256 ff = 0;
+
+        // todo: intN
+        // todo: assign signed integer to unsigned and other way
+    }
+
+    function signed() public {
+        int8 a = 0;
+        int16 b = 0;
+        int24 c = 0;
+        int32 d = 0;
+        int40 e = 0;
+        int48 f = 0;
+        int56 g = 0;
+        int64 h = 0;
+        int72 i = 0;
+        int80 j = 0;
+        int88 k = 0;
+        int96 l = 0;
+        int104 m = 0;
+        int112 n = 0;
+        int120 o = 0;
+        int128 p = 0;
+        int136 q = 0;
+        int144 r = 0;
+        int152 s = 0;
+        int160 t = 0;
+        int168 u = 0;
+        int176 v = 0;
+        int184 w = 0;
+        int192 x = 0;
+        int200 y = 0;
+        int208 z = 0;
+        int216 aa = 0;
+        int224 bb = 0;
+        int232 cc = 0;
+        int240 dd = 0;
+        int248 ee = 0;
+        int256 ff = 0;
+    }
+}


### PR DESCRIPTION
Handles implicit integer resizing (larger → smaller) for `uintN` and `intN`, as well as integer literal conversions. This is plagued by #560 however.

Closes #627 