### PR TITLE
chore(interface): expose minimum supported solidity version

### DIFF
--- a/crates/interface/src/lib.rs
+++ b/crates/interface/src/lib.rs
@@ -43,7 +43,7 @@ pub type Result<T = (), E = ErrorGuaranteed> = std::result::Result<T, E>;
 /// The minimum supported Solidity version.
 ///
 /// Solar aims to support Solidity 0.8.* and later versions.
-pub const MIN_SOLIDITY_VERSION: (u8, u8, u8) = (0, 8, 0);
+pub const MIN_SOLIDITY_VERSION: (u64, u64, u64) = (0, 8, 0);
 
 /// Pluralize a word based on a count.
 #[macro_export]


### PR DESCRIPTION
## Motivation

expose `MIN_SOLIDITY_VERSION` so that solar consumers can avoid having to hardcode `semver::Version::new(0, 8, 0)` in their code.
Instead they will be able to do:
```rs
use solar::interface::MIN_SOLIDITY_VERSION;

let (major, minor, patch) = MIN_SOLIDITY_VERSION;
let version = semver::Version::new(major, minor, patch);
```