### PR TITLE
fix(sema): avoid parameter name shadowing during type resolution

### DIFF
--- a/tests/ui/resolve/param_name_shadows_type.sol
+++ b/tests/ui/resolve/param_name_shadows_type.sol
@@ -1,0 +1,8 @@
+contract C {
+    enum EnumType {A, B, C}
+
+    struct StructType {
+        uint x;
+    }
+    error E(EnumType StructType, StructType test);
+}


### PR DESCRIPTION
### Problem
Parameter names were shadowing type names during type resolution, causing incorrect type lookups when a parameter name matched a type name used in later parameters.
This bug is described in this issue: https://github.com/paradigmxyz/solar/issues/219, where resolving the second parameter's type StructType, the compiler would incorrectly find the first parameter's name instead of the struct definition.

#### Solution
Implemented lower_variables_two_phasealternative to lower_variables that uses two phases to first resolve all parameters without declaring any names and then declares all parameters once the types are already resolved.

Added also this case as a test in `tests/ui/resolve`

### Test
Before the changes:

```
error: name has to refer to a valid user-defined type
 --> tests/ui/resolve/param_name_shadows_type.sol:7:34
  |
7 |     error E(EnumType StructType, StructType test);
  |                                  ^^^^^^^^^^
  |
  = note: created at crates/sema/src/ty/mod.rs:615:43,
          emitted at crates/sema/src/ty/mod.rs:615:63
````

After the changes

```
 Running `target/debug/solar tests/ui/resolve/param_name_shadows_type.sol --emit abi`
{"contracts":{"tests/ui/resolve/param_name_shadows_type.sol:C":{"abi":[{"type":"error","name":"E","inputs":[{"name":"StructType","type":"uint8","internalType":"enum C.EnumType"},{"name":"test","type":"tuple","internalType":"struct C.StructType","components":[{"name":"x","type":"uint256","internalType":"uint256"}]}]}]}},"version":"0.1.8"}%
```