### PR TITLE
fix: replace unnecessary repetitions of structure name

### DIFF
--- a/crates/ast/src/ast/yul.rs
+++ b/crates/ast/src/ast/yul.rs
@@ -42,7 +42,7 @@ pub struct Object<'ast> {
     /// The `code` block.
     pub code: CodeBlock<'ast>,
     /// Sub-objects, if any.
-    pub children: BoxSlice<'ast, Object<'ast>>,
+    pub children: BoxSlice<'ast, Self>,
     /// `data` segments, if any.
     pub data: BoxSlice<'ast, Data<'ast>>,
 }

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -287,7 +287,7 @@ struct Diagnostic {
     level: &'static str,
     spans: Vec<DiagnosticSpan>,
     /// Associated diagnostic messages.
-    children: Vec<Diagnostic>,
+    children: Vec<Self>,
     /// The message as the compiler would render it.
     rendered: Option<String>,
 }


### PR DESCRIPTION
`use_self` lint was recently extended to structs, cf. https://github.com/rust-lang/rust-clippy/pull/15566

This aims to fix the CI as it runs clippy with nightly toolchain.