### PR TITLE
fix: reorder to fix potential double free on OOM

### DIFF
--- a/crates/data-structures/src/bump_ext.rs
+++ b/crates/data-structures/src/bump_ext.rs
@@ -126,8 +126,7 @@ impl BumpExt for Bump {
             values.set_len(0);
 
             let slice = std::slice::from_raw_parts(ptr, len);
-            let r = self.alloc_slice_unchecked(slice);
-            r
+            self.alloc_slice_unchecked(slice)
         }
     }
 
@@ -145,8 +144,7 @@ impl BumpExt for Bump {
             values.set_len(0);
 
             let slice = std::slice::from_raw_parts(ptr, len);
-            let r = self.alloc_slice_unchecked(slice);
-            r
+            self.alloc_slice_unchecked(slice)
         }
     }
 


### PR DESCRIPTION
Move set_len(0) before alloc_slice_unchecked to prevent double free during unwinding. Previously, if allocation panicked, the Vec would drop its elements even though they were already copied to the arena.


Not that this matters tbh because if an OOM does happen the code panics and eventually terminates but this can make debugging hard and make it look like a segfault 