### PR TITLE
feat(sema): implement array slice implicit conversion

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -306,7 +306,8 @@ impl<'gcx> Ty<'gcx> {
     /// This is either an array, bytes, string, or slice.
     #[inline]
     pub fn is_sliceable(self) -> bool {
-        self.is_array_like() || matches!(self.kind, TyKind::Slice(..))
+        let inner = self.peel_refs();
+        inner.is_array_like() || matches!(inner.kind, TyKind::Slice(..))
     }
 
     /// Returns `true` if the type is dynamically sized.
@@ -429,6 +430,26 @@ impl<'gcx> Ty<'gcx> {
             && other.kind == TyKind::Elementary(ElementaryType::Address(false))
         {
             return Ok(());
+        }
+
+        // Array slices are implicitly convertible to arrays of their underlying element type.
+        // E.g., `uint256[] calldata slice` can convert to `uint256[] calldata` or `uint256[]
+        // memory`. See: https://docs.soliditylang.org/en/latest/types.html#array-slices
+        if let TyKind::Slice(underlying) = self.kind {
+            // Exact match with underlying type.
+            if underlying == other {
+                return Ok(());
+            }
+            // Allow conversion to memory arrays of the same base type.
+            // E.g., `uint256[] calldata slice` → `uint256[] memory`.
+            // Note: conversion to storage pointers is NOT allowed.
+            if let (TyKind::Ref(self_inner, _), TyKind::Ref(other_inner, other_loc)) =
+                (&underlying.kind, &other.kind)
+                && self_inner == other_inner
+                && *other_loc == DataLocation::Memory
+            {
+                return Ok(());
+            }
         }
 
         // TODO

--- a/tests/ui/typeck/implicit_slice.sol
+++ b/tests/ui/typeck/implicit_slice.sol
@@ -1,0 +1,38 @@
+//@compile-flags: -Ztypeck
+
+// Tests for array slice implicit conversions.
+// See: https://docs.soliditylang.org/en/latest/types.html#array-slices
+contract C {
+    // Array slices are implicitly convertible to arrays of their underlying type.
+    function ok(uint256[] calldata data, uint256 start, uint256 end) external pure {
+        // Take a slice and implicitly convert it to the underlying type.
+        uint256[] calldata s = data[start:end];
+    }
+
+    // Slices cannot be implicitly converted to a different element type.
+    function wrongElementType(uint256[] calldata data, uint256 start, uint256 end) external pure {
+        uint128[] calldata s = data[start:end]; //~ ERROR: mismatched types
+    }
+
+    // Slices can be implicitly converted to memory arrays of the same element type.
+    function toMemory(uint256[] calldata data, uint256 start, uint256 end) external pure {
+        uint256[] memory s = data[start:end];
+    }
+
+    // Slices can only be created from calldata arrays.
+    function notCalldata(uint256[] memory data, uint256 start, uint256 end) external pure {
+        uint256[] memory s = data[start:end]; //~ ERROR: can only slice dynamic calldata arrays
+    }
+
+    // Slices cannot be converted to a single element.
+    function wrongType(uint256[] calldata data, uint256 start, uint256 end) external pure {
+        uint256 a = data[start:end]; //~ ERROR: mismatched types
+    }
+
+    // Slices cannot be assigned to storage pointers.
+    uint256[] s;
+    function toStoragePointer(uint256[] calldata data, uint256 start, uint256 end) external {
+        uint256[] storage t = s;
+        t = data[start:end]; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/implicit_slice.stderr
+++ b/tests/ui/typeck/implicit_slice.stderr
@@ -1,0 +1,26 @@
+error: mismatched types
+  --> ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   |
+LL |         uint128[] calldata s = data[start:end];
+   |                                ^^^^^^^^^^^^^^^ expected `uint128[] calldata`, found `uint256[] calldata slice`
+
+error: can only slice dynamic calldata arrays
+  --> ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   |
+LL |         uint256[] memory s = data[start:end];
+   |                              ^^^^^^^^^^^^^^^
+
+error: mismatched types
+  --> ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   |
+LL |         uint256 a = data[start:end];
+   |                     ^^^^^^^^^^^^^^^ expected `uint256`, found `uint256[] calldata slice`
+
+error: mismatched types
+  --> ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   |
+LL |         t = data[start:end];
+   |             ^^^^^^^^^^^^^^^ expected `uint256[] storage`, found `uint256[] calldata slice`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Add implicit type conversion for array slices to their underlying array type. Slices can now convert to:
- The exact underlying type (e.g., `uint256[] calldata slice` → `uint256[] calldata`)
- Memory arrays of the same element type (e.g., `uint256[] calldata slice` → `uint256[] memory`)

Also fixes `is_sliceable()` to peel refs so reference types like `uint256[] calldata` are correctly recognized as sliceable.

Closes #621

See: https://docs.soliditylang.org/en/latest/types.html#array-slices