### PR TITLE
feat(sema): implement data location coercion for reference types 

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -435,6 +435,39 @@ impl<'gcx> Ty<'gcx> {
             // address payable -> address.
             (Elementary(Address(true)), Elementary(Address(false))) => Ok(()),
 
+            // Reference type location coercion rules.
+            // See: <https://docs.soliditylang.org/en/latest/types.html#data-location-and-assignment-behaviour>
+            (Ref(from_inner, from_loc), Ref(to_inner, to_loc)) => {
+                match (from_loc, to_loc) {
+                    // Same location: allowed if base types match.
+                    (DataLocation::Memory, DataLocation::Memory)
+                    | (DataLocation::Calldata, DataLocation::Calldata) => {
+                        from_inner.try_convert_implicit_to(to_inner)
+                    }
+
+                    // storage -> storage: allowed (reference assignment).
+                    (DataLocation::Storage, DataLocation::Storage) => {
+                        from_inner.try_convert_implicit_to(to_inner)
+                    }
+
+                    // calldata/storage -> memory: allowed (copy semantics).
+                    (DataLocation::Calldata, DataLocation::Memory)
+                    | (DataLocation::Storage, DataLocation::Memory) => {
+                        from_inner.try_convert_implicit_to(to_inner)
+                    }
+
+                    // memory/calldata -> storage: allowed (copy semantics).
+                    (DataLocation::Memory, DataLocation::Storage)
+                    | (DataLocation::Calldata, DataLocation::Storage) => {
+                        from_inner.try_convert_implicit_to(to_inner)
+                    }
+
+                    // storage -> calldata: never allowed.
+                    // memory -> calldata: never allowed.
+                    _ => Result::Err(()),
+                }
+            }
+
             // Array slices are implicitly convertible to arrays of their underlying element type.
             // Note: conversion to storage pointers is NOT allowed.
             // See: <https://docs.soliditylang.org/en/latest/types.html#array-slices>

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -1,0 +1,83 @@
+//@compile-flags: -Ztypeck
+
+// Tests for data location coercion rules.
+// See: https://docs.soliditylang.org/en/latest/types.html#data-location-and-assignment-behaviour
+
+contract C {
+    uint256[] storageArr;
+
+    // === Same location conversions (should all work) ===
+
+    function memoryToMemory(uint256[] memory a) internal pure returns (uint256[] memory) {
+        uint256[] memory b = a;
+        return b;
+    }
+
+    function calldataToCalldata(uint256[] calldata a) external pure returns (uint256[] calldata) {
+        uint256[] calldata b = a;
+        return b;
+    }
+
+    function storageToStorage() internal {
+        uint256[] storage a = storageArr;
+        uint256[] storage b = a;
+    }
+
+    // === calldata -> memory (allowed, copy semantics) ===
+
+    function calldataToMemory(uint256[] calldata a) external pure returns (uint256[] memory) {
+        uint256[] memory b = a;
+        return b;
+    }
+
+    // === memory/calldata -> storage (allowed, copy semantics) ===
+
+    function memoryToStorage(uint256[] memory a) internal {
+        storageArr = a;
+    }
+
+    function calldataToStorage(uint256[] calldata a) external {
+        storageArr = a;
+    }
+
+    // === storage -> memory (allowed, copy semantics) ===
+
+    function storageToMemory() internal view returns (uint256[] memory) {
+        uint256[] memory a = storageArr;
+        return a;
+    }
+
+    // === Disallowed conversions ===
+
+    // storage -> calldata: never allowed
+    function storageToCalldata() external {
+        uint256[] calldata a = storageArr; //~ ERROR: mismatched types
+    }
+
+    // memory -> calldata: never allowed
+    function memoryToCalldata(uint256[] memory a) external {
+        uint256[] calldata b = a; //~ ERROR: mismatched types
+    }
+
+    // === Nested array tests ===
+
+    function nestedMemoryToMemory(uint256[][] memory a) internal pure returns (uint256[][] memory) {
+        uint256[][] memory b = a;
+        return b;
+    }
+
+    function nestedCalldataToMemory(uint256[][] calldata a) external pure returns (uint256[][] memory) {
+        uint256[][] memory b = a;
+        return b;
+    }
+
+    // === Wrong element type tests ===
+
+    function wrongElementType(uint256[] memory a) internal pure {
+        uint128[] memory b = a; //~ ERROR: mismatched types
+    }
+
+    function wrongElementTypeCalldata(uint256[] calldata a) external pure {
+        uint128[] memory b = a; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/location_coercion.stderr
+++ b/tests/ui/typeck/location_coercion.stderr
@@ -1,0 +1,26 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/location_coercion.sol:LL:CC
+   │
+LL │         uint256[] calldata a = storageArr;
+   ╰╴                               ━━━━━━━━━━ expected `uint256[] calldata`, found `uint256[] storage`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/location_coercion.sol:LL:CC
+   │
+LL │         uint256[] calldata b = a;
+   ╰╴                               ━ expected `uint256[] calldata`, found `uint256[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/location_coercion.sol:LL:CC
+   │
+LL │         uint128[] memory b = a;
+   ╰╴                             ━ expected `uint128[] memory`, found `uint256[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/location_coercion.sol:LL:CC
+   │
+LL │         uint128[] memory b = a;
+   ╰╴                             ━ expected `uint128[] memory`, found `uint256[] calldata`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Add implicit conversion rules for reference types with different data locations (storage, memory, calldata) in the type checker.

Conversion matrix:
- memory -> memory: allowed
- calldata -> calldata: allowed
- storage -> storage: allowed
- calldata -> memory: allowed (copy)
- storage -> memory: allowed (copy)
- memory -> storage: allowed (copy)
- calldata -> storage: allowed (copy)
- storage -> calldata: disallowed
- memory -> calldata: disallowed

Verified against solc 0.8.31.

On top of #638