### PR TITLE
feat(typeck): implement implicit integer literal coercion

### DIFF
--- a/tests/ui/typeck/implicit_int_literal.sol
+++ b/tests/ui/typeck/implicit_int_literal.sol
@@ -1,0 +1,44 @@
+//@compile-flags: -Ztypeck
+function f() {
+    // === Non-negative literals to uint ===
+    // Value must fit in the unsigned range [0, 2^N - 1]
+    uint8 u8_max = 255;
+    uint8 u8_overflow = 256; //~ ERROR: mismatched types
+    uint16 u16_max = 65535;
+    uint16 u16_overflow = 65536; //~ ERROR: mismatched types
+    uint32 u32_max = 4294967295;
+    uint256 u256_max = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
+    // === Non-negative literals to int ===
+    // TypeSize stores the actual bit length. For signed types, non-negative values
+    // need strict bit comparison since the sign bit takes one slot.
+    // E.g., 127 needs 7 bits, and int8 has 7 bits for magnitude, so it fits.
+    // But 128 needs 8 bits, which exceeds int8's 7-bit positive range.
+
+    // int_literal[1] (1-8 bits) -> int8+ works for values that fit (0-127)
+    int8 i8_max = 127;
+    // int_literal[1] (8 bits) -> int16+ works for 128-255 (needs 8 bits, exceeds int8's 7-bit positive range)
+    int16 i16_from_128 = 128;
+    int16 i16_from_255 = 255;
+
+    // int_literal[2] (9-16 bits) -> int32+ works for 256-32767
+    int16 i16_max = 32767;
+    // 32768 needs 16 bits, exceeds int16's 15-bit positive range
+    int32 i32_from_32768 = 32768;
+    int32 i32_from_65535 = 65535;
+
+    // Overflow cases
+    int16 i16_overflow = 65536; //~ ERROR: mismatched types
+
+    // === Zero and small values ===
+    // Zero needs 1 bit, works with uint8+ and int8+
+    uint8 zero_u8 = 0;
+    uint256 zero_u256 = 0;
+    uint8 one_u8 = 1;
+    uint256 one_u256 = 1;
+
+    int8 zero_i8 = 0;
+    int256 zero_i256 = 0;
+    int8 one_i8 = 1;
+    int256 one_i256 = 1;
+}

--- a/tests/ui/typeck/implicit_int_literal.stderr
+++ b/tests/ui/typeck/implicit_int_literal.stderr
@@ -1,0 +1,20 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
+   │
+LL │     uint8 u8_overflow = 256;
+   ╰╴                        ━━━ expected `uint8`, found `int_literal[2]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
+   │
+LL │     uint16 u16_overflow = 65536;
+   ╰╴                          ━━━━━ expected `uint16`, found `int_literal[3]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
+   │
+LL │     int16 i16_overflow = 65536;
+   ╰╴                         ━━━━━ expected `int16`, found `int_literal[3]`
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/typeck/lvalue/array_length.sol
+++ b/tests/ui/typeck/lvalue/array_length.sol
@@ -1,9 +1,8 @@
 //@compile-flags: -Ztypeck
-// TODO: `mismatched types` errors on integer literals are a current limitation of solar
 
 contract Test {
     uint256[] dynamicArray;
-    uint256[10] fixedArray; //~ ERROR: mismatched types
+    uint256[10] fixedArray;
     uint256 state;
 
     function testDynamic() external {

--- a/tests/ui/typeck/lvalue/array_length.stderr
+++ b/tests/ui/typeck/lvalue/array_length.stderr
@@ -1,9 +1,3 @@
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/array_length.sol:LL:CC
-   │
-LL │     uint256[10] fixedArray;
-   ╰╴            ━━ expected `uint256`, found `int_literal[1]`
-
 error: member `length` is read-only and cannot be used to resize arrays
    ╭▸ ROOT/tests/ui/typeck/lvalue/array_length.sol:LL:CC
    │
@@ -22,5 +16,5 @@ error: member `length` is read-only and cannot be used to resize arrays
 LL │         arr.length = state;
    ╰╴        ━━━━━━━━━━
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/lvalue/constant.sol
+++ b/tests/ui/typeck/lvalue/constant.sol
@@ -1,18 +1,15 @@
 //@compile-flags: -Ztypeck
-// TODO: `mismatched types` errors on integer literals are a current limitation of solar
 
 contract Test {
-    uint256 constant CONST = 1; //~ ERROR: mismatched types
+    uint256 constant CONST = 1;
 
     function test() external {
         CONST = 2; //~ ERROR: cannot assign to a constant variable
-        //~^ ERROR: mismatched types
     }
 }
 
-uint256 constant FILE_CONST = 1; //~ ERROR: mismatched types
+uint256 constant FILE_CONST = 1;
 
 function fileLevel() {
     FILE_CONST = 2; //~ ERROR: cannot assign to a constant variable
-    //~^ ERROR: mismatched types
 }

--- a/tests/ui/typeck/lvalue/constant.stderr
+++ b/tests/ui/typeck/lvalue/constant.stderr
@@ -1,26 +1,8 @@
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/constant.sol:LL:CC
-   │
-LL │     uint256 constant CONST = 1;
-   ╰╴                             ━ expected `uint256`, found `int_literal[1]`
-
 error: cannot assign to a constant variable
    ╭▸ ROOT/tests/ui/typeck/lvalue/constant.sol:LL:CC
    │
 LL │         CONST = 2;
    ╰╴        ━━━━━
-
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/constant.sol:LL:CC
-   │
-LL │         CONST = 2;
-   ╰╴                ━ expected `uint256`, found `int_literal[1]`
-
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/constant.sol:LL:CC
-   │
-LL │ uint256 constant FILE_CONST = 1;
-   ╰╴                              ━ expected `uint256`, found `int_literal[1]`
 
 error: cannot assign to a constant variable
    ╭▸ ROOT/tests/ui/typeck/lvalue/constant.sol:LL:CC
@@ -28,11 +10,5 @@ error: cannot assign to a constant variable
 LL │     FILE_CONST = 2;
    ╰╴    ━━━━━━━━━━
 
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/constant.sol:LL:CC
-   │
-LL │     FILE_CONST = 2;
-   ╰╴                 ━ expected `uint256`, found `int_literal[1]`
-
-error: aborting due to 6 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/lvalue/immutable.sol
+++ b/tests/ui/typeck/lvalue/immutable.sol
@@ -1,6 +1,5 @@
 //@compile-flags: -Ztypeck
 // TODO: assignments to immutables in the constructor should be allowed
-// TODO: `mismatched types` errors on integer literals are a current limitation of solar
 
 contract Test {
     uint256 immutable IMMUT;
@@ -8,11 +7,9 @@ contract Test {
     constructor() {
         // This should be OK in constructor but currently errors
         IMMUT = 1; //~ ERROR: cannot assign to an immutable variable
-        //~^ ERROR: mismatched types
     }
 
     function test() external {
         IMMUT = 2; //~ ERROR: cannot assign to an immutable variable
-        //~^ ERROR: mismatched types
     }
 }

--- a/tests/ui/typeck/lvalue/immutable.stderr
+++ b/tests/ui/typeck/lvalue/immutable.stderr
@@ -4,23 +4,11 @@ error: cannot assign to an immutable variable
 LL │         IMMUT = 1;
    ╰╴        ━━━━━
 
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
-   │
-LL │         IMMUT = 1;
-   ╰╴                ━ expected `uint256`, found `int_literal[1]`
-
 error: cannot assign to an immutable variable
    ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
    │
 LL │         IMMUT = 2;
    ╰╴        ━━━━━
 
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
-   │
-LL │         IMMUT = 2;
-   ╰╴                ━ expected `uint256`, found `int_literal[1]`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/lvalue/tuple.sol
+++ b/tests/ui/typeck/lvalue/tuple.sol
@@ -1,8 +1,7 @@
 //@compile-flags: -Ztypeck
-// TODO: `mismatched types` errors on integer literals are a current limitation of solar
 
 contract Test {
-    uint256 constant CONST = 1; //~ ERROR: mismatched types
+    uint256 constant CONST = 1;
     uint256 state;
 
     function testTupleWithConstant() external {

--- a/tests/ui/typeck/lvalue/tuple.stderr
+++ b/tests/ui/typeck/lvalue/tuple.stderr
@@ -1,9 +1,3 @@
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/lvalue/tuple.sol:LL:CC
-   │
-LL │     uint256 constant CONST = 1;
-   ╰╴                             ━ expected `uint256`, found `int_literal[1]`
-
 error: cannot assign to a constant variable
    ╭▸ ROOT/tests/ui/typeck/lvalue/tuple.sol:LL:CC
    │
@@ -22,5 +16,5 @@ error: mismatched types
 LL │         (1, state) = (x, x);
    ╰╴                     ━━━━━━ expected `tuple(int_literal[1],uint256)`, found `tuple(uint256,uint256)`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Add implicit type coercion for integer literals (IntLiteral) to typed integers (uint/int). The coercion rules are:

- IntLiteral -> uint: Allowed if the literal is non-negative and fits in the target size (size.bits() <= target.bits())

- IntLiteral -> int: Allowed with strict inequality (size.bits() < target.bits()) for non-negative values due to TypeSize rounding, and non-strict for negative values

TypeSize stores ceil(bit_len/8), so int_literal[1] covers 0-255. This means we can't distinguish edge cases like 127 (fits in int8) from 128 (doesn't fit), so we conservatively require int16+ for int_literal[1].

Note: Negative literal support requires additional work in the type checker to propagate negativity through unary negation. This is provided in a follow up.

Supercedes https://github.com/paradigmxyz/solar/pull/564 and closes #627 (closes #564)

Stack:

- #647 (this)
- #648 
- #649