### PR TITLE
feat(typeck): support negative integer literal coercion 

### DIFF
--- a/tests/ui/typeck/implicit_int_literal.sol
+++ b/tests/ui/typeck/implicit_int_literal.sol
@@ -41,4 +41,25 @@ function f() {
     int256 zero_i256 = 0;
     int8 one_i8 = 1;
     int256 one_i256 = 1;
+
+    // === Negative literals to int ===
+    // Negative literals can only coerce to signed int types.
+    // TypeSize stores actual bits. Negative int_literal[N] can fit in int(N) since
+    // the negative range uses all N bits (e.g., -128 needs 8 bits, fits in int8).
+
+    // int_literal[1] negative (1-8 bits) -> int8+ works
+    int8 neg_1_i8 = -1;
+    int8 neg_128_i8 = -128;
+    int256 neg_1_i256 = -1;
+
+    // int_literal[2] negative (9-16 bits) -> int16+ works
+    int16 neg_129_i16 = -129;
+    int16 neg_32768_i16 = -32768;
+
+    // int_literal[3] negative (17-24 bits) -> int24+ works
+    int32 neg_32769_i32 = -32769;
+
+    // Negative literals cannot coerce to unsigned types
+    uint8 neg_to_uint8 = -1; //~ ERROR: mismatched types
+    uint256 neg_to_uint256 = -42; //~ ERROR: mismatched types
 }

--- a/tests/ui/typeck/implicit_int_literal.stderr
+++ b/tests/ui/typeck/implicit_int_literal.stderr
@@ -16,5 +16,17 @@ error: mismatched types
 LL │     int16 i16_overflow = 65536;
    ╰╴                         ━━━━━ expected `int16`, found `int_literal[3]`
 
-error: aborting due to 3 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
+   │
+LL │     uint8 neg_to_uint8 = -1;
+   ╰╴                         ━━ expected `uint8`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
+   │
+LL │     uint256 neg_to_uint256 = -42;
+   ╰╴                             ━━━ expected `uint256`, found `int_literal[1]`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Implement proper handling of negative integer literals in the type checker. Previously, negative literals like -42 were broken because:

1. The parser represents them as unary negation applied to a positive literal, so type_of_lit only sees the positive value
2. The negativity flag in IntLiteral was always false

This commit fixes the issue by:

- Allowing unary negation on IntLiteral types (they can always be negated since the result is just a negative literal)
- Propagating the negativity flag when applying unary negation to an IntLiteral, flipping neg from false to true
- Not propagating the expected type through negation when targeting signed types, to avoid premature type mismatch errors on the inner expression

Also simplifies the coercion rule to use strict inequality for both positive and negative literals, since TypeSize rounding means we can't reliably distinguish edge cases in either direction.

On top of #647 

Supercedes #566 (will mark @mablr as a co-author to commend effort) and closes #560 (closes #566)

Stack:

- #647
- #648 (this)
- #649