### PR TITLE
chore(sema): remove todo

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -29,7 +29,7 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         TyKind::Ref(inner, loc) => reference(gcx, ty, inner, loc),
         TyKind::DynArray(_ty) => expected_ref(),
         TyKind::Array(_ty, _len) => expected_ref(),
-        TyKind::Slice(_ty) => Default::default(), // TODO: do slices have members
+        TyKind::Slice(_ty) => Default::default(),
         TyKind::Tuple(_tys) => Default::default(),
         TyKind::Mapping(..) => Default::default(),
         TyKind::FnPtr(f) => function(gcx, f),


### PR DESCRIPTION
Slices do not have members.

> Array slices do not have any members.

Ref https://docs.soliditylang.org/en/v0.8.32/types.html#array-slices