### PR TITLE
fix(typeck): mark event/error typechecking todo

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -164,7 +164,11 @@ impl<'gcx> TypeChecker<'gcx> {
                         todo!()
                     }
                     TyKind::Type(to) => self.check_explicit_cast(expr.span, to, args),
-                    TyKind::Event(..) | TyKind::Error(..) | TyKind::Err(_) => callee_ty,
+                    TyKind::Event(..) | TyKind::Error(..) => {
+                        // return callee_ty
+                        todo!()
+                    }
+                    TyKind::Err(_) => callee_ty,
                     _ => {
                         let msg =
                             format!("expected function, found `{}`", callee_ty.display(self.gcx));


### PR DESCRIPTION
We don't actually typecheck events or errors at the moment, so we should mark this as todo.