### PR TITLE
fix(sema): add handling for event/error failures

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -164,20 +164,9 @@ impl<'gcx> TypeChecker<'gcx> {
                         todo!()
                     }
                     TyKind::Type(to) => self.check_explicit_cast(expr.span, to, args),
-                    TyKind::Event(params, _) | TyKind::Error(params, _) => {
-                        let arg_count = args.exprs().len();
-                        if arg_count != params.len() {
-                            self.dcx()
-                                .err(format!(
-                                    "wrong number of arguments for {}: expected {}, found {}",
-                                    callee_ty.display(self.gcx),
-                                    params.len(),
-                                    arg_count
-                                ))
-                                .span(expr.span)
-                                .emit();
-                        }
-                        callee_ty
+                    TyKind::Event(..) | TyKind::Error(..) => {
+                        // return callee_ty
+                        todo!()
                     }
                     TyKind::Err(_) => callee_ty,
                     _ => {


### PR DESCRIPTION
fixes #659 

```bash
error: wrong number of arguments for error AmazingContract.SimpleError(bool): expected 1, found 0
  ╭▸ testdata/test.sol:9:9
  │
9 │         SimpleError();
  │         ━━━━━━━━━━━━━
  │
  ╰ note: created at crates/sema/src/typeck/checker.rs:171:34,
          emitted at crates/sema/src/typeck/checker.rs:178:34

error: wrong number of arguments for event AmazingContract.SimpleEvent(bool): expected 1, found 2
   ╭▸ testdata/test.sol:10:9
   │
10 │         SimpleEvent(true, false);
   │         ━━━━━━━━━━━━━━━━━━━━━━━━
   │
   ╰ note: created at crates/sema/src/typeck/checker.rs:171:34,
           emitted at crates/sema/src/typeck/checker.rs:178:34

error: aborting due to 2 previous errors
```
