### PR TITLE
chore: display bits for `int_literal[n]` instead of bytes

### DIFF
--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -309,7 +309,7 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
                 write!(self.buf, "{kind}_string_literal[{}]", size.bytes())
             }
             TyKind::IntLiteral(_, size) => {
-                write!(self.buf, "int_literal[{}]", size.bytes())
+                write!(self.buf, "int_literal[{}]", size.bits())
             }
             TyKind::Slice(ty) => {
                 self.print(ty)?;

--- a/tests/ui/typeck/implicit_int_literal.stderr
+++ b/tests/ui/typeck/implicit_int_literal.stderr
@@ -2,19 +2,19 @@ error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
    │
 LL │     uint8 u8_overflow = 256;
-   ╰╴                        ━━━ expected `uint8`, found `int_literal[2]`
+   ╰╴                        ━━━ expected `uint8`, found `int_literal[9]`
 
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
    │
 LL │     uint16 u16_overflow = 65536;
-   ╰╴                          ━━━━━ expected `uint16`, found `int_literal[3]`
+   ╰╴                          ━━━━━ expected `uint16`, found `int_literal[17]`
 
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
    │
 LL │     int16 i16_overflow = 65536;
-   ╰╴                         ━━━━━ expected `int16`, found `int_literal[3]`
+   ╰╴                         ━━━━━ expected `int16`, found `int_literal[17]`
 
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
@@ -26,7 +26,7 @@ error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_int_literal.sol:LL:CC
    │
 LL │     uint256 neg_to_uint256 = -42;
-   ╰╴                             ━━━ expected `uint256`, found `int_literal[1]`
+   ╰╴                             ━━━ expected `uint256`, found `int_literal[6]`
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Makes it a bit easier to compare sizes in type errors.