### PR TITLE
feat(sema): complete implicit type conversions

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -614,8 +614,8 @@ impl<'gcx> Ty<'gcx> {
                 }
             }
 
-            // FixedBytes size conversions: smaller bytesN -> larger bytesN (right-padded with zeros).
-            // See: <https://docs.soliditylang.org/en/latest/types.html#implicit-conversions>
+            // FixedBytes size conversions: smaller bytesN -> larger bytesN (right-padded with
+            // zeros). See: <https://docs.soliditylang.org/en/latest/types.html#implicit-conversions>
             (Elementary(FixedBytes(from_size)), Elementary(FixedBytes(to_size))) => {
                 if from_size.bytes() <= to_size.bytes() {
                     Ok(())
@@ -697,17 +697,12 @@ impl<'gcx> Ty<'gcx> {
                     (Payable, NonPayable) => true,
                     _ => false,
                 };
-                if mutability_ok {
-                    Ok(())
-                } else {
-                    Result::Err(TyConvertError::Incompatible)
-                }
+                if mutability_ok { Ok(()) } else { Result::Err(TyConvertError::Incompatible) }
             }
 
             // UDVT: user-defined value types are NOT implicitly convertible to their underlying
             // type or vice versa. Explicit wrap/unwrap is required.
             // See: <https://docs.soliditylang.org/en/latest/types.html#user-defined-value-types>
-
             _ => Result::Err(TyConvertError::Incompatible),
         }
     }

--- a/tests/ui/typeck/conversion/function_type_nonpayable_payable.sol
+++ b/tests/ui/typeck/conversion/function_type_nonpayable_payable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() external {
+    }
+    function f() view external returns (bytes4) {
+        function () payable external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_nonpayable_pure.sol
+++ b/tests/ui/typeck/conversion/function_type_nonpayable_pure.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() external {
+    }
+    function f() view external returns (bytes4) {
+        function () pure external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_nonpayable_view.sol
+++ b/tests/ui/typeck/conversion/function_type_nonpayable_view.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() external {
+    }
+    function f() view external returns (bytes4) {
+        function () view external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_payable_nonpayable.sol
+++ b/tests/ui/typeck/conversion/function_type_payable_nonpayable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() payable external {
+    }
+    function f() view external returns (bytes4) {
+        function () external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_payable_pure.sol
+++ b/tests/ui/typeck/conversion/function_type_payable_pure.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() payable external {
+    }
+    function f() view external returns (bytes4) {
+        function () pure external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_payable_view.sol
+++ b/tests/ui/typeck/conversion/function_type_payable_view.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() payable external {
+    }
+    function f() view external returns (bytes4) {
+        function () view external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_pure_nonpayable.sol
+++ b/tests/ui/typeck/conversion/function_type_pure_nonpayable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() pure external {
+    }
+    function f() view external returns (bytes4) {
+        function () external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_pure_payable.sol
+++ b/tests/ui/typeck/conversion/function_type_pure_payable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() pure external {
+    }
+    function f() view external returns (bytes4) {
+        function () payable external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_pure_view.sol
+++ b/tests/ui/typeck/conversion/function_type_pure_view.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() pure external {
+    }
+    function f() view external returns (bytes4) {
+        function () view external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_view_nonpayable.sol
+++ b/tests/ui/typeck/conversion/function_type_view_nonpayable.sol
@@ -1,0 +1,10 @@
+contract C {
+	int dummy;
+    function h() view external {
+		dummy;
+    }
+    function f() view external returns (bytes4) {
+        function () external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_view_payable.sol
+++ b/tests/ui/typeck/conversion/function_type_view_payable.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() view external {
+    }
+    function f() view external returns (bytes4) {
+        function () payable external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/function_type_view_pure.sol
+++ b/tests/ui/typeck/conversion/function_type_view_pure.sol
@@ -1,0 +1,8 @@
+contract C {
+    function h() view external {
+    }
+    function f() view external returns (bytes4) {
+        function () pure external g = this.h;
+        return g.selector;
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_error_to_bytes4_function_argument.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_error_to_bytes4_function_argument.sol
@@ -1,0 +1,10 @@
+interface MyInterface {
+    error MyCustomError(uint256, bool);
+}
+
+contract MyContract {
+    function f(bytes4 arg) public {}
+    function test() public {
+        f(MyInterface.MyCustomError);
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_error_to_bytes4_return_value.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_error_to_bytes4_return_value.sol
@@ -1,0 +1,9 @@
+interface MyInterface {
+    error MyCustomError(uint256, bool);
+}
+
+contract Test {
+    function test() public returns(bytes4) {
+        return (MyInterface.MyCustomError);
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_event_to_bytes4_function_argument.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_event_to_bytes4_function_argument.sol
@@ -1,0 +1,7 @@
+contract MyContract {
+    event MyCustomEvent(uint256);
+    function f(bytes4 arg) public {}
+    function test() public {
+        f(MyCustomEvent);
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_event_to_bytes4_return_value.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_event_to_bytes4_return_value.sol
@@ -1,0 +1,7 @@
+contract Test {
+    event MyCustomEvent(uint256);
+
+    function test() public returns(bytes4) {
+        return (MyCustomEvent);
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_from_array_of_string_literals_to_calldata_string.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_from_array_of_string_literals_to_calldata_string.sol
@@ -1,0 +1,7 @@
+pragma abicoder               v2;
+
+contract C {
+    function f() public pure returns(string[5] calldata) {
+        return ["h", "e", "l", "l", "o"];
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_from_storage_array_ref.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_from_storage_array_ref.sol
@@ -1,0 +1,7 @@
+contract C {
+	int[10] x;
+	int[] y;
+	function f() public {
+		y = x;
+	}
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_from_string_literal_to_calldata_string.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_from_string_literal_to_calldata_string.sol
@@ -1,0 +1,13 @@
+contract C {
+    function f1() public pure returns(string calldata) {
+        return "hello";
+    }
+
+    function f2() public pure returns(string calldata) {
+        return unicode"hello";
+    }
+
+    function f3() public pure returns(bytes calldata) {
+        return hex"68656c6c6f";
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_from_string_literal_to_calldata_string_in_function_parameter.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_from_string_literal_to_calldata_string_in_function_parameter.sol
@@ -1,0 +1,10 @@
+contract C {
+    function g(string calldata _s) public {}
+    function h(bytes calldata _b) public {}
+
+    function f() public {
+        g("hello");
+        g(unicode"hello");
+        h(hex"68656c6c6f");
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_of_super_in_comparison.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_of_super_in_comparison.sol
@@ -1,0 +1,20 @@
+contract D {}
+
+contract C {
+    C c;
+    D d;
+
+    function foo() public {
+        // Current instance of the current contract vs super
+        super != this;
+        this != super;
+
+        // Different instance of the current contract vs super
+        super != c;
+        c != super;
+
+        // Instance of an unrelated contract vs super
+        super != d;
+        d != super;
+    }
+}

--- a/tests/ui/typeck/conversion/implicit_conversion_of_super_in_operators.sol
+++ b/tests/ui/typeck/conversion/implicit_conversion_of_super_in_operators.sol
@@ -1,0 +1,31 @@
+contract C {
+    function foo() public {
+        super << this;
+        super >> this;
+        super ^ this;
+        super | this;
+        super & this;
+
+        super * this;
+        super / this;
+        super % this;
+        super - this;
+        super + this;
+        super ** this;
+
+        super == this;
+        super != this;
+        super >= this;
+        super <= this;
+        super < this;
+        super > this;
+
+        super || this;
+        super && this;
+
+        super -= this;
+        super += this;
+
+        true ? super : this;
+    }
+}

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -1,0 +1,54 @@
+//@compile-flags: -Ztypeck
+
+// Tests for implicit array conversions.
+// Arrays allow element type widening if same signedness.
+// Fixed arrays must also have same length.
+
+contract C {
+    // === Valid: same element type assignment ===
+    function sameDynamicArray(uint256[] memory a) internal pure {
+        uint256[] memory b = a;
+    }
+
+    function sameFixedArray(uint256[3] memory a) internal pure {
+        uint256[3] memory b = a;
+    }
+
+    // === Valid: element type widening (same signedness) ===
+    function wideningDynamic(uint8[] memory a) internal pure {
+        uint256[] memory b = a; // OK - uint8 -> uint256
+    }
+
+    function wideningFixed(uint8[3] memory a) internal pure {
+        uint256[3] memory b = a; // OK - uint8 -> uint256
+    }
+
+    function wideningBytes(bytes1[] memory a) internal pure {
+        bytes32[] memory b = a; // OK - bytes1 -> bytes32
+    }
+
+    // === Invalid: different array lengths ===
+    function differentLength(uint256[3] memory a) internal pure {
+        uint256[4] memory b = a; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: fixed to dynamic array ===
+    function fixedToDynamic(uint256[3] memory a) internal pure {
+        uint256[] memory b = a; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: dynamic to fixed array ===
+    function dynamicToFixed(uint256[] memory a) internal pure {
+        uint256[3] memory b = a; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: different signedness ===
+    function signednessMismatch(int256[] memory a) internal pure {
+        uint256[] memory b = a; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: narrowing element type ===
+    function narrowingDynamic(uint256[] memory a) internal pure {
+        uint8[] memory b = a; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/implicit_array_conversions.stderr
+++ b/tests/ui/typeck/implicit_array_conversions.stderr
@@ -1,0 +1,32 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint256[4] memory b = a;
+   ╰╴                              ━ expected `uint256[4] memory`, found `uint256[3] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint256[] memory b = a;
+   ╰╴                             ━ expected `uint256[] memory`, found `uint256[3] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint256[3] memory b = a;
+   ╰╴                              ━ expected `uint256[3] memory`, found `uint256[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint256[] memory b = a;
+   ╰╴                             ━ expected `uint256[] memory`, found `int256[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint8[] memory b = a;
+   ╰╴                           ━ expected `uint8[] memory`, found `uint256[] memory`
+
+error: aborting due to 5 previous errors
+

--- a/tests/ui/typeck/implicit_fixed_bytes.sol
+++ b/tests/ui/typeck/implicit_fixed_bytes.sol
@@ -1,0 +1,47 @@
+//@compile-flags: -Ztypeck
+
+// Tests for implicit FixedBytes width conversions.
+// See: https://docs.soliditylang.org/en/latest/types.html#implicit-conversions
+// "Smaller bytesN to larger bytesN is allowed (e.g., bytes1 -> bytes32, right-padded with zeros)."
+
+contract C {
+    // === Valid: smaller bytesN -> larger bytesN (right-padded with zeros) ===
+    function validBytesWidening(bytes1 b1, bytes2 b2, bytes4 b4, bytes16 b16) public pure {
+        bytes2 a = b1;
+        bytes4 c = b1;
+        bytes8 d = b1;
+        bytes16 e = b1;
+        bytes32 f = b1;
+
+        bytes4 g = b2;
+        bytes8 h = b2;
+        bytes16 i = b2;
+        bytes32 j = b2;
+
+        bytes8 k = b4;
+        bytes16 l = b4;
+        bytes32 m = b4;
+
+        bytes32 n = b16;
+    }
+
+    // === Invalid: larger bytesN -> smaller bytesN (truncation requires explicit cast) ===
+    function invalidBytesNarrowing(bytes2 b2, bytes4 b4, bytes16 b16, bytes32 b32) public pure {
+        bytes1 a = b2;   //~ ERROR: mismatched types
+        bytes1 b = b4;   //~ ERROR: mismatched types
+        bytes1 c = b16;  //~ ERROR: mismatched types
+        bytes1 d = b32;  //~ ERROR: mismatched types
+        bytes2 e = b4;   //~ ERROR: mismatched types
+        bytes2 f = b32;  //~ ERROR: mismatched types
+        bytes4 g = b16;  //~ ERROR: mismatched types
+        bytes4 h = b32;  //~ ERROR: mismatched types
+        bytes16 i = b32; //~ ERROR: mismatched types
+    }
+
+    // === Valid: same size assignments ===
+    function validSameSize(bytes1 b1, bytes4 b4, bytes32 b32) public pure {
+        bytes1 a = b1;
+        bytes4 b = b4;
+        bytes32 c = b32;
+    }
+}

--- a/tests/ui/typeck/implicit_fixed_bytes.stderr
+++ b/tests/ui/typeck/implicit_fixed_bytes.stderr
@@ -1,0 +1,56 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes1 a = b2;
+   ╰╴                   ━━ expected `bytes1`, found `bytes2`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes1 b = b4;
+   ╰╴                   ━━ expected `bytes1`, found `bytes4`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes1 c = b16;
+   ╰╴                   ━━━ expected `bytes1`, found `bytes16`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes1 d = b32;
+   ╰╴                   ━━━ expected `bytes1`, found `bytes32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes2 e = b4;
+   ╰╴                   ━━ expected `bytes2`, found `bytes4`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes2 f = b32;
+   ╰╴                   ━━━ expected `bytes2`, found `bytes32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes4 g = b16;
+   ╰╴                   ━━━ expected `bytes4`, found `bytes16`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes4 h = b32;
+   ╰╴                   ━━━ expected `bytes4`, found `bytes32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_fixed_bytes.sol:LL:CC
+   │
+LL │         bytes16 i = b32;
+   ╰╴                    ━━━ expected `bytes16`, found `bytes32`
+
+error: aborting due to 9 previous errors
+

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -1,0 +1,66 @@
+//@compile-flags: -Ztypeck
+
+// Tests for implicit function pointer conversions.
+// See: https://docs.soliditylang.org/en/latest/types.html#function-types
+
+contract C {
+    // === Valid: same function type ===
+    function pureFunc() internal pure returns (uint256) { return 1; }
+    function viewFunc() internal view returns (uint256) { return 1; }
+    function nonPayableFunc() internal returns (uint256) { return 1; }
+
+    function assignSame() internal pure {
+        function() internal pure returns (uint256) f = pureFunc;
+    }
+
+    // === Valid: pure -> view (more restrictive -> less restrictive) ===
+    function pureToView() internal pure {
+        function() internal view returns (uint256) f = pureFunc;
+    }
+
+    // === Valid: pure -> non-payable ===
+    function pureToNonPayable() internal pure {
+        function() internal returns (uint256) f = pureFunc;
+    }
+
+    // === Valid: view -> non-payable ===
+    function viewToNonPayable() internal view {
+        function() internal returns (uint256) f = viewFunc;
+    }
+
+    // === Invalid: non-payable -> pure (less restrictive -> more restrictive) ===
+    function nonPayableToPure() internal {
+        function() internal pure returns (uint256) f = nonPayableFunc; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: non-payable -> view ===
+    function nonPayableToView() internal {
+        function() internal view returns (uint256) f = nonPayableFunc; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: view -> pure ===
+    function viewToPure() internal view {
+        function() internal pure returns (uint256) f = viewFunc; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: different parameter count ===
+    function oneParam(uint256 x) internal pure returns (uint256) { return x; }
+
+    function wrongParamCount() internal pure {
+        function() internal pure returns (uint256) f = oneParam; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: different return count ===
+    function twoReturns() internal pure returns (uint256, uint256) { return (1, 2); }
+
+    function wrongReturnCount() internal pure {
+        function() internal pure returns (uint256) f = twoReturns; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: different parameter types ===
+    function intParam(int256 x) internal pure returns (uint256) { return 0; }
+
+    function wrongParamType() internal pure {
+        function(uint256) internal pure returns (uint256) f = intParam; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/implicit_function_ptr.stderr
+++ b/tests/ui/typeck/implicit_function_ptr.stderr
@@ -1,0 +1,38 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() internal pure returns (uint256) f = nonPayableFunc;
+   ╰╴                                                       ━━━━━━━━━━━━━━ expected `function () pure returns (uint256)`, found `function () returns (uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() internal view returns (uint256) f = nonPayableFunc;
+   ╰╴                                                       ━━━━━━━━━━━━━━ expected `function () view returns (uint256)`, found `function () returns (uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() internal pure returns (uint256) f = viewFunc;
+   ╰╴                                                       ━━━━━━━━ expected `function () pure returns (uint256)`, found `function () view returns (uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() internal pure returns (uint256) f = oneParam;
+   ╰╴                                                       ━━━━━━━━ expected `function () pure returns (uint256)`, found `function (uint256) pure returns (uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() internal pure returns (uint256) f = twoReturns;
+   ╰╴                                                       ━━━━━━━━━━ expected `function () pure returns (uint256)`, found `function () pure returns (uint256,uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function(uint256) internal pure returns (uint256) f = intParam;
+   ╰╴                                                              ━━━━━━━━ expected `function (uint256) pure returns (uint256)`, found `function (int256) pure returns (uint256)`
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/typeck/implicit_integer_width.sol
+++ b/tests/ui/typeck/implicit_integer_width.sol
@@ -1,0 +1,86 @@
+//@compile-flags: -Ztypeck
+
+// Tests for implicit integer width conversions.
+// See: https://docs.soliditylang.org/en/latest/types.html#implicit-conversions
+// "Smaller width to larger width is allowed (e.g., uint8 -> uint256, int8 -> int256)."
+
+contract C {
+    // === Valid: uint -> larger uint ===
+    function validUintWidening(uint8 u8, uint16 u16, uint32 u32, uint128 u128) public pure {
+        uint16 a = u8;
+        uint32 b = u8;
+        uint64 c = u8;
+        uint128 d = u8;
+        uint256 e = u8;
+
+        uint32 f = u16;
+        uint64 g = u16;
+        uint128 h = u16;
+        uint256 i = u16;
+
+        uint64 j = u32;
+        uint128 k = u32;
+        uint256 l = u32;
+
+        uint256 m = u128;
+    }
+
+    // === Valid: int -> larger int ===
+    function validIntWidening(int8 i8, int16 i16, int32 i32, int128 i128) public pure {
+        int16 a = i8;
+        int32 b = i8;
+        int64 c = i8;
+        int128 d = i8;
+        int256 e = i8;
+
+        int32 f = i16;
+        int64 g = i16;
+        int128 h = i16;
+        int256 i = i16;
+
+        int64 j = i32;
+        int128 k = i32;
+        int256 l = i32;
+
+        int256 m = i128;
+    }
+
+    // === Invalid: uint -> smaller uint (narrowing) ===
+    function invalidUintNarrowing(uint16 u16, uint32 u32, uint256 u256) public pure {
+        uint8 a = u16;   //~ ERROR: mismatched types
+        uint8 b = u32;   //~ ERROR: mismatched types
+        uint8 c = u256;  //~ ERROR: mismatched types
+        uint16 d = u32;  //~ ERROR: mismatched types
+        uint16 e = u256; //~ ERROR: mismatched types
+        uint32 f = u256; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: int -> smaller int (narrowing) ===
+    function invalidIntNarrowing(int16 i16, int32 i32, int256 i256) public pure {
+        int8 a = i16;   //~ ERROR: mismatched types
+        int8 b = i32;   //~ ERROR: mismatched types
+        int8 c = i256;  //~ ERROR: mismatched types
+        int16 d = i32;  //~ ERROR: mismatched types
+        int16 e = i256; //~ ERROR: mismatched types
+        int32 f = i256; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: uint <-> int (different signedness) ===
+    function invalidSignednessChange(uint8 u8, uint256 u256, int8 i8, int256 i256) public pure {
+        int8 a = u8;     //~ ERROR: mismatched types
+        uint8 b = i8;    //~ ERROR: mismatched types
+        int256 c = u256; //~ ERROR: mismatched types
+        uint256 d = i256; //~ ERROR: mismatched types
+        // Even larger size doesn't help
+        int16 e = u8;    //~ ERROR: mismatched types
+        uint16 f = i8;   //~ ERROR: mismatched types
+    }
+
+    // === Valid: same width assignments ===
+    function validSameWidth(uint8 u8, uint16 u16, int8 i8, int16 i16) public pure {
+        uint8 a = u8;
+        uint16 b = u16;
+        int8 c = i8;
+        int16 d = i16;
+    }
+}

--- a/tests/ui/typeck/implicit_integer_width.stderr
+++ b/tests/ui/typeck/implicit_integer_width.stderr
@@ -1,0 +1,110 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint8 a = u16;
+   ╰╴                  ━━━ expected `uint8`, found `uint16`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint8 b = u32;
+   ╰╴                  ━━━ expected `uint8`, found `uint32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint8 c = u256;
+   ╰╴                  ━━━━ expected `uint8`, found `uint256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint16 d = u32;
+   ╰╴                   ━━━ expected `uint16`, found `uint32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint16 e = u256;
+   ╰╴                   ━━━━ expected `uint16`, found `uint256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint32 f = u256;
+   ╰╴                   ━━━━ expected `uint32`, found `uint256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int8 a = i16;
+   ╰╴                 ━━━ expected `int8`, found `int16`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int8 b = i32;
+   ╰╴                 ━━━ expected `int8`, found `int32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int8 c = i256;
+   ╰╴                 ━━━━ expected `int8`, found `int256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int16 d = i32;
+   ╰╴                  ━━━ expected `int16`, found `int32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int16 e = i256;
+   ╰╴                  ━━━━ expected `int16`, found `int256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int32 f = i256;
+   ╰╴                  ━━━━ expected `int32`, found `int256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int8 a = u8;
+   ╰╴                 ━━ expected `int8`, found `uint8`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint8 b = i8;
+   ╰╴                  ━━ expected `uint8`, found `int8`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int256 c = u256;
+   ╰╴                   ━━━━ expected `int256`, found `uint256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint256 d = i256;
+   ╰╴                    ━━━━ expected `uint256`, found `int256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         int16 e = u8;
+   ╰╴                  ━━ expected `int16`, found `uint8`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_integer_width.sol:LL:CC
+   │
+LL │         uint16 f = i8;
+   ╰╴                   ━━ expected `uint16`, found `int8`
+
+error: aborting due to 18 previous errors
+

--- a/tests/ui/typeck/implicit_tuple_conversions.sol
+++ b/tests/ui/typeck/implicit_tuple_conversions.sol
@@ -1,0 +1,52 @@
+//@compile-flags: -Ztypeck
+
+// Tests for implicit conversions in tuple contexts.
+// Tuple assignments check element-wise implicit conversions.
+
+contract C {
+    // === Valid: tuple assignment with widening ===
+    function tupleWidening(uint8 a, uint8 b) public pure {
+        (uint256 x, uint256 y) = (a, b); // implicit uint8 -> uint256
+    }
+
+    function tupleWideningInt(int8 a, int8 b) public pure {
+        (int256 x, int256 y) = (a, b); // implicit int8 -> int256
+    }
+
+    function tupleWideningMixed(uint8 a, uint16 b, uint32 c) public pure {
+        (uint256 x, uint256 y, uint256 z) = (a, b, c); // all widen to uint256
+    }
+
+    // === Valid: tuple with same types ===
+    function tupleSameType(uint256 a, uint256 b) public pure {
+        (uint256 x, uint256 y) = (a, b);
+    }
+
+    // === Invalid: tuple narrowing (larger -> smaller) ===
+    function tupleNarrowingInvalid(uint256 a, uint256 b) public pure {
+        (uint8 x, uint8 y) = (a, b); //~ ERROR: mismatched types
+        //~^ ERROR: mismatched types
+    }
+
+    function tupleNarrowingIntInvalid(int256 a, int256 b) public pure {
+        (int8 x, int8 y) = (a, b); //~ ERROR: mismatched types
+        //~^ ERROR: mismatched types
+    }
+
+    // === Invalid: tuple signedness mismatch ===
+    function tupleSignednessMismatch(uint8 a, int8 b) public pure {
+        (int8 x, uint8 y) = (a, b); //~ ERROR: mismatched types
+        //~^ ERROR: mismatched types
+    }
+
+    // === Valid: bytes widening in tuples ===
+    function tupleBytesWidening(bytes1 a, bytes2 b) public pure {
+        (bytes32 x, bytes32 y) = (a, b); // implicit widening
+    }
+
+    // === Invalid: bytes narrowing in tuples ===
+    function tupleBytesNarrowingInvalid(bytes32 a, bytes32 b) public pure {
+        (bytes1 x, bytes2 y) = (a, b); //~ ERROR: mismatched types
+        //~^ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/implicit_tuple_conversions.stderr
+++ b/tests/ui/typeck/implicit_tuple_conversions.stderr
@@ -1,0 +1,50 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (uint8 x, uint8 y) = (a, b);
+   ╰╴                              ━ expected `uint8`, found `uint256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (uint8 x, uint8 y) = (a, b);
+   ╰╴                                 ━ expected `uint8`, found `uint256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (int8 x, int8 y) = (a, b);
+   ╰╴                            ━ expected `int8`, found `int256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (int8 x, int8 y) = (a, b);
+   ╰╴                               ━ expected `int8`, found `int256`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (int8 x, uint8 y) = (a, b);
+   ╰╴                             ━ expected `int8`, found `uint8`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (int8 x, uint8 y) = (a, b);
+   ╰╴                                ━ expected `uint8`, found `int8`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (bytes1 x, bytes2 y) = (a, b);
+   ╰╴                                ━ expected `bytes1`, found `bytes32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         (bytes1 x, bytes2 y) = (a, b);
+   ╰╴                                   ━ expected `bytes2`, found `bytes32`
+
+error: aborting due to 8 previous errors
+


### PR DESCRIPTION
## Summary

Implement missing implicit type conversions in `try_convert_implicit_to` as outlined in #617.

## Changes

Added support for:

- **Integer width conversions**: smaller int -> larger int (same signedness)
  - `uint8 -> uint256`, `int8 -> int256`

- **FixedBytes size conversions**: smaller bytesN -> larger bytesN  
  - `bytes1 -> bytes32` (right-padded with zeros)

- **Tuple conversions**: element-wise implicit conversion with same length

- **Array conversions**: DynArray and fixed Array base type compatibility

- **Function pointer conversions**: 
  - Exact parameter/return types required
  - Visibility must match
  - State mutability compatibility (pure -> view -> nonpayable, payable -> nonpayable)

## Reference

Based on solc `Types.cpp` `isImplicitlyConvertibleTo` implementations for:
- `IntegerType::isImplicitlyConvertibleTo`
- `FixedBytesType::isImplicitlyConvertibleTo`
- `TupleType::isImplicitlyConvertibleTo`
- `ArrayType::isImplicitlyConvertibleTo`
- `FunctionType::isImplicitlyConvertibleTo`

## Testing

- All existing tests pass
- Verified with sample .sol files using `solar -Ztypeck`

Closes #617