### PR TITLE
fix(sema): fix typechecker ICE bugs #216 #219 #221 #222

### DIFF
--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -244,7 +244,7 @@ impl EvalErrorKind {
         EvalError { kind: self, span }
     }
 
-    fn msg(&self) -> &'static str {
+    pub fn msg(&self) -> &'static str {
         match self {
             Self::RecursionLimitReached => "recursion limit reached",
             Self::ArithmeticOverflow => "arithmetic overflow",

--- a/tests/ui/resolve/error_param_type_shadowing.sol
+++ b/tests/ui/resolve/error_param_type_shadowing.sol
@@ -1,0 +1,21 @@
+// Error/event parameters don't shadow type names for subsequent parameters.
+// https://github.com/paradigmxyz/solar/issues/219
+
+contract C {
+    enum EnumType { A, B, C }
+
+    struct StructType {
+        uint x;
+    }
+
+    // Parameter named `StructType` should not shadow the type `StructType`.
+    error E(EnumType StructType, StructType test);
+    
+    // Same for events.
+    event Ev(EnumType StructType, StructType test);
+    
+    // And for function type parameters.
+    function f(StructType memory a) public pure returns (StructType memory) {
+        return a;
+    }
+}

--- a/tests/ui/resolve/error_param_type_shadowing.sol
+++ b/tests/ui/resolve/error_param_type_shadowing.sol
@@ -18,4 +18,11 @@ contract C {
     function f(StructType memory a) public pure returns (StructType memory) {
         return a;
     }
+
+    // Ensure error can be used with revert (original bug #219 scenario).
+    error MyError(uint x);
+
+    function triggerError() public pure {
+        revert MyError(1);
+    }
 }

--- a/tests/ui/resolve/event_this_super.sol
+++ b/tests/ui/resolve/event_this_super.sol
@@ -1,0 +1,12 @@
+// Events named `this` and `super` are allowed and don't conflict with builtins.
+// https://github.com/paradigmxyz/solar/issues/216
+
+contract C {
+    event this();
+    event super();
+    
+    function emitEvents() public {
+        emit this();
+        emit super();
+    }
+}

--- a/tests/ui/typeck/literal_pow_overflow.sol
+++ b/tests/ui/typeck/literal_pow_overflow.sol
@@ -1,0 +1,24 @@
+//@compile-flags: -Ztypeck
+// Power operations with integer literals that overflow should be rejected.
+// https://github.com/paradigmxyz/solar/issues/222
+
+contract C {
+    function test() public pure returns (uint256) {
+        uint256 result = 10 ** 1e10;
+        //~^ ERROR: built-in binary operator `**` cannot be applied
+        return result;
+    }
+    
+    function test2() public pure returns (uint256) {
+        uint256 result = 2 ** 256;
+        //~^ ERROR: built-in binary operator `**` cannot be applied
+        return result;
+    }
+    
+    // Valid cases - should compile.
+    function testOk() public pure returns (uint256) {
+        uint256 a = 2 ** 255;
+        uint256 b = 10 ** 77;
+        return a + b;
+    }
+}

--- a/tests/ui/typeck/literal_pow_overflow.stderr
+++ b/tests/ui/typeck/literal_pow_overflow.stderr
@@ -1,0 +1,22 @@
+error: built-in binary operator `**` cannot be applied to types `int_literal[4]` and `int_literal[34]`
+   ╭▸ ROOT/tests/ui/typeck/literal_pow_overflow.sol:LL:CC
+   │
+LL │         uint256 result = 10 ** 1e10;
+   │                          ┬─ ━━ ──── int_literal[34]
+   │                          │
+   │                          int_literal[4]
+   │
+   ╰ note: arithmetic overflow
+
+error: built-in binary operator `**` cannot be applied to types `int_literal[2]` and `int_literal[9]`
+   ╭▸ ROOT/tests/ui/typeck/literal_pow_overflow.sol:LL:CC
+   │
+LL │         uint256 result = 2 ** 256;
+   │                          ┬ ━━ ─── int_literal[9]
+   │                          │
+   │                          int_literal[2]
+   │
+   ╰ note: arithmetic overflow
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/pure_state_access.sol
+++ b/tests/ui/typeck/pure_state_access.sol
@@ -1,0 +1,24 @@
+//@compile-flags: -Ztypeck
+// Pure functions cannot read state variables.
+// https://github.com/paradigmxyz/solar/issues/221
+
+contract C {
+    uint256 stateVar = 10;
+    uint256 constant CONST = 42;
+    
+    // Error: pure function reads state.
+    function testPure() public pure returns (uint256) {
+        return stateVar;
+        //~^ ERROR: function declared as pure, but this expression reads
+    }
+    
+    // OK: view function can read state.
+    function testView() public view returns (uint256) {
+        return stateVar;
+    }
+    
+    // OK: pure function can read constants.
+    function testPureConst() public pure returns (uint256) {
+        return CONST;
+    }
+}

--- a/tests/ui/typeck/pure_state_access.stderr
+++ b/tests/ui/typeck/pure_state_access.stderr
@@ -1,0 +1,8 @@
+error: function declared as pure, but this expression reads from the environment or state and thus requires "view"
+   ╭▸ ROOT/tests/ui/typeck/pure_state_access.sol:LL:CC
+   │
+LL │         return stateVar;
+   ╰╴               ━━━━━━━━
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## Summary

This PR fixes 4 typechecker bugs reported in GitHub issues:

### #216 - Events named `this` and `super` now allowed

Events can coexist with builtins (`this`, `super`) in the same scope without conflicts. The fix adds handling in `conflicting_declaration` to treat builtins as compatible with events.

```solidity
contract C {
    event this();  // Now compiles successfully
    event super(); // Now compiles successfully
}
```

### #219 - Error/event/struct parameter names no longer shadow type names

Parameters for error, event, and struct declarations don't declare names in scope since they don't create a lexical scope where names can be used. This prevents the first parameter's name from shadowing a type name for subsequent parameters.

```solidity
contract C {
    struct StructType { uint x; }
    // Previously failed - StructType was shadowed by the first parameter's name
    error E(uint256 StructType, StructType test);  // Now compiles successfully
}
```

### #221 - Pure functions now validated for state access

Added state mutability validation for pure functions. Pure functions now error when accessing state variables that are not constant or immutable.

```solidity
contract C {
    uint256 stateVar = 10;
    function test() public pure returns (uint256) {
        return stateVar;  // Error: requires "view"
    }
}
```

### #222 - Large exponent literals validated

Exponentiation operations with integer literals that would overflow are now rejected at compile time.

```solidity
contract C {
    function test() public pure returns (uint256) {
        return 10 ** 1e10;  // Error: arithmetic overflow
    }
}
```

## Changes

- `crates/sema/src/ast_lowering/resolve.rs`: 
  - Fixed event/builtin conflict detection
  - Parameters for events, errors, structs, and function type signatures no longer declare in scope

- `crates/sema/src/typeck/checker.rs`:
  - Added `function_state_mutability` tracking
  - Added `check_state_access` validation for pure functions
  - Added power operation validation for integer literals
  - Added `visit_function` to track function state mutability

- `crates/sema/src/eval.rs`: Made `EvalErrorKind::msg` public

## Testing

Added 4 regression tests:
- `tests/ui/resolve/event_this_super.sol`
- `tests/ui/resolve/error_param_type_shadowing.sol`  
- `tests/ui/typeck/literal_pow_overflow.sol`
- `tests/ui/typeck/pure_state_access.sol`

All existing tests continue to pass.

Fixes #216, #219, #221, #222