### PR TITLE
feat(sema): add UDVT explicit wrap/unwrap conversions

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -725,6 +725,10 @@ impl<'gcx> Ty<'gcx> {
                 }
             }
 
+            // UDVT <-> underlying type (explicit wrap/unwrap).
+            (Udvt(underlying, _), _) if underlying == other => Ok(()),
+            (_, Udvt(underlying, _)) if self == underlying => Ok(()),
+
             _ => Result::Err(TyConvertError::InvalidConversion),
         }
     }

--- a/tests/ui/typeck/udvt_explicit_conversions.sol
+++ b/tests/ui/typeck/udvt_explicit_conversions.sol
@@ -1,0 +1,46 @@
+//@compile-flags: -Ztypeck
+
+type MyUint is uint256;
+type MyAddress is address;
+type MyInt is int128;
+type Price is uint256;
+type Amount is uint128;
+
+contract UDVTTests {
+    // Valid: wrap (underlying -> UDVT).
+    function testWrap(uint256 x, address a, int128 i) public pure {
+        MyUint u = MyUint(x);
+        MyAddress ma = MyAddress(a);
+        MyInt mi = MyInt(i);
+    }
+
+    // Valid: unwrap (UDVT -> underlying).
+    function testUnwrap(MyUint u, MyAddress ma, MyInt mi) public pure {
+        uint256 x = uint256(u);
+        address a = address(ma);
+        int128 i = int128(mi);
+    }
+
+    // Valid: round-trip conversion.
+    function testRoundTrip(uint256 x) public pure returns (uint256) {
+        MyUint u = MyUint(x);
+        return uint256(u);
+    }
+}
+
+contract UDVTErrors {
+    // Invalid: cannot convert UDVT to incompatible underlying type.
+    function testWrongUnderlying(Price p) public pure {
+        int256 x = int256(p); //~ ERROR: invalid explicit type conversion
+    }
+
+    // Invalid: cannot convert one UDVT to another UDVT.
+    function testUDVTtoUDVT(MyUint u) public pure {
+        Price p = Price(u); //~ ERROR: invalid explicit type conversion
+    }
+
+    // Invalid: cannot convert UDVT to different size underlying.
+    function testUDVTtoWrongSize(Price p) public pure {
+        uint128 x = uint128(p); //~ ERROR: invalid explicit type conversion
+    }
+}

--- a/tests/ui/typeck/udvt_explicit_conversions.stderr
+++ b/tests/ui/typeck/udvt_explicit_conversions.stderr
@@ -1,0 +1,20 @@
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/udvt_explicit_conversions.sol:LL:CC
+   │
+LL │         int256 x = int256(p);
+   ╰╴                   ━━━━━━━━━ cannot convert `Price` to `int256`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/udvt_explicit_conversions.sol:LL:CC
+   │
+LL │         Price p = Price(u);
+   ╰╴                  ━━━━━━━━ cannot convert `MyUint` to `Price`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/udvt_explicit_conversions.sol:LL:CC
+   │
+LL │         uint128 x = uint128(p);
+   ╰╴                    ━━━━━━━━━━ cannot convert `Price` to `uint128`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Allow explicit conversion between user-defined value types (UDVT) and their underlying types:

- Underlying -> UDVT (wrap): e.g., `MyUint(x)` where x is uint256
- UDVT -> underlying (unwrap): e.g., `uint256(u)` where u is MyUint

This matches solc behavior where UDVTs can be explicitly wrapped and unwrapped but cannot be converted to incompatible types or other UDVTs.

Closes #609