### PR TITLE
feat(tester): enable -Ztypeck for solc tests with TypeError annotations

### DIFF
--- a/tools/tester/src/solc/mod.rs
+++ b/tools/tester/src/solc/mod.rs
@@ -82,6 +82,10 @@ impl SolcErrorKind {
         matches!(self, Self::DocstringParsingError | Self::ParserError)
     }
 
+    pub fn is_type_error(&self) -> bool {
+        matches!(self, Self::TypeError)
+    }
+
     pub(crate) fn is_error(&self) -> bool {
         !matches!(self, Self::Info | Self::Warning)
     }


### PR DESCRIPTION
## Summary
Fixes #663

- Move `--stop-after=parsing` from base program args to per-file config in the solc tester
- For solc tests with `// TypeError:` annotations (and no `ParserError`), pass `-Ztypeck` instead, running the full compiler pipeline including type checking
- Add `is_type_error()` helper to `SolcErrorKind`
- ~1593 solc tests now exercise the typechecker; exit code remains ignored since the typechecker is WIP

## Test plan
- [x] All 6531 solc-solidity tests pass
- [x] All 198 UI tests pass
- [x] Clippy clean across workspace