### PR TITLE
fix(parse): use StarStar for ** precedence

### DIFF
--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -49,10 +49,10 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         while precedence >= min_precedence {
             while token_precedence(self.token) == precedence {
                 // Parse a**b**c as a**(b**c)
-                let next_precedence = if self.token.kind == TokenKind::BinOp(BinOpToken::Star) {
-                    precedence + 1
-                } else {
+                let next_precedence = if self.token.kind == TokenKind::StarStar {
                     precedence
+                } else {
+                    precedence + 1
                 };
 
                 let token = self.token;


### PR DESCRIPTION
## Summary

Exponentiation (`**`) is lexed as `TokenKind::StarStar`, not `BinOp(Star)`. The precedence loop was checking the wrong token kind, so chained exponentiation did not get the intended right associativity (`a**b**c` as `a**(b**c)`).

## Changes

- Compare against `TokenKind::StarStar` and adjust `next_precedence` accordingly for the `**` operator.