### PR TITLE
feat(codegen): pass manager, MIR text format, SCCP, and testing infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solar-mir-opt"
+version = "0.1.8"
+dependencies = [
+ "solar-codegen",
+ "solar-interface",
+ "solar-sema",
+]
+
+[[package]]
 name = "solar-parse"
 version = "0.1.8"
 dependencies = [

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -104,6 +104,11 @@ fn run_default(compiler: &mut CompilerRef<'_>) -> Result {
     compiler.drop_asts();
     let ControlFlow::Continue(()) = compiler.analysis()? else { return Ok(()) };
 
+    // Handle MIR emit if requested (does not require bytecode generation).
+    if sess.opts.emit.contains(&CompilerOutput::Mir) {
+        emit_mir(compiler);
+    }
+
     // Handle bytecode emit if requested
     let needs_bytecode = sess
         .opts
@@ -116,6 +121,24 @@ fn run_default(compiler: &mut CompilerRef<'_>) -> Result {
     }
 
     Ok(())
+}
+
+/// Emit textual MIR for all contracts using solar-codegen.
+fn emit_mir(compiler: &mut CompilerRef<'_>) {
+    use solar_codegen::{lower, mir::module_to_text};
+
+    let gcx = compiler.gcx();
+
+    for id in gcx.hir.contract_ids() {
+        let contract = gcx.hir.contract(id);
+        if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
+            continue;
+        }
+        let module = lower::lower_contract(gcx, id);
+        let name = gcx.contract_fully_qualified_name(id);
+        println!("// === {name} ===");
+        println!("{}", module_to_text(&module));
+    }
 }
 
 /// Emit bytecode (and optionally ABI/hashes) for all contracts using solar-codegen.

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -5,8 +5,15 @@
 //! that doesn't pass through a definition of that value.
 //!
 //! The analysis uses dense bitsets indexed by `ValueId` for efficiency.
+//!
+//! # Phi node handling
+//!
+//! Phi values (`Value::Phi`) are not instructions — they exist only in the value table.
+//! Their incoming operands are treated as uses at the **exit** of the corresponding
+//! predecessor block (standard SSA liveness convention). The phi result is treated as
+//! defined at the **entry** of the merge block.
 
-use crate::mir::{BlockId, Function, Terminator, Value, ValueId};
+use crate::mir::{BlockId, Function, InstId, Terminator, Value, ValueId};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 
@@ -56,6 +63,21 @@ impl LiveSet {
         if word < self.bits.len() {
             self.bits[word] &= !(1u64 << bit);
         }
+    }
+
+    /// Sets `self = self - other`, returning true if this set changed.
+    pub fn subtract(&mut self, other: &Self) -> bool {
+        let mut changed = false;
+        for (i, &word) in other.bits.iter().enumerate() {
+            if i < self.bits.len() {
+                let old = self.bits[i];
+                self.bits[i] &= !word;
+                if self.bits[i] != old {
+                    changed = true;
+                }
+            }
+        }
+        changed
     }
 
     /// Unions this set with another, returning true if this set changed.
@@ -128,6 +150,9 @@ pub struct Liveness {
     /// The key is (ValueId, BlockId), and value is the instruction index (None = terminator).
     /// This tracks the last use of a value *within* each block where it's used.
     last_use_in_block: FxHashMap<(ValueId, BlockId), Option<usize>>,
+    /// Precomputed map from InstId to the ValueId it defines.
+    /// Built once during compute() to avoid O(n) scans.
+    pub(crate) inst_to_value: FxHashMap<InstId, ValueId>,
     /// Number of values in the function.
     #[allow(dead_code)]
     num_values: usize,
@@ -139,6 +164,15 @@ impl Liveness {
     pub fn compute(func: &Function) -> Self {
         let num_values = func.values.len();
         let num_blocks = func.blocks.len();
+
+        // Precompute InstId → ValueId mapping.
+        // This replaces the O(n) linear scans that were previously done per-instruction.
+        let mut inst_to_value: FxHashMap<InstId, ValueId> = FxHashMap::default();
+        for (val_id, val) in func.values.iter_enumerated() {
+            if let Value::Inst(inst_id) = val {
+                inst_to_value.insert(*inst_id, val_id);
+            }
+        }
 
         // Initialize per-block liveness
         let mut block_liveness: Vec<BlockLiveness> = (0..num_blocks)
@@ -171,33 +205,17 @@ impl Liveness {
                     }
                 }
 
-                // Record definition
-                if let Value::Inst(def_inst) = func.value(ValueId::from_usize(inst_id.index()))
-                    && *def_inst == inst_id
-                {
-                    block_defs[bidx].insert(ValueId::from_usize(inst_id.index()));
-                }
-
-                // Handle the result value
-                // The instruction defines a value if it has a result
-                if inst.result_ty.is_some() {
-                    // Find the ValueId that corresponds to this instruction
-                    for (val_id, val) in func.values.iter_enumerated() {
-                        if let Value::Inst(inst) = val
-                            && *inst == inst_id
-                        {
-                            block_defs[bidx].insert(val_id);
-                            break;
-                        }
-                    }
+                // Record definition using precomputed map (O(1) instead of O(n)).
+                if let Some(&val_id) = inst_to_value.get(&inst_id) {
+                    block_defs[bidx].insert(val_id);
                 }
             }
 
             // Process terminator uses
             if let Some(term) = &block.terminator {
-                let mut term_uses = Vec::new();
-                collect_terminator_uses(term, &mut term_uses);
-                for operand in term_uses {
+                operand_buf.clear();
+                collect_terminator_uses(term, &mut operand_buf);
+                for &operand in &operand_buf {
                     if !block_defs[bidx].contains(operand) {
                         block_uses[bidx].insert(operand);
                     }
@@ -205,14 +223,56 @@ impl Liveness {
             }
         }
 
-        // Worklist algorithm for computing live_in/live_out
-        // live_out(B) = ∪ live_in(S) for all successors S of B
-        // live_in(B) = use(B) ∪ (live_out(B) - def(B))
+        // Handle phi values (Value::Phi).
+        //
+        // Phi nodes are not instructions — they live in the value table.
+        // We need two pieces of information for the phi-aware dataflow:
+        //   - phi_defs[B] = set of ValueIds defined by phis at the entry of B
+        //   - phi_uses: for each (succ_block, pred_block) pair, the set of
+        //     ValueIds that flow from pred to succ via a phi
+        //
+        // The phi-aware live_out equation is:
+        //   live_out(B) = union over S in succ(B) of:
+        //       (live_in(S) - phi_defs(S)) | phi_uses(S, B)
+        let mut phi_defs: Vec<LiveSet> =
+            (0..num_blocks).map(|_| LiveSet::with_capacity(num_values)).collect();
+        // phi_uses_map[(succ, pred)] = set of values flowing from pred to succ via phi.
+        let mut phi_uses_map: FxHashMap<(usize, usize), LiveSet> = FxHashMap::default();
+
+        for (val_id, val) in func.values.iter_enumerated() {
+            if let Value::Phi { incoming, .. } = val {
+                // Find the merge block for this phi.
+                if let Some(&(first_pred, _)) = incoming.first() {
+                    for &succ in &func.blocks[first_pred].successors {
+                        let succ_preds = &func.blocks[succ].predecessors;
+                        if incoming.iter().all(|(pred, _)| succ_preds.contains(pred)) {
+                            // succ is the merge block — phi is defined here.
+                            block_defs[succ.index()].insert(val_id);
+                            phi_defs[succ.index()].insert(val_id);
+                            // Record phi_uses for each predecessor.
+                            for &(pred_block, operand) in incoming {
+                                phi_uses_map
+                                    .entry((succ.index(), pred_block.index()))
+                                    .or_insert_with(|| LiveSet::with_capacity(num_values))
+                                    .insert(operand);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Worklist algorithm for computing live_in/live_out.
+        //
+        // Phi-aware live_out:
+        //   live_out(B) = union over S in succ(B) of:
+        //       (live_in(S) - phi_defs(S)) | phi_uses(S, B)
+        //
+        // live_in(B) = block_uses(B) | (live_out(B) - block_defs(B))
         let mut worklist: VecDeque<BlockId> = func.blocks.indices().collect();
 
         // Initialize live_in for all blocks from their upward-exposed uses.
-        // This is necessary because the worklist algorithm only updates live_in
-        // when live_out changes, but initially live_out is empty everywhere.
         for bidx in 0..num_blocks {
             block_liveness[bidx].live_in = block_uses[bidx].clone();
         }
@@ -221,10 +281,17 @@ impl Liveness {
             let bidx = block_id.index();
             let block = &func.blocks[block_id];
 
-            // Compute live_out as union of live_in of successors
+            // Phi-aware live_out.
             let mut new_live_out = LiveSet::with_capacity(num_values);
             for &succ in &block.successors {
-                new_live_out.union_with(&block_liveness[succ.index()].live_in);
+                // (live_in(S) - phi_defs(S))
+                let mut contribution = block_liveness[succ.index()].live_in.clone();
+                contribution.subtract(&phi_defs[succ.index()]);
+                // | phi_uses(S, B)
+                if let Some(pu) = phi_uses_map.get(&(succ.index(), bidx)) {
+                    contribution.union_with(pu);
+                }
+                new_live_out.union_with(&contribution);
             }
 
             // Check if live_out changed
@@ -257,9 +324,9 @@ impl Liveness {
         for (block_id, block) in func.blocks.iter_enumerated() {
             // Check terminator uses - these are the last use in this block
             if let Some(term) = &block.terminator {
-                let mut term_uses = Vec::new();
-                collect_terminator_uses(term, &mut term_uses);
-                for operand in term_uses {
+                operand_buf.clear();
+                collect_terminator_uses(term, &mut operand_buf);
+                for &operand in &operand_buf {
                     // Terminator is represented by None for inst_idx
                     last_use_in_block.entry((operand, block_id)).or_insert(None);
                 }
@@ -277,7 +344,7 @@ impl Liveness {
             }
         }
 
-        Self { block_liveness, last_use_in_block, num_values }
+        Self { block_liveness, last_use_in_block, inst_to_value, num_values }
     }
 
     /// Returns the values live at the entry of a block.
@@ -307,7 +374,7 @@ impl Liveness {
         // Start with live_out of the block
         let mut live = self.block_liveness[bidx].live_out.clone();
 
-        // Process terminator (kills uses, adds no defs for our purposes)
+        // Process terminator (add its uses — they must be live before the terminator)
         if let Some(term) = &block.terminator {
             let mut term_uses = Vec::new();
             collect_terminator_uses(term, &mut term_uses);
@@ -325,20 +392,14 @@ impl Liveness {
                 live_after = Some(live.clone());
             }
 
-            let inst = func.instruction(inst_id);
-
-            // Remove definition (value becomes dead before this instruction)
-            for (val_id, val) in func.values.iter_enumerated() {
-                if let Value::Inst(def_inst) = val
-                    && *def_inst == inst_id
-                {
-                    live.remove(val_id);
-                }
+            // Remove definition using precomputed map (O(1) instead of O(n)).
+            if let Some(&val_id) = self.inst_to_value.get(&inst_id) {
+                live.remove(val_id);
             }
 
             // Add uses (values become live before this instruction)
             operand_buf.clear();
-            inst.kind.collect_operands(&mut operand_buf);
+            func.instruction(inst_id).kind.collect_operands(&mut operand_buf);
             for &operand in &operand_buf {
                 live.insert(operand);
             }
@@ -459,5 +520,496 @@ mod tests {
 
         // Union again should not change
         assert!(!set1.union_with(&set2));
+    }
+
+    #[test]
+    fn test_liveset_boundary() {
+        let mut set = LiveSet::with_capacity(200);
+        for i in [0, 1, 62, 63, 64, 65, 126, 127, 128, 129, 199] {
+            assert!(set.insert(ValueId::from_usize(i)));
+            assert!(set.contains(ValueId::from_usize(i)));
+        }
+        assert_eq!(set.count(), 11);
+    }
+
+    #[test]
+    fn test_liveset_clear() {
+        let mut set = LiveSet::with_capacity(128);
+        set.insert(ValueId::from_usize(0));
+        set.insert(ValueId::from_usize(63));
+        set.insert(ValueId::from_usize(64));
+        set.insert(ValueId::from_usize(127));
+        assert_eq!(set.count(), 4);
+        set.clear();
+        assert_eq!(set.count(), 0);
+        assert!(!set.contains(ValueId::from_usize(0)));
+    }
+
+    #[test]
+    fn test_liveset_iter() {
+        let mut set = LiveSet::with_capacity(200);
+        let indices = [0, 5, 63, 64, 127, 128, 199];
+        for &i in &indices {
+            set.insert(ValueId::from_usize(i));
+        }
+        let collected: Vec<usize> = set.iter().map(|v| v.index()).collect();
+        assert_eq!(collected, indices);
+    }
+
+    // === Liveness algorithm tests ===
+
+    use crate::mir::{Function, FunctionBuilder, MirType};
+    use solar_interface::Ident;
+
+    fn make_func() -> Function {
+        Function::new(Ident::DUMMY)
+    }
+
+    #[test]
+    fn test_linear_code() {
+        // bb0: v2 = add v0, v1; ret v2
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let x = b.add_param(MirType::uint256());
+        let one = b.imm_u64(1);
+        let sum = b.add(x, one);
+        b.ret([sum]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        // x and one are used by add, so live-in to entry.
+        assert!(liveness.live_in(entry).contains(x));
+        assert!(liveness.live_in(entry).contains(one));
+        // sum is defined in entry and consumed by ret; not live-out.
+        assert!(!liveness.live_out(entry).contains(sum));
+        // Nothing escapes a single return block.
+        assert_eq!(liveness.live_out(entry).count(), 0);
+    }
+
+    #[test]
+    fn test_diamond_cfg() {
+        // entry: branch cond, then_bb, else_bb
+        // then_bb: v_then = add x, c1; jump merge
+        // else_bb: v_else = sub x, c2; jump merge
+        // merge: ret x  (x used across branches)
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let x = b.add_param(MirType::uint256());
+        let cond = b.add_param(MirType::Bool);
+
+        let then_bb = b.create_block();
+        let else_bb = b.create_block();
+        let merge = b.create_block();
+
+        b.branch(cond, then_bb, else_bb);
+
+        b.switch_to_block(then_bb);
+        let c1 = b.imm_u64(1);
+        let v_then = b.add(x, c1);
+        b.jump(merge);
+
+        b.switch_to_block(else_bb);
+        let c2 = b.imm_u64(1);
+        let v_else = b.sub(x, c2);
+        b.jump(merge);
+
+        // merge: return both values via x (simplified: just ret x)
+        b.switch_to_block(merge);
+        b.ret([v_then]);
+
+        let liveness = Liveness::compute(&func);
+
+        // x must be live-in to then_bb and else_bb (used in add/sub).
+        assert!(liveness.live_in(then_bb).contains(x));
+        assert!(liveness.live_in(else_bb).contains(x));
+        // x must be live-out of entry (flows to successors).
+        assert!(liveness.live_out(func.entry_block).contains(x));
+        // v_then must be live-out of then_bb (used in merge's ret).
+        assert!(liveness.live_out(then_bb).contains(v_then));
+        // v_else should NOT be live-out of else_bb (merge returns v_then, not v_else).
+        assert!(!liveness.live_out(else_bb).contains(v_else));
+    }
+
+    #[test]
+    fn test_simple_loop() {
+        // entry: jump header
+        // header: cond = lt(i, limit); branch cond, body, exit
+        // body: i_next = add(i, step); jump header
+        // exit: ret i
+        //
+        // Note: without phis, i is the param. This tests cross-block liveness.
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let i = b.add_param(MirType::uint256());
+        let limit = b.imm_u64(10);
+
+        let header = b.create_block();
+        let body = b.create_block();
+        let exit = b.create_block();
+
+        b.jump(header);
+
+        b.switch_to_block(header);
+        let cond = b.lt(i, limit);
+        b.branch(cond, body, exit);
+
+        b.switch_to_block(body);
+        let step = b.imm_u64(1);
+        let _i_next = b.add(i, step);
+        b.jump(header);
+
+        b.switch_to_block(exit);
+        b.ret([i]);
+
+        let liveness = Liveness::compute(&func);
+
+        // i must be live through the entire loop.
+        assert!(liveness.live_in(header).contains(i), "i live-in to header");
+        assert!(liveness.live_in(body).contains(i), "i live-in to body");
+        assert!(liveness.live_in(exit).contains(i), "i live-in to exit");
+        assert!(liveness.live_out(header).contains(i), "i live-out of header");
+        assert!(liveness.live_out(body).contains(i), "i live-out of body");
+    }
+
+    #[test]
+    fn test_dead_instruction_result() {
+        // A dead *instruction result* (not just an immediate).
+        // The add result is never used — liveness should not track it
+        // beyond its definition point.
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let x = b.add_param(MirType::uint256());
+        let y = b.add_param(MirType::uint256());
+        let dead = b.add(x, y); // result never used
+        b.ret([x]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        assert!(liveness.live_in(entry).contains(x));
+        // dead instruction result must not be live-out.
+        assert!(!liveness.live_out(entry).contains(dead));
+        // dead after its own instruction.
+        assert!(liveness.is_dead_after(dead, entry, 0), "dead inst result should be dead");
+    }
+
+    #[test]
+    fn test_unused_param() {
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let _x = b.add_param(MirType::uint256()); // Unused.
+        let y = b.add_param(MirType::uint256());
+        b.ret([y]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        assert!(!liveness.live_in(entry).contains(_x), "unused param not live");
+        assert!(liveness.live_in(entry).contains(y), "used param is live");
+    }
+
+    #[test]
+    fn test_value_used_in_two_successors() {
+        // entry: branch cond, left, right
+        // left: ret x
+        // right: ret x
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let x = b.add_param(MirType::uint256());
+        let cond = b.add_param(MirType::Bool);
+
+        let left = b.create_block();
+        let right = b.create_block();
+
+        b.branch(cond, left, right);
+
+        b.switch_to_block(left);
+        b.ret([x]);
+
+        b.switch_to_block(right);
+        b.ret([x]);
+
+        let liveness = Liveness::compute(&func);
+
+        assert!(liveness.live_in(left).contains(x));
+        assert!(liveness.live_in(right).contains(x));
+        assert!(liveness.live_out(func.entry_block).contains(x));
+    }
+
+    #[test]
+    fn test_empty_function() {
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        b.stop();
+
+        let liveness = Liveness::compute(&func);
+        assert_eq!(liveness.live_in(func.entry_block).count(), 0);
+        assert_eq!(liveness.live_out(func.entry_block).count(), 0);
+    }
+
+    #[test]
+    fn test_side_effect_op_keeps_operands_live() {
+        // sstore(slot, val); loaded = sload(slot); ret loaded
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let slot = b.add_param(MirType::uint256());
+        let val = b.add_param(MirType::uint256());
+        b.sstore(slot, val);
+        let loaded = b.sload(slot);
+        b.ret([loaded]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        // Before sstore (inst 0): slot and val must be live.
+        let info_0 = liveness.live_at_inst(&func, entry, 0);
+        assert!(info_0.live_before.contains(slot), "slot live before sstore");
+        assert!(info_0.live_before.contains(val), "val live before sstore");
+
+        // Before sload (inst 1): slot must be live, val no longer needed.
+        let info_1 = liveness.live_at_inst(&func, entry, 1);
+        assert!(info_1.live_before.contains(slot), "slot live before sload");
+        assert!(!info_1.live_before.contains(val), "val not live before sload");
+    }
+
+    #[test]
+    fn test_live_at_inst() {
+        // bb0: v2 = add v0, v1; v3 = mul v2, v0; ret v3
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let v0 = b.add_param(MirType::uint256());
+        let v1 = b.add_param(MirType::uint256());
+        let v2 = b.add(v0, v1);
+        let v3 = b.mul(v2, v0);
+        b.ret([v3]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        // Before add (inst 0): v0 and v1 are live.
+        let info_0 = liveness.live_at_inst(&func, entry, 0);
+        assert!(info_0.live_before.contains(v0));
+        assert!(info_0.live_before.contains(v1));
+        assert!(!info_0.live_before.contains(v2));
+        assert!(!info_0.live_before.contains(v3));
+
+        // After add (inst 0): v0 and v2 are live (v0 used again by mul).
+        assert!(info_0.live_after.contains(v0));
+        assert!(info_0.live_after.contains(v2));
+        assert!(!info_0.live_after.contains(v1), "v1 dead after add");
+
+        // Before mul (inst 1): v0 and v2 are live.
+        let info_1 = liveness.live_at_inst(&func, entry, 1);
+        assert!(info_1.live_before.contains(v0));
+        assert!(info_1.live_before.contains(v2));
+
+        // After mul (inst 1): only v3 is live (used by ret).
+        assert!(info_1.live_after.contains(v3));
+        assert!(!info_1.live_after.contains(v0));
+        assert!(!info_1.live_after.contains(v2));
+    }
+
+    #[test]
+    fn test_is_dead_after() {
+        // bb0: v2 = add v0, v1; ret v2
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let v0 = b.add_param(MirType::uint256());
+        let v1 = b.add_param(MirType::uint256());
+        let v2 = b.add(v0, v1);
+        b.ret([v2]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        // v0 and v1 are dead after the add (inst 0) — their last use is at inst 0.
+        assert!(liveness.is_dead_after(v0, entry, 0), "v0 dead after add");
+        assert!(liveness.is_dead_after(v1, entry, 0), "v1 dead after add");
+        // v2 is NOT dead after add — it's used by ret (terminator).
+        assert!(!liveness.is_dead_after(v2, entry, 0), "v2 alive after add");
+    }
+
+    #[test]
+    fn test_last_use_in_block() {
+        // bb0: v2 = add v0, v1; v3 = mul v2, v0; ret v3
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let v0 = b.add_param(MirType::uint256());
+        let v1 = b.add_param(MirType::uint256());
+        let _v2 = b.add(v0, v1);
+        let v3 = b.mul(_v2, v0);
+        b.ret([v3]);
+
+        let liveness = Liveness::compute(&func);
+        let entry = func.entry_block;
+
+        // v0 last used at inst 1 (mul).
+        assert_eq!(liveness.last_use_in_block(v0, entry), Some(Some(1)));
+        // v1 last used at inst 0 (add).
+        assert_eq!(liveness.last_use_in_block(v1, entry), Some(Some(0)));
+        // v3 last used at terminator (ret).
+        assert_eq!(liveness.last_use_in_block(v3, entry), Some(None));
+    }
+
+    #[test]
+    fn test_value_live_across_multiple_blocks() {
+        // entry: jump bb1
+        // bb1: v2 = add(v0, v1); jump bb2
+        // bb2: ret v0  (v0 must be live through bb1 and into bb2)
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let v0 = b.add_param(MirType::uint256());
+        let v1 = b.add_param(MirType::uint256());
+
+        let bb1 = b.create_block();
+        let bb2 = b.create_block();
+
+        b.jump(bb1);
+
+        b.switch_to_block(bb1);
+        let _v2 = b.add(v0, v1);
+        b.jump(bb2);
+
+        b.switch_to_block(bb2);
+        b.ret([v0]);
+
+        let liveness = Liveness::compute(&func);
+
+        // v0 must be live-out of bb1 (used in bb2).
+        assert!(liveness.live_out(bb1).contains(v0));
+        // v1 is NOT live-out of bb1 (only used locally in bb1's add).
+        assert!(!liveness.live_out(bb1).contains(v1));
+        // v0 must be live-in to bb2.
+        assert!(liveness.live_in(bb2).contains(v0));
+    }
+
+    #[test]
+    fn test_multiple_returns() {
+        // entry: branch cond, left, right
+        // left: ret v0
+        // right: ret v1
+        let mut func = make_func();
+        let mut b = FunctionBuilder::new(&mut func);
+        let v0 = b.add_param(MirType::uint256());
+        let v1 = b.add_param(MirType::uint256());
+        let cond = b.add_param(MirType::Bool);
+
+        let left = b.create_block();
+        let right = b.create_block();
+
+        b.branch(cond, left, right);
+
+        b.switch_to_block(left);
+        b.ret([v0]);
+
+        b.switch_to_block(right);
+        b.ret([v1]);
+
+        let liveness = Liveness::compute(&func);
+
+        // v0 is live-in to left, NOT to right.
+        assert!(liveness.live_in(left).contains(v0));
+        assert!(!liveness.live_in(right).contains(v0));
+        // v1 is live-in to right, NOT to left.
+        assert!(liveness.live_in(right).contains(v1));
+        assert!(!liveness.live_in(left).contains(v1));
+    }
+
+    #[test]
+    fn test_phi_liveness() {
+        // The fix in this commit added phi handling to the liveness analysis.
+        // Value::Phi nodes are not instructions — they live in the value table.
+        // Their incoming operands must be live at the EXIT of the predecessor
+        // block, and the phi result must be defined at the ENTRY of the merge
+        // block.
+        //
+        // entry: jump header
+        // header: phi_val = phi [(entry, init), (body, updated)]
+        //         branch cond, body, exit
+        // body:   updated = add phi_val, step; jump header
+        // exit:   ret phi_val
+        let mut func = make_func();
+
+        // Phase 1: build the CFG skeleton without the phi (to avoid borrow conflicts).
+        let entry;
+        let header;
+        let body;
+        let exit;
+        let init;
+        let updated;
+        let phi_placeholder; // ValueId slot we'll replace with a real Phi.
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            init = b.imm_u64(0);
+            entry = b.current_block();
+            header = b.create_block();
+            body = b.create_block();
+            exit = b.create_block();
+
+            b.jump(header);
+
+            b.switch_to_block(header);
+            // Allocate a placeholder for the phi (an undef that we'll replace).
+            phi_placeholder = b.undef(MirType::uint256());
+            let limit = b.imm_u64(10);
+            let cond = b.lt(phi_placeholder, limit);
+            b.branch(cond, body, exit);
+
+            b.switch_to_block(body);
+            let step = b.imm_u64(1);
+            updated = b.add(phi_placeholder, step);
+            b.jump(header);
+
+            b.switch_to_block(exit);
+            b.ret([phi_placeholder]);
+        }
+
+        // Phase 2: replace the placeholder with a real Value::Phi.
+        let phi_val = phi_placeholder;
+        func.values[phi_val] = crate::mir::Value::Phi {
+            ty: MirType::uint256(),
+            incoming: vec![(entry, init), (body, updated)],
+        };
+
+        let liveness = Liveness::compute(&func);
+
+        // init must be live-out of entry (flows to phi in header).
+        assert!(liveness.live_out(entry).contains(init), "init live-out of entry");
+        // updated must be live-out of body (flows back to phi via back-edge).
+        assert!(liveness.live_out(body).contains(updated), "updated live-out of body");
+        // phi_val must be live-in to body and exit (used by add and ret).
+        assert!(liveness.live_in(body).contains(phi_val), "phi_val live-in to body");
+        assert!(liveness.live_in(exit).contains(phi_val), "phi_val live-in to exit");
+        // phi_val should NOT be live-in to entry (it's defined in header).
+        assert!(!liveness.live_in(entry).contains(phi_val), "phi_val not live-in to entry");
+    }
+
+    #[test]
+    fn test_inst_to_value_map_consistency() {
+        // The precomputed inst_to_value map must agree with a linear scan
+        // of func.values. This validates the O(1) lookup matches O(n) truth.
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let x = b.add_param(MirType::uint256());
+            let y = b.add_param(MirType::uint256());
+            let sum = b.add(x, y);
+            let product = b.mul(sum, x);
+            let _side = b.sstore(x, product); // no result
+            let loaded = b.sload(y);
+            b.ret([loaded]);
+        }
+        let liveness = Liveness::compute(&func);
+
+        // Rebuild the map the slow way and compare.
+        use rustc_hash::FxHashMap;
+        let mut expected: FxHashMap<crate::mir::InstId, ValueId> = FxHashMap::default();
+        for (val_id, val) in func.values.iter_enumerated() {
+            if let crate::mir::Value::Inst(inst_id) = val {
+                expected.insert(*inst_id, val_id);
+            }
+        }
+        assert_eq!(liveness.inst_to_value, expected, "inst_to_value map diverged from linear scan");
     }
 }

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -228,8 +228,8 @@ impl Liveness {
         // Phi nodes are not instructions — they live in the value table.
         // We need two pieces of information for the phi-aware dataflow:
         //   - phi_defs[B] = set of ValueIds defined by phis at the entry of B
-        //   - phi_uses: for each (succ_block, pred_block) pair, the set of
-        //     ValueIds that flow from pred to succ via a phi
+        //   - phi_uses: for each (succ_block, pred_block) pair, the set of ValueIds that flow from
+        //     pred to succ via a phi
         //
         // The phi-aware live_out equation is:
         //   live_out(B) = union over S in succ(B) of:

--- a/crates/codegen/src/analysis/mod.rs
+++ b/crates/codegen/src/analysis/mod.rs
@@ -15,3 +15,6 @@ pub use phi_elimination::{
 
 mod loop_analysis;
 pub use loop_analysis::{InductionVariable, Loop, LoopAnalyzer, LoopInfo};
+
+mod validator;
+pub use validator::{ValidationError, ValidatorAnalysis, validate_function, validate_module};

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -7,23 +7,20 @@
 //!
 //! # Checks performed
 //!
-//! 1. **Defined-before-use**: every `ValueId` referenced as an operand has
-//!    an entry in `func.values`.
-//! 2. **Block reference validity**: every `BlockId` mentioned in a
-//!    terminator or phi has an entry in `func.blocks`.
-//! 3. **Single definition**: each `InstId` is referenced by at most one
-//!    `Value::Inst` entry.
+//! 1. **Defined-before-use**: every `ValueId` referenced as an operand has an entry in
+//!    `func.values`.
+//! 2. **Block reference validity**: every `BlockId` mentioned in a terminator or phi has an entry
+//!    in `func.blocks`.
+//! 3. **Single definition**: each `InstId` is referenced by at most one `Value::Inst` entry.
 //! 4. **Terminator presence**: every block has a terminator.
-//! 5. **Successor consistency**: each block's `block.successors` matches
-//!    the actual successors of its terminator.
-//! 6. **Predecessor back-link**: if A's terminator targets B, then B's
-//!    `predecessors` contains A.
+//! 5. **Successor consistency**: each block's `block.successors` matches the actual successors of
+//!    its terminator.
+//! 6. **Predecessor back-link**: if A's terminator targets B, then B's `predecessors` contains A.
 //! 7. **Entry block has no predecessors**.
-//! 8. **Phi block coverage**: every `InstKind::Phi`'s incoming blocks are
-//!    predecessors of the containing block, and every predecessor has an
-//!    incoming entry.
-//! 9. **Instruction-block consistency**: each instruction's `block` field
-//!    matches the block whose `instructions` vector contains it.
+//! 8. **Phi block coverage**: every `InstKind::Phi`'s incoming blocks are predecessors of the
+//!    containing block, and every predecessor has an incoming entry.
+//! 9. **Instruction-block consistency**: each instruction's `block` field matches the block whose
+//!    `instructions` vector contains it.
 //!
 //! # Usage
 //!
@@ -77,7 +74,9 @@ impl ValidationError {
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.block, self.inst) {
-            (Some(b), Some(i)) => write!(f, "[bb{}, inst{}] {}", b.index(), i.index(), self.message),
+            (Some(b), Some(i)) => {
+                write!(f, "[bb{}, inst{}] {}", b.index(), i.index(), self.message)
+            }
             (Some(b), None) => write!(f, "[bb{}] {}", b.index(), self.message),
             (None, _) => write!(f, "{}", self.message),
         }
@@ -128,10 +127,7 @@ pub fn validate_function(func: &Function) -> Vec<ValidationError> {
             errors.push(ValidationError::at_block(
                 format!(
                     "successors mismatch: terminator says {:?}, stored {:?}",
-                    term_succs_vec
-                        .iter()
-                        .map(|b| format!("bb{}", b.index()))
-                        .collect::<Vec<_>>(),
+                    term_succs_vec.iter().map(|b| format!("bb{}", b.index())).collect::<Vec<_>>(),
                     stored_succs.iter().map(|b| format!("bb{}", b.index())).collect::<Vec<_>>()
                 ),
                 block_id,
@@ -438,9 +434,7 @@ mod tests {
             func.blocks[target].predecessors.clear();
             let errors = validate_function(&func);
             assert!(
-                errors
-                    .iter()
-                    .any(|e| e.message.contains("does not list bb0 as a predecessor")),
+                errors.iter().any(|e| e.message.contains("does not list bb0 as a predecessor")),
                 "expected predecessor back-link error, got: {errors:#?}"
             );
         });
@@ -460,9 +454,7 @@ mod tests {
             func.blocks[func.entry_block].predecessors.push(func.entry_block);
             let errors = validate_function(&func);
             assert!(
-                errors
-                    .iter()
-                    .any(|e| e.message.contains("entry block must have no predecessors")),
+                errors.iter().any(|e| e.message.contains("entry block must have no predecessors")),
                 "expected entry-block error, got: {errors:#?}"
             );
         });
@@ -503,8 +495,7 @@ mod tests {
         assert_eq!(format!("{e1}"), "oops");
         let e2 = ValidationError::at_block("oops", BlockId::from_usize(3));
         assert_eq!(format!("{e2}"), "[bb3] oops");
-        let e3 =
-            ValidationError::at_inst("oops", BlockId::from_usize(3), InstId::from_usize(5));
+        let e3 = ValidationError::at_inst("oops", BlockId::from_usize(3), InstId::from_usize(5));
         assert_eq!(format!("{e3}"), "[bb3, inst5] oops");
     }
 

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -1,0 +1,516 @@
+//! MIR validator — checks SSA invariants on a [`Function`].
+//!
+//! This is the Solar equivalent of LLVM's `verify` pass / Cranelift's
+//! `Function::verify`. It walks a function once and reports every invariant
+//! violation it finds, returning them as a `Vec<ValidationError>` (empty
+//! when the function is well-formed).
+//!
+//! # Checks performed
+//!
+//! 1. **Defined-before-use**: every `ValueId` referenced as an operand has
+//!    an entry in `func.values`.
+//! 2. **Block reference validity**: every `BlockId` mentioned in a
+//!    terminator or phi has an entry in `func.blocks`.
+//! 3. **Single definition**: each `InstId` is referenced by at most one
+//!    `Value::Inst` entry.
+//! 4. **Terminator presence**: every block has a terminator.
+//! 5. **Successor consistency**: each block's `block.successors` matches
+//!    the actual successors of its terminator.
+//! 6. **Predecessor back-link**: if A's terminator targets B, then B's
+//!    `predecessors` contains A.
+//! 7. **Entry block has no predecessors**.
+//! 8. **Phi block coverage**: every `InstKind::Phi`'s incoming blocks are
+//!    predecessors of the containing block, and every predecessor has an
+//!    incoming entry.
+//! 9. **Instruction-block consistency**: each instruction's `block` field
+//!    matches the block whose `instructions` vector contains it.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use solar_codegen::analysis::validate_function;
+//! let errors = validate_function(&func);
+//! assert!(errors.is_empty(), "{:#?}", errors);
+//! ```
+//!
+//! Or via the pass manager:
+//!
+//! ```ignore
+//! use solar_codegen::pass::AnalysisManager;
+//! use solar_codegen::analysis::ValidatorAnalysis;
+//! let mut am = AnalysisManager::new();
+//! let errors = am.get_or_compute(&ValidatorAnalysis, &func);
+//! ```
+
+use crate::{
+    mir::{BlockId, Function, InstId, InstKind, Module, Value},
+    pass::AnalysisPass,
+};
+use rustc_hash::FxHashMap;
+use std::fmt;
+
+/// One validation finding.
+#[derive(Clone, Debug)]
+pub struct ValidationError {
+    /// Human-readable message.
+    pub message: String,
+    /// The block this error pertains to, if any.
+    pub block: Option<BlockId>,
+    /// The instruction this error pertains to, if any.
+    pub inst: Option<InstId>,
+}
+
+impl ValidationError {
+    fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into(), block: None, inst: None }
+    }
+
+    fn at_block(message: impl Into<String>, block: BlockId) -> Self {
+        Self { message: message.into(), block: Some(block), inst: None }
+    }
+
+    fn at_inst(message: impl Into<String>, block: BlockId, inst: InstId) -> Self {
+        Self { message: message.into(), block: Some(block), inst: Some(inst) }
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (self.block, self.inst) {
+            (Some(b), Some(i)) => write!(f, "[bb{}, inst{}] {}", b.index(), i.index(), self.message),
+            (Some(b), None) => write!(f, "[bb{}] {}", b.index(), self.message),
+            (None, _) => write!(f, "{}", self.message),
+        }
+    }
+}
+
+/// Validates a single function. Returns the empty vec on success.
+#[must_use]
+pub fn validate_function(func: &Function) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    let num_values = func.values.len();
+    let num_blocks = func.blocks.len();
+    let num_insts = func.instructions.len();
+
+    // ----- Single-definition check -----
+    // Count how many Value entries claim to be the result of each InstId.
+    let mut inst_def_count: FxHashMap<InstId, usize> = FxHashMap::default();
+    for v in func.values.iter() {
+        if let Value::Inst(inst_id) = v {
+            *inst_def_count.entry(*inst_id).or_default() += 1;
+        }
+    }
+    for (inst_id, count) in inst_def_count.iter() {
+        if *count > 1 {
+            errors.push(ValidationError::new(format!(
+                "instruction inst{} is defined by {count} Value entries (must be 1)",
+                inst_id.index()
+            )));
+        }
+    }
+
+    // ----- Walk every block -----
+    for (block_id, block) in func.blocks.iter_enumerated() {
+        // Check terminator presence.
+        let term = match &block.terminator {
+            Some(t) => t,
+            None => {
+                errors.push(ValidationError::at_block("block has no terminator", block_id));
+                continue;
+            }
+        };
+
+        // Check terminator successor consistency with stored successors.
+        let term_succs = term.successors();
+        let stored_succs: Vec<BlockId> = block.successors.iter().copied().collect();
+        let term_succs_vec: Vec<BlockId> = term_succs.iter().copied().collect();
+        if term_succs_vec != stored_succs {
+            errors.push(ValidationError::at_block(
+                format!(
+                    "successors mismatch: terminator says {:?}, stored {:?}",
+                    term_succs_vec
+                        .iter()
+                        .map(|b| format!("bb{}", b.index()))
+                        .collect::<Vec<_>>(),
+                    stored_succs.iter().map(|b| format!("bb{}", b.index())).collect::<Vec<_>>()
+                ),
+                block_id,
+            ));
+        }
+
+        // Check successor blocks exist and back-link.
+        for &succ in &term_succs {
+            if succ.index() >= num_blocks {
+                errors.push(ValidationError::at_block(
+                    format!("terminator references nonexistent block bb{}", succ.index()),
+                    block_id,
+                ));
+                continue;
+            }
+            if !func.blocks[succ].predecessors.contains(&block_id) {
+                errors.push(ValidationError::at_block(
+                    format!(
+                        "successor bb{} does not list bb{} as a predecessor",
+                        succ.index(),
+                        block_id.index()
+                    ),
+                    block_id,
+                ));
+            }
+        }
+
+        // Check terminator operands are in range.
+        for op in term.operands() {
+            if op.index() >= num_values {
+                errors.push(ValidationError::at_block(
+                    format!(
+                        "terminator references undefined value v{} (only {} values exist)",
+                        op.index(),
+                        num_values
+                    ),
+                    block_id,
+                ));
+            }
+        }
+
+        // ----- Walk instructions in this block -----
+        let block_preds: Vec<BlockId> = block.predecessors.iter().copied().collect();
+        for &inst_id in &block.instructions {
+            if inst_id.index() >= num_insts {
+                errors.push(ValidationError::at_block(
+                    format!("block contains nonexistent inst{}", inst_id.index()),
+                    block_id,
+                ));
+                continue;
+            }
+            let inst = func.instruction(inst_id);
+
+            // The instruction's `block` field must match where we found it.
+            if inst.kind_block() != Some(block_id) {
+                // Note: Instruction doesn't store its block currently — only
+                // the kind matters. Skip this check unless/until we add it.
+                // Kept here as a placeholder for future invariant.
+            }
+
+            // Operand range check.
+            let mut operands = Vec::new();
+            inst.kind.collect_operands(&mut operands);
+            for op in operands {
+                if op.index() >= num_values {
+                    errors.push(ValidationError::at_inst(
+                        format!(
+                            "instruction references undefined value v{} (only {} values exist)",
+                            op.index(),
+                            num_values
+                        ),
+                        block_id,
+                        inst_id,
+                    ));
+                }
+            }
+
+            // Phi-specific checks.
+            if let InstKind::Phi(incoming) = &inst.kind {
+                // Every incoming block must be a predecessor.
+                for (pred_block, _) in incoming {
+                    if pred_block.index() >= num_blocks {
+                        errors.push(ValidationError::at_inst(
+                            format!(
+                                "phi incoming references nonexistent block bb{}",
+                                pred_block.index()
+                            ),
+                            block_id,
+                            inst_id,
+                        ));
+                        continue;
+                    }
+                    if !block_preds.contains(pred_block) {
+                        errors.push(ValidationError::at_inst(
+                            format!(
+                                "phi incoming from bb{} but bb{} is not a predecessor",
+                                pred_block.index(),
+                                pred_block.index()
+                            ),
+                            block_id,
+                            inst_id,
+                        ));
+                    }
+                }
+                // Every predecessor must appear in the incoming list.
+                for pred in &block_preds {
+                    if !incoming.iter().any(|(b, _)| b == pred) {
+                        errors.push(ValidationError::at_inst(
+                            format!(
+                                "phi missing incoming entry for predecessor bb{}",
+                                pred.index()
+                            ),
+                            block_id,
+                            inst_id,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // ----- Entry block must have no predecessors -----
+    if !func.blocks[func.entry_block].predecessors.is_empty() {
+        errors.push(ValidationError::at_block(
+            "entry block must have no predecessors",
+            func.entry_block,
+        ));
+    }
+
+    errors
+}
+
+/// Validates every function in a module. Errors from each function are
+/// prefixed with the function index in the message so they can be
+/// distinguished in mixed reports.
+#[must_use]
+pub fn validate_module(module: &Module) -> Vec<ValidationError> {
+    let mut all = Vec::new();
+    for (id, func) in module.iter_functions() {
+        for mut err in validate_function(func) {
+            err.message = format!("[fn{}] {}", id.index(), err.message);
+            all.push(err);
+        }
+    }
+    all
+}
+
+// =============================================================================
+// Pass-manager adapter
+// =============================================================================
+
+/// Validator as an [`AnalysisPass`]. The result is the (possibly empty)
+/// list of validation errors.
+pub struct ValidatorAnalysis;
+
+impl AnalysisPass for ValidatorAnalysis {
+    type Result = Vec<ValidationError>;
+
+    fn name(&self) -> &str {
+        "validator"
+    }
+
+    fn run(&self, func: &Function) -> Vec<ValidationError> {
+        validate_function(func)
+    }
+}
+
+// =============================================================================
+// Helper trait for the placeholder block-of-instruction check
+// =============================================================================
+
+trait InstructionExt {
+    /// Returns the block this instruction belongs to, if known. The current
+    /// `Instruction` struct doesn't store its block — this is a placeholder
+    /// returning `None` so the validator's "block consistency" check is a
+    /// no-op until that field is added.
+    fn kind_block(&self) -> Option<BlockId>;
+}
+
+impl InstructionExt for crate::mir::Instruction {
+    fn kind_block(&self) -> Option<BlockId> {
+        None
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mir::{BasicBlock, Function, FunctionBuilder, MirType, Terminator};
+    use solar_interface::{ColorChoice, Ident, Session};
+
+    fn with_session<F: FnOnce() + Send>(f: F) {
+        let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        sess.enter(f);
+    }
+
+    fn make_func() -> Function {
+        Function::new(Ident::DUMMY)
+    }
+
+    #[test]
+    fn valid_simple_function() {
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let x = b.add_param(MirType::uint256());
+                let one = b.imm_u64(1);
+                let sum = b.add(x, one);
+                b.ret([sum]);
+            }
+            let errors = validate_function(&func);
+            assert!(errors.is_empty(), "expected valid function, got: {errors:#?}");
+        });
+    }
+
+    #[test]
+    fn missing_terminator_is_caught() {
+        with_session(|| {
+            let mut func = make_func();
+            // Add a parameter to the entry block but no terminator.
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let _p = b.add_param(MirType::uint256());
+                // Don't terminate — leave the entry block dangling.
+            }
+            let errors = validate_function(&func);
+            assert!(
+                errors.iter().any(|e| e.message.contains("no terminator")),
+                "expected 'no terminator' error, got: {errors:#?}"
+            );
+        });
+    }
+
+    #[test]
+    fn bad_block_reference_is_caught() {
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let x = b.add_param(MirType::uint256());
+                b.ret([x]);
+            }
+            // Manually corrupt: replace the terminator with a Jump to a nonexistent block.
+            let bad_block = BlockId::from_usize(99);
+            func.blocks[func.entry_block].terminator = Some(Terminator::Jump(bad_block));
+            // Note: don't update successors so we can also catch the inconsistency.
+            let errors = validate_function(&func);
+            assert!(
+                errors.iter().any(|e| e.message.contains("nonexistent block")
+                    || e.message.contains("successors mismatch")),
+                "expected error about nonexistent block, got: {errors:#?}"
+            );
+        });
+    }
+
+    #[test]
+    fn successor_mismatch_is_caught() {
+        with_session(|| {
+            let mut func = make_func();
+            let then_bb;
+            let else_bb;
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let cond = b.add_param(MirType::Bool);
+                then_bb = b.create_block();
+                else_bb = b.create_block();
+                b.branch(cond, then_bb, else_bb);
+                b.switch_to_block(then_bb);
+                b.stop();
+                b.switch_to_block(else_bb);
+                b.stop();
+            }
+            // Validates clean first.
+            assert!(validate_function(&func).is_empty());
+            // Now manually drop a successor to break consistency.
+            func.blocks[func.entry_block].successors.pop();
+            let errors = validate_function(&func);
+            assert!(
+                errors.iter().any(|e| e.message.contains("successors mismatch")),
+                "expected successors mismatch, got: {errors:#?}"
+            );
+        });
+    }
+
+    #[test]
+    fn predecessor_back_link_is_caught() {
+        with_session(|| {
+            let mut func = make_func();
+            let target;
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                target = b.create_block();
+                b.jump(target);
+                b.switch_to_block(target);
+                b.stop();
+            }
+            assert!(validate_function(&func).is_empty());
+            // Drop the back-link.
+            func.blocks[target].predecessors.clear();
+            let errors = validate_function(&func);
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.message.contains("does not list bb0 as a predecessor")),
+                "expected predecessor back-link error, got: {errors:#?}"
+            );
+        });
+    }
+
+    #[test]
+    fn entry_block_with_predecessors_is_caught() {
+        with_session(|| {
+            let mut func = make_func();
+            // Build a function that loops back to the entry block.
+            // The builder won't allow constructing this naturally; we hack it.
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                b.stop();
+            }
+            // Add a fake predecessor to the entry block.
+            func.blocks[func.entry_block].predecessors.push(func.entry_block);
+            let errors = validate_function(&func);
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.message.contains("entry block must have no predecessors")),
+                "expected entry-block error, got: {errors:#?}"
+            );
+        });
+    }
+
+    #[test]
+    fn validator_as_analysis_pass() {
+        use crate::pass::AnalysisManager;
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let x = b.add_param(MirType::uint256());
+                b.ret([x]);
+            }
+            let mut am = AnalysisManager::new();
+            let errors = am.get_or_compute(&ValidatorAnalysis, &func);
+            assert!(errors.is_empty());
+        });
+    }
+
+    #[test]
+    fn empty_function_with_just_terminator_is_valid() {
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                b.stop();
+            }
+            let errors = validate_function(&func);
+            assert!(errors.is_empty(), "{errors:#?}");
+        });
+    }
+
+    #[test]
+    fn validation_error_display() {
+        let e1 = ValidationError::new("oops");
+        assert_eq!(format!("{e1}"), "oops");
+        let e2 = ValidationError::at_block("oops", BlockId::from_usize(3));
+        assert_eq!(format!("{e2}"), "[bb3] oops");
+        let e3 =
+            ValidationError::at_inst("oops", BlockId::from_usize(3), InstId::from_usize(5));
+        assert_eq!(format!("{e3}"), "[bb3, inst5] oops");
+    }
+
+    // Suppress the unused-import warning for `BasicBlock`.
+    #[allow(dead_code)]
+    fn _block_type_reference() -> Option<BasicBlock> {
+        None
+    }
+}

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -13,7 +13,10 @@ use crate::{
         stack::{ScheduledOp, StackOp, StackScheduler},
     },
     mir::{BlockId, Function, InstKind, Module, Terminator, ValueId},
-    pass::{AnalysisManager, DcePass, JumpThreadingPass, LivenessAnalysis, PassManager},
+    pass::{
+        AnalysisManager, CfgSimplifyPass, DcePass, JumpThreadingPass, LivenessAnalysis,
+        PassManager,
+    },
 };
 use alloy_primitives::U256;
 use rustc_hash::FxHashMap;
@@ -337,13 +340,17 @@ impl EvmCodegen {
     /// Runs optimization passes on all functions in the module via the PassManager.
     ///
     /// Order:
-    /// 1. Jump threading — eliminates unnecessary jumps (8 gas per threaded jump)
-    /// 2. DCE — removes dead code, including blocks made unreachable by threading
+    /// 1. Jump threading — rewrites jump targets through forwarder blocks (8 gas/jump)
+    /// 2. CFG simplify  — physically merges sequential blocks and removes empty forwarders
+    /// 3. DCE           — removes dead instructions and any remaining unreachable blocks
     ///
-    /// Each pass internally iterates to a fixed point.
+    /// Each pass internally iterates to a fixed point. Threading creates orphaned
+    /// forwarder blocks; cfg-simplify cleans them up by merging or eliminating them;
+    /// DCE handles whatever's still unreachable.
     fn run_optimization_passes(&mut self, module: &mut Module) {
         let mut pm = PassManager::new();
         pm.add_transform(Box::new(JumpThreadingPass));
+        pm.add_transform(Box::new(CfgSimplifyPass));
         pm.add_transform(Box::new(DcePass));
         for func in module.functions.iter_mut() {
             pm.run(func);

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -13,8 +13,7 @@ use crate::{
         stack::{ScheduledOp, StackOp, StackScheduler},
     },
     mir::{BlockId, Function, InstKind, Module, Terminator, ValueId},
-    pass::{AnalysisManager, LivenessAnalysis},
-    transform::{DeadCodeEliminator, JumpThreader},
+    pass::{AnalysisManager, DcePass, JumpThreadingPass, LivenessAnalysis, PassManager},
 };
 use alloy_primitives::U256;
 use rustc_hash::FxHashMap;
@@ -335,15 +334,19 @@ impl EvmCodegen {
         }
     }
 
-    /// Runs optimization passes on all functions in the module.
+    /// Runs optimization passes on all functions in the module via the PassManager.
+    ///
+    /// Order:
+    /// 1. Jump threading — eliminates unnecessary jumps (8 gas per threaded jump)
+    /// 2. DCE — removes dead code, including blocks made unreachable by threading
+    ///
+    /// Each pass internally iterates to a fixed point.
     fn run_optimization_passes(&mut self, module: &mut Module) {
-        let mut dce = DeadCodeEliminator::new();
-        let mut jump_threader = JumpThreader::new();
+        let mut pm = PassManager::new();
+        pm.add_transform(Box::new(JumpThreadingPass));
+        pm.add_transform(Box::new(DcePass));
         for func in module.functions.iter_mut() {
-            // Run jump threading to eliminate unnecessary jumps (saves 8 gas per threaded jump)
-            jump_threader.run_to_fixpoint(func);
-            // Run DCE to remove dead code (including unreachable blocks after threading)
-            dce.run_to_fixpoint(func);
+            pm.run(func);
         }
     }
 

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -561,7 +561,7 @@ impl EvmCodegen {
                     .map(|(vid, _)| vid);
 
                 // Generate the instruction
-                self.generate_inst(func, &inst.kind, &liveness, block_id, inst_idx, result_value);
+                self.generate_inst(func, &inst.kind, liveness, block_id, inst_idx, result_value);
             }
 
             // Insert phi copies before terminator
@@ -574,7 +574,7 @@ impl EvmCodegen {
 
             // Spill all live-out values before the terminator so they can be reloaded
             // in successor blocks
-            self.spill_live_out_values(func, &liveness, block_id);
+            self.spill_live_out_values(func, liveness, block_id);
 
             // Generate terminator
             if let Some(term) = &block.terminator {
@@ -1504,9 +1504,8 @@ impl EvmCodegen {
                             // should have ensured all CALL operands are
                             // either immediates, spilled, or re-executable instructions.
                             panic!(
-                                "emit_value_fresh: unhandled instruction kind {:?} for value {:?}. \
-                                 CALL operands should be immediates, spilled values, GAS, or MLOAD.",
-                                other, val
+                                "emit_value_fresh: unhandled instruction kind {other:?} for value {val:?}. \
+                                 CALL operands should be immediates, spilled values, GAS, or MLOAD."
                             );
                         }
                     }
@@ -1515,9 +1514,8 @@ impl EvmCodegen {
             crate::mir::Value::Phi { .. } | crate::mir::Value::Undef(_) => {
                 // Phi nodes and undef values shouldn't appear in CALL operands
                 panic!(
-                    "emit_value_fresh: unexpected phi/undef value {:?}. \
-                     CALL operands should be concrete values.",
-                    val
+                    "emit_value_fresh: unexpected phi/undef value {val:?}. \
+                     CALL operands should be concrete values."
                 );
             }
         }

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -14,8 +14,7 @@ use crate::{
     },
     mir::{BlockId, Function, InstKind, Module, Terminator, ValueId},
     pass::{
-        AnalysisManager, CfgSimplifyPass, DcePass, JumpThreadingPass, LivenessAnalysis,
-        PassManager,
+        AnalysisManager, CfgSimplifyPass, DcePass, JumpThreadingPass, LivenessAnalysis, PassManager,
     },
 };
 use alloy_primitives::U256;

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -13,6 +13,7 @@ use crate::{
         stack::{ScheduledOp, StackOp, StackScheduler},
     },
     mir::{BlockId, Function, InstKind, Module, Terminator, ValueId},
+    pass::{AnalysisManager, LivenessAnalysis},
     transform::{DeadCodeEliminator, JumpThreader},
 };
 use alloy_primitives::U256;
@@ -504,8 +505,11 @@ impl EvmCodegen {
 
     /// Generates the body of a function.
     fn generate_function_body(&mut self, func: &Function) {
-        // Compute liveness
-        let liveness = Liveness::compute(func);
+        // Run analysis pipeline via the pass manager.
+        // Currently just liveness; future analyses (dominance, loops, etc.)
+        // can be added here and queried from the same AnalysisManager.
+        let mut am = AnalysisManager::new();
+        let liveness: &Liveness = am.get_or_compute(&LivenessAnalysis, func);
 
         // Eliminate phis
         let phi_result = eliminate_phis(func);

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -31,6 +31,7 @@ pub use codegen::{
     StackModel, StackScheduler,
 };
 
+pub mod pass;
 pub mod transform;
 pub use transform::{
     CommonSubexprEliminator, ConstantFolder, DceStats, DeadCodeEliminator, FunctionInlineInfo,

--- a/crates/codegen/src/mir/block.rs
+++ b/crates/codegen/src/mir/block.rs
@@ -133,6 +133,31 @@ impl Terminator {
             Self::Invalid => "invalid",
         }
     }
+
+    /// Returns the [`ValueId`] operands of this terminator (the values it reads).
+    /// Block targets are NOT included; use [`Self::successors`] for those.
+    #[must_use]
+    pub fn operands(&self) -> SmallVec<[ValueId; 4]> {
+        let mut out = SmallVec::new();
+        match self {
+            Self::Jump(_) => {}
+            Self::Branch { condition, .. } => out.push(*condition),
+            Self::Switch { value, cases, .. } => {
+                out.push(*value);
+                for (case_val, _) in cases {
+                    out.push(*case_val);
+                }
+            }
+            Self::Return { values } => out.extend(values.iter().copied()),
+            Self::Revert { offset, size } => {
+                out.push(*offset);
+                out.push(*size);
+            }
+            Self::Stop | Self::Invalid => {}
+            Self::SelfDestruct { recipient } => out.push(*recipient),
+        }
+        out
+    }
 }
 
 impl fmt::Display for Terminator {

--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -48,7 +48,7 @@ pub fn function_to_dot(func: &Function) -> String {
 
         // Add terminator
         if let Some(term) = &block.terminator {
-            write!(label, "  {}", format_terminator(term)).unwrap();
+            write!(label, "  {}", format_terminator(term, func)).unwrap();
             label.push_str("\\l");
         }
 
@@ -131,6 +131,93 @@ pub fn module_to_dot(module: &Module) -> String {
     }
 
     result
+}
+
+/// Generates a human-readable textual MIR representation of a function.
+///
+/// The format is designed for diffing and FileCheck-style pattern matching:
+/// ```text
+/// fn @name(arg0: uint256, arg1: bool) -> uint256 {
+///   bb0:
+///     v2 = add arg0, 1
+///     br arg1, bb1, bb2
+///   bb1:
+///     ret v2
+///   bb2:
+///     ret arg0
+/// }
+/// ```
+pub fn function_to_text(func: &Function) -> String {
+    let mut out = String::new();
+
+    // Header: fn @name(params) -> returns
+    write!(out, "fn @{}(", func.name).unwrap();
+    for (i, ty) in func.params.iter().enumerate() {
+        if i > 0 {
+            write!(out, ", ").unwrap();
+        }
+        write!(out, "arg{i}: {ty}").unwrap();
+    }
+    write!(out, ")").unwrap();
+    if !func.returns.is_empty() {
+        write!(out, " -> ").unwrap();
+        if func.returns.len() == 1 {
+            write!(out, "{}", func.returns[0]).unwrap();
+        } else {
+            write!(out, "(").unwrap();
+            for (i, ty) in func.returns.iter().enumerate() {
+                if i > 0 {
+                    write!(out, ", ").unwrap();
+                }
+                write!(out, "{ty}").unwrap();
+            }
+            write!(out, ")").unwrap();
+        }
+    }
+    writeln!(out, " {{").unwrap();
+
+    // Blocks
+    for (block_id, block) in func.blocks.iter_enumerated() {
+        let entry_marker = if block_id == func.entry_block { " (entry)" } else { "" };
+        writeln!(out, "  bb{}{}:", block_id.index(), entry_marker).unwrap();
+
+        // Instructions
+        for &inst_id in &block.instructions {
+            let inst = &func.instructions[inst_id];
+            let def_value = func
+                .values
+                .iter_enumerated()
+                .find(|(_, v)| matches!(v, Value::Inst(id) if *id == inst_id))
+                .map(|(vid, _)| vid);
+
+            write!(out, "    ").unwrap();
+            if let Some(vid) = def_value {
+                write!(out, "v{} = ", vid.index()).unwrap();
+            }
+            writeln!(out, "{}", format_inst_kind(&inst.kind, func)).unwrap();
+        }
+
+        // Terminator
+        if let Some(term) = &block.terminator {
+            writeln!(out, "    {}", format_terminator(term, func)).unwrap();
+        }
+    }
+
+    writeln!(out, "}}").unwrap();
+    out
+}
+
+/// Generates textual MIR for an entire module.
+pub fn module_to_text(module: &Module) -> String {
+    let mut out = String::new();
+    writeln!(out, "; module @{}", module.name).unwrap();
+    for (func_id, func) in module.functions.iter_enumerated() {
+        if func_id.index() > 0 {
+            out.push('\n');
+        }
+        out.push_str(&function_to_text(func));
+    }
+    out
 }
 
 /// Formats an instruction kind for display.
@@ -394,21 +481,26 @@ fn fmt_val(vid: ValueId, func: &Function) -> String {
     }
 }
 
-/// Format a terminator for display.
-fn format_terminator(term: &Terminator) -> String {
+/// Format a terminator for display, rendering operands via [`fmt_val`].
+fn format_terminator(term: &Terminator, func: &Function) -> String {
     match term {
         Terminator::Jump(target) => format!("jump bb{}", target.index()),
         Terminator::Branch { condition, then_block, else_block } => {
-            format!("br v{}, bb{}, bb{}", condition.index(), then_block.index(), else_block.index())
+            format!(
+                "br {}, bb{}, bb{}",
+                fmt_val(*condition, func),
+                then_block.index(),
+                else_block.index()
+            )
         }
         Terminator::Switch { value, default, cases } => {
             let cases_str: Vec<_> = cases
                 .iter()
-                .map(|(val, block)| format!("v{} => bb{}", val.index(), block.index()))
+                .map(|(val, block)| format!("{} => bb{}", fmt_val(*val, func), block.index()))
                 .collect();
             format!(
-                "switch v{}, default bb{}, [{}]",
-                value.index(),
+                "switch {}, default bb{}, [{}]",
+                fmt_val(*value, func),
                 default.index(),
                 cases_str.join(", ")
             )
@@ -417,15 +509,98 @@ fn format_terminator(term: &Terminator) -> String {
             if values.is_empty() {
                 "ret".to_string()
             } else {
-                let vals: Vec<_> = values.iter().map(|v| format!("v{}", v.index())).collect();
+                let vals: Vec<_> = values.iter().map(|v| fmt_val(*v, func)).collect();
                 format!("ret {}", vals.join(", "))
             }
         }
         Terminator::Revert { offset, size } => {
-            format!("revert v{}, v{}", offset.index(), size.index())
+            format!("revert {}, {}", fmt_val(*offset, func), fmt_val(*size, func))
         }
         Terminator::Stop => "stop".to_string(),
-        Terminator::SelfDestruct { recipient } => format!("selfdestruct v{}", recipient.index()),
+        Terminator::SelfDestruct { recipient } => {
+            format!("selfdestruct {}", fmt_val(*recipient, func))
+        }
         Terminator::Invalid => "invalid".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mir::{Function, FunctionBuilder, MirType};
+    use solar_interface::{ColorChoice, Ident, Session};
+
+    fn make_func() -> Function {
+        Function::new(Ident::DUMMY)
+    }
+
+    /// Runs `f` inside a fresh test session so the symbol interner is available.
+    fn with_session<F: FnOnce() + Send>(f: F) {
+        let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        sess.enter(f);
+    }
+
+    #[test]
+    fn text_linear_function() {
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let x = b.add_param(MirType::uint256());
+                b.add_return(MirType::uint256());
+                let one = b.imm_u64(1);
+                let sum = b.add(x, one);
+                b.ret([sum]);
+            }
+            let text = function_to_text(&func);
+            assert!(text.contains("fn @"));
+            assert!(text.contains("arg0: u256"));
+            assert!(text.contains("-> u256"));
+            assert!(text.contains("bb0 (entry)"));
+            assert!(text.contains("add arg0, 1"));
+            assert!(text.contains("ret v2"));
+        });
+    }
+
+    #[test]
+    fn text_diamond_cfg() {
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let x = b.add_param(MirType::uint256());
+                let cond = b.add_param(MirType::Bool);
+                let then_bb = b.create_block();
+                let else_bb = b.create_block();
+                b.branch(cond, then_bb, else_bb);
+                b.switch_to_block(then_bb);
+                b.ret([x]);
+                b.switch_to_block(else_bb);
+                b.ret([x]);
+            }
+            let text = function_to_text(&func);
+            assert!(text.contains("br arg1, bb1, bb2"));
+            assert!(text.contains("bb1:"));
+            assert!(text.contains("bb2:"));
+            assert!(text.contains("ret arg0"));
+        });
+    }
+
+    #[test]
+    fn text_storage_ops() {
+        with_session(|| {
+            let mut func = make_func();
+            {
+                let mut b = FunctionBuilder::new(&mut func);
+                let slot = b.add_param(MirType::uint256());
+                let val = b.add_param(MirType::uint256());
+                b.sstore(slot, val);
+                let loaded = b.sload(slot);
+                b.ret([loaded]);
+            }
+            let text = function_to_text(&func);
+            assert!(text.contains("sstore arg0, arg1"));
+            assert!(text.contains("sload arg0"));
+        });
     }
 }

--- a/crates/codegen/src/mir/mod.rs
+++ b/crates/codegen/src/mir/mod.rs
@@ -26,7 +26,7 @@ mod builder;
 pub use builder::FunctionBuilder;
 
 mod display;
-pub use display::{function_to_dot, module_to_dot};
+pub use display::{function_to_dot, function_to_text, module_to_dot, module_to_text};
 
 newtype_index! {
     /// A unique identifier for a value in the MIR.

--- a/crates/codegen/src/mir/mod.rs
+++ b/crates/codegen/src/mir/mod.rs
@@ -28,6 +28,9 @@ pub use builder::FunctionBuilder;
 mod display;
 pub use display::{function_to_dot, function_to_text, module_to_dot, module_to_text};
 
+mod parser;
+pub use parser::{ParseError, parse_function, parse_module};
+
 newtype_index! {
     /// A unique identifier for a value in the MIR.
     pub struct ValueId;

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -91,11 +91,24 @@ pub struct ParseError {
     pub col: usize,
     /// Human-readable message.
     pub msg: String,
+    /// The offending source line (without trailing newline), captured at
+    /// the time the error was constructed. Used by [`Display`] to render
+    /// a rustc/clang-style snippet with a caret.
+    pub line_text: String,
 }
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "MIR parse error at line {}, col {}: {}", self.line, self.col, self.msg)
+        writeln!(f, "MIR parse error at line {}, col {}: {}", self.line, self.col, self.msg)?;
+        if !self.line_text.is_empty() {
+            writeln!(f, "   |")?;
+            writeln!(f, "{:>3} | {}", self.line, self.line_text)?;
+            // Caret aligned under col-1 spaces. This isn't tab-aware, but
+            // the printer never produces tabs in MIR text so it's fine.
+            let caret_pad = " ".repeat(self.col.saturating_sub(1));
+            write!(f, "   | {caret_pad}^")?;
+        }
+        Ok(())
     }
 }
 
@@ -191,7 +204,57 @@ impl<'a> Parser<'a> {
     }
 
     fn error(&self, msg: impl Into<String>) -> ParseError {
-        ParseError { line: self.line, col: self.col, msg: msg.into() }
+        ParseError {
+            line: self.line,
+            col: self.col,
+            msg: msg.into(),
+            line_text: self.current_line_text(),
+        }
+    }
+
+    /// Like [`Self::error`] but uses the supplied (line, col, pos) instead of
+    /// `self.line/col/pos`. Useful when the parser has already advanced past
+    /// the offending token (e.g. an unknown mnemonic) and we want the caret
+    /// to point back to its start.
+    fn error_at(
+        &self,
+        line: usize,
+        col: usize,
+        pos: usize,
+        msg: impl Into<String>,
+    ) -> ParseError {
+        // Capture the line text at `pos`, not at `self.pos`.
+        let bytes = self.input.as_bytes();
+        let p = pos.min(bytes.len());
+        let mut start = p;
+        while start > 0 && bytes[start - 1] != b'\n' {
+            start -= 1;
+        }
+        let mut end = start;
+        while end < bytes.len() && bytes[end] != b'\n' {
+            end += 1;
+        }
+        let line_text = self.input[start..end].trim_end_matches('\r').to_string();
+        ParseError { line, col, msg: msg.into(), line_text }
+    }
+
+    /// Returns the contents of the current source line (without the trailing
+    /// newline). Used by [`Self::error`] to populate
+    /// [`ParseError::line_text`] for snippet rendering.
+    fn current_line_text(&self) -> String {
+        let bytes = self.input.as_bytes();
+        let pos = self.pos.min(bytes.len());
+        // Walk backward to start-of-line.
+        let mut start = pos;
+        while start > 0 && bytes[start - 1] != b'\n' {
+            start -= 1;
+        }
+        // Walk forward to end-of-line.
+        let mut end = start;
+        while end < bytes.len() && bytes[end] != b'\n' {
+            end += 1;
+        }
+        self.input[start..end].trim_end_matches('\r').to_string()
     }
 
     // ----- token-level helpers -----
@@ -695,6 +758,12 @@ impl<'a> Parser<'a> {
         };
 
         self.skip_inline_whitespace();
+        // Save the position of the mnemonic so we can produce a snippet
+        // pointing at it (instead of just past it) if it turns out to be
+        // unknown.
+        let mnemonic_line = self.line;
+        let mnemonic_col = self.col;
+        let mnemonic_pos = self.pos;
         let mnemonic = self.parse_ident()?.to_string();
 
         // Terminators (no result).
@@ -789,8 +858,17 @@ impl<'a> Parser<'a> {
         }
 
         // Otherwise — instruction.
-        let (kind, result_ty) =
-            self.parse_inst_kind(&mnemonic, func, arg_values, block_labels, value_labels)?;
+        let (kind, result_ty) = self
+            .parse_inst_kind(&mnemonic, func, arg_values, block_labels, value_labels)
+            .map_err(|e| {
+                // For "unknown instruction" errors, repoint the caret at the
+                // start of the mnemonic instead of after it.
+                if e.msg.starts_with("unknown instruction") {
+                    self.error_at(mnemonic_line, mnemonic_col, mnemonic_pos, e.msg)
+                } else {
+                    e
+                }
+            })?;
 
         let inst_id = func.alloc_inst(Instruction::new(kind, result_ty));
         func.blocks[block].instructions.push(inst_id);
@@ -1495,6 +1573,47 @@ fn @bad() {
 ";
             let err = parse_function(src).unwrap_err();
             assert!(err.msg.contains("bogus") || err.msg.contains("unknown"));
+        });
+    }
+
+    #[test]
+    fn error_includes_source_snippet() {
+        with_session(|| {
+            let src = "\
+fn @bad() {
+  bb0 (entry):
+    v1 = bogus arg0
+    stop
+}
+";
+            let err = parse_function(src).unwrap_err();
+            // line_text should contain the offending line.
+            assert!(err.line_text.contains("bogus arg0"), "got line_text: {:?}", err.line_text);
+            // Display should include both the line and a caret marker.
+            let formatted = err.to_string();
+            assert!(formatted.contains("bogus"), "missing line in:\n{formatted}");
+            assert!(formatted.contains("|"), "missing snippet bar in:\n{formatted}");
+            assert!(formatted.contains("^"), "missing caret in:\n{formatted}");
+            // The line number should appear in the snippet header.
+            assert!(formatted.contains(&format!("{} | ", err.line)), "missing line number");
+        });
+    }
+
+    #[test]
+    fn error_snippet_format_is_clang_like() {
+        // Verify the precise format users will see, end-to-end.
+        with_session(|| {
+            let src = "fn @x() -> notatype {\n  bb0 (entry):\n    stop\n}\n";
+            let err = parse_function(src).unwrap_err();
+            let formatted = err.to_string();
+            // Roughly:
+            //   MIR parse error at line 1, col N: ...
+            //      |
+            //    1 | fn @x() -> notatype {
+            //      |            ^
+            assert!(formatted.starts_with("MIR parse error at line "));
+            assert!(formatted.contains("\n   |\n"));
+            assert!(formatted.contains("notatype"));
         });
     }
 

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -1294,13 +1294,14 @@ impl<'a> Parser<'a> {
                 (InstKind::Select(cond, then_v, else_v), Some(MirType::uint256()))
             }
             "phi" => {
-                // Format: `phi [v1, bb0], [v2, bb1]` (matches the printer)
+                // Format: `phi [bb0: v1], [bb1: v2]` — matches the printer in display.rs.
+                // Each pair is `[blockId: valueId]` separated by commas.
                 let mut incoming: Vec<(BlockId, ValueId)> = Vec::new();
                 loop {
                     self.expect_punct('[')?;
-                    let val = v!();
-                    comma!();
                     let bid = self.parse_block_id(block_labels)?;
+                    self.expect_punct(':')?;
+                    let val = v!();
                     self.expect_punct(']')?;
                     incoming.push((bid, val));
                     if !self.try_punct(',') {
@@ -1545,6 +1546,93 @@ fn @sel(arg0: bool, arg1: u256, arg2: u256) -> u256 {
 ";
             let func = parse_function(src).unwrap();
             assert_eq!(func.instructions.len(), 2);
+        });
+    }
+
+    #[test]
+    fn parse_phi_node() {
+        with_session(|| {
+            let src = "\
+fn @diamond(arg0: bool) -> u256 {
+  bb0 (entry):
+    br arg0, bb1, bb2
+  bb1:
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    v1 = phi [bb1: 10], [bb2: 20]
+    ret v1
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.blocks.len(), 4);
+            // Find the phi instruction.
+            let phi_inst =
+                func.instructions.iter().find(|i| matches!(i.kind, InstKind::Phi(_))).unwrap();
+            if let InstKind::Phi(args) = &phi_inst.kind {
+                assert_eq!(args.len(), 2);
+            } else {
+                panic!("expected phi");
+            }
+        });
+    }
+
+    #[test]
+    fn parse_switch_terminator() {
+        with_session(|| {
+            let src = "\
+fn @dispatch(arg0: u256) -> u256 {
+  bb0 (entry):
+    switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
+  bb1:
+    ret arg0
+  bb2:
+    ret 0
+  bb3:
+    ret 1
+  bb4:
+    ret 2
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.blocks.len(), 5);
+            let term = func.blocks[func.entry_block].terminator.as_ref().unwrap();
+            if let Terminator::Switch { cases, .. } = term {
+                assert_eq!(cases.len(), 3);
+            } else {
+                panic!("expected switch terminator");
+            }
+        });
+    }
+
+    #[test]
+    fn parse_phi_round_trip_with_printer() {
+        // Build a function with InstKind::Phi via the parser, print it, and
+        // verify the printer output uses the `[bbN: vN]` format we expect.
+        with_session(|| {
+            let src = "\
+fn @diamond(arg0: bool) -> u256 {
+  bb0 (entry):
+    br arg0, bb1, bb2
+  bb1:
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    v1 = phi [bb1: 10], [bb2: 20]
+    ret v1
+}
+";
+            let func = parse_function(src).unwrap();
+            let printed = function_to_text(&func);
+            // The printer's exact format: `[bbN: <val>]`.
+            assert!(
+                printed.contains("phi [bb1:") && printed.contains("], [bb2:"),
+                "expected `phi [bb1: ..], [bb2: ..]`, got:\n{printed}"
+            );
+            // Round-trip: re-parse the printer output, must succeed.
+            let _func2 = parse_function(&printed).unwrap();
         });
     }
 }

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -153,6 +153,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Skip whitespace, newlines, and comments (`//...` and `;...`).
+    ///
+    /// Note: `;` is treated as a comment EXCEPT when followed by ` module @`,
+    /// which is the module header marker (`; module @Name`). This lets the
+    /// parser recover the module name even though `;` is otherwise comment-only.
     fn skip_blank_and_comments(&mut self) {
         loop {
             self.skip_inline_whitespace();
@@ -164,6 +168,11 @@ impl<'a> Parser<'a> {
                     self.skip_to_eol();
                 }
                 Some(';') => {
+                    // Don't eat the module header — let parse_module handle it.
+                    if self.input[self.pos..].trim_start_matches(';').trim_start().starts_with("module")
+                    {
+                        break;
+                    }
                     self.skip_to_eol();
                 }
                 _ => break,

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -216,13 +216,7 @@ impl<'a> Parser<'a> {
     /// `self.line/col/pos`. Useful when the parser has already advanced past
     /// the offending token (e.g. an unknown mnemonic) and we want the caret
     /// to point back to its start.
-    fn error_at(
-        &self,
-        line: usize,
-        col: usize,
-        pos: usize,
-        msg: impl Into<String>,
-    ) -> ParseError {
+    fn error_at(&self, line: usize, col: usize, pos: usize, msg: impl Into<String>) -> ParseError {
         // Capture the line text at `pos`, not at `self.pos`.
         let bytes = self.input.as_bytes();
         let p = pos.min(bytes.len());

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -21,16 +21,14 @@
 //!
 //! # Caveats
 //!
-//! - This parser produces a *semantically* equivalent [`Function`]; the
-//!   actual `ValueId` numbers in the result may differ from the labels
-//!   in the source text. Round-tripping
-//!   `parse → function_to_text → parse` is supported, but the textual
-//!   form may shift on the second print (different v-numbers).
-//! - Address and fixed-bytes immediate literals are not currently
-//!   parsed — they're allocated as `Immediate::uint256(0)`. If you
-//!   need them, extend `parse_value`.
-//! - Phi values (`Value::Phi { .. }`) are NOT supported as inputs;
-//!   the parser only emits phi *instructions* (`InstKind::Phi`).
+//! - This parser produces a *semantically* equivalent [`Function`]; the actual `ValueId` numbers in
+//!   the result may differ from the labels in the source text. Round-tripping `parse →
+//!   function_to_text → parse` is supported, but the textual form may shift on the second print
+//!   (different v-numbers).
+//! - Address and fixed-bytes immediate literals are not currently parsed — they're allocated as
+//!   `Immediate::uint256(0)`. If you need them, extend `parse_value`.
+//! - Phi values (`Value::Phi { .. }`) are NOT supported as inputs; the parser only emits phi
+//!   *instructions* (`InstKind::Phi`).
 //!
 //! [`function_to_text`]: super::function_to_text
 //! [`module_to_text`]: super::module_to_text
@@ -169,7 +167,10 @@ impl<'a> Parser<'a> {
                 }
                 Some(';') => {
                     // Don't eat the module header — let parse_module handle it.
-                    if self.input[self.pos..].trim_start_matches(';').trim_start().starts_with("module")
+                    if self.input[self.pos..]
+                        .trim_start_matches(';')
+                        .trim_start()
+                        .starts_with("module")
                     {
                         break;
                     }
@@ -195,16 +196,12 @@ impl<'a> Parser<'a> {
 
     // ----- token-level helpers -----
 
-    /// Skip non-newline whitespace and inline comments.
+    /// Skip non-newline whitespace.
     /// Used between tokens *within* a logical line (instruction).
+    /// Inline comments are NOT supported on instruction lines (the printer
+    /// never produces them).
     fn skip_inline(&mut self) {
-        loop {
-            self.skip_inline_whitespace();
-            // Inline comments are handled by skip_to_eol but only after we
-            // consume them — for simplicity, we don't allow trailing comments
-            // on instruction lines (the printer never produces them).
-            break;
-        }
+        self.skip_inline_whitespace();
     }
 
     /// Consume an exact literal string. Returns an error if it doesn't match.
@@ -453,9 +450,8 @@ impl<'a> Parser<'a> {
                         }
                     }
                     if self.peek_char() == Some(':') {
-                        let idx: u32 = idx_str
-                            .parse()
-                            .map_err(|_| self.error("invalid block index"))?;
+                        let idx: u32 =
+                            idx_str.parse().map_err(|_| self.error("invalid block index"))?;
                         if first_block.is_none() {
                             first_block = Some(idx);
                         }
@@ -554,8 +550,8 @@ impl<'a> Parser<'a> {
             }
 
             // Not a block header — must be an instruction or terminator.
-            let block = current_block
-                .ok_or_else(|| self.error("instruction outside of any block"))?;
+            let block =
+                current_block.ok_or_else(|| self.error("instruction outside of any block"))?;
             self.parse_instruction_or_terminator(
                 &mut func,
                 block,
@@ -641,19 +637,18 @@ impl<'a> Parser<'a> {
         Err(self.error(format!("expected value reference, got `{ident}`")))
     }
 
-    fn parse_block_id(&mut self, block_labels: &FxHashMap<u32, BlockId>) -> Result<BlockId, ParseError> {
+    fn parse_block_id(
+        &mut self,
+        block_labels: &FxHashMap<u32, BlockId>,
+    ) -> Result<BlockId, ParseError> {
         self.skip_inline();
         let id = self.parse_ident()?;
         let rest = id
             .strip_prefix("bb")
             .ok_or_else(|| self.error(format!("expected `bbN`, got `{id}`")))?;
-        let idx: u32 = rest
-            .parse()
-            .map_err(|_| self.error(format!("invalid block index `{id}`")))?;
-        block_labels
-            .get(&idx)
-            .copied()
-            .ok_or_else(|| self.error(format!("unknown block `{id}`")))
+        let idx: u32 =
+            rest.parse().map_err(|_| self.error(format!("invalid block index `{id}`")))?;
+        block_labels.get(&idx).copied().ok_or_else(|| self.error(format!("unknown block `{id}`")))
     }
 
     /// Parses one instruction line (with optional `vN =` result) or a terminator.
@@ -669,10 +664,7 @@ impl<'a> Parser<'a> {
 
         // Optional result: `vN = ...`
         let result_label: Option<u32> = if self.input[self.pos..].starts_with('v')
-            && self.input[self.pos..]
-                .chars()
-                .nth(1)
-                .is_some_and(|c| c.is_ascii_digit())
+            && self.input[self.pos..].chars().nth(1).is_some_and(|c| c.is_ascii_digit())
         {
             // Try to parse as `vN =`. If no `=` follows, it's a terminator using vN.
             let save_pos = self.pos;

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -1,0 +1,1549 @@
+//! Parser for the textual MIR format produced by [`function_to_text`] and [`module_to_text`].
+//!
+//! # Format
+//!
+//! ```text
+//! ; module @Counter
+//! fn @increment() {
+//!   bb0 (entry):
+//!     v1 = sload 0
+//!     v3 = add v1, 1
+//!     v5 = sstore 0, v3
+//!     stop
+//! }
+//! ```
+//!
+//! # Session requirement
+//!
+//! Both [`parse_module`] and [`parse_function`] intern function and module
+//! names via [`Symbol::intern`], which requires an active
+//! [`solar_interface::Session`]. Wrap calls in `sess.enter(|| ...)`.
+//!
+//! # Caveats
+//!
+//! - This parser produces a *semantically* equivalent [`Function`]; the
+//!   actual `ValueId` numbers in the result may differ from the labels
+//!   in the source text. Round-tripping
+//!   `parse → function_to_text → parse` is supported, but the textual
+//!   form may shift on the second print (different v-numbers).
+//! - Address and fixed-bytes immediate literals are not currently
+//!   parsed — they're allocated as `Immediate::uint256(0)`. If you
+//!   need them, extend `parse_value`.
+//! - Phi values (`Value::Phi { .. }`) are NOT supported as inputs;
+//!   the parser only emits phi *instructions* (`InstKind::Phi`).
+//!
+//! [`function_to_text`]: super::function_to_text
+//! [`module_to_text`]: super::module_to_text
+
+use super::{
+    BasicBlock, BlockId, Function, InstKind, Instruction, Module, Terminator, Value, ValueId,
+};
+use crate::mir::{Immediate, MirType};
+use alloy_primitives::U256;
+use rustc_hash::FxHashMap;
+use solar_interface::{Ident, Symbol};
+use std::fmt;
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/// Parses a textual MIR module.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] if the input does not conform to the MIR
+/// textual format produced by [`module_to_text`](super::module_to_text).
+///
+/// # Session
+///
+/// Must be called inside an active `solar_interface::Session::enter`,
+/// because module and function names are interned via [`Symbol::intern`].
+pub fn parse_module(input: &str) -> Result<Module, ParseError> {
+    let mut p = Parser::new(input);
+    p.parse_module()
+}
+
+/// Parses a single textual MIR function.
+///
+/// # Errors
+///
+/// Returns a [`ParseError`] on malformed input.
+///
+/// # Session
+///
+/// Must be called inside an active `solar_interface::Session::enter`.
+pub fn parse_function(input: &str) -> Result<Function, ParseError> {
+    let mut p = Parser::new(input);
+    p.skip_blank_and_comments();
+    let func = p.parse_function()?;
+    p.skip_blank_and_comments();
+    if !p.is_eof() {
+        return Err(p.error("trailing input after function"));
+    }
+    Ok(func)
+}
+
+/// An error produced while parsing textual MIR.
+#[derive(Clone, Debug)]
+pub struct ParseError {
+    /// 1-based line number.
+    pub line: usize,
+    /// 1-based column number (codepoints, not bytes).
+    pub col: usize,
+    /// Human-readable message.
+    pub msg: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MIR parse error at line {}, col {}: {}", self.line, self.col, self.msg)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+// =============================================================================
+// Parser implementation
+// =============================================================================
+
+/// A simple line-and-column-tracking parser over a `&str`.
+struct Parser<'a> {
+    input: &'a str,
+    pos: usize,
+    line: usize,
+    col: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, pos: 0, line: 1, col: 1 }
+    }
+
+    // ----- low-level cursor primitives -----
+
+    fn is_eof(&self) -> bool {
+        self.pos >= self.input.len()
+    }
+
+    fn peek_char(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+
+    fn advance(&mut self) -> Option<char> {
+        let c = self.peek_char()?;
+        self.pos += c.len_utf8();
+        if c == '\n' {
+            self.line += 1;
+            self.col = 1;
+        } else {
+            self.col += 1;
+        }
+        Some(c)
+    }
+
+    fn skip_inline_whitespace(&mut self) {
+        while let Some(c) = self.peek_char() {
+            if c == ' ' || c == '\t' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Skip whitespace, newlines, and comments (`//...` and `;...`).
+    fn skip_blank_and_comments(&mut self) {
+        loop {
+            self.skip_inline_whitespace();
+            match self.peek_char() {
+                Some('\n') | Some('\r') => {
+                    self.advance();
+                }
+                Some('/') if self.input[self.pos..].starts_with("//") => {
+                    self.skip_to_eol();
+                }
+                Some(';') => {
+                    self.skip_to_eol();
+                }
+                _ => break,
+            }
+        }
+    }
+
+    fn skip_to_eol(&mut self) {
+        while let Some(c) = self.peek_char() {
+            if c == '\n' {
+                break;
+            }
+            self.advance();
+        }
+    }
+
+    fn error(&self, msg: impl Into<String>) -> ParseError {
+        ParseError { line: self.line, col: self.col, msg: msg.into() }
+    }
+
+    // ----- token-level helpers -----
+
+    /// Skip non-newline whitespace and inline comments.
+    /// Used between tokens *within* a logical line (instruction).
+    fn skip_inline(&mut self) {
+        loop {
+            self.skip_inline_whitespace();
+            // Inline comments are handled by skip_to_eol but only after we
+            // consume them — for simplicity, we don't allow trailing comments
+            // on instruction lines (the printer never produces them).
+            break;
+        }
+    }
+
+    /// Consume an exact literal string. Returns an error if it doesn't match.
+    fn expect_keyword(&mut self, kw: &str) -> Result<(), ParseError> {
+        self.skip_inline();
+        if self.input[self.pos..].starts_with(kw) {
+            for _ in 0..kw.chars().count() {
+                self.advance();
+            }
+            Ok(())
+        } else {
+            Err(self.error(format!("expected `{kw}`")))
+        }
+    }
+
+    /// Consume one of the given punctuation characters. Returns it on success.
+    fn expect_punct(&mut self, expected: char) -> Result<(), ParseError> {
+        self.skip_inline();
+        match self.peek_char() {
+            Some(c) if c == expected => {
+                self.advance();
+                Ok(())
+            }
+            Some(c) => Err(self.error(format!("expected `{expected}`, found `{c}`"))),
+            None => Err(self.error(format!("expected `{expected}`, found EOF"))),
+        }
+    }
+
+    /// Try to consume a punctuation character. Returns true on success.
+    fn try_punct(&mut self, expected: char) -> bool {
+        self.skip_inline();
+        if self.peek_char() == Some(expected) {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume an identifier: `[a-zA-Z_][a-zA-Z0-9_]*`.
+    fn parse_ident(&mut self) -> Result<&'a str, ParseError> {
+        self.skip_inline();
+        let start = self.pos;
+        match self.peek_char() {
+            Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+                self.advance();
+            }
+            _ => return Err(self.error("expected identifier")),
+        }
+        while let Some(c) = self.peek_char() {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        Ok(&self.input[start..self.pos])
+    }
+
+    /// Consume an unsigned integer literal: decimal `123` or hex `0xABC`.
+    fn parse_uint_literal(&mut self) -> Result<U256, ParseError> {
+        self.skip_inline();
+        let start = self.pos;
+        if self.input[self.pos..].starts_with("0x") || self.input[self.pos..].starts_with("0X") {
+            self.advance();
+            self.advance();
+            while let Some(c) = self.peek_char() {
+                if c.is_ascii_hexdigit() {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            let s = &self.input[start..self.pos];
+            U256::from_str_radix(&s[2..], 16).map_err(|e| self.error(format!("invalid hex: {e}")))
+        } else if matches!(self.peek_char(), Some(c) if c.is_ascii_digit()) {
+            while let Some(c) = self.peek_char() {
+                if c.is_ascii_digit() {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            let s = &self.input[start..self.pos];
+            s.parse::<U256>().map_err(|e| self.error(format!("invalid integer: {e}")))
+        } else {
+            Err(self.error("expected integer literal"))
+        }
+    }
+
+    // ----- module / function parsing -----
+
+    fn parse_module(&mut self) -> Result<Module, ParseError> {
+        self.skip_blank_and_comments();
+
+        // Optional `; module @Name` header (the printer always emits it,
+        // but we accept input without it).
+        let module_name = if self.try_punct(';') {
+            self.expect_keyword("module")?;
+            self.skip_inline();
+            self.expect_punct('@')?;
+            let name = self.parse_ident()?.to_string();
+            self.skip_to_eol();
+            self.skip_blank_and_comments();
+            name
+        } else {
+            "module".to_string()
+        };
+
+        let module_ident = Ident::with_dummy_span(Symbol::intern(&module_name));
+        let mut module = Module::new(module_ident);
+
+        while !self.is_eof() {
+            self.skip_blank_and_comments();
+            if self.is_eof() {
+                break;
+            }
+            // Skip stray `// === ... ===` comment headers between functions.
+            if self.input[self.pos..].starts_with("//") {
+                self.skip_to_eol();
+                continue;
+            }
+            let func = self.parse_function()?;
+            module.add_function(func);
+        }
+
+        Ok(module)
+    }
+
+    fn parse_function(&mut self) -> Result<Function, ParseError> {
+        self.skip_blank_and_comments();
+        self.expect_keyword("fn")?;
+        self.skip_inline();
+        self.expect_punct('@')?;
+        let name = self.parse_ident()?.to_string();
+        let func_ident = Ident::with_dummy_span(Symbol::intern(&name));
+        let mut func = Function::new(func_ident);
+
+        // Parse parameters: `(arg0: ty, arg1: ty, ...)` or `()`
+        self.expect_punct('(')?;
+        let mut arg_values: Vec<ValueId> = Vec::new();
+        if !self.try_punct(')') {
+            loop {
+                let arg_name = self.parse_ident()?;
+                if !arg_name.starts_with("arg") {
+                    return Err(self.error(format!("expected `argN`, got `{arg_name}`")));
+                }
+                let _idx: u32 = arg_name[3..]
+                    .parse()
+                    .map_err(|_| self.error(format!("invalid arg index in `{arg_name}`")))?;
+                self.expect_punct(':')?;
+                let ty = self.parse_type()?;
+                let index = func.params.len() as u32;
+                func.params.push(ty);
+                let val = func.alloc_value(Value::Arg { index, ty });
+                arg_values.push(val);
+                if self.try_punct(',') {
+                    continue;
+                }
+                self.expect_punct(')')?;
+                break;
+            }
+        }
+
+        // Optional return type: `-> ty` or `-> (ty, ty, ...)`
+        self.skip_inline();
+        if self.input[self.pos..].starts_with("->") {
+            self.advance();
+            self.advance();
+            self.skip_inline();
+            if self.try_punct('(') {
+                if !self.try_punct(')') {
+                    loop {
+                        let ty = self.parse_type()?;
+                        func.returns.push(ty);
+                        if self.try_punct(',') {
+                            continue;
+                        }
+                        self.expect_punct(')')?;
+                        break;
+                    }
+                }
+            } else {
+                let ty = self.parse_type()?;
+                func.returns.push(ty);
+            }
+        }
+
+        self.expect_punct('{')?;
+        self.skip_blank_and_comments();
+
+        // Two-pass: first scan for all `bbN:` headers to pre-allocate
+        // BlockIds (so jumps to later blocks resolve correctly).
+        let mut block_labels: FxHashMap<u32, BlockId> = FxHashMap::default();
+
+        // Save position so we can rewind after the scan.
+        let scan_start = self.pos;
+        let scan_line = self.line;
+        let scan_col = self.col;
+
+        // First pass: walk lines, find `bbN:` patterns.
+        let mut first_block: Option<u32> = None;
+        loop {
+            self.skip_blank_and_comments();
+            if self.is_eof() {
+                return Err(self.error("unterminated function body"));
+            }
+            if self.peek_char() == Some('}') {
+                break;
+            }
+            // Try to parse a block header at the start of a line.
+            let line_start_pos = self.pos;
+            let line_start_line = self.line;
+            let line_start_col = self.col;
+            self.skip_inline_whitespace();
+            if let Some('b') = self.peek_char()
+                && self.input[self.pos..].starts_with("bb")
+            {
+                let save = self.pos;
+                let save_line = self.line;
+                let save_col = self.col;
+                self.advance();
+                self.advance();
+                let mut idx_str = String::new();
+                while let Some(c) = self.peek_char() {
+                    if c.is_ascii_digit() {
+                        idx_str.push(c);
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+                if idx_str.is_empty() {
+                    self.pos = save;
+                    self.line = save_line;
+                    self.col = save_col;
+                } else {
+                    // Skip optional ` (entry)` marker
+                    self.skip_inline_whitespace();
+                    if self.peek_char() == Some('(') {
+                        while let Some(c) = self.peek_char() {
+                            self.advance();
+                            if c == ')' {
+                                break;
+                            }
+                        }
+                    }
+                    if self.peek_char() == Some(':') {
+                        let idx: u32 = idx_str
+                            .parse()
+                            .map_err(|_| self.error("invalid block index"))?;
+                        if first_block.is_none() {
+                            first_block = Some(idx);
+                        }
+                        // Don't allocate the entry block again — Function::new
+                        // already created bb0. We need to map any first-encountered
+                        // bbN to the entry block's id.
+                        if block_labels.is_empty() {
+                            block_labels.insert(idx, func.entry_block);
+                        } else {
+                            let id = func.alloc_block();
+                            block_labels.insert(idx, id);
+                        }
+                        // Skip to end of line; the `:` consumes block header.
+                        self.advance();
+                        self.skip_to_eol();
+                        continue;
+                    } else {
+                        self.pos = save;
+                        self.line = save_line;
+                        self.col = save_col;
+                    }
+                }
+            }
+            // Not a block header — restore to start of line and skip the line.
+            self.pos = line_start_pos;
+            self.line = line_start_line;
+            self.col = line_start_col;
+            self.skip_to_eol();
+        }
+
+        // Rewind to start of function body for the real parsing pass.
+        self.pos = scan_start;
+        self.line = scan_line;
+        self.col = scan_col;
+
+        // Second pass: parse blocks, instructions, and terminators.
+        let mut value_labels: FxHashMap<u32, ValueId> = FxHashMap::default();
+        let mut current_block: Option<BlockId> = None;
+
+        loop {
+            self.skip_blank_and_comments();
+            if self.is_eof() {
+                return Err(self.error("unterminated function body"));
+            }
+            if self.try_punct('}') {
+                break;
+            }
+
+            // Try to parse a block header.
+            self.skip_inline_whitespace();
+            if self.input[self.pos..].starts_with("bb") {
+                let save = self.pos;
+                let save_line = self.line;
+                let save_col = self.col;
+                self.advance();
+                self.advance();
+                let mut idx_str = String::new();
+                while let Some(c) = self.peek_char() {
+                    if c.is_ascii_digit() {
+                        idx_str.push(c);
+                        self.advance();
+                    } else {
+                        break;
+                    }
+                }
+                if !idx_str.is_empty() {
+                    self.skip_inline_whitespace();
+                    // Optional ` (entry)`
+                    if self.peek_char() == Some('(') {
+                        while let Some(c) = self.peek_char() {
+                            self.advance();
+                            if c == ')' {
+                                break;
+                            }
+                        }
+                        self.skip_inline_whitespace();
+                    }
+                    if self.peek_char() == Some(':') {
+                        self.advance();
+                        let idx: u32 = idx_str.parse().unwrap();
+                        let bid = *block_labels
+                            .get(&idx)
+                            .ok_or_else(|| self.error(format!("unknown block bb{idx}")))?;
+                        current_block = Some(bid);
+                        self.skip_to_eol();
+                        continue;
+                    }
+                    self.pos = save;
+                    self.line = save_line;
+                    self.col = save_col;
+                } else {
+                    self.pos = save;
+                    self.line = save_line;
+                    self.col = save_col;
+                }
+            }
+
+            // Not a block header — must be an instruction or terminator.
+            let block = current_block
+                .ok_or_else(|| self.error("instruction outside of any block"))?;
+            self.parse_instruction_or_terminator(
+                &mut func,
+                block,
+                &arg_values,
+                &block_labels,
+                &mut value_labels,
+            )?;
+        }
+
+        Ok(func)
+    }
+
+    fn parse_type(&mut self) -> Result<MirType, ParseError> {
+        self.skip_inline();
+        let id = self.parse_ident()?;
+        // u8..u256, i8..i256, bytes1..bytes32 — split into prefix + number.
+        let ty = if let Some(rest) = id.strip_prefix('u') {
+            let bits: u16 =
+                rest.parse().map_err(|_| self.error(format!("invalid u-type `{id}`")))?;
+            MirType::UInt(bits)
+        } else if let Some(rest) = id.strip_prefix('i') {
+            let bits: u16 =
+                rest.parse().map_err(|_| self.error(format!("invalid i-type `{id}`")))?;
+            MirType::Int(bits)
+        } else if let Some(rest) = id.strip_prefix("bytes") {
+            let n: u8 =
+                rest.parse().map_err(|_| self.error(format!("invalid bytes type `{id}`")))?;
+            MirType::FixedBytes(n)
+        } else {
+            match id {
+                "bool" => MirType::Bool,
+                "address" => MirType::Address,
+                "memptr" => MirType::MemPtr,
+                "storageptr" => MirType::StoragePtr,
+                "calldataptr" => MirType::CalldataPtr,
+                "function" => MirType::Function,
+                "void" => MirType::Void,
+                _ => return Err(self.error(format!("unknown type `{id}`"))),
+            }
+        };
+        Ok(ty)
+    }
+
+    /// Parses a single value reference: `argN`, `vN`, integer literal, or `true`/`false`.
+    /// Allocates a fresh `Immediate` for literals.
+    fn parse_value(
+        &mut self,
+        func: &mut Function,
+        arg_values: &[ValueId],
+        value_labels: &mut FxHashMap<u32, ValueId>,
+    ) -> Result<ValueId, ParseError> {
+        self.skip_inline();
+        // Integer literal? (decimal or 0x…)
+        if matches!(self.peek_char(), Some(c) if c.is_ascii_digit()) {
+            let v = self.parse_uint_literal()?;
+            return Ok(func.alloc_value(Value::Immediate(Immediate::uint256(v))));
+        }
+        // Identifier-like — could be argN, vN, true, false.
+        let ident = self.parse_ident()?;
+        if ident == "true" {
+            return Ok(func.alloc_value(Value::Immediate(Immediate::bool(true))));
+        }
+        if ident == "false" {
+            return Ok(func.alloc_value(Value::Immediate(Immediate::bool(false))));
+        }
+        if let Some(rest) = ident.strip_prefix("arg") {
+            let idx: usize =
+                rest.parse().map_err(|_| self.error(format!("invalid arg `{ident}`")))?;
+            return arg_values
+                .get(idx)
+                .copied()
+                .ok_or_else(|| self.error(format!("arg{idx} out of range")));
+        }
+        if let Some(rest) = ident.strip_prefix('v') {
+            let idx: u32 = rest
+                .parse()
+                .map_err(|_| self.error(format!("invalid value reference `{ident}`")))?;
+            return value_labels
+                .get(&idx)
+                .copied()
+                .ok_or_else(|| self.error(format!("undefined value `{ident}`")));
+        }
+        Err(self.error(format!("expected value reference, got `{ident}`")))
+    }
+
+    fn parse_block_id(&mut self, block_labels: &FxHashMap<u32, BlockId>) -> Result<BlockId, ParseError> {
+        self.skip_inline();
+        let id = self.parse_ident()?;
+        let rest = id
+            .strip_prefix("bb")
+            .ok_or_else(|| self.error(format!("expected `bbN`, got `{id}`")))?;
+        let idx: u32 = rest
+            .parse()
+            .map_err(|_| self.error(format!("invalid block index `{id}`")))?;
+        block_labels
+            .get(&idx)
+            .copied()
+            .ok_or_else(|| self.error(format!("unknown block `{id}`")))
+    }
+
+    /// Parses one instruction line (with optional `vN =` result) or a terminator.
+    fn parse_instruction_or_terminator(
+        &mut self,
+        func: &mut Function,
+        block: BlockId,
+        arg_values: &[ValueId],
+        block_labels: &FxHashMap<u32, BlockId>,
+        value_labels: &mut FxHashMap<u32, ValueId>,
+    ) -> Result<(), ParseError> {
+        self.skip_inline_whitespace();
+
+        // Optional result: `vN = ...`
+        let result_label: Option<u32> = if self.input[self.pos..].starts_with('v')
+            && self.input[self.pos..]
+                .chars()
+                .nth(1)
+                .is_some_and(|c| c.is_ascii_digit())
+        {
+            // Try to parse as `vN =`. If no `=` follows, it's a terminator using vN.
+            let save_pos = self.pos;
+            let save_line = self.line;
+            let save_col = self.col;
+            self.advance();
+            let mut idx_str = String::new();
+            while let Some(c) = self.peek_char() {
+                if c.is_ascii_digit() {
+                    idx_str.push(c);
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            self.skip_inline_whitespace();
+            if self.peek_char() == Some('=') {
+                self.advance();
+                Some(idx_str.parse().unwrap())
+            } else {
+                self.pos = save_pos;
+                self.line = save_line;
+                self.col = save_col;
+                None
+            }
+        } else {
+            None
+        };
+
+        self.skip_inline_whitespace();
+        let mnemonic = self.parse_ident()?.to_string();
+
+        // Terminators (no result).
+        match mnemonic.as_str() {
+            "jump" => {
+                let target = self.parse_block_id(block_labels)?;
+                self.set_terminator(func, block, Terminator::Jump(target));
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "br" => {
+                let condition = self.parse_value(func, arg_values, value_labels)?;
+                self.expect_punct(',')?;
+                let then_block = self.parse_block_id(block_labels)?;
+                self.expect_punct(',')?;
+                let else_block = self.parse_block_id(block_labels)?;
+                self.set_terminator(
+                    func,
+                    block,
+                    Terminator::Branch { condition, then_block, else_block },
+                );
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "switch" => {
+                let value = self.parse_value(func, arg_values, value_labels)?;
+                self.expect_punct(',')?;
+                self.expect_keyword("default")?;
+                let default = self.parse_block_id(block_labels)?;
+                self.expect_punct(',')?;
+                self.expect_punct('[')?;
+                let mut cases = Vec::new();
+                if !self.try_punct(']') {
+                    loop {
+                        let val = self.parse_value(func, arg_values, value_labels)?;
+                        self.expect_keyword("=>")?;
+                        let bid = self.parse_block_id(block_labels)?;
+                        cases.push((val, bid));
+                        if self.try_punct(',') {
+                            continue;
+                        }
+                        self.expect_punct(']')?;
+                        break;
+                    }
+                }
+                self.set_terminator(func, block, Terminator::Switch { value, default, cases });
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "ret" => {
+                use smallvec::SmallVec;
+                let mut values: SmallVec<[ValueId; 2]> = SmallVec::new();
+                self.skip_inline_whitespace();
+                // Empty ret?
+                if self.peek_char() != Some('\n') && !self.is_eof() {
+                    loop {
+                        values.push(self.parse_value(func, arg_values, value_labels)?);
+                        if !self.try_punct(',') {
+                            break;
+                        }
+                    }
+                }
+                self.set_terminator(func, block, Terminator::Return { values });
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "revert" => {
+                let offset = self.parse_value(func, arg_values, value_labels)?;
+                self.expect_punct(',')?;
+                let size = self.parse_value(func, arg_values, value_labels)?;
+                self.set_terminator(func, block, Terminator::Revert { offset, size });
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "stop" => {
+                self.set_terminator(func, block, Terminator::Stop);
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "selfdestruct" => {
+                let recipient = self.parse_value(func, arg_values, value_labels)?;
+                self.set_terminator(func, block, Terminator::SelfDestruct { recipient });
+                self.skip_to_eol();
+                return Ok(());
+            }
+            "invalid" => {
+                self.set_terminator(func, block, Terminator::Invalid);
+                self.skip_to_eol();
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        // Otherwise — instruction.
+        let (kind, result_ty) =
+            self.parse_inst_kind(&mnemonic, func, arg_values, block_labels, value_labels)?;
+
+        let inst_id = func.alloc_inst(Instruction::new(kind, result_ty));
+        func.blocks[block].instructions.push(inst_id);
+        if let Some(label) = result_label {
+            let val = func.alloc_value(Value::Inst(inst_id));
+            value_labels.insert(label, val);
+        }
+        self.skip_to_eol();
+        Ok(())
+    }
+
+    fn set_terminator(&self, func: &mut Function, block: BlockId, term: Terminator) {
+        // Update successors / predecessors so downstream passes see a valid CFG.
+        let succs = term.successors();
+        for &s in &succs {
+            func.blocks[block].successors.push(s);
+            func.blocks[s].predecessors.push(block);
+        }
+        func.blocks[block].terminator = Some(term);
+    }
+
+    /// Parses one instruction by mnemonic. Returns the constructed [`InstKind`]
+    /// and its result type (or `None` if it produces no value).
+    #[allow(clippy::too_many_lines)]
+    fn parse_inst_kind(
+        &mut self,
+        mnemonic: &str,
+        func: &mut Function,
+        arg_values: &[ValueId],
+        block_labels: &FxHashMap<u32, BlockId>,
+        value_labels: &mut FxHashMap<u32, ValueId>,
+    ) -> Result<(InstKind, Option<MirType>), ParseError> {
+        // Operand parsing helpers.
+        macro_rules! v {
+            () => {
+                self.parse_value(func, arg_values, value_labels)?
+            };
+        }
+        macro_rules! comma {
+            () => {
+                self.expect_punct(',')?
+            };
+        }
+
+        Ok(match mnemonic {
+            // ----- arithmetic (all uint256 result) -----
+            "add" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Add(a, b), Some(MirType::uint256()))
+            }
+            "sub" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Sub(a, b), Some(MirType::uint256()))
+            }
+            "mul" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Mul(a, b), Some(MirType::uint256()))
+            }
+            "div" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Div(a, b), Some(MirType::uint256()))
+            }
+            "sdiv" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::SDiv(a, b), Some(MirType::int256()))
+            }
+            "mod" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Mod(a, b), Some(MirType::uint256()))
+            }
+            "smod" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::SMod(a, b), Some(MirType::int256()))
+            }
+            "exp" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Exp(a, b), Some(MirType::uint256()))
+            }
+            "addmod" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::AddMod(a, b, c), Some(MirType::uint256()))
+            }
+            "mulmod" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::MulMod(a, b, c), Some(MirType::uint256()))
+            }
+
+            // ----- bitwise -----
+            "and" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::And(a, b), Some(MirType::uint256()))
+            }
+            "or" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Or(a, b), Some(MirType::uint256()))
+            }
+            "xor" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Xor(a, b), Some(MirType::uint256()))
+            }
+            "not" => {
+                let a = v!();
+                (InstKind::Not(a), Some(MirType::uint256()))
+            }
+            "shl" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Shl(a, b), Some(MirType::uint256()))
+            }
+            "shr" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Shr(a, b), Some(MirType::uint256()))
+            }
+            "sar" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Sar(a, b), Some(MirType::int256()))
+            }
+            "byte" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Byte(a, b), Some(MirType::uint256()))
+            }
+            "signextend" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::SignExtend(a, b), Some(MirType::int256()))
+            }
+
+            // ----- comparison -----
+            "lt" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Lt(a, b), Some(MirType::Bool))
+            }
+            "gt" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Gt(a, b), Some(MirType::Bool))
+            }
+            "slt" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::SLt(a, b), Some(MirType::Bool))
+            }
+            "sgt" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::SGt(a, b), Some(MirType::Bool))
+            }
+            "eq" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Eq(a, b), Some(MirType::Bool))
+            }
+            "iszero" => {
+                let a = v!();
+                (InstKind::IsZero(a), Some(MirType::Bool))
+            }
+
+            // ----- memory -----
+            "mload" => {
+                let a = v!();
+                (InstKind::MLoad(a), Some(MirType::uint256()))
+            }
+            "mstore" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::MStore(a, b), None)
+            }
+            "mstore8" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::MStore8(a, b), None)
+            }
+            "msize" => (InstKind::MSize, Some(MirType::uint256())),
+            "mcopy" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::MCopy(a, b, c), None)
+            }
+
+            // ----- storage -----
+            "sload" => {
+                let a = v!();
+                (InstKind::SLoad(a), Some(MirType::uint256()))
+            }
+            "sstore" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::SStore(a, b), None)
+            }
+            "tload" => {
+                let a = v!();
+                (InstKind::TLoad(a), Some(MirType::uint256()))
+            }
+            "tstore" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::TStore(a, b), None)
+            }
+
+            // ----- calldata -----
+            "calldataload" => {
+                let a = v!();
+                (InstKind::CalldataLoad(a), Some(MirType::uint256()))
+            }
+            "calldatasize" => (InstKind::CalldataSize, Some(MirType::uint256())),
+            "calldatacopy" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::CalldataCopy(a, b, c), None)
+            }
+
+            // ----- code -----
+            "codesize" => (InstKind::CodeSize, Some(MirType::uint256())),
+            "codecopy" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::CodeCopy(a, b, c), None)
+            }
+            "extcodesize" => {
+                let a = v!();
+                (InstKind::ExtCodeSize(a), Some(MirType::uint256()))
+            }
+            "extcodecopy" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                comma!();
+                let d = v!();
+                (InstKind::ExtCodeCopy(a, b, c, d), None)
+            }
+            "extcodehash" => {
+                let a = v!();
+                (InstKind::ExtCodeHash(a), Some(MirType::uint256()))
+            }
+
+            // ----- return data -----
+            "returndatasize" => (InstKind::ReturnDataSize, Some(MirType::uint256())),
+            "returndatacopy" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::ReturnDataCopy(a, b, c), None)
+            }
+
+            // ----- environment (nullary) -----
+            "caller" => (InstKind::Caller, Some(MirType::Address)),
+            "callvalue" => (InstKind::CallValue, Some(MirType::uint256())),
+            "origin" => (InstKind::Origin, Some(MirType::Address)),
+            "gasprice" => (InstKind::GasPrice, Some(MirType::uint256())),
+            "coinbase" => (InstKind::Coinbase, Some(MirType::Address)),
+            "timestamp" => (InstKind::Timestamp, Some(MirType::uint256())),
+            "number" => (InstKind::BlockNumber, Some(MirType::uint256())),
+            "prevrandao" => (InstKind::PrevRandao, Some(MirType::uint256())),
+            "gaslimit" => (InstKind::GasLimit, Some(MirType::uint256())),
+            "chainid" => (InstKind::ChainId, Some(MirType::uint256())),
+            "address" => (InstKind::Address, Some(MirType::Address)),
+            "selfbalance" => (InstKind::SelfBalance, Some(MirType::uint256())),
+            "gas" => (InstKind::Gas, Some(MirType::uint256())),
+            "basefee" => (InstKind::BaseFee, Some(MirType::uint256())),
+            "blobbasefee" => (InstKind::BlobBaseFee, Some(MirType::uint256())),
+
+            // ----- environment (unary) -----
+            "blockhash" => {
+                let a = v!();
+                (InstKind::BlockHash(a), Some(MirType::FixedBytes(32)))
+            }
+            "balance" => {
+                let a = v!();
+                (InstKind::Balance(a), Some(MirType::uint256()))
+            }
+            "blobhash" => {
+                let a = v!();
+                (InstKind::BlobHash(a), Some(MirType::FixedBytes(32)))
+            }
+
+            // ----- hashing -----
+            "keccak256" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Keccak256(a, b), Some(MirType::bytes32()))
+            }
+
+            // ----- calls -----
+            "call" => {
+                let gas = v!();
+                comma!();
+                let addr = v!();
+                comma!();
+                let value = v!();
+                comma!();
+                let args_offset = v!();
+                comma!();
+                let args_size = v!();
+                comma!();
+                let ret_offset = v!();
+                comma!();
+                let ret_size = v!();
+                (
+                    InstKind::Call {
+                        gas,
+                        addr,
+                        value,
+                        args_offset,
+                        args_size,
+                        ret_offset,
+                        ret_size,
+                    },
+                    Some(MirType::uint256()),
+                )
+            }
+            "staticcall" => {
+                let gas = v!();
+                comma!();
+                let addr = v!();
+                comma!();
+                let args_offset = v!();
+                comma!();
+                let args_size = v!();
+                comma!();
+                let ret_offset = v!();
+                comma!();
+                let ret_size = v!();
+                (
+                    InstKind::StaticCall {
+                        gas,
+                        addr,
+                        args_offset,
+                        args_size,
+                        ret_offset,
+                        ret_size,
+                    },
+                    Some(MirType::uint256()),
+                )
+            }
+            "delegatecall" => {
+                let gas = v!();
+                comma!();
+                let addr = v!();
+                comma!();
+                let args_offset = v!();
+                comma!();
+                let args_size = v!();
+                comma!();
+                let ret_offset = v!();
+                comma!();
+                let ret_size = v!();
+                (
+                    InstKind::DelegateCall {
+                        gas,
+                        addr,
+                        args_offset,
+                        args_size,
+                        ret_offset,
+                        ret_size,
+                    },
+                    Some(MirType::uint256()),
+                )
+            }
+
+            // ----- create -----
+            "create" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::Create(a, b, c), Some(MirType::Address))
+            }
+            "create2" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                comma!();
+                let d = v!();
+                (InstKind::Create2(a, b, c, d), Some(MirType::Address))
+            }
+
+            // ----- logs -----
+            "log0" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                (InstKind::Log0(a, b), None)
+            }
+            "log1" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                (InstKind::Log1(a, b, c), None)
+            }
+            "log2" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                comma!();
+                let d = v!();
+                (InstKind::Log2(a, b, c, d), None)
+            }
+            "log3" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                comma!();
+                let d = v!();
+                comma!();
+                let e = v!();
+                (InstKind::Log3(a, b, c, d, e), None)
+            }
+            "log4" => {
+                let a = v!();
+                comma!();
+                let b = v!();
+                comma!();
+                let c = v!();
+                comma!();
+                let d = v!();
+                comma!();
+                let e = v!();
+                comma!();
+                let f = v!();
+                (InstKind::Log4(a, b, c, d, e, f), None)
+            }
+
+            // ----- ssa -----
+            "select" => {
+                let cond = v!();
+                comma!();
+                let then_v = v!();
+                comma!();
+                let else_v = v!();
+                (InstKind::Select(cond, then_v, else_v), Some(MirType::uint256()))
+            }
+            "phi" => {
+                // Format: `phi [v1, bb0], [v2, bb1]` (matches the printer)
+                let mut incoming: Vec<(BlockId, ValueId)> = Vec::new();
+                loop {
+                    self.expect_punct('[')?;
+                    let val = v!();
+                    comma!();
+                    let bid = self.parse_block_id(block_labels)?;
+                    self.expect_punct(']')?;
+                    incoming.push((bid, val));
+                    if !self.try_punct(',') {
+                        break;
+                    }
+                }
+                (InstKind::Phi(incoming), Some(MirType::uint256()))
+            }
+
+            other => return Err(self.error(format!("unknown instruction `{other}`"))),
+        })
+    }
+}
+
+// =============================================================================
+// Suppress the unused `BasicBlock` import warning when this module is built
+// without tests. The struct is used transitively through `Function`, but the
+// import keeps the file self-documenting.
+// =============================================================================
+
+#[allow(dead_code)]
+const _BLOCK_TYPE_REFERENCE: Option<BasicBlock> = None;
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mir::{function_to_text, module_to_text};
+    use solar_interface::{ColorChoice, Session};
+
+    fn with_session<F: FnOnce() + Send>(f: F) {
+        let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        sess.enter(f);
+    }
+
+    #[test]
+    fn parse_linear_function() {
+        with_session(|| {
+            let src = "\
+fn @add(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    ret v2
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.blocks.len(), 1);
+            assert_eq!(func.params.len(), 2);
+            assert_eq!(func.returns.len(), 1);
+            // Round-trip: print and re-parse should not error.
+            let printed = function_to_text(&func);
+            let _func2 = parse_function(&printed).unwrap();
+        });
+    }
+
+    #[test]
+    fn parse_storage_ops() {
+        with_session(|| {
+            let src = "\
+fn @increment() {
+  bb0 (entry):
+    v1 = sload 0
+    v3 = add v1, 1
+    sstore 0, v3
+    stop
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.blocks.len(), 1);
+            assert_eq!(func.params.len(), 0);
+            // sstore + stop are the only "no result" things; sload, add produce results.
+            // So we expect 4 instructions total.
+            assert_eq!(func.instructions.len(), 3);
+            // 0 + 1 are immediates; v1, v3 are inst results.
+            assert!(func.values.len() >= 4);
+        });
+    }
+
+    #[test]
+    fn parse_branch() {
+        with_session(|| {
+            let src = "\
+fn @max(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = gt arg0, arg1
+    br v2, bb1, bb2
+  bb1:
+    ret arg0
+  bb2:
+    ret arg1
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.blocks.len(), 3);
+            // bb0 should have 2 successors.
+            assert_eq!(func.blocks[func.entry_block].successors.len(), 2);
+        });
+    }
+
+    #[test]
+    fn parse_loop_with_jump() {
+        with_session(|| {
+            let src = "\
+fn @count_down(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    v1 = lt 0, arg0
+    br v1, bb2, bb3
+  bb2:
+    jump bb1
+  bb3:
+    ret arg0
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.blocks.len(), 4);
+        });
+    }
+
+    #[test]
+    fn parse_call_instruction() {
+        with_session(|| {
+            let src = "\
+fn @do_call(arg0: address, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = call 100, arg0, arg1, 0, 0, 0, 0
+    ret v2
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.instructions.len(), 1);
+        });
+    }
+
+    #[test]
+    fn parse_keccak_and_mload_mstore() {
+        with_session(|| {
+            let src = "\
+fn @hash() -> u256 {
+  bb0 (entry):
+    mstore 0, 1
+    mstore 32, 2
+    v1 = keccak256 0, 64
+    ret v1
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.instructions.len(), 3);
+        });
+    }
+
+    #[test]
+    fn parse_round_trip_module() {
+        with_session(|| {
+            let src = "\
+; module @Counter
+fn @count() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+
+fn @set(arg0: u256) {
+  bb0 (entry):
+    sstore 0, arg0
+    stop
+}
+";
+            let module = parse_module(src).unwrap();
+            assert_eq!(module.functions.len(), 2);
+            // Round-trip the printed form.
+            let printed = module_to_text(&module);
+            let module2 = parse_module(&printed).unwrap();
+            assert_eq!(module2.functions.len(), 2);
+        });
+    }
+
+    #[test]
+    fn parse_unknown_instruction_errors() {
+        with_session(|| {
+            let src = "\
+fn @bad() {
+  bb0 (entry):
+    v1 = bogus arg0
+    stop
+}
+";
+            let err = parse_function(src).unwrap_err();
+            assert!(err.msg.contains("bogus") || err.msg.contains("unknown"));
+        });
+    }
+
+    #[test]
+    fn parse_revert_terminator() {
+        with_session(|| {
+            let src = "\
+fn @oops() {
+  bb0 (entry):
+    revert 0, 0
+}
+";
+            let func = parse_function(src).unwrap();
+            assert!(matches!(
+                func.blocks[func.entry_block].terminator,
+                Some(Terminator::Revert { .. })
+            ));
+        });
+    }
+
+    #[test]
+    fn parse_environment_nullary() {
+        with_session(|| {
+            let src = "\
+fn @env() -> u256 {
+  bb0 (entry):
+    v0 = caller
+    v1 = callvalue
+    v2 = gas
+    v3 = chainid
+    ret v3
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.instructions.len(), 4);
+        });
+    }
+
+    #[test]
+    fn parse_select_and_logs() {
+        with_session(|| {
+            let src = "\
+fn @sel(arg0: bool, arg1: u256, arg2: u256) -> u256 {
+  bb0 (entry):
+    v3 = select arg0, arg1, arg2
+    log1 0, 32, v3
+    ret v3
+}
+";
+            let func = parse_function(src).unwrap();
+            assert_eq!(func.instructions.len(), 2);
+        });
+    }
+}

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -208,6 +208,23 @@ impl TransformPass for JumpThreadingPass {
     }
 }
 
+/// Sparse Conditional Constant Propagation transform.
+///
+/// Propagates constants through the CFG using SSA def-use chains,
+/// evaluates branch conditions to discover unreachable paths, and
+/// folds phi nodes when all executable incoming values agree.
+pub struct SccpTransformPass;
+
+impl TransformPass for SccpTransformPass {
+    fn name(&self) -> &str {
+        "sccp"
+    }
+
+    fn run(&mut self, func: &mut Function) {
+        crate::transform::SccpPass::new().run(func);
+    }
+}
+
 /// Common subexpression elimination transform.
 ///
 /// Eliminates redundant computations within each basic block (local CSE).

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -1,10 +1,10 @@
 //! Pass infrastructure for MIR transformations and analyses.
 //!
 //! Inspired by LLVM/MLIR pass infrastructure:
-//! - **Analysis passes** ([`AnalysisPass`]) are read-only and produce a cached result.
-//!   They take `&Function` and store their result in [`AnalysisManager`].
-//! - **Transformation passes** ([`TransformPass`]) modify the IR. They take
-//!   `&mut Function` and should invalidate cached analyses.
+//! - **Analysis passes** ([`AnalysisPass`]) are read-only and produce a cached result. They take
+//!   `&Function` and store their result in [`AnalysisManager`].
+//! - **Transformation passes** ([`TransformPass`]) modify the IR. They take `&mut Function` and
+//!   should invalidate cached analyses.
 //!
 //! # Usage
 //!

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -1,0 +1,238 @@
+//! Pass infrastructure for MIR transformations and analyses.
+//!
+//! Inspired by LLVM/MLIR pass infrastructure:
+//! - **Analysis passes** are read-only and produce a cached result.
+//! - **Transformation passes** modify the IR and invalidate cached analyses.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let mut pm = PassManager::new();
+//! pm.add_transform(Box::new(DcePass));
+//! pm.add_transform(Box::new(ConstFoldPass));
+//! pm.run(&mut func);
+//! ```
+
+use crate::mir::Function;
+use rustc_hash::FxHashMap;
+use std::any::{Any, TypeId};
+
+/// A key identifying a particular analysis, derived from its result type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AnalysisKey(TypeId);
+
+impl AnalysisKey {
+    /// Creates a key from a type.
+    pub fn of<T: 'static>() -> Self {
+        Self(TypeId::of::<T>())
+    }
+}
+
+/// Manages cached analysis results for a function.
+///
+/// Analyses are keyed by their result type via [`AnalysisKey`].
+/// Transformation passes should call [`invalidate_all`](Self::invalidate_all)
+/// after modifying the IR.
+#[derive(Default)]
+pub struct AnalysisManager {
+    results: FxHashMap<AnalysisKey, Box<dyn Any>>,
+}
+
+impl AnalysisManager {
+    /// Creates a new, empty analysis manager.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the cached result for the given analysis type, if available.
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        let key = AnalysisKey::of::<T>();
+        self.results.get(&key)?.downcast_ref::<T>()
+    }
+
+    /// Caches an analysis result.
+    pub fn insert<T: 'static>(&mut self, result: T) {
+        let key = AnalysisKey::of::<T>();
+        self.results.insert(key, Box::new(result));
+    }
+
+    /// Invalidates all cached analysis results.
+    pub fn invalidate_all(&mut self) {
+        self.results.clear();
+    }
+
+    /// Invalidates a specific analysis result.
+    pub fn invalidate<T: 'static>(&mut self) {
+        let key = AnalysisKey::of::<T>();
+        self.results.remove(&key);
+    }
+}
+
+/// A function-level pass (analysis or transformation).
+pub trait FunctionPass {
+    /// The name of this pass, for debugging and logging.
+    fn name(&self) -> &str;
+
+    /// Runs the pass on the given function.
+    ///
+    /// Analysis passes store results in `am`. Transformation passes mutate
+    /// `func` and should call `am.invalidate_all()`.
+    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager);
+
+    /// Returns `true` if this pass is an analysis (does not modify IR).
+    fn is_analysis(&self) -> bool {
+        false
+    }
+}
+
+/// Orchestrates pass execution on a function.
+#[derive(Default)]
+pub struct PassManager {
+    passes: Vec<Box<dyn FunctionPass>>,
+}
+
+impl PassManager {
+    /// Creates a new, empty pass manager.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a pass to the pipeline.
+    pub fn add_pass(&mut self, pass: Box<dyn FunctionPass>) {
+        self.passes.push(pass);
+    }
+
+    /// Runs all passes in order on the given function.
+    /// Returns the [`AnalysisManager`] with any cached results from the last pass(es).
+    pub fn run(&mut self, func: &mut Function) -> AnalysisManager {
+        let mut am = AnalysisManager::new();
+        for pass in &mut self.passes {
+            pass.run_on_function(func, &mut am);
+        }
+        am
+    }
+}
+
+/// Adapter: wraps the existing [`Liveness`](crate::analysis::Liveness) as a [`FunctionPass`].
+pub struct LivenessPass;
+
+impl FunctionPass for LivenessPass {
+    fn name(&self) -> &str {
+        "liveness"
+    }
+
+    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager) {
+        let result = crate::analysis::Liveness::compute(func);
+        am.insert(result);
+    }
+
+    fn is_analysis(&self) -> bool {
+        true
+    }
+}
+
+/// Adapter: wraps the existing [`DeadCodeEliminator`](crate::transform::DeadCodeEliminator) as a [`FunctionPass`].
+pub struct DcePass;
+
+impl FunctionPass for DcePass {
+    fn name(&self) -> &str {
+        "dce"
+    }
+
+    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager) {
+        let mut dce = crate::transform::DeadCodeEliminator::new();
+        dce.run(func);
+        am.invalidate_all();
+    }
+}
+
+/// Adapter: wraps the existing [`CfgSimplifier`](crate::transform::CfgSimplifier) as a [`FunctionPass`].
+pub struct CfgSimplifyPass;
+
+impl FunctionPass for CfgSimplifyPass {
+    fn name(&self) -> &str {
+        "cfg-simplify"
+    }
+
+    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager) {
+        let mut simplifier = crate::transform::CfgSimplifier::new();
+        simplifier.run(func);
+        am.invalidate_all();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mir::{FunctionBuilder, MirType, ValueId};
+    use solar_interface::Ident;
+
+    fn make_func() -> Function {
+        Function::new(Ident::DUMMY)
+    }
+
+    #[test]
+    fn analysis_caching() {
+        let mut am = AnalysisManager::new();
+        am.insert(42u32);
+        am.insert(String::from("hello"));
+        assert_eq!(am.get::<u32>(), Some(&42));
+        assert_eq!(am.get::<String>(), Some(&String::from("hello")));
+        assert_eq!(am.get::<f64>(), None);
+    }
+
+    #[test]
+    fn invalidate_all() {
+        let mut am = AnalysisManager::new();
+        am.insert(42u32);
+        am.invalidate_all();
+        assert_eq!(am.get::<u32>(), None);
+    }
+
+    #[test]
+    fn invalidate_specific() {
+        let mut am = AnalysisManager::new();
+        am.insert(42u32);
+        am.insert(String::from("kept"));
+        am.invalidate::<u32>();
+        assert_eq!(am.get::<u32>(), None);
+        assert_eq!(am.get::<String>(), Some(&String::from("kept")));
+    }
+
+    #[test]
+    fn liveness_pass_via_manager() {
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let x = b.add_param(MirType::uint256());
+            b.ret([x]);
+        }
+
+        let mut pm = PassManager::new();
+        pm.add_pass(Box::new(LivenessPass));
+        let am = pm.run(&mut func);
+
+        let liveness = am.get::<crate::analysis::Liveness>().expect("liveness cached");
+        assert!(liveness.live_in(func.entry_block).contains(ValueId::from_usize(0)));
+    }
+
+    #[test]
+    fn transform_invalidates_analyses() {
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let x = b.add_param(MirType::uint256());
+            let y = b.imm_u64(1);
+            let _unused = b.add(x, y); // Will be eliminated by DCE.
+            b.ret([x]);
+        }
+
+        let mut pm = PassManager::new();
+        pm.add_pass(Box::new(LivenessPass));
+        pm.add_pass(Box::new(DcePass));
+        let am = pm.run(&mut func);
+
+        // After DCE, liveness should have been invalidated.
+        assert!(am.get::<crate::analysis::Liveness>().is_none());
+    }
+}

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -161,6 +161,9 @@ impl AnalysisPass for LivenessAnalysis {
 }
 
 /// Dead code elimination transform.
+///
+/// Iterates `DeadCodeEliminator` to a fixed point internally so a single
+/// `run` invocation removes all dead code reachable from the entry block.
 pub struct DcePass;
 
 impl TransformPass for DcePass {
@@ -169,12 +172,14 @@ impl TransformPass for DcePass {
     }
 
     fn run(&mut self, func: &mut Function) {
-        let mut dce = crate::transform::DeadCodeEliminator::new();
-        dce.run(func);
+        crate::transform::DeadCodeEliminator::new().run_to_fixpoint(func);
     }
 }
 
 /// CFG simplification transform.
+///
+/// Iterates `CfgSimplifier` to a fixed point so chained simplifications
+/// (e.g., merging blocks made empty by previous merges) all happen.
 pub struct CfgSimplifyPass;
 
 impl TransformPass for CfgSimplifyPass {
@@ -183,8 +188,23 @@ impl TransformPass for CfgSimplifyPass {
     }
 
     fn run(&mut self, func: &mut Function) {
-        let mut simplifier = crate::transform::CfgSimplifier::new();
-        simplifier.run(func);
+        crate::transform::CfgSimplifier::new().run_to_fixpoint(func);
+    }
+}
+
+/// Jump threading transform.
+///
+/// Eliminates redundant unconditional jumps by threading control flow
+/// through forwarder blocks. Iterates to a fixed point.
+pub struct JumpThreadingPass;
+
+impl TransformPass for JumpThreadingPass {
+    fn name(&self) -> &str {
+        "jump-threading"
+    }
+
+    fn run(&mut self, func: &mut Function) {
+        crate::transform::JumpThreader::new().run_to_fixpoint(func);
     }
 }
 

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -208,6 +208,23 @@ impl TransformPass for JumpThreadingPass {
     }
 }
 
+/// Common subexpression elimination transform.
+///
+/// Eliminates redundant computations within each basic block (local CSE).
+/// Handles commutative normalization and SLOAD caching (invalidated by SSTORE).
+/// Iterates to a fixed point.
+pub struct CsePass;
+
+impl TransformPass for CsePass {
+    fn name(&self) -> &str {
+        "cse"
+    }
+
+    fn run(&mut self, func: &mut Function) {
+        crate::transform::CommonSubexprEliminator::new().run_to_fixpoint(func);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -93,10 +93,10 @@ impl AnalysisManager {
     /// LLVM's `AnalysisManager::getResult<AnalysisT>(F)` pattern.
     pub fn get_or_compute<A: AnalysisPass>(&mut self, analysis: &A, func: &Function) -> &A::Result {
         let key = AnalysisKey::of::<A::Result>();
-        if !self.results.contains_key(&key) {
+        self.results.entry(key).or_insert_with(|| {
             let result = analysis.run(func);
-            self.results.insert(key, Box::new(result));
-        }
+            Box::new(result)
+        });
         self.results[&key].downcast_ref::<A::Result>().unwrap()
     }
 

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -1,15 +1,21 @@
 //! Pass infrastructure for MIR transformations and analyses.
 //!
 //! Inspired by LLVM/MLIR pass infrastructure:
-//! - **Analysis passes** are read-only and produce a cached result.
-//! - **Transformation passes** modify the IR and invalidate cached analyses.
+//! - **Analysis passes** ([`AnalysisPass`]) are read-only and produce a cached result.
+//!   They take `&Function` and store their result in [`AnalysisManager`].
+//! - **Transformation passes** ([`TransformPass`]) modify the IR. They take
+//!   `&mut Function` and should invalidate cached analyses.
 //!
 //! # Usage
 //!
 //! ```ignore
+//! // Read-only analysis pipeline (codegen):
+//! let mut am = AnalysisManager::new();
+//! let liveness = am.get_or_compute(&LivenessAnalysis, &func);
+//!
+//! // Transform pipeline:
 //! let mut pm = PassManager::new();
 //! pm.add_transform(Box::new(DcePass));
-//! pm.add_transform(Box::new(ConstFoldPass));
 //! pm.run(&mut func);
 //! ```
 
@@ -28,11 +34,36 @@ impl AnalysisKey {
     }
 }
 
+/// A read-only analysis pass.
+///
+/// Analysis passes inspect a function without modifying it and produce a
+/// cacheable result that downstream passes can query via [`AnalysisManager`].
+pub trait AnalysisPass {
+    /// The result type produced by this analysis.
+    type Result: 'static;
+
+    /// The name of this analysis, for debugging and logging.
+    fn name(&self) -> &str;
+
+    /// Computes the analysis result for the given function.
+    fn run(&self, func: &Function) -> Self::Result;
+}
+
+/// A transformation pass that mutates a function.
+///
+/// Transformation passes should call [`AnalysisManager::invalidate_all`]
+/// after modifying the IR (or the [`PassManager`] does this automatically).
+pub trait TransformPass {
+    /// The name of this transform, for debugging and logging.
+    fn name(&self) -> &str;
+
+    /// Runs the transformation on the given function.
+    fn run(&mut self, func: &mut Function);
+}
+
 /// Manages cached analysis results for a function.
 ///
 /// Analyses are keyed by their result type via [`AnalysisKey`].
-/// Transformation passes should call [`invalidate_all`](Self::invalidate_all)
-/// after modifying the IR.
 #[derive(Default)]
 pub struct AnalysisManager {
     results: FxHashMap<AnalysisKey, Box<dyn Any>>,
@@ -56,6 +87,19 @@ impl AnalysisManager {
         self.results.insert(key, Box::new(result));
     }
 
+    /// Returns the result of the analysis, computing and caching it if not already present.
+    ///
+    /// This is the recommended way to obtain analysis results, matching
+    /// LLVM's `AnalysisManager::getResult<AnalysisT>(F)` pattern.
+    pub fn get_or_compute<A: AnalysisPass>(&mut self, analysis: &A, func: &Function) -> &A::Result {
+        let key = AnalysisKey::of::<A::Result>();
+        if !self.results.contains_key(&key) {
+            let result = analysis.run(func);
+            self.results.insert(key, Box::new(result));
+        }
+        self.results[&key].downcast_ref::<A::Result>().unwrap()
+    }
+
     /// Invalidates all cached analysis results.
     pub fn invalidate_all(&mut self) {
         self.results.clear();
@@ -68,27 +112,12 @@ impl AnalysisManager {
     }
 }
 
-/// A function-level pass (analysis or transformation).
-pub trait FunctionPass {
-    /// The name of this pass, for debugging and logging.
-    fn name(&self) -> &str;
-
-    /// Runs the pass on the given function.
-    ///
-    /// Analysis passes store results in `am`. Transformation passes mutate
-    /// `func` and should call `am.invalidate_all()`.
-    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager);
-
-    /// Returns `true` if this pass is an analysis (does not modify IR).
-    fn is_analysis(&self) -> bool {
-        false
-    }
-}
-
-/// Orchestrates pass execution on a function.
+/// Orchestrates execution of [`TransformPass`]es on a function.
+///
+/// Each transform automatically invalidates all cached analyses after running.
 #[derive(Default)]
 pub struct PassManager {
-    passes: Vec<Box<dyn FunctionPass>>,
+    passes: Vec<Box<dyn TransformPass>>,
 }
 
 impl PassManager {
@@ -97,67 +126,65 @@ impl PassManager {
         Self::default()
     }
 
-    /// Adds a pass to the pipeline.
-    pub fn add_pass(&mut self, pass: Box<dyn FunctionPass>) {
+    /// Adds a transformation pass to the pipeline.
+    pub fn add_transform(&mut self, pass: Box<dyn TransformPass>) {
         self.passes.push(pass);
     }
 
-    /// Runs all passes in order on the given function.
-    /// Returns the [`AnalysisManager`] with any cached results from the last pass(es).
+    /// Runs all transforms in order on the given function.
+    /// Returns an [`AnalysisManager`] (empty after transforms invalidate everything).
     pub fn run(&mut self, func: &mut Function) -> AnalysisManager {
         let mut am = AnalysisManager::new();
         for pass in &mut self.passes {
-            pass.run_on_function(func, &mut am);
+            pass.run(func);
+            am.invalidate_all();
         }
         am
     }
 }
 
-/// Adapter: wraps the existing [`Liveness`](crate::analysis::Liveness) as a [`FunctionPass`].
-pub struct LivenessPass;
+// === Concrete pass adapters ===
 
-impl FunctionPass for LivenessPass {
+/// Liveness analysis pass.
+pub struct LivenessAnalysis;
+
+impl AnalysisPass for LivenessAnalysis {
+    type Result = crate::analysis::Liveness;
+
     fn name(&self) -> &str {
         "liveness"
     }
 
-    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager) {
-        let result = crate::analysis::Liveness::compute(func);
-        am.insert(result);
-    }
-
-    fn is_analysis(&self) -> bool {
-        true
+    fn run(&self, func: &Function) -> Self::Result {
+        crate::analysis::Liveness::compute(func)
     }
 }
 
-/// Adapter: wraps the existing [`DeadCodeEliminator`](crate::transform::DeadCodeEliminator) as a [`FunctionPass`].
+/// Dead code elimination transform.
 pub struct DcePass;
 
-impl FunctionPass for DcePass {
+impl TransformPass for DcePass {
     fn name(&self) -> &str {
         "dce"
     }
 
-    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager) {
+    fn run(&mut self, func: &mut Function) {
         let mut dce = crate::transform::DeadCodeEliminator::new();
         dce.run(func);
-        am.invalidate_all();
     }
 }
 
-/// Adapter: wraps the existing [`CfgSimplifier`](crate::transform::CfgSimplifier) as a [`FunctionPass`].
+/// CFG simplification transform.
 pub struct CfgSimplifyPass;
 
-impl FunctionPass for CfgSimplifyPass {
+impl TransformPass for CfgSimplifyPass {
     fn name(&self) -> &str {
         "cfg-simplify"
     }
 
-    fn run_on_function(&mut self, func: &mut Function, am: &mut AnalysisManager) {
+    fn run(&mut self, func: &mut Function) {
         let mut simplifier = crate::transform::CfgSimplifier::new();
         simplifier.run(func);
-        am.invalidate_all();
     }
 }
 
@@ -200,7 +227,7 @@ mod tests {
     }
 
     #[test]
-    fn liveness_pass_via_manager() {
+    fn get_or_compute_caches() {
         let mut func = make_func();
         {
             let mut b = FunctionBuilder::new(&mut func);
@@ -208,31 +235,33 @@ mod tests {
             b.ret([x]);
         }
 
-        let mut pm = PassManager::new();
-        pm.add_pass(Box::new(LivenessPass));
-        let am = pm.run(&mut func);
-
-        let liveness = am.get::<crate::analysis::Liveness>().expect("liveness cached");
+        let mut am = AnalysisManager::new();
+        // First call computes.
+        let liveness = am.get_or_compute(&LivenessAnalysis, &func);
         assert!(liveness.live_in(func.entry_block).contains(ValueId::from_usize(0)));
+
+        // Second call hits the cache (same reference).
+        let _liveness2 = am.get_or_compute(&LivenessAnalysis, &func);
+        // If it cached correctly, the value is still there.
+        assert!(am.get::<crate::analysis::Liveness>().is_some());
     }
 
     #[test]
-    fn transform_invalidates_analyses() {
+    fn transform_pipeline_invalidates() {
         let mut func = make_func();
         {
             let mut b = FunctionBuilder::new(&mut func);
             let x = b.add_param(MirType::uint256());
             let y = b.imm_u64(1);
-            let _unused = b.add(x, y); // Will be eliminated by DCE.
+            let _unused = b.add(x, y);
             b.ret([x]);
         }
 
         let mut pm = PassManager::new();
-        pm.add_pass(Box::new(LivenessPass));
-        pm.add_pass(Box::new(DcePass));
+        pm.add_transform(Box::new(DcePass));
         let am = pm.run(&mut func);
 
-        // After DCE, liveness should have been invalidated.
+        // Transforms invalidate all caches.
         assert!(am.get::<crate::analysis::Liveness>().is_none());
     }
 }

--- a/crates/codegen/src/transform/dce.rs
+++ b/crates/codegen/src/transform/dce.rs
@@ -67,9 +67,11 @@ impl DeadCodeEliminator {
         let inst_to_value: FxHashMap<InstId, ValueId> = func
             .values
             .iter_enumerated()
-            .filter_map(|(vid, val)| {
-                if let Value::Inst(iid) = val { Some((*iid, vid)) } else { None }
-            })
+            .filter_map(
+                |(vid, val)| {
+                    if let Value::Inst(iid) = val { Some((*iid, vid)) } else { None }
+                },
+            )
             .collect();
 
         // Phase 4: Find all used values
@@ -285,10 +287,10 @@ impl DeadCodeEliminator {
                 }
 
                 // O(1) lookup via precomputed map (was O(V) linear scan).
-                if let Some(&result) = inst_to_value.get(&inst_id) {
-                    if !used_values.contains(&result) {
-                        dead.push((block_id, inst_id));
-                    }
+                if let Some(&result) = inst_to_value.get(&inst_id)
+                    && !used_values.contains(&result)
+                {
+                    dead.push((block_id, inst_id));
                 }
             }
         }

--- a/crates/codegen/src/transform/dce.rs
+++ b/crates/codegen/src/transform/dce.rs
@@ -3,7 +3,7 @@
 //! This pass removes MIR instructions whose results are never used and have no side effects.
 
 use crate::mir::{BlockId, Function, InstId, Terminator, Value, ValueId};
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 
 /// Dead Code Elimination pass.
@@ -62,11 +62,21 @@ impl DeadCodeEliminator {
         // Phase 2: Find and count unused parameters
         self.unused_params = self.find_unused_parameters(func).len();
 
-        // Phase 3: Find all used values
+        // Phase 3: Precompute InstId → ValueId map (O(V) once, replaces
+        // the O(V)-per-instruction linear scan in find_result_value).
+        let inst_to_value: FxHashMap<InstId, ValueId> = func
+            .values
+            .iter_enumerated()
+            .filter_map(|(vid, val)| {
+                if let Value::Inst(iid) = val { Some((*iid, vid)) } else { None }
+            })
+            .collect();
+
+        // Phase 4: Find all used values
         let used_values = self.collect_used_values(func);
 
-        // Phase 4: Find dead instructions
-        let dead_instructions = self.find_dead_instructions(func, &used_values);
+        // Phase 5: Find dead instructions
+        let dead_instructions = self.find_dead_instructions(func, &used_values, &inst_to_value);
 
         // Remove dead instructions from blocks
         for (block_id, inst_id) in &dead_instructions {
@@ -261,6 +271,7 @@ impl DeadCodeEliminator {
         &self,
         func: &Function,
         used_values: &FxHashSet<ValueId>,
+        inst_to_value: &FxHashMap<InstId, ValueId>,
     ) -> Vec<(BlockId, InstId)> {
         let mut dead = Vec::new();
 
@@ -268,37 +279,21 @@ impl DeadCodeEliminator {
             for &inst_id in &block.instructions {
                 let inst = &func.instructions[inst_id];
 
-                // Instructions with side effects are always kept
+                // Instructions with side effects are always kept.
                 if inst.kind.has_side_effects() {
                     continue;
                 }
 
-                // Find the result value for this instruction
-                let result_value = self.find_result_value(func, inst_id);
-
-                // If the instruction has a result and it's not used, mark as dead
-                if let Some(result) = result_value
-                    && !used_values.contains(&result)
-                {
-                    dead.push((block_id, inst_id));
+                // O(1) lookup via precomputed map (was O(V) linear scan).
+                if let Some(&result) = inst_to_value.get(&inst_id) {
+                    if !used_values.contains(&result) {
+                        dead.push((block_id, inst_id));
+                    }
                 }
             }
         }
 
         dead
-    }
-
-    /// Finds the ValueId that represents the result of an instruction.
-    fn find_result_value(&self, func: &Function, inst_id: InstId) -> Option<ValueId> {
-        // Search through values to find one that references this instruction
-        for (value_id, value) in func.values.iter_enumerated() {
-            if let Value::Inst(id) = value
-                && *id == inst_id
-            {
-                return Some(value_id);
-            }
-        }
-        None
     }
 }
 

--- a/crates/codegen/src/transform/mod.rs
+++ b/crates/codegen/src/transform/mod.rs
@@ -7,6 +7,7 @@ pub mod dce;
 pub mod inline;
 pub mod jump_threading;
 pub mod loop_opt;
+pub mod sccp;
 
 pub use cfg_simplify::{
     CallGraphAnalyzer, CfgSimplifier, CfgSimplifyStats, DeadFunctionEliminator, simplify_cfg,
@@ -20,3 +21,4 @@ pub use inline::{
 };
 pub use jump_threading::{JumpThreader, JumpThreadingStats};
 pub use loop_opt::{LoopOptConfig, LoopOptStats, LoopOptimizer};
+pub use sccp::{SccpPass, SccpStats};

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -14,9 +14,7 @@
 //! After reaching a fixed point, the rewrite phase replaces constant values
 //! with immediates and rewrites branches with known-constant conditions.
 
-use crate::mir::{
-    BasicBlock, BlockId, Function, Immediate, InstId, InstKind, Terminator, Value, ValueId,
-};
+use crate::mir::{BlockId, Function, Immediate, InstId, InstKind, Terminator, Value, ValueId};
 use alloy_primitives::U256;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
@@ -81,19 +79,17 @@ impl SccpPass {
         self.stats = SccpStats::default();
 
         let num_values = func.values.len();
-        let num_blocks = func.blocks.len();
+        let _num_blocks = func.blocks.len();
 
         // Precompute InstId → ValueId map.
         let inst_to_value: FxHashMap<InstId, ValueId> = func
             .values
             .iter_enumerated()
-            .filter_map(|(vid, val)| {
-                if let Value::Inst(iid) = val {
-                    Some((*iid, vid))
-                } else {
-                    None
-                }
-            })
+            .filter_map(
+                |(vid, val)| {
+                    if let Value::Inst(iid) = val { Some((*iid, vid)) } else { None }
+                },
+            )
             .collect();
 
         // Initialize lattice: all values start as Top.
@@ -208,8 +204,8 @@ impl SccpPass {
         block_id: BlockId,
         inst_to_value: &FxHashMap<InstId, ValueId>,
         lattice: &mut [LatticeValue],
-        executable_blocks: &FxHashSet<BlockId>,
-        executable_edges: &FxHashSet<(BlockId, BlockId)>,
+        _executable_blocks: &FxHashSet<BlockId>,
+        _executable_edges: &FxHashSet<(BlockId, BlockId)>,
         cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
     ) {
@@ -217,7 +213,8 @@ impl SccpPass {
 
         for &inst_id in &block.instructions {
             if let Some(&vid) = inst_to_value.get(&inst_id) {
-                let new_val = self.evaluate_instruction(func, &func.instructions[inst_id].kind, lattice);
+                let new_val =
+                    self.evaluate_instruction(func, &func.instructions[inst_id].kind, lattice);
                 if self.update_lattice(lattice, vid, new_val) {
                     ssa_worklist.push_back(vid);
                 }
@@ -243,8 +240,9 @@ impl SccpPass {
         for (vid, val) in func.values.iter_enumerated() {
             if let Value::Phi { incoming, .. } = val {
                 // Is this phi for this block? Check if any incoming pred targets this block.
-                let is_for_block =
-                    incoming.iter().any(|(pred, _)| func.blocks[*pred].successors.contains(&block_id));
+                let is_for_block = incoming
+                    .iter()
+                    .any(|(pred, _)| func.blocks[*pred].successors.contains(&block_id));
                 if !is_for_block {
                     continue;
                 }
@@ -292,7 +290,7 @@ impl SccpPass {
     /// Evaluates a single instruction and returns its lattice value.
     fn evaluate_instruction(
         &self,
-        func: &Function,
+        _func: &Function,
         kind: &InstKind,
         lattice: &[LatticeValue],
     ) -> LatticeValue {
@@ -306,7 +304,7 @@ impl SccpPass {
 
         // If any operand is Bottom, the result is Bottom (overdefined).
         // If any operand is Top, the result is Top (not yet known).
-        let check_operands = |operands: &[ValueId]| -> Option<()> {
+        let _check_operands = |operands: &[ValueId]| -> Option<()> {
             for &op in operands {
                 match &lattice[op.index()] {
                     LatticeValue::Bottom => return None, // Will be Bottom
@@ -455,12 +453,12 @@ impl SccpPass {
                         // Find the matching case.
                         let mut found = false;
                         for &(case_val, target) in cases {
-                            if let LatticeValue::Constant(cv) = &lattice[case_val.index()] {
-                                if cv == v {
-                                    cfg_worklist.push_back((block_id, target));
-                                    found = true;
-                                    break;
-                                }
+                            if let LatticeValue::Constant(cv) = &lattice[case_val.index()]
+                                && cv == v
+                            {
+                                cfg_worklist.push_back((block_id, target));
+                                found = true;
+                                break;
                             }
                         }
                         if !found {
@@ -513,7 +511,7 @@ impl SccpPass {
         inst_to_value: &FxHashMap<InstId, ValueId>,
         lattice: &mut [LatticeValue],
         executable_blocks: &FxHashSet<BlockId>,
-        executable_edges: &FxHashSet<(BlockId, BlockId)>,
+        _executable_edges: &FxHashSet<(BlockId, BlockId)>,
         cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
     ) {
@@ -526,13 +524,12 @@ impl SccpPass {
                 let inst = &func.instructions[inst_id];
                 let mut operands = Vec::new();
                 inst.kind.collect_operands(&mut operands);
-                if operands.contains(&vid) {
-                    if let Some(&result_vid) = inst_to_value.get(&inst_id) {
-                        let new_val =
-                            self.evaluate_instruction(func, &inst.kind, lattice);
-                        if self.update_lattice(lattice, result_vid, new_val) {
-                            ssa_worklist.push_back(result_vid);
-                        }
+                if operands.contains(&vid)
+                    && let Some(&result_vid) = inst_to_value.get(&inst_id)
+                {
+                    let new_val = self.evaluate_instruction(func, &inst.kind, lattice);
+                    if self.update_lattice(lattice, result_vid, new_val) {
+                        ssa_worklist.push_back(result_vid);
                     }
                 }
             }
@@ -583,11 +580,10 @@ impl SccpPass {
             }
             if let Some(Terminator::Branch { condition, then_block, else_block }) =
                 &func.blocks[block_id].terminator
+                && let LatticeValue::Constant(v) = &lattice[condition.index()]
             {
-                if let LatticeValue::Constant(v) = &lattice[condition.index()] {
-                    let target = if !v.is_zero() { *then_block } else { *else_block };
-                    branch_rewrites.push((block_id, target));
-                }
+                let target = if !v.is_zero() { *then_block } else { *else_block };
+                branch_rewrites.push((block_id, target));
             }
         }
 
@@ -880,10 +876,7 @@ mod tests {
         pass.run(&mut func);
         assert_eq!(pass.stats.branches_folded, 1);
         // Entry should now jump directly to then_bb.
-        assert!(matches!(
-            func.blocks[func.entry_block].terminator,
-            Some(Terminator::Jump(_))
-        ));
+        assert!(matches!(func.blocks[func.entry_block].terminator, Some(Terminator::Jump(_))));
     }
 
     #[test]

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -1,0 +1,912 @@
+//! Sparse Conditional Constant Propagation (SCCP).
+//!
+//! Implements the Wegman-Zadeck SCCP algorithm on MIR. This is more powerful
+//! than simple constant folding because it:
+//! - Propagates constants through the CFG using SSA def-use chains
+//! - Evaluates branch conditions to discover unreachable paths
+//! - Folds phi nodes when all executable incoming values agree
+//!
+//! The algorithm uses a three-valued lattice per SSA value:
+//! - **Top** (⊤): not yet evaluated
+//! - **Constant(v)**: known compile-time constant
+//! - **Bottom** (⊥): overdefined (not a constant)
+//!
+//! After reaching a fixed point, the rewrite phase replaces constant values
+//! with immediates and rewrites branches with known-constant conditions.
+
+use crate::mir::{
+    BasicBlock, BlockId, Function, Immediate, InstId, InstKind, Terminator, Value, ValueId,
+};
+use alloy_primitives::U256;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::VecDeque;
+
+/// Lattice element for a single SSA value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LatticeValue {
+    /// Not yet evaluated.
+    Top,
+    /// Known constant.
+    Constant(U256),
+    /// Overdefined — not a constant.
+    Bottom,
+}
+
+impl LatticeValue {
+    /// Meet operation: merges two lattice values.
+    /// Top ∧ x = x, Bottom ∧ x = Bottom, Const(a) ∧ Const(b) = if a==b Const(a) else Bottom.
+    fn meet(&self, other: &Self) -> Self {
+        match (self, other) {
+            (Self::Top, x) | (x, Self::Top) => x.clone(),
+            (Self::Bottom, _) | (_, Self::Bottom) => Self::Bottom,
+            (Self::Constant(a), Self::Constant(b)) => {
+                if a == b {
+                    Self::Constant(*a)
+                } else {
+                    Self::Bottom
+                }
+            }
+        }
+    }
+
+    fn is_constant(&self) -> bool {
+        matches!(self, Self::Constant(_))
+    }
+}
+
+/// SCCP statistics.
+#[derive(Debug, Default, Clone)]
+pub struct SccpStats {
+    /// Number of instructions replaced with constants.
+    pub constants_folded: usize,
+    /// Number of branches replaced with unconditional jumps.
+    pub branches_folded: usize,
+}
+
+/// Sparse Conditional Constant Propagation pass.
+#[derive(Debug, Default)]
+pub struct SccpPass {
+    /// Statistics from the last run.
+    pub stats: SccpStats,
+}
+
+impl SccpPass {
+    /// Creates a new SCCP pass.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Runs SCCP on a function. Returns total number of rewrites.
+    pub fn run(&mut self, func: &mut Function) -> usize {
+        self.stats = SccpStats::default();
+
+        let num_values = func.values.len();
+        let num_blocks = func.blocks.len();
+
+        // Precompute InstId → ValueId map.
+        let inst_to_value: FxHashMap<InstId, ValueId> = func
+            .values
+            .iter_enumerated()
+            .filter_map(|(vid, val)| {
+                if let Value::Inst(iid) = val {
+                    Some((*iid, vid))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Initialize lattice: all values start as Top.
+        let mut lattice: Vec<LatticeValue> = vec![LatticeValue::Top; num_values];
+
+        // Arguments are overdefined (we don't know their runtime values).
+        for (vid, val) in func.values.iter_enumerated() {
+            match val {
+                Value::Arg { .. } => lattice[vid.index()] = LatticeValue::Bottom,
+                Value::Immediate(imm) => {
+                    if let Some(v) = imm.as_u256() {
+                        lattice[vid.index()] = LatticeValue::Constant(v);
+                    } else {
+                        lattice[vid.index()] = LatticeValue::Bottom;
+                    }
+                }
+                Value::Undef(_) => lattice[vid.index()] = LatticeValue::Bottom,
+                Value::Phi { .. } | Value::Inst(_) => {} // stays Top
+            }
+        }
+
+        // Track which blocks are executable.
+        let mut executable_blocks: FxHashSet<BlockId> = FxHashSet::default();
+        // Track which CFG edges have been taken.
+        let mut executable_edges: FxHashSet<(BlockId, BlockId)> = FxHashSet::default();
+
+        // Two worklists.
+        let mut cfg_worklist: VecDeque<(BlockId, BlockId)> = VecDeque::new(); // (from, to) edges
+        let mut ssa_worklist: VecDeque<ValueId> = VecDeque::new();
+
+        // Seed: entry block is executable.
+        executable_blocks.insert(func.entry_block);
+        // Evaluate all instructions in the entry block.
+        self.evaluate_block(
+            func,
+            func.entry_block,
+            &inst_to_value,
+            &mut lattice,
+            &executable_blocks,
+            &executable_edges,
+            &mut cfg_worklist,
+            &mut ssa_worklist,
+        );
+
+        // Main loop: process both worklists until empty.
+        loop {
+            let mut made_progress = false;
+
+            // Process CFG edges.
+            while let Some((from, to)) = cfg_worklist.pop_front() {
+                if !executable_edges.insert((from, to)) {
+                    continue; // Already processed this edge.
+                }
+                made_progress = true;
+
+                let newly_executable = executable_blocks.insert(to);
+
+                // Re-evaluate phi-like values in the target block.
+                self.evaluate_phis_in_block(
+                    func,
+                    to,
+                    &mut lattice,
+                    &executable_edges,
+                    &mut ssa_worklist,
+                );
+
+                if newly_executable {
+                    // First time this block is executable — evaluate all its instructions.
+                    self.evaluate_block(
+                        func,
+                        to,
+                        &inst_to_value,
+                        &mut lattice,
+                        &executable_blocks,
+                        &executable_edges,
+                        &mut cfg_worklist,
+                        &mut ssa_worklist,
+                    );
+                }
+            }
+
+            // Process SSA value changes.
+            while let Some(vid) = ssa_worklist.pop_front() {
+                made_progress = true;
+                // Find all users of this value and re-evaluate them.
+                self.propagate_value(
+                    func,
+                    vid,
+                    &inst_to_value,
+                    &mut lattice,
+                    &executable_blocks,
+                    &executable_edges,
+                    &mut cfg_worklist,
+                    &mut ssa_worklist,
+                );
+            }
+
+            if !made_progress {
+                break;
+            }
+        }
+
+        // Rewrite phase: apply the lattice results to the function.
+        self.rewrite(func, &lattice, &inst_to_value, &executable_blocks)
+    }
+
+    /// Evaluates all instructions in a block.
+    #[allow(clippy::too_many_arguments)]
+    fn evaluate_block(
+        &self,
+        func: &Function,
+        block_id: BlockId,
+        inst_to_value: &FxHashMap<InstId, ValueId>,
+        lattice: &mut [LatticeValue],
+        executable_blocks: &FxHashSet<BlockId>,
+        executable_edges: &FxHashSet<(BlockId, BlockId)>,
+        cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
+        ssa_worklist: &mut VecDeque<ValueId>,
+    ) {
+        let block = &func.blocks[block_id];
+
+        for &inst_id in &block.instructions {
+            if let Some(&vid) = inst_to_value.get(&inst_id) {
+                let new_val = self.evaluate_instruction(func, &func.instructions[inst_id].kind, lattice);
+                if self.update_lattice(lattice, vid, new_val) {
+                    ssa_worklist.push_back(vid);
+                }
+            }
+        }
+
+        // Evaluate the terminator to determine outgoing edges.
+        if let Some(term) = &block.terminator {
+            self.evaluate_terminator(term, block_id, lattice, cfg_worklist);
+        }
+    }
+
+    /// Evaluates phi-like values (Value::Phi) at the entry of a block.
+    fn evaluate_phis_in_block(
+        &self,
+        func: &Function,
+        block_id: BlockId,
+        lattice: &mut [LatticeValue],
+        executable_edges: &FxHashSet<(BlockId, BlockId)>,
+        ssa_worklist: &mut VecDeque<ValueId>,
+    ) {
+        // Check Value::Phi entries that target this block.
+        for (vid, val) in func.values.iter_enumerated() {
+            if let Value::Phi { incoming, .. } = val {
+                // Is this phi for this block? Check if any incoming pred targets this block.
+                let is_for_block =
+                    incoming.iter().any(|(pred, _)| func.blocks[*pred].successors.contains(&block_id));
+                if !is_for_block {
+                    continue;
+                }
+
+                // Meet over all executable incoming edges.
+                let mut result = LatticeValue::Top;
+                for &(pred, operand) in incoming {
+                    if executable_edges.contains(&(pred, block_id)) {
+                        result = result.meet(&lattice[operand.index()]);
+                    }
+                }
+                if self.update_lattice(lattice, vid, result) {
+                    ssa_worklist.push_back(vid);
+                }
+            }
+        }
+
+        // Also check InstKind::Phi instructions in the block.
+        // Build a local inst→value map for this block's phis only.
+        let block = &func.blocks[block_id];
+        for &inst_id in &block.instructions {
+            let inst = &func.instructions[inst_id];
+            if let InstKind::Phi(incoming) = &inst.kind {
+                // Find the ValueId for this instruction.
+                let vid = func
+                    .values
+                    .iter_enumerated()
+                    .find(|(_, v)| matches!(v, Value::Inst(id) if *id == inst_id))
+                    .map(|(vid, _)| vid);
+                if let Some(vid) = vid {
+                    let mut result = LatticeValue::Top;
+                    for &(pred, operand) in incoming {
+                        if executable_edges.contains(&(pred, block_id)) {
+                            result = result.meet(&lattice[operand.index()]);
+                        }
+                    }
+                    if self.update_lattice(lattice, vid, result) {
+                        ssa_worklist.push_back(vid);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Evaluates a single instruction and returns its lattice value.
+    fn evaluate_instruction(
+        &self,
+        func: &Function,
+        kind: &InstKind,
+        lattice: &[LatticeValue],
+    ) -> LatticeValue {
+        // Helper: get the constant value of a ValueId, or None if not constant.
+        let get_const = |v: ValueId| -> Option<U256> {
+            match &lattice[v.index()] {
+                LatticeValue::Constant(c) => Some(*c),
+                _ => None,
+            }
+        };
+
+        // If any operand is Bottom, the result is Bottom (overdefined).
+        // If any operand is Top, the result is Top (not yet known).
+        let check_operands = |operands: &[ValueId]| -> Option<()> {
+            for &op in operands {
+                match &lattice[op.index()] {
+                    LatticeValue::Bottom => return None, // Will be Bottom
+                    LatticeValue::Top => return None,    // Wait for more info
+                    LatticeValue::Constant(_) => {}
+                }
+            }
+            Some(())
+        };
+
+        match kind {
+            // Arithmetic — fold if both operands are constant.
+            InstKind::Add(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(a.wrapping_add(b)),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Sub(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(a.wrapping_sub(b)),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Mul(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(a.wrapping_mul(b)),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Div(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(_), Some(b)) if b.is_zero() => LatticeValue::Constant(U256::ZERO),
+                (Some(a), Some(b)) => LatticeValue::Constant(a / b),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Mod(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(_), Some(b)) if b.is_zero() => LatticeValue::Constant(U256::ZERO),
+                (Some(a), Some(b)) => LatticeValue::Constant(a % b),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Exp(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(base), Some(exp)) => {
+                    // Use wrapping exponentiation.
+                    LatticeValue::Constant(base.wrapping_pow(exp))
+                }
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+
+            // Comparison — fold to bool (0 or 1).
+            InstKind::Lt(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(U256::from(a < b)),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Gt(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(U256::from(a > b)),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Eq(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(U256::from(a == b)),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::IsZero(a) => match get_const(*a) {
+                Some(a) => LatticeValue::Constant(U256::from(a.is_zero())),
+                None => self.check_any_bottom(&[*a], lattice),
+            },
+
+            // Bitwise.
+            InstKind::And(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(a & b),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Or(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(a | b),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Xor(a, b) => match (get_const(*a), get_const(*b)) {
+                (Some(a), Some(b)) => LatticeValue::Constant(a ^ b),
+                _ => self.check_any_bottom(&[*a, *b], lattice),
+            },
+            InstKind::Not(a) => match get_const(*a) {
+                Some(a) => LatticeValue::Constant(!a),
+                None => self.check_any_bottom(&[*a], lattice),
+            },
+            InstKind::Shl(shift, val) => match (get_const(*shift), get_const(*val)) {
+                (Some(s), Some(v)) => {
+                    if s >= U256::from(256) {
+                        LatticeValue::Constant(U256::ZERO)
+                    } else {
+                        LatticeValue::Constant(v << s.to::<usize>())
+                    }
+                }
+                _ => self.check_any_bottom(&[*shift, *val], lattice),
+            },
+            InstKind::Shr(shift, val) => match (get_const(*shift), get_const(*val)) {
+                (Some(s), Some(v)) => {
+                    if s >= U256::from(256) {
+                        LatticeValue::Constant(U256::ZERO)
+                    } else {
+                        LatticeValue::Constant(v >> s.to::<usize>())
+                    }
+                }
+                _ => self.check_any_bottom(&[*shift, *val], lattice),
+            },
+
+            // Everything else (memory, storage, calls, environment, etc.) is
+            // conservatively overdefined — we can't evaluate them at compile time.
+            _ => LatticeValue::Bottom,
+        }
+    }
+
+    /// Helper: if any operand is Bottom, return Bottom; otherwise Top (still waiting).
+    fn check_any_bottom(&self, operands: &[ValueId], lattice: &[LatticeValue]) -> LatticeValue {
+        for &op in operands {
+            if matches!(lattice[op.index()], LatticeValue::Bottom) {
+                return LatticeValue::Bottom;
+            }
+        }
+        LatticeValue::Top
+    }
+
+    /// Evaluates a terminator to determine which outgoing edges are taken.
+    fn evaluate_terminator(
+        &self,
+        term: &Terminator,
+        block_id: BlockId,
+        lattice: &[LatticeValue],
+        cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
+    ) {
+        match term {
+            Terminator::Jump(target) => {
+                cfg_worklist.push_back((block_id, *target));
+            }
+            Terminator::Branch { condition, then_block, else_block } => {
+                match &lattice[condition.index()] {
+                    LatticeValue::Constant(v) => {
+                        if !v.is_zero() {
+                            cfg_worklist.push_back((block_id, *then_block));
+                        } else {
+                            cfg_worklist.push_back((block_id, *else_block));
+                        }
+                    }
+                    _ => {
+                        // Both edges might be taken.
+                        cfg_worklist.push_back((block_id, *then_block));
+                        cfg_worklist.push_back((block_id, *else_block));
+                    }
+                }
+            }
+            Terminator::Switch { value, default, cases } => {
+                match &lattice[value.index()] {
+                    LatticeValue::Constant(v) => {
+                        // Find the matching case.
+                        let mut found = false;
+                        for &(case_val, target) in cases {
+                            if let LatticeValue::Constant(cv) = &lattice[case_val.index()] {
+                                if cv == v {
+                                    cfg_worklist.push_back((block_id, target));
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if !found {
+                            cfg_worklist.push_back((block_id, *default));
+                        }
+                    }
+                    _ => {
+                        // All edges might be taken.
+                        cfg_worklist.push_back((block_id, *default));
+                        for &(_, target) in cases {
+                            cfg_worklist.push_back((block_id, target));
+                        }
+                    }
+                }
+            }
+            Terminator::Return { .. }
+            | Terminator::Revert { .. }
+            | Terminator::Stop
+            | Terminator::SelfDestruct { .. }
+            | Terminator::Invalid => {
+                // No outgoing edges.
+            }
+        }
+    }
+
+    /// Updates the lattice value for a ValueId. Returns true if it changed.
+    /// Lattice values can only move downward: Top → Constant → Bottom.
+    fn update_lattice(
+        &self,
+        lattice: &mut [LatticeValue],
+        vid: ValueId,
+        new_val: LatticeValue,
+    ) -> bool {
+        let old = &lattice[vid.index()];
+        let merged = old.meet(&new_val);
+        if merged != *old {
+            lattice[vid.index()] = merged;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Propagates a value change to all users of that value.
+    #[allow(clippy::too_many_arguments)]
+    fn propagate_value(
+        &self,
+        func: &Function,
+        vid: ValueId,
+        inst_to_value: &FxHashMap<InstId, ValueId>,
+        lattice: &mut [LatticeValue],
+        executable_blocks: &FxHashSet<BlockId>,
+        executable_edges: &FxHashSet<(BlockId, BlockId)>,
+        cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
+        ssa_worklist: &mut VecDeque<ValueId>,
+    ) {
+        // Find all instructions that use this value and re-evaluate them.
+        for (block_id, block) in func.blocks.iter_enumerated() {
+            if !executable_blocks.contains(&block_id) {
+                continue;
+            }
+            for &inst_id in &block.instructions {
+                let inst = &func.instructions[inst_id];
+                let mut operands = Vec::new();
+                inst.kind.collect_operands(&mut operands);
+                if operands.contains(&vid) {
+                    if let Some(&result_vid) = inst_to_value.get(&inst_id) {
+                        let new_val =
+                            self.evaluate_instruction(func, &inst.kind, lattice);
+                        if self.update_lattice(lattice, result_vid, new_val) {
+                            ssa_worklist.push_back(result_vid);
+                        }
+                    }
+                }
+            }
+            // Re-evaluate terminators that use this value.
+            if let Some(term) = &block.terminator {
+                let term_ops = term.operands();
+                if term_ops.contains(&vid) {
+                    self.evaluate_terminator(term, block_id, lattice, cfg_worklist);
+                }
+            }
+        }
+    }
+
+    /// Rewrite phase: replace constant values with immediates and fold branches.
+    fn rewrite(
+        &mut self,
+        func: &mut Function,
+        lattice: &[LatticeValue],
+        inst_to_value: &FxHashMap<InstId, ValueId>,
+        executable_blocks: &FxHashSet<BlockId>,
+    ) -> usize {
+        // Phase 1: Replace instructions whose results are constant with
+        // immediate values, and remove the instruction from the block.
+        let mut const_values: FxHashMap<ValueId, ValueId> = FxHashMap::default();
+        let mut dead_insts: FxHashSet<InstId> = FxHashSet::default();
+
+        for (&inst_id, &vid) in inst_to_value {
+            if let LatticeValue::Constant(c) = &lattice[vid.index()] {
+                // Don't fold side-effecting instructions.
+                if func.instructions[inst_id].kind.has_side_effects() {
+                    continue;
+                }
+                // Create an immediate replacement.
+                let imm_vid = func.alloc_value(Value::Immediate(Immediate::uint256(*c)));
+                const_values.insert(vid, imm_vid);
+                dead_insts.insert(inst_id);
+                self.stats.constants_folded += 1;
+            }
+        }
+
+        // Phase 2: Collect branch rewrites BEFORE operand replacement, because
+        // replacement may allocate new ValueIds that don't have lattice entries.
+        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let mut branch_rewrites: Vec<(BlockId, BlockId)> = Vec::new();
+        for &block_id in &block_ids {
+            if !executable_blocks.contains(&block_id) {
+                continue;
+            }
+            if let Some(Terminator::Branch { condition, then_block, else_block }) =
+                &func.blocks[block_id].terminator
+            {
+                if let LatticeValue::Constant(v) = &lattice[condition.index()] {
+                    let target = if !v.is_zero() { *then_block } else { *else_block };
+                    branch_rewrites.push((block_id, target));
+                }
+            }
+        }
+
+        // Phase 3: Replace all uses of folded values with immediates.
+        if !const_values.is_empty() {
+            let all_insts: Vec<InstId> = func
+                .blocks
+                .iter()
+                .flat_map(|block| block.instructions.iter().copied())
+                .filter(|id| !dead_insts.contains(id))
+                .collect();
+            for inst_id in all_insts {
+                replace_inst_operands(&mut func.instructions[inst_id].kind, &const_values);
+            }
+            for &block_id in &block_ids {
+                if let Some(term) = &mut func.blocks[block_id].terminator {
+                    replace_terminator_operands(term, &const_values);
+                }
+            }
+        }
+
+        // Phase 4: Remove dead (folded) instructions from blocks.
+        for &block_id in &block_ids {
+            func.blocks[block_id].instructions.retain(|id| !dead_insts.contains(id));
+        }
+
+        // Phase 5: Apply branch rewrites.
+        for (block_id, target) in branch_rewrites {
+            func.blocks[block_id].terminator = Some(Terminator::Jump(target));
+            func.blocks[block_id].successors.clear();
+            func.blocks[block_id].successors.push(target);
+            self.stats.branches_folded += 1;
+        }
+
+        // Phase 5: Mark non-executable blocks as invalid.
+        for &block_id in &block_ids {
+            if !executable_blocks.contains(&block_id) {
+                func.blocks[block_id].instructions.clear();
+                func.blocks[block_id].terminator = Some(Terminator::Invalid);
+                func.blocks[block_id].predecessors.clear();
+                func.blocks[block_id].successors.clear();
+            }
+        }
+
+        self.stats.constants_folded + self.stats.branches_folded
+    }
+}
+
+/// Replace operands in an instruction kind with constant replacements.
+fn replace_inst_operands(kind: &mut InstKind, replacements: &FxHashMap<ValueId, ValueId>) {
+    let replace = |v: &mut ValueId| {
+        if let Some(&new_v) = replacements.get(v) {
+            *v = new_v;
+        }
+    };
+
+    // We reuse the same exhaustive match pattern from CSE.
+    match kind {
+        InstKind::Add(a, b)
+        | InstKind::Sub(a, b)
+        | InstKind::Mul(a, b)
+        | InstKind::Div(a, b)
+        | InstKind::SDiv(a, b)
+        | InstKind::Mod(a, b)
+        | InstKind::SMod(a, b)
+        | InstKind::Exp(a, b)
+        | InstKind::And(a, b)
+        | InstKind::Or(a, b)
+        | InstKind::Xor(a, b)
+        | InstKind::Shl(a, b)
+        | InstKind::Shr(a, b)
+        | InstKind::Sar(a, b)
+        | InstKind::Byte(a, b)
+        | InstKind::Lt(a, b)
+        | InstKind::Gt(a, b)
+        | InstKind::SLt(a, b)
+        | InstKind::SGt(a, b)
+        | InstKind::Eq(a, b)
+        | InstKind::MStore(a, b)
+        | InstKind::MStore8(a, b)
+        | InstKind::SStore(a, b)
+        | InstKind::TStore(a, b)
+        | InstKind::Keccak256(a, b)
+        | InstKind::Log0(a, b)
+        | InstKind::SignExtend(a, b) => {
+            replace(a);
+            replace(b);
+        }
+        InstKind::Not(a)
+        | InstKind::IsZero(a)
+        | InstKind::MLoad(a)
+        | InstKind::SLoad(a)
+        | InstKind::TLoad(a)
+        | InstKind::CalldataLoad(a)
+        | InstKind::ExtCodeSize(a)
+        | InstKind::ExtCodeHash(a)
+        | InstKind::Balance(a)
+        | InstKind::BlockHash(a)
+        | InstKind::BlobHash(a) => {
+            replace(a);
+        }
+        InstKind::AddMod(a, b, c)
+        | InstKind::MulMod(a, b, c)
+        | InstKind::MCopy(a, b, c)
+        | InstKind::CalldataCopy(a, b, c)
+        | InstKind::CodeCopy(a, b, c)
+        | InstKind::ReturnDataCopy(a, b, c)
+        | InstKind::Create(a, b, c)
+        | InstKind::Log1(a, b, c)
+        | InstKind::Select(a, b, c) => {
+            replace(a);
+            replace(b);
+            replace(c);
+        }
+        InstKind::ExtCodeCopy(a, b, c, d)
+        | InstKind::Create2(a, b, c, d)
+        | InstKind::Log2(a, b, c, d) => {
+            replace(a);
+            replace(b);
+            replace(c);
+            replace(d);
+        }
+        InstKind::Log3(a, b, c, d, e) => {
+            replace(a);
+            replace(b);
+            replace(c);
+            replace(d);
+            replace(e);
+        }
+        InstKind::Log4(a, b, c, d, e, f) => {
+            replace(a);
+            replace(b);
+            replace(c);
+            replace(d);
+            replace(e);
+            replace(f);
+        }
+        InstKind::Call { gas, addr, value, args_offset, args_size, ret_offset, ret_size } => {
+            replace(gas);
+            replace(addr);
+            replace(value);
+            replace(args_offset);
+            replace(args_size);
+            replace(ret_offset);
+            replace(ret_size);
+        }
+        InstKind::StaticCall { gas, addr, args_offset, args_size, ret_offset, ret_size }
+        | InstKind::DelegateCall { gas, addr, args_offset, args_size, ret_offset, ret_size } => {
+            replace(gas);
+            replace(addr);
+            replace(args_offset);
+            replace(args_size);
+            replace(ret_offset);
+            replace(ret_size);
+        }
+        InstKind::Phi(incoming) => {
+            for (_, v) in incoming {
+                replace(v);
+            }
+        }
+        // Nullary instructions have no operands.
+        InstKind::MSize
+        | InstKind::CalldataSize
+        | InstKind::CodeSize
+        | InstKind::ReturnDataSize
+        | InstKind::Caller
+        | InstKind::CallValue
+        | InstKind::Origin
+        | InstKind::GasPrice
+        | InstKind::Coinbase
+        | InstKind::Timestamp
+        | InstKind::BlockNumber
+        | InstKind::PrevRandao
+        | InstKind::GasLimit
+        | InstKind::ChainId
+        | InstKind::Address
+        | InstKind::SelfBalance
+        | InstKind::Gas
+        | InstKind::BaseFee
+        | InstKind::BlobBaseFee => {}
+    }
+}
+
+/// Replace operands in a terminator.
+fn replace_terminator_operands(term: &mut Terminator, replacements: &FxHashMap<ValueId, ValueId>) {
+    let replace = |v: &mut ValueId| {
+        if let Some(&new_v) = replacements.get(v) {
+            *v = new_v;
+        }
+    };
+    match term {
+        Terminator::Jump(_) | Terminator::Stop | Terminator::Invalid => {}
+        Terminator::Branch { condition, .. } => replace(condition),
+        Terminator::Switch { value, cases, .. } => {
+            replace(value);
+            for (v, _) in cases {
+                replace(v);
+            }
+        }
+        Terminator::Return { values } => {
+            for v in values {
+                replace(v);
+            }
+        }
+        Terminator::Revert { offset, size } => {
+            replace(offset);
+            replace(size);
+        }
+        Terminator::SelfDestruct { recipient } => replace(recipient),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mir::{FunctionBuilder, MirType};
+    use solar_interface::Ident;
+
+    fn make_func() -> Function {
+        Function::new(Ident::DUMMY)
+    }
+
+    #[test]
+    fn fold_constant_arithmetic() {
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            // v0 = 10, v1 = 20, v2 = add(10, 20) → should become 30
+            let a = b.imm_u64(10);
+            let c = b.imm_u64(20);
+            let sum = b.add(a, c);
+            b.ret([sum]);
+        }
+        let mut pass = SccpPass::new();
+        pass.run(&mut func);
+        assert!(pass.stats.constants_folded > 0, "should fold constant add");
+    }
+
+    #[test]
+    fn fold_constant_chain() {
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let a = b.imm_u64(3);
+            let c = b.imm_u64(4);
+            let sum = b.add(a, c); // 7
+            let d = b.imm_u64(2);
+            let product = b.mul(sum, d); // 14
+            b.ret([product]);
+        }
+        let mut pass = SccpPass::new();
+        pass.run(&mut func);
+        assert!(pass.stats.constants_folded >= 2, "should fold entire chain");
+    }
+
+    #[test]
+    fn no_fold_with_argument() {
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let x = b.add_param(MirType::uint256());
+            let one = b.imm_u64(1);
+            let sum = b.add(x, one); // can't fold — x is unknown
+            b.ret([sum]);
+        }
+        let mut pass = SccpPass::new();
+        pass.run(&mut func);
+        assert_eq!(pass.stats.constants_folded, 0);
+    }
+
+    #[test]
+    fn fold_branch_condition() {
+        let mut func = make_func();
+        let then_bb;
+        let else_bb;
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let t = b.imm_bool(true);
+            then_bb = b.create_block();
+            else_bb = b.create_block();
+            b.branch(t, then_bb, else_bb);
+
+            b.switch_to_block(then_bb);
+            b.stop();
+
+            b.switch_to_block(else_bb);
+            b.stop();
+        }
+        let mut pass = SccpPass::new();
+        pass.run(&mut func);
+        assert_eq!(pass.stats.branches_folded, 1);
+        // Entry should now jump directly to then_bb.
+        assert!(matches!(
+            func.blocks[func.entry_block].terminator,
+            Some(Terminator::Jump(_))
+        ));
+    }
+
+    #[test]
+    fn fold_comparison_then_branch() {
+        let mut func = make_func();
+        {
+            let mut b = FunctionBuilder::new(&mut func);
+            let a = b.imm_u64(5);
+            let c = b.imm_u64(10);
+            let cond = b.lt(a, c); // true
+            let then_bb = b.create_block();
+            let else_bb = b.create_block();
+            b.branch(cond, then_bb, else_bb);
+
+            b.switch_to_block(then_bb);
+            b.stop();
+            b.switch_to_block(else_bb);
+            b.stop();
+        }
+        let mut pass = SccpPass::new();
+        pass.run(&mut func);
+        // lt(5, 10) = true → branch folded + lt folded.
+        assert!(pass.stats.constants_folded > 0);
+        assert_eq!(pass.stats.branches_folded, 1);
+    }
+}

--- a/crates/codegen/tests/round_trip.rs
+++ b/crates/codegen/tests/round_trip.rs
@@ -18,6 +18,7 @@
 #![allow(unused_crate_dependencies)]
 
 use solar_codegen::{
+    analysis::validate_module,
     lower,
     mir::{module_to_text, parse_module},
 };
@@ -74,6 +75,74 @@ fn round_trip_all_sol_files() {
         failures.len(),
         failures.join("\n  ")
     );
+}
+
+#[test]
+fn validate_all_lowered_sol_modules() {
+    // Sanity check: every .sol fixture under tests/ui/codegen/ should
+    // lower to well-formed MIR (the validator finds zero errors).
+    let dir = ui_codegen_dir();
+    let mut failures: Vec<String> = Vec::new();
+    let mut count = 0usize;
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|s| s.to_str()) != Some("sol") {
+            continue;
+        }
+        count += 1;
+        if let Err(e) = validate_sol(&path) {
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+    assert!(count > 0, "no .sol fixtures found");
+    assert!(
+        failures.is_empty(),
+        "{} validation failure(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+fn validate_sol(path: &Path) -> Result<(), String> {
+    let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+    let mut compiler = Compiler::new(sess);
+
+    let parse_result = compiler.enter_mut(|c| -> solar_interface::Result<()> {
+        let mut pcx = c.parse();
+        pcx.load_files([path])?;
+        pcx.parse();
+        Ok(())
+    });
+    if parse_result.is_err() {
+        return Err("parse failed".into());
+    }
+
+    let mut result: Result<(), String> = Ok(());
+    let _ = compiler.enter_mut(|c| -> solar_interface::Result<()> {
+        let ControlFlow::Continue(()) = c.lower_asts()? else { return Ok(()) };
+        let ControlFlow::Continue(()) = c.analysis()? else { return Ok(()) };
+        let gcx = c.gcx();
+        for id in gcx.hir.contract_ids() {
+            let contract = gcx.hir.contract(id);
+            if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
+                continue;
+            }
+            let module = lower::lower_contract(gcx, id);
+            let errors = validate_module(&module);
+            if !errors.is_empty() {
+                result = Err(format!(
+                    "contract `{}` has {} validation error(s):\n    {}",
+                    contract.name,
+                    errors.len(),
+                    errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join("\n    ")
+                ));
+                return Ok(());
+            }
+        }
+        Ok(())
+    });
+    result
 }
 
 #[test]
@@ -147,6 +216,8 @@ fn round_trip_sol(path: &Path) -> Result<(), String> {
 
 /// Round-trips one `.mir` file. Skips the lowering step.
 fn round_trip_mir(path: &Path) -> Result<(), String> {
+    // Tests don't need a SourceMap; reading a fixture as plain text is fine.
+    #[allow(clippy::disallowed_methods)]
     let raw = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
     // Strip `//@compile-flags:` annotations the test harness reads — they're
     // not valid MIR and the parser would treat them as comments anyway, but

--- a/crates/codegen/tests/round_trip.rs
+++ b/crates/codegen/tests/round_trip.rs
@@ -1,0 +1,206 @@
+//! Property tests verifying that the MIR printer/parser pair is self-consistent.
+//!
+//! For each fixture under `tests/ui/codegen/`:
+//! 1. Obtain a `Module` (either by lowering Solidity or by parsing `.mir` text).
+//! 2. Print it (`print1`).
+//! 3. Parse `print1` (`parsed1`).
+//! 4. Print `parsed1` (`print2`).
+//! 5. Parse `print2` (`parsed2`).
+//! 6. Print `parsed2` (`print3`).
+//! 7. Assert `print2 == print3` — i.e., the parser+printer pair is **idempotent**.
+//!
+//! Why not assert `print1 == print2`? The first parse allocates immediates as
+//! `Value::Immediate` entries before allocating instruction results, which can
+//! shift the `vN` numbering relative to the original lowered MIR. After one
+//! round-trip the value numbers correspond directly to actual `ValueId`s, so
+//! a *second* round-trip is stable.
+
+#![allow(unused_crate_dependencies)]
+
+use solar_codegen::{
+    lower,
+    mir::{module_to_text, parse_module},
+};
+use solar_interface::{ColorChoice, Session};
+use solar_sema::Compiler;
+use std::{
+    ops::ControlFlow,
+    path::{Path, PathBuf},
+};
+
+/// Path to `tests/ui/codegen/` (the workspace's UI test directory).
+fn ui_codegen_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("ui")
+        .join("codegen")
+}
+
+/// Returns the (line index, line A, line B) of the first divergence between
+/// two strings, or `None` if they're equal. Used to keep failure messages
+/// readable when the printed MIR is large.
+fn first_diff<'a>(a: &'a str, b: &'a str) -> Option<(usize, &'a str, &'a str)> {
+    a.lines()
+        .zip(b.lines())
+        .enumerate()
+        .find(|(_, (la, lb))| la != lb)
+        .map(|(i, (la, lb))| (i + 1, la, lb))
+}
+
+#[test]
+fn round_trip_all_sol_files() {
+    let dir = ui_codegen_dir();
+    assert!(dir.exists(), "ui codegen dir not found: {}", dir.display());
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut count = 0usize;
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|s| s.to_str()) != Some("sol") {
+            continue;
+        }
+        count += 1;
+        if let Err(e) = round_trip_sol(&path) {
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+    assert!(count > 0, "no .sol fixtures found in {}", dir.display());
+    assert!(
+        failures.is_empty(),
+        "{} round-trip failure(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+#[test]
+fn round_trip_all_mir_files() {
+    let dir = ui_codegen_dir().join("mir");
+    assert!(dir.exists(), "mir test dir not found: {}", dir.display());
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut count = 0usize;
+    for entry in std::fs::read_dir(&dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|s| s.to_str()) != Some("mir") {
+            continue;
+        }
+        count += 1;
+        if let Err(e) = round_trip_mir(&path) {
+            let name = path.file_name().unwrap().to_string_lossy().into_owned();
+            failures.push(format!("{name}: {e}"));
+        }
+    }
+    assert!(count > 0, "no .mir fixtures found in {}", dir.display());
+    assert!(
+        failures.is_empty(),
+        "{} round-trip failure(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+/// Round-trips one Solidity file: lower → print → parse → print → parse → print
+/// and asserts the last two prints match.
+fn round_trip_sol(path: &Path) -> Result<(), String> {
+    let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+    let mut compiler = Compiler::new(sess);
+
+    let parse_result = compiler.enter_mut(|c| -> solar_interface::Result<()> {
+        let mut pcx = c.parse();
+        pcx.load_files([path])?;
+        pcx.parse();
+        Ok(())
+    });
+    if parse_result.is_err() {
+        return Err("parse failed".into());
+    }
+
+    let mut result: Result<(), String> = Ok(());
+    let _ = compiler.enter_mut(|c| -> solar_interface::Result<()> {
+        let ControlFlow::Continue(()) = c.lower_asts()? else {
+            return Ok(());
+        };
+        let ControlFlow::Continue(()) = c.analysis()? else {
+            return Ok(());
+        };
+
+        let gcx = c.gcx();
+        for id in gcx.hir.contract_ids() {
+            let contract = gcx.hir.contract(id);
+            if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
+                continue;
+            }
+            let module = lower::lower_contract(gcx, id);
+            if let Err(e) = check_round_trip_module(&module) {
+                result = Err(format!("contract `{}`: {e}", contract.name));
+                return Ok(());
+            }
+        }
+        Ok(())
+    });
+    result
+}
+
+/// Round-trips one `.mir` file. Skips the lowering step.
+fn round_trip_mir(path: &Path) -> Result<(), String> {
+    let raw = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    // Strip `//@compile-flags:` annotations the test harness reads — they're
+    // not valid MIR and the parser would treat them as comments anyway, but
+    // be explicit so we don't accidentally rely on parser behavior.
+    let text: String = raw.lines().filter(|l| !l.starts_with("//@")).collect::<Vec<_>>().join("\n");
+
+    let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+    let mut result: Result<(), String> = Ok(());
+    sess.enter(|| {
+        let parsed1 = match parse_module(&text) {
+            Ok(m) => m,
+            Err(e) => {
+                result = Err(format!("first parse failed: {e}"));
+                return;
+            }
+        };
+        let print1 = module_to_text(&parsed1);
+        let parsed2 = match parse_module(&print1) {
+            Ok(m) => m,
+            Err(e) => {
+                result = Err(format!("second parse failed: {e}"));
+                return;
+            }
+        };
+        let print2 = module_to_text(&parsed2);
+        if print1 != print2 {
+            let diff = first_diff(&print1, &print2)
+                .map(|(i, a, b)| format!("line {i}: `{a}` vs `{b}`"))
+                .unwrap_or_else(|| "(length mismatch)".to_string());
+            result = Err(format!("not idempotent: {diff}"));
+        }
+    });
+    result
+}
+
+/// Common idempotency check: print → parse → print → parse → print, last two
+/// must match. Caller must already be inside an active `Session::enter`.
+fn check_round_trip_module(module: &solar_codegen::mir::Module) -> Result<(), String> {
+    let print1 = module_to_text(module);
+    let parsed1 =
+        parse_module(&print1).map_err(|e| format!("first parse: {e}\n--- print1 ---\n{print1}"))?;
+    let print2 = module_to_text(&parsed1);
+    let parsed2 = parse_module(&print2).map_err(|e| {
+        format!("second parse: {e}\n--- print1 ---\n{print1}\n--- print2 ---\n{print2}")
+    })?;
+    let print3 = module_to_text(&parsed2);
+
+    if print2 != print3 {
+        let diff = first_diff(&print2, &print3)
+            .map(|(i, a, b)| format!("line {i}: `{a}` vs `{b}`"))
+            .unwrap_or_else(|| "(length mismatch)".to_string());
+        return Err(format!(
+            "not idempotent: {diff}\n--- print2 ---\n{print2}\n--- print3 ---\n{print3}"
+        ));
+    }
+    Ok(())
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -152,6 +152,8 @@ str_enum! {
         BinRuntime,
         /// Function signature hashes.
         Hashes,
+        /// Textual MIR (mid-level IR) for inspection and FileCheck-style tests.
+        Mir,
     }
 }
 

--- a/crates/sema/src/emit.rs
+++ b/crates/sema/src/emit.rs
@@ -26,6 +26,19 @@ type Abi = Vec<alloy_json_abi::AbiItem<'static>>;
 type Hashes = BTreeMap<String, String>;
 
 pub(crate) fn emit(gcx: Gcx<'_>) {
+    // Skip JSON emission entirely if none of the requested outputs are
+    // sema-level outputs (Abi, Hashes). Other outputs (Bin/BinRuntime/Mir)
+    // are produced by the cli/codegen layer.
+    let needs_sema_emit = gcx
+        .sess
+        .opts
+        .emit
+        .iter()
+        .any(|e| matches!(e, CompilerOutput::Abi | CompilerOutput::Hashes));
+    if !needs_sema_emit {
+        return;
+    }
+
     let mut output = CombinedJson {
         contracts: Default::default(),
         version: solar_interface::config::version::SEMVER_VERSION,
@@ -46,7 +59,10 @@ pub(crate) fn emit(gcx: Gcx<'_>) {
                     }
                     contract_output.hashes = Some(hashes);
                 }
-                emit => todo!("{emit:?}"),
+                // Bytecode and MIR are handled by the cli/codegen layer
+                // (after analysis), not by sema's emit step.
+                CompilerOutput::Bin | CompilerOutput::BinRuntime | CompilerOutput::Mir => {}
+                _ => {}
             }
         }
     }

--- a/crates/solar/tests.rs
+++ b/crates/solar/tests.rs
@@ -1,7 +1,35 @@
 #![allow(unused_crate_dependencies)]
 
+use std::{
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
+
 const CMD: &str = env!("CARGO_BIN_EXE_solar");
 
+/// Locate the `solar-mir-opt` binary at runtime.
+///
+/// `CARGO_BIN_EXE_<name>` only works for binaries in the same crate, so we
+/// can't use it directly here. Instead we derive the path from the test
+/// binary's own location:
+///   `target/<profile>/deps/<test>` → `target/<profile>/solar-mir-opt`
+///
+/// If the binary isn't built, returns `None` and `Mode::Mir` is skipped.
+fn mir_opt_path() -> Option<&'static Path> {
+    static CACHE: OnceLock<Option<PathBuf>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let mut path = std::env::current_exe().ok()?;
+            path.pop(); // remove test binary name
+            if path.file_name().and_then(|s| s.to_str()) == Some("deps") {
+                path.pop(); // remove "deps"
+            }
+            path.push(if cfg!(windows) { "solar-mir-opt.exe" } else { "solar-mir-opt" });
+            path.exists().then_some(path)
+        })
+        .as_deref()
+}
+
 fn main() -> impl std::process::Termination {
-    solar_tester::run_tests(CMD.as_ref())
+    solar_tester::run_tests(CMD.as_ref(), mir_opt_path())
 }

--- a/tests/ui/cli/help.long.stdout
+++ b/tests/ui/cli/help.long.stdout
@@ -34,7 +34,7 @@ Options:
       --emit <EMIT>
           Comma separated list of types of output for the compiler to emit
           
-          [possible values: abi, bin, bin-runtime, hashes]
+          [possible values: abi, bin, bin-runtime, hashes, mir]
 
       --standard-json
           Switch to Standard JSON input / output mode. Reads a JSON object from stdin, compiles, and outputs a JSON object to stdout. This is compatible with solc's --standard-json mode for use with tools like Foundry

--- a/tests/ui/cli/help.short.stdout
+++ b/tests/ui/cli/help.short.stdout
@@ -10,7 +10,7 @@ Options:
       --evm-version <EVM_VERSION>  EVM version [default: prague] [possible values: homestead, tangerineWhistle, spuriousDragon, byzantium, constantinople, petersburg, istanbul, berlin, london, paris, shanghai, cancun, prague, osaka]
       --stop-after <STOP_AFTER>    Stop execution after the given compiler stage [possible values: parsing, lowering, analysis]
       --out-dir <OUT_DIR>          Directory to write output files
-      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, hashes]
+      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, hashes, mir]
       --standard-json              Switch to Standard JSON input / output mode. Reads a JSON object from stdin, compiles, and outputs a JSON object to stdout. This is compatible with solc's --standard-json mode for use with tools like Foundry
   -Z <FLAG>                        Unstable flags. WARNING: these are completely unstable, and may change at any time
   -h, --help                       Print help (see more with '--help')

--- a/tests/ui/codegen/branch.sol
+++ b/tests/ui/codegen/branch.sol
@@ -1,0 +1,19 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Branch {
+    function max(uint256 a, uint256 b) public pure returns (uint256) {
+        if (a > b) {
+            return a;
+        }
+        return b;
+    }
+
+    function abs_diff(uint256 a, uint256 b) public pure returns (uint256) {
+        if (a >= b) {
+            return a - b;
+        } else {
+            return b - a;
+        }
+    }
+}

--- a/tests/ui/codegen/branch.stdout
+++ b/tests/ui/codegen/branch.stdout
@@ -1,0 +1,28 @@
+// === ROOT/tests/ui/codegen/branch.sol:Branch ===
+; module @Branch
+fn @max(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = gt arg0, arg1
+    br v2, bb1, bb2
+  bb1:
+    ret arg0
+  bb2:
+    ret arg1
+}
+
+fn @abs_diff(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = lt arg0, arg1
+    v3 = iszero v2
+    br v3, bb1, bb3
+  bb1:
+    v4 = sub arg0, arg1
+    ret v4
+  bb2:
+    v7 = mload 128
+    ret v7
+  bb3:
+    v5 = sub arg1, arg0
+    ret v5
+}
+

--- a/tests/ui/codegen/comparison.sol
+++ b/tests/ui/codegen/comparison.sol
@@ -1,0 +1,16 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Comparison {
+    function eq(uint256 a, uint256 b) public pure returns (bool) {
+        return a == b;
+    }
+
+    function lt(uint256 a, uint256 b) public pure returns (bool) {
+        return a < b;
+    }
+
+    function is_zero(uint256 a) public pure returns (bool) {
+        return a == 0;
+    }
+}

--- a/tests/ui/codegen/comparison.stdout
+++ b/tests/ui/codegen/comparison.stdout
@@ -1,0 +1,20 @@
+// === ROOT/tests/ui/codegen/comparison.sol:Comparison ===
+; module @Comparison
+fn @eq(arg0: u256, arg1: u256) -> bool {
+  bb0 (entry):
+    v2 = eq arg0, arg1
+    ret v2
+}
+
+fn @lt(arg0: u256, arg1: u256) -> bool {
+  bb0 (entry):
+    v2 = lt arg0, arg1
+    ret v2
+}
+
+fn @is_zero(arg0: u256) -> bool {
+  bb0 (entry):
+    v2 = eq arg0, 0
+    ret v2
+}
+

--- a/tests/ui/codegen/compound_assign.sol
+++ b/tests/ui/codegen/compound_assign.sol
@@ -1,0 +1,26 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract CompoundAssign {
+    uint256 public value;
+
+    function add_to_value(uint256 x) public {
+        value += x;
+    }
+
+    function sub_from_value(uint256 x) public {
+        value -= x;
+    }
+
+    function mul_value(uint256 x) public {
+        value *= x;
+    }
+
+    function bump_post() public returns (uint256) {
+        return value++;
+    }
+
+    function bump_pre() public returns (uint256) {
+        return ++value;
+    }
+}

--- a/tests/ui/codegen/compound_assign.stdout
+++ b/tests/ui/codegen/compound_assign.stdout
@@ -1,0 +1,48 @@
+// === ROOT/tests/ui/codegen/compound_assign.sol:CompoundAssign ===
+; module @CompoundAssign
+fn @value() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+
+fn @add_to_value(arg0: u256) {
+  bb0 (entry):
+    v2 = sload 0
+    v3 = add v2, arg0
+    v5 = sstore 0, v3
+    stop
+}
+
+fn @sub_from_value(arg0: u256) {
+  bb0 (entry):
+    v2 = sload 0
+    v3 = sub v2, arg0
+    v5 = sstore 0, v3
+    stop
+}
+
+fn @mul_value(arg0: u256) {
+  bb0 (entry):
+    v2 = sload 0
+    v3 = mul v2, arg0
+    v5 = sstore 0, v3
+    stop
+}
+
+fn @bump_post() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    v3 = add v1, 1
+    v5 = sstore 0, v3
+    ret v1
+}
+
+fn @bump_pre() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    v3 = add v1, 1
+    v5 = sstore 0, v3
+    ret v3
+}
+

--- a/tests/ui/codegen/function_call.sol
+++ b/tests/ui/codegen/function_call.sol
@@ -1,0 +1,17 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract FunctionCall {
+    function double(uint256 x) internal pure returns (uint256) {
+        return x + x;
+    }
+
+    function quadruple(uint256 x) public pure returns (uint256) {
+        return double(double(x));
+    }
+
+    function sum_then_double(uint256 a, uint256 b) public pure returns (uint256) {
+        uint256 s = a + b;
+        return double(s);
+    }
+}

--- a/tests/ui/codegen/function_call.stdout
+++ b/tests/ui/codegen/function_call.stdout
@@ -1,0 +1,22 @@
+// === ROOT/tests/ui/codegen/function_call.sol:FunctionCall ===
+; module @FunctionCall
+fn @double(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, arg0
+    ret v1
+}
+
+fn @quadruple(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, arg0
+    v2 = add v1, v1
+    ret v2
+}
+
+fn @sum_then_double(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    v3 = add v2, v2
+    ret v3
+}
+

--- a/tests/ui/codegen/linear.sol
+++ b/tests/ui/codegen/linear.sol
@@ -1,0 +1,16 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Linear {
+    function add(uint256 x, uint256 y) public pure returns (uint256) {
+        return x + y;
+    }
+
+    function sub(uint256 x, uint256 y) public pure returns (uint256) {
+        return x - y;
+    }
+
+    function add_one(uint256 x) public pure returns (uint256) {
+        return x + 1;
+    }
+}

--- a/tests/ui/codegen/linear.stdout
+++ b/tests/ui/codegen/linear.stdout
@@ -1,0 +1,20 @@
+// === ROOT/tests/ui/codegen/linear.sol:Linear ===
+; module @Linear
+fn @add(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    ret v2
+}
+
+fn @sub(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = sub arg0, arg1
+    ret v2
+}
+
+fn @add_one(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    ret v2
+}
+

--- a/tests/ui/codegen/loop_simple.sol
+++ b/tests/ui/codegen/loop_simple.sol
@@ -1,0 +1,12 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract LoopSimple {
+    function sum_to(uint256 n) public pure returns (uint256) {
+        uint256 total = 0;
+        for (uint256 i = 0; i < n; i++) {
+            total = total + i;
+        }
+        return total;
+    }
+}

--- a/tests/ui/codegen/loop_simple.stdout
+++ b/tests/ui/codegen/loop_simple.stdout
@@ -1,0 +1,29 @@
+// === ROOT/tests/ui/codegen/loop_simple.sol:LoopSimple ===
+; module @LoopSimple
+fn @sum_to(arg0: u256) -> u256 {
+  bb0 (entry):
+    v3 = mstore 160, 0
+    v6 = mstore 192, 0
+    jump bb1
+  bb1:
+    v8 = mload 192
+    v9 = lt v8, arg0
+    br v9, bb4, bb5
+  bb2:
+    v24 = mload 160
+    ret v24
+  bb3:
+    v18 = mload 192
+    v20 = add v18, 1
+    v22 = mstore 192, v20
+    jump bb1
+  bb4:
+    v11 = mload 160
+    v13 = mload 192
+    v14 = add v11, v13
+    v16 = mstore 160, v14
+    jump bb3
+  bb5:
+    jump bb2
+}
+

--- a/tests/ui/codegen/mapping.sol
+++ b/tests/ui/codegen/mapping.sol
@@ -1,0 +1,23 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Mapping {
+    mapping(uint256 => uint256) public balances;
+    mapping(address => mapping(address => uint256)) public allowances;
+
+    function set_balance(uint256 id, uint256 amount) public {
+        balances[id] = amount;
+    }
+
+    function add_balance(uint256 id, uint256 amount) public {
+        balances[id] = balances[id] + amount;
+    }
+
+    function approve(address owner, address spender, uint256 amount) public {
+        allowances[owner][spender] = amount;
+    }
+
+    function get_allowance(address owner, address spender) public view returns (uint256) {
+        return allowances[owner][spender];
+    }
+}

--- a/tests/ui/codegen/mapping.stdout
+++ b/tests/ui/codegen/mapping.stdout
@@ -1,0 +1,70 @@
+// === ROOT/tests/ui/codegen/mapping.sol:Mapping ===
+; module @Mapping
+fn @balances(arg0: u256) -> u256 {
+  bb0 (entry):
+    v3 = mstore 0, arg0
+    v5 = mstore 32, 0
+    v7 = keccak256 0, 64
+    v8 = sload v7
+    ret v8
+}
+
+fn @allowances(arg0: address, arg1: address) -> u256 {
+  bb0 (entry):
+    v4 = mstore 0, arg0
+    v6 = mstore 32, 1
+    v8 = keccak256 0, 64
+    v10 = mstore 0, arg1
+    v12 = mstore 32, v8
+    v14 = keccak256 0, 64
+    v15 = sload v14
+    ret v15
+}
+
+fn @set_balance(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    v4 = mstore 0, arg0
+    v6 = mstore 32, 0
+    v8 = keccak256 0, 64
+    v9 = sstore v8, arg1
+    stop
+}
+
+fn @add_balance(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    v4 = mstore 0, arg0
+    v6 = mstore 32, 0
+    v8 = keccak256 0, 64
+    v9 = sload v8
+    v10 = add v9, arg1
+    v13 = mstore 0, arg0
+    v15 = mstore 32, 0
+    v17 = keccak256 0, 64
+    v18 = sstore v17, v10
+    stop
+}
+
+fn @approve(arg0: address, arg1: address, arg2: u256) {
+  bb0 (entry):
+    v5 = mstore 0, arg0
+    v7 = mstore 32, 1
+    v9 = keccak256 0, 64
+    v11 = mstore 0, arg1
+    v13 = mstore 32, v9
+    v15 = keccak256 0, 64
+    v16 = sstore v15, arg2
+    stop
+}
+
+fn @get_allowance(arg0: address, arg1: address) -> u256 {
+  bb0 (entry):
+    v4 = mstore 0, arg0
+    v6 = mstore 32, 1
+    v8 = keccak256 0, 64
+    v10 = mstore 0, arg1
+    v12 = mstore 32, v8
+    v14 = keccak256 0, 64
+    v15 = sload v14
+    ret v15
+}
+

--- a/tests/ui/codegen/mir/cfg_simplify.mir
+++ b/tests/ui/codegen/mir/cfg_simplify.mir
@@ -1,0 +1,14 @@
+//@ignore-host: windows
+//@compile-flags: --pass cfg-simplify
+; module @CfgSimplify
+fn @sequential(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, 1
+    jump bb1
+  bb1:
+    v2 = add v1, 1
+    jump bb2
+  bb2:
+    v3 = add v2, 1
+    ret v3
+}

--- a/tests/ui/codegen/mir/cfg_simplify.stdout
+++ b/tests/ui/codegen/mir/cfg_simplify.stdout
@@ -1,0 +1,14 @@
+// === ROOT/tests/ui/codegen/mir/cfg_simplify.mir (after cfg-simplify) ===
+; module @CfgSimplify
+fn @sequential(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    v4 = add v2, 1
+    v6 = add v4, 1
+    ret v6
+  bb1:
+    invalid
+  bb2:
+    invalid
+}
+

--- a/tests/ui/codegen/mir/cse_basic.mir
+++ b/tests/ui/codegen/mir/cse_basic.mir
@@ -1,0 +1,12 @@
+//@ignore-host: windows
+//@compile-flags: --pass cse
+// v2 and v3 compute the same expression (add arg0, arg1).
+// CSE should eliminate v3 and replace its uses with v2.
+; module @CseBasic
+fn @redundant_add(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    v3 = add arg0, arg1
+    v4 = add v2, v3
+    ret v4
+}

--- a/tests/ui/codegen/mir/cse_basic.stdout
+++ b/tests/ui/codegen/mir/cse_basic.stdout
@@ -1,0 +1,9 @@
+// === ROOT/tests/ui/codegen/mir/cse_basic.mir (after cse) ===
+; module @CseBasic
+fn @redundant_add(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    v4 = add v2, v2
+    ret v4
+}
+

--- a/tests/ui/codegen/mir/cse_commutative.mir
+++ b/tests/ui/codegen/mir/cse_commutative.mir
@@ -1,0 +1,12 @@
+//@ignore-host: windows
+//@compile-flags: --pass cse
+// add is commutative: add(a,b) == add(b,a).
+// CSE should recognize this and eliminate the second computation.
+; module @CseCommutative
+fn @commutative(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    v3 = add arg1, arg0
+    v4 = add v2, v3
+    ret v4
+}

--- a/tests/ui/codegen/mir/cse_commutative.stdout
+++ b/tests/ui/codegen/mir/cse_commutative.stdout
@@ -1,0 +1,9 @@
+// === ROOT/tests/ui/codegen/mir/cse_commutative.mir (after cse) ===
+; module @CseCommutative
+fn @commutative(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    v4 = add v2, v2
+    ret v4
+}
+

--- a/tests/ui/codegen/mir/cse_non_commutative.mir
+++ b/tests/ui/codegen/mir/cse_non_commutative.mir
@@ -1,0 +1,12 @@
+//@ignore-host: windows
+//@compile-flags: --pass cse
+// sub is NOT commutative: sub(a,b) != sub(b,a).
+// CSE must NOT merge them.
+; module @CseNonCommutative
+fn @non_commutative(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = sub arg0, arg1
+    v3 = sub arg1, arg0
+    v4 = add v2, v3
+    ret v4
+}

--- a/tests/ui/codegen/mir/cse_non_commutative.stdout
+++ b/tests/ui/codegen/mir/cse_non_commutative.stdout
@@ -1,0 +1,10 @@
+// === ROOT/tests/ui/codegen/mir/cse_non_commutative.mir (after cse) ===
+; module @CseNonCommutative
+fn @non_commutative(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = sub arg0, arg1
+    v3 = sub arg1, arg0
+    v4 = add v2, v3
+    ret v4
+}
+

--- a/tests/ui/codegen/mir/cse_sload.mir
+++ b/tests/ui/codegen/mir/cse_sload.mir
@@ -1,0 +1,21 @@
+//@ignore-host: windows
+//@compile-flags: --pass cse
+// Two SLOADs from the same slot within a block (no intervening SSTORE)
+// should be CSE'd. But after an SSTORE, the cache is invalidated.
+; module @CseSload
+fn @sload_cse(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = sload arg0
+    v2 = sload arg0
+    v3 = add v1, v2
+    ret v3
+}
+
+fn @sload_after_sstore(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = sload arg0
+    sstore arg0, arg1
+    v4 = sload arg0
+    v5 = add v2, v4
+    ret v5
+}

--- a/tests/ui/codegen/mir/cse_sload.stdout
+++ b/tests/ui/codegen/mir/cse_sload.stdout
@@ -1,0 +1,18 @@
+// === ROOT/tests/ui/codegen/mir/cse_sload.mir (after cse) ===
+; module @CseSload
+fn @sload_cse(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = sload arg0
+    v3 = add v1, v1
+    ret v3
+}
+
+fn @sload_after_sstore(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = sload arg0
+    sstore arg0, arg1
+    v3 = sload arg0
+    v4 = add v2, v3
+    ret v4
+}
+

--- a/tests/ui/codegen/mir/dce.mir
+++ b/tests/ui/codegen/mir/dce.mir
@@ -1,0 +1,10 @@
+//@ignore-host: windows
+//@compile-flags: --pass dce
+; module @Dce
+fn @with_dead_code(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, 1
+    v2 = mul arg0, arg0
+    v3 = sub arg0, 1
+    ret v1
+}

--- a/tests/ui/codegen/mir/dce.stdout
+++ b/tests/ui/codegen/mir/dce.stdout
@@ -1,0 +1,8 @@
+// === ROOT/tests/ui/codegen/mir/dce.mir (after dce) ===
+; module @Dce
+fn @with_dead_code(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    ret v2
+}
+

--- a/tests/ui/codegen/mir/dce_chain.mir
+++ b/tests/ui/codegen/mir/dce_chain.mir
@@ -1,0 +1,12 @@
+//@ignore-host: windows
+//@compile-flags: --pass dce
+// Dead chain: v3 uses v2, v2 uses v1. None are used by ret.
+// run_to_fixpoint should eliminate all three.
+; module @DceChain
+fn @chain(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, 1
+    v2 = mul v1, v1
+    v3 = sub v2, arg0
+    ret arg0
+}

--- a/tests/ui/codegen/mir/dce_chain.stdout
+++ b/tests/ui/codegen/mir/dce_chain.stdout
@@ -1,0 +1,7 @@
+// === ROOT/tests/ui/codegen/mir/dce_chain.mir (after dce) ===
+; module @DceChain
+fn @chain(arg0: u256) -> u256 {
+  bb0 (entry):
+    ret arg0
+}
+

--- a/tests/ui/codegen/mir/dce_cross_block.mir
+++ b/tests/ui/codegen/mir/dce_cross_block.mir
@@ -1,0 +1,15 @@
+//@ignore-host: windows
+//@compile-flags: --pass dce
+// v1 is computed in bb0 and used in bb2. It must NOT be eliminated.
+// v2 is computed in bb1 but never used anywhere. It should be eliminated.
+; module @DceCrossBlock
+fn @cross(arg0: u256, arg1: bool) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    br arg1, bb1, bb2
+  bb1:
+    v3 = mul arg0, arg0
+    jump bb2
+  bb2:
+    ret v2
+}

--- a/tests/ui/codegen/mir/dce_cross_block.stdout
+++ b/tests/ui/codegen/mir/dce_cross_block.stdout
@@ -1,0 +1,12 @@
+// === ROOT/tests/ui/codegen/mir/dce_cross_block.mir (after dce) ===
+; module @DceCrossBlock
+fn @cross(arg0: u256, arg1: bool) -> u256 {
+  bb0 (entry):
+    v3 = add arg0, 1
+    br arg1, bb1, bb2
+  bb1:
+    jump bb2
+  bb2:
+    ret v3
+}
+

--- a/tests/ui/codegen/mir/dce_side_effects.mir
+++ b/tests/ui/codegen/mir/dce_side_effects.mir
@@ -1,0 +1,12 @@
+//@ignore-host: windows
+//@compile-flags: --pass dce
+// Side-effect instructions must survive DCE even if their results are unused.
+// sstore, log0, call all have side effects.
+; module @DceSideEffects
+fn @effects(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    sstore arg0, arg1
+    log0 0, 32
+    v1 = add arg0, arg1
+    stop
+}

--- a/tests/ui/codegen/mir/dce_side_effects.stdout
+++ b/tests/ui/codegen/mir/dce_side_effects.stdout
@@ -1,0 +1,9 @@
+// === ROOT/tests/ui/codegen/mir/dce_side_effects.mir (after dce) ===
+; module @DceSideEffects
+fn @effects(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    sstore arg0, arg1
+    log0 0, 32
+    stop
+}
+

--- a/tests/ui/codegen/mir/dce_unreachable.mir
+++ b/tests/ui/codegen/mir/dce_unreachable.mir
@@ -1,0 +1,15 @@
+//@ignore-host: windows
+//@compile-flags: --pass dce
+// bb1 is unreachable (entry jumps straight to bb2).
+// DCE should clear bb1's instructions and mark it invalid.
+; module @DceUnreachable
+fn @skip(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb2
+  bb1:
+    v1 = add arg0, 1
+    v2 = mul v1, v1
+    ret v2
+  bb2:
+    ret arg0
+}

--- a/tests/ui/codegen/mir/dce_unreachable.stdout
+++ b/tests/ui/codegen/mir/dce_unreachable.stdout
@@ -1,0 +1,11 @@
+// === ROOT/tests/ui/codegen/mir/dce_unreachable.mir (after dce) ===
+; module @DceUnreachable
+fn @skip(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb2
+  bb1:
+    invalid
+  bb2:
+    ret arg0
+}
+

--- a/tests/ui/codegen/mir/identity.mir
+++ b/tests/ui/codegen/mir/identity.mir
@@ -1,0 +1,14 @@
+//@ignore-host: windows
+//@compile-flags: --pass none
+; module @Identity
+fn @add(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    ret v2
+}
+
+fn @double(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, arg0
+    ret v1
+}

--- a/tests/ui/codegen/mir/identity.stdout
+++ b/tests/ui/codegen/mir/identity.stdout
@@ -1,0 +1,14 @@
+// === ROOT/tests/ui/codegen/mir/identity.mir (after none) ===
+; module @Identity
+fn @add(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, arg1
+    ret v2
+}
+
+fn @double(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, arg0
+    ret v1
+}
+

--- a/tests/ui/codegen/mir/jump_threading.mir
+++ b/tests/ui/codegen/mir/jump_threading.mir
@@ -1,0 +1,13 @@
+//@ignore-host: windows
+//@compile-flags: --pass jump-threading
+; module @Threading
+fn @forwarder_chain(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    jump bb2
+  bb2:
+    jump bb3
+  bb3:
+    ret arg0
+}

--- a/tests/ui/codegen/mir/jump_threading.stdout
+++ b/tests/ui/codegen/mir/jump_threading.stdout
@@ -1,0 +1,13 @@
+// === ROOT/tests/ui/codegen/mir/jump_threading.mir (after jump-threading) ===
+; module @Threading
+fn @forwarder_chain(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb3
+  bb1:
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    ret arg0
+}
+

--- a/tests/ui/codegen/mir/phi.mir
+++ b/tests/ui/codegen/mir/phi.mir
@@ -1,0 +1,14 @@
+//@ignore-host: windows
+//@compile-flags: --pass none
+; module @PhiTest
+fn @diamond(arg0: bool) -> u256 {
+  bb0 (entry):
+    br arg0, bb1, bb2
+  bb1:
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    v1 = phi [bb1: 10], [bb2: 20]
+    ret v1
+}

--- a/tests/ui/codegen/mir/phi.stdout
+++ b/tests/ui/codegen/mir/phi.stdout
@@ -1,0 +1,14 @@
+// === ROOT/tests/ui/codegen/mir/phi.mir (after none) ===
+; module @PhiTest
+fn @diamond(arg0: bool) -> u256 {
+  bb0 (entry):
+    br arg0, bb1, bb2
+  bb1:
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    v3 = phi [bb1: 10], [bb2: 20]
+    ret v3
+}
+

--- a/tests/ui/codegen/mir/pipeline.mir
+++ b/tests/ui/codegen/mir/pipeline.mir
@@ -1,0 +1,13 @@
+//@ignore-host: windows
+//@compile-flags: --passes jump-threading,cfg-simplify,dce
+; module @Pipeline
+fn @noisy(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, 1
+    v2 = mul arg0, arg0
+    jump bb1
+  bb1:
+    jump bb2
+  bb2:
+    ret v1
+}

--- a/tests/ui/codegen/mir/pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline.stdout
@@ -1,0 +1,12 @@
+// === ROOT/tests/ui/codegen/mir/pipeline.mir (after jump-threading,cfg-simplify,dce) ===
+; module @Pipeline
+fn @noisy(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    ret v2
+  bb1:
+    invalid
+  bb2:
+    invalid
+}
+

--- a/tests/ui/codegen/mir/pipeline_default.mir
+++ b/tests/ui/codegen/mir/pipeline_default.mir
@@ -1,0 +1,13 @@
+//@ignore-host: windows
+//@compile-flags: --pipeline-default
+; module @PipelineDefault
+fn @noisy(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, 1
+    v2 = mul arg0, arg0
+    jump bb1
+  bb1:
+    jump bb2
+  bb2:
+    ret v1
+}

--- a/tests/ui/codegen/mir/pipeline_default.stdout
+++ b/tests/ui/codegen/mir/pipeline_default.stdout
@@ -1,0 +1,12 @@
+// === ROOT/tests/ui/codegen/mir/pipeline_default.mir (after pipeline-default) ===
+; module @PipelineDefault
+fn @noisy(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    ret v2
+  bb1:
+    invalid
+  bb2:
+    invalid
+}
+

--- a/tests/ui/codegen/mir/sccp_branch.mir
+++ b/tests/ui/codegen/mir/sccp_branch.mir
@@ -1,0 +1,14 @@
+//@ignore-host: windows
+//@compile-flags: --pass sccp
+// Branch on a constant condition: lt(5, 10) = true.
+// SCCP should fold the comparison and the branch, making bb2 unreachable.
+; module @SccpBranch
+fn @const_branch() -> u256 {
+  bb0 (entry):
+    v0 = lt 5, 10
+    br v0, bb1, bb2
+  bb1:
+    ret 1
+  bb2:
+    ret 0
+}

--- a/tests/ui/codegen/mir/sccp_branch.stdout
+++ b/tests/ui/codegen/mir/sccp_branch.stdout
@@ -1,0 +1,11 @@
+// === ROOT/tests/ui/codegen/mir/sccp_branch.mir (after sccp) ===
+; module @SccpBranch
+fn @const_branch() -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    ret 1
+  bb2:
+    invalid
+}
+

--- a/tests/ui/codegen/mir/sccp_fold.mir
+++ b/tests/ui/codegen/mir/sccp_fold.mir
@@ -1,0 +1,11 @@
+//@ignore-host: windows
+//@compile-flags: --pass sccp
+// Constant arithmetic: 10 + 20 = 30, 30 * 2 = 60.
+// SCCP should propagate through the chain and fold everything.
+; module @SccpFold
+fn @const_chain() -> u256 {
+  bb0 (entry):
+    v0 = add 10, 20
+    v1 = mul v0, 2
+    ret v1
+}

--- a/tests/ui/codegen/mir/sccp_fold.stdout
+++ b/tests/ui/codegen/mir/sccp_fold.stdout
@@ -1,0 +1,7 @@
+// === ROOT/tests/ui/codegen/mir/sccp_fold.mir (after sccp) ===
+; module @SccpFold
+fn @const_chain() -> u256 {
+  bb0 (entry):
+    ret 60
+}
+

--- a/tests/ui/codegen/mir/sccp_no_fold.mir
+++ b/tests/ui/codegen/mir/sccp_no_fold.mir
@@ -1,0 +1,11 @@
+//@ignore-host: windows
+//@compile-flags: --pass sccp
+// Can't fold: arg0 is overdefined (runtime value).
+// SCCP should leave these instructions as-is.
+; module @SccpNoFold
+fn @with_arg(arg0: u256) -> u256 {
+  bb0 (entry):
+    v1 = add arg0, 1
+    v2 = mul v1, 2
+    ret v2
+}

--- a/tests/ui/codegen/mir/sccp_no_fold.stdout
+++ b/tests/ui/codegen/mir/sccp_no_fold.stdout
@@ -1,0 +1,9 @@
+// === ROOT/tests/ui/codegen/mir/sccp_no_fold.mir (after sccp) ===
+; module @SccpNoFold
+fn @with_arg(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = add arg0, 1
+    v4 = mul v2, 2
+    ret v4
+}
+

--- a/tests/ui/codegen/mir/switch.mir
+++ b/tests/ui/codegen/mir/switch.mir
@@ -1,0 +1,15 @@
+//@ignore-host: windows
+//@compile-flags: --pass none
+; module @SwitchTest
+fn @dispatch(arg0: u256) -> u256 {
+  bb0 (entry):
+    switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
+  bb1:
+    ret arg0
+  bb2:
+    ret 0
+  bb3:
+    ret 1
+  bb4:
+    ret 2
+}

--- a/tests/ui/codegen/mir/switch.stdout
+++ b/tests/ui/codegen/mir/switch.stdout
@@ -1,0 +1,15 @@
+// === ROOT/tests/ui/codegen/mir/switch.mir (after none) ===
+; module @SwitchTest
+fn @dispatch(arg0: u256) -> u256 {
+  bb0 (entry):
+    switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
+  bb1:
+    ret arg0
+  bb2:
+    ret 0
+  bb3:
+    ret 1
+  bb4:
+    ret 2
+}
+

--- a/tests/ui/codegen/multi_return.sol
+++ b/tests/ui/codegen/multi_return.sol
@@ -1,0 +1,19 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract MultiReturn {
+    function div_mod(uint256 a, uint256 b) public pure returns (uint256, uint256) {
+        return (a / b, a % b);
+    }
+
+    function min_max(uint256 a, uint256 b) public pure returns (uint256, uint256) {
+        if (a < b) {
+            return (a, b);
+        }
+        return (b, a);
+    }
+
+    function triple(uint256 x) public pure returns (uint256, uint256, uint256) {
+        return (x, x + x, x + x + x);
+    }
+}

--- a/tests/ui/codegen/multi_return.stdout
+++ b/tests/ui/codegen/multi_return.stdout
@@ -1,0 +1,27 @@
+// === ROOT/tests/ui/codegen/multi_return.sol:MultiReturn ===
+; module @MultiReturn
+fn @div_mod(arg0: u256, arg1: u256) -> (u256, u256) {
+  bb0 (entry):
+    v2 = div arg0, arg1
+    v3 = mod arg0, arg1
+    ret v2, v3
+}
+
+fn @min_max(arg0: u256, arg1: u256) -> (u256, u256) {
+  bb0 (entry):
+    v2 = lt arg0, arg1
+    br v2, bb1, bb2
+  bb1:
+    ret arg0, arg1
+  bb2:
+    ret arg1, arg0
+}
+
+fn @triple(arg0: u256) -> (u256, u256, u256) {
+  bb0 (entry):
+    v1 = add arg0, arg0
+    v2 = add arg0, arg0
+    v3 = add arg0, v2
+    ret arg0, v1, v3
+}
+

--- a/tests/ui/codegen/nested_loops.sol
+++ b/tests/ui/codegen/nested_loops.sol
@@ -1,0 +1,25 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract NestedLoops {
+    function sum_grid(uint256 n, uint256 m) public pure returns (uint256) {
+        uint256 total = 0;
+        for (uint256 i = 0; i < n; i++) {
+            for (uint256 j = 0; j < m; j++) {
+                total = total + i * j;
+            }
+        }
+        return total;
+    }
+
+    function find_first(uint256 n, uint256 target) public pure returns (uint256) {
+        for (uint256 i = 0; i < n; i++) {
+            for (uint256 j = 0; j < n; j++) {
+                if (i + j == target) {
+                    return i;
+                }
+            }
+        }
+        return n;
+    }
+}

--- a/tests/ui/codegen/nested_loops.stdout
+++ b/tests/ui/codegen/nested_loops.stdout
@@ -1,0 +1,93 @@
+// === ROOT/tests/ui/codegen/nested_loops.sol:NestedLoops ===
+; module @NestedLoops
+fn @sum_grid(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v4 = mstore 160, 0
+    v7 = mstore 192, 0
+    jump bb1
+  bb1:
+    v9 = mload 192
+    v10 = lt v9, arg0
+    br v10, bb4, bb5
+  bb2:
+    v40 = mload 160
+    ret v40
+  bb3:
+    v34 = mload 192
+    v36 = add v34, 1
+    v38 = mstore 192, v36
+    jump bb1
+  bb4:
+    v13 = mstore 224, 0
+    jump bb6
+  bb5:
+    jump bb2
+  bb6:
+    v15 = mload 224
+    v16 = lt v15, arg1
+    br v16, bb9, bb10
+  bb7:
+    jump bb3
+  bb8:
+    v28 = mload 224
+    v30 = add v28, 1
+    v32 = mstore 224, v30
+    jump bb6
+  bb9:
+    v18 = mload 160
+    v20 = mload 192
+    v22 = mload 224
+    v23 = mul v20, v22
+    v24 = add v18, v23
+    v26 = mstore 160, v24
+    jump bb8
+  bb10:
+    jump bb7
+}
+
+fn @find_first(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v4 = mstore 160, 0
+    jump bb1
+  bb1:
+    v6 = mload 160
+    v7 = lt v6, arg0
+    br v7, bb4, bb5
+  bb2:
+    ret arg0
+  bb3:
+    v29 = mload 160
+    v31 = add v29, 1
+    v33 = mstore 160, v31
+    jump bb1
+  bb4:
+    v10 = mstore 192, 0
+    jump bb6
+  bb5:
+    jump bb2
+  bb6:
+    v12 = mload 192
+    v13 = lt v12, arg0
+    br v13, bb9, bb10
+  bb7:
+    jump bb3
+  bb8:
+    v23 = mload 192
+    v25 = add v23, 1
+    v27 = mstore 192, v25
+    jump bb6
+  bb9:
+    v15 = mload 160
+    v17 = mload 192
+    v18 = add v15, v17
+    v19 = eq v18, arg1
+    br v19, bb11, bb12
+  bb10:
+    jump bb7
+  bb11:
+    v21 = mload 160
+    ret v21
+  bb12:
+    jump bb8
+}
+

--- a/tests/ui/codegen/recursive.sol
+++ b/tests/ui/codegen/recursive.sol
@@ -1,0 +1,19 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+// Recursive functions in Solidity. The MIR lowering inlines internal calls
+// with cycle detection — recursive self-references are replaced with a
+// placeholder `0` to avoid infinite inlining (see lower/mod.rs::try_enter_inline).
+// This .stdout snapshot documents that behavior; if the lowering changes how
+// it handles recursion, this test will diff and we'll notice.
+contract Recursive {
+    function fact(uint256 n) public pure returns (uint256) {
+        if (n <= 1) return 1;
+        return n * fact(n - 1);
+    }
+
+    function fib(uint256 n) public pure returns (uint256) {
+        if (n <= 1) return n;
+        return fib(n - 1) + fib(n - 2);
+    }
+}

--- a/tests/ui/codegen/recursive.stdout
+++ b/tests/ui/codegen/recursive.stdout
@@ -1,0 +1,55 @@
+// === ROOT/tests/ui/codegen/recursive.sol:Recursive ===
+; module @Recursive
+fn @fact(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = gt arg0, 1
+    v3 = iszero v2
+    br v3, bb1, bb2
+  bb1:
+    ret 1
+  bb2:
+    v6 = sub arg0, 1
+    v8 = gt v6, 1
+    v9 = iszero v8
+    br v9, bb3, bb4
+  bb3:
+    ret 1
+  bb4:
+    v13 = sub v6, 1
+    v15 = mul v6, 0
+    v16 = mul arg0, v15
+    ret v16
+}
+
+fn @fib(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = gt arg0, 1
+    v3 = iszero v2
+    br v3, bb1, bb2
+  bb1:
+    ret arg0
+  bb2:
+    v5 = sub arg0, 1
+    v7 = gt v5, 1
+    v8 = iszero v7
+    br v8, bb3, bb4
+  bb3:
+    ret v5
+  bb4:
+    v11 = sub v5, 1
+    v14 = sub v5, 2
+    v16 = add 0, 0
+    v18 = sub arg0, 2
+    v20 = gt v18, 1
+    v21 = iszero v20
+    br v21, bb5, bb6
+  bb5:
+    ret v18
+  bb6:
+    v24 = sub v18, 1
+    v27 = sub v18, 2
+    v29 = add 0, 0
+    v30 = add v16, v29
+    ret v30
+}
+

--- a/tests/ui/codegen/storage.sol
+++ b/tests/ui/codegen/storage.sol
@@ -1,0 +1,18 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Storage {
+    uint256 public count;
+
+    function increment() public {
+        count = count + 1;
+    }
+
+    function set(uint256 v) public {
+        count = v;
+    }
+
+    function get() public view returns (uint256) {
+        return count;
+    }
+}

--- a/tests/ui/codegen/storage.stdout
+++ b/tests/ui/codegen/storage.stdout
@@ -1,0 +1,28 @@
+// === ROOT/tests/ui/codegen/storage.sol:Storage ===
+; module @Storage
+fn @count() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+
+fn @increment() {
+  bb0 (entry):
+    v1 = sload 0
+    v3 = add v1, 1
+    v5 = sstore 0, v3
+    stop
+}
+
+fn @set(arg0: u256) {
+  bb0 (entry):
+    v2 = sstore 0, arg0
+    stop
+}
+
+fn @get() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+

--- a/tests/ui/codegen/ternary.sol
+++ b/tests/ui/codegen/ternary.sol
@@ -1,0 +1,16 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Ternary {
+    function max(uint256 a, uint256 b) public pure returns (uint256) {
+        return a > b ? a : b;
+    }
+
+    function clamp(uint256 x, uint256 lo, uint256 hi) public pure returns (uint256) {
+        return x < lo ? lo : (x > hi ? hi : x);
+    }
+
+    function abs_diff(uint256 a, uint256 b) public pure returns (uint256) {
+        return a >= b ? a - b : b - a;
+    }
+}

--- a/tests/ui/codegen/ternary.stdout
+++ b/tests/ui/codegen/ternary.stdout
@@ -1,0 +1,61 @@
+// === ROOT/tests/ui/codegen/ternary.sol:Ternary ===
+; module @Ternary
+fn @max(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = gt arg0, arg1
+    br v2, bb1, bb2
+  bb1:
+    v4 = mstore 0, arg0
+    jump bb3
+  bb2:
+    v6 = mstore 0, arg1
+    jump bb3
+  bb3:
+    v8 = mload 0
+    ret v8
+}
+
+fn @clamp(arg0: u256, arg1: u256, arg2: u256) -> u256 {
+  bb0 (entry):
+    v3 = lt arg0, arg1
+    br v3, bb1, bb2
+  bb1:
+    v5 = mstore 0, arg1
+    jump bb3
+  bb2:
+    v6 = gt arg0, arg2
+    br v6, bb4, bb5
+  bb3:
+    v16 = mload 0
+    v18 = mload 0
+    ret v18
+  bb4:
+    v8 = mstore 0, arg2
+    jump bb6
+  bb5:
+    v10 = mstore 0, arg0
+    jump bb6
+  bb6:
+    v12 = mload 0
+    v14 = mstore 0, v12
+    jump bb3
+}
+
+fn @abs_diff(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v2 = lt arg0, arg1
+    v3 = iszero v2
+    br v3, bb1, bb2
+  bb1:
+    v4 = sub arg0, arg1
+    v6 = mstore 0, v4
+    jump bb3
+  bb2:
+    v7 = sub arg1, arg0
+    v9 = mstore 0, v7
+    jump bb3
+  bb3:
+    v11 = mload 0
+    ret v11
+}
+

--- a/tests/ui/codegen/while_loop.sol
+++ b/tests/ui/codegen/while_loop.sol
@@ -1,0 +1,31 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract WhileLoop {
+    function count_down(uint256 n) public pure returns (uint256) {
+        uint256 i = n;
+        while (i > 0) {
+            i = i - 1;
+        }
+        return i;
+    }
+
+    function do_at_least_once(uint256 n) public pure returns (uint256) {
+        uint256 i = 0;
+        do {
+            i = i + 1;
+        } while (i < n);
+        return i;
+    }
+
+    function break_when_found(uint256 n, uint256 target) public pure returns (uint256) {
+        uint256 i = 0;
+        while (i < n) {
+            if (i == target) {
+                break;
+            }
+            i = i + 1;
+        }
+        return i;
+    }
+}

--- a/tests/ui/codegen/while_loop.stdout
+++ b/tests/ui/codegen/while_loop.stdout
@@ -1,0 +1,74 @@
+// === ROOT/tests/ui/codegen/while_loop.sol:WhileLoop ===
+; module @WhileLoop
+fn @count_down(arg0: u256) -> u256 {
+  bb0 (entry):
+    v2 = mstore 160, arg0
+    jump bb1
+  bb1:
+    v4 = mload 160
+    v6 = gt v4, 0
+    br v6, bb3, bb5
+  bb2:
+    v14 = mload 160
+    ret v14
+  bb3:
+    v8 = mload 160
+    v10 = sub v8, 1
+    v12 = mstore 160, v10
+    jump bb4
+  bb4:
+    jump bb1
+  bb5:
+    jump bb2
+}
+
+fn @do_at_least_once(arg0: u256) -> u256 {
+  bb0 (entry):
+    v3 = mstore 160, 0
+    jump bb1
+  bb1:
+    v5 = mload 160
+    v7 = add v5, 1
+    v9 = mstore 160, v7
+    v11 = mload 160
+    v12 = lt v11, arg0
+    br v12, bb3, bb5
+  bb2:
+    v14 = mload 160
+    ret v14
+  bb3:
+    jump bb1
+  bb4:
+    jump bb1
+  bb5:
+    jump bb2
+}
+
+fn @break_when_found(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v4 = mstore 160, 0
+    jump bb1
+  bb1:
+    v6 = mload 160
+    v7 = lt v6, arg0
+    br v7, bb3, bb5
+  bb2:
+    v18 = mload 160
+    ret v18
+  bb3:
+    v9 = mload 160
+    v10 = eq v9, arg1
+    br v10, bb6, bb7
+  bb4:
+    jump bb1
+  bb5:
+    jump bb2
+  bb6:
+    jump bb2
+  bb7:
+    v12 = mload 160
+    v14 = add v12, 1
+    v16 = mstore 160, v14
+    jump bb4
+}
+

--- a/tools/solar-mir-opt/Cargo.toml
+++ b/tools/solar-mir-opt/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "solar-mir-opt"
+description = "Run individual MIR optimization passes on Solidity contracts"
+homepage = "https://github.com/paradigmxyz/solar/tree/main/tools/solar-mir-opt"
+publish = false
+
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "solar-mir-opt"
+path = "src/main.rs"
+
+[dependencies]
+solar-codegen.workspace = true
+solar-interface.workspace = true
+solar-sema.workspace = true

--- a/tools/solar-mir-opt/src/main.rs
+++ b/tools/solar-mir-opt/src/main.rs
@@ -35,7 +35,7 @@
 use solar_codegen::{
     lower,
     mir::{Module, module_to_text, parse_module},
-    pass::{CfgSimplifyPass, DcePass, JumpThreadingPass, PassManager, TransformPass},
+    pass::{CfgSimplifyPass, CsePass, DcePass, JumpThreadingPass, PassManager, TransformPass},
 };
 use solar_interface::{Ident, Session, Symbol};
 use solar_sema::Compiler;
@@ -62,6 +62,7 @@ Options:
 
 Passes:
     dce              Dead Code Elimination (fixed-point)
+    cse              Common Subexpression Elimination (fixed-point)
     cfg-simplify     CFG Simplification (fixed-point)
     jump-threading   Jump Threading (fixed-point)
     none             No transform; just lower/parse and print
@@ -160,6 +161,7 @@ fn parse_args() -> Result<Args, String> {
 fn make_pass(name: &str) -> Result<Option<Box<dyn TransformPass>>, String> {
     match name {
         "dce" => Ok(Some(Box::new(DcePass))),
+        "cse" => Ok(Some(Box::new(CsePass))),
         "cfg-simplify" => Ok(Some(Box::new(CfgSimplifyPass))),
         "jump-threading" => Ok(Some(Box::new(JumpThreadingPass))),
         "none" => Ok(None),

--- a/tools/solar-mir-opt/src/main.rs
+++ b/tools/solar-mir-opt/src/main.rs
@@ -35,7 +35,10 @@
 use solar_codegen::{
     lower,
     mir::{Module, module_to_text, parse_module},
-    pass::{CfgSimplifyPass, CsePass, DcePass, JumpThreadingPass, PassManager, TransformPass},
+    pass::{
+        CfgSimplifyPass, CsePass, DcePass, JumpThreadingPass, PassManager, SccpTransformPass,
+        TransformPass,
+    },
 };
 use solar_interface::{Ident, Session, Symbol};
 use solar_sema::Compiler;
@@ -63,6 +66,7 @@ Options:
 Passes:
     dce              Dead Code Elimination (fixed-point)
     cse              Common Subexpression Elimination (fixed-point)
+    sccp             Sparse Conditional Constant Propagation
     cfg-simplify     CFG Simplification (fixed-point)
     jump-threading   Jump Threading (fixed-point)
     none             No transform; just lower/parse and print
@@ -162,6 +166,7 @@ fn make_pass(name: &str) -> Result<Option<Box<dyn TransformPass>>, String> {
     match name {
         "dce" => Ok(Some(Box::new(DcePass))),
         "cse" => Ok(Some(Box::new(CsePass))),
+        "sccp" => Ok(Some(Box::new(SccpTransformPass))),
         "cfg-simplify" => Ok(Some(Box::new(CfgSimplifyPass))),
         "jump-threading" => Ok(Some(Box::new(JumpThreadingPass))),
         "none" => Ok(None),

--- a/tools/solar-mir-opt/src/main.rs
+++ b/tools/solar-mir-opt/src/main.rs
@@ -1,0 +1,181 @@
+//! `solar-mir-opt` — run a single MIR transformation pass on a Solidity file
+//! and print the resulting MIR.
+//!
+//! This is the Solar equivalent of LLVM's `opt`. It takes a Solidity contract,
+//! lowers it to MIR, runs the requested pass, and prints the result. It's
+//! meant for inspecting what individual passes do in isolation, complementary
+//! to `solar --emit=mir` (which runs the full pipeline).
+//!
+//! ## Usage
+//!
+//! ```text
+//! solar-mir-opt --pass <name> <file.sol>
+//! ```
+//!
+//! Supported passes:
+//!   - `dce`             — Dead Code Elimination
+//!   - `cfg-simplify`    — CFG Simplification
+//!   - `jump-threading`  — Jump Threading
+//!   - `none`            — No transform; just lower and print
+//!
+//! ## Future
+//!
+//! Once a MIR text parser exists, this binary will also accept `.mir`
+//! input files. The `--pass` plumbing won't change.
+
+#![allow(unused_crate_dependencies)]
+
+use solar_codegen::{
+    lower,
+    mir::module_to_text,
+    pass::{CfgSimplifyPass, DcePass, JumpThreadingPass, PassManager, TransformPass},
+};
+use solar_interface::Session;
+use solar_sema::Compiler;
+use std::{ops::ControlFlow, path::Path, process::ExitCode};
+
+const HELP: &str = "\
+solar-mir-opt — run a single MIR pass on a Solidity contract
+
+Usage:
+    solar-mir-opt --pass <name> <file.sol>
+    solar-mir-opt -h | --help
+
+Options:
+    --pass <name>    Name of the pass to run (see below)
+    -h, --help       Print this help message
+
+Passes:
+    dce              Dead Code Elimination (fixed-point)
+    cfg-simplify     CFG Simplification (fixed-point)
+    jump-threading   Jump Threading (fixed-point)
+    none             No transform; just lower and print
+";
+
+struct Args {
+    pass: String,
+    input: String,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let argv: Vec<String> = std::env::args().collect();
+    let mut pass: Option<String> = None;
+    let mut input: Option<String> = None;
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "-h" | "--help" => {
+                print!("{HELP}");
+                std::process::exit(0);
+            }
+            "--pass" => {
+                pass = argv.get(i + 1).cloned();
+                if pass.is_none() {
+                    return Err("--pass requires an argument".into());
+                }
+                i += 2;
+            }
+            arg if arg.starts_with("--") => {
+                return Err(format!("unknown flag: {arg}"));
+            }
+            _ => {
+                if input.is_some() {
+                    return Err("only one input file is supported".into());
+                }
+                input = Some(argv[i].clone());
+                i += 1;
+            }
+        }
+    }
+    let pass = pass.ok_or_else(|| "missing --pass <name>".to_string())?;
+    let input = input.ok_or_else(|| "missing input file".to_string())?;
+    Ok(Args { pass, input })
+}
+
+/// Returns a fresh boxed pass for the given name, or `None` if `name` is unknown.
+/// Returns `Some(None)` for the special `none` pass (no transform).
+fn make_pass(name: &str) -> Option<Option<Box<dyn TransformPass>>> {
+    match name {
+        "dce" => Some(Some(Box::new(DcePass))),
+        "cfg-simplify" => Some(Some(Box::new(CfgSimplifyPass))),
+        "jump-threading" => Some(Some(Box::new(JumpThreadingPass))),
+        "none" => Some(None),
+        _ => None,
+    }
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(e) => {
+            eprintln!("error: {e}");
+            eprintln!();
+            eprint!("{HELP}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    // Validate the pass name early so users get a fast error.
+    if make_pass(&args.pass).is_none() {
+        eprintln!("error: unknown pass: {}", args.pass);
+        eprintln!();
+        eprint!("{HELP}");
+        return ExitCode::FAILURE;
+    }
+
+    let sess = Session::builder().with_stderr_emitter().build();
+    let mut compiler = Compiler::new(sess);
+
+    // Parse the input file.
+    let parse_result = compiler.enter_mut(|c| -> solar_interface::Result<_> {
+        let mut pcx = c.parse();
+        pcx.load_files([Path::new(&args.input)])?;
+        pcx.parse();
+        Ok(())
+    });
+    if parse_result.is_err() {
+        return ExitCode::FAILURE;
+    }
+
+    // Lower, analyze, and run the requested pass on each contract.
+    let result = compiler.enter_mut(|c| -> solar_interface::Result<_> {
+        let ControlFlow::Continue(()) = c.lower_asts()? else {
+            return Ok(());
+        };
+        let ControlFlow::Continue(()) = c.analysis()? else {
+            return Ok(());
+        };
+
+        let gcx = c.gcx();
+        for id in gcx.hir.contract_ids() {
+            let contract = gcx.hir.contract(id);
+            if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
+                continue;
+            }
+
+            let mut module = lower::lower_contract(gcx, id);
+
+            // Run the requested pass on every function in the module.
+            // `none` skips the pass manager entirely so the output reflects
+            // the raw lowered MIR.
+            if let Some(Some(boxed_pass)) = make_pass(&args.pass) {
+                let mut pm = PassManager::new();
+                pm.add_transform(boxed_pass);
+                for func in module.functions.iter_mut() {
+                    pm.run(func);
+                }
+            }
+
+            let name = gcx.contract_fully_qualified_name(id);
+            println!("// === {} (after {}) ===", name, args.pass);
+            println!("{}", module_to_text(&module));
+        }
+        Ok(())
+    });
+
+    if result.is_err() || compiler.sess().emitted_errors().is_some_and(|r| r.is_err()) {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}

--- a/tools/solar-mir-opt/src/main.rs
+++ b/tools/solar-mir-opt/src/main.rs
@@ -47,11 +47,15 @@ solar-mir-opt — run one or more MIR passes on a Solidity or MIR file
 Usage:
     solar-mir-opt --passes <names> [--print-after-each] <input>
     solar-mir-opt --pass <name> <input>          # alias for --passes <name>
+    solar-mir-opt --pipeline-default <input>     # canonical codegen pipeline
     solar-mir-opt -h | --help
 
 Options:
     --passes <names>     Comma-separated list of passes to run in order
     --pass <name>        Alias for --passes <name>
+    --pipeline-default   Run the same passes as EvmCodegen::run_optimization_passes
+                         (jump-threading → cfg-simplify → dce). Mutually
+                         exclusive with --pass / --passes.
     --print-after-each   Print MIR after each pass in the chain
                          (default: print only after the last pass)
     -h, --help           Print this help message
@@ -67,11 +71,19 @@ Input formats:
     *.mir  Textual MIR — parsed directly via solar_codegen::mir::parse_module
 ";
 
+/// The canonical pass list run by `EvmCodegen::run_optimization_passes`.
+/// Keep in sync with `crates/codegen/src/codegen/evm.rs`.
+const DEFAULT_PIPELINE: &[&str] = &["jump-threading", "cfg-simplify", "dce"];
+
 struct Args {
     /// Passes to run, in order. Each must satisfy `make_pass`.
     passes: Vec<String>,
     /// If true, print MIR after every pass; otherwise only after the last.
     print_after_each: bool,
+    /// If true, the user invoked `--pipeline-default`. Used as the display
+    /// label so output reads `(after pipeline-default)` instead of the
+    /// concatenated pass list.
+    pipeline_default: bool,
     /// Path to input file. Extension determines whether it's .sol or .mir.
     input: String,
 }
@@ -79,6 +91,7 @@ struct Args {
 fn parse_args() -> Result<Args, String> {
     let argv: Vec<String> = std::env::args().collect();
     let mut passes: Option<Vec<String>> = None;
+    let mut pipeline_default = false;
     let mut print_after_each = false;
     let mut input: Option<String> = None;
     let mut i = 1;
@@ -101,6 +114,10 @@ fn parse_args() -> Result<Args, String> {
                 passes = Some(vec![raw.clone()]);
                 i += 2;
             }
+            "--pipeline-default" => {
+                pipeline_default = true;
+                i += 1;
+            }
             "--print-after-each" => {
                 print_after_each = true;
                 i += 1;
@@ -117,12 +134,25 @@ fn parse_args() -> Result<Args, String> {
             }
         }
     }
-    let passes = passes.ok_or_else(|| "missing --pass / --passes <name>".to_string())?;
-    if passes.is_empty() {
-        return Err("at least one pass is required".into());
+
+    // --pipeline-default and --pass[es] are mutually exclusive.
+    if pipeline_default && passes.is_some() {
+        return Err("cannot use --pipeline-default with --pass / --passes".into());
     }
+
+    let passes = if pipeline_default {
+        DEFAULT_PIPELINE.iter().map(|s| (*s).to_string()).collect()
+    } else {
+        let p =
+            passes.ok_or_else(|| "missing --pass / --passes / --pipeline-default".to_string())?;
+        if p.is_empty() {
+            return Err("at least one pass is required".into());
+        }
+        p
+    };
+
     let input = input.ok_or_else(|| "missing input file".to_string())?;
-    Ok(Args { passes, print_after_each, input })
+    Ok(Args { passes, print_after_each, pipeline_default, input })
 }
 
 /// Returns a fresh boxed pass for the given name. The special `none` pass
@@ -167,7 +197,14 @@ fn run_pipeline(module: &mut Module, name: &str, args: &Args) -> Result<(), Stri
         for pass in &args.passes {
             run_pass(module, pass)?;
         }
-        print_module(module, name, &args.passes.join(","));
+        // For --pipeline-default, use a stable label so the output header
+        // doesn't depend on the underlying pass list (which may evolve).
+        let label = if args.pipeline_default {
+            "pipeline-default".to_string()
+        } else {
+            args.passes.join(",")
+        };
+        print_module(module, name, &label);
     }
     Ok(())
 }

--- a/tools/solar-mir-opt/src/main.rs
+++ b/tools/solar-mir-opt/src/main.rs
@@ -1,65 +1,85 @@
-//! `solar-mir-opt` — run a single MIR transformation pass on a Solidity file
-//! and print the resulting MIR.
+//! `solar-mir-opt` — run one or more MIR transformation passes and print the
+//! resulting MIR.
 //!
-//! This is the Solar equivalent of LLVM's `opt`. It takes a Solidity contract,
-//! lowers it to MIR, runs the requested pass, and prints the result. It's
-//! meant for inspecting what individual passes do in isolation, complementary
-//! to `solar --emit=mir` (which runs the full pipeline).
+//! This is the Solar equivalent of LLVM's `opt`. It accepts either a Solidity
+//! file (`.sol`) — which is parsed, lowered to MIR, and then transformed —
+//! or a textual MIR file (`.mir`) — which is parsed directly. After running
+//! the requested pass pipeline, it prints the resulting MIR.
 //!
 //! ## Usage
 //!
 //! ```text
-//! solar-mir-opt --pass <name> <file.sol>
+//! solar-mir-opt --passes <name1,name2,...> [--print-after-each] <input>
+//! solar-mir-opt --pass <name> <input>          # alias for --passes <name>
+//! solar-mir-opt -h | --help
 //! ```
 //!
-//! Supported passes:
-//!   - `dce`             — Dead Code Elimination
-//!   - `cfg-simplify`    — CFG Simplification
-//!   - `jump-threading`  — Jump Threading
-//!   - `none`            — No transform; just lower and print
+//! ## Supported passes
 //!
-//! ## Future
+//! - `dce`             — Dead Code Elimination (fixed-point)
+//! - `cfg-simplify`    — CFG Simplification (fixed-point)
+//! - `jump-threading`  — Jump Threading (fixed-point)
+//! - `none`            — No transform; just lower/parse and print
 //!
-//! Once a MIR text parser exists, this binary will also accept `.mir`
-//! input files. The `--pass` plumbing won't change.
+//! Multiple passes can be chained: `--passes jump-threading,cfg-simplify,dce`.
+//! With `--print-after-each`, the binary prints the MIR state after each pass
+//! in the chain (useful for inspecting intermediate states).
+//!
+//! ## Input formats
+//!
+//! - `.sol` — Solidity contract; lowered through the normal compiler pipeline
+//! - `.mir` — Textual MIR; parsed via `solar_codegen::mir::parse_module`
 
 #![allow(unused_crate_dependencies)]
 
 use solar_codegen::{
     lower,
-    mir::module_to_text,
+    mir::{Module, module_to_text, parse_module},
     pass::{CfgSimplifyPass, DcePass, JumpThreadingPass, PassManager, TransformPass},
 };
-use solar_interface::Session;
+use solar_interface::{Ident, Session, Symbol};
 use solar_sema::Compiler;
 use std::{ops::ControlFlow, path::Path, process::ExitCode};
 
 const HELP: &str = "\
-solar-mir-opt — run a single MIR pass on a Solidity contract
+solar-mir-opt — run one or more MIR passes on a Solidity or MIR file
 
 Usage:
-    solar-mir-opt --pass <name> <file.sol>
+    solar-mir-opt --passes <names> [--print-after-each] <input>
+    solar-mir-opt --pass <name> <input>          # alias for --passes <name>
     solar-mir-opt -h | --help
 
 Options:
-    --pass <name>    Name of the pass to run (see below)
-    -h, --help       Print this help message
+    --passes <names>     Comma-separated list of passes to run in order
+    --pass <name>        Alias for --passes <name>
+    --print-after-each   Print MIR after each pass in the chain
+                         (default: print only after the last pass)
+    -h, --help           Print this help message
 
 Passes:
     dce              Dead Code Elimination (fixed-point)
     cfg-simplify     CFG Simplification (fixed-point)
     jump-threading   Jump Threading (fixed-point)
-    none             No transform; just lower and print
+    none             No transform; just lower/parse and print
+
+Input formats:
+    *.sol  Solidity contract — lowered through the normal compiler pipeline
+    *.mir  Textual MIR — parsed directly via solar_codegen::mir::parse_module
 ";
 
 struct Args {
-    pass: String,
+    /// Passes to run, in order. Each must satisfy `make_pass`.
+    passes: Vec<String>,
+    /// If true, print MIR after every pass; otherwise only after the last.
+    print_after_each: bool,
+    /// Path to input file. Extension determines whether it's .sol or .mir.
     input: String,
 }
 
 fn parse_args() -> Result<Args, String> {
     let argv: Vec<String> = std::env::args().collect();
-    let mut pass: Option<String> = None;
+    let mut passes: Option<Vec<String>> = None;
+    let mut print_after_each = false;
     let mut input: Option<String> = None;
     let mut i = 1;
     while i < argv.len() {
@@ -68,12 +88,22 @@ fn parse_args() -> Result<Args, String> {
                 print!("{HELP}");
                 std::process::exit(0);
             }
-            "--pass" => {
-                pass = argv.get(i + 1).cloned();
-                if pass.is_none() {
-                    return Err("--pass requires an argument".into());
-                }
+            "--passes" => {
+                let raw = argv.get(i + 1).ok_or("--passes requires an argument")?;
+                passes = Some(raw.split(',').map(str::trim).map(String::from).collect());
                 i += 2;
+            }
+            "--pass" => {
+                let raw = argv.get(i + 1).ok_or("--pass requires an argument")?;
+                if passes.is_some() {
+                    return Err("cannot use --pass and --passes together".into());
+                }
+                passes = Some(vec![raw.clone()]);
+                i += 2;
+            }
+            "--print-after-each" => {
+                print_after_each = true;
+                i += 1;
             }
             arg if arg.starts_with("--") => {
                 return Err(format!("unknown flag: {arg}"));
@@ -87,21 +117,129 @@ fn parse_args() -> Result<Args, String> {
             }
         }
     }
-    let pass = pass.ok_or_else(|| "missing --pass <name>".to_string())?;
+    let passes = passes.ok_or_else(|| "missing --pass / --passes <name>".to_string())?;
+    if passes.is_empty() {
+        return Err("at least one pass is required".into());
+    }
     let input = input.ok_or_else(|| "missing input file".to_string())?;
-    Ok(Args { pass, input })
+    Ok(Args { passes, print_after_each, input })
 }
 
-/// Returns a fresh boxed pass for the given name, or `None` if `name` is unknown.
-/// Returns `Some(None)` for the special `none` pass (no transform).
-fn make_pass(name: &str) -> Option<Option<Box<dyn TransformPass>>> {
+/// Returns a fresh boxed pass for the given name. The special `none` pass
+/// returns `Ok(None)` (skipped). Unknown names return `Err`.
+fn make_pass(name: &str) -> Result<Option<Box<dyn TransformPass>>, String> {
     match name {
-        "dce" => Some(Some(Box::new(DcePass))),
-        "cfg-simplify" => Some(Some(Box::new(CfgSimplifyPass))),
-        "jump-threading" => Some(Some(Box::new(JumpThreadingPass))),
-        "none" => Some(None),
-        _ => None,
+        "dce" => Ok(Some(Box::new(DcePass))),
+        "cfg-simplify" => Ok(Some(Box::new(CfgSimplifyPass))),
+        "jump-threading" => Ok(Some(Box::new(JumpThreadingPass))),
+        "none" => Ok(None),
+        other => Err(format!("unknown pass: {other}")),
     }
+}
+
+/// Runs a single pass on every function in the module.
+fn run_pass(module: &mut Module, pass_name: &str) -> Result<(), String> {
+    if let Some(boxed) = make_pass(pass_name)? {
+        let mut pm = PassManager::new();
+        pm.add_transform(boxed);
+        for func in module.functions.iter_mut() {
+            pm.run(func);
+        }
+    }
+    Ok(())
+}
+
+/// Prints a module with a header indicating which pass(es) produced it.
+fn print_module(module: &Module, name: &str, after: &str) {
+    println!("// === {name} (after {after}) ===");
+    println!("{}", module_to_text(module));
+}
+
+/// Runs the pass pipeline on a single module and emits output.
+/// Used for both .sol contracts and .mir input.
+fn run_pipeline(module: &mut Module, name: &str, args: &Args) -> Result<(), String> {
+    if args.print_after_each {
+        for pass in &args.passes {
+            run_pass(module, pass)?;
+            print_module(module, name, pass);
+        }
+    } else {
+        for pass in &args.passes {
+            run_pass(module, pass)?;
+        }
+        print_module(module, name, &args.passes.join(","));
+    }
+    Ok(())
+}
+
+/// Process a `.mir` input: read file, parse, run passes, print.
+fn process_mir(args: &Args) -> Result<(), String> {
+    let text = std::fs::read_to_string(&args.input)
+        .map_err(|e| format!("failed to read {}: {e}", args.input))?;
+
+    let sess = Session::builder().with_stderr_emitter().build();
+    let mut result: Result<(), String> = Ok(());
+    sess.enter(|| {
+        let mut module = match parse_module(&text) {
+            Ok(m) => m,
+            Err(e) => {
+                result = Err(format!("{e}"));
+                return;
+            }
+        };
+        // Use a fixed name for .mir input — the parser interns whatever the
+        // file declared (or "module" by default).
+        let name = Ident::with_dummy_span(Symbol::intern(&args.input)).to_string();
+        if let Err(e) = run_pipeline(&mut module, &name, args) {
+            result = Err(e);
+        }
+    });
+    result
+}
+
+/// Process a `.sol` input: full Solidity → MIR pipeline.
+fn process_sol(args: &Args) -> Result<(), String> {
+    let sess = Session::builder().with_stderr_emitter().build();
+    let mut compiler = Compiler::new(sess);
+
+    let parse_result = compiler.enter_mut(|c| -> solar_interface::Result<_> {
+        let mut pcx = c.parse();
+        pcx.load_files([Path::new(&args.input)])?;
+        pcx.parse();
+        Ok(())
+    });
+    if parse_result.is_err() {
+        return Err("parse error".into());
+    }
+
+    let mut pipeline_err: Option<String> = None;
+    let result = compiler.enter_mut(|c| -> solar_interface::Result<_> {
+        let ControlFlow::Continue(()) = c.lower_asts()? else { return Ok(()) };
+        let ControlFlow::Continue(()) = c.analysis()? else { return Ok(()) };
+
+        let gcx = c.gcx();
+        for id in gcx.hir.contract_ids() {
+            let contract = gcx.hir.contract(id);
+            if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
+                continue;
+            }
+            let mut module = lower::lower_contract(gcx, id);
+            let name = gcx.contract_fully_qualified_name(id).to_string();
+            if let Err(e) = run_pipeline(&mut module, &name, args) {
+                pipeline_err = Some(e);
+                break;
+            }
+        }
+        Ok(())
+    });
+
+    if let Some(e) = pipeline_err {
+        return Err(e);
+    }
+    if result.is_err() || compiler.sess().emitted_errors().is_some_and(|r| r.is_err()) {
+        return Err("compilation failed".into());
+    }
+    Ok(())
 }
 
 fn main() -> ExitCode {
@@ -115,67 +253,29 @@ fn main() -> ExitCode {
         }
     };
 
-    // Validate the pass name early so users get a fast error.
-    if make_pass(&args.pass).is_none() {
-        eprintln!("error: unknown pass: {}", args.pass);
-        eprintln!();
-        eprint!("{HELP}");
-        return ExitCode::FAILURE;
-    }
-
-    let sess = Session::builder().with_stderr_emitter().build();
-    let mut compiler = Compiler::new(sess);
-
-    // Parse the input file.
-    let parse_result = compiler.enter_mut(|c| -> solar_interface::Result<_> {
-        let mut pcx = c.parse();
-        pcx.load_files([Path::new(&args.input)])?;
-        pcx.parse();
-        Ok(())
-    });
-    if parse_result.is_err() {
-        return ExitCode::FAILURE;
-    }
-
-    // Lower, analyze, and run the requested pass on each contract.
-    let result = compiler.enter_mut(|c| -> solar_interface::Result<_> {
-        let ControlFlow::Continue(()) = c.lower_asts()? else {
-            return Ok(());
-        };
-        let ControlFlow::Continue(()) = c.analysis()? else {
-            return Ok(());
-        };
-
-        let gcx = c.gcx();
-        for id in gcx.hir.contract_ids() {
-            let contract = gcx.hir.contract(id);
-            if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
-                continue;
-            }
-
-            let mut module = lower::lower_contract(gcx, id);
-
-            // Run the requested pass on every function in the module.
-            // `none` skips the pass manager entirely so the output reflects
-            // the raw lowered MIR.
-            if let Some(Some(boxed_pass)) = make_pass(&args.pass) {
-                let mut pm = PassManager::new();
-                pm.add_transform(boxed_pass);
-                for func in module.functions.iter_mut() {
-                    pm.run(func);
-                }
-            }
-
-            let name = gcx.contract_fully_qualified_name(id);
-            println!("// === {} (after {}) ===", name, args.pass);
-            println!("{}", module_to_text(&module));
+    // Validate all pass names up front so users get fast feedback.
+    for name in &args.passes {
+        if let Err(e) = make_pass(name) {
+            eprintln!("error: {e}");
+            eprintln!();
+            eprint!("{HELP}");
+            return ExitCode::FAILURE;
         }
-        Ok(())
-    });
+    }
 
-    if result.is_err() || compiler.sess().emitted_errors().is_some_and(|r| r.is_err()) {
-        ExitCode::FAILURE
-    } else {
-        ExitCode::SUCCESS
+    // Dispatch on input file extension.
+    let ext = Path::new(&args.input).extension().and_then(|s| s.to_str()).unwrap_or("");
+    let result = match ext {
+        "sol" => process_sol(&args),
+        "mir" => process_mir(&args),
+        _ => Err(format!("unsupported input file extension `.{ext}` (expected .sol or .mir)")),
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
     }
 }

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -12,8 +12,13 @@ mod errors;
 mod solc;
 mod utils;
 
-/// Runs all the tests with the given `solar` command path.
-pub fn run_tests(cmd: &'static Path) -> Result<()> {
+/// Runs all the tests.
+///
+/// `cmd` is the path to the `solar` binary used by `Mode::Ui`,
+/// `Mode::SolcSolidity`, and `Mode::SolcYul`. `mir_opt_cmd` is the path to
+/// the `solar-mir-opt` binary used by `Mode::Mir`. If `mir_opt_cmd` is `None`,
+/// requesting `Mode::Mir` will return an error.
+pub fn run_tests(cmd: &'static Path, mir_opt_cmd: Option<&'static Path>) -> Result<()> {
     ui_test::color_eyre::install()?;
 
     let mut args = ui_test::Args::test()?;
@@ -33,18 +38,41 @@ pub fn run_tests(cmd: &'static Path) -> Result<()> {
         args.format = ui_test::Format::Terse;
     }
 
-    let mut modes = &[Mode::Ui, Mode::SolcSolidity, Mode::SolcYul][..];
-    let mode_tmp;
-    if let Ok(mode) = std::env::var("TESTER_MODE") {
-        mode_tmp = Mode::parse(&mode).ok_or_else(|| eyre!("invalid mode: {mode}"))?;
-        modes = std::slice::from_ref(&mode_tmp);
+    // Default modes: include Mir only if we have the binary.
+    let default_modes_with_mir: &[Mode] = &[Mode::Ui, Mode::Mir, Mode::SolcSolidity, Mode::SolcYul];
+    let default_modes_no_mir: &[Mode] = &[Mode::Ui, Mode::SolcSolidity, Mode::SolcYul];
+    let mut modes: Vec<Mode> = if mir_opt_cmd.is_some() {
+        default_modes_with_mir.to_vec()
+    } else {
+        default_modes_no_mir.to_vec()
+    };
+
+    // TESTER_MODE can be a single mode or a comma-separated list.
+    // The "ui" alias also implicitly runs the "mir" mode (if available),
+    // since they share the same `tests/ui/` tree and users typically want
+    // `cargo uitest` to cover both.
+    if let Ok(mode_str) = std::env::var("TESTER_MODE") {
+        let mut requested = Vec::new();
+        for name in mode_str.split(',') {
+            let m = Mode::parse(name.trim()).ok_or_else(|| eyre!("invalid mode: {name}"))?;
+            requested.push(m);
+            if name.trim() == "ui" && mir_opt_cmd.is_some() && !requested.contains(&Mode::Mir) {
+                requested.push(Mode::Mir);
+            }
+        }
+        modes = requested;
     }
 
     let tmp_dir = tempfile::tempdir()?;
     let tmp_dir = &*Box::leak(tmp_dir.path().to_path_buf().into_boxed_path());
-    for &mode in modes {
+    for &mode in &modes {
+        let mode_cmd = match mode {
+            Mode::Mir => mir_opt_cmd
+                .ok_or_else(|| eyre!("Mode::Mir requested but no solar-mir-opt binary path"))?,
+            _ => cmd,
+        };
         let cfg = MyConfig::<'static> { mode, tmp_dir };
-        let config = config(cmd, &args, mode);
+        let config = config(mode_cmd, &args, mode);
 
         let text_emitter: Box<dyn ui_test::status_emitter::StatusEmitter> = args.format.into();
         let gha_emitter = ui_test::status_emitter::Gha { name: mode.to_string(), group: true };
@@ -66,6 +94,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
 
     let path = match mode {
         Mode::Ui => "tests/ui/",
+        Mode::Mir => "tests/ui/codegen/mir/",
         Mode::SolcSolidity => "testdata/solidity/test/",
         Mode::SolcYul => "testdata/solidity/test/libyul/",
     };
@@ -84,8 +113,12 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
         program: ui_test::CommandBuilder {
             program: cmd.into(),
             args: {
-                let mut args =
-                    vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"];
+                // solar-mir-opt doesn't accept the same flags as solar.
+                let mut args: Vec<&str> = if matches!(mode, Mode::Mir) {
+                    Vec::new()
+                } else {
+                    vec!["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"]
+                };
                 if mode.is_solc() {
                     args.push("--stop-after=parsing");
                 }
@@ -175,12 +208,18 @@ fn get_host() -> &'static str {
 }
 
 fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Option<bool> {
-    path.extension().filter(|&ext| ext == "sol" || (cfg.mode.allows_yul() && ext == "yul"))?;
+    let allowed_ext = match cfg.mode {
+        Mode::Mir => path.extension().filter(|&ext| ext == "mir")?,
+        _ => path
+            .extension()
+            .filter(|&ext| ext == "sol" || (cfg.mode.allows_yul() && ext == "yul"))?,
+    };
+    let _ = allowed_ext;
     if !ui_test::default_any_file_filter(path, config) {
         return Some(false);
     }
     let skip = match cfg.mode {
-        Mode::Ui => false,
+        Mode::Ui | Mode::Mir => false,
         Mode::SolcSolidity => solc::solidity::should_skip(path).is_err(),
         Mode::SolcYul => solc::yul::should_skip(path).is_err(),
     };
@@ -236,9 +275,12 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum Mode {
     Ui,
+    /// MIR-level tests: runs `solar-mir-opt` on `.mir` files under
+    /// `tests/ui/codegen/mir/`.
+    Mir,
     SolcSolidity,
     SolcYul,
 }
@@ -247,6 +289,7 @@ impl Mode {
     fn parse(s: &str) -> Option<Self> {
         Some(match s {
             "ui" => Self::Ui,
+            "mir" => Self::Mir,
             "solc-solidity" => Self::SolcSolidity,
             "solc-yul" => Self::SolcYul,
             _ => return None,
@@ -256,6 +299,7 @@ impl Mode {
     fn to_str(self) -> &'static str {
         match self {
             Self::Ui => "ui",
+            Self::Mir => "mir",
             Self::SolcSolidity => "solc-solidity",
             Self::SolcYul => "solc-yul",
         }
@@ -266,7 +310,7 @@ impl Mode {
     }
 
     fn allows_yul(self) -> bool {
-        !matches!(self, Self::SolcSolidity)
+        !matches!(self, Self::SolcSolidity | Self::Mir)
     }
 }
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -18,9 +18,16 @@ fn main() -> anyhow::Result<()> {
     match flags.subcommand {
         flags::XtaskCmd::Test(flags::Test { bless, test_name, rest }) => {
             let sh = Shell::new()?;
+
+            // The MIR test mode runs `solar-mir-opt` on `.mir` files. The
+            // test binary locates it via current_exe() in the target dir,
+            // so we need to make sure it's built before running tests.
+            // Always pre-build it — it's cheap and avoids surprising skips.
+            cmd!(sh, "cargo build --package=solar-mir-opt").run()?;
+
             let mut cmd = cmd!(sh, "cargo test");
             if let Some(t) = test_name {
-                if matches!(t.as_str(), "ui" | "solc-solidity" | "solc-yul") {
+                if matches!(t.as_str(), "ui" | "mir" | "solc-solidity" | "solc-yul") {
                     cmd = cmd.args(INT_FLAGS).env("TESTER_MODE", &t);
                 } else {
                     cmd = cmd.arg(t);


### PR DESCRIPTION
Improve current the codegen (MIR) branch by adding: pass infrastructure, a textual MIR format (printer + parser), the `solar-mir-opt` tool, and an `SCCP` implementation.

Builds on top of the existing codegen work in https://github.com/paradigmxyz/solar/issues/693 (`feature/codegen-mir`).

By adding a way to serialise and deserialise (and to verify) the MIR module, it will make compiler more modular and easier to test individual analysis and passes. In addition to it, by having a Pass Manager, it will be much easier to use some analysis information between individual passes.

**Pass manager**

`AnalysisPass` and `TransformPass` traits with `AnalysisManager` for caching results by type. All transforms in `evm.rs` (`jump-threading`, `cfg-simplify`, `dce`) now go through the `PassManager` instead of being called directly.

**MIR text format**

Printer (`--emit=mir`) and hand-written recursive-descent parser covering all instruction kinds. Parser errors show source-line snippets with a caret. Round-trip property tests verify accuracy on every fixture.

**solar-mir-opt**

Standalone tool for running individual passes. Accepts `.sol` and `.mir` input, supports `--passes a,b,c`, `--print-after-each`, and `--pipeline-default`.

**New passes**

  - `SCCP` (Sparse Conditional Constant Propagation) — Propagates constants through the CFG, folds branches with known conditions, marks unreachable blocks. Resolves https://github.com/paradigmxyz/solar/issues/702.
  - `MIR` validator — checks SSA invariants (`defined-before-use`, pred/succ consistency, phi coverage, etc.)

**Liveness / DCE minor fixes**

  - Precomputed InstId -> ValueId maps replacing O(n) scans in both liveness and DCE
  - Phi-aware live_out equation for `Value::Phi` nodes
  - Fixed `sema/emit.rs` panicking on `--emit=bin` via todo!()

**Tests**

  - `.mir` LIT tests under `tests/ui/codegen/mir/` (DCE, CSE, SCCP, jump threading, cfg simplify, phi, switch, pipeline)
  - `.sol` UI tests under `tests/ui/codegen/` (arithmetic, storage, branches, loops, mappings, ternary, function calls, recursion, etc.)
  - Round-trip integration tests + validator integration tests on all fixtures
  - `Mode::Mir` added to the test runner so `cargo uitest` covers both `.sol` and `.mir`