### PR TITLE
fix(sema): suppress parse drop warning after errors

### DIFF
--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -390,7 +390,7 @@ impl<'gcx> ParsingContext<'gcx> {
 
 impl Drop for ParsingContext<'_> {
     fn drop(&mut self) {
-        if self.parsed {
+        if self.parsed || self.dcx().has_errors().is_err() {
             return;
         }
         // This used to be a call to `bug` but it can be hit legitimately for example when there is


### PR DESCRIPTION
## Summary

Suppress the `ParsingContext::parse` drop-time warning when diagnostics have already been emitted. This path is legitimate when parsing exits early after an error, for example the missing-file UI test.

## Verification

- `cargo check --workspace`
- `cargo uitest`

This is intended as the small base fix for the frontend performance stack.