### PR TITLE
fix(sema): allow events/errors to shadow builtin identifiers

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1585,6 +1585,16 @@ impl Declarations {
             return None;
         }
 
+        // Allow events and errors to shadow builtin identifiers (this, super).
+        // Events/errors don't create conflicts with builtins since they exist in different
+        // namespaces and cannot be confused in usage.
+        if matches!(decl.res, Item(Event(_) | Error(_)))
+            && declarations.len() == 1
+            && matches!(declarations[0].res, Builtin(_))
+        {
+            return None;
+        }
+
         // https://github.com/argotorg/solidity/blob/de1a017ccb935d149ed6bcbdb730d89883f8ce02/libsolidity/analysis/DeclarationContainer.cpp#L35
         if matches!(decl.res, Item(Function(_) | Event(_))) {
             let mut getter = None;

--- a/tests/ui/resolve/event_error_shadow_builtin.sol
+++ b/tests/ui/resolve/event_error_shadow_builtin.sol
@@ -1,0 +1,21 @@
+//@check-pass
+// Events and errors can shadow builtin identifiers (this, super).
+// This is allowed because they exist in different namespaces and cannot be confused.
+
+contract C {
+    event this();
+    event super();
+}
+
+contract D {
+    error this();
+    error super();
+}
+
+contract E {
+    // Can use both event and function with builtin names
+    event this();
+    function f() public {
+        address x = address(this);
+    }
+}


### PR DESCRIPTION
## Description

Events and errors can now be named `this` or `super` without conflicting with builtin identifiers. This fix allows these declarations to shadow builtins since they exist in different namespaces and cannot be confused in usage.

Fixes #216

## Problem

Previously, declaring an event or error with the name `this` or `super` would incorrectly trigger a conflict error:

```solidity
contract C {
    event this(); // Error: identifier `this` already declared
}

contract D {
    event super(); // Error: identifier `super` already declared
}
```

This behavior was inconsistent with `solc`, which allows these declarations since events/errors and builtins exist in different namespaces.

## Solution

Modified the `conflicting_declaration` method in `crates/sema/src/ast_lowering/resolve.rs` to allow events and errors to shadow builtin identifiers (`this`, `super`). The check verifies:
1. The new declaration is an event or error
2. There's exactly one existing declaration
3. The existing declaration is a builtin

When these conditions are met, no conflict is reported, allowing the event/error to shadow the builtin.

## Changes

- **Modified**: `crates/sema/src/ast_lowering/resolve.rs`
  - Added special case in `conflicting_declaration()` to allow events/errors to shadow builtins
- **Added**: `tests/ui/resolve/event_error_shadow_builtin.sol`
  - UI test covering events and errors named `this` and `super`
  - Verifies that both can coexist with builtin usage in the same contract

## Testing

All tests pass:
- 199 UI/integration tests (including new test)
- 105 unit tests
- 7 documentation tests
- Clippy (no warnings)
- Code formatting (`cargo +nightly fmt`)
- Spellcheck (typos)
- Documentation build

Verified with original failing examples from issue #216 - both now compile successfully.

## Compatibility

This change aligns Solar's behavior with `solc` and does not introduce any breaking changes. Events, errors, and builtins continue to work as expected in their respective contexts.
