### PR TITLE
fix(parse): replace match with ? operator for clippy::question_mark

### DIFF
--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -669,14 +669,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     first = false;
                 } else {
                     // check for separator
-                    match self.expect(sep_kind) {
-                        Ok(recovered_) => {
-                            if recovered_ == Recovered::Yes {
-                                recovered = Recovered::Yes;
-                                break;
-                            }
+                    {
+                        let recovered_ = self.expect(sep_kind)?;
+                        if recovered_ == Recovered::Yes {
+                            recovered = Recovered::Yes;
+                            break;
                         }
-                        Err(e) => return Err(e),
                     }
 
                     if self.check(ket) {


### PR DESCRIPTION
## Summary
Fixes `clippy::question_mark` lint error that was failing in CI.

## Problem
CI was failing because a `match` expression in `parse_seq_inner()` was manually handling `Ok`/`Err` cases where the `?` operator provides cleaner, idiomatic error propagation.

## Solution
Replaced the explicit `match` on `Result` with the `?` operator. The logic and behavior remain identical — the `?` operator automatically returns early on `Err`, while the success case proceeds with the same recovery logic.

### Before
```rust
match self.expect(sep_kind) {
    Ok(recovered_) => {
        if recovered_ == Recovered::Yes {
            recovered = Recovered::Yes;
            break;
        }
    }
    Err(e) => return Err(e),
}
```

### After
```rust
{
    let recovered_ = self.expect(sep_kind)?;
    if recovered_ == Recovered::Yes {
        recovered = Recovered::Yes;
        break;
    }
}
```