### PR TITLE
fix(file_resolver): implement sanitize_path for cross-platform separator normalization

### DIFF
--- a/crates/interface/src/source_map/file_resolver.rs
+++ b/crates/interface/src/source_map/file_resolver.rs
@@ -367,9 +367,12 @@ impl<'a> FileResolver<'a> {
     }
 }
 
-fn sanitize_path(s: &str) -> impl std::ops::Deref<Target = str> + '_ {
-    // TODO: Equivalent of: `boost::filesystem::path(_path).generic_string()`
-    s
+/// Equivalent of `boost::filesystem::path(_path).generic_string()`: returns the
+/// path with every platform-specific separator (`\`) replaced by the generic
+/// one (`/`), so import-path comparison in remappings is consistent across
+/// platforms. Allocation is avoided when the input is already in generic form.
+fn sanitize_path(s: &str) -> Cow<'_, str> {
+    if s.contains('\\') { Cow::Owned(s.replace('\\', "/")) } else { Cow::Borrowed(s) }
 }
 
 #[cfg(test)]
@@ -507,5 +510,40 @@ mod tests {
         ];
         run(&TestCase { remappings: &["a:x/y/z=d", "a/b:x=e"], sources });
         run(&TestCase { remappings: &["a/b:x=e", "a:x/y/z=d"], sources });
+    }
+
+    // Tests for `sanitize_path`: it must mirror
+    // `boost::filesystem::path(_path).generic_string()` semantics — replace the
+    // platform-specific separator (`\`) with the generic one (`/`), and leave
+    // every other character untouched.
+    #[test]
+    fn sanitize_path_empty() {
+        assert_eq!(&*sanitize_path(""), "");
+    }
+
+    #[test]
+    fn sanitize_path_no_separators() {
+        assert_eq!(&*sanitize_path("plainfile.sol"), "plainfile.sol");
+    }
+
+    #[test]
+    fn sanitize_path_already_generic() {
+        assert_eq!(&*sanitize_path("a/b/c.sol"), "a/b/c.sol");
+    }
+
+    #[test]
+    fn sanitize_path_all_backslashes() {
+        assert_eq!(&*sanitize_path("a\\b\\c.sol"), "a/b/c.sol");
+    }
+
+    #[test]
+    fn sanitize_path_mixed_separators() {
+        assert_eq!(&*sanitize_path("a/b\\c/d.sol"), "a/b/c/d.sol");
+    }
+
+    #[test]
+    fn sanitize_path_preserves_consecutive_separators() {
+        // boost's generic_string does not collapse separators.
+        assert_eq!(&*sanitize_path("a\\\\b"), "a//b");
     }
 }


### PR DESCRIPTION
## Summary

Resolves the `TODO` at `crates/interface/src/source_map/file_resolver.rs:371` by implementing `sanitize_path` with the semantics promised by the comment: an equivalent of `boost::filesystem::path(_path).generic_string()`.

```rust
// before
fn sanitize_path(s: &str) -> impl std::ops::Deref<Target = str> + '_ {
    // TODO: Equivalent of: `boost::filesystem::path(_path).generic_string()`
    s
}

// after
fn sanitize_path(s: &str) -> Cow<'_, str> {
    if s.contains('\\') { Cow::Owned(s.replace('\\', "/")) } else { Cow::Borrowed(s) }
}
```

## Why

`sanitize_path` is invoked at three call sites in `FileResolver::remap_path_` to normalize the `context`, `prefix`, and `target` strings of import remappings before string-level prefix matching. While Solidity import paths always use `/`, paths sourced from the filesystem on Windows can contain `\`. With the previous no-op stub, prefix comparison silently failed for any user-supplied remapping with backslash separators on Windows. solc itself avoids this trap by funneling these strings through `boost::filesystem::path(_path).generic_string()`, which rewrites `\` to `/`. This PR brings Solar's implementation in line with that contract.

`Cow<'_, str>` is used so the common case — inputs already in generic form (i.e. virtually all inputs on Linux/macOS, and most on Windows) — stays allocation-free.

## Scope

- **Surface**: a single private function in `solar-interface`.
- **Behavior change**: visible only when the input contains `\` (in practice, Windows users who supply remappings with backslashes).
- **Compatibility**: `generic_string()` does not lexically normalize (`..`/`.` are not collapsed and consecutive separators are preserved); this implementation matches that exactly. No callers should be affected on Linux/macOS.

## Test plan

- [x] `cargo test -p solar-interface --lib source_map::file_resolver` → **10 / 10 ok** (4 existing + 6 new unit tests)
- [x] `cargo test --workspace` → all suites green
- [x] `cargo check --workspace --all-targets` → clean
- [x] `cargo clippy --workspace --all-targets` → no new warnings introduced
- [x] `cargo +nightly fmt --check -p solar-interface` → clean

The 6 new unit tests cover:

| case | input | expected |
| --- | --- | --- |
| empty | `""` | `""` |
| no separators | `"plainfile.sol"` | `"plainfile.sol"` |
| already generic | `"a/b/c.sol"` | `"a/b/c.sol"` |
| all backslashes | `"a\\b\\c.sol"` | `"a/b/c.sol"` |
| mixed separators | `"a/b\\c/d.sol"` | `"a/b/c/d.sol"` |
| consecutive backslashes preserved | `"a\\\\b"` | `"a//b"` |

## Out of scope

- Lexical normalization (`..` / `.` collapsing) — would diverge from the `generic_string()` contract.
- UNC path handling on Windows — already covered by the `dunce` crate at file-load time.
