### PR TITLE
ci(codegen): run solar benchmark corpus

### DIFF
--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -148,6 +148,7 @@ def main() -> int:
     repo_runtime = runtime_issue_details(repo_results)
     for detail in repo_runtime:
         warning(f"repository runtime mismatch recorded: {detail}")
+    failures.extend(f"repo {failure}" for failure in repo_runtime)
 
     if failures:
         print("codegen benchmark failures:", file=sys.stderr)

--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -31,18 +31,74 @@ def compiler_failures(results: list[dict[str, Any]]) -> list[str]:
     return failures
 
 
-def runtime_failures(results: list[dict[str, Any]]) -> list[str]:
-    failures = []
+def shorten(value: Any, limit: int = 160) -> str:
+    text = str(value).replace("\n", " ")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def format_values(values: dict[str, Any]) -> str:
+    return ", ".join(f"{compiler}={shorten(value)}" for compiler, value in values.items())
+
+
+def runtime_issue_details(results: list[dict[str, Any]]) -> list[str]:
+    details = []
     for result in results:
         status = result.get("runtime_status")
         if status in (None, "skipped", "ok"):
             continue
-        failures.append(f"{result.get('test_id', '<unknown>')}: runtime_status={status}")
-    return failures
+        test_id = result.get("test_id", "<unknown>")
+        before = len(details)
+
+        for mismatch in result.get("runtime_mismatches") or []:
+            label = mismatch.get("label", "<unknown>")
+            values = mismatch.get("values") or {}
+            details.append(f"{test_id} {label}: {format_values(values)}")
+
+        for compiler_id, data in (result.get("compilers") or {}).items():
+            for check in data.get("runtime_results") or []:
+                if check.get("status") == "ok":
+                    continue
+                label = check.get("label", "<unknown>")
+                error = check.get("error") or check.get("status")
+                details.append(f"{test_id} {compiler_id} {label}: {shorten(error)}")
+
+        if len(details) == before:
+            details.append(f"{test_id}: runtime_status={status}")
+
+    return details
 
 
 def warning(message: str) -> None:
-    print(f"::warning::{message}")
+    escaped = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    print(f"::warning::{escaped}")
+
+
+def markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", "<br>")
+
+
+def runtime_summary(result: dict[str, Any]) -> str:
+    status = result.get("runtime_status")
+    if status in (None, "skipped", "ok"):
+        return ""
+
+    parts = []
+    for mismatch in result.get("runtime_mismatches") or []:
+        label = mismatch.get("label", "<unknown>")
+        values = mismatch.get("values") or {}
+        parts.append(f"{label}: {format_values(values)}")
+
+    for compiler_id, data in (result.get("compilers") or {}).items():
+        for check in data.get("runtime_results") or []:
+            if check.get("status") == "ok":
+                continue
+            label = check.get("label", "<unknown>")
+            error = check.get("error") or check.get("status")
+            parts.append(f"{compiler_id} {label}: {shorten(error)}")
+
+    return "<br>".join(markdown_cell(part) for part in parts) or str(status)
 
 
 def append_summary(title: str, results: list[dict[str, Any]]) -> None:
@@ -53,8 +109,8 @@ def append_summary(title: str, results: list[dict[str, Any]]) -> None:
     lines = [
         f"### {title}",
         "",
-        "| Test | Compile | Runtime |",
-        "| ---- | ------- | ------- |",
+        "| Test | Compile | Runtime | Details |",
+        "| ---- | ------- | ------- | ------- |",
     ]
     for result in results:
         compilers = result.get("compilers", {})
@@ -62,7 +118,8 @@ def append_summary(title: str, results: list[dict[str, Any]]) -> None:
         runtime_status = result.get("runtime_status") or "not run"
         lines.append(
             f"| {result.get('test_id', '<unknown>')} | "
-            f"{'ok' if compile_ok else 'failed'} | {runtime_status} |"
+            f"{'ok' if compile_ok else 'failed'} | {runtime_status} | "
+            f"{runtime_summary(result)} |"
         )
     lines.append("")
 
@@ -85,12 +142,12 @@ def main() -> int:
 
     failures = []
     failures.extend(f"micro {failure}" for failure in compiler_failures(micro_results))
-    failures.extend(f"micro {failure}" for failure in runtime_failures(micro_results))
+    failures.extend(f"micro {failure}" for failure in runtime_issue_details(micro_results))
     failures.extend(f"repo {failure}" for failure in compiler_failures(repo_results))
 
-    repo_runtime = runtime_failures(repo_results)
-    for failure in repo_runtime:
-        warning(f"repository runtime mismatch recorded: {failure}")
+    repo_runtime = runtime_issue_details(repo_results)
+    for detail in repo_runtime:
+        warning(f"repository runtime mismatch recorded: {detail}")
 
     if failures:
         print("codegen benchmark failures:", file=sys.stderr)

--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate Solar codegen benchmark JSON emitted by solar_bench.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_results(path: Path) -> list[dict[str, Any]]:
+    with path.open() as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise SystemExit(f"{path}: expected a list of benchmark results")
+    return data
+
+
+def compiler_failures(results: list[dict[str, Any]]) -> list[str]:
+    failures = []
+    for result in results:
+        test_id = result.get("test_id", "<unknown>")
+        compilers = result.get("compilers", {})
+        for compiler_id, data in compilers.items():
+            if data.get("status") != "ok":
+                error = str(data.get("error") or "").splitlines()[0]
+                failures.append(f"{test_id} {compiler_id}: {error}")
+    return failures
+
+
+def runtime_failures(results: list[dict[str, Any]]) -> list[str]:
+    failures = []
+    for result in results:
+        status = result.get("runtime_status")
+        if status in (None, "skipped", "ok"):
+            continue
+        failures.append(f"{result.get('test_id', '<unknown>')}: runtime_status={status}")
+    return failures
+
+
+def warning(message: str) -> None:
+    print(f"::warning::{message}")
+
+
+def append_summary(title: str, results: list[dict[str, Any]]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    lines = [
+        f"### {title}",
+        "",
+        "| Test | Compile | Runtime |",
+        "| ---- | ------- | ------- |",
+    ]
+    for result in results:
+        compilers = result.get("compilers", {})
+        compile_ok = all(data.get("status") == "ok" for data in compilers.values())
+        runtime_status = result.get("runtime_status") or "not run"
+        lines.append(
+            f"| {result.get('test_id', '<unknown>')} | "
+            f"{'ok' if compile_ok else 'failed'} | {runtime_status} |"
+        )
+    lines.append("")
+
+    with open(summary_path, "a") as f:
+        f.write("\n".join(lines))
+        f.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--micro", type=Path, required=True)
+    parser.add_argument("--repo", type=Path, required=True)
+    args = parser.parse_args()
+
+    micro_results = load_results(args.micro)
+    repo_results = load_results(args.repo)
+
+    append_summary("Solar micro codegen benchmark", micro_results)
+    append_summary("Solar repository codegen benchmark", repo_results)
+
+    failures = []
+    failures.extend(f"micro {failure}" for failure in compiler_failures(micro_results))
+    failures.extend(f"micro {failure}" for failure in runtime_failures(micro_results))
+    failures.extend(f"repo {failure}" for failure in compiler_failures(repo_results))
+
+    repo_runtime = runtime_failures(repo_results)
+    for failure in repo_runtime:
+        warning(f"repository runtime mismatch recorded: {failure}")
+
+    if failures:
+        print("codegen benchmark failures:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("codegen benchmark checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,128 @@
+name: Codegen
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/check_codegen_benchmark.py"
+      - ".github/workflows/codegen.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/cli/**"
+      - "crates/codegen/**"
+      - "crates/sema/**"
+      - "crates/solar/**"
+      - "tests/ui/codegen/**"
+      - "tools/solar-mir-opt/**"
+      - "tools/tester/**"
+  pull_request:
+    paths:
+      - ".github/scripts/check_codegen_benchmark.py"
+      - ".github/workflows/codegen.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/cli/**"
+      - "crates/codegen/**"
+      - "crates/sema/**"
+      - "crates/solar/**"
+      - "tests/ui/codegen/**"
+      - "tools/solar-mir-opt/**"
+      - "tools/tester/**"
+  workflow_dispatch:
+    inputs:
+      benchmark_ref:
+        description: "Ref to checkout from walnuthq/solidity-compiler-benchmarks"
+        required: false
+        default: main
+
+env:
+  CARGO_TERM_COLOR: always
+  SOLC_VERSION: 0.8.30
+  BENCHMARK_REPOSITORY: walnuthq/solidity-compiler-benchmarks
+  BENCHMARK_PATH: solidity-compiler-benchmarks
+
+jobs:
+  solar-vs-solc:
+    name: Solar vs solc codegen
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Solar
+        uses: actions/checkout@v6
+
+      - name: Checkout benchmark corpus
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BENCHMARK_REPOSITORY }}
+          ref: ${{ github.event.inputs.benchmark_ref || 'main' }}
+          path: ${{ env.BENCHMARK_PATH }}
+          submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Install solc
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/solc"
+          curl -fsSL \
+            "https://github.com/ethereum/solidity/releases/download/v${SOLC_VERSION}/solc-static-linux" \
+            -o "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}"
+          chmod +x "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}"
+          "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" --version
+
+      - name: Build Solar
+        run: cargo build -p solar-compiler --bin solar
+
+      - name: Run micro codegen runtime checks
+        working-directory: ${{ env.BENCHMARK_PATH }}
+        run: |
+          set -euo pipefail
+          python3 ./solar_bench.py --verbose \
+            --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
+            --solar "$GITHUB_WORKSPACE/target/debug/solar" \
+            --gas \
+            --start-anvil \
+            --output "$RUNNER_TEMP/solar-codegen-micro.json"
+
+      - name: Run repository codegen benchmarks
+        working-directory: ${{ env.BENCHMARK_PATH }}
+        run: |
+          set -euo pipefail
+          python3 ./solar_bench.py --verbose \
+            --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
+            --solar "$GITHUB_WORKSPACE/target/debug/solar" \
+            --suite repo \
+            --gas \
+            --start-anvil \
+            --allow-failures \
+            --output "$RUNNER_TEMP/solar-codegen-repo.json"
+
+      - name: Check benchmark results
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/check_codegen_benchmark.py \
+            --micro "$RUNNER_TEMP/solar-codegen-micro.json" \
+            --repo "$RUNNER_TEMP/solar-codegen-repo.json"
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: solar-codegen-benchmark-results
+          path: |
+            ${{ runner.temp }}/solar-codegen-micro.json
+            ${{ runner.temp }}/solar-codegen-repo.json
+          retention-days: 14

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -272,11 +272,6 @@ impl Liveness {
         // live_in(B) = block_uses(B) | (live_out(B) - block_defs(B))
         let mut worklist: VecDeque<BlockId> = func.blocks.indices().collect();
 
-        // Initialize live_in for all blocks from their upward-exposed uses.
-        for bidx in 0..num_blocks {
-            block_liveness[bidx].live_in = block_uses[bidx].clone();
-        }
-
         while let Some(block_id) = worklist.pop_front() {
             let bidx = block_id.index();
             let block = &func.blocks[block_id];
@@ -294,25 +289,23 @@ impl Liveness {
                 new_live_out.union_with(&contribution);
             }
 
-            // Check if live_out changed
-            if new_live_out != block_liveness[bidx].live_out {
-                block_liveness[bidx].live_out = new_live_out;
-
-                // Compute live_in = use ∪ (live_out - def)
-                let mut new_live_in = block_uses[bidx].clone();
-                for val in block_liveness[bidx].live_out.iter() {
-                    if !block_defs[bidx].contains(val) {
-                        new_live_in.insert(val);
-                    }
+            // live_in = use ∪ (live_out - def)
+            let mut new_live_in = block_uses[bidx].clone();
+            for val in new_live_out.iter() {
+                if !block_defs[bidx].contains(val) {
+                    new_live_in.insert(val);
                 }
+            }
 
-                if new_live_in != block_liveness[bidx].live_in {
-                    block_liveness[bidx].live_in = new_live_in;
+            if new_live_out != block_liveness[bidx].live_out
+                || new_live_in != block_liveness[bidx].live_in
+            {
+                block_liveness[bidx].live_out = new_live_out;
+                block_liveness[bidx].live_in = new_live_in;
 
-                    // Add predecessors to worklist
-                    for &pred in &block.predecessors {
-                        worklist.push_back(pred);
-                    }
+                // Add predecessors to worklist
+                for &pred in &block.predecessors {
+                    worklist.push_back(pred);
                 }
             }
         }

--- a/crates/codegen/src/analysis/phi_elimination.rs
+++ b/crates/codegen/src/analysis/phi_elimination.rs
@@ -95,7 +95,7 @@ pub fn eliminate_phis(func: &Function) -> PhiEliminationResult {
 
     // Sequentialize parallel copies to handle cycles
     let mut temp_counter = 0u32;
-    for (_, copies) in block_copies.iter_mut() {
+    for copies in block_copies.values_mut() {
         sequentialize_copies(&mut copies.copies, &mut temp_counter);
     }
 

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -530,6 +530,8 @@ impl EvmCodegen {
         // Reset scheduler
         self.scheduler = StackScheduler::new();
 
+        self.preallocate_cross_block_spills(func, liveness);
+
         // Create labels for each block
         self.block_labels.clear();
         for block_id in func.blocks.indices() {
@@ -584,6 +586,25 @@ impl EvmCodegen {
         }
     }
 
+    /// Preallocates stable spill slots for values that may cross block boundaries.
+    ///
+    /// Blocks are emitted in layout order, not necessarily dominance order, so a block can be
+    /// emitted before the predecessor that stores one of its live-in values. Reserving the slot up
+    /// front lets the later load use a stable memory location; stores still happen only when the
+    /// value is actually available on the stack.
+    fn preallocate_cross_block_spills(&mut self, func: &Function, liveness: &Liveness) {
+        for block_id in func.blocks.indices() {
+            for val in liveness.live_in(block_id).iter().chain(liveness.live_out(block_id).iter()) {
+                if matches!(
+                    func.value(val),
+                    crate::mir::Value::Inst(_) | crate::mir::Value::Phi { .. }
+                ) {
+                    self.scheduler.spills.allocate(val);
+                }
+            }
+        }
+    }
+
     /// Spills all live-out values that are currently on the stack to memory.
     /// This ensures values that need to be accessed in successor blocks can be reloaded.
     fn spill_live_out_values(&mut self, func: &Function, liveness: &Liveness, block_id: BlockId) {
@@ -603,31 +624,26 @@ impl EvmCodegen {
             _ => {}
         }
 
-        // If the value is not already spilled, spill it
-        if !self.scheduler.spills.is_spilled(val) {
-            // Check if value is on the stack
-            if let Some(depth) = self.scheduler.stack.find(val) {
-                // Allocate a spill slot
-                let slot = self.scheduler.spills.allocate(val);
+        if let Some(depth) = self.scheduler.stack.find(val) {
+            let slot = self.scheduler.spills.allocate(val);
 
-                // DUP the value to top of stack for storing.
-                // We need to DUP (not just use ensure_on_top) because:
-                // 1. If value is on top, ensure_on_top does nothing but we need a copy
-                // 2. MSTORE will consume the value, and we want to preserve the original
-                let dup_n = (depth + 1) as u8;
-                self.asm.emit_op(opcodes::dup(dup_n));
-                self.scheduler.stack.dup(dup_n);
+            // DUP the value to top of stack for storing.
+            // We need to DUP (not just use ensure_on_top) because:
+            // 1. If value is on top, ensure_on_top does nothing but we need a copy
+            // 2. MSTORE will consume the value, and we want to preserve the original
+            let dup_n = (depth + 1) as u8;
+            self.asm.emit_op(opcodes::dup(dup_n));
+            self.scheduler.stack.dup(dup_n);
 
-                // Store to spill slot: PUSH offset, MSTORE
-                // The PUSH creates an untracked stack entry, so we track it as unknown
-                self.asm.emit_push(U256::from(slot.byte_offset()));
-                self.scheduler.stack.push_unknown();
+            // Store to spill slot: PUSH offset, MSTORE
+            // The PUSH creates an untracked stack entry, so we track it as unknown
+            self.asm.emit_push(U256::from(slot.byte_offset()));
+            self.scheduler.stack.push_unknown();
 
-                self.asm.emit_op(opcodes::MSTORE);
-                // MSTORE consumes 2 values: the untracked offset and the DUP'd value
-                self.scheduler.stack.pop(); // pop the untracked offset
-                self.scheduler.stack.pop(); // pop the DUP'd value (original remains)
-            }
+            self.asm.emit_op(opcodes::MSTORE);
+            // MSTORE consumes 2 values: the untracked offset and the DUP'd value
+            self.scheduler.stack.pop(); // pop the untracked offset
+            self.scheduler.stack.pop(); // pop the DUP'd value (original remains)
         }
     }
 
@@ -1327,6 +1343,12 @@ impl EvmCodegen {
                 self.asm.emit_op(opcodes::EXTCODECOPY);
                 self.scheduler.instruction_executed(4, None);
             }
+        }
+
+        if let Some(result) = result_value
+            && liveness.live_out(block).contains(result)
+        {
+            self.spill_value_if_needed(func, result);
         }
 
         // Drop dead values after the instruction

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1187,7 +1187,15 @@ impl<'gcx> ResolveContext<'gcx> {
     #[instrument(name = "lower_type", level = "trace", skip_all)]
     fn lower_type(&mut self, ty: &ast::Type<'_>) -> hir::Type<'gcx> {
         let kind = match &ty.kind {
-            ast::TypeKind::Elementary(ty) => hir::TypeKind::Elementary(*ty),
+            ast::TypeKind::Elementary(ty) => hir::TypeKind::Elementary(match *ty {
+                ast::ElementaryType::Int(size) if size == ast::TypeSize::ZERO => {
+                    ast::ElementaryType::Int(ast::TypeSize::new_int_bits(256))
+                }
+                ast::ElementaryType::UInt(size) if size == ast::TypeSize::ZERO => {
+                    ast::ElementaryType::UInt(ast::TypeSize::new_int_bits(256))
+                }
+                ty => ty,
+            }),
             ast::TypeKind::Array(array) => hir::TypeKind::Array(self.arena.alloc(hir::TypeArray {
                 element: self.lower_type(&array.element),
                 size: self.lower_expr_opt(array.size.as_deref()),


### PR DESCRIPTION
Adds `codegen` CI using [solidity-compiler-benchmarks](https://github.com/walnuthq/solidity-compiler-benchmarks)

The workflow builds `solar`, compiles the benchmark corpus with both `solc` and `solar`, then checks:
  - bytecode size
  - gas usage on Anvil
  - runtime output equality for the same calls/inputs

While trying to build the contracts from the set of contracts I shared, some `codegen` issues occurred. In this PR, I fixed a `codegen` bug: cross-block MIR values were not always spilled before leaving a block, so successor blocks could lose values after the stack model was cleared. The fix improves liveness propagation and preallocates/spills live cross-block values in EVM `codegen`.
Besides that, there is `fix(sema): canonicalize bare integer types`, and it should be a separate PR; it fixes `uint/uint256` alias handling, detected in `maple-erc20`.