### PR TITLE
fix(sema): canonicalize bare integer aliases

### DIFF
--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -669,14 +669,10 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     first = false;
                 } else {
                     // check for separator
-                    match self.expect(sep_kind) {
-                        Ok(recovered_) => {
-                            if recovered_ == Recovered::Yes {
-                                recovered = Recovered::Yes;
-                                break;
-                            }
-                        }
-                        Err(e) => return Err(e),
+                    let recovered_ = self.expect(sep_kind)?;
+                    if recovered_ == Recovered::Yes {
+                        recovered = Recovered::Yes;
+                        break;
                     }
 
                     if self.check(ket) {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1138,7 +1138,15 @@ impl<'gcx> ResolveContext<'gcx> {
     #[instrument(name = "lower_type", level = "trace", skip_all)]
     fn lower_type(&mut self, ty: &ast::Type<'_>) -> hir::Type<'gcx> {
         let kind = match &ty.kind {
-            ast::TypeKind::Elementary(ty) => hir::TypeKind::Elementary(*ty),
+            ast::TypeKind::Elementary(ty) => hir::TypeKind::Elementary(match *ty {
+                ast::ElementaryType::Int(size) if size == ast::TypeSize::ZERO => {
+                    ast::ElementaryType::Int(ast::TypeSize::new_int_bits(256))
+                }
+                ast::ElementaryType::UInt(size) if size == ast::TypeSize::ZERO => {
+                    ast::ElementaryType::UInt(ast::TypeSize::new_int_bits(256))
+                }
+                ty => ty,
+            }),
             ast::TypeKind::Array(array) => hir::TypeKind::Array(self.arena.alloc(hir::TypeArray {
                 element: self.lower_type(&array.element),
                 size: self.lower_expr_opt(array.size.as_deref()),

--- a/tests/ui/overrides/bare_int_aliases.sol
+++ b/tests/ui/overrides/bare_int_aliases.sol
@@ -1,0 +1,36 @@
+// `int` and `uint` are aliases for `int256` and `uint256`.
+// Override matching must compare the canonical types.
+
+interface IERC20Like {
+    function permit(
+        address owner,
+        address spender,
+        uint amount,
+        uint deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}
+
+contract ERC20Like is IERC20Like {
+    function permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public override {}
+}
+
+abstract contract SignedBase {
+    function f(int value) public virtual returns (int);
+}
+
+contract SignedDerived is SignedBase {
+    function f(int256 value) public override returns (int256) {
+        return value;
+    }
+}


### PR DESCRIPTION
This fixes uint/uint256 alias handling.
It was detected during `codegen` testing (https://github.com/paradigmxyz/solar/pull/760), in particular while building `maple-erc20`.

