### PR TITLE
refactor(sema): defer type flag checks

### DIFF
--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -111,7 +111,10 @@ fn analysis(gcx: Gcx<'_>) -> Result<ControlFlow<()>> {
     gcx.hir.par_item_ids().for_each(|id| {
         let _ = gcx.type_of_item(id);
         match id {
-            hir::ItemId::Struct(id) => _ = gcx.struct_field_types(id),
+            hir::ItemId::Struct(id) => {
+                let _ = gcx.struct_recursiveness(id);
+                let _ = gcx.struct_field_types(id);
+            }
             hir::ItemId::Contract(id) => _ = gcx.interface_functions(id),
             _ => {}
         }

--- a/crates/sema/src/ty/common.rs
+++ b/crates/sema/src/ty/common.rs
@@ -1,4 +1,4 @@
-use super::{Interner, Ty, TyFlags, TyKind};
+use super::{Interner, Ty, TyKind};
 use solar_ast::{DataLocation, ElementaryType, TypeSize};
 
 /// Pre-interned types.
@@ -37,10 +37,7 @@ impl<'gcx> CommonTypes<'gcx> {
         use TyKind::*;
         use std::array::from_fn;
 
-        // NOTE: We need to skip calculating flags here because it would require `Gcx` when we
-        // haven't built one yet. This is fine since elementary types don't have any flags.
-        // If that ever changes, then this closure should also reflect that.
-        let mk = |kind| interner.intern_ty_with_flags(bump, kind, |_| TyFlags::empty());
+        let mk = |kind| interner.intern_ty(bump, kind);
         let mk_refs = |ty| EachDataLoc {
             storage: mk(Ref(ty, DataLocation::Storage)),
             transient: mk(Ref(ty, DataLocation::Transient)),

--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -23,14 +23,10 @@ impl<'gcx> Interner<'gcx> {
         Self::default()
     }
 
-    pub(super) fn intern_ty_with_flags(
-        &self,
-        bump: &'gcx bumpalo::Bump,
-        kind: TyKind<'gcx>,
-        mk_flags: impl FnOnce(&TyKind<'gcx>) -> TyFlags,
-    ) -> Ty<'gcx> {
+    pub(super) fn intern_ty(&self, bump: &'gcx bumpalo::Bump, kind: TyKind<'gcx>) -> Ty<'gcx> {
         Ty(Interned::new_unchecked(
-            self.tys.intern(kind, |kind| bump.alloc(TyData { flags: mk_flags(&kind), kind })),
+            self.tys
+                .intern(kind, |kind| bump.alloc(TyData { flags: TyFlags::calculate(&kind), kind })),
         ))
     }
 

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -336,7 +336,7 @@ impl<'gcx> Gcx<'gcx> {
     }
 
     pub fn mk_ty(self, kind: TyKind<'gcx>) -> Ty<'gcx> {
-        self.interner.intern_ty_with_flags(self.bump(), kind, |kind| TyFlags::calculate(self, kind))
+        self.interner.intern_ty(self.bump(), kind)
     }
 
     pub fn mk_tys(self, tys: &[Ty<'gcx>]) -> &'gcx [Ty<'gcx>] {
@@ -744,7 +744,7 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                 result = Err(guar);
                 continue;
             }
-            if !ty.can_be_exported() {
+            if !ty.can_be_exported(gcx) {
                 // TODO: implement `interfaceType`
                 if c.kind.is_library() {
                     result = Err(ErrorGuaranteed::new_unchecked());
@@ -752,9 +752,9 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                 }
 
                 let kind = f.description();
-                let msg = if ty.has_mapping() {
+                let msg = if ty.has_mapping(gcx) {
                     format!("types containing mappings cannot be parameter or return types of public {kind}s")
-                } else if ty.is_recursive() {
+                } else if ty.is_recursive(gcx) {
                     format!("recursive types cannot be parameter or return types of public {kind}s")
                 } else if ty.has_internal_function() {
                     format!("types containing internal function pointers cannot be parameter or return types of public {kind}s")
@@ -917,12 +917,17 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
     use hir::DataLocation::*;
 
     // https://github.com/argotorg/solidity/blob/48d40d5eaf97c835cf55896a7a161eedc57c57f9/libsolidity/ast/AST.cpp#L820
-    let has_reference_or_mapping_type = ty.is_reference_type() || ty.has_mapping();
+    let mut has_reference_or_mapping_type_slot = None;
+    let mut has_reference_or_mapping_type = || {
+        *has_reference_or_mapping_type_slot
+            .get_or_insert_with(|| ty.is_reference_type() || ty.has_mapping(gcx))
+    };
+
     let mut func_vis = None;
     let mut locs;
     let allowed: &[_] = if var.is_state_variable() {
         &[None, Some(Transient)]
-    } else if !has_reference_or_mapping_type || var.is_event_or_error_parameter() {
+    } else if !has_reference_or_mapping_type() || var.is_event_or_error_parameter() {
         &[None]
     } else if var.is_callable_or_catch_parameter() {
         locs = SmallVec::<[_; 3]>::new();
@@ -954,7 +959,7 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
     let mut var_loc = var.data_location;
     if !allowed.contains(&var_loc) {
         if !ty.references_error() {
-            let msg = if !has_reference_or_mapping_type {
+            let msg = if !has_reference_or_mapping_type() {
                 "data location can only be specified for array, struct or mapping types".to_string()
             } else if let Some(var_loc) = var_loc {
                 format!("invalid data location `{var_loc}`")
@@ -962,7 +967,7 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
                 "expected data location".to_string()
             };
             let mut err = gcx.dcx().err(msg).span(var.span);
-            if has_reference_or_mapping_type {
+            if has_reference_or_mapping_type() {
                 let note = format!(
                     "data location must be {expected} for {vis}{descr}{got}",
                     expected = or_list(
@@ -1016,7 +1021,7 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
             Some(loc @ (Memory | Storage | Calldata)) => loc,
             Some(Transient) => unimplemented!(),
             None => {
-                assert!(!has_reference_or_mapping_type, "data location not properly set");
+                debug_assert!(!has_reference_or_mapping_type(), "data location not properly set");
                 Memory
             }
         }

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -242,15 +242,28 @@ impl<'gcx> Ty<'gcx> {
     }
 
     /// Returns `true` if the type is recursive.
-    #[inline]
-    pub fn is_recursive(self) -> bool {
-        self.flags.contains(TyFlags::IS_RECURSIVE)
+    pub fn is_recursive(self, gcx: Gcx<'gcx>) -> bool {
+        self.visit_with_structs(gcx, &mut |ty| match ty.kind {
+            TyKind::Struct(id)
+                if matches!(gcx.struct_recursiveness(id), Recursiveness::Recursive) =>
+            {
+                ControlFlow::Break(())
+            }
+            _ => ControlFlow::Continue(()),
+        })
+        .is_break()
     }
 
     /// Returns `true` if this type contains a mapping.
-    #[inline]
-    pub fn has_mapping(self) -> bool {
-        self.flags.contains(TyFlags::HAS_MAPPING)
+    pub fn has_mapping(self, gcx: Gcx<'gcx>) -> bool {
+        self.visit_with_structs(gcx, &mut |ty| {
+            if matches!(ty.kind, TyKind::Mapping(..)) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .is_break()
     }
 
     /// Returns `true` if this type contains a non-public (internal/private) function pointer.
@@ -273,9 +286,9 @@ impl<'gcx> Ty<'gcx> {
 
     /// Returns `true` if this type can be part of an externally callable function.
     #[inline]
-    pub fn can_be_exported(self) -> bool {
-        !(self.is_recursive()
-            || self.has_mapping()
+    pub fn can_be_exported(self, gcx: Gcx<'gcx>) -> bool {
+        !(self.is_recursive(gcx)
+            || self.has_mapping(gcx)
             || self.has_internal_function()
             || self.references_error())
     }
@@ -363,6 +376,54 @@ impl<'gcx> Ty<'gcx> {
         }
     }
 
+    /// Visits the type, its subtypes, and non-recursive struct fields.
+    fn visit_with_structs<T>(
+        self,
+        gcx: Gcx<'gcx>,
+        f: &mut impl FnMut(Self) -> ControlFlow<T>,
+    ) -> ControlFlow<T> {
+        f(self)?;
+        match self.kind {
+            TyKind::Struct(id) => {
+                if let Recursiveness::None = gcx.struct_recursiveness(id) {
+                    for &ty in gcx.struct_field_types(id) {
+                        ty.visit_with_structs(gcx, f)?;
+                    }
+                }
+                ControlFlow::Continue(())
+            }
+            TyKind::Elementary(_)
+            | TyKind::StringLiteral(..)
+            | TyKind::IntLiteral(..)
+            | TyKind::Contract(_)
+            | TyKind::FnPtr(_)
+            | TyKind::Enum(_)
+            | TyKind::Module(_)
+            | TyKind::BuiltinModule(_)
+            | TyKind::Err(_) => ControlFlow::Continue(()),
+
+            TyKind::Ref(ty, _)
+            | TyKind::DynArray(ty)
+            | TyKind::Array(ty, _)
+            | TyKind::Slice(ty)
+            | TyKind::Udvt(ty, _)
+            | TyKind::Type(ty)
+            | TyKind::Meta(ty) => ty.visit_with_structs(gcx, f),
+
+            TyKind::Error(list, _) | TyKind::Event(list, _) | TyKind::Tuple(list) => {
+                for ty in list {
+                    ty.visit_with_structs(gcx, f)?;
+                }
+                ControlFlow::Continue(())
+            }
+
+            TyKind::Mapping(k, v) => {
+                k.visit_with_structs(gcx, f)?;
+                v.visit_with_structs(gcx, f)
+            }
+        }
+    }
+
     /// Returns `true` if the type is an array.
     #[inline]
     pub fn is_array(self) -> bool {
@@ -403,7 +464,7 @@ impl<'gcx> Ty<'gcx> {
     pub fn is_dynamically_encoded(self, gcx: Gcx<'gcx>) -> bool {
         match self.kind {
             TyKind::Struct(id) => {
-                self.is_recursive()
+                self.is_recursive(gcx)
                     || gcx.struct_field_types(id).iter().any(|ty| ty.is_dynamically_encoded(gcx))
             }
             TyKind::Array(element, _) => element.is_dynamically_encoded(gcx),
@@ -1020,31 +1081,28 @@ bitflags::bitflags! {
     /// [`Ty`] flags.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub struct TyFlags: u8 {
-        /// Whether this type is recursive.
-        const IS_RECURSIVE = 1 << 0;
-        /// Whether this type contains a mapping.
-        const HAS_MAPPING  = 1 << 1;
         /// Whether an error is reachable.
-        const HAS_ERROR    = 1 << 2;
+        const HAS_ERROR    = 1 << 0;
         /// Whether this type contains a non-public (internal/private) function pointer.
-        const HAS_INTERNAL_FN = 1 << 3;
+        const HAS_INTERNAL_FN = 1 << 1;
     }
 }
 
 impl TyFlags {
-    pub(super) fn calculate<'gcx>(gcx: Gcx<'gcx>, ty: &TyKind<'gcx>) -> Self {
+    pub(super) fn calculate(ty: &TyKind<'_>) -> Self {
         let mut flags = Self::empty();
-        flags.add_ty_kind(gcx, ty);
+        flags.add_ty_kind(ty);
         flags
     }
 
-    fn add_ty_kind<'gcx>(&mut self, gcx: Gcx<'gcx>, ty: &TyKind<'gcx>) {
+    fn add_ty_kind(&mut self, ty: &TyKind<'_>) {
         match *ty {
             TyKind::Elementary(_)
             | TyKind::StringLiteral(..)
             | TyKind::IntLiteral(..)
             | TyKind::Contract(_)
             | TyKind::Enum(_)
+            | TyKind::Struct(_)
             | TyKind::Module(_)
             | TyKind::BuiltinModule(_) => {}
 
@@ -1069,18 +1127,7 @@ impl TyFlags {
             TyKind::Mapping(k, v) => {
                 self.add_ty(k);
                 self.add_ty(v);
-                self.add(Self::HAS_MAPPING);
             }
-
-            TyKind::Struct(id) => match gcx.struct_recursiveness(id) {
-                Recursiveness::None => self.add_tys(gcx.struct_field_types(id)),
-                Recursiveness::Recursive => {
-                    self.add(Self::IS_RECURSIVE);
-                }
-                Recursiveness::Infinite(_guar) => {
-                    self.add(Self::HAS_ERROR);
-                }
-            },
 
             TyKind::Err(_) => self.add(Self::HAS_ERROR),
         }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -422,7 +422,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         self.gcx.mk_ty_err(err.emit())
                     }
                     _ if ty.is_array_like() => {
-                        if ty.has_mapping() {
+                        if ty.has_mapping(self.gcx) {
                             self.gcx.mk_ty_err(
                                 self.dcx()
                                     .err("cannot instantiate mappings")
@@ -582,7 +582,7 @@ impl<'gcx> TypeChecker<'gcx> {
 
         // Types containing mappings cannot be assigned to, unless the lvalue is a local/return
         // variable (local storage pointers are OK).
-        if ty.has_mapping() && !self.is_local_or_return_variable(expr) {
+        if ty.has_mapping(self.gcx) && !self.is_local_or_return_variable(expr) {
             self.dcx()
                 .err("types in storage containing (nested) mappings cannot be assigned to")
                 .span(expr.span)
@@ -853,7 +853,7 @@ impl<'gcx> TypeChecker<'gcx> {
         let ty = self.gcx.type_of_item(id.into());
 
         if let Some(init) = var.initializer {
-            if var.is_state_variable() && ty.has_mapping() {
+            if var.is_state_variable() && ty.has_mapping(self.gcx) {
                 self.dcx()
                     .err("types in storage containing (nested) mappings cannot be assigned to")
                     .span(var.span)
@@ -885,7 +885,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 var.data_location,
                 Some(DataLocation::Calldata) | Some(DataLocation::Memory)
             )
-            && ty.has_mapping()
+            && ty.has_mapping(self.gcx)
         {
             self.dcx()
                 .err(format!(


### PR DESCRIPTION
This removes the need for `Gcx` while interning types by keeping only context-free flags on `TyData`. Recursive-type and mapping containment checks now run through a `Gcx`-aware type visitor, so struct fields can still be inspected when those queries need semantic context.

The analysis pass now explicitly evaluates struct recursiveness while lowering HIR types, preserving the previous eager diagnostics that used to happen as a side effect of flag calculation during interning.
