### PR TITLE
perf(sema): skip unnecessary visitor walks

### DIFF
--- a/crates/sema/src/ast_lowering/lower.rs
+++ b/crates/sema/src/ast_lowering/lower.rs
@@ -384,6 +384,12 @@ struct YulFunctionCollector<'a, 'gcx> {
 impl<'gcx> Visit<'gcx> for YulFunctionCollector<'_, 'gcx> {
     type BreakValue = Never;
 
+    // Yul function definitions only appear in statements. Short-circuit expressions.
+    #[inline]
+    fn visit_expr(&mut self, _expr: &'gcx ast::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
+        ControlFlow::Continue(())
+    }
+
     fn visit_yul_function(
         &mut self,
         function: &'gcx ast::yul::Function<'gcx>,
@@ -392,6 +398,15 @@ impl<'gcx> Visit<'gcx> for YulFunctionCollector<'_, 'gcx> {
         self.lcx.yul_functions.insert(super::yul_function_key(function), id);
         self.items.push(hir::ItemId::Function(id));
         self.visit_yul_block(&function.body)
+    }
+
+    // Yul function definitions only appear in statements. Short-circuit expressions.
+    #[inline]
+    fn visit_yul_expr(
+        &mut self,
+        _expr: &'gcx ast::yul::Expr<'gcx>,
+    ) -> ControlFlow<Self::BreakValue> {
+        ControlFlow::Continue(())
     }
 }
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -383,4 +383,10 @@ impl<'gcx> Visit<'gcx> for BreakContinueChecker<'gcx> {
 
         self.walk_stmt(stmt)
     }
+
+    // Statements don't appear in expressions. Short-circuit to avoid walking the full tree.
+    #[inline]
+    fn visit_expr(&mut self, _expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
+        ControlFlow::Continue(())
+    }
 }


### PR DESCRIPTION
This avoids walking expression subtrees in visitor passes that only need statement structure.

The break/continue checker can skip HIR expressions because `break` and `continue` are statements. The Yul function collector can skip both Solidity and Yul expressions because Yul function definitions are discovered through statement traversal.
