### PR TITLE
fix(sema): coerce private function pointers

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -723,8 +723,12 @@ impl<'gcx> Ty<'gcx> {
                     return Result::Err(TyConvertError::Incompatible);
                 }
 
-                // Visibility must match.
-                if from_fn.visibility != to_fn.visibility {
+                let visibility_ok = from_fn.visibility == to_fn.visibility
+                    || matches!(
+                        (from_fn.visibility, to_fn.visibility),
+                        (Visibility::Private, Visibility::Internal)
+                    );
+                if !visibility_ok {
                     return Result::Err(TyConvertError::Incompatible);
                 }
 

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -1,10 +1,19 @@
 //@compile-flags: -Ztypeck
 
 // Tests for implicit function pointer conversions.
-// Function pointers require exact parameter/return types and visibility.
+// Function pointers require exact parameter/return types.
+// Visibility must match, except private functions can convert to internal function pointers.
 // State mutability follows: pure -> view -> nonpayable, payable -> nonpayable.
 
 contract C {
+    function privateTarget() private pure returns (uint256) {
+        return 1;
+    }
+
+    function internalTarget() internal pure returns (uint256) {
+        return 1;
+    }
+
     // === Valid: same function type ===
     function sameFnType() internal pure {
         function() external pure returns (uint256) f;
@@ -33,6 +42,11 @@ contract C {
     function payableToNonpayable() internal pure {
         function() external payable returns (uint256) f;
         function() external returns (uint256) g = f;
+    }
+
+    // === Valid: private function -> internal function pointer ===
+    function privateToInternal() internal pure {
+        function() internal pure returns (uint256) f = privateTarget;
     }
 
     // === Invalid: view -> pure (view is less restrictive) ===
@@ -69,6 +83,16 @@ contract C {
     function differentVisibility() internal pure {
         function() external pure f;
         function() internal pure g = f; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: internal function -> external function pointer ===
+    function internalToExternal() internal pure {
+        function() external pure returns (uint256) f = internalTarget; //~ ERROR: mismatched types
+    }
+
+    // === Invalid: private function -> external function pointer ===
+    function privateToExternal() internal pure {
+        function() external pure returns (uint256) f = privateTarget; //~ ERROR: mismatched types
     }
 }
 

--- a/tests/ui/typeck/implicit_function_ptr.stderr
+++ b/tests/ui/typeck/implicit_function_ptr.stderr
@@ -37,6 +37,18 @@ LL │         function() internal pure g = f;
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
    │
+LL │         function() external pure returns (uint256) f = internalTarget;
+   ╰╴                                                       ━━━━━━━━━━━━━━ expected `function () pure external returns (uint256)`, found `function () pure returns (uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() external pure returns (uint256) f = privateTarget;
+   ╰╴                                                       ━━━━━━━━━━━━━ expected `function () pure external returns (uint256)`, found `function () pure returns (uint256)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
 LL │         function() payable external g = this.h;
    ╰╴                                        ━━━━━━ expected `function () payable external`, found `function () external`
 
@@ -82,5 +94,5 @@ error: mismatched types
 LL │         function() pure external g = this.h;
    ╰╴                                     ━━━━━━ expected `function () pure external`, found `function () view external`
 
-error: aborting due to 14 previous errors
+error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Solidity allows a private function value to be used where an internal function pointer is expected, while still rejecting conversions to external function pointers. This narrows function pointer visibility compatibility to exact matches plus the private-to-internal case and adds focused UI coverage for the accepted and rejected directions.
