### PR TITLE
fix(typeck): allow immutable construction writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,13 +62,12 @@ Use `^` or `v` to point to lines above/below.
 
 ### Porting Tests from Solc
 
-Always look at the corresponding Solc test when porting behavior. Solc tests may
-embed multiple source files in one `.sol` file with `==== Source: ... ====`
-annotations. When porting those tests, split the secondary sources into the
-UI test's `auxiliary/` directory and update imports accordingly. Do not put them
-in `aux/`; that directory name is invalid on Windows and will be rejected. Add
-the Solc test path at the top of the ported test, or above the ported function
-when only one function is copied.
+Always look at the corresponding Solc test when porting behavior. Solc is always
+available in `testdata/solidity`. Solc tests may embed multiple source files in
+one `.sol` file with `==== Source: ... ====` annotations. When porting those
+tests, split the secondary sources into the UI test's `auxiliary/` directory and
+update imports accordingly. Add the Solc test path at the top of
+the ported test, or above the ported function when only one function is copied.
 
 ## Diagnostics Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ fn visit_expr(&mut self, expr: &'ast Expr) -> ControlFlow<Self::BreakValue> {
 
 - **Unit tests**: In source files
 - **UI tests**: In `tests/ui/`, verify compiler output
-- Auxiliary files go in `auxiliary/` subdirectory
+- Auxiliary files go in an `auxiliary/` subdirectory next to the UI test that needs
+  imports or secondary source files. Do not use `aux/`: Windows rejects it.
 
 ### UI Test Annotations
 
@@ -58,6 +59,16 @@ contract Test {
 
 Annotations: `//~ ERROR:`, `//~ WARN:`, `//~ NOTE:`, `//~ HELP:`
 Use `^` or `v` to point to lines above/below.
+
+### Porting Tests from Solc
+
+Always look at the corresponding Solc test when porting behavior. Solc tests may
+embed multiple source files in one `.sol` file with `==== Source: ... ====`
+annotations. When porting those tests, split the secondary sources into the
+UI test's `auxiliary/` directory and update imports accordingly. Do not put them
+in `aux/`; that directory name is invalid on Windows and will be rejected. Add
+the Solc test path at the top of the ported test, or above the ported function
+when only one function is copied.
 
 ## Diagnostics Style
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -20,6 +20,7 @@ struct TypeChecker<'gcx> {
     source: hir::SourceId,
     contract: Option<hir::ContractId>,
     function: Option<hir::FunctionId>,
+    construction_context: u32,
 
     types: FxHashMap<hir::ExprId, Ty<'gcx>>,
 
@@ -49,6 +50,7 @@ impl<'gcx> TypeChecker<'gcx> {
             source,
             contract: None,
             function: None,
+            construction_context: 0,
             types: Default::default(),
             lvalue_context: None,
             in_emit: false,
@@ -904,7 +906,11 @@ impl<'gcx> TypeChecker<'gcx> {
                     .span(var.span)
                     .emit();
             } else if expect {
-                let _ = self.expect_ty(init, ty);
+                let _ = if var.is_state_variable() {
+                    self.with_construction_context(|this| this.expect_ty(init, ty))
+                } else {
+                    self.expect_ty(init, ty)
+                };
             }
         }
 
@@ -1059,7 +1065,15 @@ impl<'gcx> TypeChecker<'gcx> {
     }
 
     fn in_constructor_context(&self) -> bool {
-        self.function.is_some_and(|id| self.gcx.hir.function(id).kind.is_constructor())
+        self.construction_context != 0
+            || self.function.is_some_and(|id| self.gcx.hir.function(id).kind.is_constructor())
+    }
+
+    fn with_construction_context<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.construction_context += 1;
+        let result = f(self);
+        self.construction_context -= 1;
+        result
     }
 
     fn res_not_lvalue_reason(&self, res: hir::Res) -> Option<NotLvalueReason> {
@@ -1149,6 +1163,26 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
         r
     }
 
+    fn visit_function(&mut self, func: &'gcx hir::Function<'gcx>) -> ControlFlow<Self::BreakValue> {
+        for &param in func.parameters {
+            self.visit_nested_var(param)?;
+        }
+        for modifier in func.modifiers.iter() {
+            if !matches!(modifier.id, hir::ItemId::Contract(_)) {
+                self.visit_modifier(modifier)?;
+            }
+        }
+        for &ret in func.returns {
+            self.visit_nested_var(ret)?;
+        }
+        if let Some(ref body) = func.body {
+            for stmt in body.iter() {
+                self.visit_stmt(stmt)?;
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
     fn visit_contract(
         &mut self,
         contract: &'gcx hir::Contract<'gcx>,
@@ -1177,15 +1211,19 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                         for (arg_expr, expected_arg_ty) in
                             modifier.args.exprs().zip(ctor_param_types.iter())
                         {
-                            let actual_arg_ty =
-                                self.check_expr_kind(arg_expr, Some(*expected_arg_ty));
+                            let actual_arg_ty = self.with_construction_context(|this| {
+                                this.check_expr_kind(arg_expr, Some(*expected_arg_ty))
+                            });
                             self.check_expected(arg_expr, actual_arg_ty, *expected_arg_ty);
                         }
                     }
                 }
             }
         }
-        self.walk_contract(contract)
+        for &item in contract.items {
+            self.visit_nested_item(item)?;
+        }
+        ControlFlow::Continue(())
     }
 
     fn visit_nested_var(&mut self, id: hir::VariableId) -> ControlFlow<Self::BreakValue> {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1036,30 +1036,29 @@ impl<'gcx> TypeChecker<'gcx> {
             return ty;
         }
 
-        if matches!(result, Err(NotLvalueReason::Immutable)) {
-            self.dcx()
-                .err("cannot assign to immutable here")
-                .span(expr.span)
-                .help("immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies")
-                .emit();
-            return ty;
-        }
-
-        let msg = match result {
-            Err(NotLvalueReason::Constant) => "cannot assign to a constant variable",
-            Err(NotLvalueReason::CalldataArray) => "calldata arrays are read-only",
-            Err(NotLvalueReason::CalldataStruct) => "calldata structs are read-only",
+        let (msg, help) = match result {
+            Err(NotLvalueReason::Constant) => ("cannot assign to a constant variable", None),
+            Err(NotLvalueReason::Immutable) => (
+                "cannot assign to immutable here",
+                Some(
+                    "immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies",
+                ),
+            ),
+            Err(NotLvalueReason::CalldataArray) => ("calldata arrays are read-only", None),
+            Err(NotLvalueReason::CalldataStruct) => ("calldata structs are read-only", None),
             Err(NotLvalueReason::FixedBytesIndex) => {
-                "single bytes in fixed bytes arrays cannot be modified"
+                ("single bytes in fixed bytes arrays cannot be modified", None)
             }
             Err(NotLvalueReason::ArrayLength) => {
-                "member `length` is read-only and cannot be used to resize arrays"
+                ("member `length` is read-only and cannot be used to resize arrays", None)
             }
-            Err(NotLvalueReason::Immutable) | Err(NotLvalueReason::Generic) | Ok(()) => {
-                "expression has to be an lvalue"
-            }
+            Err(NotLvalueReason::Generic) | Ok(()) => ("expression has to be an lvalue", None),
         };
-        self.dcx().err(msg).span(expr.span).emit();
+        let mut diag = self.dcx().err(msg).span(expr.span);
+        if let Some(help) = help {
+            diag = diag.help(help);
+        }
+        diag.emit();
 
         ty
     }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1163,23 +1163,18 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
         r
     }
 
-    fn visit_function(&mut self, func: &'gcx hir::Function<'gcx>) -> ControlFlow<Self::BreakValue> {
-        for &param in func.parameters {
-            self.visit_nested_var(param)?;
+    fn visit_modifier(
+        &mut self,
+        modifier: &'gcx hir::Modifier<'gcx>,
+    ) -> ControlFlow<Self::BreakValue> {
+        if matches!(modifier.id, hir::ItemId::Contract(_)) {
+            return ControlFlow::Continue(());
         }
-        for modifier in func.modifiers.iter() {
-            if !matches!(modifier.id, hir::ItemId::Contract(_)) {
-                self.visit_modifier(modifier)?;
-            }
-        }
-        for &ret in func.returns {
-            self.visit_nested_var(ret)?;
-        }
-        if let Some(ref body) = func.body {
-            for stmt in body.iter() {
-                self.visit_stmt(stmt)?;
-            }
-        }
+        self.walk_modifier(modifier)
+    }
+
+    fn visit_nested_var(&mut self, id: hir::VariableId) -> ControlFlow<Self::BreakValue> {
+        let _ = self.check_var(id);
         ControlFlow::Continue(())
     }
 
@@ -1223,11 +1218,6 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
         for &item in contract.items {
             self.visit_nested_item(item)?;
         }
-        ControlFlow::Continue(())
-    }
-
-    fn visit_nested_var(&mut self, id: hir::VariableId) -> ControlFlow<Self::BreakValue> {
-        let _ = self.check_var(id);
         ControlFlow::Continue(())
     }
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1036,9 +1036,17 @@ impl<'gcx> TypeChecker<'gcx> {
             return ty;
         }
 
+        if matches!(result, Err(NotLvalueReason::Immutable)) {
+            self.dcx()
+                .err("cannot assign to immutable here")
+                .span(expr.span)
+                .help("immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies")
+                .emit();
+            return ty;
+        }
+
         let msg = match result {
             Err(NotLvalueReason::Constant) => "cannot assign to a constant variable",
-            Err(NotLvalueReason::Immutable) => "cannot assign to an immutable variable",
             Err(NotLvalueReason::CalldataArray) => "calldata arrays are read-only",
             Err(NotLvalueReason::CalldataStruct) => "calldata structs are read-only",
             Err(NotLvalueReason::FixedBytesIndex) => {
@@ -1047,7 +1055,9 @@ impl<'gcx> TypeChecker<'gcx> {
             Err(NotLvalueReason::ArrayLength) => {
                 "member `length` is read-only and cannot be used to resize arrays"
             }
-            Err(NotLvalueReason::Generic) | Ok(()) => "expression has to be an lvalue",
+            Err(NotLvalueReason::Immutable) | Err(NotLvalueReason::Generic) | Ok(()) => {
+                "expression has to be an lvalue"
+            }
         };
         self.dcx().err(msg).span(expr.span).emit();
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1173,11 +1173,6 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
         self.walk_modifier(modifier)
     }
 
-    fn visit_nested_var(&mut self, id: hir::VariableId) -> ControlFlow<Self::BreakValue> {
-        let _ = self.check_var(id);
-        ControlFlow::Continue(())
-    }
-
     fn visit_contract(
         &mut self,
         contract: &'gcx hir::Contract<'gcx>,
@@ -1218,6 +1213,11 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
         for &item in contract.items {
             self.visit_nested_item(item)?;
         }
+        ControlFlow::Continue(())
+    }
+
+    fn visit_nested_var(&mut self, id: hir::VariableId) -> ControlFlow<Self::BreakValue> {
+        let _ = self.check_var(id);
         ControlFlow::Continue(())
     }
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -19,6 +19,7 @@ struct TypeChecker<'gcx> {
     gcx: Gcx<'gcx>,
     source: hir::SourceId,
     contract: Option<hir::ContractId>,
+    function: Option<hir::FunctionId>,
 
     types: FxHashMap<hir::ExprId, Ty<'gcx>>,
 
@@ -47,6 +48,7 @@ impl<'gcx> TypeChecker<'gcx> {
             gcx,
             source,
             contract: None,
+            function: None,
             types: Default::default(),
             lvalue_context: None,
             in_emit: false,
@@ -253,7 +255,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             hir::ExprKind::Ident(res) => {
                 let res = self.resolve_overloads(res, expr.span);
-                if let Some(reason) = res_not_lvalue_reason(self.gcx, res) {
+                if let Some(reason) = self.res_not_lvalue_reason(res) {
                     self.try_set_not_lvalue(reason);
                 }
                 self.type_of_res(res)
@@ -379,9 +381,9 @@ impl<'gcx> TypeChecker<'gcx> {
                     TyKind::Type(ty)
                         if matches!(ty.kind, TyKind::Contract(_))
                             && possible_members.len() == 1
-                            && possible_members[0].res.is_some_and(|res| {
-                                res_not_lvalue_reason(self.gcx, res).is_some()
-                            }) =>
+                            && possible_members[0]
+                                .res
+                                .is_some_and(|res| self.res_not_lvalue_reason(res).is_some()) =>
                     {
                         Some(NotLvalueReason::Generic)
                     }
@@ -1056,6 +1058,14 @@ impl<'gcx> TypeChecker<'gcx> {
         self.lvalue_context.is_some()
     }
 
+    fn in_constructor_context(&self) -> bool {
+        self.function.is_some_and(|id| self.gcx.hir.function(id).kind.is_constructor())
+    }
+
+    fn res_not_lvalue_reason(&self, res: hir::Res) -> Option<NotLvalueReason> {
+        res_not_lvalue_reason(self.gcx, res, self.in_constructor_context())
+    }
+
     fn resolve_overloads(&self, res: &[hir::Res], span: Span) -> hir::Res {
         match self.try_resolve_overloads(res) {
             Ok(res) => res,
@@ -1131,9 +1141,11 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
     fn visit_nested_function(&mut self, id: hir::FunctionId) -> ControlFlow<Self::BreakValue> {
         let contract = self.gcx.hir.function(id).contract;
         let prev = self.contract;
+        let prev_function = self.function.replace(id);
         self.contract = contract.or(prev);
         let r = self.visit_function(self.gcx.hir.function(id));
         self.contract = prev;
+        self.function = prev_function;
         r
     }
 
@@ -1340,13 +1352,17 @@ impl<T> FromIterator<T> for WantOne<T> {
     }
 }
 
-fn res_not_lvalue_reason(gcx: Gcx<'_>, res: hir::Res) -> Option<NotLvalueReason> {
+fn res_not_lvalue_reason(
+    gcx: Gcx<'_>,
+    res: hir::Res,
+    allow_immutable: bool,
+) -> Option<NotLvalueReason> {
     match res {
         hir::Res::Item(hir::ItemId::Variable(var)) => {
             let var = gcx.hir.variable(var);
             match var.mutability {
                 Some(m) if m.is_constant() => Some(NotLvalueReason::Constant),
-                Some(m) if m.is_immutable() => Some(NotLvalueReason::Immutable),
+                Some(m) if m.is_immutable() && !allow_immutable => Some(NotLvalueReason::Immutable),
                 _ => None,
             }
         }

--- a/tests/ui/typeck/lvalue/immutable.sol
+++ b/tests/ui/typeck/lvalue/immutable.sol
@@ -35,10 +35,12 @@ contract Test is Base {
     }
 
     function test() external {
-        IMMUT = 7; //~ ERROR: cannot assign to an immutable variable
+        IMMUT = 7; //~ ERROR: cannot assign to immutable here
+        //~^ HELP: immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies
     }
 
     function indirect() internal {
-        IMMUT = 8; //~ ERROR: cannot assign to an immutable variable
+        IMMUT = 8; //~ ERROR: cannot assign to immutable here
+        //~^ HELP: immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies
     }
 }

--- a/tests/ui/typeck/lvalue/immutable.sol
+++ b/tests/ui/typeck/lvalue/immutable.sol
@@ -1,16 +1,30 @@
 //@compile-flags: -Ztypeck
+// Ported from test/libsolidity/syntaxTests/immutable/variable_declaration_value.sol.
+// Ported from test/libsolidity/semanticTests/immutable/multiple_initializations.sol.
+// Ported from test/libsolidity/syntaxTests/immutable/ctor_initialization_tuple.sol.
+// Ported from test/libsolidity/syntaxTests/immutable/inheritance_ctor_argument.sol.
+// Ported from test/libsolidity/syntaxTests/immutable/writing_after_initialization.sol.
+// Ported from test/libsolidity/syntaxTests/immutable/ctor_indirect_initialization.sol.
 
-contract Test {
+contract Base {
+    constructor(uint256) {}
+}
+
+contract Test is Base {
+    uint256 immutable INLINE_ASSIGN = INLINE_ASSIGN = 1;
+    uint256 immutable STATE_INIT;
     uint256 immutable IMMUT;
     uint256 immutable OTHER;
     uint256 immutable VIA_MODIFIER;
+    uint256 immutable VIA_BASE;
+    uint256 state = STATE_INIT = 5;
 
     modifier init(uint256 value) {
         value;
         _;
     }
 
-    constructor() init(VIA_MODIFIER = 6) {
+    constructor() Base(VIA_BASE = 9) init(VIA_MODIFIER = 6) {
         uint256 two = 2;
         uint256 three = 3;
         IMMUT = 1;

--- a/tests/ui/typeck/lvalue/immutable.sol
+++ b/tests/ui/typeck/lvalue/immutable.sol
@@ -1,15 +1,30 @@
 //@compile-flags: -Ztypeck
-// TODO: assignments to immutables in the constructor should be allowed
 
 contract Test {
     uint256 immutable IMMUT;
+    uint256 immutable OTHER;
+    uint256 immutable VIA_MODIFIER;
 
-    constructor() {
-        // This should be OK in constructor but currently errors
-        IMMUT = 1; //~ ERROR: cannot assign to an immutable variable
+    modifier init(uint256 value) {
+        value;
+        _;
+    }
+
+    constructor() init(VIA_MODIFIER = 6) {
+        uint256 two = 2;
+        uint256 three = 3;
+        IMMUT = 1;
+        (IMMUT, OTHER) = (two, three);
+        IMMUT += 4;
+        IMMUT++;
+        delete OTHER;
     }
 
     function test() external {
-        IMMUT = 2; //~ ERROR: cannot assign to an immutable variable
+        IMMUT = 7; //~ ERROR: cannot assign to an immutable variable
+    }
+
+    function indirect() internal {
+        IMMUT = 8; //~ ERROR: cannot assign to an immutable variable
     }
 }

--- a/tests/ui/typeck/lvalue/immutable.stderr
+++ b/tests/ui/typeck/lvalue/immutable.stderr
@@ -1,14 +1,18 @@
-error: cannot assign to an immutable variable
+error: cannot assign to immutable here
    ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
    │
 LL │         IMMUT = 7;
-   ╰╴        ━━━━━
+   │         ━━━━━
+   │
+   ╰ help: immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies
 
-error: cannot assign to an immutable variable
+error: cannot assign to immutable here
    ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
    │
 LL │         IMMUT = 8;
-   ╰╴        ━━━━━
+   │         ━━━━━
+   │
+   ╰ help: immutables can only be assigned in state variable initializers, constructor arguments, or constructor bodies
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/lvalue/immutable.stderr
+++ b/tests/ui/typeck/lvalue/immutable.stderr
@@ -1,13 +1,13 @@
 error: cannot assign to an immutable variable
    ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
    │
-LL │         IMMUT = 1;
+LL │         IMMUT = 7;
    ╰╴        ━━━━━
 
 error: cannot assign to an immutable variable
    ╭▸ ROOT/tests/ui/typeck/lvalue/immutable.sol:LL:CC
    │
-LL │         IMMUT = 2;
+LL │         IMMUT = 8;
    ╰╴        ━━━━━
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
This updates type checking so immutable variables can be written in Solidity's construction-time contexts, matching solc: state variable initializers, constructor arguments, and constructor bodies. Writes from ordinary functions, helper functions, and modifier bodies remain rejected, and the diagnostic now explains where immutable writes are allowed.

The UI coverage is ported from solc immutable tests and records the upstream test paths in the test file. The agent guidance was also clarified for future solc test ports, including the bundled `testdata/solidity` location and the required `auxiliary/` directory for split source files.
