### PR TITLE
test: normalize solc port annotations

### DIFF
--- a/tests/ui/overrides/calldata_memory.sol
+++ b/tests/ui/overrides/calldata_memory.sol
@@ -1,5 +1,5 @@
-// Tests for calldata/memory override variations
-// Based on solc tests: calldata_memory_interface.sol, calldata_memory_struct.sol
+// Ported from test/libsolidity/syntaxTests/inheritance/override/calldata_memory_interface.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/calldata_memory_struct.sol.
 
 // ==== Valid: interface calldata can be implemented with memory (external -> public) ====
 interface ICalldataToMemory {

--- a/tests/ui/overrides/diamond_public_vars.sol
+++ b/tests/ui/overrides/diamond_public_vars.sol
@@ -1,5 +1,13 @@
-// Tests for diamond inheritance with public state variables
-// Based on solc tests: public_vars_multiple_diamond*.sol, diamond_*.sol
+// Ported from test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond1.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/public_vars_multiple_diamond2.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_interface_empty_intermediate_public_state_variable_and_function.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_interface_intermediate_public_state_variable.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_interface_intermediate_public_state_variable_and_function.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_interface_intermediate_public_state_variable_and_function_implemented.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_top_implemented_intermediate_empty_bottom_public_state_variable.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_top_implemented_intermediate_implemented_public_state_variable.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/diamond_top_implemented_intermediate_public_state_variable.sol.
 
 // ==== Valid: public var can override single interface function ====
 interface ISimple {

--- a/tests/ui/overrides/interface_exception.sol
+++ b/tests/ui/overrides/interface_exception.sol
@@ -1,5 +1,6 @@
-// Tests for interface override exception (when override is optional vs required)
-// Based on solc tests: interfaceException/*.sol
+// Ported from test/libsolidity/syntaxTests/inheritance/override/interfaceException/abstract_needed.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/interfaceException/diamond_needed.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/interfaceException/regular_optional.sol.
 
 // ==== Valid: single interface - override is optional ====
 interface ISingle {

--- a/tests/ui/overrides/multi_layered.sol
+++ b/tests/ui/overrides/multi_layered.sol
@@ -1,5 +1,5 @@
-// Tests for complex multi-layered inheritance chains
-// Based on solc tests: override_multi_layered_fine.sol, override_multi_layered_error.sol
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_multi_layered_fine.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_multi_layered_error.sol.
 
 // ==== Valid: multi-layered with proper override specification ====
 interface IBase {

--- a/tests/ui/overrides/shared_base.sol
+++ b/tests/ui/overrides/shared_base.sol
@@ -1,5 +1,6 @@
-// Tests for shared base scenarios
-// Based on solc tests: override_shared_base*.sol
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_shared_base.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_shared_base_partial.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_shared_base_simple.sol.
 
 // ==== Valid: shared non-virtual base (C3 linearization resolves) ====
 contract SharedNonVirtual {

--- a/tests/ui/overrides/stricter_mutability.sol
+++ b/tests/ui/overrides/stricter_mutability.sol
@@ -1,5 +1,12 @@
-// Tests for override mutability permutations (error code: 6959)
-// Based on solc tests: override_stricter_mutability*.sol, override_less_strict_mutability.sol
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability1.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability2.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability3.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability4.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability5.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability6.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_stricter_mutability7.sol.
+// Ported from test/libsolidity/syntaxTests/inheritance/override/override_less_strict_mutability.sol.
 
 // ==== Valid: pure can override view ====
 contract ViewBase {

--- a/tests/ui/typeck/function_calls/event_error_context.sol
+++ b/tests/ui/typeck/function_calls/event_error_context.sol
@@ -1,12 +1,9 @@
 //@compile-flags: -Ztypeck
-
-// Tests for event/error invocation context validation.
-// Based on solc tests:
-// - syntaxTests/events/event_without_emit_deprecated.sol
-// - syntaxTests/events/multiple_event_without_emit.sol
-// - syntaxTests/emit/emit_non_event.sol
-// - syntaxTests/revertStatement/error_used_elsewhere.sol
-// - syntaxTests/revertStatement/revert_event.sol
+// Ported from test/libsolidity/syntaxTests/events/event_without_emit_deprecated.sol.
+// Ported from test/libsolidity/syntaxTests/events/multiple_event_without_emit.sol.
+// Ported from test/libsolidity/syntaxTests/emit/emit_non_event.sol.
+// Ported from test/libsolidity/syntaxTests/revertStatement/error_used_elsewhere.sol.
+// Ported from test/libsolidity/syntaxTests/revertStatement/revert_event.sol.
 
 contract EventErrorContext {
     event MyEvent(uint a, bytes32 b);
@@ -27,7 +24,7 @@ contract EventErrorContext {
         revert EmptyError();
     }
 
-    // === Event invocations outside emit (solc error 3132) ===
+    // === Event invocations outside emit (error 3132) ===
     function eventAsExpression() public {
         MyEvent(1, "hi"); //~ ERROR: event invocations have to be prefixed by `emit`
     }
@@ -43,7 +40,6 @@ contract EventErrorContext {
         //~^ ERROR: mismatched types
     }
 
-    // Solc test: multiple_event_without_emit.sol
     function multipleEvents() external {
         emit MyEvent(0, "x");
         // Second invocation without emit should still error.
@@ -52,7 +48,7 @@ contract EventErrorContext {
 
     function takeBytes(bytes memory) public pure {}
 
-    // === Error invocations outside revert (solc error 7757) ===
+    // === Error invocations outside revert (error 7757) ===
     function errorAsExpression() public pure {
         MyError(404, "not found"); //~ ERROR: errors can only be used with revert statements
     }
@@ -68,12 +64,12 @@ contract EventErrorContext {
         //~^ ERROR: mismatched types
     }
 
-    // === Non-event in emit statement (solc error 9292) ===
+    // === Non-event in emit statement (error 9292) ===
     function emitNonEvent() public {
         emit Test(); //~ ERROR: expression has to be an event invocation
     }
 
-    // === Non-error in revert statement (solc error 1885) ===
+    // === Non-error in revert statement (error 1885) ===
     function revertEvent() public pure {
         revert EmptyEvent(); //~ ERROR: event invocations have to be prefixed by `emit`
         //~^ ERROR: expression has to be an error
@@ -160,5 +156,5 @@ contract EventErrorContext {
     }
 
     // TODO: require(condition, MyError(...)) should be allowed but is not yet implemented.
-    // See: syntaxTests/errors/require_custom.sol
+    // See: test/libsolidity/syntaxTests/errors/require_custom.sol.
 }

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -96,7 +96,18 @@ contract C {
     }
 }
 
-// Tests from solc for member access on function types with state mutability conversions.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_nonpayable_payable.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_nonpayable_pure.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_nonpayable_view.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_payable_nonpayable.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_payable_pure.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_payable_view.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_pure_nonpayable.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_pure_payable.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_pure_view.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_view_nonpayable.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_view_payable.sol.
+// Ported from test/libsolidity/syntaxTests/conversion/function_type_view_pure.sol.
 
 contract NonpayableToPayable {
     function h() external {}

--- a/tests/ui/typeck/library_mappings.sol
+++ b/tests/ui/typeck/library_mappings.sol
@@ -1,6 +1,8 @@
+//@compile-flags: -Ztypeck
+// Ported from test/libsolidity/syntaxTests/lvalues/library_mapping.sol.
+
 contract L {
     function f(mapping(uint=>uint) storage x, mapping(uint=>uint) storage y) internal {
-        // TODO: disallow assignment
-        x = y;
+        x = y; //~ ERROR: types in storage containing (nested) mappings cannot be assigned to
     }
 }

--- a/tests/ui/typeck/library_mappings.stderr
+++ b/tests/ui/typeck/library_mappings.stderr
@@ -1,0 +1,8 @@
+error: types in storage containing (nested) mappings cannot be assigned to
+   ╭▸ ROOT/tests/ui/typeck/library_mappings.sol:LL:CC
+   │
+LL │         x = y;
+   ╰╴        ━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/yul_lowering/solc_for_statement_2.sol
+++ b/tests/ui/yul_lowering/solc_for_statement_2.sol
@@ -1,8 +1,8 @@
 //@compile-flags: -Ztypeck
+// Ported from test/libyul/yulSyntaxTests/for_statement_2.yul.
 
 contract C {
     function f() public returns (uint256 x) {
-        // Ported from solc test/libyul/yulSyntaxTests/for_statement_2.yul.
         assembly {
             { let limit := calldatasize() for { let i := 0 } lt(i, limit) { i := add(i, 1) } { x := add(x, 2) } }
         }

--- a/tests/ui/yul_lowering/solc_inline_assembly_instructions_allowed.sol
+++ b/tests/ui/yul_lowering/solc_inline_assembly_instructions_allowed.sol
@@ -1,8 +1,8 @@
 //@compile-flags: -Ztypeck
+// Ported from test/libsolidity/syntaxTests/viewPureChecker/inline_assembly_instructions_allowed.sol.
 
 contract C {
     function f() public returns (uint256 x) {
-        // Ported from solc syntaxTests/viewPureChecker/inline_assembly_instructions_allowed.sol.
         assembly {
             pop(calldatasize())
             calldatacopy(0, 1, 2)


### PR DESCRIPTION
This removes a stale TODO from the library mapping lvalue UI test, records the Solc source test path, and checks the expected nested-mapping assignment diagnostic.

It also normalizes existing Solc-derived UI tests to use explicit `// Ported from ...` comments at the top of the test file or the ported section.
