### PR TITLE
fix(typeck): allow implicit fixed bytes literals

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -783,6 +783,8 @@ impl<'gcx> Ty<'gcx> {
 
     /// Checks if the type is explicitly convertible to the given type.
     ///
+    /// Explicit conversions are a superset of implicit conversions.
+    ///
     /// See: <https://docs.soliditylang.org/en/latest/types.html#explicit-conversions>
     fn can_convert_explicit_to(self, other: Self, gcx: Gcx<'gcx>) -> Result<(), TyConvertError> {
         use ElementaryType::*;

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -658,6 +658,12 @@ impl<'gcx> Ty<'gcx> {
                     Result::Err(TyConvertError::LiteralTooLarge)
                 }
             }
+            (IntLiteral(_, _, Some(TypeSize::ZERO)), Elementary(FixedBytes(_))) => Ok(()),
+            (IntLiteral(false, _, Some(size_from)), Elementary(FixedBytes(size_to)))
+                if size_from == size_to =>
+            {
+                Ok(())
+            }
 
             // Integer literals can coerce to typed integers if they fit.
             // Non-negative literals can coerce to both uint and int types.

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -822,12 +822,6 @@ impl<'gcx> Ty<'gcx> {
             {
                 Ok(())
             }
-            (IntLiteral(_, _, Some(TypeSize::ZERO)), Elementary(FixedBytes(_))) => Ok(()),
-            (IntLiteral(false, _, Some(size_from)), Elementary(FixedBytes(size_to)))
-                if size_from == size_to =>
-            {
-                Ok(())
-            }
 
             // address <-> bytes20.
             (Elementary(Address(false)), Elementary(FixedBytes(s))) if s.bytes() == 20 => Ok(()),

--- a/tests/ui/typeck/fixed_bytes_conversions.sol
+++ b/tests/ui/typeck/fixed_bytes_conversions.sol
@@ -28,6 +28,15 @@ contract C {
         bytes32 b32 = bytes32(0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff);
     }
 
+    // Valid: same-size hex integer literals implicitly convert to FixedBytes.
+    function validImplicitHexLiteralToBytes() public pure {
+        bytes1 b1 = 0xff;
+        bytes2 b2 = 0x0001;
+        bytes4 b4 = 0x01ffc9a7;
+        bytes32 b32 =
+            (0x4b9f2d36e1b4c93de62cc077b00b1a91d84b6c31b4a14e012718dcca230689e7);
+    }
+
     // Valid: zero integer literals to FixedBytes.
     function validZeroLiteralToBytes() public pure {
         bytes1 b1 = bytes1(0);
@@ -36,6 +45,16 @@ contract C {
         bytes1 b3 = bytes1(1 - 1);
         bytes32 b4 = bytes32(0x01 - 0x01);
         bytes16 b16 = bytes16(0x00 + 0);
+    }
+
+    // Valid: zero integer literals implicitly convert to FixedBytes.
+    function validImplicitZeroLiteralToBytes() public pure {
+        bytes1 b1 = 0;
+        bytes2 b2 = 0x00000;
+        bytes32 b32 = -0x0;
+        bytes1 b3 = 1 - 1;
+        bytes32 b4 = 0x01 - 0x01;
+        bytes16 b16 = 0x00 + 0;
     }
 
     // Invalid: FixedBytes to signed Int (not allowed)
@@ -73,5 +92,19 @@ contract C {
         bytes1 b8 = bytes1(0x02 - 0x01); //~ ERROR: invalid explicit type conversion
         bytes1 b9 = bytes1(0x00 + 0x01); //~ ERROR: invalid explicit type conversion
         bytes2 b10 = bytes2(0x0102 + 0); //~ ERROR: invalid explicit type conversion
+    }
+
+    // Invalid: non-zero integer literals do not implicitly convert to FixedBytes unless they are same-size hex literals.
+    function invalidImplicitIntLiteralToBytes() public pure {
+        bytes1 b1 = 1; //~ ERROR: mismatched types
+        bytes2 b2 = 256; //~ ERROR: mismatched types
+        bytes1 b3 = -0x01; //~ ERROR: mismatched types
+        bytes1 b4 = 0x1; //~ ERROR: mismatched types
+        bytes2 b5 = 0xff; //~ ERROR: mismatched types
+        bytes1 b6 = 0x0100; //~ ERROR: mismatched types
+        bytes2 b7 = 0x010000; //~ ERROR: mismatched types
+        bytes1 b8 = 0x02 - 0x01; //~ ERROR: mismatched types
+        bytes1 b9 = 0x00 + 0x01; //~ ERROR: mismatched types
+        bytes2 b10 = 0x0102 + 0; //~ ERROR: mismatched types
     }
 }

--- a/tests/ui/typeck/fixed_bytes_conversions.sol
+++ b/tests/ui/typeck/fixed_bytes_conversions.sol
@@ -1,12 +1,41 @@
 //@compile-flags: -Ztypeck
 
 contract C {
+    // Valid: implicit FixedBytes widening and same-size conversion.
+    function validImplicitBytesToBytes(bytes1 b1, bytes4 b4) public pure {
+        bytes2 b2 = b1;
+        bytes32 b32 = b4;
+        bytes4 same = b4;
+    }
+
+    // Invalid: implicit FixedBytes narrowing.
+    function invalidImplicitBytesToBytes(bytes2 b2, bytes32 b32) public pure {
+        bytes1 b1 = b2; //~ ERROR: mismatched types
+        bytes4 b4 = b32; //~ ERROR: mismatched types
+    }
+
     // Valid: FixedBytes to FixedBytes (any size)
     function validBytesToBytes(bytes4 b4) public pure {
         bytes32 b32 = bytes32(b4);  // smaller to larger: right-pads with zeros
         bytes2 b2 = bytes2(b32);    // larger to smaller: truncates right
         bytes1 b1 = bytes1(b4);     // larger to smaller
         bytes16 b16 = bytes16(b1);  // smaller to larger
+    }
+
+    // Valid: explicit bytes to FixedBytes conversion.
+    function validBytesToFixedBytes(bytes memory b) public pure {
+        bytes4 b4 = bytes4(b);
+    }
+
+    // Invalid: explicit FixedBytes to bytes conversion.
+    function invalidFixedBytesToBytes(bytes4 b4) public pure {
+        bytes memory b = bytes(b4); //~ ERROR: invalid explicit type conversion
+    }
+
+    // Invalid: implicit bytes and FixedBytes conversions.
+    function invalidImplicitBytes(bytes memory b, bytes4 b4) public pure {
+        bytes4 b4FromBytes = b; //~ ERROR: mismatched types
+        bytes memory bytesFromB4 = b4; //~ ERROR: mismatched types
     }
 
     // Valid: FixedBytes to UInt (same size only)
@@ -18,6 +47,26 @@ contract C {
     // Valid: UInt to FixedBytes (same size only)
     function validUintToBytes(uint32 u32) public pure {
         bytes4 b4 = bytes4(u32);    // uint32 (4 bytes) to bytes4 (4 bytes)
+    }
+
+    // Invalid: implicit FixedBytes and integer conversions.
+    function invalidImplicitIntegerConversions(bytes4 b4, uint32 u32, int32 i32) public pure {
+        uint32 u32FromB4 = b4; //~ ERROR: mismatched types
+        bytes4 b4FromU32 = u32; //~ ERROR: mismatched types
+        int32 i32FromB4 = b4; //~ ERROR: mismatched types
+        bytes4 b4FromI32 = i32; //~ ERROR: mismatched types
+    }
+
+    // Valid: explicit address and FixedBytes conversions.
+    function validAddressBytes20(address a, bytes20 b20) public pure {
+        bytes20 b20FromAddress = bytes20(a);
+        address addressFromB20 = address(b20);
+    }
+
+    // Invalid: implicit address and FixedBytes conversions.
+    function invalidImplicitAddressBytes20(address a, bytes20 b20) public pure {
+        bytes20 b20FromAddress = a; //~ ERROR: mismatched types
+        address addressFromB20 = b20; //~ ERROR: mismatched types
     }
 
     // Valid: same-size hex integer literals to FixedBytes.

--- a/tests/ui/typeck/fixed_bytes_conversions.stderr
+++ b/tests/ui/typeck/fixed_bytes_conversions.stderr
@@ -100,5 +100,65 @@ error: invalid explicit type conversion
 LL │         bytes2 b10 = bytes2(0x0102 + 0);
    ╰╴                     ━━━━━━━━━━━━━━━━━━ cannot convert `int_literal[9]` to `bytes2`
 
-error: aborting due to 17 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b1 = 1;
+   ╰╴                    ━ expected `bytes1`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes2 b2 = 256;
+   ╰╴                    ━━━ expected `bytes2`, found `int_literal[9]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b3 = -0x01;
+   ╰╴                    ━━━━━ expected `bytes1`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b4 = 0x1;
+   ╰╴                    ━━━ expected `bytes1`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes2 b5 = 0xff;
+   ╰╴                    ━━━━ expected `bytes2`, found `int_literal[8]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b6 = 0x0100;
+   ╰╴                    ━━━━━━ expected `bytes1`, found `int_literal[9]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes2 b7 = 0x010000;
+   ╰╴                    ━━━━━━━━ expected `bytes2`, found `int_literal[17]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b8 = 0x02 - 0x01;
+   ╰╴                    ━━━━━━━━━━━ expected `bytes1`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b9 = 0x00 + 0x01;
+   ╰╴                    ━━━━━━━━━━━ expected `bytes1`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes2 b10 = 0x0102 + 0;
+   ╰╴                     ━━━━━━━━━━ expected `bytes2`, found `int_literal[9]`
+
+error: aborting due to 27 previous errors
 

--- a/tests/ui/typeck/fixed_bytes_conversions.stderr
+++ b/tests/ui/typeck/fixed_bytes_conversions.stderr
@@ -1,3 +1,69 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes1 b1 = b2;
+   ╰╴                    ━━ expected `bytes1`, found `bytes2`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes4 b4 = b32;
+   ╰╴                    ━━━ expected `bytes4`, found `bytes32`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes memory b = bytes(b4);
+   ╰╴                         ━━━━━━━━━ cannot convert `bytes4` to `bytes`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes4 b4FromBytes = b;
+   ╰╴                             ━ expected `bytes4`, found `bytes memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes memory bytesFromB4 = b4;
+   ╰╴                                   ━━ expected `bytes memory`, found `bytes4`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         uint32 u32FromB4 = b4;
+   ╰╴                           ━━ expected `uint32`, found `bytes4`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes4 b4FromU32 = u32;
+   ╰╴                           ━━━ expected `bytes4`, found `uint32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         int32 i32FromB4 = b4;
+   ╰╴                          ━━ expected `int32`, found `bytes4`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes4 b4FromI32 = i32;
+   ╰╴                           ━━━ expected `bytes4`, found `int32`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         bytes20 b20FromAddress = a;
+   ╰╴                                 ━ expected `bytes20`, found `address`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         address addressFromB20 = b20;
+   ╰╴                                 ━━━ expected `address`, found `bytes20`
+
 error: invalid explicit type conversion
    ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
    │
@@ -160,5 +226,5 @@ error: mismatched types
 LL │         bytes2 b10 = 0x0102 + 0;
    ╰╴                     ━━━━━━━━━━ expected `bytes2`, found `int_literal[9]`
 
-error: aborting due to 27 previous errors
+error: aborting due to 38 previous errors
 


### PR DESCRIPTION
Solar already tracked exact fixed-bytes compatibility for hex integer literals, but only used it for explicit casts. This teaches implicit conversion to accept the same zero and exact-size hex literal cases, matching solc behavior for declarations like `bytes32 x = 0x...`.

The existing fixed-bytes conversion UI test now covers implicit accepted cases, including the Seaport-style parenthesized bytes32 literal, plus rejected non-zero literals that are not exact-size hex literals.
