### PR TITLE
fix(typeck): locate dynamic casts

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -816,6 +816,7 @@ impl<'gcx> Ty<'gcx> {
                     Result::Err(TyConvertError::InvalidConversion)
                 }
             }
+            (Ref(from_inner, _), _) if from_inner == other && other.is_reference_type() => Ok(()),
 
             // FixedBytes <-> UInt: same size only (signed integers not allowed).
             (Elementary(FixedBytes(size_from)), Elementary(UInt(size_to)))
@@ -932,10 +933,15 @@ impl<'gcx> Ty<'gcx> {
     ) -> Result<Self, TyConvertError> {
         self.can_convert_explicit_to(other, gcx)?;
 
-        // Handle special case: bytes <-> string with unlocated target inherits source location.
+        // Handle special cases where unlocated reference targets get a data location.
         use ElementaryType::*;
         use TyKind::*;
         Ok(match (self.kind, other.kind) {
+            (StringLiteral(..), Elementary(Bytes)) => gcx.types.bytes_ref.memory,
+            (StringLiteral(true, _), Elementary(String)) => gcx.types.string_ref.memory,
+            (Ref(from_inner, loc), _) if from_inner == other && other.is_reference_type() => {
+                other.with_loc(gcx, loc)
+            }
             (Ref(from_inner, loc), Elementary(Bytes))
                 if matches!(from_inner.kind, Elementary(String)) =>
             {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -541,7 +541,6 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
             }
             hir::ExprKind::Type(ref ty) => {
-                debug_assert!(ty.kind.is_elementary(), "non-elementary ExprKind::Type: {ty:?}");
                 self.gcx.mk_ty(TyKind::Type(self.gcx.type_of_hir_ty(ty)))
             }
             hir::ExprKind::Unary(op, inner) => {

--- a/tests/ui/typeck/bytes_string_explicit_conversions.sol
+++ b/tests/ui/typeck/bytes_string_explicit_conversions.sol
@@ -1,6 +1,16 @@
 //@compile-flags: -Ztypeck
 
 contract BytesStringTests {
+    // Valid: string literal -> bytes memory.
+    function testStringLiteralToBytes() public pure returns (bytes memory) {
+        return bytes("abc");
+    }
+
+    // Valid: string literal -> string memory.
+    function testStringLiteralToString() public pure returns (string memory) {
+        return string("abc");
+    }
+
     // Valid: string memory -> bytes memory (via unlocated cast).
     function testStringToBytes(string memory s) public pure returns (bytes memory) {
         return bytes(s);

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -36,6 +36,29 @@ contract C {
         return uint256[3](a);
     }
 
+    // === Invalid: explicit array conversions must preserve shape and element type ===
+
+    function explicitFixedToDynamic(uint256[3] memory a) internal pure returns (uint256[] memory) {
+        return uint256[](a); //~ ERROR: invalid explicit type conversion
+    }
+
+    function explicitDynamicToFixed(uint256[] memory a) internal pure returns (uint256[3] memory) {
+        return uint256[3](a); //~ ERROR: invalid explicit type conversion
+    }
+
+    function explicitElementMismatch(uint8[] memory a) internal pure returns (uint256[] memory) {
+        return uint256[](a); //~ ERROR: invalid explicit type conversion
+    }
+
+    function explicitMemoryToCalldata(uint256[] memory a) external pure {
+        uint256[] calldata b = uint256[](a); //~ ERROR: mismatched types
+    }
+
+    function explicitStorageToCalldata() external view {
+        uint256[] storage a = storageArr;
+        uint256[] calldata b = uint256[](a); //~ ERROR: mismatched types
+    }
+
     // === Invalid: different array lengths ===
     function differentLength(uint256[3] memory a) internal pure {
         uint256[4] memory b = a; //~ ERROR: mismatched types

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -5,6 +5,8 @@
 // Fixed arrays must also have the same length.
 
 contract C {
+    uint256[] storageArr;
+
     // === Valid: same element type assignment ===
     function sameDynamicArray(uint256[] memory a) internal pure {
         uint256[] memory b = a;
@@ -12,6 +14,26 @@ contract C {
 
     function sameFixedArray(uint256[3] memory a) internal pure {
         uint256[3] memory b = a;
+    }
+
+    // === Valid: explicit conversions preserve data locations ===
+
+    function explicitMemoryArray(uint256[] memory a) internal pure returns (uint256[] memory) {
+        return uint256[](a);
+    }
+
+    function explicitCalldataArray(uint256[] calldata a) external pure returns (uint256[] memory) {
+        return uint256[](a);
+    }
+
+    function explicitStorageArray() internal view returns (uint256) {
+        uint256[] storage a = storageArr;
+        uint256[] storage b = uint256[](a);
+        return b.length;
+    }
+
+    function explicitFixedArray(uint256[3] memory a) internal pure returns (uint256[3] memory) {
+        return uint256[3](a);
     }
 
     // === Invalid: different array lengths ===

--- a/tests/ui/typeck/implicit_array_conversions.stderr
+++ b/tests/ui/typeck/implicit_array_conversions.stderr
@@ -1,3 +1,33 @@
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         return uint256[](a);
+   ╰╴               ━━━━━━━━━━━━ cannot convert `uint256[3] memory` to `uint256[]`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         return uint256[3](a);
+   ╰╴               ━━━━━━━━━━━━━ cannot convert `uint256[] memory` to `uint256[3]`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         return uint256[](a);
+   ╰╴               ━━━━━━━━━━━━ cannot convert `uint8[] memory` to `uint256[]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint256[] calldata b = uint256[](a);
+   ╰╴                               ━━━━━━━━━━━━ expected `uint256[] calldata`, found `uint256[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint256[] calldata b = uint256[](a);
+   ╰╴                               ━━━━━━━━━━━━ expected `uint256[] calldata`, found `uint256[] storage`
+
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
    │
@@ -40,5 +70,5 @@ error: mismatched types
 LL │         uint8[] memory b = a;
    ╰╴                           ━ expected `uint8[] memory`, found `uint256[] memory`
 
-error: aborting due to 7 previous errors
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
Explicit conversions to unlocated dynamic types need a concrete data location in the resulting type. String literal conversions like `bytes("...")` and `string("...")` default to memory in solc, while exact reference-type conversions such as `uint[](x)` preserve the source location.

This fixes the Seaport EIP-712 type string construction errors and also lets array type conversions go through the normal explicit-cast path instead of tripping the elementary-type assumption for type expressions.
