### PR TITLE
fix(typeck): allow address literal casts

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -835,6 +835,13 @@ impl<'gcx> Ty<'gcx> {
 
             // address -> address payable.
             (Elementary(Address(false)), Elementary(Address(true))) => Ok(()),
+
+            // Integer literals -> address.
+            (IntLiteral(_, _, Some(TypeSize::ZERO)), Elementary(Address(_))) => Ok(()),
+            (IntLiteral(false, size, _), Elementary(Address(false))) if size.bits() <= 160 => {
+                Ok(())
+            }
+
             // IntLiteral -> IntLiteral: explicit conversion to a literal type shouldn't be
             // possible.
             (IntLiteral(..), IntLiteral(..)) => unreachable!(),

--- a/tests/ui/typeck/fixed_bytes_conversions.sol
+++ b/tests/ui/typeck/fixed_bytes_conversions.sol
@@ -60,13 +60,35 @@ contract C {
     // Valid: explicit address and FixedBytes conversions.
     function validAddressBytes20(address a, bytes20 b20) public pure {
         bytes20 b20FromAddress = bytes20(a);
+        bytes20 b20FromZeroAddress = bytes20(address(0));
         address addressFromB20 = address(b20);
+    }
+
+    // Valid: integer literals to address.
+    function validIntLiteralToAddress() public pure {
+        address a0 = address(0);
+        address a1 = address(1);
+        address a2 = address(0x1);
+        address a3 = address(0x0102);
+        address a4 = address(1 - 1);
+        address payable p0 = payable(0);
+        address payable p1 = payable(-0x0);
+        address payable p2 = payable(0x01 - 0x01);
+        address payable p3 = payable(address(1));
     }
 
     // Invalid: implicit address and FixedBytes conversions.
     function invalidImplicitAddressBytes20(address a, bytes20 b20) public pure {
         bytes20 b20FromAddress = a; //~ ERROR: mismatched types
         address addressFromB20 = b20; //~ ERROR: mismatched types
+    }
+
+    // Invalid: integer literals to address.
+    function invalidIntLiteralToAddress() public pure {
+        address a0 = address(-1); //~ ERROR: invalid explicit type conversion
+        address a1 = address(0x010000000000000000000000000000000000000000); //~ ERROR: invalid explicit type conversion
+        address payable p0 = payable(1); //~ ERROR: invalid explicit type conversion
+        address payable p1 = payable(0x01); //~ ERROR: invalid explicit type conversion
     }
 
     // Valid: same-size hex integer literals to FixedBytes.

--- a/tests/ui/typeck/fixed_bytes_conversions.sol
+++ b/tests/ui/typeck/fixed_bytes_conversions.sol
@@ -67,14 +67,17 @@ contract C {
     // Valid: integer literals to address.
     function validIntLiteralToAddress() public pure {
         address a0 = address(0);
-        address a1 = address(1);
-        address a2 = address(0x1);
-        address a3 = address(0x0102);
-        address a4 = address(1 - 1);
+        address a1 = address(-0x0);
+        address a2 = address(1);
+        address a3 = address(0x1);
+        address a4 = address(0x0102);
+        address a5 = address(1 - 1);
+        address a6 = address(1461501637330902918203684832716283019655932542975);
         address payable p0 = payable(0);
-        address payable p1 = payable(-0x0);
-        address payable p2 = payable(0x01 - 0x01);
-        address payable p3 = payable(address(1));
+        address payable p1 = payable(0x00);
+        address payable p2 = payable(-0x0);
+        address payable p3 = payable(0x01 - 0x01);
+        address payable p4 = payable(address(1));
     }
 
     // Invalid: implicit address and FixedBytes conversions.
@@ -86,9 +89,10 @@ contract C {
     // Invalid: integer literals to address.
     function invalidIntLiteralToAddress() public pure {
         address a0 = address(-1); //~ ERROR: invalid explicit type conversion
-        address a1 = address(0x010000000000000000000000000000000000000000); //~ ERROR: invalid explicit type conversion
+        address a1 = address(1461501637330902918203684832716283019655932542976); //~ ERROR: invalid explicit type conversion
         address payable p0 = payable(1); //~ ERROR: invalid explicit type conversion
         address payable p1 = payable(0x01); //~ ERROR: invalid explicit type conversion
+        address payable p2 = payable(1461501637330902918203684832716283019655932542975); //~ ERROR: invalid explicit type conversion
     }
 
     // Valid: same-size hex integer literals to FixedBytes.

--- a/tests/ui/typeck/fixed_bytes_conversions.stderr
+++ b/tests/ui/typeck/fixed_bytes_conversions.stderr
@@ -73,8 +73,8 @@ LL │         address a0 = address(-1);
 error: invalid explicit type conversion
    ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
    │
-LL │         address a1 = address(0x010000000000000000000000000000000000000000);
-   ╰╴                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ cannot convert `int_literal[161]` to `address`
+LL │         address a1 = address(1461501637330902918203684832716283019655932542976);
+   ╰╴                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ cannot convert `int_literal[161]` to `address`
 
 error: invalid explicit type conversion
    ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
@@ -87,6 +87,12 @@ error: invalid explicit type conversion
    │
 LL │         address payable p1 = payable(0x01);
    ╰╴                                     ━━━━ cannot convert `int_literal[1]` to `address payable`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         address payable p2 = payable(1461501637330902918203684832716283019655932542975);
+   ╰╴                                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ cannot convert `int_literal[160]` to `address payable`
 
 error: invalid explicit type conversion
    ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
@@ -250,5 +256,5 @@ error: mismatched types
 LL │         bytes2 b10 = 0x0102 + 0;
    ╰╴                     ━━━━━━━━━━ expected `bytes2`, found `int_literal[9]`
 
-error: aborting due to 42 previous errors
+error: aborting due to 43 previous errors
 

--- a/tests/ui/typeck/fixed_bytes_conversions.stderr
+++ b/tests/ui/typeck/fixed_bytes_conversions.stderr
@@ -67,6 +67,30 @@ LL │         address addressFromB20 = b20;
 error: invalid explicit type conversion
    ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
    │
+LL │         address a0 = address(-1);
+   ╰╴                     ━━━━━━━━━━━ cannot convert `int_literal[1]` to `address`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         address a1 = address(0x010000000000000000000000000000000000000000);
+   ╰╴                     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ cannot convert `int_literal[161]` to `address`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         address payable p0 = payable(1);
+   ╰╴                                     ━ cannot convert `int_literal[1]` to `address payable`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
+LL │         address payable p1 = payable(0x01);
+   ╰╴                                     ━━━━ cannot convert `int_literal[1]` to `address payable`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/fixed_bytes_conversions.sol:LL:CC
+   │
 LL │         int32 i32 = int32(b4);
    ╰╴                    ━━━━━━━━━ cannot convert `bytes4` to `int32`
 
@@ -226,5 +250,5 @@ error: mismatched types
 LL │         bytes2 b10 = 0x0102 + 0;
    ╰╴                     ━━━━━━━━━━ expected `bytes2`, found `int_literal[9]`
 
-error: aborting due to 38 previous errors
+error: aborting due to 42 previous errors
 


### PR DESCRIPTION
This allows explicit integer literal casts to address in the same cases accepted by solc: zero constants can cast to address or address payable, and non-zero non-negative constants can cast to non-payable address when they fit in 160 bits.

The fixed bytes conversion UI test now covers bytes20(address(0)) plus the valid and invalid address literal conversion edges.
