### PR TITLE
fix(typeck): preserve mapping element locations

### DIFF
--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1723,7 +1723,7 @@ impl TypeKind<'_> {
     pub fn is_reference_type(&self) -> bool {
         match self {
             TypeKind::Elementary(t) => t.is_reference_type(),
-            TypeKind::Custom(ItemId::Struct(_)) | TypeKind::Array(_) => true,
+            TypeKind::Custom(ItemId::Struct(_)) | TypeKind::Array(_) | TypeKind::Mapping(_) => true,
             _ => false,
         }
     }

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -236,7 +236,11 @@ impl<'gcx> Ty<'gcx> {
     pub fn is_reference_type(self) -> bool {
         match self.kind {
             TyKind::Elementary(t) => t.is_reference_type(),
-            TyKind::Struct(_) | TyKind::Array(..) | TyKind::DynArray(_) | TyKind::Slice(_) => true,
+            TyKind::Struct(_)
+            | TyKind::Array(..)
+            | TyKind::DynArray(_)
+            | TyKind::Slice(_)
+            | TyKind::Mapping(..) => true,
             _ => false,
         }
     }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -690,9 +690,7 @@ impl<'gcx> TypeChecker<'gcx> {
             | TyKind::Elementary(ElementaryType::FixedBytes(_)) => {
                 (self.gcx.types.uint(256), self.gcx.types.fixed_bytes(1))
             }
-            TyKind::Mapping(key, value) => {
-                (key, value.with_loc_if_ref(self.gcx, loc.unwrap_or(DataLocation::Storage)))
-            }
+            TyKind::Mapping(key, value) => (key, value.with_loc_if_ref_opt(self.gcx, loc)),
             _ => return None,
         })
     }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -690,7 +690,9 @@ impl<'gcx> TypeChecker<'gcx> {
             | TyKind::Elementary(ElementaryType::FixedBytes(_)) => {
                 (self.gcx.types.uint(256), self.gcx.types.fixed_bytes(1))
             }
-            TyKind::Mapping(key, value) => (key, value.with_loc_if_ref_opt(self.gcx, loc)),
+            TyKind::Mapping(key, value) => {
+                (key, value.with_loc_if_ref(self.gcx, loc.unwrap_or(DataLocation::Storage)))
+            }
             _ => return None,
         })
     }

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -15,6 +15,7 @@ contract C {
     mapping(bytes32 => S) structs;
     mapping(bytes32 => S[]) structArrays;
     mapping(bytes32 => mapping(uint256 => S)) nestedStructs;
+    mapping(bytes32 => mapping(uint256 => uint256)) nestedMappings;
 
     // === Same location conversions (should all work) ===
 
@@ -59,6 +60,10 @@ contract C {
 
     function nestedMappingStructToStorage(bytes32 key) internal view returns (S storage s) {
         s = nestedStructs[key][0];
+    }
+
+    function nestedMappingToStorage(bytes32 key) internal view returns (mapping(uint256 => uint256) storage m) {
+        m = nestedMappings[key];
     }
 
     // === calldata -> memory (allowed, copy semantics) ===

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -9,6 +9,9 @@ contract C {
     }
 
     uint256[] storageArr;
+    S[] structArr;
+    S[2] fixedStructArr;
+    S[][] nestedStructArr;
     mapping(bytes32 => S) structs;
     mapping(bytes32 => S[]) structArrays;
     mapping(bytes32 => mapping(uint256 => S)) nestedStructs;
@@ -28,6 +31,22 @@ contract C {
     function storageToStorage() internal {
         uint256[] storage a = storageArr;
         uint256[] storage b = a;
+    }
+
+    function arrayStructElementToStorage() internal view returns (S storage s) {
+        s = structArr[0];
+    }
+
+    function fixedArrayStructElementToStorage() internal view returns (S storage s) {
+        s = fixedStructArr[0];
+    }
+
+    function nestedArrayToStorage() internal view returns (S[] storage s) {
+        s = nestedStructArr[0];
+    }
+
+    function nestedArrayStructElementToStorage() internal view returns (S storage s) {
+        s = nestedStructArr[0][0];
     }
 
     function mappingStructToStorage(bytes32 key) internal view returns (S storage s) {

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -4,7 +4,14 @@
 // See: https://docs.soliditylang.org/en/latest/types.html#data-location-and-assignment-behaviour
 
 contract C {
+    struct S {
+        uint256 x;
+    }
+
     uint256[] storageArr;
+    mapping(bytes32 => S) structs;
+    mapping(bytes32 => S[]) structArrays;
+    mapping(bytes32 => mapping(uint256 => S)) nestedStructs;
 
     // === Same location conversions (should all work) ===
 
@@ -21,6 +28,18 @@ contract C {
     function storageToStorage() internal {
         uint256[] storage a = storageArr;
         uint256[] storage b = a;
+    }
+
+    function mappingStructToStorage(bytes32 key) internal view returns (S storage s) {
+        s = structs[key];
+    }
+
+    function mappingStructArrayElementToStorage(bytes32 key) internal view returns (S storage s) {
+        s = structArrays[key][0];
+    }
+
+    function nestedMappingStructToStorage(bytes32 key) internal view returns (S storage s) {
+        s = nestedStructs[key][0];
     }
 
     // === calldata -> memory (allowed, copy semantics) ===

--- a/tests/ui/typeck/var_decl_rules.stderr
+++ b/tests/ui/typeck/var_decl_rules.stderr
@@ -34,7 +34,7 @@ error: type `struct C.WithMapping memory` is only valid in storage because it co
 LL │         WithMapping memory localWithMapping;
    ╰╴        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: type `mapping(uint256 => uint256)` is only valid in storage because it contains a (nested) mapping
+error: type `mapping(uint256 => uint256) memory` is only valid in storage because it contains a (nested) mapping
    ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
    │
 LL │         mapping(uint => uint) memory m;


### PR DESCRIPTION
Mapping index expressions were only preserving the outer data location when the mapping type itself was wrapped in a reference. State-variable mappings are represented as mapping types directly, so indexing `mapping(bytes32 => S)` produced bare `S` instead of `S storage`, which rejected valid storage pointer assignments like Seaport's `_orderStatus[orderHash]`.

This treats mapping values as storage-backed when no explicit outer location is present, while still preserving an explicit location if one exists. The data-location coercion UI coverage now includes storage pointers returned from mapping-to-struct indexes, nested mapping indexes, and mapping-to-array element indexes checked against solc behavior.
