### PR TITLE
fix(typeck): allow dynamic array new args

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -446,7 +446,11 @@ impl<'gcx> TypeChecker<'gcx> {
                             )
                         } else {
                             let ty = ty.with_loc(self.gcx, DataLocation::Memory);
-                            self.gcx.mk_builtin_fn(&[], hir::StateMutability::Pure, &[ty])
+                            self.gcx.mk_builtin_fn(
+                                &[self.gcx.types.uint(256)],
+                                hir::StateMutability::Pure,
+                                &[ty],
+                            )
                         }
                     }
                     TyKind::Err(_) => ty,

--- a/tests/ui/typeck/new_dynamic_arrays.sol
+++ b/tests/ui/typeck/new_dynamic_arrays.sol
@@ -1,0 +1,15 @@
+//@compile-flags: -Ztypeck
+
+contract C {
+    struct S {
+        uint256 x;
+    }
+
+    function f(uint256 n) public pure {
+        bytes memory b = new bytes(n);
+        string memory s = new string(n);
+        uint256[] memory a = new uint256[](n);
+        S[] memory structs = new S[](n);
+        uint256[][] memory nested = new uint256[][](n);
+    }
+}


### PR DESCRIPTION
Dynamic array creation in Solidity takes a single length argument, but the type checker modeled `new` for array-like types as a zero-argument builtin. This caused `new bytes(n)` and `new T[](n)` to fail during call argument checking before the resulting memory array type could be used.

This changes the builtin signature for array-like `new` expressions to accept a `uint256` length and keeps the memory return type unchanged. I compared the covered forms with solc 0.8.35, including `bytes`, `string`, primitive dynamic arrays, struct arrays, and nested dynamic arrays.
