### PR TITLE
fix(sema): type yul string literals as words

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -338,6 +338,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.gcx.mk_ty_err(self.dcx().err("cannot index").span(expr.span).emit())
                 }
             }
+            hir::ExprKind::Lit(lit) if self.in_yul => self.check_yul_lit(lit),
             hir::ExprKind::Lit(lit) => self.gcx.type_of_lit(lit),
             hir::ExprKind::Member(expr, ident) => {
                 let expr_ty = self.check_expr(expr);

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -15,7 +15,7 @@ impl<'gcx> TypeChecker<'gcx> {
             } else {
                 self.gcx.mk_ty_err(
                     self.dcx()
-                        .err(format!("string literal too long ({len} > 32)"))
+                        .err(format!("String literal too long ({len} > 32)"))
                         .span(lit.span)
                         .emit(),
                 )

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -15,7 +15,7 @@ impl<'gcx> TypeChecker<'gcx> {
             } else {
                 self.gcx.mk_ty_err(
                     self.dcx()
-                        .err(format!("String literal too long ({len} > 32)"))
+                        .err(format!("string literal too long ({len} > 32)"))
                         .span(lit.span)
                         .emit(),
                 )

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -3,10 +3,28 @@ use crate::{
     hir,
     ty::{Ty, TyKind},
 };
-use solar_ast::{DataLocation, ElementaryType, Span};
+use solar_ast::{DataLocation, ElementaryType, LitKind, Span};
 use solar_interface::{Ident, Symbol, diagnostics::ErrorGuaranteed, kw, sym};
 
 impl<'gcx> TypeChecker<'gcx> {
+    pub(super) fn check_yul_lit(&self, lit: &'gcx hir::Lit<'gcx>) -> Ty<'gcx> {
+        if let LitKind::Str(_, s, _) = &lit.kind {
+            let len = s.as_byte_str().len();
+            return if len <= 32 {
+                self.gcx.types.uint(256)
+            } else {
+                self.gcx.mk_ty_err(
+                    self.dcx()
+                        .err(format!("string literal too long ({len} > 32)"))
+                        .span(lit.span)
+                        .emit(),
+                )
+            };
+        }
+
+        self.gcx.type_of_lit(lit)
+    }
+
     /// Checks whether a resolved identifier should be treated as an external Solidity reference in
     /// Yul. Returns `Ok(true)` when the identifier was accepted and should be typed as a Yul word,
     /// `Ok(false)` when it is not a Yul external reference and normal typing should continue, and

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -126,9 +126,9 @@ contract C {
 
             constantValue := 1 //~ ERROR: cannot assign to a constant variable
 
-            pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg") //~ ERROR: String literal too long (33 > 32)
+            pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg") //~ ERROR: string literal too long (33 > 32)
 
-            pop(hex"123456789012345678901234567890123456789012345678901234567890123456") //~ ERROR: String literal too long (33 > 32)
+            pop(hex"123456789012345678901234567890123456789012345678901234567890123456") //~ ERROR: string literal too long (33 > 32)
 
             pop(stringConstant) //~ ERROR: only direct number constants are supported in inline assembly
 

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -126,9 +126,9 @@ contract C {
 
             constantValue := 1 //~ ERROR: cannot assign to a constant variable
 
-            pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg") //~ ERROR: string literal too long (33 > 32)
+            pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg") //~ ERROR: String literal too long (33 > 32)
 
-            pop(hex"123456789012345678901234567890123456789012345678901234567890123456") //~ ERROR: string literal too long (33 > 32)
+            pop(hex"123456789012345678901234567890123456789012345678901234567890123456") //~ ERROR: String literal too long (33 > 32)
 
             pop(stringConstant) //~ ERROR: only direct number constants are supported in inline assembly
 

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -68,6 +68,10 @@ contract C {
             pop(addressConstant)
             pop(bytes32Constant)
             pop(convertedConstant)
+            pop("abc")
+            pop(hex"1234")
+            mstore(0, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef")
+            mstore(32, hex"1234567890123456789012345678901234567890123456789012345678901234")
             storageRef.slot := state.slot
 
             pop(data.offset)
@@ -121,6 +125,10 @@ contract C {
             udvtState := 1 //~ ERROR: only local variables are supported in inline assembly
 
             constantValue := 1 //~ ERROR: cannot assign to a constant variable
+
+            pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg") //~ ERROR: string literal too long (33 > 32)
+
+            pop(hex"123456789012345678901234567890123456789012345678901234567890123456") //~ ERROR: string literal too long (33 > 32)
 
             pop(stringConstant) //~ ERROR: only direct number constants are supported in inline assembly
 

--- a/tests/ui/typeck/yul_type_checking.stderr
+++ b/tests/ui/typeck/yul_type_checking.stderr
@@ -48,6 +48,18 @@ error: cannot assign to a constant variable
 LL │             constantValue := 1
    ╰╴            ━━━━━━━━━━━━━
 
+error: string literal too long (33 > 32)
+   ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
+   │
+LL │             pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg")
+   ╰╴                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: string literal too long (33 > 32)
+   ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
+   │
+LL │             pop(hex"123456789012345678901234567890123456789012345678901234567890123456")
+   ╰╴                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 error: only direct number constants are supported in inline assembly
    ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
    │
@@ -286,5 +298,5 @@ error: expression has to be an lvalue
 LL │             CustomEvent := 1
    ╰╴            ━━━━━━━━━━━
 
-error: aborting due to 46 previous errors
+error: aborting due to 48 previous errors
 

--- a/tests/ui/typeck/yul_type_checking.stderr
+++ b/tests/ui/typeck/yul_type_checking.stderr
@@ -48,13 +48,13 @@ error: cannot assign to a constant variable
 LL │             constantValue := 1
    ╰╴            ━━━━━━━━━━━━━
 
-error: String literal too long (33 > 32)
+error: string literal too long (33 > 32)
    ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
    │
 LL │             pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg")
    ╰╴                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: String literal too long (33 > 32)
+error: string literal too long (33 > 32)
    ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
    │
 LL │             pop(hex"123456789012345678901234567890123456789012345678901234567890123456")

--- a/tests/ui/typeck/yul_type_checking.stderr
+++ b/tests/ui/typeck/yul_type_checking.stderr
@@ -48,13 +48,13 @@ error: cannot assign to a constant variable
 LL │             constantValue := 1
    ╰╴            ━━━━━━━━━━━━━
 
-error: string literal too long (33 > 32)
+error: String literal too long (33 > 32)
    ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
    │
 LL │             pop("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefg")
    ╰╴                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: string literal too long (33 > 32)
+error: String literal too long (33 > 32)
    ╭▸ ROOT/tests/ui/typeck/yul_type_checking.sol:LL:CC
    │
 LL │             pop(hex"123456789012345678901234567890123456789012345678901234567890123456")


### PR DESCRIPTION
Inline assembly treats string and hex string literals up to 32 bytes as stack words. Solady hits this in its Base64 table setup, where `mstore` and `xor` receive 32-byte string literals directly.

This adds a Yul-specific literal typing path that maps string literals of at most one word to `uint256` and reports the solc-style length error for longer literals. After this change, the initial Solady Yul string literal failures are gone; the remaining Solady failures are unrelated overload/member-resolution gaps.
