### PR TITLE
fix(sema): model function member kinds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Guidance for AI coding agents working in this repository.
 
 Solar is a blazingly fast, modular Solidity compiler written in Rust, aiming to be a modern alternative to solc.
 
+For testing and comparing behavior and semantics, the current tracked solc version (usually the latest stable release) is always available as a submodule `./testdata/solidity`.
+
 ## Commands
 
 ```bash
@@ -63,7 +65,7 @@ Use `^` or `v` to point to lines above/below.
 ### Porting Tests from Solc
 
 Always look at the corresponding Solc test when porting behavior. Solc is always
-available in `testdata/solidity`. Solc tests may embed multiple source files in
+available in `./testdata/solidity`. Solc tests may embed multiple source files in
 one `.sol` file with `==== Source: ... ====` annotations. When porting those
 tests, split the secondary sources into the UI test's `auxiliary/` directory and
 update imports accordingly. Add the Solc test path at the top of

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -994,6 +994,7 @@ symbols! {
         require,
         ripemd160,
         runtimeCode,
+        salt,
         selector,
         send,
         sender,

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1667,21 +1667,32 @@ impl<'gcx> ResolveContext<'gcx> {
 
     fn lower_call_callee(
         &mut self,
-        mut callee: &ast::Expr<'_>,
-    ) -> (&'gcx hir::Expr<'gcx>, Option<&'gcx [hir::CallOptions<'gcx>]>) {
-        let mut options = SmallVec::<[_; 2]>::new();
-        while let ast::ExprKind::CallOptions(inner, args) = &callee.kind {
-            options.push(hir::CallOptions { span: callee.span, args: self.lower_named_args(args) });
-            callee = inner.peel_parens();
-        }
-        let callee = self.lower_expr(callee);
-        let options = if options.is_empty() {
-            None
-        } else {
-            options.reverse();
-            Some(&*self.arena.alloc_slice_copy(&options))
+        callee: &ast::Expr<'_>,
+    ) -> (&'gcx hir::Expr<'gcx>, Option<&'gcx hir::CallOptions<'gcx>>) {
+        let callee = callee.peel_parens();
+        let ast::ExprKind::CallOptions(inner, args) = &callee.kind else {
+            return (self.lower_expr(callee), None);
         };
-        (callee, options)
+
+        let mut options = hir::CallOptions { span: callee.span, args: self.lower_named_args(args) };
+        let mut inner = inner.peel_parens();
+        let mut has_nested_options = false;
+        while let ast::ExprKind::CallOptions(next, args) = &inner.kind {
+            has_nested_options = true;
+            options = hir::CallOptions { span: inner.span, args: self.lower_named_args(args) };
+            inner = next.peel_parens();
+        }
+
+        if has_nested_options {
+            self.sess
+                .dcx
+                .err("function call options have already been set")
+                .span(callee.span)
+                .help("combine them into a single `{...}` option")
+                .emit();
+        }
+
+        (self.lower_expr(inner), Some(self.arena.alloc(options)))
     }
 
     fn lower_named_args(&mut self, options: &[ast::NamedArg<'_>]) -> &'gcx [hir::NamedArg<'gcx>] {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1599,8 +1599,17 @@ impl<'gcx> ResolveContext<'gcx> {
                 hir::ExprKind::Call(callee, self.lower_call_args(args), options)
             }
             ast::ExprKind::CallOptions(callee, options) => {
-                let _ = options;
-                return self.lower_expr_full(callee.peel_parens());
+                let callee = self.lower_expr(callee);
+                let _options = self.lower_named_args(options);
+                let options_span = callee.span.shrink_to_hi().with_hi(expr.span.hi());
+                hir::ExprKind::Err(
+                    self.sess
+                        .dcx
+                        .err("call options must be part of a call expression")
+                        .span(options_span)
+                        .span_note(expr.span, "this expression is not a function call expression")
+                        .emit(),
+                )
             }
             ast::ExprKind::Delete(expr) => hir::ExprKind::Delete(self.lower_expr(expr)),
             ast::ExprKind::Ident(name) => {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1595,7 +1595,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 hir::ExprKind::Binary(self.lower_expr(lhs), *op, self.lower_expr(rhs))
             }
             ast::ExprKind::Call(callee, args) => {
-                let (callee, options) = self.lower_call_callee(callee.peel_parens());
+                let (callee, options) = self.lower_call_callee(callee);
                 hir::ExprKind::Call(callee, self.lower_call_args(args), options)
             }
             ast::ExprKind::CallOptions(callee, options) => {
@@ -1669,19 +1669,24 @@ impl<'gcx> ResolveContext<'gcx> {
         &mut self,
         callee: &ast::Expr<'_>,
     ) -> (&'gcx hir::Expr<'gcx>, Option<&'gcx hir::CallOptions<'gcx>>) {
-        let callee = callee.peel_parens();
-        let ast::ExprKind::CallOptions(inner, args) = &callee.kind else {
-            return (self.lower_expr(callee), None);
-        };
-
-        let mut options = hir::CallOptions { span: callee.span, args: self.lower_named_args(args) };
-        let mut inner = inner.peel_parens();
+        let mut inner = callee.peel_parens();
+        let mut options = None;
         let mut has_nested_options = false;
-        while let ast::ExprKind::CallOptions(next, args) = &inner.kind {
-            has_nested_options = true;
-            options = hir::CallOptions { span: inner.span, args: self.lower_named_args(args) };
+
+        #[expect(clippy::while_let_loop, reason = "this is intentionally shaped like a do-while")]
+        loop {
+            let ast::ExprKind::CallOptions(next, args) = &inner.kind else { break };
+            if options.is_some() {
+                has_nested_options = true;
+            }
+            options =
+                Some(hir::CallOptions { span: inner.span, args: self.lower_named_args(args) });
             inner = next.peel_parens();
         }
+
+        let Some(options) = options else {
+            return (self.lower_expr(inner), None);
+        };
 
         if has_nested_options {
             self.sess

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1673,9 +1673,7 @@ impl<'gcx> ResolveContext<'gcx> {
         let mut options = None;
         let mut has_nested_options = false;
 
-        #[expect(clippy::while_let_loop, reason = "this is intentionally shaped like a do-while")]
-        loop {
-            let ast::ExprKind::CallOptions(next, args) = &inner.kind else { break };
+        while let ast::ExprKind::CallOptions(next, args) = &inner.kind {
             if options.is_some() {
                 has_nested_options = true;
             }

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1243,7 +1243,7 @@ impl<'gcx> ResolveContext<'gcx> {
                     hir::ExprKind::Ident(res),
                     call.name.span,
                 );
-                hir::ExprKind::Call(callee, self.lower_yul_call_args(call.arguments, span))
+                hir::ExprKind::Call(callee, self.lower_yul_call_args(call.arguments, span), None)
             }
             Err(guar) => hir::ExprKind::Err(guar),
         }
@@ -1426,13 +1426,12 @@ impl<'gcx> ResolveContext<'gcx> {
                     id: self.next_id(),
                     kind: hir::ExprKind::Ident(res),
                     span: path.last().span,
-                    call_options: None,
                 }),
                 self.lower_call_args(args),
+                None,
             ),
             id: self.next_id(),
             span,
-            call_options: None,
         })
     }
 
@@ -1595,12 +1594,13 @@ impl<'gcx> ResolveContext<'gcx> {
             ast::ExprKind::Binary(lhs, op, rhs) => {
                 hir::ExprKind::Binary(self.lower_expr(lhs), *op, self.lower_expr(rhs))
             }
-            ast::ExprKind::Call(callee, args) => hir::ExprKind::Call(
-                self.lower_expr(callee.peel_parens()),
-                self.lower_call_args(args),
-            ),
+            ast::ExprKind::Call(callee, args) => {
+                let (callee, options) = self.lower_call_callee(callee.peel_parens());
+                hir::ExprKind::Call(callee, self.lower_call_args(args), options)
+            }
             ast::ExprKind::CallOptions(callee, options) => {
-                return self.lower_call_options_expr(callee, options, expr.span);
+                let _ = options;
+                return self.lower_expr_full(callee.peel_parens());
             }
             ast::ExprKind::Delete(expr) => hir::ExprKind::Delete(self.lower_expr(expr)),
             ast::ExprKind::Ident(name) => {
@@ -1656,24 +1656,23 @@ impl<'gcx> ResolveContext<'gcx> {
         self.arena.alloc_with(|| lit.copy_without_data())
     }
 
-    fn lower_call_options_expr(
+    fn lower_call_callee(
         &mut self,
-        callee: &ast::Expr<'_>,
-        options: &[ast::NamedArg<'_>],
-        span: Span,
-    ) -> hir::Expr<'gcx> {
-        let mut expr = self.lower_expr_full(callee.peel_parens());
-        let option = hir::CallOptions { span, args: self.lower_named_args(options) };
-        expr.call_options = Some(match expr.call_options {
-            Some(existing) => {
-                let mut options = SmallVec::<[_; 2]>::from_slice(existing);
-                options.push(option);
-                self.arena.alloc_slice_copy(&options)
-            }
-            None => self.arena.alloc_as_slice(option),
-        });
-        expr.span = span;
-        expr
+        mut callee: &ast::Expr<'_>,
+    ) -> (&'gcx hir::Expr<'gcx>, Option<&'gcx [hir::CallOptions<'gcx>]>) {
+        let mut options = SmallVec::<[_; 2]>::new();
+        while let ast::ExprKind::CallOptions(inner, args) = &callee.kind {
+            options.push(hir::CallOptions { span: callee.span, args: self.lower_named_args(args) });
+            callee = inner.peel_parens();
+        }
+        let callee = self.lower_expr(callee);
+        let options = if options.is_empty() {
+            None
+        } else {
+            options.reverse();
+            Some(&*self.arena.alloc_slice_copy(&options))
+        };
+        (callee, options)
     }
 
     fn lower_named_args(&mut self, options: &[ast::NamedArg<'_>]) -> &'gcx [hir::NamedArg<'gcx>] {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1243,7 +1243,7 @@ impl<'gcx> ResolveContext<'gcx> {
                     hir::ExprKind::Ident(res),
                     call.name.span,
                 );
-                hir::ExprKind::Call(callee, self.lower_yul_call_args(call.arguments, span), None)
+                hir::ExprKind::Call(callee, self.lower_yul_call_args(call.arguments, span))
             }
             Err(guar) => hir::ExprKind::Err(guar),
         }
@@ -1426,12 +1426,13 @@ impl<'gcx> ResolveContext<'gcx> {
                     id: self.next_id(),
                     kind: hir::ExprKind::Ident(res),
                     span: path.last().span,
+                    call_options: None,
                 }),
                 self.lower_call_args(args),
-                None,
             ),
             id: self.next_id(),
             span,
+            call_options: None,
         })
     }
 
@@ -1594,18 +1595,12 @@ impl<'gcx> ResolveContext<'gcx> {
             ast::ExprKind::Binary(lhs, op, rhs) => {
                 hir::ExprKind::Binary(self.lower_expr(lhs), *op, self.lower_expr(rhs))
             }
-            ast::ExprKind::Call(callee, args) => {
-                let callee = callee.peel_parens();
-                let (callee, options) =
-                    if let ast::ExprKind::CallOptions(expr, options) = &callee.kind {
-                        (self.lower_expr(expr), Some(self.lower_named_args(options)))
-                    } else {
-                        (self.lower_expr(callee), None)
-                    };
-                hir::ExprKind::Call(callee, self.lower_call_args(args), options)
-            }
+            ast::ExprKind::Call(callee, args) => hir::ExprKind::Call(
+                self.lower_expr(callee.peel_parens()),
+                self.lower_call_args(args),
+            ),
             ast::ExprKind::CallOptions(callee, options) => {
-                hir::ExprKind::CallOptions(self.lower_expr(callee), self.lower_named_args(options))
+                return self.lower_call_options_expr(callee, options, expr.span);
             }
             ast::ExprKind::Delete(expr) => hir::ExprKind::Delete(self.lower_expr(expr)),
             ast::ExprKind::Ident(name) => {
@@ -1659,6 +1654,26 @@ impl<'gcx> ResolveContext<'gcx> {
 
     fn lower_lit(&mut self, lit: &ast::Lit<'_>) -> &'gcx ast::Lit<'gcx> {
         self.arena.alloc_with(|| lit.copy_without_data())
+    }
+
+    fn lower_call_options_expr(
+        &mut self,
+        callee: &ast::Expr<'_>,
+        options: &[ast::NamedArg<'_>],
+        span: Span,
+    ) -> hir::Expr<'gcx> {
+        let mut expr = self.lower_expr_full(callee.peel_parens());
+        let option = hir::CallOptions { span, args: self.lower_named_args(options) };
+        expr.call_options = Some(match expr.call_options {
+            Some(existing) => {
+                let mut options = SmallVec::<[_; 2]>::from_slice(existing);
+                options.push(option);
+                self.arena.alloc_slice_copy(&options)
+            }
+            None => self.arena.alloc_as_slice(option),
+        });
+        expr.span = span;
+        expr
     }
 
     fn lower_named_args(&mut self, options: &[ast::NamedArg<'_>]) -> &'gcx [hir::NamedArg<'gcx>] {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1605,17 +1605,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 hir::ExprKind::Call(callee, self.lower_call_args(args), options)
             }
             ast::ExprKind::CallOptions(callee, options) => {
-                let callee = self.lower_expr(callee);
-                let _options = self.lower_named_args(options);
-                let options_span = callee.span.shrink_to_hi().with_hi(expr.span.hi());
-                hir::ExprKind::Err(
-                    self.sess
-                        .dcx
-                        .err("call options must be part of a call expression")
-                        .span(options_span)
-                        .span_note(expr.span, "this expression is not a function call expression")
-                        .emit(),
-                )
+                hir::ExprKind::CallOptions(self.lower_expr(callee), self.lower_named_args(options))
             }
             ast::ExprKind::Delete(expr) => hir::ExprKind::Delete(self.lower_expr(expr)),
             ast::ExprKind::Ident(name) => {

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -204,8 +204,7 @@ fn reference<'gcx>(
 // `Enum.Variant`, `Udvt.wrap`
 fn type_type<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberListOwned<'gcx> {
     match ty.kind {
-        // TODO: https://github.com/argotorg/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L3913
-        TyKind::Contract(_) => Default::default(),
+        TyKind::Contract(id) => contract_type(gcx, id),
         TyKind::Enum(id) => {
             gcx.hir.enumm(id).variants.iter().map(|v| Member::new(v.name, ty)).collect()
         }
@@ -224,6 +223,28 @@ fn type_type<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberListOwned<'gcx> {
         TyKind::Elementary(ElementaryType::String) => string_ty(gcx),
         TyKind::Elementary(ElementaryType::Bytes) => bytes_ty(gcx),
         _ => Default::default(),
+    }
+}
+
+fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
+    let contract = gcx.hir.contract(id);
+    if contract.kind.is_library() {
+        contract
+            .functions()
+            .filter(|&id| gcx.hir.function(id).is_ordinary())
+            .map(|id| {
+                let item = hir::ItemId::from(id);
+                Member::with_res(gcx.item_name(item).name, gcx.type_of_item(item), item)
+            })
+            .collect()
+    } else {
+        gcx.interface_functions(id)
+            .iter()
+            .map(|f| {
+                let id = hir::ItemId::from(f.id);
+                Member::with_res(gcx.item_name(id).name, f.ty, id)
+            })
+            .collect()
     }
 }
 

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -142,7 +142,7 @@ pub(crate) fn contract(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_>
 
 fn function<'gcx>(gcx: Gcx<'gcx>, f: &'gcx TyFnPtr<'gcx>) -> MemberListOwned<'gcx> {
     let mut members = Vec::with_capacity(2);
-    if f.visibility >= hir::Visibility::Public {
+    if f.visibility >= hir::Visibility::Public || f.special {
         members.push(Member::of_builtin(gcx, Builtin::FunctionSelector));
     }
     if f.visibility == hir::Visibility::External {
@@ -234,7 +234,12 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
             .filter(|&id| gcx.hir.function(id).is_ordinary())
             .map(|id| {
                 let item = hir::ItemId::from(id);
-                Member::with_res(gcx.item_name(item).name, gcx.type_of_item(item), item)
+                let ty = if gcx.hir.function(id).visibility >= hir::Visibility::Public {
+                    gcx.type_of_item(item).as_externally_callable_library_function(gcx)
+                } else {
+                    gcx.type_of_item(item)
+                };
+                Member::with_res(gcx.item_name(item).name, ty, item)
             })
             .collect()
     } else {

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -273,6 +273,7 @@ fn function_via_contract<'gcx>(gcx: Gcx<'gcx>, id: hir::FunctionId) -> Ty<'gcx> 
             returns: fn_ty.returns,
             state_mutability: fn_ty.state_mutability,
             function_id: fn_ty.function_id,
+            options: fn_ty.options,
         })
     }
 }

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -3,6 +3,7 @@ use crate::{
     hir,
     ty::{Gcx, Ty, TyFn, TyFnKind, TyKind},
 };
+use either::Either;
 use solar_ast::{DataLocation, ElementaryType, StateMutability as SM, Visibility};
 use solar_data_structures::BumpExt;
 use solar_interface::Symbol;
@@ -232,49 +233,37 @@ fn type_type<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberListOwned<'gcx> {
 
 fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
     let contract = gcx.hir.contract(id);
-    if contract.kind.is_library() {
-        contract
-            .functions()
-            .filter(|&id| {
-                let f = gcx.hir.function(id);
-                f.is_ordinary() && f.visibility >= Visibility::Internal
-            })
-            .map(|id| {
-                let item = hir::ItemId::from(id);
-                Member::with_res(gcx.item_name(item).name, function_via_contract(gcx, id), item)
-            })
-            .collect()
+    let is_library = contract.kind.is_library();
+    let functions = if is_library {
+        Either::Left(contract.functions().filter(|&id| {
+            let f = gcx.hir.function(id);
+            f.is_ordinary() && f.visibility >= Visibility::Internal
+        }))
     } else {
-        gcx.interface_functions(id)
-            .iter()
-            .map(|f| {
-                let id = hir::ItemId::from(f.id);
-                let ty = function_via_contract(gcx, f.id);
-                Member::with_res(gcx.item_name(id).name, ty, id)
-            })
-            .collect()
-    }
-}
-
-fn function_via_contract<'gcx>(gcx: Gcx<'gcx>, id: hir::FunctionId) -> Ty<'gcx> {
-    let f = gcx.hir.function(id);
-    let ty = gcx.type_of_item(id.into());
-    if f.contract.is_some_and(|contract_id| gcx.hir.contract(contract_id).kind.is_library()) {
-        if f.visibility >= Visibility::Public {
-            ty.as_externally_callable_function(true, gcx)
-        } else {
-            ty
-        }
-    } else {
-        let TyKind::Fn(fn_ty) = ty.kind else { unreachable!() };
-        gcx.mk_ty_fn(TyFn {
-            kind: TyFnKind::Declaration,
-            parameters: fn_ty.parameters,
-            returns: fn_ty.returns,
-            state_mutability: fn_ty.state_mutability,
-            function_id: fn_ty.function_id,
+        Either::Right(gcx.interface_functions(id).iter().map(|f| f.id))
+    };
+    functions
+        .map(|id| {
+            let item = hir::ItemId::from(id);
+            let f = gcx.hir.function(id);
+            let ty = gcx.type_of_item(id.into());
+            let ty = if is_library && f.visibility >= Visibility::Public {
+                ty.as_externally_callable_function(true, gcx)
+            } else if is_library {
+                ty
+            } else {
+                let TyKind::Fn(fn_ty) = ty.kind else { unreachable!() };
+                gcx.mk_ty_fn(TyFn {
+                    kind: TyFnKind::Declaration,
+                    parameters: fn_ty.parameters,
+                    returns: fn_ty.returns,
+                    state_mutability: fn_ty.state_mutability,
+                    function_id: fn_ty.function_id,
+                })
+            };
+            Member::with_res(gcx.item_name(item).name, ty, item)
         })
-    }
+        .collect()
 }
 
 // `type(T)`

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -33,6 +33,7 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         TyKind::Tuple(_tys) => Default::default(),
         TyKind::Mapping(..) => Default::default(),
         TyKind::Fn(f) => function(gcx, f),
+        TyKind::CallOptions(ty) => native_members(gcx, ty).to_vec(),
         TyKind::Contract(id) => contract(gcx, id),
         TyKind::Struct(_id) => expected_ref(),
         TyKind::Enum(_id) => Default::default(),

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -33,7 +33,6 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         TyKind::Tuple(_tys) => Default::default(),
         TyKind::Mapping(..) => Default::default(),
         TyKind::Fn(f) => function(gcx, f),
-        TyKind::CallOptions(ty) => native_members(gcx, ty).to_vec(),
         TyKind::Contract(id) => contract(gcx, id),
         TyKind::Struct(_id) => expected_ref(),
         TyKind::Enum(_id) => Default::default(),

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -1,7 +1,7 @@
 use super::Builtin;
 use crate::{
     hir,
-    ty::{Gcx, Ty, TyFn, TyKind},
+    ty::{Gcx, Ty, TyFn, TyFnKind, TyKind},
 };
 use solar_ast::{DataLocation, ElementaryType, StateMutability as SM, Visibility};
 use solar_data_structures::BumpExt;
@@ -135,7 +135,11 @@ pub(crate) fn contract(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_>
         .iter()
         .map(|f| {
             let id = hir::ItemId::from(f.id);
-            Member::with_res(gcx.item_name(id).name, f.ty.as_externally_callable_function(gcx), id)
+            Member::with_res(
+                gcx.item_name(id).name,
+                f.ty.as_externally_callable_function(false, gcx),
+                id,
+            )
         })
         .collect()
 }
@@ -257,12 +261,19 @@ fn function_via_contract<'gcx>(gcx: Gcx<'gcx>, id: hir::FunctionId) -> Ty<'gcx> 
     let ty = gcx.type_of_item(id.into());
     if f.contract.is_some_and(|contract_id| gcx.hir.contract(contract_id).kind.is_library()) {
         if f.visibility >= Visibility::Public {
-            ty.as_externally_callable_library_function(gcx)
+            ty.as_externally_callable_function(true, gcx)
         } else {
             ty
         }
     } else {
-        ty.as_declaration_function(gcx)
+        let TyKind::Fn(fn_ty) = ty.kind else { unreachable!() };
+        gcx.mk_ty_fn(TyFn {
+            kind: TyFnKind::Declaration,
+            parameters: fn_ty.parameters,
+            returns: fn_ty.returns,
+            state_mutability: fn_ty.state_mutability,
+            function_id: fn_ty.function_id,
+        })
     }
 }
 

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -1,7 +1,7 @@
 use super::Builtin;
 use crate::{
     hir,
-    ty::{Gcx, Ty, TyFnPtr, TyKind},
+    ty::{Gcx, Ty, TyFn, TyKind},
 };
 use solar_ast::{DataLocation, ElementaryType, StateMutability as SM};
 use solar_data_structures::BumpExt;
@@ -32,7 +32,7 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         TyKind::Slice(_ty) => Default::default(),
         TyKind::Tuple(_tys) => Default::default(),
         TyKind::Mapping(..) => Default::default(),
-        TyKind::FnPtr(f) => function(gcx, f),
+        TyKind::Fn(f) => function(gcx, f),
         TyKind::Contract(id) => contract(gcx, id),
         TyKind::Struct(_id) => expected_ref(),
         TyKind::Enum(_id) => Default::default(),
@@ -140,12 +140,12 @@ pub(crate) fn contract(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_>
         .collect()
 }
 
-fn function<'gcx>(gcx: Gcx<'gcx>, f: &'gcx TyFnPtr<'gcx>) -> MemberListOwned<'gcx> {
+fn function<'gcx>(gcx: Gcx<'gcx>, f: &'gcx TyFn<'gcx>) -> MemberListOwned<'gcx> {
     let mut members = Vec::with_capacity(2);
-    if f.visibility >= hir::Visibility::Public || f.special {
+    if f.has_selector() {
         members.push(Member::of_builtin(gcx, Builtin::FunctionSelector));
     }
-    if f.visibility == hir::Visibility::External {
+    if f.has_address() {
         members.push(Member::of_builtin(gcx, Builtin::FunctionAddress));
     }
     members
@@ -234,12 +234,11 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
             .filter(|&id| gcx.hir.function(id).is_ordinary())
             .map(|id| {
                 let item = hir::ItemId::from(id);
-                let ty = if gcx.hir.function(id).visibility >= hir::Visibility::Public {
-                    gcx.type_of_item(item).as_externally_callable_library_function(gcx)
-                } else {
-                    gcx.type_of_item(item)
-                };
-                Member::with_res(gcx.item_name(item).name, ty, item)
+                Member::with_res(
+                    gcx.item_name(item).name,
+                    gcx.type_of_function_via_contract_name(id),
+                    item,
+                )
             })
             .collect()
     } else {
@@ -247,7 +246,8 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
             .iter()
             .map(|f| {
                 let id = hir::ItemId::from(f.id);
-                Member::with_res(gcx.item_name(id).name, f.ty, id)
+                let ty = gcx.type_of_function_via_contract_name(f.id);
+                Member::with_res(gcx.item_name(id).name, ty, id)
             })
             .collect()
     }

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -3,7 +3,7 @@ use crate::{
     hir,
     ty::{Gcx, Ty, TyFn, TyKind},
 };
-use solar_ast::{DataLocation, ElementaryType, StateMutability as SM};
+use solar_ast::{DataLocation, ElementaryType, StateMutability as SM, Visibility};
 use solar_data_structures::BumpExt;
 use solar_interface::Symbol;
 
@@ -231,14 +231,13 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
     if contract.kind.is_library() {
         contract
             .functions()
-            .filter(|&id| gcx.hir.function(id).is_ordinary())
+            .filter(|&id| {
+                let f = gcx.hir.function(id);
+                f.is_ordinary() && f.visibility >= Visibility::Internal
+            })
             .map(|id| {
                 let item = hir::ItemId::from(id);
-                Member::with_res(
-                    gcx.item_name(item).name,
-                    gcx.type_of_function_via_contract_name(id),
-                    item,
-                )
+                Member::with_res(gcx.item_name(item).name, function_via_contract(gcx, id), item)
             })
             .collect()
     } else {
@@ -246,10 +245,24 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
             .iter()
             .map(|f| {
                 let id = hir::ItemId::from(f.id);
-                let ty = gcx.type_of_function_via_contract_name(f.id);
+                let ty = function_via_contract(gcx, f.id);
                 Member::with_res(gcx.item_name(id).name, ty, id)
             })
             .collect()
+    }
+}
+
+fn function_via_contract<'gcx>(gcx: Gcx<'gcx>, id: hir::FunctionId) -> Ty<'gcx> {
+    let f = gcx.hir.function(id);
+    let ty = gcx.type_of_item(id.into());
+    if f.contract.is_some_and(|contract_id| gcx.hir.contract(contract_id).kind.is_library()) {
+        if f.visibility >= Visibility::Public {
+            ty.as_externally_callable_library_function(gcx)
+        } else {
+            ty
+        }
+    } else {
+        ty.as_declaration_function(gcx)
     }
 }
 

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -273,7 +273,6 @@ fn function_via_contract<'gcx>(gcx: Gcx<'gcx>, id: hir::FunctionId) -> Ty<'gcx> 
             returns: fn_ty.returns,
             state_mutability: fn_ty.state_mutability,
             function_id: fn_ty.function_id,
-            options: fn_ty.options,
         })
     }
 }

--- a/crates/sema/src/builtins/mod.rs
+++ b/crates/sema/src/builtins/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast_lowering::resolve::{Declaration, Declarations},
     hir,
-    ty::{Gcx, Ty},
+    ty::{Gcx, Ty, TyFnKind},
 };
 use solar_ast::StateMutability as SM;
 use solar_data_structures::map::FxHashMap;
@@ -197,11 +197,11 @@ declare_builtins! {
     AddressCodehash        => sym::codehash
                            => gcx.types.fixed_bytes(32);
     AddressCall            => kw::Call
-                           => gcx.mk_builtin_fn(&[gcx.types.bytes_ref.memory], SM::View, &[gcx.types.bytes_ref.memory]);
+                           => gcx.mk_ty_fn_with_kind(TyFnKind::BareCall, &[gcx.types.bytes_ref.memory], SM::Payable, &[gcx.types.bool, gcx.types.bytes_ref.memory]);
     AddressDelegatecall    => kw::Delegatecall
-                           => gcx.mk_builtin_fn(&[gcx.types.bytes_ref.memory], SM::View, &[gcx.types.bytes_ref.memory]);
+                           => gcx.mk_ty_fn_with_kind(TyFnKind::BareDelegateCall, &[gcx.types.bytes_ref.memory], SM::NonPayable, &[gcx.types.bool, gcx.types.bytes_ref.memory]);
     AddressStaticcall      => kw::Staticcall
-                           => gcx.mk_builtin_fn(&[gcx.types.bytes_ref.memory], SM::View, &[gcx.types.bytes_ref.memory]);
+                           => gcx.mk_ty_fn_with_kind(TyFnKind::BareStaticCall, &[gcx.types.bytes_ref.memory], SM::View, &[gcx.types.bool, gcx.types.bytes_ref.memory]);
 
     AddressPayableTransfer => sym::transfer
                            => gcx.mk_builtin_fn(&[gcx.types.uint(256)], SM::NonPayable, &[]);

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -93,7 +93,6 @@ impl<'gcx> ConstantEvaluator<'gcx> {
                 l.binop(r, bin_op.kind).map_err(Into::into)
             }
             // hir::ExprKind::Call(_, _) => unimplemented!(),
-            // hir::ExprKind::CallOptions(_, _) => unimplemented!(),
             // hir::ExprKind::Delete(_) => unimplemented!(),
             hir::ExprKind::Ident(res) => {
                 // Ignore invalid overloads since they will get correctly detected later.

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -343,17 +343,17 @@ impl<'hir, 'id> HirBuilder<'hir, 'id> {
 
     /// Creates a HIR expression with ID, kind and span.
     pub fn expr(&self, id: ExprId, kind: ExprKind<'hir>, span: Span) -> &'hir Expr<'hir> {
-        self.arena.alloc(Expr { id, kind, span, call_options: None })
+        self.arena.alloc(Expr { id, kind, span })
     }
 
     /// Creates a HIR expression with the given kind (as requested in GitHub issue).
     pub fn expr_kind(&self, kind: ExprKind<'hir>) -> Expr<'hir> {
-        Expr { id: self.next_expr_id(), kind, span: Span::DUMMY, call_options: None }
+        Expr { id: self.next_expr_id(), kind, span: Span::DUMMY }
     }
 
     /// Creates an allocated HIR expression.
     pub fn expr_alloc(&self, id: ExprId, kind: ExprKind<'hir>, span: Span) -> &'hir Expr<'hir> {
-        self.arena.alloc(Expr { id, kind, span, call_options: None })
+        self.arena.alloc(Expr { id, kind, span })
     }
 
     /// Creates an allocated HIR statement.
@@ -393,12 +393,12 @@ impl<'hir, 'id> HirBuilder<'hir, 'id> {
 
     /// Creates an owned HIR expression with the given ID, kind and span.
     pub fn expr_owned(&self, id: ExprId, kind: ExprKind<'hir>, span: Span) -> Expr<'hir> {
-        Expr { id, kind, span, call_options: None }
+        Expr { id, kind, span }
     }
 
     /// Creates an owned HIR expression with automatically generated ID.
     pub fn expr_auto(&self, kind: ExprKind<'hir>, span: Span) -> Expr<'hir> {
-        Expr { id: self.next_expr_id(), kind, span, call_options: None }
+        Expr { id: self.next_expr_id(), kind, span }
     }
 
     /// Creates a HIR statement with the given kind and span.
@@ -1463,8 +1463,6 @@ pub struct Expr<'hir> {
     pub kind: ExprKind<'hir>,
     /// The expression span.
     pub span: Span,
-    /// Function call options attached to this expression, e.g. `foo{ gas: 100_000 }`.
-    pub call_options: Option<&'hir [CallOptions<'hir>]>,
 }
 
 impl Expr<'_> {
@@ -1491,7 +1489,7 @@ pub enum ExprKind<'hir> {
     Binary(&'hir Expr<'hir>, BinOp, &'hir Expr<'hir>),
 
     /// A function call expression: `foo(42)`, `foo({ bar: 42 })`, `foo{ gas: 100_000 }(42)`.
-    Call(&'hir Expr<'hir>, CallArgs<'hir>),
+    Call(&'hir Expr<'hir>, CallArgs<'hir>, Option<&'hir [CallOptions<'hir>]>),
 
     // TODO: Add a MethodCall variant
     /// A unary `delete` expression: `delete vector`.
@@ -1800,7 +1798,7 @@ mod tests {
         assert_size::<TypeKind<'_>>(str!["16"]);
         assert_size::<Type<'_>>(str!["24"]);
 
-        assert_size::<ExprKind<'_>>(str!["40"]);
+        assert_size::<ExprKind<'_>>(str!["56"]);
         assert_size::<Expr<'_>>(str!["72"]);
 
         assert_size::<StmtKind<'_>>(str!["32"]);

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1489,7 +1489,7 @@ pub enum ExprKind<'hir> {
     Binary(&'hir Expr<'hir>, BinOp, &'hir Expr<'hir>),
 
     /// A function call expression: `foo(42)`, `foo({ bar: 42 })`, `foo{ gas: 100_000 }(42)`.
-    Call(&'hir Expr<'hir>, CallArgs<'hir>, Option<&'hir [CallOptions<'hir>]>),
+    Call(&'hir Expr<'hir>, CallArgs<'hir>, Option<&'hir CallOptions<'hir>>),
 
     // TODO: Add a MethodCall variant
     /// A unary `delete` expression: `delete vector`.
@@ -1798,8 +1798,8 @@ mod tests {
         assert_size::<TypeKind<'_>>(str!["16"]);
         assert_size::<Type<'_>>(str!["24"]);
 
-        assert_size::<ExprKind<'_>>(str!["56"]);
-        assert_size::<Expr<'_>>(str!["72"]);
+        assert_size::<ExprKind<'_>>(str!["48"]);
+        assert_size::<Expr<'_>>(str!["64"]);
 
         assert_size::<StmtKind<'_>>(str!["32"]);
         assert_size::<Stmt<'_>>(str!["40"]);

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -343,17 +343,17 @@ impl<'hir, 'id> HirBuilder<'hir, 'id> {
 
     /// Creates a HIR expression with ID, kind and span.
     pub fn expr(&self, id: ExprId, kind: ExprKind<'hir>, span: Span) -> &'hir Expr<'hir> {
-        self.arena.alloc(Expr { id, kind, span })
+        self.arena.alloc(Expr { id, kind, span, call_options: None })
     }
 
     /// Creates a HIR expression with the given kind (as requested in GitHub issue).
     pub fn expr_kind(&self, kind: ExprKind<'hir>) -> Expr<'hir> {
-        Expr { id: self.next_expr_id(), kind, span: Span::DUMMY }
+        Expr { id: self.next_expr_id(), kind, span: Span::DUMMY, call_options: None }
     }
 
     /// Creates an allocated HIR expression.
     pub fn expr_alloc(&self, id: ExprId, kind: ExprKind<'hir>, span: Span) -> &'hir Expr<'hir> {
-        self.arena.alloc(Expr { id, kind, span })
+        self.arena.alloc(Expr { id, kind, span, call_options: None })
     }
 
     /// Creates an allocated HIR statement.
@@ -393,12 +393,12 @@ impl<'hir, 'id> HirBuilder<'hir, 'id> {
 
     /// Creates an owned HIR expression with the given ID, kind and span.
     pub fn expr_owned(&self, id: ExprId, kind: ExprKind<'hir>, span: Span) -> Expr<'hir> {
-        Expr { id, kind, span }
+        Expr { id, kind, span, call_options: None }
     }
 
     /// Creates an owned HIR expression with automatically generated ID.
     pub fn expr_auto(&self, kind: ExprKind<'hir>, span: Span) -> Expr<'hir> {
-        Expr { id: self.next_expr_id(), kind, span }
+        Expr { id: self.next_expr_id(), kind, span, call_options: None }
     }
 
     /// Creates a HIR statement with the given kind and span.
@@ -1463,6 +1463,8 @@ pub struct Expr<'hir> {
     pub kind: ExprKind<'hir>,
     /// The expression span.
     pub span: Span,
+    /// Function call options attached to this expression, e.g. `foo{ gas: 100_000 }`.
+    pub call_options: Option<&'hir [CallOptions<'hir>]>,
 }
 
 impl Expr<'_> {
@@ -1489,10 +1491,7 @@ pub enum ExprKind<'hir> {
     Binary(&'hir Expr<'hir>, BinOp, &'hir Expr<'hir>),
 
     /// A function call expression: `foo(42)`, `foo({ bar: 42 })`, `foo{ gas: 100_000 }(42)`.
-    Call(&'hir Expr<'hir>, CallArgs<'hir>, Option<&'hir [NamedArg<'hir>]>),
-
-    /// Function call options: `foo{ gas: 100_000 }`.
-    CallOptions(&'hir Expr<'hir>, &'hir [NamedArg<'hir>]),
+    Call(&'hir Expr<'hir>, CallArgs<'hir>),
 
     // TODO: Add a MethodCall variant
     /// A unary `delete` expression: `delete vector`.
@@ -1547,6 +1546,13 @@ pub enum ExprKind<'hir> {
 pub struct NamedArg<'hir> {
     pub name: Ident,
     pub value: Expr<'hir>,
+}
+
+/// Function call options: `foo{ gas: 100_000 }`.
+#[derive(Clone, Copy, Debug)]
+pub struct CallOptions<'hir> {
+    pub span: Span,
+    pub args: &'hir [NamedArg<'hir>],
 }
 
 /// A list of function call arguments.
@@ -1794,7 +1800,7 @@ mod tests {
         assert_size::<TypeKind<'_>>(str!["16"]);
         assert_size::<Type<'_>>(str!["24"]);
 
-        assert_size::<ExprKind<'_>>(str!["56"]);
+        assert_size::<ExprKind<'_>>(str!["40"]);
         assert_size::<Expr<'_>>(str!["72"]);
 
         assert_size::<StmtKind<'_>>(str!["32"]);

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1491,6 +1491,9 @@ pub enum ExprKind<'hir> {
     /// A function call expression: `foo(42)`, `foo({ bar: 42 })`, `foo{ gas: 100_000 }(42)`.
     Call(&'hir Expr<'hir>, CallArgs<'hir>, Option<&'hir [NamedArg<'hir>]>),
 
+    /// Function call options: `foo{ gas: 100_000 }`.
+    CallOptions(&'hir Expr<'hir>, &'hir [NamedArg<'hir>]),
+
     // TODO: Add a MethodCall variant
     /// A unary `delete` expression: `delete vector`.
     Delete(&'hir Expr<'hir>),

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -144,21 +144,17 @@ pub trait Visit<'hir> {
     }
 
     fn visit_expr(&mut self, expr: &'hir Expr<'hir>) -> ControlFlow<Self::BreakValue> {
-        match expr.kind {
-            ExprKind::Call(expr, ref args, opts) => {
-                self.visit_expr(expr)?;
-                if let Some(opts) = opts {
-                    for opt in opts {
-                        self.visit_expr(&opt.value)?;
-                    }
+        if let Some(options) = expr.call_options {
+            for option in options {
+                for arg in option.args {
+                    self.visit_expr(&arg.value)?;
                 }
-                self.visit_call_args(args)?;
             }
-            ExprKind::CallOptions(expr, opts) => {
+        }
+        match expr.kind {
+            ExprKind::Call(expr, ref args) => {
                 self.visit_expr(expr)?;
-                for opt in opts {
-                    self.visit_expr(&opt.value)?;
-                }
+                self.visit_call_args(args)?;
             }
             ExprKind::Delete(expr)
             | ExprKind::Member(expr, _)

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -154,6 +154,12 @@ pub trait Visit<'hir> {
                 }
                 self.visit_call_args(args)?;
             }
+            ExprKind::CallOptions(expr, opts) => {
+                self.visit_expr(expr)?;
+                for opt in opts {
+                    self.visit_expr(&opt.value)?;
+                }
+            }
             ExprKind::Delete(expr)
             | ExprKind::Member(expr, _)
             | ExprKind::Payable(expr)

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -148,10 +148,8 @@ pub trait Visit<'hir> {
             ExprKind::Call(expr, ref args, opts) => {
                 self.visit_expr(expr)?;
                 if let Some(opts) = opts {
-                    for opt in opts {
-                        for arg in opt.args {
-                            self.visit_expr(&arg.value)?;
-                        }
+                    for arg in opts.args {
+                        self.visit_expr(&arg.value)?;
                     }
                 }
                 self.visit_call_args(args)?;

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -144,16 +144,16 @@ pub trait Visit<'hir> {
     }
 
     fn visit_expr(&mut self, expr: &'hir Expr<'hir>) -> ControlFlow<Self::BreakValue> {
-        if let Some(options) = expr.call_options {
-            for option in options {
-                for arg in option.args {
-                    self.visit_expr(&arg.value)?;
-                }
-            }
-        }
         match expr.kind {
-            ExprKind::Call(expr, ref args) => {
+            ExprKind::Call(expr, ref args, opts) => {
                 self.visit_expr(expr)?;
+                if let Some(opts) = opts {
+                    for opt in opts {
+                        for arg in opt.args {
+                            self.visit_expr(&arg.value)?;
+                        }
+                    }
+                }
                 self.visit_call_args(args)?;
             }
             ExprKind::Delete(expr)

--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -1,8 +1,8 @@
 //! Type interner.
 //!
-//! Creates and stores unique instances of types, type lists, and function pointers.
+//! Creates and stores unique instances of types, type lists, and function values.
 
-use super::{Ty, TyData, TyFlags, TyFnPtr, TyKind};
+use super::{Ty, TyData, TyFlags, TyFn, TyKind};
 use solar_data_structures::{Interned, map::FxBuildHasher};
 use std::{
     borrow::Borrow,
@@ -15,7 +15,7 @@ type InternSet<T> = once_map::OnceMap<T, (), FxBuildHasher>;
 pub(super) struct Interner<'gcx> {
     pub(super) tys: InternSet<&'gcx TyData<'gcx>>,
     pub(super) ty_lists: InternSet<&'gcx [Ty<'gcx>]>,
-    pub(super) fn_ptrs: InternSet<&'gcx TyFnPtr<'gcx>>,
+    pub(super) fns: InternSet<&'gcx TyFn<'gcx>>,
 }
 
 impl<'gcx> Interner<'gcx> {
@@ -51,12 +51,12 @@ impl<'gcx> Interner<'gcx> {
         })
     }
 
-    pub(super) fn intern_ty_fn_ptr(
+    pub(super) fn intern_ty_fn(
         &self,
         bump: &'gcx bumpalo::Bump,
-        ptr: TyFnPtr<'gcx>,
-    ) -> &'gcx TyFnPtr<'gcx> {
-        self.fn_ptrs.intern(ptr, |ptr| bump.alloc(ptr))
+        ptr: TyFn<'gcx>,
+    ) -> &'gcx TyFn<'gcx> {
+        self.fns.intern(ptr, |ptr| bump.alloc(ptr))
     }
 }
 

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -42,7 +42,7 @@ use interner::Interner;
 
 #[allow(clippy::module_inception)]
 mod ty;
-pub use ty::{Ty, TyConvertError, TyData, TyFlags, TyFn, TyFnKind, TyKind};
+pub use ty::{Ty, TyConvertError, TyData, TyFlags, TyFn, TyFnKind, TyFnOptions, TyKind};
 
 type FxOnceMap<K, V> = once_map::OnceMap<K, V, FxBuildHasher>;
 type NatSpecContractKey = (Symbol, hir::SourceId);
@@ -401,6 +401,7 @@ impl<'gcx> Gcx<'gcx> {
             returns: self.mk_tys(returns),
             state_mutability: fn_state_mutability(kind, state_mutability),
             function_id: None,
+            options: Default::default(),
         })
     }
 
@@ -618,6 +619,7 @@ impl<'gcx> Gcx<'gcx> {
                     returns: self.mk_item_tys(f.returns),
                     state_mutability: fn_state_mutability(kind, f.state_mutability),
                     function_id: None,
+                    options: Default::default(),
                 });
             }
             hir::TypeKind::Mapping(mapping) => {
@@ -797,6 +799,7 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                 returns: gcx.mk_item_tys(f.returns),
                 state_mutability: fn_state_mutability(TyFnKind::External, f.state_mutability),
                 function_id: Some(f_id),
+                options: Default::default(),
             })
             .as_externally_callable_function(false, gcx);
         let TyKind::Fn(ty_f) = ty.kind else { unreachable!() };
@@ -908,6 +911,7 @@ pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
                 returns: gcx.mk_item_tys(f.returns),
                 state_mutability: fn_state_mutability(TyFnKind::Internal, f.state_mutability),
                 function_id: Some(id),
+                options: Default::default(),
             });
         }
         hir::ItemId::Variable(id) => {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -42,7 +42,7 @@ use interner::Interner;
 
 #[allow(clippy::module_inception)]
 mod ty;
-pub use ty::{Ty, TyConvertError, TyData, TyFlags, TyFn, TyFnKind, TyFnOptions, TyKind};
+pub use ty::{Ty, TyConvertError, TyData, TyFlags, TyFn, TyFnKind, TyKind};
 
 type FxOnceMap<K, V> = once_map::OnceMap<K, V, FxBuildHasher>;
 type NatSpecContractKey = (Symbol, hir::SourceId);
@@ -401,7 +401,6 @@ impl<'gcx> Gcx<'gcx> {
             returns: self.mk_tys(returns),
             state_mutability: fn_state_mutability(kind, state_mutability),
             function_id: None,
-            options: Default::default(),
         })
     }
 
@@ -619,7 +618,6 @@ impl<'gcx> Gcx<'gcx> {
                     returns: self.mk_item_tys(f.returns),
                     state_mutability: fn_state_mutability(kind, f.state_mutability),
                     function_id: None,
-                    options: Default::default(),
                 });
             }
             hir::TypeKind::Mapping(mapping) => {
@@ -799,7 +797,6 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                 returns: gcx.mk_item_tys(f.returns),
                 state_mutability: fn_state_mutability(TyFnKind::External, f.state_mutability),
                 function_id: Some(f_id),
-                options: Default::default(),
             })
             .as_externally_callable_function(false, gcx);
         let TyKind::Fn(ty_f) = ty.kind else { unreachable!() };
@@ -911,7 +908,6 @@ pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
                 returns: gcx.mk_item_tys(f.returns),
                 state_mutability: fn_state_mutability(TyFnKind::Internal, f.state_mutability),
                 function_id: Some(id),
-                options: Default::default(),
             });
         }
         hir::ItemId::Variable(id) => {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -395,29 +395,12 @@ impl<'gcx> Gcx<'gcx> {
         state_mutability: StateMutability,
         returns: &[Ty<'gcx>],
     ) -> Ty<'gcx> {
-        self.mk_ty_fn_with_id(kind, parameters, state_mutability, returns, None)
-    }
-
-    pub fn mk_ty_fn_with_id(
-        self,
-        kind: TyFnKind,
-        parameters: &[Ty<'gcx>],
-        state_mutability: StateMutability,
-        returns: &[Ty<'gcx>],
-        function_id: Option<hir::FunctionId>,
-    ) -> Ty<'gcx> {
-        let state_mutability =
-            if kind == TyFnKind::Internal && state_mutability == StateMutability::Payable {
-                StateMutability::NonPayable
-            } else {
-                state_mutability
-            };
         self.mk_ty_fn(TyFn {
             kind,
             parameters: self.mk_tys(parameters),
             returns: self.mk_tys(returns),
-            state_mutability,
-            function_id,
+            state_mutability: fn_state_mutability(kind, state_mutability),
+            function_id: None,
         })
     }
 
@@ -629,12 +612,13 @@ impl<'gcx> Gcx<'gcx> {
                 } else {
                     TyFnKind::Internal
                 };
-                return self.mk_ty_fn_with_kind(
+                return self.mk_ty_fn(TyFn {
                     kind,
-                    self.mk_item_tys(f.parameters),
-                    f.state_mutability,
-                    self.mk_item_tys(f.returns),
-                );
+                    parameters: self.mk_item_tys(f.parameters),
+                    returns: self.mk_item_tys(f.returns),
+                    state_mutability: fn_state_mutability(kind, f.state_mutability),
+                    function_id: None,
+                });
             }
             hir::TypeKind::Mapping(mapping) => {
                 let key = self.type_of_hir_ty(&mapping.key);
@@ -728,6 +712,14 @@ fn compatible_fixed_bytes_type(lit: &hir::Lit<'_>) -> Option<TypeSize> {
     }
 }
 
+fn fn_state_mutability(kind: TyFnKind, state_mutability: StateMutability) -> StateMutability {
+    if kind == TyFnKind::Internal && state_mutability == StateMutability::Payable {
+        StateMutability::NonPayable
+    } else {
+        state_mutability
+    }
+}
+
 macro_rules! cached {
     ($($(#[$attr:meta])* $vis:vis fn $name:ident($gcx:ident: _, $key:ident : $key_type:ty) -> $value:ty $imp:block)*) => {
         #[derive(Default)]
@@ -798,7 +790,15 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
         functions
     }).filter_map(|f_id| {
         let f = gcx.hir.function(f_id);
-        let ty = gcx.type_of_interface_function(f_id);
+        let ty = gcx
+            .mk_ty_fn(TyFn {
+                kind: TyFnKind::External,
+                parameters: gcx.mk_item_tys(f.parameters),
+                returns: gcx.mk_item_tys(f.returns),
+                state_mutability: fn_state_mutability(TyFnKind::External, f.state_mutability),
+                function_id: Some(f_id),
+            })
+            .as_externally_callable_function(gcx);
         let TyKind::Fn(ty_f) = ty.kind else { unreachable!() };
         let mut result = Ok(());
         for (var_id, ty) in f.variables().zip(ty_f.tys()) {
@@ -891,50 +891,6 @@ pub(crate) fn item_selector(gcx: _, id: hir::ItemId) -> B256 {
     keccak256(gcx.item_signature(id))
 }
 
-/// Returns the function definition type.
-///
-/// This corresponds to solc `FunctionDefinition::type()`.
-pub fn type_of_function(gcx: _, id: hir::FunctionId) -> Ty<'gcx> {
-    let f = gcx.hir.function(id);
-    gcx.mk_ty_fn_with_id(
-        TyFnKind::Internal,
-        gcx.mk_item_tys(f.parameters),
-        f.state_mutability,
-        gcx.mk_item_tys(f.returns),
-        Some(id),
-    )
-}
-
-/// Returns the function type used in external interfaces.
-pub fn type_of_interface_function(gcx: _, id: hir::FunctionId) -> Ty<'gcx> {
-    let f = gcx.hir.function(id);
-    gcx.mk_ty_fn_with_id(
-        TyFnKind::External,
-        gcx.mk_item_tys(f.parameters),
-        f.state_mutability,
-        gcx.mk_item_tys(f.returns),
-        Some(id),
-    )
-    .as_externally_callable_function(gcx)
-}
-
-/// Returns the function type exposed by contract-type member access.
-///
-/// This corresponds to solc `FunctionDefinition::typeViaContractName()`.
-pub fn type_of_function_via_contract_name(gcx: _, id: hir::FunctionId) -> Ty<'gcx> {
-    let f = gcx.hir.function(id);
-    let ty = gcx.type_of_function(id);
-    if f.contract.is_some_and(|contract_id| gcx.hir.contract(contract_id).kind.is_library()) {
-        if f.visibility >= Visibility::Public {
-            ty.as_externally_callable_library_function(gcx)
-        } else {
-            ty
-        }
-    } else {
-        ty.as_declaration_function(gcx)
-    }
-}
-
 /// Returns the type of the given builtin.
 pub fn type_of_builtin(gcx: _, builtin: Builtin) -> Ty<'gcx> {
     builtin.ty_impl(gcx)
@@ -944,7 +900,16 @@ pub fn type_of_builtin(gcx: _, builtin: Builtin) -> Ty<'gcx> {
 pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
     let kind = match id {
         hir::ItemId::Contract(id) => TyKind::Contract(id),
-        hir::ItemId::Function(id) => return gcx.type_of_function(id),
+        hir::ItemId::Function(id) => {
+            let f = gcx.hir.function(id);
+            return gcx.mk_ty_fn(TyFn {
+                kind: TyFnKind::Internal,
+                parameters: gcx.mk_item_tys(f.parameters),
+                returns: gcx.mk_item_tys(f.returns),
+                state_mutability: fn_state_mutability(TyFnKind::Internal, f.state_mutability),
+                function_id: Some(id),
+            });
+        }
         hir::ItemId::Variable(id) => {
             let var = gcx.hir.variable(id);
             let ty = gcx.type_of_hir_ty(&var.ty);

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -401,6 +401,7 @@ impl<'gcx> Gcx<'gcx> {
             state_mutability,
             visibility,
             function_id: None,
+            special: false,
         })
     }
 
@@ -613,6 +614,7 @@ impl<'gcx> Gcx<'gcx> {
                     state_mutability: f.state_mutability,
                     visibility: f.visibility,
                     function_id: None,
+                    special: false,
                 });
             }
             hir::TypeKind::Mapping(mapping) => {
@@ -887,6 +889,7 @@ pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
                 state_mutability: f.state_mutability,
                 visibility: f.visibility,
                 function_id: Some(id),
+                special: false,
             }))
         }
         hir::ItemId::Variable(id) => {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -352,7 +352,7 @@ impl<'gcx> Gcx<'gcx> {
         self.mk_ty(TyKind::Tuple(tys))
     }
 
-    fn mk_item_tys<T: Into<hir::ItemId> + Copy>(self, ids: &[T]) -> &'gcx [Ty<'gcx>] {
+    pub(crate) fn mk_item_tys<T: Into<hir::ItemId> + Copy>(self, ids: &[T]) -> &'gcx [Ty<'gcx>] {
         self.mk_ty_iter(ids.iter().map(|&id| self.type_of_item(id.into())))
     }
 
@@ -417,6 +417,15 @@ impl<'gcx> Gcx<'gcx> {
         let parameters = vec![self.types.uint(256); parameters];
         let returns = vec![self.types.uint(256); returns];
         self.mk_builtin_fn(&parameters, StateMutability::NonPayable, &returns)
+    }
+
+    pub(crate) fn mk_creation_fn(
+        self,
+        parameters: &[Ty<'gcx>],
+        state_mutability: StateMutability,
+        returns: &[Ty<'gcx>],
+    ) -> Ty<'gcx> {
+        self.mk_ty_fn_with_kind(TyFnKind::Creation, parameters, state_mutability, returns)
     }
 
     pub(crate) fn mk_builtin_mod(self, builtin: Builtin) -> Ty<'gcx> {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -42,7 +42,7 @@ use interner::Interner;
 
 #[allow(clippy::module_inception)]
 mod ty;
-pub use ty::{Ty, TyConvertError, TyData, TyFlags, TyFnPtr, TyKind};
+pub use ty::{Ty, TyConvertError, TyData, TyFlags, TyFn, TyFnKind, TyKind};
 
 type FxOnceMap<K, V> = once_map::OnceMap<K, V, FxBuildHasher>;
 type NatSpecContractKey = (Symbol, hir::SourceId);
@@ -54,7 +54,7 @@ pub struct InterfaceFunction<'gcx> {
     pub id: hir::FunctionId,
     /// The function 4-byte selector.
     pub selector: Selector,
-    /// The function type. This is always a function pointer.
+    /// The function type.
     pub ty: Ty<'gcx>,
 }
 
@@ -384,24 +384,40 @@ impl<'gcx> Gcx<'gcx> {
         )))
     }
 
-    pub fn mk_ty_fn_ptr(self, ptr: TyFnPtr<'gcx>) -> Ty<'gcx> {
-        self.mk_ty(TyKind::FnPtr(self.interner.intern_ty_fn_ptr(self.bump(), ptr)))
+    pub fn mk_ty_fn(self, ptr: TyFn<'gcx>) -> Ty<'gcx> {
+        self.mk_ty(TyKind::Fn(self.interner.intern_ty_fn(self.bump(), ptr)))
     }
 
-    pub fn mk_ty_fn(
+    pub fn mk_ty_fn_with_kind(
         self,
+        kind: TyFnKind,
         parameters: &[Ty<'gcx>],
         state_mutability: StateMutability,
-        visibility: Visibility,
         returns: &[Ty<'gcx>],
     ) -> Ty<'gcx> {
-        self.mk_ty_fn_ptr(TyFnPtr {
+        self.mk_ty_fn_with_id(kind, parameters, state_mutability, returns, None)
+    }
+
+    pub fn mk_ty_fn_with_id(
+        self,
+        kind: TyFnKind,
+        parameters: &[Ty<'gcx>],
+        state_mutability: StateMutability,
+        returns: &[Ty<'gcx>],
+        function_id: Option<hir::FunctionId>,
+    ) -> Ty<'gcx> {
+        let state_mutability =
+            if kind == TyFnKind::Internal && state_mutability == StateMutability::Payable {
+                StateMutability::NonPayable
+            } else {
+                state_mutability
+            };
+        self.mk_ty_fn(TyFn {
+            kind,
             parameters: self.mk_tys(parameters),
             returns: self.mk_tys(returns),
             state_mutability,
-            visibility,
-            function_id: None,
-            special: false,
+            function_id,
         })
     }
 
@@ -411,7 +427,7 @@ impl<'gcx> Gcx<'gcx> {
         state_mutability: StateMutability,
         returns: &[Ty<'gcx>],
     ) -> Ty<'gcx> {
-        self.mk_ty_fn(parameters, state_mutability, Visibility::Internal, returns)
+        self.mk_ty_fn_with_kind(TyFnKind::Internal, parameters, state_mutability, returns)
     }
 
     pub(crate) fn mk_yul_builtin_fn(self, parameters: usize, returns: usize) -> Ty<'gcx> {
@@ -608,14 +624,17 @@ impl<'gcx> Gcx<'gcx> {
                 }
             }
             hir::TypeKind::Function(f) => {
-                return self.mk_ty_fn_ptr(TyFnPtr {
-                    parameters: self.mk_item_tys(f.parameters),
-                    returns: self.mk_item_tys(f.returns),
-                    state_mutability: f.state_mutability,
-                    visibility: f.visibility,
-                    function_id: None,
-                    special: false,
-                });
+                let kind = if f.visibility == Visibility::External {
+                    TyFnKind::External
+                } else {
+                    TyFnKind::Internal
+                };
+                return self.mk_ty_fn_with_kind(
+                    kind,
+                    self.mk_item_tys(f.parameters),
+                    f.state_mutability,
+                    self.mk_item_tys(f.returns),
+                );
             }
             hir::TypeKind::Mapping(mapping) => {
                 let key = self.type_of_hir_ty(&mapping.key);
@@ -779,8 +798,8 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
         functions
     }).filter_map(|f_id| {
         let f = gcx.hir.function(f_id);
-        let ty = gcx.type_of_item(f_id.into());
-        let TyKind::FnPtr(ty_f) = ty.kind else { unreachable!() };
+        let ty = gcx.type_of_interface_function(f_id);
+        let TyKind::Fn(ty_f) = ty.kind else { unreachable!() };
         let mut result = Ok(());
         for (var_id, ty) in f.variables().zip(ty_f.tys()) {
             if let Err(guar) = ty.error_reported() {
@@ -872,6 +891,50 @@ pub(crate) fn item_selector(gcx: _, id: hir::ItemId) -> B256 {
     keccak256(gcx.item_signature(id))
 }
 
+/// Returns the function definition type.
+///
+/// This corresponds to solc `FunctionDefinition::type()`.
+pub fn type_of_function(gcx: _, id: hir::FunctionId) -> Ty<'gcx> {
+    let f = gcx.hir.function(id);
+    gcx.mk_ty_fn_with_id(
+        TyFnKind::Internal,
+        gcx.mk_item_tys(f.parameters),
+        f.state_mutability,
+        gcx.mk_item_tys(f.returns),
+        Some(id),
+    )
+}
+
+/// Returns the function type used in external interfaces.
+pub fn type_of_interface_function(gcx: _, id: hir::FunctionId) -> Ty<'gcx> {
+    let f = gcx.hir.function(id);
+    gcx.mk_ty_fn_with_id(
+        TyFnKind::External,
+        gcx.mk_item_tys(f.parameters),
+        f.state_mutability,
+        gcx.mk_item_tys(f.returns),
+        Some(id),
+    )
+    .as_externally_callable_function(gcx)
+}
+
+/// Returns the function type exposed by contract-type member access.
+///
+/// This corresponds to solc `FunctionDefinition::typeViaContractName()`.
+pub fn type_of_function_via_contract_name(gcx: _, id: hir::FunctionId) -> Ty<'gcx> {
+    let f = gcx.hir.function(id);
+    let ty = gcx.type_of_function(id);
+    if f.contract.is_some_and(|contract_id| gcx.hir.contract(contract_id).kind.is_library()) {
+        if f.visibility >= Visibility::Public {
+            ty.as_externally_callable_library_function(gcx)
+        } else {
+            ty
+        }
+    } else {
+        ty.as_declaration_function(gcx)
+    }
+}
+
 /// Returns the type of the given builtin.
 pub fn type_of_builtin(gcx: _, builtin: Builtin) -> Ty<'gcx> {
     builtin.ty_impl(gcx)
@@ -881,17 +944,7 @@ pub fn type_of_builtin(gcx: _, builtin: Builtin) -> Ty<'gcx> {
 pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
     let kind = match id {
         hir::ItemId::Contract(id) => TyKind::Contract(id),
-        hir::ItemId::Function(id) => {
-            let f = gcx.hir.function(id);
-            TyKind::FnPtr(gcx.interner.intern_ty_fn_ptr(gcx.bump(), TyFnPtr {
-                parameters: gcx.mk_item_tys(f.parameters),
-                returns: gcx.mk_item_tys(f.returns),
-                state_mutability: f.state_mutability,
-                visibility: f.visibility,
-                function_id: Some(id),
-                special: false,
-            }))
-        }
+        hir::ItemId::Function(id) => return gcx.type_of_function(id),
         hir::ItemId::Variable(id) => {
             let var = gcx.hir.variable(id);
             let ty = gcx.type_of_hir_ty(&var.ty);

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -798,7 +798,7 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                 state_mutability: fn_state_mutability(TyFnKind::External, f.state_mutability),
                 function_id: Some(f_id),
             })
-            .as_externally_callable_function(gcx);
+            .as_externally_callable_function(false, gcx);
         let TyKind::Fn(ty_f) = ty.kind else { unreachable!() };
         let mut result = Ok(());
         for (var_id, ty) in f.variables().zip(ty_f.tys()) {

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -187,6 +187,7 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
             TyKind::Elementary(ty) => ty.write_abi_str(&mut self.buf),
             TyKind::Contract(_) => self.buf.write_str("address"),
             TyKind::Fn(_) => self.buf.write_str("function"),
+            TyKind::CallOptions(ty) => self.print(ty),
             TyKind::Struct(id) => match self.mode {
                 TyAbiPrinterMode::Signature => {
                     if self.gcx.struct_recursiveness(id).is_recursive() {
@@ -302,6 +303,7 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
                 }
                 Ok(())
             }
+            TyKind::CallOptions(ty) => self.print(ty),
             TyKind::Struct(id) => {
                 write!(self.buf, "struct {}", self.gcx.item_canonical_name(id))
             }

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -280,9 +280,27 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
                 write!(self.buf, " {}", c.name)
             }
             TyKind::Fn(f) => {
-                let def =
-                    if f.is_declaration() { f.function_id.map(hir::ItemId::from) } else { None };
-                self.print_function(def, f.parameters, f.returns, f.state_mutability, f.kind)
+                self.buf.write_str("function ")?;
+                if f.is_declaration()
+                    && let Some(id) = f.function_id
+                {
+                    let name = self.gcx.item_canonical_name(hir::ItemId::from(id));
+                    write!(self.buf, "{name}")?;
+                }
+                self.print_tuple(f.parameters)?;
+
+                if f.state_mutability != hir::StateMutability::NonPayable {
+                    write!(self.buf, " {}", f.state_mutability)?;
+                }
+                if f.kind == TyFnKind::External {
+                    self.buf.write_str(" external")?;
+                }
+
+                if !f.returns.is_empty() {
+                    self.buf.write_str(" returns ")?;
+                    self.print_tuple(f.returns)?;
+                }
+                Ok(())
             }
             TyKind::Struct(id) => {
                 write!(self.buf, "struct {}", self.gcx.item_canonical_name(id))
@@ -351,35 +369,6 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
 
             TyKind::Err(_) => self.buf.write_str("<error>"),
         }
-    }
-
-    fn print_function(
-        &mut self,
-        def: Option<hir::ItemId>,
-        parameters: &[Ty<'gcx>],
-        returns: &[Ty<'gcx>],
-        state_mutability: hir::StateMutability,
-        kind: TyFnKind,
-    ) -> fmt::Result {
-        self.buf.write_str("function ")?;
-        if let Some(def) = def {
-            let name = self.gcx.item_canonical_name(def);
-            write!(self.buf, "{name}")?;
-        }
-        self.print_tuple(parameters)?;
-
-        if state_mutability != hir::StateMutability::NonPayable {
-            write!(self.buf, " {state_mutability}")?;
-        }
-        if kind == TyFnKind::External {
-            self.buf.write_str(" external")?;
-        }
-
-        if !returns.is_empty() {
-            self.buf.write_str(" returns ")?;
-            self.print_tuple(returns)?;
-        }
-        Ok(())
     }
 
     fn print_tuple(&mut self, tys: &[Ty<'gcx>]) -> fmt::Result {

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -186,7 +186,7 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
         match ty.kind {
             TyKind::Elementary(ty) => ty.write_abi_str(&mut self.buf),
             TyKind::Contract(_) => self.buf.write_str("address"),
-            TyKind::FnPtr(_) => self.buf.write_str("function"),
+            TyKind::Fn(_) => self.buf.write_str("function"),
             TyKind::Struct(id) => match self.mode {
                 TyAbiPrinterMode::Signature => {
                     if self.gcx.struct_recursiveness(id).is_recursive() {
@@ -279,8 +279,13 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
                 self.buf.write_str(if c.kind.is_library() { "library" } else { "contract" })?;
                 write!(self.buf, " {}", c.name)
             }
-            TyKind::FnPtr(f) => {
-                self.print_function(None, f.parameters, f.returns, f.state_mutability, f.visibility)
+            TyKind::Fn(f) => {
+                let visibility = if f.is_external() {
+                    hir::Visibility::External
+                } else {
+                    hir::Visibility::Internal
+                };
+                self.print_function(None, f.parameters, f.returns, f.state_mutability, visibility)
             }
             TyKind::Struct(id) => {
                 write!(self.buf, "struct {}", self.gcx.item_canonical_name(id))

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -187,7 +187,6 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
             TyKind::Elementary(ty) => ty.write_abi_str(&mut self.buf),
             TyKind::Contract(_) => self.buf.write_str("address"),
             TyKind::Fn(_) => self.buf.write_str("function"),
-            TyKind::CallOptions(ty) => self.print(ty),
             TyKind::Struct(id) => match self.mode {
                 TyAbiPrinterMode::Signature => {
                     if self.gcx.struct_recursiveness(id).is_recursive() {
@@ -303,7 +302,6 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
                 }
                 Ok(())
             }
-            TyKind::CallOptions(ty) => self.print(ty),
             TyKind::Struct(id) => {
                 write!(self.buf, "struct {}", self.gcx.item_canonical_name(id))
             }

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -1,4 +1,4 @@
-use super::{Gcx, Ty, TyKind};
+use super::{Gcx, Ty, TyFnKind, TyKind};
 use crate::hir;
 use alloy_json_abi as json;
 use solar_ast::ElementaryType;
@@ -280,12 +280,9 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
                 write!(self.buf, " {}", c.name)
             }
             TyKind::Fn(f) => {
-                let visibility = if f.is_external() {
-                    hir::Visibility::External
-                } else {
-                    hir::Visibility::Internal
-                };
-                self.print_function(None, f.parameters, f.returns, f.state_mutability, visibility)
+                let def =
+                    if f.is_declaration() { f.function_id.map(hir::ItemId::from) } else { None };
+                self.print_function(def, f.parameters, f.returns, f.state_mutability, f.kind)
             }
             TyKind::Struct(id) => {
                 write!(self.buf, "struct {}", self.gcx.item_canonical_name(id))
@@ -362,7 +359,7 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
         parameters: &[Ty<'gcx>],
         returns: &[Ty<'gcx>],
         state_mutability: hir::StateMutability,
-        visibility: hir::Visibility,
+        kind: TyFnKind,
     ) -> fmt::Result {
         self.buf.write_str("function ")?;
         if let Some(def) = def {
@@ -374,7 +371,7 @@ impl<'gcx, W: fmt::Write> TySolcPrinter<'gcx, W> {
         if state_mutability != hir::StateMutability::NonPayable {
             write!(self.buf, " {state_mutability}")?;
         }
-        if visibility == hir::Visibility::External {
+        if kind == TyFnKind::External {
             self.buf.write_str(" external")?;
         }
 

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -142,6 +142,13 @@ impl<'gcx> Ty<'gcx> {
         self
     }
 
+    pub fn peel_call_options(mut self) -> Self {
+        while let TyKind::CallOptions(inner) = self.kind {
+            self = inner;
+        }
+        self
+    }
+
     pub fn as_externally_callable_function(self, in_library: bool, gcx: Gcx<'gcx>) -> Self {
         let TyKind::Fn(f) = self.kind else { return self };
         let kind = if in_library { TyFnKind::DelegateCall } else { f.kind };
@@ -353,6 +360,7 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::DynArray(ty)
             | TyKind::Array(ty, _)
             | TyKind::Slice(ty)
+            | TyKind::CallOptions(ty)
             | TyKind::Udvt(ty, _)
             | TyKind::Type(ty)
             | TyKind::Meta(ty) => ty.visit(f),
@@ -401,6 +409,7 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::DynArray(ty)
             | TyKind::Array(ty, _)
             | TyKind::Slice(ty)
+            | TyKind::CallOptions(ty)
             | TyKind::Udvt(ty, _)
             | TyKind::Type(ty)
             | TyKind::Meta(ty) => ty.visit_with_structs(gcx, f),
@@ -1046,6 +1055,9 @@ pub enum TyKind<'gcx> {
     /// Function pointer: `function(...) returns (...)`.
     Fn(&'gcx TyFn<'gcx>),
 
+    /// A function call options expression: `f{gas: x}`.
+    CallOptions(Ty<'gcx>),
+
     /// Contract.
     Contract(hir::ContractId),
 
@@ -1210,6 +1222,7 @@ impl TyFlags {
             | TyKind::DynArray(ty)
             | TyKind::Array(ty, _)
             | TyKind::Slice(ty)
+            | TyKind::CallOptions(ty)
             | TyKind::Udvt(ty, _)
             | TyKind::Type(ty)
             | TyKind::Meta(ty) => self.add_ty(ty),

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -142,8 +142,9 @@ impl<'gcx> Ty<'gcx> {
         self
     }
 
-    fn as_externally_callable_function_with_kind(self, kind: TyFnKind, gcx: Gcx<'gcx>) -> Self {
+    pub fn as_externally_callable_function(self, in_library: bool, gcx: Gcx<'gcx>) -> Self {
         let TyKind::Fn(f) = self.kind else { return self };
+        let kind = if in_library { TyFnKind::DelegateCall } else { f.kind };
         let is_calldata = |param: &Ty<'_>| param.is_ref_at(DataLocation::Calldata);
         let parameters = self.parameters().unwrap_or_default();
         let returns = self.returns().unwrap_or_default();
@@ -170,29 +171,6 @@ impl<'gcx> Ty<'gcx> {
             kind,
             parameters,
             returns,
-            state_mutability: f.state_mutability,
-            function_id: f.function_id,
-        })
-    }
-
-    pub fn as_externally_callable_function(self, gcx: Gcx<'gcx>) -> Self {
-        let TyKind::Fn(f) = self.kind else { return self };
-        self.as_externally_callable_function_with_kind(f.kind, gcx)
-    }
-
-    pub fn as_externally_callable_library_function(self, gcx: Gcx<'gcx>) -> Self {
-        self.as_externally_callable_function_with_kind(TyFnKind::DelegateCall, gcx)
-    }
-
-    pub fn as_declaration_function(self, gcx: Gcx<'gcx>) -> Self {
-        let TyKind::Fn(f) = self.kind else { return self };
-        if f.is_declaration() {
-            return self;
-        }
-        gcx.mk_ty_fn(TyFn {
-            kind: TyFnKind::Declaration,
-            parameters: f.parameters,
-            returns: f.returns,
             state_mutability: f.state_mutability,
             function_id: f.function_id,
         })

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -166,7 +166,13 @@ impl<'gcx> Ty<'gcx> {
         } else {
             returns
         };
-        gcx.mk_ty_fn_with_id(kind, parameters, f.state_mutability, returns, f.function_id)
+        gcx.mk_ty_fn(TyFn {
+            kind,
+            parameters,
+            returns,
+            state_mutability: f.state_mutability,
+            function_id: f.function_id,
+        })
     }
 
     pub fn as_externally_callable_function(self, gcx: Gcx<'gcx>) -> Self {
@@ -183,13 +189,13 @@ impl<'gcx> Ty<'gcx> {
         if f.is_declaration() {
             return self;
         }
-        gcx.mk_ty_fn_with_id(
-            TyFnKind::Declaration,
-            f.parameters,
-            f.state_mutability,
-            f.returns,
-            f.function_id,
-        )
+        gcx.mk_ty_fn(TyFn {
+            kind: TyFnKind::Declaration,
+            parameters: f.parameters,
+            returns: f.returns,
+            state_mutability: f.state_mutability,
+            function_id: f.function_id,
+        })
     }
 
     pub fn make_ref(self, gcx: Gcx<'gcx>, loc: DataLocation) -> Self {

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -173,7 +173,6 @@ impl<'gcx> Ty<'gcx> {
             returns,
             state_mutability: f.state_mutability,
             function_id: f.function_id,
-            options: f.options,
         })
     }
 
@@ -723,10 +722,6 @@ impl<'gcx> Ty<'gcx> {
                 if from_fn.kind != to_fn.kind {
                     return Result::Err(TyConvertError::Incompatible);
                 }
-                if from_fn.options != to_fn.options {
-                    return Result::Err(TyConvertError::Incompatible);
-                }
-
                 // Parameter and return types must match exactly (no implicit conversion).
                 if from_fn.parameters != to_fn.parameters || from_fn.returns != to_fn.returns {
                     return Result::Err(TyConvertError::Incompatible);
@@ -1100,23 +1095,6 @@ pub struct TyFn<'gcx> {
     pub state_mutability: StateMutability,
     /// The declaration this function value refers to, if known.
     pub function_id: Option<hir::FunctionId>,
-    /// Additional call options and binding state carried on the function value.
-    pub options: TyFnOptions,
-}
-
-/// Extra function-value options that affect stack layout.
-///
-/// This mirrors solc `FunctionType::Options`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct TyFnOptions {
-    /// Whether the gas value to be used is on the stack.
-    pub gas_set: bool,
-    /// Whether the value to be sent is on the stack.
-    pub value_set: bool,
-    /// Whether the create2 salt value to be used is on the stack.
-    pub salt_set: bool,
-    /// Whether the first argument is bound as `self`.
-    pub has_bound_first_argument: bool,
 }
 
 /// The semantic kind of a function value.
@@ -1185,20 +1163,6 @@ impl<'gcx> TyFn<'gcx> {
     #[inline]
     pub fn has_address(&self) -> bool {
         self.is_external()
-    }
-
-    /// Returns the number of stack slots occupied by this function value.
-    pub fn stack_size(&self) -> usize {
-        let mut size = match self.kind {
-            TyFnKind::External | TyFnKind::DelegateCall => 2,
-            TyFnKind::Internal => 1,
-            TyFnKind::Declaration => 0,
-        };
-        size += usize::from(self.options.gas_set);
-        size += usize::from(self.options.value_set);
-        size += usize::from(self.options.salt_set);
-        size += usize::from(self.options.has_bound_first_argument);
-        size
     }
 
     /// Returns an iterator over all the types in the function value.

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -722,6 +722,7 @@ impl<'gcx> Ty<'gcx> {
                 if from_fn.kind != to_fn.kind {
                     return Result::Err(TyConvertError::Incompatible);
                 }
+
                 // Parameter and return types must match exactly (no implicit conversion).
                 if from_fn.parameters != to_fn.parameters || from_fn.returns != to_fn.returns {
                     return Result::Err(TyConvertError::Incompatible);

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -173,6 +173,20 @@ impl<'gcx> Ty<'gcx> {
             state_mutability: self.state_mutability().unwrap_or(StateMutability::NonPayable),
             visibility: self.visibility().unwrap_or(Visibility::Public),
             function_id: None,
+            special: false,
+        })
+    }
+
+    pub fn as_externally_callable_library_function(self, gcx: Gcx<'gcx>) -> Self {
+        let ty = self.as_externally_callable_function(gcx);
+        let TyKind::FnPtr(f) = ty.kind else { return ty };
+        gcx.mk_ty_fn_ptr(TyFnPtr {
+            parameters: f.parameters,
+            returns: f.returns,
+            state_mutability: f.state_mutability,
+            visibility: Visibility::Internal,
+            function_id: f.function_id,
+            special: true,
         })
     }
 
@@ -728,6 +742,10 @@ impl<'gcx> Ty<'gcx> {
             // Function pointer conversions.
             // See: <https://docs.soliditylang.org/en/latest/types.html#function-types>
             (FnPtr(from_fn), FnPtr(to_fn)) => {
+                if from_fn.special || to_fn.special {
+                    return Result::Err(TyConvertError::Incompatible);
+                }
+
                 // Parameter and return types must match exactly (no implicit conversion).
                 if from_fn.parameters != to_fn.parameters || from_fn.returns != to_fn.returns {
                     return Result::Err(TyConvertError::Incompatible);
@@ -1109,6 +1127,8 @@ pub struct TyFnPtr<'gcx> {
     pub state_mutability: StateMutability,
     pub visibility: Visibility,
     pub function_id: Option<hir::FunctionId>,
+    /// Whether this is a special function value that cannot convert to function pointer types.
+    pub special: bool,
 }
 
 impl<'gcx> TyFnPtr<'gcx> {

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -173,6 +173,7 @@ impl<'gcx> Ty<'gcx> {
             returns,
             state_mutability: f.state_mutability,
             function_id: f.function_id,
+            options: f.options,
         })
     }
 
@@ -722,6 +723,9 @@ impl<'gcx> Ty<'gcx> {
                 if from_fn.kind != to_fn.kind {
                     return Result::Err(TyConvertError::Incompatible);
                 }
+                if from_fn.options != to_fn.options {
+                    return Result::Err(TyConvertError::Incompatible);
+                }
 
                 // Parameter and return types must match exactly (no implicit conversion).
                 if from_fn.parameters != to_fn.parameters || from_fn.returns != to_fn.returns {
@@ -1096,6 +1100,23 @@ pub struct TyFn<'gcx> {
     pub state_mutability: StateMutability,
     /// The declaration this function value refers to, if known.
     pub function_id: Option<hir::FunctionId>,
+    /// Additional call options and binding state carried on the function value.
+    pub options: TyFnOptions,
+}
+
+/// Extra function-value options that affect stack layout.
+///
+/// This mirrors solc `FunctionType::Options`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TyFnOptions {
+    /// Whether the gas value to be used is on the stack.
+    pub gas_set: bool,
+    /// Whether the value to be sent is on the stack.
+    pub value_set: bool,
+    /// Whether the create2 salt value to be used is on the stack.
+    pub salt_set: bool,
+    /// Whether the first argument is bound as `self`.
+    pub has_bound_first_argument: bool,
 }
 
 /// The semantic kind of a function value.
@@ -1164,6 +1185,20 @@ impl<'gcx> TyFn<'gcx> {
     #[inline]
     pub fn has_address(&self) -> bool {
         self.is_external()
+    }
+
+    /// Returns the number of stack slots occupied by this function value.
+    pub fn stack_size(&self) -> usize {
+        let mut size = match self.kind {
+            TyFnKind::External | TyFnKind::DelegateCall => 2,
+            TyFnKind::Internal => 1,
+            TyFnKind::Declaration => 0,
+        };
+        size += usize::from(self.options.gas_set);
+        size += usize::from(self.options.value_set);
+        size += usize::from(self.options.salt_set);
+        size += usize::from(self.options.has_bound_first_argument);
+        size
     }
 
     /// Returns an iterator over all the types in the function value.

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1115,6 +1115,10 @@ pub enum TyFnKind {
     /// This is solc's `FunctionType::Kind::DelegateCall`. It has a `.selector` member, but is not
     /// assignable to ordinary function types.
     DelegateCall,
+    /// A contract creation function, e.g. `new C`.
+    ///
+    /// This is solc's `FunctionType::Kind::Creation`.
+    Creation,
 }
 
 impl<'gcx> TyFn<'gcx> {
@@ -1146,6 +1150,12 @@ impl<'gcx> TyFn<'gcx> {
     #[inline]
     pub fn is_delegate_call(&self) -> bool {
         self.kind == TyFnKind::DelegateCall
+    }
+
+    /// Returns whether this is a contract creation function.
+    #[inline]
+    pub fn is_creation(&self) -> bool {
+        self.kind == TyFnKind::Creation
     }
 
     /// Returns whether this function value has a known declaration.

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -270,6 +270,17 @@ impl<'gcx> Ty<'gcx> {
         .is_break()
     }
 
+    /// Returns `true` if this type contains a library contract type.
+    pub fn contains_library(self, gcx: Gcx<'gcx>) -> bool {
+        self.visit_with_structs(gcx, &mut |ty| match ty.kind {
+            TyKind::Contract(id) if gcx.hir.contract(id).kind.is_library() => {
+                ControlFlow::Break(())
+            }
+            _ => ControlFlow::Continue(()),
+        })
+        .is_break()
+    }
+
     /// Returns `true` if this type contains a non-public (internal/private) function type.
     #[inline]
     pub fn has_internal_function(self) -> bool {

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1123,12 +1123,15 @@ pub enum TyFnKind {
     Declaration,
     /// A public library function accessed through the library type, e.g. `L.f`.
     ///
-    /// This is solc's `FunctionType::Kind::DelegateCall`. It has a `.selector` member, but is not
-    /// assignable to ordinary function types.
+    /// It has a `.selector` member, but is not assignable to ordinary function types.
     DelegateCall,
+    /// A low-level `address.call` function.
+    BareCall,
+    /// A low-level `address.delegatecall` function.
+    BareDelegateCall,
+    /// A low-level `address.staticcall` function.
+    BareStaticCall,
     /// A contract creation function, e.g. `new C`.
-    ///
-    /// This is solc's `FunctionType::Kind::Creation`.
     Creation,
 }
 
@@ -1161,6 +1164,15 @@ impl<'gcx> TyFn<'gcx> {
     #[inline]
     pub fn is_delegate_call(&self) -> bool {
         self.kind == TyFnKind::DelegateCall
+    }
+
+    /// Returns whether this is a low-level call function.
+    #[inline]
+    pub fn is_bare_call(&self) -> bool {
+        matches!(
+            self.kind,
+            TyFnKind::BareCall | TyFnKind::BareDelegateCall | TyFnKind::BareStaticCall
+        )
     }
 
     /// Returns whether this is a contract creation function.

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -142,13 +142,6 @@ impl<'gcx> Ty<'gcx> {
         self
     }
 
-    pub fn peel_call_options(mut self) -> Self {
-        while let TyKind::CallOptions(inner) = self.kind {
-            self = inner;
-        }
-        self
-    }
-
     pub fn as_externally_callable_function(self, in_library: bool, gcx: Gcx<'gcx>) -> Self {
         let TyKind::Fn(f) = self.kind else { return self };
         let kind = if in_library { TyFnKind::DelegateCall } else { f.kind };
@@ -360,7 +353,6 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::DynArray(ty)
             | TyKind::Array(ty, _)
             | TyKind::Slice(ty)
-            | TyKind::CallOptions(ty)
             | TyKind::Udvt(ty, _)
             | TyKind::Type(ty)
             | TyKind::Meta(ty) => ty.visit(f),
@@ -409,7 +401,6 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::DynArray(ty)
             | TyKind::Array(ty, _)
             | TyKind::Slice(ty)
-            | TyKind::CallOptions(ty)
             | TyKind::Udvt(ty, _)
             | TyKind::Type(ty)
             | TyKind::Meta(ty) => ty.visit_with_structs(gcx, f),
@@ -1055,9 +1046,6 @@ pub enum TyKind<'gcx> {
     /// Function pointer: `function(...) returns (...)`.
     Fn(&'gcx TyFn<'gcx>),
 
-    /// A function call options expression: `f{gas: x}`.
-    CallOptions(Ty<'gcx>),
-
     /// Contract.
     Contract(hir::ContractId),
 
@@ -1222,7 +1210,6 @@ impl TyFlags {
             | TyKind::DynArray(ty)
             | TyKind::Array(ty, _)
             | TyKind::Slice(ty)
-            | TyKind::CallOptions(ty)
             | TyKind::Udvt(ty, _)
             | TyKind::Type(ty)
             | TyKind::Meta(ty) => self.add_ty(ty),

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1,7 +1,7 @@
 use super::{Gcx, Recursiveness, print::TySolcPrinter};
 use crate::{builtins::Builtin, hir};
 use alloy_primitives::U256;
-use solar_ast::{DataLocation, ElementaryType, StateMutability, TypeSize, Visibility};
+use solar_ast::{DataLocation, ElementaryType, StateMutability, TypeSize};
 use solar_data_structures::{Interned, fmt};
 use solar_interface::diagnostics::ErrorGuaranteed;
 use std::{borrow::Borrow, hash::Hash, ops::ControlFlow};
@@ -142,52 +142,54 @@ impl<'gcx> Ty<'gcx> {
         self
     }
 
-    pub fn as_externally_callable_function(self, gcx: Gcx<'gcx>) -> Self {
+    fn as_externally_callable_function_with_kind(self, kind: TyFnKind, gcx: Gcx<'gcx>) -> Self {
+        let TyKind::Fn(f) = self.kind else { return self };
         let is_calldata = |param: &Ty<'_>| param.is_ref_at(DataLocation::Calldata);
         let parameters = self.parameters().unwrap_or_default();
         let returns = self.returns().unwrap_or_default();
         let any_parameter = parameters.iter().any(is_calldata);
         let any_return = returns.iter().any(is_calldata);
-        if !any_parameter && !any_return {
+        if !any_parameter && !any_return && f.kind == kind {
             return self;
         }
-        gcx.mk_ty_fn_ptr(TyFnPtr {
-            parameters: if any_parameter {
-                gcx.mk_ty_iter(parameters.iter().map(|param| {
-                    if is_calldata(param) {
-                        param.with_loc(gcx, DataLocation::Memory)
-                    } else {
-                        *param
-                    }
-                }))
-            } else {
-                parameters
-            },
-            returns: if any_return {
-                gcx.mk_ty_iter(returns.iter().map(|ret| {
-                    if is_calldata(ret) { ret.with_loc(gcx, DataLocation::Memory) } else { *ret }
-                }))
-            } else {
-                returns
-            },
-            state_mutability: self.state_mutability().unwrap_or(StateMutability::NonPayable),
-            visibility: self.visibility().unwrap_or(Visibility::Public),
-            function_id: None,
-            special: false,
-        })
+        let parameters = if any_parameter {
+            gcx.mk_ty_iter(parameters.iter().map(|param| {
+                if is_calldata(param) { param.with_loc(gcx, DataLocation::Memory) } else { *param }
+            }))
+        } else {
+            parameters
+        };
+        let returns = if any_return {
+            gcx.mk_ty_iter(returns.iter().map(|ret| {
+                if is_calldata(ret) { ret.with_loc(gcx, DataLocation::Memory) } else { *ret }
+            }))
+        } else {
+            returns
+        };
+        gcx.mk_ty_fn_with_id(kind, parameters, f.state_mutability, returns, f.function_id)
+    }
+
+    pub fn as_externally_callable_function(self, gcx: Gcx<'gcx>) -> Self {
+        let TyKind::Fn(f) = self.kind else { return self };
+        self.as_externally_callable_function_with_kind(f.kind, gcx)
     }
 
     pub fn as_externally_callable_library_function(self, gcx: Gcx<'gcx>) -> Self {
-        let ty = self.as_externally_callable_function(gcx);
-        let TyKind::FnPtr(f) = ty.kind else { return ty };
-        gcx.mk_ty_fn_ptr(TyFnPtr {
-            parameters: f.parameters,
-            returns: f.returns,
-            state_mutability: f.state_mutability,
-            visibility: Visibility::Internal,
-            function_id: f.function_id,
-            special: true,
-        })
+        self.as_externally_callable_function_with_kind(TyFnKind::DelegateCall, gcx)
+    }
+
+    pub fn as_declaration_function(self, gcx: Gcx<'gcx>) -> Self {
+        let TyKind::Fn(f) = self.kind else { return self };
+        if f.is_declaration() {
+            return self;
+        }
+        gcx.mk_ty_fn_with_id(
+            TyFnKind::Declaration,
+            f.parameters,
+            f.state_mutability,
+            f.returns,
+            f.function_id,
+        )
     }
 
     pub fn make_ref(self, gcx: Gcx<'gcx>, loc: DataLocation) -> Self {
@@ -240,7 +242,7 @@ impl<'gcx> Ty<'gcx> {
     pub fn is_value_type(self) -> bool {
         match self.kind {
             TyKind::Elementary(t) => t.is_value_type(),
-            TyKind::Contract(_) | TyKind::FnPtr(_) | TyKind::Enum(_) | TyKind::Udvt(..) => true,
+            TyKind::Contract(_) | TyKind::Fn(_) | TyKind::Enum(_) | TyKind::Udvt(..) => true,
             _ => false,
         }
     }
@@ -284,7 +286,7 @@ impl<'gcx> Ty<'gcx> {
         .is_break()
     }
 
-    /// Returns `true` if this type contains a non-public (internal/private) function pointer.
+    /// Returns `true` if this type contains a non-public (internal/private) function type.
     #[inline]
     pub fn has_internal_function(self) -> bool {
         self.flags.contains(TyFlags::HAS_INTERNAL_FN)
@@ -315,7 +317,7 @@ impl<'gcx> Ty<'gcx> {
     #[inline]
     pub fn parameters(self) -> Option<&'gcx [Self]> {
         Some(match self.kind {
-            TyKind::FnPtr(f) => f.parameters,
+            TyKind::Fn(f) => f.parameters,
             TyKind::Event(tys, _) | TyKind::Error(tys, _) => tys,
             _ => return None,
         })
@@ -325,7 +327,7 @@ impl<'gcx> Ty<'gcx> {
     #[inline]
     pub fn returns(self) -> Option<&'gcx [Self]> {
         Some(match self.kind {
-            TyKind::FnPtr(f) => f.returns,
+            TyKind::Fn(f) => f.returns,
             _ => return None,
         })
     }
@@ -334,25 +336,16 @@ impl<'gcx> Ty<'gcx> {
     #[inline]
     pub fn state_mutability(self) -> Option<StateMutability> {
         match self.kind {
-            TyKind::FnPtr(f) => Some(f.state_mutability),
+            TyKind::Fn(f) => Some(f.state_mutability),
             _ => None,
         }
     }
 
-    /// Returns the visibility of the type.
-    #[inline]
-    pub fn visibility(self) -> Option<Visibility> {
-        match self.kind {
-            TyKind::FnPtr(f) => Some(f.visibility),
-            _ => None,
-        }
-    }
-
-    /// Returns the function ID if this is a function pointer type with a specific function.
+    /// Returns the function ID if this is a function type with a specific function.
     #[inline]
     pub fn function_id(self) -> Option<hir::FunctionId> {
         match self.kind {
-            TyKind::FnPtr(f) => f.function_id,
+            TyKind::Fn(f) => f.function_id,
             _ => None,
         }
     }
@@ -365,7 +358,7 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::StringLiteral(..)
             | TyKind::IntLiteral(..)
             | TyKind::Contract(_)
-            | TyKind::FnPtr(_)
+            | TyKind::Fn(_)
             | TyKind::Enum(_)
             | TyKind::Module(_)
             | TyKind::BuiltinModule(_)
@@ -414,7 +407,7 @@ impl<'gcx> Ty<'gcx> {
             | TyKind::StringLiteral(..)
             | TyKind::IntLiteral(..)
             | TyKind::Contract(_)
-            | TyKind::FnPtr(_)
+            | TyKind::Fn(_)
             | TyKind::Enum(_)
             | TyKind::Module(_)
             | TyKind::BuiltinModule(_)
@@ -741,8 +734,8 @@ impl<'gcx> Ty<'gcx> {
 
             // Function pointer conversions.
             // See: <https://docs.soliditylang.org/en/latest/types.html#function-types>
-            (FnPtr(from_fn), FnPtr(to_fn)) => {
-                if from_fn.special || to_fn.special {
+            (Fn(from_fn), Fn(to_fn)) => {
+                if from_fn.kind != to_fn.kind {
                     return Result::Err(TyConvertError::Incompatible);
                 }
 
@@ -751,22 +744,9 @@ impl<'gcx> Ty<'gcx> {
                     return Result::Err(TyConvertError::Incompatible);
                 }
 
-                let visibility_ok = from_fn.visibility == to_fn.visibility
-                    || matches!(
-                        (from_fn.visibility, to_fn.visibility),
-                        (Visibility::Private, Visibility::Internal)
-                    );
-                if !visibility_ok {
-                    return Result::Err(TyConvertError::Incompatible);
-                }
-
-                // Function ID: a FnPtr with an ID can coerce to one without an ID, but not vice
-                // versa.
-                let function_id_ok = match (from_fn.function_id, to_fn.function_id) {
-                    (_, None) => true,
-                    (a, b) => a == b,
-                };
-                if !function_id_ok {
+                // Declaration function values name a concrete declaration accessed through a
+                // contract type and are only compatible with that same declaration.
+                if from_fn.is_declaration() && from_fn.function_id != to_fn.function_id {
                     return Result::Err(TyConvertError::Incompatible);
                 }
 
@@ -1081,7 +1061,7 @@ pub enum TyKind<'gcx> {
     Mapping(Ty<'gcx>, Ty<'gcx>),
 
     /// Function pointer: `function(...) returns (...)`.
-    FnPtr(&'gcx TyFnPtr<'gcx>),
+    Fn(&'gcx TyFn<'gcx>),
 
     /// Contract.
     Contract(hir::ContractId),
@@ -1121,18 +1101,88 @@ pub enum TyKind<'gcx> {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct TyFnPtr<'gcx> {
+pub struct TyFn<'gcx> {
+    /// The semantic kind of this function value.
+    pub kind: TyFnKind,
+    /// The parameter types.
     pub parameters: &'gcx [Ty<'gcx>],
+    /// The return types.
     pub returns: &'gcx [Ty<'gcx>],
+    /// The function state mutability.
     pub state_mutability: StateMutability,
-    pub visibility: Visibility,
+    /// The declaration this function value refers to, if known.
     pub function_id: Option<hir::FunctionId>,
-    /// Whether this is a special function value that cannot convert to function pointer types.
-    pub special: bool,
 }
 
-impl<'gcx> TyFnPtr<'gcx> {
-    /// Returns an iterator over all the types in the function pointer.
+/// The semantic kind of a function value.
+///
+/// This mirrors the solc `FunctionType::Kind` variants that are relevant to the current type
+/// system.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TyFnKind {
+    /// An ordinary internal function value.
+    Internal,
+    /// An ordinary external function value.
+    External,
+    /// A function declaration accessed through a contract type, e.g. `C.f`.
+    Declaration,
+    /// A public library function accessed through the library type, e.g. `L.f`.
+    ///
+    /// This is solc's `FunctionType::Kind::DelegateCall`. It has a `.selector` member, but is not
+    /// assignable to ordinary function types.
+    DelegateCall,
+}
+
+impl<'gcx> TyFn<'gcx> {
+    /// Returns the semantic kind of this function value.
+    #[inline]
+    pub fn kind(&self) -> TyFnKind {
+        self.kind
+    }
+
+    /// Returns whether this is an internal function value.
+    #[inline]
+    pub fn is_internal(&self) -> bool {
+        self.kind == TyFnKind::Internal
+    }
+
+    /// Returns whether this is an external function value.
+    #[inline]
+    pub fn is_external(&self) -> bool {
+        self.kind == TyFnKind::External
+    }
+
+    /// Returns whether this is a contract-type function declaration value.
+    #[inline]
+    pub fn is_declaration(&self) -> bool {
+        self.kind == TyFnKind::Declaration
+    }
+
+    /// Returns whether this is a public library function value.
+    #[inline]
+    pub fn is_delegate_call(&self) -> bool {
+        self.kind == TyFnKind::DelegateCall
+    }
+
+    /// Returns whether this function value has a known declaration.
+    #[inline]
+    pub fn has_declaration(&self) -> bool {
+        self.function_id.is_some()
+    }
+
+    /// Returns whether this function value has a `.selector` member.
+    #[inline]
+    pub fn has_selector(&self) -> bool {
+        matches!(self.kind, TyFnKind::External | TyFnKind::Declaration | TyFnKind::DelegateCall)
+    }
+
+    /// Returns whether this function value has an `.address` member.
+    #[inline]
+    pub fn has_address(&self) -> bool {
+        self.is_external()
+    }
+
+    /// Returns an iterator over all the types in the function value.
     pub fn tys(&self) -> impl DoubleEndedIterator<Item = Ty<'gcx>> + Clone {
         self.parameters.iter().copied().chain(self.returns.iter().copied())
     }
@@ -1144,7 +1194,7 @@ bitflags::bitflags! {
     pub struct TyFlags: u8 {
         /// Whether an error is reachable.
         const HAS_ERROR    = 1 << 0;
-        /// Whether this type contains a non-public (internal/private) function pointer.
+        /// Whether this type contains a non-public (internal/private) function type.
         const HAS_INTERNAL_FN = 1 << 1;
     }
 }
@@ -1167,8 +1217,8 @@ impl TyFlags {
             | TyKind::Module(_)
             | TyKind::BuiltinModule(_) => {}
 
-            TyKind::FnPtr(f) => {
-                if f.visibility < hir::Visibility::Public {
+            TyKind::Fn(f) => {
+                if f.is_internal() {
                     self.add(Self::HAS_INTERNAL_FN);
                 }
             }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::Builtin,
     eval::ConstantEvaluator,
     hir::{self, Visit},
-    ty::{Gcx, Ty, TyKind},
+    ty::{Gcx, Ty, TyFnKind, TyKind},
 };
 use alloy_primitives::U256;
 use solar_ast::{DataLocation, ElementaryType, Span, StateMutability, TypeSize};
@@ -195,6 +195,14 @@ impl<'gcx> TypeChecker<'gcx> {
 
                 let ty = match callee_ty.kind {
                     TyKind::Fn(f) => {
+                        if f.is_declaration() {
+                            return self.gcx.mk_ty_err(
+                                self.dcx()
+                                    .err("cannot call function via contract type name")
+                                    .span(expr.span)
+                                    .emit(),
+                            );
+                        }
                         let param_names = if let Some(struct_id) = struct_id {
                             Some(self.get_struct_field_names(struct_id))
                         } else {
@@ -821,7 +829,7 @@ impl<'gcx> TypeChecker<'gcx> {
         };
 
         let creation = f.is_creation();
-        if !creation && !f.is_external() {
+        if !creation && !f.is_external() && !f.is_bare_call() {
             self.dcx()
                 .err("function call options can only be set on external function calls or contract creations")
                 .span(span)
@@ -846,7 +854,17 @@ impl<'gcx> TypeChecker<'gcx> {
                     std::mem::replace(&mut gas_set, true)
                 }
                 sym::value => {
-                    if f.state_mutability != StateMutability::Payable {
+                    if f.kind == TyFnKind::BareDelegateCall {
+                        self.dcx()
+                            .err("cannot set option `value` for delegatecall")
+                            .span(opt.name.span)
+                            .emit();
+                    } else if f.kind == TyFnKind::BareStaticCall {
+                        self.dcx()
+                            .err("cannot set option `value` for staticcall")
+                            .span(opt.name.span)
+                            .emit();
+                    } else if f.state_mutability != StateMutability::Payable {
                         let msg = if creation
                             && let Some(ret) = f.returns.first()
                             && let TyKind::Contract(id) = ret.kind

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -260,6 +260,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             hir::ExprKind::CallOptions(callee, opts) => {
                 let callee_ty = self.check_expr(callee);
+                let callee = callee.peel_parens();
                 let already_set = matches!(callee.kind, hir::ExprKind::CallOptions(..));
                 self.check_call_options(
                     callee_ty,
@@ -686,8 +687,7 @@ impl<'gcx> TypeChecker<'gcx> {
     ) -> Ty<'gcx> {
         let call_options_comparison = op.kind.is_cmp()
             && matches!((lhs.kind, rhs.kind), (TyKind::Fn(_), TyKind::Fn(_)))
-            && (matches!(lhs_e.kind, hir::ExprKind::CallOptions(..))
-                || matches!(rhs_e.kind, hir::ExprKind::CallOptions(..)));
+            && (is_call_options_expr(lhs_e) || is_call_options_expr(rhs_e));
         let common = if call_options_comparison {
             None
         } else {
@@ -760,7 +760,7 @@ impl<'gcx> TypeChecker<'gcx> {
         actual: Ty<'gcx>,
         expected: Ty<'gcx>,
     ) {
-        if matches!(expr.kind, hir::ExprKind::CallOptions(..))
+        if is_call_options_expr(expr)
             && matches!((actual.kind, expected.kind), (TyKind::Fn(_), TyKind::Fn(_)))
         {
             let mut diag = self.dcx().err("mismatched types").span(expr.span);
@@ -1727,6 +1727,10 @@ fn valid_shift<'gcx>(ty: Ty<'gcx>, other: Ty<'gcx>, op: hir::BinOpKind) -> Optio
         return None;
     }
     Some(ty)
+}
+
+fn is_call_options_expr(expr: &hir::Expr<'_>) -> bool {
+    matches!(expr.peel_parens().kind, hir::ExprKind::CallOptions(..))
 }
 
 fn valid_meta_type(ty: Ty<'_>) -> bool {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -177,15 +177,12 @@ impl<'gcx> TypeChecker<'gcx> {
             hir::ExprKind::Call(callee, ref args, opts) => {
                 let mut callee_ty = self.check_expr(callee);
                 if let Some(opts) = opts {
-                    for (i, opts) in opts.iter().enumerate() {
-                        callee_ty = self.check_call_options(
-                            callee_ty,
-                            opts.args,
-                            opts.span,
-                            matches!(callee.kind, hir::ExprKind::New(_)),
-                            i > 0,
-                        );
-                    }
+                    callee_ty = self.check_call_options(
+                        callee_ty,
+                        opts.args,
+                        opts.span,
+                        matches!(callee.kind, hir::ExprKind::New(_)),
+                    );
                 }
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
@@ -813,7 +810,6 @@ impl<'gcx> TypeChecker<'gcx> {
         opts: &'gcx [hir::NamedArg<'gcx>],
         span: Span,
         creation: bool,
-        already_set: bool,
     ) -> Ty<'gcx> {
         let TyKind::Fn(f) = ty.kind else {
             for opt in opts {
@@ -827,10 +823,6 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             return ty;
         };
-
-        if already_set {
-            self.dcx().err("function call options have already been set").span(span).emit();
-        }
 
         if !creation && !f.is_external() {
             self.dcx()

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -2,12 +2,12 @@ use crate::{
     builtins::Builtin,
     eval::ConstantEvaluator,
     hir::{self, Visit},
-    ty::{Gcx, Ty, TyKind},
+    ty::{Gcx, Ty, TyFn, TyKind},
 };
 use alloy_primitives::U256;
-use solar_ast::{DataLocation, ElementaryType, Span, TypeSize};
+use solar_ast::{DataLocation, ElementaryType, Span, StateMutability, TypeSize};
 use solar_data_structures::{Never, map::FxHashMap, pluralize, smallvec::SmallVec};
-use solar_interface::{diagnostics::DiagCtxt, sym};
+use solar_interface::{diagnostics::DiagCtxt, kw, sym};
 use std::ops::ControlFlow;
 
 mod yul;
@@ -174,8 +174,15 @@ impl<'gcx> TypeChecker<'gcx> {
 
                 self.check_binop(lhs_e, lhs, rhs_e, rhs, op, false)
             }
-            hir::ExprKind::Call(callee, ref args, ref _opts) => {
+            hir::ExprKind::Call(callee, ref args, ref opts) => {
                 let mut callee_ty = self.check_expr(callee);
+                if let Some(opts) = opts {
+                    callee_ty = self.check_call_options(
+                        callee_ty,
+                        opts,
+                        matches!(callee.kind, hir::ExprKind::New(_)),
+                    );
+                }
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
                 let struct_id = if let TyKind::Type(struct_ty) = callee_ty.kind
@@ -249,6 +256,14 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
 
                 ty
+            }
+            hir::ExprKind::CallOptions(callee, opts) => {
+                let callee_ty = self.check_expr(callee);
+                self.check_call_options(
+                    callee_ty,
+                    opts,
+                    matches!(callee.kind, hir::ExprKind::New(_)),
+                )
             }
             hir::ExprKind::Delete(expr) => {
                 let ty = self.require_lvalue(expr);
@@ -794,6 +809,110 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
             }
         }
+    }
+
+    fn check_call_options(
+        &mut self,
+        ty: Ty<'gcx>,
+        opts: &'gcx [hir::NamedArg<'gcx>],
+        creation: bool,
+    ) -> Ty<'gcx> {
+        let TyKind::Fn(f) = ty.kind else {
+            for opt in opts {
+                let _ = self.check_expr(&opt.value);
+            }
+            if !ty.references_error() {
+                self.dcx()
+                    .err("function call options can only be set on external function calls or contract creations")
+                    .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
+                    .emit();
+            }
+            return ty;
+        };
+
+        if !creation && !f.is_external() {
+            self.dcx()
+                .err("function call options can only be set on external function calls or contract creations")
+                .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
+                .emit();
+        }
+
+        if f.options.gas_set || f.options.value_set || f.options.salt_set {
+            self.dcx()
+                .err("function call options have already been set")
+                .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
+                .emit();
+        }
+
+        let mut options = f.options;
+        let mut gas_set = false;
+        let mut value_set = false;
+        let mut salt_set = false;
+        for opt in opts {
+            let name = opt.name.name;
+            let duplicate = match name {
+                kw::Gas => {
+                    if creation {
+                        self.dcx()
+                            .err("function call option `gas` cannot be used with `new`")
+                            .span(opt.name.span)
+                            .emit();
+                    } else {
+                        let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
+                        options.gas_set = true;
+                    }
+                    std::mem::replace(&mut gas_set, true)
+                }
+                sym::value => {
+                    if f.state_mutability != StateMutability::Payable {
+                        self.dcx()
+                            .err("cannot set option `value` on a non-payable function type")
+                            .span(opt.name.span)
+                            .emit();
+                    }
+                    let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
+                    options.value_set = true;
+                    std::mem::replace(&mut value_set, true)
+                }
+                sym::salt => {
+                    if !creation {
+                        self.dcx()
+                            .err("function call option `salt` can only be used with `new`")
+                            .span(opt.name.span)
+                            .emit();
+                    }
+                    let _ = self.expect_ty(&opt.value, self.gcx.types.fixed_bytes(32));
+                    options.salt_set = true;
+                    std::mem::replace(&mut salt_set, true)
+                }
+                _ => {
+                    self.dcx()
+                        .err(format!("unknown call option `{name}`"))
+                        .span(opt.name.span)
+                        .emit();
+                    let _ = self.check_expr(&opt.value);
+                    false
+                }
+            };
+            if duplicate {
+                self.dcx()
+                    .err(format!("duplicate call option `{name}`"))
+                    .span(opt.name.span)
+                    .emit();
+            }
+        }
+
+        if creation || !f.is_external() {
+            return ty;
+        }
+        self.gcx.mk_ty_fn(TyFn {
+            kind: f.kind,
+            parameters: f.parameters,
+            returns: f.returns,
+            state_mutability: f.state_mutability,
+            function_id: f.function_id,
+            options,
+        })
     }
 
     fn check_positional_call_args(
@@ -1375,6 +1494,7 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         hir::ExprKind::Array(_)
         | hir::ExprKind::Assign(..)
         | hir::ExprKind::Binary(..)
+        | hir::ExprKind::CallOptions(..)
         | hir::ExprKind::Delete(_)
         | hir::ExprKind::Slice(..)
         | hir::ExprKind::Lit(_)
@@ -1550,8 +1670,16 @@ fn binop_common_type<'gcx>(
             if !matches!(op, Eq | Ne) {
                 return None;
             }
-            if !((f.is_internal() && other_fn.is_internal())
-                || (f.is_external() && other_fn.is_external()))
+            if !((f.is_internal()
+                && f.stack_size() == 1
+                && other_fn.is_internal()
+                && other_fn.stack_size() == 1)
+                || (f.is_external()
+                    && f.stack_size() == 2
+                    && !f.options.has_bound_first_argument
+                    && other_fn.is_external()
+                    && other_fn.stack_size() == 2
+                    && !other_fn.options.has_bound_first_argument))
             {
                 return None;
             }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::Builtin,
     eval::ConstantEvaluator,
     hir::{self, Visit},
-    ty::{Gcx, Ty, TyFn, TyKind},
+    ty::{Gcx, Ty, TyKind},
 };
 use alloy_primitives::U256;
 use solar_ast::{DataLocation, ElementaryType, Span, StateMutability, TypeSize};
@@ -181,6 +181,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         callee_ty,
                         opts,
                         matches!(callee.kind, hir::ExprKind::New(_)),
+                        false,
                     );
                 }
 
@@ -259,10 +260,12 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             hir::ExprKind::CallOptions(callee, opts) => {
                 let callee_ty = self.check_expr(callee);
+                let already_set = matches!(callee.kind, hir::ExprKind::CallOptions(..));
                 self.check_call_options(
                     callee_ty,
                     opts,
                     matches!(callee.kind, hir::ExprKind::New(_)),
+                    already_set,
                 )
             }
             hir::ExprKind::Delete(expr) => {
@@ -681,7 +684,15 @@ impl<'gcx> TypeChecker<'gcx> {
         op: hir::BinOp,
         assign: bool,
     ) -> Ty<'gcx> {
-        let common = binop_common_type(self.gcx, lhs, rhs, op.kind);
+        let call_options_comparison = op.kind.is_cmp()
+            && matches!((lhs.kind, rhs.kind), (TyKind::Fn(_), TyKind::Fn(_)))
+            && (matches!(lhs_e.kind, hir::ExprKind::CallOptions(..))
+                || matches!(rhs_e.kind, hir::ExprKind::CallOptions(..)));
+        let common = if call_options_comparison {
+            None
+        } else {
+            binop_common_type(self.gcx, lhs, rhs, op.kind)
+        };
         // TODO: custom operators
         if let Some(common) = common
             && !(assign && common != lhs)
@@ -749,6 +760,22 @@ impl<'gcx> TypeChecker<'gcx> {
         actual: Ty<'gcx>,
         expected: Ty<'gcx>,
     ) {
+        if matches!(expr.kind, hir::ExprKind::CallOptions(..))
+            && matches!((actual.kind, expected.kind), (TyKind::Fn(_), TyKind::Fn(_)))
+        {
+            let mut diag = self.dcx().err("mismatched types").span(expr.span);
+            diag = diag.span_label(
+                expr.span,
+                format!(
+                    "expected `{}`, found `{}`",
+                    expected.display(self.gcx),
+                    actual.display(self.gcx)
+                ),
+            );
+            diag.emit();
+            return;
+        }
+
         let Err(err) = actual.try_convert_implicit_to(expected, self.gcx) else { return };
 
         let mut diag = self.dcx().err("mismatched types").span(expr.span);
@@ -816,6 +843,7 @@ impl<'gcx> TypeChecker<'gcx> {
         ty: Ty<'gcx>,
         opts: &'gcx [hir::NamedArg<'gcx>],
         creation: bool,
+        already_set: bool,
     ) -> Ty<'gcx> {
         let TyKind::Fn(f) = ty.kind else {
             for opt in opts {
@@ -830,6 +858,13 @@ impl<'gcx> TypeChecker<'gcx> {
             return ty;
         };
 
+        if already_set {
+            self.dcx()
+                .err("function call options have already been set")
+                .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
+                .emit();
+        }
+
         if !creation && !f.is_external() {
             self.dcx()
                 .err("function call options can only be set on external function calls or contract creations")
@@ -837,14 +872,6 @@ impl<'gcx> TypeChecker<'gcx> {
                 .emit();
         }
 
-        if f.options.gas_set || f.options.value_set || f.options.salt_set {
-            self.dcx()
-                .err("function call options have already been set")
-                .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
-                .emit();
-        }
-
-        let mut options = f.options;
         let mut gas_set = false;
         let mut value_set = false;
         let mut salt_set = false;
@@ -859,7 +886,6 @@ impl<'gcx> TypeChecker<'gcx> {
                             .emit();
                     } else {
                         let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
-                        options.gas_set = true;
                     }
                     std::mem::replace(&mut gas_set, true)
                 }
@@ -871,7 +897,6 @@ impl<'gcx> TypeChecker<'gcx> {
                             .emit();
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
-                    options.value_set = true;
                     std::mem::replace(&mut value_set, true)
                 }
                 sym::salt => {
@@ -882,7 +907,6 @@ impl<'gcx> TypeChecker<'gcx> {
                             .emit();
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.fixed_bytes(32));
-                    options.salt_set = true;
                     std::mem::replace(&mut salt_set, true)
                 }
                 _ => {
@@ -902,17 +926,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
         }
 
-        if creation || !f.is_external() {
-            return ty;
-        }
-        self.gcx.mk_ty_fn(TyFn {
-            kind: f.kind,
-            parameters: f.parameters,
-            returns: f.returns,
-            state_mutability: f.state_mutability,
-            function_id: f.function_id,
-            options,
-        })
+        ty
     }
 
     fn check_positional_call_args(
@@ -1670,16 +1684,8 @@ fn binop_common_type<'gcx>(
             if !matches!(op, Eq | Ne) {
                 return None;
             }
-            if !((f.is_internal()
-                && f.stack_size() == 1
-                && other_fn.is_internal()
-                && other_fn.stack_size() == 1)
-                || (f.is_external()
-                    && f.stack_size() == 2
-                    && !f.options.has_bound_first_argument
-                    && other_fn.is_external()
-                    && other_fn.stack_size() == 2
-                    && !other_fn.options.has_bound_first_argument))
+            if !((f.is_internal() && other_fn.is_internal())
+                || (f.is_external() && other_fn.is_external()))
             {
                 return None;
             }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -102,14 +102,7 @@ impl<'gcx> TypeChecker<'gcx> {
         expr: &'gcx hir::Expr<'gcx>,
         expected: Option<Ty<'gcx>>,
     ) -> Ty<'gcx> {
-        let mut ty = self.check_expr_kind(expr, expected);
-        if let Some(options) = expr.call_options {
-            let creation = matches!(expr.kind, hir::ExprKind::New(_));
-            for (i, options) in options.iter().enumerate() {
-                let already_set = i > 0 || matches!(ty.kind, TyKind::CallOptions(_));
-                ty = self.check_call_options(ty, options.args, options.span, creation, already_set);
-            }
-        }
+        let ty = self.check_expr_kind(expr, expected);
         self.register_ty(expr, ty);
         ty
     }
@@ -181,9 +174,19 @@ impl<'gcx> TypeChecker<'gcx> {
 
                 self.check_binop(lhs_e, lhs, rhs_e, rhs, op, false)
             }
-            hir::ExprKind::Call(callee, ref args) => {
-                let callee_ty = self.check_expr(callee);
-                let mut callee_ty = callee_ty.peel_call_options();
+            hir::ExprKind::Call(callee, ref args, opts) => {
+                let mut callee_ty = self.check_expr(callee);
+                if let Some(opts) = opts {
+                    for (i, opts) in opts.iter().enumerate() {
+                        callee_ty = self.check_call_options(
+                            callee_ty,
+                            opts.args,
+                            opts.span,
+                            matches!(callee.kind, hir::ExprKind::New(_)),
+                            i > 0,
+                        );
+                    }
+                }
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
                 let struct_id = if let TyKind::Type(struct_ty) = callee_ty.kind
@@ -812,18 +815,17 @@ impl<'gcx> TypeChecker<'gcx> {
         creation: bool,
         already_set: bool,
     ) -> Ty<'gcx> {
-        let base_ty = ty.peel_call_options();
-        let TyKind::Fn(f) = base_ty.kind else {
+        let TyKind::Fn(f) = ty.kind else {
             for opt in opts {
                 let _ = self.check_expr(&opt.value);
             }
-            if !base_ty.references_error() {
+            if !ty.references_error() {
                 self.dcx()
                     .err("function call options can only be set on external function calls or contract creations")
                     .span(span)
                     .emit();
             }
-            return base_ty;
+            return ty;
         };
 
         if already_set {
@@ -891,7 +893,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
         }
 
-        self.gcx.mk_ty(TyKind::CallOptions(base_ty))
+        ty
     }
 
     fn check_positional_call_args(
@@ -1461,10 +1463,6 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
 ///
 /// If `false`, it cannot be an lvalue.
 fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
-    if expr.call_options.is_some() {
-        return false;
-    }
-
     match expr.kind {
         hir::ExprKind::Ident(_)
         | hir::ExprKind::Index(..)
@@ -1674,7 +1672,6 @@ fn binop_common_type<'gcx>(
         | TyKind::Module(_)
         | TyKind::BuiltinModule(_)
         | TyKind::Type(_)
-        | TyKind::CallOptions(_)
         | TyKind::Meta(_) => None,
 
         TyKind::Err(_) => Some(ty),

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -177,12 +177,7 @@ impl<'gcx> TypeChecker<'gcx> {
             hir::ExprKind::Call(callee, ref args, opts) => {
                 let mut callee_ty = self.check_expr(callee);
                 if let Some(opts) = opts {
-                    callee_ty = self.check_call_options(
-                        callee_ty,
-                        opts.args,
-                        opts.span,
-                        matches!(callee.kind, hir::ExprKind::New(_)),
-                    );
+                    callee_ty = self.check_call_options(callee_ty, opts.args, opts.span);
                 }
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
@@ -432,16 +427,11 @@ impl<'gcx> TypeChecker<'gcx> {
                             let mut parameters: &[Ty<'_>] = &[];
                             let mut sm = hir::StateMutability::NonPayable;
                             if let Some(ctor) = c.ctor {
-                                let func_ty = self.gcx.type_of_item(ctor.into());
-                                let TyKind::Fn(f) = func_ty.kind else { unreachable!() };
-                                parameters = f.parameters;
+                                let f = self.gcx.hir.function(ctor);
+                                parameters = self.gcx.mk_item_tys(f.parameters);
                                 sm = f.state_mutability;
-                                debug_assert!(
-                                    f.returns.is_empty(),
-                                    "non-empty constructor returns"
-                                );
                             }
-                            self.gcx.mk_builtin_fn(parameters, sm, &[ty])
+                            self.gcx.mk_creation_fn(parameters, sm, &[ty])
                         }
                     }
                     TyKind::Array(..) => {
@@ -809,7 +799,6 @@ impl<'gcx> TypeChecker<'gcx> {
         ty: Ty<'gcx>,
         opts: &'gcx [hir::NamedArg<'gcx>],
         span: Span,
-        creation: bool,
     ) -> Ty<'gcx> {
         let TyKind::Fn(f) = ty.kind else {
             for opt in opts {
@@ -824,6 +813,7 @@ impl<'gcx> TypeChecker<'gcx> {
             return ty;
         };
 
+        let creation = f.is_creation();
         if !creation && !f.is_external() {
             self.dcx()
                 .err("function call options can only be set on external function calls or contract creations")
@@ -850,10 +840,18 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
                 sym::value => {
                     if f.state_mutability != StateMutability::Payable {
-                        self.dcx()
-                            .err("cannot set option `value` on a non-payable function type")
-                            .span(opt.name.span)
-                            .emit();
+                        let msg = if creation
+                            && let Some(ret) = f.returns.first()
+                            && let TyKind::Contract(id) = ret.kind
+                        {
+                            let name = self.gcx.item_name(hir::ItemId::from(id)).name;
+                            format!(
+                                "cannot set option `value`, since the constructor of contract `{name}` is not payable"
+                            )
+                        } else {
+                            "cannot set option `value` on a non-payable function type".to_string()
+                        };
+                        self.dcx().err(msg).span(opt.name.span).emit();
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
                     std::mem::replace(&mut value_set, true)

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -191,7 +191,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 let is_array_push = false;
 
                 let ty = match callee_ty.kind {
-                    TyKind::FnPtr(f) => {
+                    TyKind::Fn(f) => {
                         let param_names = if let Some(struct_id) = struct_id {
                             Some(self.get_struct_field_names(struct_id))
                         } else {
@@ -425,7 +425,7 @@ impl<'gcx> TypeChecker<'gcx> {
                             let mut sm = hir::StateMutability::NonPayable;
                             if let Some(ctor) = c.ctor {
                                 let func_ty = self.gcx.type_of_item(ctor.into());
-                                let TyKind::FnPtr(f) = func_ty.kind else { unreachable!() };
+                                let TyKind::Fn(f) = func_ty.kind else { unreachable!() };
                                 parameters = f.parameters;
                                 sm = f.state_mutability;
                                 debug_assert!(
@@ -929,8 +929,8 @@ impl<'gcx> TypeChecker<'gcx> {
                     .span(var.span)
                     .emit();
             }
-            if let TyKind::FnPtr(f) = ty.kind
-                && f.visibility == hir::Visibility::External
+            if let TyKind::Fn(f) = ty.kind
+                && f.is_external()
             {
                 self.dcx()
                     .err("immutable variables of external function type are not yet supported")
@@ -1439,7 +1439,7 @@ fn valid_delete(ty: Ty<'_>) -> bool {
     }
 
     match ty.kind {
-        TyKind::Elementary(_) | TyKind::Contract(_) | TyKind::Enum(_) | TyKind::FnPtr(_) => true,
+        TyKind::Elementary(_) | TyKind::Contract(_) | TyKind::Enum(_) | TyKind::Fn(_) => true,
         TyKind::Ref(_, loc) => !matches!(loc, DataLocation::Calldata),
 
         TyKind::Err(_) => true,
@@ -1543,10 +1543,19 @@ fn binop_common_type<'gcx>(
             }
         }
 
-        TyKind::FnPtr(_) => {
-            // TODO: Compare internal function pointers
-            // https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/ast/Types.cpp#L3193
-            None
+        TyKind::Fn(f) => {
+            use hir::BinOpKind::*;
+
+            let TyKind::Fn(other_fn) = other.kind else { return None };
+            if !matches!(op, Eq | Ne) {
+                return None;
+            }
+            if !((f.is_internal() && other_fn.is_internal())
+                || (f.is_external() && other_fn.is_external()))
+            {
+                return None;
+            }
+            ty.common_type(other, gcx)
         }
 
         TyKind::Elementary(hir::ElementaryType::String)

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -184,6 +184,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         false,
                     );
                 }
+                let mut callee_ty = callee_ty.peel_call_options();
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
                 let struct_id = if let TyKind::Type(struct_ty) = callee_ty.kind
@@ -685,14 +686,7 @@ impl<'gcx> TypeChecker<'gcx> {
         op: hir::BinOp,
         assign: bool,
     ) -> Ty<'gcx> {
-        let call_options_comparison = op.kind.is_cmp()
-            && matches!((lhs.kind, rhs.kind), (TyKind::Fn(_), TyKind::Fn(_)))
-            && (is_call_options_expr(lhs_e) || is_call_options_expr(rhs_e));
-        let common = if call_options_comparison {
-            None
-        } else {
-            binop_common_type(self.gcx, lhs, rhs, op.kind)
-        };
+        let common = binop_common_type(self.gcx, lhs, rhs, op.kind);
         // TODO: custom operators
         if let Some(common) = common
             && !(assign && common != lhs)
@@ -760,22 +754,6 @@ impl<'gcx> TypeChecker<'gcx> {
         actual: Ty<'gcx>,
         expected: Ty<'gcx>,
     ) {
-        if is_call_options_expr(expr)
-            && matches!((actual.kind, expected.kind), (TyKind::Fn(_), TyKind::Fn(_)))
-        {
-            let mut diag = self.dcx().err("mismatched types").span(expr.span);
-            diag = diag.span_label(
-                expr.span,
-                format!(
-                    "expected `{}`, found `{}`",
-                    expected.display(self.gcx),
-                    actual.display(self.gcx)
-                ),
-            );
-            diag.emit();
-            return;
-        }
-
         let Err(err) = actual.try_convert_implicit_to(expected, self.gcx) else { return };
 
         let mut diag = self.dcx().err("mismatched types").span(expr.span);
@@ -845,17 +823,18 @@ impl<'gcx> TypeChecker<'gcx> {
         creation: bool,
         already_set: bool,
     ) -> Ty<'gcx> {
-        let TyKind::Fn(f) = ty.kind else {
+        let base_ty = ty.peel_call_options();
+        let TyKind::Fn(f) = base_ty.kind else {
             for opt in opts {
                 let _ = self.check_expr(&opt.value);
             }
-            if !ty.references_error() {
+            if !base_ty.references_error() {
                 self.dcx()
                     .err("function call options can only be set on external function calls or contract creations")
                     .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
                     .emit();
             }
-            return ty;
+            return base_ty;
         };
 
         if already_set {
@@ -926,7 +905,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
         }
 
-        ty
+        self.gcx.mk_ty(TyKind::CallOptions(base_ty))
     }
 
     fn check_positional_call_args(
@@ -1706,6 +1685,7 @@ fn binop_common_type<'gcx>(
         | TyKind::Module(_)
         | TyKind::BuiltinModule(_)
         | TyKind::Type(_)
+        | TyKind::CallOptions(_)
         | TyKind::Meta(_) => None,
 
         TyKind::Err(_) => Some(ty),
@@ -1727,10 +1707,6 @@ fn valid_shift<'gcx>(ty: Ty<'gcx>, other: Ty<'gcx>, op: hir::BinOpKind) -> Optio
         return None;
     }
     Some(ty)
-}
-
-fn is_call_options_expr(expr: &hir::Expr<'_>) -> bool {
-    matches!(expr.peel_parens().kind, hir::ExprKind::CallOptions(..))
 }
 
 fn valid_meta_type(ty: Ty<'_>) -> bool {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -419,10 +419,27 @@ impl<'gcx> TypeChecker<'gcx> {
                 match ty.kind {
                     TyKind::Contract(id) => {
                         let c = self.gcx.hir.contract(id);
-                        let kind = c.kind;
-                        if !kind.is_contract() {
-                            let msg = format!("cannot instantiate {kind}s");
-                            self.gcx.mk_ty_err(self.dcx().err(msg).span(hir_ty.span).emit())
+                        if c.kind.is_library() {
+                            self.gcx.mk_ty_err(
+                                self.dcx()
+                                    .err("invalid use of a library name")
+                                    .span(hir_ty.span)
+                                    .emit(),
+                            )
+                        } else if c.kind.is_interface() {
+                            self.gcx.mk_ty_err(
+                                self.dcx()
+                                    .err("cannot instantiate an interface")
+                                    .span(expr.span)
+                                    .emit(),
+                            )
+                        } else if c.is_abstract() {
+                            self.gcx.mk_ty_err(
+                                self.dcx()
+                                    .err("cannot instantiate an abstract contract")
+                                    .span(expr.span)
+                                    .emit(),
+                            )
                         } else {
                             let mut parameters: &[Ty<'_>] = &[];
                             let mut sm = hir::StateMutability::NonPayable;
@@ -435,7 +452,8 @@ impl<'gcx> TypeChecker<'gcx> {
                         }
                     }
                     TyKind::Array(..) => {
-                        let mut err = self.dcx().err("cannot instantiate static arrays");
+                        let mut err =
+                            self.dcx().err("cannot instantiate static arrays").span(hir_ty.span);
                         if let hir::TypeKind::Array(hir::TypeArray {
                             element: _,
                             size: Some(size_expr),
@@ -453,6 +471,13 @@ impl<'gcx> TypeChecker<'gcx> {
                             self.gcx.mk_ty_err(
                                 self.dcx()
                                     .err("cannot instantiate mappings")
+                                    .span(hir_ty.span)
+                                    .emit(),
+                            )
+                        } else if ty.contains_library(self.gcx) {
+                            self.gcx.mk_ty_err(
+                                self.dcx()
+                                    .err("invalid use of a library name")
                                     .span(hir_ty.span)
                                     .emit(),
                             )

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -102,7 +102,14 @@ impl<'gcx> TypeChecker<'gcx> {
         expr: &'gcx hir::Expr<'gcx>,
         expected: Option<Ty<'gcx>>,
     ) -> Ty<'gcx> {
-        let ty = self.check_expr_kind(expr, expected);
+        let mut ty = self.check_expr_kind(expr, expected);
+        if let Some(options) = expr.call_options {
+            let creation = matches!(expr.kind, hir::ExprKind::New(_));
+            for (i, options) in options.iter().enumerate() {
+                let already_set = i > 0 || matches!(ty.kind, TyKind::CallOptions(_));
+                ty = self.check_call_options(ty, options.args, options.span, creation, already_set);
+            }
+        }
         self.register_ty(expr, ty);
         ty
     }
@@ -174,16 +181,8 @@ impl<'gcx> TypeChecker<'gcx> {
 
                 self.check_binop(lhs_e, lhs, rhs_e, rhs, op, false)
             }
-            hir::ExprKind::Call(callee, ref args, ref opts) => {
-                let mut callee_ty = self.check_expr(callee);
-                if let Some(opts) = opts {
-                    callee_ty = self.check_call_options(
-                        callee_ty,
-                        opts,
-                        matches!(callee.kind, hir::ExprKind::New(_)),
-                        false,
-                    );
-                }
+            hir::ExprKind::Call(callee, ref args) => {
+                let callee_ty = self.check_expr(callee);
                 let mut callee_ty = callee_ty.peel_call_options();
 
                 // Get the function type for struct constructors, keeping struct_id for field names.
@@ -258,17 +257,6 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
 
                 ty
-            }
-            hir::ExprKind::CallOptions(callee, opts) => {
-                let callee_ty = self.check_expr(callee);
-                let callee = callee.peel_parens();
-                let already_set = matches!(callee.kind, hir::ExprKind::CallOptions(..));
-                self.check_call_options(
-                    callee_ty,
-                    opts,
-                    matches!(callee.kind, hir::ExprKind::New(_)),
-                    already_set,
-                )
             }
             hir::ExprKind::Delete(expr) => {
                 let ty = self.require_lvalue(expr);
@@ -820,6 +808,7 @@ impl<'gcx> TypeChecker<'gcx> {
         &mut self,
         ty: Ty<'gcx>,
         opts: &'gcx [hir::NamedArg<'gcx>],
+        span: Span,
         creation: bool,
         already_set: bool,
     ) -> Ty<'gcx> {
@@ -831,23 +820,20 @@ impl<'gcx> TypeChecker<'gcx> {
             if !base_ty.references_error() {
                 self.dcx()
                     .err("function call options can only be set on external function calls or contract creations")
-                    .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
+                    .span(span)
                     .emit();
             }
             return base_ty;
         };
 
         if already_set {
-            self.dcx()
-                .err("function call options have already been set")
-                .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
-                .emit();
+            self.dcx().err("function call options have already been set").span(span).emit();
         }
 
         if !creation && !f.is_external() {
             self.dcx()
                 .err("function call options can only be set on external function calls or contract creations")
-                .span(opts.first().map_or(Span::DUMMY, |opt| opt.name.span))
+                .span(span)
                 .emit();
         }
 
@@ -1475,6 +1461,10 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
 ///
 /// If `false`, it cannot be an lvalue.
 fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
+    if expr.call_options.is_some() {
+        return false;
+    }
+
     match expr.kind {
         hir::ExprKind::Ident(_)
         | hir::ExprKind::Index(..)
@@ -1487,7 +1477,6 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         hir::ExprKind::Array(_)
         | hir::ExprKind::Assign(..)
         | hir::ExprKind::Binary(..)
-        | hir::ExprKind::CallOptions(..)
         | hir::ExprKind::Delete(_)
         | hir::ExprKind::Slice(..)
         | hir::ExprKind::Lit(_)

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -419,27 +419,9 @@ impl<'gcx> TypeChecker<'gcx> {
                 match ty.kind {
                     TyKind::Contract(id) => {
                         let c = self.gcx.hir.contract(id);
-                        if c.kind.is_library() {
-                            self.gcx.mk_ty_err(
-                                self.dcx()
-                                    .err("invalid use of a library name")
-                                    .span(hir_ty.span)
-                                    .emit(),
-                            )
-                        } else if c.kind.is_interface() {
-                            self.gcx.mk_ty_err(
-                                self.dcx()
-                                    .err("cannot instantiate an interface")
-                                    .span(expr.span)
-                                    .emit(),
-                            )
-                        } else if c.is_abstract() {
-                            self.gcx.mk_ty_err(
-                                self.dcx()
-                                    .err("cannot instantiate an abstract contract")
-                                    .span(expr.span)
-                                    .emit(),
-                            )
+                        if !c.kind.is_contract() {
+                            let msg = format!("cannot instantiate {}s", c.kind);
+                            self.gcx.mk_ty_err(self.dcx().err(msg).span(hir_ty.span).emit())
                         } else {
                             let mut parameters: &[Ty<'_>] = &[];
                             let mut sm = hir::StateMutability::NonPayable;

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -103,7 +103,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 .emit());
         }
 
-        if matches!(ty.kind, TyKind::FnPtr(f) if f.visibility == hir::Visibility::External) {
+        if matches!(ty.kind, TyKind::Fn(f) if f.is_external()) {
             return Err(self
                 .dcx()
                 .err("only types that use one stack slot are supported")
@@ -301,10 +301,8 @@ fn yul_member_set(var: &hir::Variable<'_>, ty: Ty<'_>) -> Option<YulMemberSet> {
         return Some(YulMemberSet::Calldata);
     }
 
-    if let TyKind::FnPtr(f) = ty.kind {
-        return Some(YulMemberSet::Function {
-            external: f.visibility == hir::Visibility::External,
-        });
+    if let TyKind::Fn(f) = ty.kind {
+        return Some(YulMemberSet::Function { external: f.is_external() });
     }
 
     None

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -156,7 +156,7 @@ fn check_duplicate_definitions(gcx: Gcx<'_>, scope: &Declarations) {
 }
 
 fn same_external_params<'gcx>(gcx: Gcx<'gcx>, a: Ty<'gcx>, b: Ty<'gcx>) -> bool {
-    let key = |ty: Ty<'gcx>| ty.as_externally_callable_function(gcx).parameters().unwrap();
+    let key = |ty: Ty<'gcx>| ty.as_externally_callable_function(false, gcx).parameters().unwrap();
     key(a) == key(b)
 }
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -292,7 +292,7 @@ fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Option<U256> {
         | TyKind::Contract(..)
         | TyKind::Udvt(..)
         | TyKind::Enum(..)
-        | TyKind::FnPtr(..)
+        | TyKind::Fn(..)
         | TyKind::DynArray(..) => Some(U256::from(1)),
         TyKind::Ref(ty, _) => ty_storage_size_upper_bound(ty, gcx),
         TyKind::Array(ty, uint) => {

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -311,6 +311,7 @@ fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Option<U256> {
         }
 
         TyKind::Slice(..)
+        | TyKind::CallOptions(..)
         | TyKind::Type(..)
         | TyKind::Tuple(..)
         | TyKind::Module(..)

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -311,7 +311,6 @@ fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Option<U256> {
         }
 
         TyKind::Slice(..)
-        | TyKind::CallOptions(..)
         | TyKind::Type(..)
         | TyKind::Tuple(..)
         | TyKind::Module(..)

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -317,7 +317,7 @@ impl<'gcx> OverrideGraph<'gcx> {
         let ty = proxy.ty(self.gcx);
         let ext_ty = ty.as_externally_callable_function(self.gcx);
         let param_types =
-            if let TyKind::FnPtr(fn_ptr) = ext_ty.kind { Some(fn_ptr.parameters) } else { None };
+            if let TyKind::Fn(fn_ty) = ext_ty.kind { Some(fn_ty.parameters) } else { None };
         param_types == self.signature.param_types
     }
 }
@@ -406,7 +406,7 @@ impl<'gcx> OverrideChecker<'gcx> {
         let param_types = if kind.is_function() {
             let ty = proxy.ty(self.gcx);
             let ext_ty = ty.as_externally_callable_function(self.gcx);
-            if let TyKind::FnPtr(fn_ptr) = ext_ty.kind { Some(fn_ptr.parameters) } else { None }
+            if let TyKind::Fn(fn_ty) = ext_ty.kind { Some(fn_ty.parameters) } else { None }
         } else {
             None
         };
@@ -810,8 +810,7 @@ impl<'gcx> OverrideChecker<'gcx> {
         let overriding_ext = overriding_ty.as_externally_callable_function(gcx);
         let base_ext = base_ty.as_externally_callable_function(gcx);
 
-        let (TyKind::FnPtr(overriding_fn), TyKind::FnPtr(base_fn)) =
-            (overriding_ext.kind, base_ext.kind)
+        let (TyKind::Fn(overriding_fn), TyKind::Fn(base_fn)) = (overriding_ext.kind, base_ext.kind)
         else {
             return false;
         };

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -315,7 +315,7 @@ impl<'gcx> OverrideGraph<'gcx> {
         }
 
         let ty = proxy.ty(self.gcx);
-        let ext_ty = ty.as_externally_callable_function(self.gcx);
+        let ext_ty = ty.as_externally_callable_function(false, self.gcx);
         let param_types =
             if let TyKind::Fn(fn_ty) = ext_ty.kind { Some(fn_ty.parameters) } else { None };
         param_types == self.signature.param_types
@@ -405,7 +405,7 @@ impl<'gcx> OverrideChecker<'gcx> {
         let kind = proxy.function_kind(self.gcx);
         let param_types = if kind.is_function() {
             let ty = proxy.ty(self.gcx);
-            let ext_ty = ty.as_externally_callable_function(self.gcx);
+            let ext_ty = ty.as_externally_callable_function(false, self.gcx);
             if let TyKind::Fn(fn_ty) = ext_ty.kind { Some(fn_ty.parameters) } else { None }
         } else {
             None
@@ -807,8 +807,8 @@ impl<'gcx> OverrideChecker<'gcx> {
         let overriding_ty = overriding.ty(gcx);
         let base_ty = base.ty(gcx);
 
-        let overriding_ext = overriding_ty.as_externally_callable_function(gcx);
-        let base_ext = base_ty.as_externally_callable_function(gcx);
+        let overriding_ext = overriding_ty.as_externally_callable_function(false, gcx);
+        let base_ext = base_ty.as_externally_callable_function(false, gcx);
 
         let (TyKind::Fn(overriding_fn), TyKind::Fn(base_fn)) = (overriding_ext.kind, base_ext.kind)
         else {

--- a/tests/ui/typeck/function_calls/call_options_standalone.sol
+++ b/tests/ui/typeck/function_calls/call_options_standalone.sol
@@ -2,6 +2,10 @@ contract CallOptionMembers {
     function g() external {}
     function h() external payable {}
 
+    function nested() external {
+        this.h{gas: 42}{value: 5}(); //~ ERROR: function call options have already been set
+    }
+
     function callOptionMembers() external returns (bool) {
         return this.g{gas: 42}.address == this.g.address && //~ ERROR: call options must be part of a call expression
             this.g{gas: 42}.selector == this.g.selector && //~ ERROR: call options must be part of a call expression

--- a/tests/ui/typeck/function_calls/call_options_standalone.sol
+++ b/tests/ui/typeck/function_calls/call_options_standalone.sol
@@ -1,0 +1,13 @@
+contract CallOptionMembers {
+    function g() external {}
+    function h() external payable {}
+
+    function callOptionMembers() external returns (bool) {
+        return this.g{gas: 42}.address == this.g.address && //~ ERROR: call options must be part of a call expression
+            this.g{gas: 42}.selector == this.g.selector && //~ ERROR: call options must be part of a call expression
+            this.h{gas: 42}.address == this.h.address && //~ ERROR: call options must be part of a call expression
+            this.h{gas: 42}.selector == this.h.selector && //~ ERROR: call options must be part of a call expression
+            this.h{gas: 42, value: 5}.address == this.h.address && //~ ERROR: call options must be part of a call expression
+            this.h{gas: 42, value: 5}.selector == this.h.selector; //~ ERROR: call options must be part of a call expression
+    }
+}

--- a/tests/ui/typeck/function_calls/call_options_standalone.stderr
+++ b/tests/ui/typeck/function_calls/call_options_standalone.stderr
@@ -1,3 +1,11 @@
+error: function call options have already been set
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │         this.h{gas: 42}{value: 5}();
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: combine them into a single `{...}` option
+
 error: call options must be part of a call expression
    ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
    │
@@ -70,5 +78,5 @@ note: this expression is not a function call expression
 LL │             this.h{gas: 42, value: 5}.selector == this.h.selector;
    ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/function_calls/call_options_standalone.stderr
+++ b/tests/ui/typeck/function_calls/call_options_standalone.stderr
@@ -1,0 +1,74 @@
+error: call options must be part of a call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │         return this.g{gas: 42}.address == this.g.address &&
+   │                      ━━━━━━━━━
+   ╰╴
+note: this expression is not a function call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │         return this.g{gas: 42}.address == this.g.address &&
+   ╰╴               ━━━━━━━━━━━━━━━
+
+error: call options must be part of a call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.g{gas: 42}.selector == this.g.selector &&
+   │                   ━━━━━━━━━
+   ╰╴
+note: this expression is not a function call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.g{gas: 42}.selector == this.g.selector &&
+   ╰╴            ━━━━━━━━━━━━━━━
+
+error: call options must be part of a call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42}.address == this.h.address &&
+   │                   ━━━━━━━━━
+   ╰╴
+note: this expression is not a function call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42}.address == this.h.address &&
+   ╰╴            ━━━━━━━━━━━━━━━
+
+error: call options must be part of a call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42}.selector == this.h.selector &&
+   │                   ━━━━━━━━━
+   ╰╴
+note: this expression is not a function call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42}.selector == this.h.selector &&
+   ╰╴            ━━━━━━━━━━━━━━━
+
+error: call options must be part of a call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42, value: 5}.address == this.h.address &&
+   │                   ━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: this expression is not a function call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42, value: 5}.address == this.h.address &&
+   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: call options must be part of a call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42, value: 5}.selector == this.h.selector;
+   │                   ━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: this expression is not a function call expression
+   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
+   │
+LL │             this.h{gas: 42, value: 5}.selector == this.h.selector;
+   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/typeck/function_calls/declaration_function_calls.sol
+++ b/tests/ui/typeck/function_calls/declaration_function_calls.sol
@@ -1,0 +1,43 @@
+//@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/call_function_via_contract_name.sol
+// ported-from: test/libsolidity/syntaxTests/freeFunctions/free_call_via_contract_type.sol
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/145_external_base_visibility.sol
+// ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/base_contract_invalid.sol
+
+contract A {
+    function f() external {}
+    function g() external pure {}
+    function h() public pure {}
+}
+
+contract B {
+    function i() external {
+        A.f(); //~ ERROR: cannot call function via contract type name
+        A.g(); //~ ERROR: cannot call function via contract type name
+        A.h(); //~ ERROR: cannot call function via contract type name
+    }
+}
+
+function freeFunction() {
+    A.f(); //~ ERROR: cannot call function via contract type name
+}
+
+contract Base {
+    function externalBase() external {}
+}
+
+contract Derived is Base {
+    function derivedCall() public {
+        Base.externalBase(); //~ ERROR: cannot call function via contract type name
+    }
+}
+
+contract BaseMembers {
+    function externalMember() external {}
+}
+
+contract DerivedMembers is BaseMembers {
+    function memberCall() public {
+        BaseMembers.externalMember(); //~ ERROR: cannot call function via contract type name
+    }
+}

--- a/tests/ui/typeck/function_calls/declaration_function_calls.stderr
+++ b/tests/ui/typeck/function_calls/declaration_function_calls.stderr
@@ -1,0 +1,38 @@
+error: cannot call function via contract type name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/declaration_function_calls.sol:LL:CC
+   │
+LL │         A.f();
+   ╰╴        ━━━━━
+
+error: cannot call function via contract type name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/declaration_function_calls.sol:LL:CC
+   │
+LL │         A.g();
+   ╰╴        ━━━━━
+
+error: cannot call function via contract type name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/declaration_function_calls.sol:LL:CC
+   │
+LL │         A.h();
+   ╰╴        ━━━━━
+
+error: cannot call function via contract type name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/declaration_function_calls.sol:LL:CC
+   │
+LL │     A.f();
+   ╰╴    ━━━━━
+
+error: cannot call function via contract type name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/declaration_function_calls.sol:LL:CC
+   │
+LL │         Base.externalBase();
+   ╰╴        ━━━━━━━━━━━━━━━━━━━
+
+error: cannot call function via contract type name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/declaration_function_calls.sol:LL:CC
+   │
+LL │         BaseMembers.externalMember();
+   ╰╴        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/typeck/function_calls/low_level_call_options.sol
+++ b/tests/ui/typeck/function_calls/low_level_call_options.sol
@@ -1,0 +1,18 @@
+//@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/syntaxTests/functionCalls/calloptions_on_delegatecall.sol
+// ported-from: test/libsolidity/syntaxTests/functionCalls/calloptions_on_staticcall.sol
+// ported-from: test/libsolidity/smtCheckerTests/external_calls/external_call_with_gas_1.sol
+
+contract C {
+    function valid(address addr, bytes memory data) public payable {
+        (bool s1, bytes memory r1) = addr.call{value: 1, gas: 1000}(data);
+        (bool s2, bytes memory r2) = addr.delegatecall{gas: 1000}(data);
+        (bool s3, bytes memory r3) = addr.staticcall{gas: 1000}(data);
+        s1; r1; s2; r2; s3; r3;
+    }
+
+    function invalid(address addr, bytes memory data) public {
+        addr.delegatecall{value: 1, gas: 1000}(data); //~ ERROR: cannot set option `value` for delegatecall
+        addr.staticcall{value: 1, gas: 1000}(data); //~ ERROR: cannot set option `value` for staticcall
+    }
+}

--- a/tests/ui/typeck/function_calls/low_level_call_options.stderr
+++ b/tests/ui/typeck/function_calls/low_level_call_options.stderr
@@ -1,0 +1,14 @@
+error: cannot set option `value` for delegatecall
+   ╭▸ ROOT/tests/ui/typeck/function_calls/low_level_call_options.sol:LL:CC
+   │
+LL │         addr.delegatecall{value: 1, gas: 1000}(data);
+   ╰╴                          ━━━━━
+
+error: cannot set option `value` for staticcall
+   ╭▸ ROOT/tests/ui/typeck/function_calls/low_level_call_options.sol:LL:CC
+   │
+LL │         addr.staticcall{value: 1, gas: 1000}(data);
+   ╰╴                        ━━━━━
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/function_calls/new_call_options.sol
+++ b/tests/ui/typeck/function_calls/new_call_options.sol
@@ -1,0 +1,51 @@
+//@compile-flags: -Ztypeck
+// testdata/solidity/test/libsolidity/syntaxTests/constructor/payable_new.sol
+contract PayableA1 {}
+contract PayableB1 is PayableA1 {
+    constructor() payable {}
+}
+
+contract PayableA2 {
+    constructor() {}
+}
+contract PayableB2 is PayableA2 {
+    constructor() payable {}
+}
+
+contract PayableB3 {
+    constructor() payable {}
+}
+
+contract PayableCreator {
+    function f() public payable {
+        new PayableB1{value: 10}();
+        new PayableB2{value: 10}();
+        new PayableB3{value: 10}();
+    }
+}
+
+// testdata/solidity/test/libsolidity/syntaxTests/constructor/nonpayable_new.sol
+contract NonPayableA1 {
+    constructor() {}
+}
+contract NonPayableB1 is NonPayableA1 {}
+
+contract NonPayableA2 {
+    constructor() payable {}
+}
+contract NonPayableB2 is NonPayableA2 {}
+
+contract NonPayableB3 {}
+
+contract NonPayableB4 {
+    constructor() {}
+}
+
+contract NonPayableCreator {
+    function f() public payable {
+        new NonPayableB1{value: 10}(); //~ ERROR: cannot set option `value`
+        new NonPayableB2{value: 10}(); //~ ERROR: cannot set option `value`
+        new NonPayableB3{value: 10}(); //~ ERROR: cannot set option `value`
+        new NonPayableB4{value: 10}(); //~ ERROR: cannot set option `value`
+    }
+}

--- a/tests/ui/typeck/function_calls/new_call_options.stderr
+++ b/tests/ui/typeck/function_calls/new_call_options.stderr
@@ -1,0 +1,26 @@
+error: cannot set option `value`, since the constructor of contract `NonPayableB1` is not payable
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_call_options.sol:LL:CC
+   │
+LL │         new NonPayableB1{value: 10}();
+   ╰╴                         ━━━━━
+
+error: cannot set option `value`, since the constructor of contract `NonPayableB2` is not payable
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_call_options.sol:LL:CC
+   │
+LL │         new NonPayableB2{value: 10}();
+   ╰╴                         ━━━━━
+
+error: cannot set option `value`, since the constructor of contract `NonPayableB3` is not payable
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_call_options.sol:LL:CC
+   │
+LL │         new NonPayableB3{value: 10}();
+   ╰╴                         ━━━━━
+
+error: cannot set option `value`, since the constructor of contract `NonPayableB4` is not payable
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_call_options.sol:LL:CC
+   │
+LL │         new NonPayableB4{value: 10}();
+   ╰╴                         ━━━━━
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/typeck/function_calls/new_exprs.sol
+++ b/tests/ui/typeck/function_calls/new_exprs.sol
@@ -1,0 +1,38 @@
+//@compile-flags: -Ztypeck
+
+// testdata/solidity/test/libsolidity/syntaxTests/functionCalls/new_library.sol
+// testdata/solidity/test/libsolidity/syntaxTests/array/library_array.sol
+library L {}
+
+// testdata/solidity/test/libsolidity/syntaxTests/nameAndTypeResolution/523_reject_interface_creation.sol
+interface I {}
+
+// testdata/solidity/test/libsolidity/syntaxTests/nameAndTypeResolution/029_create_abstract_contract.sol
+abstract contract A {
+    function a() public virtual;
+}
+
+contract ValidContract {}
+
+contract C {
+    function f(uint256 n) public {
+        new L(); //~ ERROR: invalid use of a library name
+        new L[](2); //~ ERROR: invalid use of a library name
+        new I(); //~ ERROR: cannot instantiate an interface
+        new A(); //~ ERROR: cannot instantiate an abstract contract
+
+        // testdata/solidity/test/libsolidity/syntaxTests/nameAndTypeResolution/265_new_for_non_array.sol
+        uint256 x = new uint256(7); //~ ERROR: expected contract or dynamic array type
+
+        // testdata/solidity/test/libsolidity/syntaxTests/array/new_no_parentheses.sol
+        new uint256[1]; //~ ERROR: cannot instantiate static arrays
+
+        // testdata/solidity/test/libsolidity/syntaxTests/nameAndTypeResolution/invalidArgs/creating_memory_array.sol
+        uint256[] memory y = new uint256[](); //~ ERROR: wrong argument count
+
+        bytes memory b = new bytes(n);
+        string memory s = new string(n);
+        address payable[] memory a = new address payable[](10);
+        ValidContract[] memory contracts = new ValidContract[](1);
+    }
+}

--- a/tests/ui/typeck/function_calls/new_exprs.sol
+++ b/tests/ui/typeck/function_calls/new_exprs.sol
@@ -16,10 +16,10 @@ contract ValidContract {}
 
 contract C {
     function f(uint256 n) public {
-        new L(); //~ ERROR: invalid use of a library name
+        new L(); //~ ERROR: cannot instantiate librarys
         new L[](2); //~ ERROR: invalid use of a library name
-        new I(); //~ ERROR: cannot instantiate an interface
-        new A(); //~ ERROR: cannot instantiate an abstract contract
+        new I(); //~ ERROR: cannot instantiate interfaces
+        new A(); //~ ERROR: cannot instantiate abstract contracts
 
         // testdata/solidity/test/libsolidity/syntaxTests/nameAndTypeResolution/265_new_for_non_array.sol
         uint256 x = new uint256(7); //~ ERROR: expected contract or dynamic array type

--- a/tests/ui/typeck/function_calls/new_exprs.stderr
+++ b/tests/ui/typeck/function_calls/new_exprs.stderr
@@ -1,0 +1,52 @@
+error: invalid use of a library name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         new L();
+   ╰╴            ━
+
+error: invalid use of a library name
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         new L[](2);
+   ╰╴            ━━━
+
+error: cannot instantiate an interface
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         new I();
+   ╰╴        ━━━━━
+
+error: cannot instantiate an abstract contract
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         new A();
+   ╰╴        ━━━━━
+
+error: expected contract or dynamic array type
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         uint256 x = new uint256(7);
+   ╰╴                        ━━━━━━━
+
+error: cannot instantiate static arrays
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         new uint256[1];
+   │             ━━━━━━━━━━
+   ╰╴
+help: the length must be placed inside the parentheses after the array type
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         new uint256[1];
+   ╰╴                    ━
+
+error: wrong argument count for function call: 0 arguments given but expected 1
+   ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
+   │
+LL │         uint256[] memory y = new uint256[]();
+   │                              ━━━━━━━━━━━━━┬─
+   │                                           │
+   ╰╴                                          expected 1 argument, found 0
+
+error: aborting due to 7 previous errors
+

--- a/tests/ui/typeck/function_calls/new_exprs.stderr
+++ b/tests/ui/typeck/function_calls/new_exprs.stderr
@@ -1,4 +1,4 @@
-error: invalid use of a library name
+error: cannot instantiate librarys
    ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
    │
 LL │         new L();
@@ -10,17 +10,17 @@ error: invalid use of a library name
 LL │         new L[](2);
    ╰╴            ━━━
 
-error: cannot instantiate an interface
+error: cannot instantiate interfaces
    ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
    │
 LL │         new I();
-   ╰╴        ━━━━━
+   ╰╴            ━
 
-error: cannot instantiate an abstract contract
+error: cannot instantiate abstract contracts
    ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC
    │
 LL │         new A();
-   ╰╴        ━━━━━
+   ╰╴            ━
 
 error: expected contract or dynamic array type
    ╭▸ ROOT/tests/ui/typeck/function_calls/new_exprs.sol:LL:CC

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -1,4 +1,7 @@
 //@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/semanticTests/libraries/library_function_selectors.sol
+// ported-from: test/libsolidity/smtCheckerTests/function_selector/function_selector_via_contract_name.sol
+// ported-from: test/libsolidity/syntaxTests/functionTypes/external_library_function_to_external_function_type.sol
 
 type Pointer is uint256;
 
@@ -6,6 +9,10 @@ library PointerLib {
     function offset(Pointer ptr, uint256 by) internal pure returns (Pointer next) {
         ptr;
         by;
+    }
+
+    function select(Pointer ptr) external pure returns (Pointer next) {
+        return ptr;
     }
 }
 
@@ -21,5 +28,16 @@ contract C {
 
     function interfaceFunctionSelector() public pure returns (bytes4) {
         return Executor.execute.selector;
+    }
+
+    function libraryFunctionSelector() public pure returns (bytes4) {
+        return PointerLib.select.selector;
+    }
+
+    function run(function(Pointer) external pure returns (Pointer) fn) internal pure {}
+
+    function externalLibraryFunctionIsSpecial() public pure {
+        run(PointerLib.select); //~ ERROR: mismatched types
+        function(Pointer) external pure returns (Pointer) fn = PointerLib.select; //~ ERROR: mismatched types
     }
 }

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -81,19 +81,3 @@ contract C {
         emit ExternalFunction(PointerLib.ping); //~ ERROR: mismatched types
     }
 }
-
-contract FunctionCallOptionMembers {
-    function g() external {}
-    function h() external payable {}
-
-    function callOptionMembers() external returns (bool) {
-        return this.g.address == this.g.address &&
-            this.g{gas: 42}.address == this.g.address &&
-            this.g{gas: 42}.selector == this.g.selector &&
-            this.h.address == this.h.address &&
-            this.h{gas: 42}.address == this.h.address &&
-            this.h{gas: 42}.selector == this.h.selector &&
-            this.h{gas: 42, value: 5}.address == this.h.address &&
-            this.h{gas: 42, value: 5}.selector == this.h.selector;
-    }
-}

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -2,10 +2,19 @@
 // ported-from: test/libsolidity/semanticTests/libraries/library_function_selectors.sol
 // ported-from: test/libsolidity/smtCheckerTests/function_selector/function_selector_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/external_library_function_to_external_function_type.sol
+// ported-from: test/libsolidity/syntaxTests/events/event_library_function.sol
+// ported-from: test/libsolidity/syntaxTests/abiEncoder/v2_call_to_v2_library_function_pointer_accepting_struct.sol
+// ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/assign_function_via_contract_name_to_var.sol
 
 type Pointer is uint256;
 
 library PointerLib {
+    struct Item {
+        uint256 x;
+    }
+
+    function ping() public {}
+
     function offset(Pointer ptr, uint256 by) internal pure returns (Pointer next) {
         ptr;
         by;
@@ -14,13 +23,28 @@ library PointerLib {
     function select(Pointer ptr) external pure returns (Pointer next) {
         return ptr;
     }
+
+    function get(Item memory item) external pure returns (Item memory) {
+        return item;
+    }
+
+    function read(uint256[] storage items) external view returns (uint256) {
+        return items.length;
+    }
+
+    function mirror(uint256[] memory items) public pure returns (uint256) {
+        return items.length;
+    }
 }
 
 interface Executor {
     function execute(uint256 value) external returns (bytes4 magic);
+    function check() external pure;
 }
 
 contract C {
+    event ExternalFunction(function() external indexed);
+
     function libraryFunctionPointer() public pure {
         function(Pointer, uint256) internal pure returns (Pointer) fn = PointerLib.offset;
         fn;
@@ -30,8 +54,18 @@ contract C {
         return Executor.execute.selector;
     }
 
+    function interfaceFunctionIsDeclaration() public pure {
+        function() external pure fn = Executor.check; //~ ERROR: mismatched types
+        Executor.check.address; //~ ERROR: member `address` not found
+        Executor.check.selector;
+    }
+
     function libraryFunctionSelector() public pure returns (bytes4) {
         return PointerLib.select.selector;
+    }
+
+    function libraryFunctionSelectors() public pure returns (bytes4, bytes4, bytes4) {
+        return (PointerLib.select.selector, PointerLib.read.selector, PointerLib.mirror.selector);
     }
 
     function run(function(Pointer) external pure returns (Pointer) fn) internal pure {}
@@ -39,5 +73,10 @@ contract C {
     function externalLibraryFunctionIsSpecial() public pure {
         run(PointerLib.select); //~ ERROR: mismatched types
         function(Pointer) external pure returns (Pointer) fn = PointerLib.select; //~ ERROR: mismatched types
+        function(PointerLib.Item memory) external pure returns (PointerLib.Item memory) structFn = PointerLib.get; //~ ERROR: mismatched types
+    }
+
+    function eventLibraryFunctionIsSpecial() public {
+        emit ExternalFunction(PointerLib.ping); //~ ERROR: mismatched types
     }
 }

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -1,0 +1,25 @@
+//@compile-flags: -Ztypeck
+
+type Pointer is uint256;
+
+library PointerLib {
+    function offset(Pointer ptr, uint256 by) internal pure returns (Pointer next) {
+        ptr;
+        by;
+    }
+}
+
+interface Executor {
+    function execute(uint256 value) external returns (bytes4 magic);
+}
+
+contract C {
+    function libraryFunctionPointer() public pure {
+        function(Pointer, uint256) internal pure returns (Pointer) fn = PointerLib.offset;
+        fn;
+    }
+
+    function interfaceFunctionSelector() public pure returns (bytes4) {
+        return Executor.execute.selector;
+    }
+}

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -5,6 +5,7 @@
 // ported-from: test/libsolidity/syntaxTests/events/event_library_function.sol
 // ported-from: test/libsolidity/syntaxTests/abiEncoder/v2_call_to_v2_library_function_pointer_accepting_struct.sol
 // ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/assign_function_via_contract_name_to_var.sol
+// ported-from: test/libsolidity/semanticTests/functionTypes/stack_height_check_on_adding_gas_variable_to_function.sol
 
 type Pointer is uint256;
 
@@ -78,5 +79,21 @@ contract C {
 
     function eventLibraryFunctionIsSpecial() public {
         emit ExternalFunction(PointerLib.ping); //~ ERROR: mismatched types
+    }
+}
+
+contract FunctionCallOptionMembers {
+    function g() external {}
+    function h() external payable {}
+
+    function callOptionMembers() external returns (bool) {
+        return this.g.address == this.g.address &&
+            this.g{gas: 42}.address == this.g.address &&
+            this.g{gas: 42}.selector == this.g.selector &&
+            this.h.address == this.h.address &&
+            this.h{gas: 42}.address == this.h.address &&
+            this.h{gas: 42}.selector == this.h.selector &&
+            this.h{gas: 42, value: 5}.address == this.h.address &&
+            this.h{gas: 42, value: 5}.selector == this.h.selector;
     }
 }

--- a/tests/ui/typeck/function_calls/type_members.stderr
+++ b/tests/ui/typeck/function_calls/type_members.stderr
@@ -1,0 +1,14 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
+LL │         run(PointerLib.select);
+   ╰╴            ━━━━━━━━━━━━━━━━━ expected `function (Pointer) pure external returns (Pointer)`, found `function (Pointer) pure returns (Pointer)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
+LL │         function(Pointer) external pure returns (Pointer) fn = PointerLib.select;
+   ╰╴                                                               ━━━━━━━━━━━━━━━━━ expected `function (Pointer) pure external returns (Pointer)`, found `function (Pointer) pure returns (Pointer)`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/function_calls/type_members.stderr
+++ b/tests/ui/typeck/function_calls/type_members.stderr
@@ -2,9 +2,9 @@ error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
    │
 LL │         function() external pure fn = Executor.check;
-   ╰╴                                      ━━━━━━━━━━━━━━ expected `function () pure external`, found `function () pure`
+   ╰╴                                      ━━━━━━━━━━━━━━ expected `function () pure external`, found `function Executor.check() pure`
 
-error: member `address` not found on type `function () pure`
+error: member `address` not found on type `function Executor.check() pure`
    ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
    │
 LL │         Executor.check.address;

--- a/tests/ui/typeck/function_calls/type_members.stderr
+++ b/tests/ui/typeck/function_calls/type_members.stderr
@@ -1,6 +1,18 @@
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
    │
+LL │         function() external pure fn = Executor.check;
+   ╰╴                                      ━━━━━━━━━━━━━━ expected `function () pure external`, found `function () pure`
+
+error: member `address` not found on type `function () pure`
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
+LL │         Executor.check.address;
+   ╰╴                       ━━━━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
 LL │         run(PointerLib.select);
    ╰╴            ━━━━━━━━━━━━━━━━━ expected `function (Pointer) pure external returns (Pointer)`, found `function (Pointer) pure returns (Pointer)`
 
@@ -10,5 +22,17 @@ error: mismatched types
 LL │         function(Pointer) external pure returns (Pointer) fn = PointerLib.select;
    ╰╴                                                               ━━━━━━━━━━━━━━━━━ expected `function (Pointer) pure external returns (Pointer)`, found `function (Pointer) pure returns (Pointer)`
 
-error: aborting due to 2 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
+LL │ …re returns (PointerLib.Item memory) structFn = PointerLib.get;
+   ╰╴                                                ━━━━━━━━━━━━━━ expected `function (struct PointerLib.Item memory) pure external returns (struct PointerLib.Item memory)`, found `function (struct PointerLib.Item memory) pure returns (struct PointerLib.Item memory)`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
+LL │         emit ExternalFunction(PointerLib.ping);
+   ╰╴                              ━━━━━━━━━━━━━━━ expected `function () external`, found `function ()`
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -193,22 +193,6 @@ contract FunctionComparison {
     }
 }
 
-contract FunctionComparisonWithCallOptions {
-    function external_test_function() external payable {}
-
-    function invalidCallOptionComparisons() external returns (bool) {
-        return (this.external_test_function{value: 4} == this.external_test_function) && //~ ERROR: cannot apply builtin operator
-            (this.external_test_function{value: 4} == this.external_test_function{value: 4}) && //~ ERROR: cannot apply builtin operator
-            ((this.external_test_function{value: 4}) == this.external_test_function) && //~ ERROR: cannot apply builtin operator
-            (this.external_test_function{value: 4} == (this.external_test_function{value: 4})); //~ ERROR: cannot apply builtin operator
-    }
-
-    function invalidCallOptionAssignment() external {
-        function() external payable fn = this.external_test_function{value: 4}; //~ ERROR: mismatched types
-        function() external payable fn2 = (this.external_test_function{value: 4}); //~ ERROR: mismatched types
-    }
-}
-
 // Ported from test/libsolidity/syntaxTests/conversion/function_type_nonpayable_payable.sol.
 // Ported from test/libsolidity/syntaxTests/conversion/function_type_nonpayable_pure.sol.
 // Ported from test/libsolidity/syntaxTests/conversion/function_type_nonpayable_view.sol.

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -2,7 +2,7 @@
 
 // Tests for implicit function pointer conversions.
 // Function pointers require exact parameter/return types.
-// Visibility must match, except private functions can convert to internal function pointers.
+// Function kinds must match.
 // State mutability follows: pure -> view -> nonpayable, payable -> nonpayable.
 
 contract C {
@@ -93,6 +93,102 @@ contract C {
     // === Invalid: private function -> external function pointer ===
     function privateToExternal() internal pure {
         function() external pure returns (uint256) f = privateTarget; //~ ERROR: mismatched types
+    }
+}
+
+// Ported from test/libsolidity/semanticTests/functionTypes/comparison_operators_for_external_functions.sol.
+// Ported from test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_1.sol.
+// Ported from test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_2.sol.
+// Ported from test/libsolidity/syntaxTests/functionTypes/comparison_operators_between_internal_and_external_function_pointers.sol.
+// Ported from test/libsolidity/syntaxTests/functionTypes/comparison_operators_external_functions_with_different_parameters.sol.
+library FunctionComparisonLib {
+    function f() public {}
+    function g() public {}
+}
+
+contract FunctionComparison {
+    function f() external {}
+    function g() external {}
+    function h() pure external {}
+    function i() view external {}
+    function externalWithUint(uint256) external {}
+    function externalWithBool(bool) external {}
+    function internalTarget() internal pure {}
+    function internalOther() internal pure {}
+
+    function externalComparisons() public returns (bool) {
+        return this.f != this.g &&
+            this.f != this.h &&
+            this.f != this.i &&
+            this.g != this.h &&
+            this.g != this.i &&
+            this.h != this.i &&
+            this.f == this.f &&
+            this.g == this.g &&
+            this.h == this.h &&
+            this.i == this.i;
+    }
+
+    function localExternalComparisons() public returns (bool) {
+        function () external f_local = this.f;
+        function () external g_local = this.g;
+        function () external pure h_local = this.h;
+        function () external view i_local = this.i;
+
+        return f_local == this.f &&
+            g_local == this.g &&
+            h_local == this.h &&
+            i_local == this.i &&
+            f_local != this.g &&
+            f_local != this.h &&
+            f_local != this.i &&
+            g_local != this.f &&
+            g_local != this.h &&
+            g_local != this.i &&
+            h_local != this.f &&
+            h_local != this.g &&
+            h_local != this.i &&
+            i_local != this.f &&
+            i_local != this.g &&
+            i_local != this.h &&
+            f_local == f_local &&
+            f_local != g_local &&
+            f_local != h_local &&
+            f_local != i_local &&
+            g_local == g_local &&
+            g_local != h_local &&
+            g_local != i_local &&
+            h_local == h_local &&
+            i_local == i_local &&
+            h_local != i_local;
+    }
+
+    function internalComparisons() public pure returns (bool) {
+        function () internal ptr = internalTarget;
+        return internalTarget == internalTarget &&
+            ptr == internalOther &&
+            ptr != internalTarget;
+    }
+
+    function invalidInternalExternal(function () external externalPtr) external returns (bool) {
+        function () internal internalPtr = internalTarget;
+        return internalPtr != externalPtr && //~ ERROR: cannot apply builtin operator
+            internalTarget != this.f; //~ ERROR: cannot apply builtin operator
+    }
+
+    function invalidExternalParameters() external returns (bool) {
+        function () external externalPtr1 = this.externalWithUint; //~ ERROR: mismatched types
+        function () external externalPtr2 = this.externalWithBool; //~ ERROR: mismatched types
+
+        return this.externalWithUint == externalPtr1 && //~ ERROR: cannot apply builtin operator
+            this.externalWithBool == externalPtr2 && //~ ERROR: cannot apply builtin operator
+            externalPtr2 != externalPtr1 &&
+            this.externalWithBool != this.externalWithUint; //~ ERROR: cannot apply builtin operator
+    }
+
+    function invalidLibraryComparisons(function () external externalPtr) external view returns (bool) {
+        return FunctionComparisonLib.f == externalPtr || //~ ERROR: cannot apply builtin operator
+            FunctionComparisonLib.f == FunctionComparisonLib.g; //~ ERROR: cannot apply builtin operator
     }
 }
 

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -198,11 +198,14 @@ contract FunctionComparisonWithCallOptions {
 
     function invalidCallOptionComparisons() external returns (bool) {
         return (this.external_test_function{value: 4} == this.external_test_function) && //~ ERROR: cannot apply builtin operator
-            (this.external_test_function{value: 4} == this.external_test_function{value: 4}); //~ ERROR: cannot apply builtin operator
+            (this.external_test_function{value: 4} == this.external_test_function{value: 4}) && //~ ERROR: cannot apply builtin operator
+            ((this.external_test_function{value: 4}) == this.external_test_function) && //~ ERROR: cannot apply builtin operator
+            (this.external_test_function{value: 4} == (this.external_test_function{value: 4})); //~ ERROR: cannot apply builtin operator
     }
 
     function invalidCallOptionAssignment() external {
         function() external payable fn = this.external_test_function{value: 4}; //~ ERROR: mismatched types
+        function() external payable fn2 = (this.external_test_function{value: 4}); //~ ERROR: mismatched types
     }
 }
 

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -101,6 +101,7 @@ contract C {
 // Ported from test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_2.sol.
 // Ported from test/libsolidity/syntaxTests/functionTypes/comparison_operators_between_internal_and_external_function_pointers.sol.
 // Ported from test/libsolidity/syntaxTests/functionTypes/comparison_operators_external_functions_with_different_parameters.sol.
+// Ported from test/libsolidity/syntaxTests/functionTypes/comparison_operator_for_external_functions_with_call_options.sol.
 library FunctionComparisonLib {
     function f() public {}
     function g() public {}
@@ -189,6 +190,19 @@ contract FunctionComparison {
     function invalidLibraryComparisons(function () external externalPtr) external view returns (bool) {
         return FunctionComparisonLib.f == externalPtr || //~ ERROR: cannot apply builtin operator
             FunctionComparisonLib.f == FunctionComparisonLib.g; //~ ERROR: cannot apply builtin operator
+    }
+}
+
+contract FunctionComparisonWithCallOptions {
+    function external_test_function() external payable {}
+
+    function invalidCallOptionComparisons() external returns (bool) {
+        return (this.external_test_function{value: 4} == this.external_test_function) && //~ ERROR: cannot apply builtin operator
+            (this.external_test_function{value: 4} == this.external_test_function{value: 4}); //~ ERROR: cannot apply builtin operator
+    }
+
+    function invalidCallOptionAssignment() external {
+        function() external payable fn = this.external_test_function{value: 4}; //~ ERROR: mismatched types
     }
 }
 

--- a/tests/ui/typeck/implicit_function_ptr.stderr
+++ b/tests/ui/typeck/implicit_function_ptr.stderr
@@ -46,6 +46,74 @@ error: mismatched types
 LL │         function() external pure returns (uint256) f = privateTarget;
    ╰╴                                                       ━━━━━━━━━━━━━ expected `function () pure external returns (uint256)`, found `function () pure returns (uint256)`
 
+error: cannot apply builtin operator `!=` to `function ()` and `function () external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         return internalPtr != externalPtr &&
+   │                ┬────────── ━━ ─────────── function () external
+   │                │
+   ╰╴               function ()
+
+error: cannot apply builtin operator `!=` to `function () pure` and `function () external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │             internalTarget != this.f;
+   │             ┬───────────── ━━ ────── function () external
+   │             │
+   ╰╴            function () pure
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function () external externalPtr1 = this.externalWithUint;
+   ╰╴                                            ━━━━━━━━━━━━━━━━━━━━━ expected `function () external`, found `function (uint256) external`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function () external externalPtr2 = this.externalWithBool;
+   ╰╴                                            ━━━━━━━━━━━━━━━━━━━━━ expected `function () external`, found `function (bool) external`
+
+error: cannot apply builtin operator `==` to `function (uint256) external` and `function () external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         return this.externalWithUint == externalPtr1 &&
+   │                ┬──────────────────── ━━ ──────────── function () external
+   │                │
+   ╰╴               function (uint256) external
+
+error: cannot apply builtin operator `==` to `function (bool) external` and `function () external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │             this.externalWithBool == externalPtr2 &&
+   │             ┬──────────────────── ━━ ──────────── function () external
+   │             │
+   ╰╴            function (bool) external
+
+error: cannot apply builtin operator `!=` to `function (bool) external` and `function (uint256) external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │             this.externalWithBool != this.externalWithUint;
+   │             ┬──────────────────── ━━ ───────────────────── function (uint256) external
+   │             │
+   ╰╴            function (bool) external
+
+error: cannot apply builtin operator `==` to `function ()` and `function () external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         return FunctionComparisonLib.f == externalPtr ||
+   │                ┬────────────────────── ━━ ─────────── function () external
+   │                │
+   ╰╴               function ()
+
+error: cannot apply builtin operator `==` to `function ()` and `function ()`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │             FunctionComparisonLib.f == FunctionComparisonLib.g;
+   │             ┬────────────────────── ━━ ─────────────────────── function ()
+   │             │
+   ╰╴            function ()
+
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
    │
@@ -94,5 +162,5 @@ error: mismatched types
 LL │         function() pure external g = this.h;
    ╰╴                                     ━━━━━━ expected `function () pure external`, found `function () view external`
 
-error: aborting due to 16 previous errors
+error: aborting due to 25 previous errors
 

--- a/tests/ui/typeck/implicit_function_ptr.stderr
+++ b/tests/ui/typeck/implicit_function_ptr.stderr
@@ -114,50 +114,6 @@ LL │             FunctionComparisonLib.f == FunctionComparisonLib.g;
    │             │
    ╰╴            function ()
 
-error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
-   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
-   │
-LL │         return (this.external_test_function{value: 4} == this.external_test_function) &&
-   │                 ┬──────────────────────────────────── ━━ ─────────────────────────── function () payable external
-   │                 │
-   ╰╴                function () payable external
-
-error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
-   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
-   │
-LL │ …     (this.external_test_function{value: 4} == this.external_test_function{value: 4}) &&
-   │        ┬──────────────────────────────────── ━━ ───────────────────────────────────── function () payable external
-   │        │
-   ╰╴       function () payable external
-
-error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
-   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
-   │
-LL │             ((this.external_test_function{value: 4}) == this.external_test_function) &&
-   │              ┬────────────────────────────────────── ━━ ─────────────────────────── function () payable external
-   │              │
-   ╰╴             function () payable external
-
-error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
-   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
-   │
-LL │ …     (this.external_test_function{value: 4} == (this.external_test_function{value: 4}));
-   │        ┬──────────────────────────────────── ━━ ─────────────────────────────────────── function () payable external
-   │        │
-   ╰╴       function () payable external
-
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
-   │
-LL │         function() external payable fn = this.external_test_function{value: 4};
-   ╰╴                                         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ expected `function () payable external`, found `function () payable external`
-
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
-   │
-LL │         function() external payable fn2 = (this.external_test_function{value: 4});
-   ╰╴                                           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ expected `function () payable external`, found `function () payable external`
-
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
    │
@@ -206,5 +162,5 @@ error: mismatched types
 LL │         function() pure external g = this.h;
    ╰╴                                     ━━━━━━ expected `function () pure external`, found `function () view external`
 
-error: aborting due to 31 previous errors
+error: aborting due to 25 previous errors
 

--- a/tests/ui/typeck/implicit_function_ptr.stderr
+++ b/tests/ui/typeck/implicit_function_ptr.stderr
@@ -114,6 +114,28 @@ LL │             FunctionComparisonLib.f == FunctionComparisonLib.g;
    │             │
    ╰╴            function ()
 
+error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         return (this.external_test_function{value: 4} == this.external_test_function) &&
+   │                 ┬──────────────────────────────────── ━━ ─────────────────────────── function () payable external
+   │                 │
+   ╰╴                function () payable external
+
+error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │             (this.external_test_function{value: 4} == this.external_test_function{value: 4});
+   │              ┬──────────────────────────────────── ━━ ───────────────────────────────────── function () payable external
+   │              │
+   ╰╴             function () payable external
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() external payable fn = this.external_test_function{value: 4};
+   ╰╴                                         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ expected `function () payable external`, found `function () payable external`
+
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
    │
@@ -162,5 +184,5 @@ error: mismatched types
 LL │         function() pure external g = this.h;
    ╰╴                                     ━━━━━━ expected `function () pure external`, found `function () view external`
 
-error: aborting due to 25 previous errors
+error: aborting due to 28 previous errors
 

--- a/tests/ui/typeck/implicit_function_ptr.stderr
+++ b/tests/ui/typeck/implicit_function_ptr.stderr
@@ -125,16 +125,38 @@ LL │         return (this.external_test_function{value: 4} == this.external_te
 error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
    │
-LL │             (this.external_test_function{value: 4} == this.external_test_function{value: 4});
-   │              ┬──────────────────────────────────── ━━ ───────────────────────────────────── function () payable external
+LL │ …     (this.external_test_function{value: 4} == this.external_test_function{value: 4}) &&
+   │        ┬──────────────────────────────────── ━━ ───────────────────────────────────── function () payable external
+   │        │
+   ╰╴       function () payable external
+
+error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │             ((this.external_test_function{value: 4}) == this.external_test_function) &&
+   │              ┬────────────────────────────────────── ━━ ─────────────────────────── function () payable external
    │              │
    ╰╴             function () payable external
+
+error: cannot apply builtin operator `==` to `function () payable external` and `function () payable external`
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │ …     (this.external_test_function{value: 4} == (this.external_test_function{value: 4}));
+   │        ┬──────────────────────────────────── ━━ ─────────────────────────────────────── function () payable external
+   │        │
+   ╰╴       function () payable external
 
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
    │
 LL │         function() external payable fn = this.external_test_function{value: 4};
    ╰╴                                         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ expected `function () payable external`, found `function () payable external`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
+   │
+LL │         function() external payable fn2 = (this.external_test_function{value: 4});
+   ╰╴                                           ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ expected `function () payable external`, found `function () payable external`
 
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_function_ptr.sol:LL:CC
@@ -184,5 +206,5 @@ error: mismatched types
 LL │         function() pure external g = this.h;
    ╰╴                                     ━━━━━━ expected `function () pure external`, found `function () view external`
 
-error: aborting due to 28 previous errors
+error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Exposes contract and library function members through contract-type lookup while preserving the invocation kind carried by those values. Contract-type declarations remain selector-only declaration values instead of callable external functions, and public library members are represented as delegatecall-style library values so they expose selectors without converting to ordinary external function pointers.

Call-option checking now uses that kind information for the cases that need it: creation calls preserve payable constructors, low-level address call/delegatecall/staticcall builtins accept valid call options, and invalid declaration calls through contract type names are rejected during type checking.

The ported UI coverage follows the Solidity corpus cases for contract type function members, library function selectors, function pointer compatibility, constructor call options, invalid new targets, low-level call options, and calls via contract type names.
