### PR TITLE
fixup: fix codegen for evm

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -106,7 +106,7 @@ fn run_default(compiler: &mut CompilerRef<'_>) -> Result {
 
     // Handle MIR emit if requested (does not require bytecode generation).
     if sess.opts.emit.contains(&CompilerOutput::Mir) {
-        emit_mir(compiler);
+        emit_mir(compiler)?;
     }
 
     // Handle bytecode emit if requested
@@ -124,7 +124,7 @@ fn run_default(compiler: &mut CompilerRef<'_>) -> Result {
 }
 
 /// Emit textual MIR for all contracts using solar-codegen.
-fn emit_mir(compiler: &mut CompilerRef<'_>) {
+fn emit_mir(compiler: &mut CompilerRef<'_>) -> Result {
     use solar_codegen::{lower, mir::module_to_text};
 
     let gcx = compiler.gcx();
@@ -135,10 +135,13 @@ fn emit_mir(compiler: &mut CompilerRef<'_>) {
             continue;
         }
         let module = lower::lower_contract(gcx, id);
+        gcx.dcx().has_errors()?;
         let name = gcx.contract_fully_qualified_name(id);
         println!("// === {name} ===");
         println!("{}", module_to_text(&module));
     }
+
+    Ok(())
 }
 
 /// Emit bytecode (and optionally ABI/hashes) for all contracts using solar-codegen.
@@ -162,6 +165,7 @@ fn emit_bytecode(compiler: &mut CompilerRef<'_>) -> Result {
         let contract = gcx.hir.contract(id);
         if !contract.kind.is_interface() && !contract.kind.is_abstract_contract() {
             let mut module = lower::lower_contract(gcx, id);
+            gcx.dcx().has_errors()?;
             let mut codegen = EvmCodegen::new();
             let (deployment_bytecode, _) = codegen.generate_deployment_bytecode(&mut module);
             all_bytecodes.insert(id, deployment_bytecode);
@@ -198,6 +202,7 @@ fn emit_bytecode(compiler: &mut CompilerRef<'_>) -> Result {
         if !contract.kind.is_interface() && !contract.kind.is_abstract_contract() {
             // Lower to MIR with all bytecodes available
             let mut module = lower::lower_contract_with_bytecodes(gcx, id, &all_bytecodes);
+            gcx.dcx().has_errors()?;
 
             // Generate bytecode
             let mut codegen = EvmCodegen::new();

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -10,15 +10,18 @@ use crate::{
     analysis::{CopyDest, CopySource, Liveness, ParallelCopy, eliminate_phis},
     codegen::{
         assembler::{Assembler, Label, opcodes},
-        stack::{ScheduledOp, StackOp, StackScheduler},
+        stack::{ScheduledOp, SpillSlot, StackOp, StackScheduler},
     },
-    mir::{BlockId, Function, InstKind, MirType, Module, Terminator, ValueId},
+    mir::{BlockId, Function, FunctionId, InstKind, MirType, Module, Terminator, ValueId},
     pass::{
         AnalysisManager, CfgSimplifyPass, DcePass, JumpThreadingPass, LivenessAnalysis, PassManager,
     },
 };
 use alloy_primitives::U256;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+const INTERNAL_FRAME_PTR_SLOT: u64 = 0x2000;
+const FREE_MEMORY_START: u64 = 0x4000;
 
 /// Describes the stack effect of an EVM instruction.
 /// This is used to keep the scheduler's stack model in sync with the actual EVM stack.
@@ -50,6 +53,10 @@ pub struct EvmCodegen {
     scheduler: StackScheduler,
     /// Block labels.
     block_labels: FxHashMap<BlockId, Label>,
+    /// Function labels for direct internal calls.
+    function_labels: FxHashMap<FunctionId, Label>,
+    /// Per-function local frame sizes for direct internal calls.
+    function_frame_sizes: FxHashMap<FunctionId, u64>,
     /// Copies to insert at block exits (from phi elimination).
     block_copies: FxHashMap<BlockId, Vec<ParallelCopy>>,
     /// Whether we're currently generating constructor code.
@@ -57,6 +64,8 @@ pub struct EvmCodegen {
     in_constructor: bool,
     /// Number of constructor parameters (used for CODECOPY offset calculation).
     constructor_param_count: u32,
+    /// Whether we're emitting an internal function body.
+    in_internal_function: bool,
 }
 
 impl EvmCodegen {
@@ -67,9 +76,12 @@ impl EvmCodegen {
             asm: Assembler::new(),
             scheduler: StackScheduler::new(),
             block_labels: FxHashMap::default(),
+            function_labels: FxHashMap::default(),
+            function_frame_sizes: FxHashMap::default(),
             block_copies: FxHashMap::default(),
             in_constructor: false,
             constructor_param_count: 0,
+            in_internal_function: false,
         }
     }
 
@@ -242,8 +254,8 @@ impl EvmCodegen {
             self.block_labels.clear();
             self.block_copies.clear();
 
-            // Initialize free memory pointer: MSTORE(0x40, 0x80)
-            self.asm.emit_push(U256::from(0x80));
+            // Initialize free memory pointer above compiler-reserved scratch/local space.
+            self.asm.emit_push(U256::from(FREE_MEMORY_START));
             self.asm.emit_push(U256::from(0x40));
             self.asm.emit_op(opcodes::MSTORE);
 
@@ -366,10 +378,12 @@ impl EvmCodegen {
     fn generate_runtime_code(&mut self, module: &Module) -> Vec<u8> {
         self.asm = Assembler::new();
         self.block_labels.clear();
+        self.function_labels.clear();
+        self.function_frame_sizes.clear();
         self.block_copies.clear();
 
-        // Initialize free memory pointer: MSTORE(0x40, 0x80)
-        self.asm.emit_push(U256::from(0x80));
+        // Initialize free memory pointer above compiler-reserved scratch/local space.
+        self.asm.emit_push(U256::from(FREE_MEMORY_START));
         self.asm.emit_push(U256::from(0x40));
         self.asm.emit_op(opcodes::MSTORE);
 
@@ -400,14 +414,33 @@ impl EvmCodegen {
         let receive_idx = module.functions.iter().position(|f| f.attributes.is_receive);
         let fallback_idx = module.functions.iter().position(|f| f.attributes.is_fallback);
 
-        // Create labels only for externally reachable runtime entry points. Internal functions are
-        // inlined during lowering, so emitting their standalone bodies just bloats bytecode.
-        let mut func_labels: Vec<Option<Label>> = Vec::new();
+        let mut internal_targets = FxHashSet::default();
         for func in module.functions.iter() {
-            let reachable = func.selector.is_some()
+            for inst in func.instructions.iter() {
+                if let InstKind::InternalCall { function, .. } = &inst.kind {
+                    internal_targets.insert(*function);
+                }
+            }
+        }
+
+        for (func_id, func) in module.functions.iter_enumerated() {
+            self.function_frame_sizes
+                .insert(func_id, func.internal_frame_size + Self::spill_frame_size(func));
+        }
+
+        // Create labels for externally reachable runtime entry points and internal-call targets.
+        let mut func_labels: Vec<Option<Label>> = Vec::new();
+        for (func_id, func) in module.functions.iter_enumerated() {
+            let external = func.selector.is_some()
                 || func.attributes.is_receive
                 || func.attributes.is_fallback;
-            func_labels.push(reachable.then(|| self.asm.new_label()));
+            let needs_body = !func.attributes.is_constructor
+                && (external || internal_targets.contains(&func_id));
+            let label = needs_body.then(|| self.asm.new_label());
+            if let Some(label) = label {
+                self.function_labels.insert(func_id, label);
+            }
+            func_labels.push(label);
         }
         let revert_label = self.asm.new_label();
         let has_calldata_label = self.asm.new_label();
@@ -463,8 +496,14 @@ impl EvmCodegen {
             self.asm.emit_op(opcodes::JUMP);
         }
 
-        // Define function entry points
+        // Define external function entry points.
         for (i, func) in module.functions.iter().enumerate() {
+            let external = func.selector.is_some()
+                || func.attributes.is_receive
+                || func.attributes.is_fallback;
+            if !external {
+                continue;
+            }
             let Some(label) = func_labels[i] else { continue };
             self.asm.define_label(label);
             self.asm.emit_op(opcodes::JUMPDEST);
@@ -478,7 +517,25 @@ impl EvmCodegen {
             self.emit_payable_check(func);
 
             // Generate function body
+            self.in_internal_function = false;
             self.generate_function_body(func);
+        }
+
+        // Define internal-call targets once. Calls jump here and return through the frame's
+        // saved return address.
+        for (i, func) in module.functions.iter().enumerate() {
+            let external = func.selector.is_some()
+                || func.attributes.is_receive
+                || func.attributes.is_fallback;
+            if external {
+                continue;
+            }
+            let Some(label) = func_labels[i] else { continue };
+            self.asm.define_label(label);
+            self.asm.emit_op(opcodes::JUMPDEST);
+            self.in_internal_function = true;
+            self.generate_function_body(func);
+            self.in_internal_function = false;
         }
 
         // Revert label
@@ -647,7 +704,7 @@ impl EvmCodegen {
 
             // Store to spill slot: PUSH offset, MSTORE
             // The PUSH creates an untracked stack entry, so we track it as unknown
-            self.asm.emit_push(U256::from(slot.byte_offset()));
+            self.emit_spill_slot_addr(func, slot);
             self.scheduler.stack.push_unknown();
 
             self.asm.emit_op(opcodes::MSTORE);
@@ -1260,6 +1317,26 @@ impl EvmCodegen {
                 );
             }
 
+            InstKind::InternalCall { function, args, returns } => {
+                self.emit_internal_call(
+                    func,
+                    *function,
+                    args,
+                    *returns,
+                    result_value,
+                    liveness,
+                    block,
+                    inst_idx,
+                );
+            }
+
+            InstKind::InternalFrameAddr(offset) => {
+                self.emit_current_internal_frame_addr(*offset);
+                if let Some(result) = result_value {
+                    self.scheduler.stack.push(result);
+                }
+            }
+
             // Log operations
             InstKind::Log0(offset, size) => {
                 // LOG0(offset, size) - stack order: offset on top, then size
@@ -1373,42 +1450,175 @@ impl EvmCodegen {
         }
     }
 
+    fn emit_new_internal_frame_addr(&mut self, offset: u64) {
+        self.asm.emit_push(U256::from(0x40));
+        self.asm.emit_op(opcodes::MLOAD);
+        if offset != 0 {
+            self.asm.emit_push(U256::from(offset));
+            self.asm.emit_op(opcodes::ADD);
+        }
+    }
+
+    fn emit_current_internal_frame_addr(&mut self, offset: u64) {
+        self.asm.emit_push(U256::from(INTERNAL_FRAME_PTR_SLOT));
+        self.asm.emit_op(opcodes::MLOAD);
+        if offset != 0 {
+            self.asm.emit_push(U256::from(offset));
+            self.asm.emit_op(opcodes::ADD);
+        }
+    }
+
+    fn spill_frame_size(func: &Function) -> u64 {
+        func.values.len() as u64 * 32
+    }
+
+    fn emit_spill_slot_addr(&mut self, func: &Function, slot: SpillSlot) {
+        if self.in_internal_function {
+            let spill_base =
+                64 + (func.params.len() as u64) * 32 + (func.returns.len() as u64) * 32;
+            self.emit_current_internal_frame_addr(
+                spill_base + func.internal_frame_size + u64::from(slot.offset) * 32,
+            );
+        } else {
+            self.asm.emit_push(U256::from(slot.byte_offset()));
+        }
+    }
+
+    fn emit_internal_arg_load(&mut self, index: u32) {
+        self.emit_current_internal_frame_addr(64 + u64::from(index) * 32);
+        self.asm.emit_op(opcodes::MLOAD);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_internal_call(
+        &mut self,
+        func: &Function,
+        callee: FunctionId,
+        args: &[ValueId],
+        returns: usize,
+        result: Option<ValueId>,
+        liveness: &Liveness,
+        block: BlockId,
+        inst_idx: usize,
+    ) {
+        let Some(&callee_label) = self.function_labels.get(&callee) else {
+            return;
+        };
+        let return_label = self.asm.new_label();
+        let local_frame_size = self.function_frame_sizes.get(&callee).copied().unwrap_or_default();
+        let frame_size = 64 + ((args.len() + returns) as u64) * 32 + local_frame_size;
+
+        // frame[0] = return label
+        self.asm.emit_push_label(return_label);
+        self.emit_new_internal_frame_addr(0);
+        self.asm.emit_op(opcodes::MSTORE);
+
+        // frame[32] = previous frame pointer
+        self.asm.emit_push(U256::from(INTERNAL_FRAME_PTR_SLOT));
+        self.asm.emit_op(opcodes::MLOAD);
+        self.emit_new_internal_frame_addr(32);
+        self.asm.emit_op(opcodes::MSTORE);
+
+        for (i, &arg) in args.iter().enumerate() {
+            self.emit_value(func, arg);
+            self.emit_new_internal_frame_addr(64 + (i as u64) * 32);
+            self.asm.emit_op(opcodes::MSTORE);
+            self.scheduler.stack.pop();
+        }
+
+        self.spill_live_stack_values(func, liveness, block, inst_idx);
+        self.pop_all_stack_values();
+        self.scheduler.clear_stack();
+
+        // current_frame = frame
+        self.emit_new_internal_frame_addr(0);
+        self.asm.emit_push(U256::from(INTERNAL_FRAME_PTR_SLOT));
+        self.asm.emit_op(opcodes::MSTORE);
+
+        // free_ptr += frame_size
+        self.emit_new_internal_frame_addr(frame_size);
+        self.asm.emit_push(U256::from(0x40));
+        self.asm.emit_op(opcodes::MSTORE);
+
+        self.asm.emit_push_label(callee_label);
+        self.asm.emit_op(opcodes::JUMP);
+
+        self.asm.define_label(return_label);
+        self.asm.emit_op(opcodes::JUMPDEST);
+        self.scheduler.clear_stack();
+
+        if let Some(result) = result
+            && returns > 0
+        {
+            self.emit_current_internal_frame_addr(64 + (args.len() as u64) * 32);
+            self.asm.emit_op(opcodes::MLOAD);
+            self.scheduler.stack.push(result);
+        }
+
+        // Restore the caller frame pointer. If a result is on the stack, this leaves it there.
+        self.emit_current_internal_frame_addr(32);
+        self.asm.emit_op(opcodes::MLOAD);
+        self.asm.emit_push(U256::from(INTERNAL_FRAME_PTR_SLOT));
+        self.asm.emit_op(opcodes::MSTORE);
+    }
+
+    fn spill_live_stack_values(
+        &mut self,
+        func: &Function,
+        liveness: &Liveness,
+        block: BlockId,
+        inst_idx: usize,
+    ) {
+        let stack_values: Vec<_> = self.scheduler.stack.iter().flatten().collect();
+        for value in stack_values {
+            if !liveness.is_dead_after(value, block, inst_idx) {
+                self.spill_value_if_needed(func, value);
+            }
+        }
+    }
+
     /// Emits a value to the stack.
     fn emit_value(&mut self, func: &Function, val: ValueId) {
-        let ops = self.scheduler.ensure_on_top(val, func);
+        let ops = self.scheduler.ensure_on_top(val, func).to_vec();
         for op in ops {
             match op {
                 ScheduledOp::Stack(stack_op) => {
                     self.asm.emit_op(stack_op.opcode());
                 }
                 ScheduledOp::PushImmediate(imm) => {
-                    self.asm.emit_push(*imm);
+                    self.asm.emit_push(imm);
                 }
                 ScheduledOp::LoadSpill(slot) => {
                     // PUSH slot_offset, MLOAD
-                    self.asm.emit_push(U256::from(slot.byte_offset()));
+                    self.emit_spill_slot_addr(func, slot);
                     self.asm.emit_op(opcodes::MLOAD);
                 }
                 ScheduledOp::SaveSpill(slot) => {
                     // PUSH slot_offset, MSTORE
-                    self.asm.emit_push(U256::from(slot.byte_offset()));
+                    self.emit_spill_slot_addr(func, slot);
                     self.asm.emit_op(opcodes::MSTORE);
                 }
                 ScheduledOp::LoadArg(index) => {
-                    let arg_ty = func.params.get(*index as usize).copied();
-                    if self.in_constructor && matches!(arg_ty, Some(MirType::MemPtr)) {
-                        Self::emit_constructor_short_string_arg(&mut self.asm, *index);
+                    let arg_ty = func.params.get(index as usize).copied();
+                    if self.in_internal_function {
+                        self.asm.emit_push(U256::from(INTERNAL_FRAME_PTR_SLOT));
+                        self.asm.emit_op(opcodes::MLOAD);
+                        self.asm.emit_push(U256::from(64 + u64::from(index) * 32));
+                        self.asm.emit_op(opcodes::ADD);
+                        self.asm.emit_op(opcodes::MLOAD);
+                    } else if self.in_constructor && matches!(arg_ty, Some(MirType::MemPtr)) {
+                        Self::emit_constructor_short_string_arg(&mut self.asm, index);
                     } else if self.in_constructor {
                         // Constructor args were copied to memory at 0x80
                         // Load from memory: 0x80 + index * 32
-                        let offset = 0x80 + (*index as u64) * 32;
+                        let offset = 0x80 + (index as u64) * 32;
                         self.asm.emit_push(U256::from(offset));
                         self.asm.emit_op(opcodes::MLOAD);
                     } else {
                         // Runtime function: load from calldata
                         // ABI encoding: selector (4 bytes) + args (32 bytes each)
                         // Offset = 4 + index * 32
-                        let offset = 4 + (*index as u64) * 32;
+                        let offset = 4 + (index as u64) * 32;
                         self.asm.emit_push(U256::from(offset));
                         self.asm.emit_op(opcodes::CALLDATALOAD);
                     }
@@ -1466,7 +1676,9 @@ impl EvmCodegen {
                 }
             }
             crate::mir::Value::Arg { index, .. } => {
-                if self.in_constructor {
+                if self.in_internal_function {
+                    self.emit_internal_arg_load(*index);
+                } else if self.in_constructor {
                     let offset = 0x80 + (*index as u64) * 32;
                     self.asm.emit_push(U256::from(offset));
                     self.asm.emit_op(opcodes::MLOAD);
@@ -1482,7 +1694,7 @@ impl EvmCodegen {
                 // or if they're instruction results that produce fresh values (like GAS, MLOAD)
                 if let Some(slot) = self.scheduler.spills.get(val) {
                     // Load from spill slot
-                    self.asm.emit_push(U256::from(slot.byte_offset()));
+                    self.emit_spill_slot_addr(func, slot);
                     self.asm.emit_op(opcodes::MLOAD);
                     self.scheduler.stack.push(val);
                 } else {
@@ -1509,6 +1721,10 @@ impl EvmCodegen {
                         }
                         crate::mir::InstKind::CalldataSize => {
                             self.asm.emit_op(opcodes::CALLDATASIZE);
+                            self.scheduler.stack.push(val);
+                        }
+                        crate::mir::InstKind::InternalFrameAddr(offset) => {
+                            self.emit_current_internal_frame_addr(*offset);
                             self.scheduler.stack.push(val);
                         }
                         crate::mir::InstKind::Timestamp => {
@@ -1804,7 +2020,7 @@ impl EvmCodegen {
                 // Spill the value on top of stack to the destination's spill slot
                 // This allows the successor block to reload it
                 let slot = self.scheduler.spills.allocate(*dst_val);
-                self.asm.emit_push(U256::from(slot.byte_offset()));
+                self.emit_spill_slot_addr(func, slot);
                 self.scheduler.stack.push_unknown();
                 self.asm.emit_op(opcodes::MSTORE);
                 self.scheduler.stack.pop(); // pop the untracked offset
@@ -1827,6 +2043,21 @@ impl EvmCodegen {
             self.asm.emit_op(opcodes::POP);
             self.scheduler.stack.pop();
         }
+    }
+
+    fn emit_internal_return(&mut self, func: &Function, values: &[ValueId]) {
+        let return_base = 64 + (func.params.len() as u64) * 32;
+        for (i, &value) in values.iter().enumerate() {
+            self.emit_value(func, value);
+            self.emit_current_internal_frame_addr(return_base + (i as u64) * 32);
+            self.asm.emit_op(opcodes::MSTORE);
+            self.scheduler.stack.pop();
+        }
+
+        self.pop_all_stack_values();
+        self.emit_current_internal_frame_addr(0);
+        self.asm.emit_op(opcodes::MLOAD);
+        self.asm.emit_op(opcodes::JUMP);
     }
 
     /// Generates bytecode for a terminator.
@@ -1892,6 +2123,11 @@ impl EvmCodegen {
             }
 
             Terminator::Return { values } => {
+                if self.in_internal_function {
+                    self.emit_internal_return(func, values);
+                    return;
+                }
+
                 if values.is_empty() {
                     self.asm.emit_push(U256::ZERO);
                     self.asm.emit_push(U256::ZERO);
@@ -1935,7 +2171,11 @@ impl EvmCodegen {
             }
 
             Terminator::Stop => {
-                self.asm.emit_op(opcodes::STOP);
+                if self.in_internal_function {
+                    self.emit_internal_return(func, &[]);
+                } else {
+                    self.asm.emit_op(opcodes::STOP);
+                }
             }
 
             Terminator::SelfDestruct { recipient } => {

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -12,7 +12,7 @@ use crate::{
         assembler::{Assembler, Label, opcodes},
         stack::{ScheduledOp, StackOp, StackScheduler},
     },
-    mir::{BlockId, Function, InstKind, Module, Terminator, ValueId},
+    mir::{BlockId, Function, InstKind, MirType, Module, Terminator, ValueId},
     pass::{
         AnalysisManager, CfgSimplifyPass, DcePass, JumpThreadingPass, LivenessAnalysis, PassManager,
     },
@@ -164,8 +164,22 @@ impl EvmCodegen {
         let runtime_code = self.generate_runtime_code(module);
         let runtime_len = runtime_code.len();
 
-        // Generate constructor initialization code (if any)
-        let constructor_code = self.generate_constructor_code(module);
+        // Generate constructor initialization code (if any). Constructor arguments are appended
+        // after the generated deployment bytecode, so the constructor arg offset depends on the
+        // constructor code length. Iterate until the push widths stabilize.
+        let mut constructor_arg_offset = 0usize;
+        let mut constructor_code =
+            self.generate_constructor_code(module, Some(constructor_arg_offset));
+        for _ in 0..8 {
+            let deploy_code_len =
+                Self::calculate_deploy_code_len(constructor_code.len(), runtime_len);
+            let next_arg_offset = deploy_code_len + runtime_len;
+            if next_arg_offset == constructor_arg_offset {
+                break;
+            }
+            constructor_arg_offset = next_arg_offset;
+            constructor_code = self.generate_constructor_code(module, Some(constructor_arg_offset));
+        }
 
         // Deploy code structure:
         // [constructor_code]    ; run constructor (SSTOREs for initializers)
@@ -177,48 +191,7 @@ impl EvmCodegen {
         // PUSH0                 ; memory offset = 0
         // RETURN                ; return the runtime code
 
-        // Calculate push sizes
-        let len_push_size = if runtime_len == 0 {
-            1 // PUSH0
-        } else if runtime_len <= 0xFF {
-            2 // PUSH1
-        } else if runtime_len <= 0xFFFF {
-            3 // PUSH2
-        } else {
-            4 // PUSH3
-        };
-
-        // We need to calculate deploy_code_len, but it depends on the push size for
-        // deploy_code_len itself (circular). We solve by computing iteratively:
-        // - Start with minimum offset_push_size = 2 (PUSH1 for offset up to 255)
-        // - Compute deploy_code_len
-        // - Adjust offset_push_size if needed
-        //
-        // Return code structure:
-        // 1. PUSH runtime_len     (len_push_size bytes)
-        // 2. DUP1                 (1 byte)
-        // 3. PUSH deploy_code_len (offset_push_size bytes)
-        // 4. PUSH0                (1 byte - memory destination)
-        // 5. CODECOPY             (1 byte)
-        // 6. PUSH0                (1 byte - return offset)
-        // 7. RETURN               (1 byte)
-        // Total: len_push_size + offset_push_size + 5
-
-        // First estimate with PUSH1 for offset (2 bytes)
-        let mut offset_push_size = 2;
-        let mut deploy_code_len = constructor_code.len() + len_push_size + offset_push_size + 5;
-
-        // Check if we need PUSH2 for the offset
-        if deploy_code_len > 255 {
-            offset_push_size = 3; // PUSH2
-            deploy_code_len = constructor_code.len() + len_push_size + offset_push_size + 5;
-        }
-
-        // Check if we need PUSH3 for the offset (very large contracts)
-        if deploy_code_len > 65535 {
-            offset_push_size = 4; // PUSH3
-            deploy_code_len = constructor_code.len() + len_push_size + offset_push_size + 5;
-        }
+        let deploy_code_len = Self::calculate_deploy_code_len(constructor_code.len(), runtime_len);
 
         // Build the deployment bytecode
         let mut deploy_bytecode = Vec::new();
@@ -252,7 +225,11 @@ impl EvmCodegen {
     ///
     /// Constructor arguments are read from the end of the initcode using CODECOPY.
     /// The args are ABI-encoded and appended after the deployment bytecode.
-    fn generate_constructor_code(&mut self, module: &Module) -> Vec<u8> {
+    fn generate_constructor_code(
+        &mut self,
+        module: &Module,
+        constructor_arg_offset: Option<usize>,
+    ) -> Vec<u8> {
         // Find constructor function if it exists
         let constructor = module.functions.iter().find(|f| f.attributes.is_constructor);
 
@@ -274,17 +251,15 @@ impl EvmCodegen {
             self.in_constructor = true;
             self.constructor_param_count = ctor.params.len() as u32;
 
-            // If constructor has parameters, emit code to copy args from code end to memory
-            // Constructor args are appended after bytecode, read via CODECOPY
+            // If constructor has parameters, copy the full ABI-encoded argument blob to memory.
+            // Constructor args are appended after generated deployment bytecode, so the copy size
+            // is `CODESIZE - constructor_arg_offset`.
             if !ctor.params.is_empty() {
-                let args_size = ctor.params.len() * 32;
-                // CODESIZE - args_size = offset where args start
-                // CODECOPY(destOffset=0x80, offset=CODESIZE-args_size, size=args_size)
-                // We use memory starting at 0x80 (after Solidity's scratch space)
-                self.asm.emit_push(U256::from(args_size)); // size
-                self.asm.emit_push(U256::from(args_size)); // for subtraction
+                let arg_offset = constructor_arg_offset.unwrap_or(0);
+                self.asm.emit_push(U256::from(arg_offset));
                 self.asm.emit_op(opcodes::CODESIZE);
-                self.asm.emit_op(opcodes::SUB); // CODESIZE - args_size = offset
+                self.asm.emit_op(opcodes::SUB); // size = CODESIZE - arg_offset
+                self.asm.emit_push(U256::from(arg_offset)); // code offset
                 self.asm.emit_push(U256::from(0x80)); // destOffset in memory
                 self.asm.emit_op(opcodes::CODECOPY);
             }
@@ -335,6 +310,36 @@ impl EvmCodegen {
             bytecode.push(0x5f + num_bytes as u8); // PUSH1 = 0x60, PUSH2 = 0x61, etc.
             bytecode.extend_from_slice(&bytes[first_non_zero..]);
         }
+    }
+
+    fn push_size(value: usize) -> usize {
+        if value == 0 {
+            1
+        } else if value <= 0xFF {
+            2
+        } else if value <= 0xFFFF {
+            3
+        } else {
+            4
+        }
+    }
+
+    fn calculate_deploy_code_len(constructor_len: usize, runtime_len: usize) -> usize {
+        let len_push_size = Self::push_size(runtime_len);
+        let mut offset_push_size = 2;
+        let mut deploy_code_len = constructor_len + len_push_size + offset_push_size + 5;
+
+        if deploy_code_len > 255 {
+            offset_push_size = 3;
+            deploy_code_len = constructor_len + len_push_size + offset_push_size + 5;
+        }
+
+        if deploy_code_len > 65535 {
+            offset_push_size = 4;
+            deploy_code_len = constructor_len + len_push_size + offset_push_size + 5;
+        }
+
+        deploy_code_len
     }
 
     /// Runs optimization passes on all functions in the module via the PassManager.
@@ -395,10 +400,14 @@ impl EvmCodegen {
         let receive_idx = module.functions.iter().position(|f| f.attributes.is_receive);
         let fallback_idx = module.functions.iter().position(|f| f.attributes.is_fallback);
 
-        // Create labels for each function
-        let mut func_labels: Vec<Label> = Vec::new();
-        for _ in module.functions.iter() {
-            func_labels.push(self.asm.new_label());
+        // Create labels only for externally reachable runtime entry points. Internal functions are
+        // inlined during lowering, so emitting their standalone bodies just bloats bytecode.
+        let mut func_labels: Vec<Option<Label>> = Vec::new();
+        for func in module.functions.iter() {
+            let reachable = func.selector.is_some()
+                || func.attributes.is_receive
+                || func.attributes.is_fallback;
+            func_labels.push(reachable.then(|| self.asm.new_label()));
         }
         let revert_label = self.asm.new_label();
         let has_calldata_label = self.asm.new_label();
@@ -412,10 +421,10 @@ impl EvmCodegen {
         // Solidity semantics: if receive exists, call it; else if fallback exists, call it; else
         // revert
         if let Some(recv_idx) = receive_idx {
-            self.asm.emit_push_label(func_labels[recv_idx]);
+            self.asm.emit_push_label(func_labels[recv_idx].expect("receive label missing"));
             self.asm.emit_op(opcodes::JUMP);
         } else if let Some(fb_idx) = fallback_idx {
-            self.asm.emit_push_label(func_labels[fb_idx]);
+            self.asm.emit_push_label(func_labels[fb_idx].expect("fallback label missing"));
             self.asm.emit_op(opcodes::JUMP);
         } else {
             self.asm.emit_push_label(revert_label);
@@ -438,7 +447,7 @@ impl EvmCodegen {
                 self.asm.emit_op(opcodes::dup(1));
                 self.asm.emit_push(U256::from_be_slice(&selector));
                 self.asm.emit_op(opcodes::EQ);
-                self.asm.emit_push_label(func_labels[i]);
+                self.asm.emit_push_label(func_labels[i].expect("selector label missing"));
                 self.asm.emit_op(opcodes::JUMPI);
             }
         }
@@ -447,7 +456,7 @@ impl EvmCodegen {
         if let Some(fb_idx) = fallback_idx {
             // Pop selector and jump to fallback
             self.asm.emit_op(opcodes::POP);
-            self.asm.emit_push_label(func_labels[fb_idx]);
+            self.asm.emit_push_label(func_labels[fb_idx].expect("fallback label missing"));
             self.asm.emit_op(opcodes::JUMP);
         } else {
             self.asm.emit_push_label(revert_label);
@@ -456,7 +465,8 @@ impl EvmCodegen {
 
         // Define function entry points
         for (i, func) in module.functions.iter().enumerate() {
-            self.asm.define_label(func_labels[i]);
+            let Some(label) = func_labels[i] else { continue };
+            self.asm.define_label(label);
             self.asm.emit_op(opcodes::JUMPDEST);
 
             // Pop the selector for regular functions (receive/fallback don't have it on stack)
@@ -1385,7 +1395,10 @@ impl EvmCodegen {
                     self.asm.emit_op(opcodes::MSTORE);
                 }
                 ScheduledOp::LoadArg(index) => {
-                    if self.in_constructor {
+                    let arg_ty = func.params.get(*index as usize).copied();
+                    if self.in_constructor && matches!(arg_ty, Some(MirType::MemPtr)) {
+                        Self::emit_constructor_short_string_arg(&mut self.asm, *index);
+                    } else if self.in_constructor {
                         // Constructor args were copied to memory at 0x80
                         // Load from memory: 0x80 + index * 32
                         let offset = 0x80 + (*index as u64) * 32;
@@ -1402,6 +1415,43 @@ impl EvmCodegen {
                 }
             }
         }
+    }
+
+    /// Emits a constructor dynamic string/bytes argument as a short storage string word.
+    ///
+    /// Constructor args are copied to memory at 0x80 in ABI encoding:
+    /// head[index] = dynamic tail offset, tail = [length][data...].
+    /// The current codegen supports short storage strings (<=31 bytes). Long storage strings need
+    /// separate data-slot handling.
+    fn emit_constructor_short_string_arg(asm: &mut Assembler, index: u32) {
+        let head_offset = 0x80 + (index as u64) * 32;
+        let low_byte_mask = U256::MAX - U256::from(0xffu64);
+
+        // data_ptr = 0x80 + mload(head_offset)
+        asm.emit_push(U256::from(head_offset));
+        asm.emit_op(opcodes::MLOAD);
+        asm.emit_push(U256::from(0x80));
+        asm.emit_op(opcodes::ADD);
+
+        // Stack: data_ptr
+        // Keep data_ptr while loading length and first data word.
+        asm.emit_op(opcodes::dup(1));
+        asm.emit_op(opcodes::MLOAD); // data_ptr, len
+        asm.emit_op(opcodes::dup(2)); // data_ptr, len, data_ptr
+        asm.emit_push(U256::from(32));
+        asm.emit_op(opcodes::ADD);
+        asm.emit_op(opcodes::MLOAD); // data_ptr, len, data_word
+
+        // Clear the low length byte in the data word.
+        asm.emit_push(low_byte_mask);
+        asm.emit_op(opcodes::AND); // data_ptr, len, data_clean
+
+        // Drop data_ptr, then OR data_clean with len * 2.
+        asm.emit_op(opcodes::swap(2)); // data_clean, len, data_ptr
+        asm.emit_op(opcodes::POP); // data_clean, len
+        asm.emit_push(U256::from(1));
+        asm.emit_op(opcodes::SHL); // data_clean, len * 2
+        asm.emit_op(opcodes::OR); // encoded short storage string
     }
 
     /// Emits a value fresh, without trying to DUP from the stack.
@@ -1845,6 +1895,9 @@ impl EvmCodegen {
                 if values.is_empty() {
                     self.asm.emit_push(U256::ZERO);
                     self.asm.emit_push(U256::ZERO);
+                } else if values.len() == 1 && matches!(func.returns.first(), Some(MirType::MemPtr))
+                {
+                    self.emit_short_storage_string_return(func, values[0]);
                 } else if values.len() == 1 {
                     // Single return value - simple case
                     self.emit_value(func, values[0]);
@@ -1894,6 +1947,40 @@ impl EvmCodegen {
                 self.asm.emit_op(opcodes::INVALID);
             }
         }
+    }
+
+    /// Emits ABI return data for a short storage string word.
+    ///
+    /// Input value layout: high bytes contain the left-aligned data, low byte is `len * 2`.
+    /// Output ABI layout for one dynamic string/bytes return:
+    /// `[offset=0x20][length][data-word]`.
+    fn emit_short_storage_string_return(&mut self, func: &Function, value: ValueId) {
+        let low_byte_mask = U256::MAX - U256::from(0xffu64);
+
+        self.emit_value(func, value);
+
+        // length = (encoded & 0xff) >> 1, store at 0x20.
+        self.asm.emit_op(opcodes::dup(1));
+        self.asm.emit_push(U256::from(0xffu64));
+        self.asm.emit_op(opcodes::AND);
+        self.asm.emit_push(U256::from(1));
+        self.asm.emit_op(opcodes::SHR);
+        self.asm.emit_push(U256::from(0x20));
+        self.asm.emit_op(opcodes::MSTORE);
+
+        // data = encoded & !0xff, store at 0x40.
+        self.asm.emit_push(low_byte_mask);
+        self.asm.emit_op(opcodes::AND);
+        self.asm.emit_push(U256::from(0x40));
+        self.asm.emit_op(opcodes::MSTORE);
+
+        // Dynamic ABI head offset.
+        self.asm.emit_push(U256::from(0x20));
+        self.asm.emit_push(U256::ZERO);
+        self.asm.emit_op(opcodes::MSTORE);
+
+        self.asm.emit_push(U256::from(0x60));
+        self.asm.emit_push(U256::ZERO);
     }
 }
 

--- a/crates/codegen/src/codegen/evm.rs
+++ b/crates/codegen/src/codegen/evm.rs
@@ -1630,7 +1630,7 @@ impl EvmCodegen {
     /// Emits a constructor dynamic string/bytes argument as a short storage string word.
     ///
     /// Constructor args are copied to memory at 0x80 in ABI encoding:
-    /// head[index] = dynamic tail offset, tail = [length][data...].
+    /// `head[index] = dynamic tail offset, tail = [length][data...]`.
     /// The current codegen supports short storage strings (<=31 bytes). Long storage strings need
     /// separate data-slot handling.
     fn emit_constructor_short_string_arg(asm: &mut Assembler, index: u32) {

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -102,13 +102,26 @@ impl<'gcx> Lowerer<'gcx> {
                         None => builder.imm_u64(0),
                     };
                     let slot_val = builder.imm_u64(slot);
-                    let computed_slot = self.compute_mapping_slot(builder, index_val, slot_val);
+                    let (key_is_dynamic, value_is_mapping) = {
+                        let var = self.gcx.hir.variable(var_id);
+                        if let hir::TypeKind::Mapping(map) = &var.ty.kind {
+                            (
+                                Self::is_dynamic_mapping_key(&map.key.kind),
+                                matches!(map.value.kind, hir::TypeKind::Mapping(_)),
+                            )
+                        } else {
+                            (false, false)
+                        }
+                    };
+                    let computed_slot = self.compute_mapping_slot_for_index(
+                        builder,
+                        index.as_deref(),
+                        index_val,
+                        slot_val,
+                        key_is_dynamic,
+                    );
 
-                    // Check if this is a nested mapping
-                    let var = self.gcx.hir.variable(var_id);
-                    if let hir::TypeKind::Mapping(map) = &var.ty.kind
-                        && matches!(map.value.kind, hir::TypeKind::Mapping(_))
-                    {
+                    if value_is_mapping {
                         // Nested mapping - return the computed slot for further indexing
                         return computed_slot;
                     }
@@ -165,7 +178,12 @@ impl<'gcx> Lowerer<'gcx> {
                 };
                 let offset_32 = builder.imm_u64(32);
                 let byte_offset = builder.mul(index_val, offset_32);
-                let addr = builder.add(base_val, byte_offset);
+                let data_base = if self.is_dynamic_memory_array_expr(base) {
+                    builder.add(base_val, offset_32)
+                } else {
+                    base_val
+                };
+                let addr = builder.add(data_base, byte_offset);
                 builder.mload(addr)
             }
 
@@ -188,6 +206,23 @@ impl<'gcx> Lowerer<'gcx> {
                     for (i, variant) in enum_def.variants.iter().enumerate() {
                         if variant.name == member.name {
                             return builder.imm_u64(i as u64);
+                        }
+                    }
+                }
+
+                // Handle contract/library constants (e.g. MachineLib.NO_RECOVERY_PC).
+                if let ExprKind::Ident(res_slice) = &base.kind
+                    && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) =
+                        res_slice.first()
+                {
+                    let contract = self.gcx.hir.contract(*contract_id);
+                    for var_id in contract.variables() {
+                        let var = self.gcx.hir.variable(var_id);
+                        if var.is_constant()
+                            && var.name.is_some_and(|name| name.name == member.name)
+                            && let Some(init) = var.initializer
+                        {
+                            return self.lower_expr(builder, init);
                         }
                     }
                 }
@@ -240,6 +275,14 @@ impl<'gcx> Lowerer<'gcx> {
                     return builder.sload(slot_val);
                 }
 
+                // Handle function selector member access: `this.foo.selector`.
+                if member.name == sym::selector
+                    && let ExprKind::Member(receiver, function_name) = &base.kind
+                {
+                    let selector = self.compute_member_selector(receiver, *function_name);
+                    return builder.imm_u256(U256::from(selector) << 224);
+                }
+
                 // Handle address member access: addr.balance
                 if member.name.as_str() == "balance" {
                     let addr = self.lower_expr(builder, base);
@@ -269,7 +312,7 @@ impl<'gcx> Lowerer<'gcx> {
                     // Get the base pointer for the outermost struct
                     let base_ptr = if let Some(offset) = self.get_local_memory_offset(&var_id) {
                         // Variable is stored in local memory slot
-                        let offset_val = builder.imm_u64(offset);
+                        let offset_val = self.local_memory_addr(builder, offset);
                         builder.mload(offset_val)
                     } else if let Some(&val) = self.locals.get(&var_id) {
                         // Variable is an SSA value (pointer to struct)
@@ -409,7 +452,7 @@ impl<'gcx> Lowerer<'gcx> {
 
                     // Check if it's a local variable stored in memory
                     if let Some(offset) = self.get_local_memory_offset(var_id) {
-                        let offset_val = builder.imm_u64(offset);
+                        let offset_val = self.local_memory_addr(builder, offset);
                         return builder.mload(offset_val);
                     }
 
@@ -835,6 +878,12 @@ impl<'gcx> Lowerer<'gcx> {
         builder: &mut FunctionBuilder<'_>,
         args: &CallArgs<'_>,
     ) -> ValueId {
+        let args: Vec<_> = args.exprs().collect();
+        let total_len: u64 =
+            args.iter().map(|arg| self.get_packed_size_from_expr(arg) as u64).sum();
+        let aligned_data_len = total_len.div_ceil(32) * 32;
+        let total_size = 32 + aligned_data_len;
+
         // Get free memory pointer
         let free_mem_ptr_slot = builder.imm_u64(0x40);
         let ptr = builder.mload(free_mem_ptr_slot);
@@ -843,9 +892,33 @@ impl<'gcx> Lowerer<'gcx> {
         let thirty_two = builder.imm_u64(32);
         let data_start = builder.add(ptr, thirty_two);
 
+        // Reserve the output buffer before lowering arguments. Nested calls in arguments may
+        // allocate memory too, and must not reuse/clobber this buffer while it is being filled.
+        let total_size_val = builder.imm_u64(total_size);
+        let new_free_ptr = builder.add(ptr, total_size_val);
+        builder.mstore(free_mem_ptr_slot, new_free_ptr);
+
+        let length = builder.imm_u64(total_len);
+        builder.mstore(ptr, length);
+
         let mut current_offset: u64 = 0;
 
-        for arg in args.exprs() {
+        for arg in args {
+            if let ExprKind::Lit(lit) = &arg.kind
+                && let LitKind::Str(_, bytes, _) = &lit.kind
+            {
+                for chunk in bytes.as_byte_str().chunks(32) {
+                    let mut padded = [0u8; 32];
+                    padded[..chunk.len()].copy_from_slice(chunk);
+                    let val = builder.imm_u256(U256::from_be_bytes(padded));
+                    let offset = builder.imm_u64(current_offset);
+                    let dest = builder.add(data_start, offset);
+                    builder.mstore(dest, val);
+                    current_offset += chunk.len() as u64;
+                }
+                continue;
+            }
+
             let packed_size = self.get_packed_size_from_expr(arg);
             let val = self.lower_expr(builder, arg);
 
@@ -868,17 +941,6 @@ impl<'gcx> Lowerer<'gcx> {
             }
             current_offset += packed_size as u64;
         }
-
-        // Store length at ptr
-        let length = builder.imm_u64(current_offset);
-        builder.mstore(ptr, length);
-
-        // Update free memory pointer: ptr + 32 + ceil(length/32)*32
-        let aligned_data_len = current_offset.div_ceil(32) * 32;
-        let total_size = 32 + aligned_data_len;
-        let total_size_val = builder.imm_u64(total_size);
-        let new_free_ptr = builder.add(ptr, total_size_val);
-        builder.mstore(free_mem_ptr_slot, new_free_ptr);
 
         // Return pointer to the bytes value
         ptr
@@ -914,8 +976,16 @@ impl<'gcx> Lowerer<'gcx> {
                 32
             }
 
-            // For calls, default to 32 bytes (we can't easily determine the return type)
-            ExprKind::Call(_, _, _) => 32,
+            ExprKind::Call(callee, _, _) => {
+                if let ExprKind::Type(ty) = &callee.kind {
+                    return self.get_packed_size_from_hir_type(ty);
+                }
+                32
+            }
+
+            ExprKind::Member(base, member) => {
+                self.get_member_packed_size(base, *member).unwrap_or(32)
+            }
 
             // Default
             _ => 32,
@@ -939,9 +1009,26 @@ impl<'gcx> Lowerer<'gcx> {
                     size.bytes() as usize
                 }
             },
+            TypeKind::Custom(item_id) => match item_id {
+                hir::ItemId::Enum(_) => 1,
+                hir::ItemId::Contract(_) => 20,
+                _ => 32,
+            },
             // Everything else: 32 bytes default
             _ => 32,
         }
+    }
+
+    fn get_member_packed_size(&self, base: &hir::Expr<'_>, member: Ident) -> Option<usize> {
+        let struct_id = self.expr_struct_id(base)?;
+        let strukt = self.gcx.hir.strukt(struct_id);
+        for &field_id in strukt.fields {
+            let field = self.gcx.hir.variable(field_id);
+            if field.name.is_some_and(|name| name.name == member.name) {
+                return Some(self.get_packed_size_from_hir_type(&field.ty));
+            }
+        }
+        None
     }
 
     /// Lowers a unary operation.
@@ -985,7 +1072,7 @@ impl<'gcx> Lowerer<'gcx> {
 
                     // Check if it's a local variable stored in memory
                     if let Some(offset) = self.get_local_memory_offset(var_id) {
-                        let offset_val = builder.imm_u64(offset);
+                        let offset_val = self.local_memory_addr(builder, offset);
                         builder.mstore(offset_val, rhs);
                     } else if self.locals.contains_key(var_id) {
                         // Function parameter - update SSA mapping (shouldn't happen normally)
@@ -1014,7 +1101,14 @@ impl<'gcx> Lowerer<'gcx> {
                         None => builder.imm_u64(0),
                     };
                     let slot_val = builder.imm_u64(slot);
-                    let computed_slot = self.compute_mapping_slot(builder, index_val, slot_val);
+                    let key_is_dynamic = self.mapping_base_has_dynamic_key(base);
+                    let computed_slot = self.compute_mapping_slot_for_index(
+                        builder,
+                        index.as_deref(),
+                        index_val,
+                        slot_val,
+                        key_is_dynamic,
+                    );
                     builder.sstore(computed_slot, rhs);
                     return;
                 }
@@ -1039,7 +1133,12 @@ impl<'gcx> Lowerer<'gcx> {
                 };
                 let offset_32 = builder.imm_u64(32);
                 let byte_offset = builder.mul(index_val, offset_32);
-                let addr = builder.add(base_val, byte_offset);
+                let data_base = if self.is_dynamic_memory_array_expr(base) {
+                    builder.add(base_val, offset_32)
+                } else {
+                    base_val
+                };
+                let addr = builder.add(data_base, byte_offset);
                 builder.mstore(addr, rhs);
             }
             ExprKind::Member(base, member) => {
@@ -1069,7 +1168,7 @@ impl<'gcx> Lowerer<'gcx> {
                     // Get the base pointer for the outermost struct
                     let base_ptr = if let Some(offset) = self.get_local_memory_offset(&var_id) {
                         // Variable is stored in local memory slot
-                        let offset_val = builder.imm_u64(offset);
+                        let offset_val = self.local_memory_addr(builder, offset);
                         builder.mload(offset_val)
                     } else if let Some(&val) = self.locals.get(&var_id) {
                         // Variable is an SSA value (pointer to struct)
@@ -1133,6 +1232,9 @@ impl<'gcx> Lowerer<'gcx> {
 
         // Handle `new Contract(args)` - contract creation
         if let ExprKind::New(ty) = &callee.kind {
+            if matches!(ty.kind, hir::TypeKind::Array(_)) {
+                return self.lower_new_array(builder, ty, args);
+            }
             return self.lower_new_contract(builder, ty, args, call_opts);
         }
 
@@ -1204,6 +1306,40 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         builder.imm_u64(0)
+    }
+
+    /// Lowers a `new T[](len)` memory array expression.
+    fn lower_new_array(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: &hir::Type<'_>,
+        args: &CallArgs<'_>,
+    ) -> ValueId {
+        let hir::TypeKind::Array(array) = &ty.kind else {
+            return builder.imm_u64(0);
+        };
+        if array.size.is_some() {
+            return builder.imm_u64(0);
+        }
+
+        let len = args
+            .exprs()
+            .next()
+            .map(|arg| self.lower_expr(builder, arg))
+            .unwrap_or_else(|| builder.imm_u64(0));
+
+        let free_ptr_addr = builder.imm_u64(0x40);
+        let ptr = builder.mload(free_ptr_addr);
+        builder.mstore(ptr, len);
+
+        let word_size = builder.imm_u64(32);
+        let data_size = builder.mul(len, word_size);
+        let total_size = builder.add(data_size, word_size);
+        let new_free_ptr = builder.add(ptr, total_size);
+        let free_ptr_addr = builder.imm_u64(0x40);
+        builder.mstore(free_ptr_addr, new_free_ptr);
+
+        ptr
     }
 
     /// Lowers a `new Contract(args)` expression.
@@ -1317,6 +1453,12 @@ impl<'gcx> Lowerer<'gcx> {
                 let mut exprs = args.exprs();
                 if let Some(first) = exprs.next() {
                     let arg_val = self.lower_expr(builder, first);
+                    if self.is_dynamic_bytes_expr(first) {
+                        let len = builder.mload(arg_val);
+                        let word_size = builder.imm_u64(32);
+                        let data = builder.add(arg_val, word_size);
+                        return builder.keccak256(data, len);
+                    }
                     let ptr = builder.imm_u64(0);
                     builder.mstore(ptr, arg_val);
                     let size = builder.imm_u64(32);
@@ -1878,6 +2020,20 @@ impl<'gcx> Lowerer<'gcx> {
                 }
             }
         }
+
+        if let Some(ty) = self.get_expr_type(base)
+            && let solar_sema::ty::TyKind::Struct(struct_id) = ty.kind
+        {
+            let strukt = self.gcx.hir.strukt(struct_id);
+            for (i, &field_id) in strukt.fields.iter().enumerate() {
+                let field = self.gcx.hir.variable(field_id);
+                if let Some(field_name) = field.name
+                    && field_name.name == member.name
+                {
+                    return Some((struct_id, i));
+                }
+            }
+        }
         None
     }
 
@@ -2319,6 +2475,73 @@ impl<'gcx> Lowerer<'gcx> {
         builder.keccak256(mem_0, size_64)
     }
 
+    fn compute_mapping_slot_for_index(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        index_expr: Option<&hir::Expr<'_>>,
+        key: ValueId,
+        slot: ValueId,
+        key_is_dynamic: bool,
+    ) -> ValueId {
+        if key_is_dynamic && self.is_dynamic_calldata_arg(index_expr) {
+            return self.compute_dynamic_calldata_mapping_slot(builder, key, slot);
+        }
+        self.compute_mapping_slot(builder, key, slot)
+    }
+
+    fn compute_dynamic_calldata_mapping_slot(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        head_offset: ValueId,
+        slot: ValueId,
+    ) -> ValueId {
+        let mem_0 = builder.imm_u64(0);
+        let selector_size = builder.imm_u64(4);
+        let data_head = builder.add(head_offset, selector_size);
+        let len = builder.calldataload(data_head);
+        let word_size = builder.imm_u64(32);
+        let data_start = builder.add(data_head, word_size);
+        builder.calldatacopy(mem_0, data_start, len);
+        builder.mstore(len, slot);
+        let hash_len = builder.add(len, word_size);
+        builder.keccak256(mem_0, hash_len)
+    }
+
+    fn mapping_base_has_dynamic_key(&self, expr: &hir::Expr<'_>) -> bool {
+        let Some((var_id, _)) = self.get_mapping_base_slot(expr) else {
+            return false;
+        };
+        let var = self.gcx.hir.variable(var_id);
+        let hir::TypeKind::Mapping(map) = &var.ty.kind else {
+            return false;
+        };
+        Self::is_dynamic_mapping_key(&map.key.kind)
+    }
+
+    fn is_dynamic_mapping_key(kind: &hir::TypeKind<'_>) -> bool {
+        matches!(
+            kind,
+            hir::TypeKind::Elementary(hir::ElementaryType::String | hir::ElementaryType::Bytes)
+        )
+    }
+
+    fn is_dynamic_calldata_arg(&self, expr: Option<&hir::Expr<'_>>) -> bool {
+        let Some(expr) = expr else {
+            return false;
+        };
+        let ExprKind::Ident(res_slice) = &expr.kind else {
+            return false;
+        };
+        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+            return false;
+        };
+        if !self.locals.contains_key(var_id) || self.get_local_memory_offset(var_id).is_some() {
+            return false;
+        }
+        let var = self.gcx.hir.variable(*var_id);
+        Self::is_dynamic_mapping_key(&var.ty.kind)
+    }
+
     /// Computes the function selector for a member call.
     pub(super) fn compute_member_selector(&self, base: &hir::Expr<'_>, member: Ident) -> u32 {
         // Try to get the type of the base expression and find the function
@@ -2368,13 +2591,10 @@ impl<'gcx> Lowerer<'gcx> {
         // Case 3: base is `this` (Builtin::This)
         if let ExprKind::Ident(res_slice) = &base.kind
             && let Some(hir::Res::Builtin(Builtin::This)) = res_slice.first()
+            && let Some(contract_id) = self.current_contract_id
+            && let Some(sel) = lookup_in_contract(contract_id)
         {
-            // Look up the function in the current contract
-            for contract_id in self.gcx.hir.contract_ids() {
-                if let Some(sel) = lookup_in_contract(contract_id) {
-                    return sel;
-                }
-            }
+            return sel;
         }
 
         // Fallback: compute selector from member name
@@ -2823,6 +3043,18 @@ impl<'gcx> Lowerer<'gcx> {
                 arg_vals.push(self.lower_expr(builder, arg));
             }
 
+            if !self.lowering_constructor
+                && !self.function_returns_memory_reference(func)
+                && !Self::is_simple_return_function(func)
+            {
+                let result_ty = func
+                    .returns
+                    .first()
+                    .map(|&ret_id| self.lower_type_from_var(self.gcx.hir.variable(ret_id)));
+                let mir_id = self.ensure_function_lowered(func_id);
+                return builder.internal_call(mir_id, arg_vals, result_ty);
+            }
+
             if func.returns.is_empty() {
                 return self.lower_inline_void_call(builder, func_id, arg_vals);
             }
@@ -2837,6 +3069,13 @@ impl<'gcx> Lowerer<'gcx> {
             // This works for pure functions that don't mutate parameters
             // Save current locals
             let saved_locals = std::mem::take(&mut self.locals);
+            let saved_local_memory_slots = std::mem::take(&mut self.local_memory_slots);
+            let saved_next_local_memory_offset = self.next_local_memory_offset;
+            let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
+
+            if let Some(body) = &func.body {
+                self.collect_assigned_vars_block(body);
+            }
 
             // Bind parameters to argument values directly (SSA style)
             for (i, &param_id) in func.parameters.iter().enumerate() {
@@ -2854,6 +3093,9 @@ impl<'gcx> Lowerer<'gcx> {
 
             // Restore locals
             self.locals = saved_locals;
+            self.local_memory_slots = saved_local_memory_slots;
+            self.next_local_memory_offset = saved_next_local_memory_offset;
+            self.assigned_vars = saved_assigned_vars;
 
             // Exit inline tracking
             self.exit_inline();
@@ -2866,96 +3108,123 @@ impl<'gcx> Lowerer<'gcx> {
         }
     }
 
+    fn function_returns_memory_reference(&self, func: &hir::Function<'_>) -> bool {
+        func.returns.iter().any(|&var_id| {
+            let var = self.gcx.hir.variable(var_id);
+            matches!(self.lower_type_from_var(var), MirType::MemPtr)
+        })
+    }
+
+    fn is_simple_return_function(func: &hir::Function<'_>) -> bool {
+        let Some(body) = func.body else {
+            return false;
+        };
+        body.stmts.iter().any(|stmt| matches!(stmt.kind, hir::StmtKind::Return(Some(_))))
+            && body.stmts.iter().all(|stmt| {
+                matches!(
+                    stmt.kind,
+                    hir::StmtKind::DeclSingle(_)
+                        | hir::StmtKind::Expr(_)
+                        | hir::StmtKind::Return(Some(_))
+                )
+            })
+    }
+
     /// Lowers a simple library function body.
     /// For functions with a single return statement, directly evaluate the return expression.
     fn lower_library_body_simple(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         body: &hir::Block<'_>,
-        _func: &hir::Function<'_>,
+        func: &hir::Function<'_>,
     ) -> ValueId {
-        // Look for a return statement and evaluate its expression
-        for stmt in body.stmts {
-            match &stmt.kind {
-                hir::StmtKind::Return(Some(expr)) => {
-                    return self.lower_expr(builder, expr);
-                }
-                hir::StmtKind::Return(None) => {
-                    return builder.imm_u64(0);
-                }
-                hir::StmtKind::DeclSingle(var_id) => {
-                    // Handle local variable declarations
-                    let var = self.gcx.hir.variable(*var_id);
-                    let init_val = if let Some(init) = var.initializer {
-                        self.lower_expr(builder, init)
-                    } else {
-                        builder.imm_u64(0)
-                    };
-                    self.locals.insert(*var_id, init_val);
-                }
-                hir::StmtKind::Expr(expr) => {
-                    self.lower_expr(builder, expr);
-                }
-                hir::StmtKind::If(cond, then_stmt, else_stmt) => {
-                    // Check if this is an early return pattern: `if (cond) return val;`
-                    // followed by more code (no else branch)
-                    let cond_val = self.lower_expr(builder, cond);
-                    let then_return = self.lower_library_stmt_return(builder, then_stmt);
-
-                    if else_stmt.is_none() && then_return != builder.imm_u64(0) {
-                        // Early return pattern: `if (cond) return val;`
-                        // We need to continue processing remaining statements for the else case
-                        // The remaining statements in the current body are the "else" branch
-                        // We'll process them and create a Select between early return and result
-                        // Store cond and then_return, continue processing remaining stmts
-                        // This is handled by building proper control flow with branches
-                        // For now, use proper branching via lower_if
-                        let then_block = builder.create_block();
-                        let merge_block = builder.create_block();
-
-                        builder.branch(cond_val, then_block, merge_block);
-
-                        // Then block: return the early return value
-                        builder.switch_to_block(then_block);
-                        builder.ret([then_return]);
-
-                        // Merge block: continue with rest of function
-                        builder.switch_to_block(merge_block);
-                        // Continue processing remaining statements (fall through to next iteration)
-                    } else if else_stmt.is_some() {
-                        // If-else: both branches have potential returns
-                        let else_val = self.lower_library_stmt_return(builder, else_stmt.unwrap());
-                        if then_return != builder.imm_u64(0) || else_val != builder.imm_u64(0) {
-                            return builder.select(cond_val, then_return, else_val);
-                        }
-                    }
-                    // If no return in either branch, continue processing
-                }
-                _ => {}
-            }
+        for &return_id in func.returns {
+            let zero = builder.imm_u64(0);
+            self.locals.insert(return_id, zero);
         }
+
+        if let Some(value) = self.lower_library_block_return(builder, body) {
+            return value;
+        }
+
+        if let Some(&return_id) = func.returns.first()
+            && let Some(&value) = self.locals.get(&return_id)
+        {
+            return value;
+        }
+
         builder.imm_u64(0)
     }
 
-    /// Extract return value from a statement (for simple conditional handling).
+    fn lower_library_block_return(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        block: &hir::Block<'_>,
+    ) -> Option<ValueId> {
+        for stmt in block.stmts {
+            if let Some(value) = self.lower_library_stmt_return(builder, stmt) {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    /// Extract return value from a statement after lowering prior side effects in that statement.
     fn lower_library_stmt_return(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         stmt: &hir::Stmt<'_>,
-    ) -> ValueId {
+    ) -> Option<ValueId> {
         match &stmt.kind {
-            hir::StmtKind::Return(Some(expr)) => self.lower_expr(builder, expr),
-            hir::StmtKind::Return(None) => builder.imm_u64(0),
-            hir::StmtKind::Block(block) => {
-                // Recursively process nested blocks
-                for inner_stmt in block.stmts {
-                    if let hir::StmtKind::Return(Some(expr)) = &inner_stmt.kind {
-                        return self.lower_expr(builder, expr);
-                    }
-                }
-                builder.imm_u64(0)
+            hir::StmtKind::Return(Some(expr)) => Some(self.lower_expr(builder, expr)),
+            hir::StmtKind::Return(None) => Some(builder.imm_u64(0)),
+            hir::StmtKind::DeclSingle(var_id) => {
+                let var = self.gcx.hir.variable(*var_id);
+                let init_val = if let Some(init) = var.initializer {
+                    self.lower_expr(builder, init)
+                } else {
+                    builder.imm_u64(0)
+                };
+                self.locals.insert(*var_id, init_val);
+                None
             }
-            _ => builder.imm_u64(0),
+            hir::StmtKind::Expr(expr) => {
+                self.lower_expr(builder, expr);
+                None
+            }
+            hir::StmtKind::Block(block) => self.lower_library_block_return(builder, block),
+            hir::StmtKind::UncheckedBlock(block) => self.lower_library_block_return(builder, block),
+            hir::StmtKind::If(cond, then_stmt, else_stmt) => {
+                let cond_val = self.lower_expr(builder, cond);
+                let then_return = self.lower_library_stmt_return(builder, then_stmt);
+                let else_return =
+                    else_stmt.map(|else_stmt| self.lower_library_stmt_return(builder, else_stmt));
+
+                match (then_return, else_return.flatten()) {
+                    (Some(then_val), Some(else_val)) => {
+                        Some(builder.select(cond_val, then_val, else_val))
+                    }
+                    // A one-sided return is an early-return control-flow shape. This helper
+                    // returns expression values only, so let later statements provide the
+                    // fallthrough value instead of treating the branch as unconditional.
+                    _ => None,
+                }
+            }
+            hir::StmtKind::DeclMulti(vars, rhs) => {
+                self.lower_multi_var_decl(builder, vars, rhs);
+                None
+            }
+            hir::StmtKind::Loop(..)
+            | hir::StmtKind::Emit(_)
+            | hir::StmtKind::Revert(_)
+            | hir::StmtKind::Break
+            | hir::StmtKind::Continue
+            | hir::StmtKind::Try(_)
+            | hir::StmtKind::Placeholder
+            | hir::StmtKind::Err(_) => {
+                self.lower_stmt(builder, stmt);
+                None
+            }
         }
     }
 
@@ -3102,6 +3371,14 @@ impl<'gcx> Lowerer<'gcx> {
                     continue;
                 }
 
+                let Some(&first_param_id) = func.parameters.first() else {
+                    continue;
+                };
+                let first_param = self.gcx.hir.variable(first_param_id);
+                if !self.types_match_for_using(&base_ty, &first_param.ty) {
+                    continue;
+                }
+
                 // Found a matching function
                 return Some(func_id);
             }
@@ -3118,6 +3395,53 @@ impl<'gcx> Lowerer<'gcx> {
         {
             let var = self.gcx.hir.variable(*var_id);
             return Some(self.gcx.type_of_hir_ty(&var.ty));
+        }
+
+        // Case 2: Struct field access - get the declared field type.
+        if let ExprKind::Member(base, member) = &expr.kind
+            && let Some(struct_id) = self.expr_struct_id(base)
+        {
+            let strukt = self.gcx.hir.strukt(struct_id);
+            for &field_id in strukt.fields {
+                let field = self.gcx.hir.variable(field_id);
+                if field.name.is_some_and(|name| name.name == member.name) {
+                    return Some(self.gcx.type_of_hir_ty(&field.ty));
+                }
+            }
+        }
+
+        // Case 3: Array indexing - use the array element type.
+        if let ExprKind::Index(base, _) = &expr.kind
+            && let Some(element_ty) = self.array_element_type(base)
+        {
+            return Some(element_ty);
+        }
+
+        // Case 3: Call result - use the callee's first return type.
+        if let ExprKind::Call(callee, args, _) = &expr.kind {
+            if let ExprKind::Ident(res_slice) = &callee.kind
+                && let Some(hir::Res::Item(hir::ItemId::Function(func_id))) = res_slice.first()
+            {
+                return self.first_return_type(*func_id);
+            }
+
+            if let ExprKind::Member(base, member) = &callee.kind {
+                if let Some(func_id) = self.resolve_using_directive_call(base, member.name) {
+                    return self.first_return_type(func_id);
+                }
+
+                if let ExprKind::Ident(res_slice) = &base.kind
+                    && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) =
+                        res_slice.first()
+                {
+                    let arg_count = args.exprs().count();
+                    if let Some(func_id) =
+                        self.find_library_function(*contract_id, member.name, arg_count)
+                    {
+                        return self.first_return_type(func_id);
+                    }
+                }
+            }
         }
 
         // Case 2: Literal - could be integer, string, etc.
@@ -3142,6 +3466,150 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         None
+    }
+
+    fn array_element_type(&self, expr: &hir::Expr<'_>) -> Option<solar_sema::ty::Ty<'gcx>> {
+        match &expr.kind {
+            ExprKind::Ident(res_slice) => {
+                let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+                    return None;
+                };
+                let var = self.gcx.hir.variable(*var_id);
+                if let hir::TypeKind::Array(array) = &var.ty.kind {
+                    return Some(self.gcx.type_of_hir_ty(&array.element));
+                }
+                None
+            }
+            ExprKind::Member(base, member) => {
+                let struct_id = self.expr_struct_id(base)?;
+                let strukt = self.gcx.hir.strukt(struct_id);
+                for &field_id in strukt.fields {
+                    let field = self.gcx.hir.variable(field_id);
+                    if field.name.is_some_and(|name| name.name == member.name)
+                        && let hir::TypeKind::Array(array) = &field.ty.kind
+                    {
+                        return Some(self.gcx.type_of_hir_ty(&array.element));
+                    }
+                }
+                None
+            }
+            ExprKind::Index(base, _) => {
+                let base_ty = self.array_element_type(base)?;
+                match base_ty.kind {
+                    solar_sema::ty::TyKind::Array(element, _)
+                    | solar_sema::ty::TyKind::DynArray(element) => Some(element),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn first_return_type(&self, func_id: hir::FunctionId) -> Option<solar_sema::ty::Ty<'gcx>> {
+        let func = self.gcx.hir.function(func_id);
+        let ret_id = *func.returns.first()?;
+        let ret = self.gcx.hir.variable(ret_id);
+        Some(self.gcx.type_of_hir_ty(&ret.ty))
+    }
+
+    fn is_dynamic_memory_array_expr(&self, expr: &hir::Expr<'_>) -> bool {
+        match &expr.kind {
+            ExprKind::Ident(res_slice) => {
+                let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+                    return false;
+                };
+                if self.storage_slots.contains_key(var_id) {
+                    return false;
+                }
+                let var = self.gcx.hir.variable(*var_id);
+                matches!(&var.ty.kind, hir::TypeKind::Array(array) if array.size.is_none())
+            }
+            ExprKind::Member(base, member) => {
+                let Some(struct_id) = self.expr_struct_id(base) else {
+                    return false;
+                };
+                let strukt = self.gcx.hir.strukt(struct_id);
+                for &field_id in strukt.fields {
+                    let field = self.gcx.hir.variable(field_id);
+                    if field.name.is_some_and(|name| name.name == member.name) {
+                        return matches!(
+                            &field.ty.kind,
+                            hir::TypeKind::Array(array) if array.size.is_none()
+                        );
+                    }
+                }
+                false
+            }
+            ExprKind::Call(callee, _, _) => {
+                matches!(&callee.kind, ExprKind::New(ty) if matches!(&ty.kind, hir::TypeKind::Array(array) if array.size.is_none()))
+            }
+            _ => false,
+        }
+    }
+
+    fn is_dynamic_bytes_expr(&self, expr: &hir::Expr<'_>) -> bool {
+        match &expr.kind {
+            ExprKind::Ident(res_slice) => {
+                let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+                    return false;
+                };
+                let var = self.gcx.hir.variable(*var_id);
+                matches!(
+                    var.ty.kind,
+                    hir::TypeKind::Elementary(
+                        hir::ElementaryType::String | hir::ElementaryType::Bytes
+                    )
+                )
+            }
+            ExprKind::Call(callee, _, _) => {
+                let ExprKind::Member(base, member) = &callee.kind else {
+                    return false;
+                };
+                let ExprKind::Ident(res_slice) = &base.kind else {
+                    return false;
+                };
+                matches!(res_slice.first(), Some(hir::Res::Builtin(Builtin::Abi)))
+                    && matches!(
+                        member.name.as_str(),
+                        "encode" | "encodePacked" | "encodeWithSelector" | "encodeWithSignature"
+                    )
+            }
+            _ => false,
+        }
+    }
+
+    fn expr_struct_id(&self, expr: &hir::Expr<'_>) -> Option<hir::StructId> {
+        match &expr.kind {
+            ExprKind::Ident(res_slice) => {
+                let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+                    return None;
+                };
+                if self.struct_storage_base_slots.contains_key(var_id) {
+                    return None;
+                }
+                let var = self.gcx.hir.variable(*var_id);
+                if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &var.ty.kind {
+                    Some(*struct_id)
+                } else {
+                    None
+                }
+            }
+            ExprKind::Member(base, member) => {
+                let base_struct_id = self.expr_struct_id(base)?;
+                let strukt = self.gcx.hir.strukt(base_struct_id);
+                for &field_id in strukt.fields {
+                    let field = self.gcx.hir.variable(field_id);
+                    if field.name.is_some_and(|name| name.name == member.name)
+                        && let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) =
+                            &field.ty.kind
+                    {
+                        return Some(*struct_id);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
     }
 
     /// Checks if an expression type matches a using directive target type.

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -411,7 +411,11 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     /// Lowers a literal to a MIR value.
-    fn lower_literal(&mut self, builder: &mut FunctionBuilder<'_>, lit: &hir::Lit<'_>) -> ValueId {
+    pub(super) fn lower_literal(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        lit: &hir::Lit<'_>,
+    ) -> ValueId {
         match &lit.kind {
             LitKind::Bool(b) => builder.imm_bool(*b),
             LitKind::Number(n) => builder.imm_u256(*n),
@@ -1298,14 +1302,87 @@ impl<'gcx> Lowerer<'gcx> {
 
         // Handle Type(expr) where callee is an explicit Type expression
         // e.g., uint256(x), address(y), bytes32(z)
-        if let ExprKind::Type(_ty) = &callee.kind {
-            // Type conversion: return the first argument
-            if let Some(first_arg) = args.exprs().next() {
-                return self.lower_expr(builder, first_arg);
-            }
+        if let ExprKind::Type(ty) = &callee.kind
+            && let Some(first_arg) = args.exprs().next()
+        {
+            let value = self.lower_expr(builder, first_arg);
+            return self.lower_type_conversion(builder, ty, value);
         }
 
         builder.imm_u64(0)
+    }
+
+    fn lower_type_conversion(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: &hir::Type<'_>,
+        value: ValueId,
+    ) -> ValueId {
+        match &ty.kind {
+            hir::TypeKind::Elementary(elem) => {
+                self.lower_elementary_type_conversion(builder, elem, value)
+            }
+            hir::TypeKind::Custom(hir::ItemId::Enum(_)) => self.mask_to_bits(builder, value, 8),
+            _ => value,
+        }
+    }
+
+    fn lower_elementary_type_conversion(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        elem: &ElementaryType,
+        value: ValueId,
+    ) -> ValueId {
+        match elem {
+            ElementaryType::Bool => {
+                let is_zero = builder.iszero(value);
+                builder.iszero(is_zero)
+            }
+            ElementaryType::Address(_) => self.mask_to_bits(builder, value, 160),
+            ElementaryType::UInt(size) => {
+                let bits = size.bits() as u32;
+                self.mask_to_bits(builder, value, bits)
+            }
+            ElementaryType::Int(size) => {
+                let bits = size.bits() as u32;
+                self.sign_extend_to_bits(builder, value, bits)
+            }
+            ElementaryType::FixedBytes(_) => value,
+            ElementaryType::String
+            | ElementaryType::Bytes
+            | ElementaryType::Fixed(_, _)
+            | ElementaryType::UFixed(_, _) => value,
+        }
+    }
+
+    fn mask_to_bits(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        value: ValueId,
+        bits: u32,
+    ) -> ValueId {
+        if bits == 0 || bits >= 256 {
+            return value;
+        }
+
+        let mask = (U256::from(1) << bits) - U256::from(1);
+        let mask = builder.imm_u256(mask);
+        builder.and(value, mask)
+    }
+
+    fn sign_extend_to_bits(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        value: ValueId,
+        bits: u32,
+    ) -> ValueId {
+        if bits == 0 || bits >= 256 {
+            return value;
+        }
+
+        let shift = builder.imm_u64(u64::from(256 - bits));
+        let shifted = builder.shl(shift, value);
+        builder.sar(shift, shifted)
     }
 
     /// Lowers a `new T[](len)` memory array expression.
@@ -3215,6 +3292,7 @@ impl<'gcx> Lowerer<'gcx> {
                 None
             }
             hir::StmtKind::Loop(..)
+            | hir::StmtKind::Assembly(_)
             | hir::StmtKind::Emit(_)
             | hir::StmtKind::Revert(_)
             | hir::StmtKind::Break

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -2651,6 +2651,10 @@ impl<'gcx> Lowerer<'gcx> {
         let arg_vals: Vec<ValueId> =
             args.exprs().map(|arg| self.lower_expr(builder, arg)).collect();
 
+        if func.returns.is_empty() {
+            return self.lower_inline_void_call(builder, func_id, arg_vals);
+        }
+
         // Check for recursive inlining cycle AFTER evaluating arguments
         if !self.try_enter_inline(func_id) {
             // Cycle detected or max depth exceeded - return placeholder
@@ -2683,6 +2687,112 @@ impl<'gcx> Lowerer<'gcx> {
         result
     }
 
+    /// Lowers a base constructor call using already-resolved constructor arguments.
+    pub(super) fn lower_base_constructor_call(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ctor_id: hir::FunctionId,
+        modifier: Option<&hir::Modifier<'_>>,
+    ) -> ValueId {
+        let ctor = self.gcx.hir.function(ctor_id);
+        let arg_exprs: Vec<_> = modifier.map(|m| m.args.exprs().collect()).unwrap_or_default();
+        let arg_vals: Vec<ValueId> = ctor
+            .parameters
+            .iter()
+            .enumerate()
+            .map(|(i, &param_id)| {
+                let param = self.gcx.hir.variable(param_id);
+                if let Some(arg) = arg_exprs.get(i) {
+                    self.lower_constructor_arg(builder, arg, &param.ty)
+                } else {
+                    builder.imm_u64(0)
+                }
+            })
+            .collect();
+
+        self.lower_inline_void_call(builder, ctor_id, arg_vals)
+    }
+
+    /// Lowers a void internal function by inlining its full statement body.
+    fn lower_inline_void_call(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        func_id: hir::FunctionId,
+        arg_vals: Vec<ValueId>,
+    ) -> ValueId {
+        let func = self.gcx.hir.function(func_id);
+        let parameters: Vec<_> = func.parameters.to_vec();
+        let body = func.body;
+
+        if !self.try_enter_inline(func_id) {
+            return builder.imm_u64(0);
+        }
+
+        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_local_memory_slots = std::mem::take(&mut self.local_memory_slots);
+        let saved_next_local_memory_offset = self.next_local_memory_offset;
+        let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
+
+        if let Some(body) = body {
+            self.collect_assigned_vars_block(&body);
+        }
+
+        for (i, param_id) in parameters.into_iter().enumerate() {
+            if let Some(&arg_val) = arg_vals.get(i) {
+                self.locals.insert(param_id, arg_val);
+            }
+        }
+
+        if let Some(body) = body {
+            self.lower_block(builder, &body);
+        }
+
+        self.locals = saved_locals;
+        self.local_memory_slots = saved_local_memory_slots;
+        self.next_local_memory_offset = saved_next_local_memory_offset;
+        self.assigned_vars = saved_assigned_vars;
+        self.exit_inline();
+
+        builder.imm_u64(0)
+    }
+
+    /// Lowers constructor arguments, encoding short string/bytes literals the same way storage
+    /// strings are represented so base constructors like ERC20("Name", "SYM") initialize public
+    /// string slots correctly.
+    fn lower_constructor_arg(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        arg: &hir::Expr<'_>,
+        param_ty: &hir::Type<'_>,
+    ) -> ValueId {
+        if matches!(
+            param_ty.kind,
+            hir::TypeKind::Elementary(hir::ElementaryType::String | hir::ElementaryType::Bytes)
+        ) && let Some(encoded) = Self::short_string_storage_literal(arg)
+        {
+            return builder.imm_u256(encoded);
+        }
+
+        self.lower_expr(builder, arg)
+    }
+
+    fn short_string_storage_literal(arg: &hir::Expr<'_>) -> Option<U256> {
+        let ExprKind::Lit(lit) = &arg.kind else { return None };
+        let LitKind::Str(_, bytes, _) = &lit.kind else { return None };
+        Self::encode_short_storage_bytes(bytes.as_byte_str())
+    }
+
+    fn encode_short_storage_bytes(bytes: &[u8]) -> Option<U256> {
+        if bytes.len() > 31 {
+            return None;
+        }
+
+        let mut encoded = [0u8; 32];
+        encoded[..bytes.len()].copy_from_slice(bytes);
+        encoded[31] = (bytes.len() as u8) * 2;
+        Some(U256::from_be_bytes(encoded))
+    }
+
     /// Lowers an internal library function call by inlining it.
     /// For internal library functions, we inline the function body.
     fn lower_library_call(
@@ -2711,6 +2821,10 @@ impl<'gcx> Lowerer<'gcx> {
             // Lower all explicit arguments
             for arg in args.exprs() {
                 arg_vals.push(self.lower_expr(builder, arg));
+            }
+
+            if func.returns.is_empty() {
+                return self.lower_inline_void_call(builder, func_id, arg_vals);
             }
 
             // Check for recursive inlining cycle AFTER evaluating arguments

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -751,9 +751,12 @@ impl<'gcx> Lowerer<'gcx> {
                 let ret_var = self.gcx.hir.variable(ret_id);
                 let ty = self.lower_type_from_var(ret_var);
                 builder.add_return(ty);
-                // Allocate memory for return variables so they can be assigned to
-                // within the function body (e.g., `liquidity = 1` in if/else branches)
                 let offset = self.alloc_local_memory(ret_id);
+                if ret_var.name.is_none() {
+                    continue;
+                }
+
+                // Named return variables are in-scope locals initialized to zero.
                 let offset_val = self.local_memory_addr(&mut builder, offset);
                 if let hir::TypeKind::Custom(hir::ItemId::Struct(_)) = &ret_var.ty.kind {
                     let struct_size = self.calculate_memory_words_for_type(&ret_var.ty) * 32;

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -641,6 +641,12 @@ impl<'gcx> Lowerer<'gcx> {
                 self.alloc_local_memory(ret_id);
             }
 
+            if hir_func.kind == hir::FunctionKind::Constructor
+                && let Some(contract_id) = hir_func.contract
+            {
+                self.lower_constructor_prelude(&mut builder, contract_id);
+            }
+
             if let Some(body) = &hir_func.body {
                 self.lower_block(&mut builder, body);
             }
@@ -668,6 +674,52 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         self.module.add_function(mir_func)
+    }
+
+    /// Lowers state-variable initializers and base constructors for an explicit constructor.
+    fn lower_constructor_prelude(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        contract_id: ContractId,
+    ) {
+        let contract = self.gcx.hir.contract(contract_id);
+
+        // Solidity runs construction from base to derived. For each contract in that order,
+        // initialize its state variables, then run its constructor body. The current contract's
+        // own constructor body is lowered by the caller after this prelude.
+        let construction_order: Vec<_> = contract
+            .linearized_bases
+            .iter()
+            .enumerate()
+            .map(|(idx, &base_id)| {
+                let args = idx.checked_sub(1).and_then(|arg_idx| {
+                    contract.linearized_bases_args.get(arg_idx).and_then(|m| *m)
+                });
+                (base_id, args)
+            })
+            .collect();
+
+        for (base_id, args) in construction_order.into_iter().rev() {
+            let base_contract = self.gcx.hir.contract(base_id);
+            for var_id in base_contract.variables() {
+                let var = self.gcx.hir.variable(var_id);
+                if var.is_state_variable()
+                    && !var.is_constant()
+                    && let Some(init) = var.initializer
+                    && let Some(&slot) = self.storage_slots.get(&var_id)
+                {
+                    let init_val = self.lower_expr(builder, init);
+                    let slot_val = builder.imm_u64(slot);
+                    builder.sstore(slot_val, init_val);
+                }
+            }
+
+            if base_id != contract_id
+                && let Some(ctor_id) = base_contract.ctor
+            {
+                self.lower_base_constructor_call(builder, ctor_id, args);
+            }
+        }
     }
 
     /// Computes the 4-byte function selector.

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -476,6 +476,54 @@ impl<'gcx> Lowerer<'gcx> {
         offset
     }
 
+    /// Loads a memory struct as flattened ABI return words.
+    pub(super) fn load_struct_return_values(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        struct_id: hir::StructId,
+        struct_ptr: ValueId,
+    ) -> Vec<ValueId> {
+        let mut values = Vec::new();
+        self.load_struct_return_values_at(builder, struct_id, struct_ptr, 0, &mut values);
+        values
+    }
+
+    fn load_struct_return_values_at(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        struct_id: hir::StructId,
+        struct_ptr: ValueId,
+        base_offset: u64,
+        values: &mut Vec<ValueId>,
+    ) -> u64 {
+        let strukt = self.gcx.hir.strukt(struct_id);
+        let mut offset = base_offset;
+
+        for &field_id in strukt.fields {
+            let field = self.gcx.hir.variable(field_id);
+            if let hir::TypeKind::Custom(hir::ItemId::Struct(inner_struct_id)) = &field.ty.kind {
+                offset = self.load_struct_return_values_at(
+                    builder,
+                    *inner_struct_id,
+                    struct_ptr,
+                    offset,
+                    values,
+                );
+            } else {
+                let field_ptr = if offset == 0 {
+                    struct_ptr
+                } else {
+                    let offset_val = builder.imm_u64(offset);
+                    builder.add(struct_ptr, offset_val)
+                };
+                values.push(builder.mload(field_ptr));
+                offset += 32;
+            }
+        }
+
+        offset
+    }
+
     /// Recursively copies a struct from storage to memory.
     /// Handles nested structs by flattening them into contiguous memory.
     /// Returns the next memory offset after all fields are copied.
@@ -705,7 +753,16 @@ impl<'gcx> Lowerer<'gcx> {
                 builder.add_return(ty);
                 // Allocate memory for return variables so they can be assigned to
                 // within the function body (e.g., `liquidity = 1` in if/else branches)
-                self.alloc_local_memory(ret_id);
+                let offset = self.alloc_local_memory(ret_id);
+                let offset_val = self.local_memory_addr(&mut builder, offset);
+                if let hir::TypeKind::Custom(hir::ItemId::Struct(_)) = &ret_var.ty.kind {
+                    let struct_size = self.calculate_memory_words_for_type(&ret_var.ty) * 32;
+                    let struct_ptr = self.allocate_memory(&mut builder, struct_size);
+                    builder.mstore(offset_val, struct_ptr);
+                } else {
+                    let zero = builder.imm_u256(U256::ZERO);
+                    builder.mstore(offset_val, zero);
+                }
             }
 
             if hir_func.kind == hir::FunctionKind::Constructor
@@ -723,18 +780,29 @@ impl<'gcx> Lowerer<'gcx> {
                     builder.stop();
                 } else {
                     // Load return values from memory (where they were stored during execution)
-                    let ret_vals: Vec<ValueId> = hir_func
-                        .returns
-                        .iter()
-                        .map(|&ret_id| {
-                            if let Some(offset) = self.get_local_memory_offset(&ret_id) {
-                                let offset_val = self.local_memory_addr(&mut builder, offset);
-                                builder.mload(offset_val)
-                            } else {
-                                builder.imm_u256(U256::ZERO)
-                            }
-                        })
-                        .collect();
+                    let mut ret_vals = Vec::new();
+                    for &ret_id in hir_func.returns {
+                        let ret_var = self.gcx.hir.variable(ret_id);
+                        let ret_val = if let Some(offset) = self.get_local_memory_offset(&ret_id) {
+                            let offset_val = self.local_memory_addr(&mut builder, offset);
+                            builder.mload(offset_val)
+                        } else {
+                            builder.imm_u256(U256::ZERO)
+                        };
+
+                        if uses_external_abi
+                            && let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) =
+                                &ret_var.ty.kind
+                        {
+                            ret_vals.extend(self.load_struct_return_values(
+                                &mut builder,
+                                *struct_id,
+                                ret_val,
+                            ));
+                        } else {
+                            ret_vals.push(ret_val);
+                        }
+                    }
                     builder.ret(ret_vals);
                 }
             }
@@ -930,6 +998,9 @@ impl<'gcx> Lowerer<'gcx> {
                     self.collect_assigned_vars_block(&clause.block);
                 }
             }
+            StmtKind::Assembly(assembly) => {
+                self.collect_assigned_vars_yul_block(&assembly.block);
+            }
             StmtKind::DeclSingle(_)
             | StmtKind::DeclMulti(_, _)
             | StmtKind::Return(None)
@@ -937,6 +1008,48 @@ impl<'gcx> Lowerer<'gcx> {
             | StmtKind::Break
             | StmtKind::Placeholder
             | StmtKind::Err(_) => {}
+        }
+    }
+
+    fn collect_assigned_vars_yul_block(&mut self, block: &hir::yul::Block<'_>) {
+        for stmt in block.stmts {
+            self.collect_assigned_vars_yul_stmt(stmt);
+        }
+    }
+
+    fn collect_assigned_vars_yul_stmt(&mut self, stmt: &hir::yul::Stmt<'_>) {
+        use hir::yul::StmtKind;
+        match &stmt.kind {
+            StmtKind::Block(block) => self.collect_assigned_vars_yul_block(block),
+            StmtKind::AssignSingle(path, _) => self.mark_assigned_yul_path(path),
+            StmtKind::AssignMulti(paths, _) => {
+                for path in *paths {
+                    self.mark_assigned_yul_path(path);
+                }
+            }
+            StmtKind::If(_, block) => self.collect_assigned_vars_yul_block(block),
+            StmtKind::For(for_stmt) => {
+                self.collect_assigned_vars_yul_block(&for_stmt.init);
+                self.collect_assigned_vars_yul_block(&for_stmt.step);
+                self.collect_assigned_vars_yul_block(&for_stmt.body);
+            }
+            StmtKind::Switch(switch) => {
+                for case in switch.cases {
+                    self.collect_assigned_vars_yul_block(&case.body);
+                }
+            }
+            StmtKind::FunctionDef(_)
+            | StmtKind::VarDecl(_, _)
+            | StmtKind::Expr(_)
+            | StmtKind::Leave
+            | StmtKind::Break
+            | StmtKind::Continue => {}
+        }
+    }
+
+    fn mark_assigned_yul_path(&mut self, path: &hir::yul::Path<'_>) {
+        if let hir::yul::PathRes::SolidityVariable(var_id) = path.res {
+            self.assigned_vars.insert(var_id);
         }
     }
 

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -11,7 +11,7 @@ use crate::mir::{
 };
 use alloy_primitives::U256;
 use rustc_hash::{FxHashMap, FxHashSet};
-use solar_interface::Ident;
+use solar_interface::{Ident, Symbol};
 use solar_sema::{
     hir::{self, ContractId, FunctionId as HirFunctionId, VariableId},
     ty::Gcx,
@@ -70,6 +70,8 @@ pub struct Lowerer<'gcx> {
     pub struct_field_offsets: FxHashMap<(hir::StructId, usize), u64>,
     /// Cached struct field memory offsets: (struct_type_id, field_index) -> byte offset from base.
     pub struct_field_memory_offsets: FxHashMap<(hir::StructId, usize), u64>,
+    /// Stack of Yul local scopes for inline assembly lowering.
+    yul_scopes: Vec<FxHashMap<Symbol, ValueId>>,
 }
 
 impl<'gcx> Lowerer<'gcx> {
@@ -95,6 +97,7 @@ impl<'gcx> Lowerer<'gcx> {
             struct_storage_base_slots: FxHashMap::default(),
             struct_field_offsets: FxHashMap::default(),
             struct_field_memory_offsets: FxHashMap::default(),
+            yul_scopes: Vec::new(),
         }
     }
 

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -56,6 +56,14 @@ pub struct Lowerer<'gcx> {
     assigned_vars: FxHashSet<VariableId>,
     /// Stack of function IDs currently being inlined (for cycle detection).
     inline_stack: Vec<HirFunctionId>,
+    /// HIR functions already lowered into this MIR module.
+    hir_to_mir_functions: FxHashMap<HirFunctionId, FunctionId>,
+    /// Functions currently being lowered on demand.
+    lowering_functions: FxHashSet<HirFunctionId>,
+    /// Whether the current function body is constructor code.
+    lowering_constructor: bool,
+    /// Whether local memory slots should be addressed through the internal-call frame.
+    lowering_internal_function: bool,
     /// Mapping from struct state variable ID to base storage slot.
     pub struct_storage_base_slots: FxHashMap<VariableId, u64>,
     /// Cached struct field slot offsets: (struct_type_id, field_index) -> slot offset from base.
@@ -80,6 +88,10 @@ impl<'gcx> Lowerer<'gcx> {
             loop_stack: Vec::new(),
             assigned_vars: FxHashSet::default(),
             inline_stack: Vec::new(),
+            hir_to_mir_functions: FxHashMap::default(),
+            lowering_functions: FxHashSet::default(),
+            lowering_constructor: false,
+            lowering_internal_function: false,
             struct_storage_base_slots: FxHashMap::default(),
             struct_field_offsets: FxHashMap::default(),
             struct_field_memory_offsets: FxHashMap::default(),
@@ -103,6 +115,8 @@ impl<'gcx> Lowerer<'gcx> {
 
     /// Maximum inline depth to prevent excessive recursion.
     const MAX_INLINE_DEPTH: usize = 32;
+    /// Historical base used by local memory slots in external function bodies.
+    const LOCAL_MEMORY_BASE: u64 = 0x80;
 
     /// Attempts to enter inlining for a function. Returns false if a cycle is detected
     /// or the max inline depth is exceeded.
@@ -136,6 +150,19 @@ impl<'gcx> Lowerer<'gcx> {
     /// Gets the memory offset for a local variable, if it's stored in memory.
     pub fn get_local_memory_offset(&self, var_id: &VariableId) -> Option<u64> {
         self.local_memory_slots.get(var_id).copied()
+    }
+
+    /// Returns the address for a local memory slot in the current lowering context.
+    pub fn local_memory_addr(&self, builder: &mut FunctionBuilder<'_>, offset: u64) -> ValueId {
+        if self.lowering_internal_function {
+            let header_size = 64;
+            let arg_size = (builder.func().params.len() as u64) * 32;
+            let return_size = (builder.func().returns.len() as u64) * 32;
+            let local_offset = offset.saturating_sub(Self::LOCAL_MEMORY_BASE);
+            builder.internal_frame_addr(header_size + arg_size + return_size + local_offset)
+        } else {
+            builder.imm_u64(offset)
+        }
     }
 
     /// Registers a contract's bytecode for use in `new` expressions.
@@ -179,7 +206,7 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         for func_id in functions {
-            self.lower_function(func_id);
+            self.ensure_function_lowered(func_id);
         }
 
         self.current_contract_id = None;
@@ -302,6 +329,10 @@ impl<'gcx> Lowerer<'gcx> {
 
         {
             let mut builder = FunctionBuilder::new(&mut mir_func);
+            let saved_lowering_constructor = self.lowering_constructor;
+            let saved_lowering_internal_function = self.lowering_internal_function;
+            self.lowering_constructor = true;
+            self.lowering_internal_function = false;
 
             // Initialize each state variable
             for var_id in vars_with_init {
@@ -319,6 +350,8 @@ impl<'gcx> Lowerer<'gcx> {
             }
 
             builder.stop();
+            self.lowering_constructor = saved_lowering_constructor;
+            self.lowering_internal_function = saved_lowering_internal_function;
         }
 
         self.module.add_function(mir_func);
@@ -427,7 +460,7 @@ impl<'gcx> Lowerer<'gcx> {
         }
     }
 
-    /// Gets the memory byte offset for a struct field (flattened for nested structs).
+    /// Gets the memory byte offset for a struct field.
     pub fn get_struct_field_memory_offset(
         &mut self,
         struct_id: hir::StructId,
@@ -437,15 +470,7 @@ impl<'gcx> Lowerer<'gcx> {
             return offset;
         }
 
-        let strukt = self.gcx.hir.strukt(struct_id);
-        let mut offset = 0u64;
-        for (i, &field_id) in strukt.fields.iter().enumerate() {
-            if i == field_index {
-                break;
-            }
-            let field = self.gcx.hir.variable(field_id);
-            offset += self.calculate_memory_words_for_type(&field.ty) * 32;
-        }
+        let offset = (field_index as u64) * 32;
 
         self.struct_field_memory_offsets.insert((struct_id, field_index), offset);
         offset
@@ -553,6 +578,42 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     /// Lowers a function to MIR.
+    pub(super) fn ensure_function_lowered(&mut self, func_id: hir::FunctionId) -> FunctionId {
+        if let Some(&mir_id) = self.hir_to_mir_functions.get(&func_id) {
+            return mir_id;
+        }
+
+        if self.lowering_functions.contains(&func_id) {
+            return self.module.add_function(Function::new(Ident::new(
+                solar_interface::Symbol::intern("_recursive_internal"),
+                solar_interface::Span::DUMMY,
+            )));
+        }
+
+        let saved_locals = std::mem::take(&mut self.locals);
+        let saved_local_memory_slots = std::mem::take(&mut self.local_memory_slots);
+        let saved_next_local_memory_offset = self.next_local_memory_offset;
+        let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
+        let saved_current_contract_id = self.current_contract_id;
+        let saved_lowering_constructor = self.lowering_constructor;
+        let saved_lowering_internal_function = self.lowering_internal_function;
+
+        self.lowering_functions.insert(func_id);
+        self.current_contract_id = self.gcx.hir.function(func_id).contract;
+        let mir_id = self.lower_function(func_id);
+        self.lowering_functions.remove(&func_id);
+
+        self.locals = saved_locals;
+        self.local_memory_slots = saved_local_memory_slots;
+        self.next_local_memory_offset = saved_next_local_memory_offset;
+        self.assigned_vars = saved_assigned_vars;
+        self.current_contract_id = saved_current_contract_id;
+        self.lowering_constructor = saved_lowering_constructor;
+        self.lowering_internal_function = saved_lowering_internal_function;
+
+        mir_id
+    }
+
     fn lower_function(&mut self, func_id: hir::FunctionId) -> FunctionId {
         let hir_func = self.gcx.hir.function(func_id);
 
@@ -578,11 +639,15 @@ impl<'gcx> Lowerer<'gcx> {
         if mir_func.is_public() && !is_special {
             mir_func.selector = Some(self.compute_selector(hir_func));
         }
+        let uses_external_abi = mir_func.is_public() && !is_special;
+        let uses_internal_frame = !uses_external_abi && !is_special;
 
         self.locals.clear();
         self.local_memory_slots.clear();
         self.next_local_memory_offset = 0x80;
         self.assigned_vars.clear();
+        self.lowering_constructor = hir_func.kind == hir::FunctionKind::Constructor;
+        self.lowering_internal_function = uses_internal_frame;
 
         // Pre-analyze function body to find variables that are assigned after declaration.
         // Variables that are only initialized (never reassigned) can stay as SSA values.
@@ -598,7 +663,9 @@ impl<'gcx> Lowerer<'gcx> {
                 let ty = self.lower_type_from_var(param);
 
                 // Check if this is a struct parameter that needs special handling
-                if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &param.ty.kind {
+                if uses_external_abi
+                    && let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &param.ty.kind
+                {
                     // Struct parameters: copy fields from calldata to memory
                     let strukt = self.gcx.hir.strukt(*struct_id);
                     let num_fields = strukt.fields.len();
@@ -661,7 +728,7 @@ impl<'gcx> Lowerer<'gcx> {
                         .iter()
                         .map(|&ret_id| {
                             if let Some(offset) = self.get_local_memory_offset(&ret_id) {
-                                let offset_val = builder.imm_u64(offset);
+                                let offset_val = self.local_memory_addr(&mut builder, offset);
                                 builder.mload(offset_val)
                             } else {
                                 builder.imm_u256(U256::ZERO)
@@ -673,7 +740,16 @@ impl<'gcx> Lowerer<'gcx> {
             }
         }
 
-        self.module.add_function(mir_func)
+        self.lowering_constructor = false;
+        self.lowering_internal_function = false;
+        if uses_internal_frame {
+            mir_func.internal_frame_size =
+                self.next_local_memory_offset.saturating_sub(Self::LOCAL_MEMORY_BASE);
+        }
+
+        let mir_id = self.module.add_function(mir_func);
+        self.hir_to_mir_functions.insert(func_id, mir_id);
+        mir_id
     }
 
     /// Lowers state-variable initializers and base constructors for an explicit constructor.
@@ -777,10 +853,7 @@ impl<'gcx> Lowerer<'gcx> {
                     // Enums are represented as uint8 in ABI encoding
                     "uint8".to_string()
                 }
-                hir::ItemId::Contract(contract_id) => {
-                    let c = self.gcx.hir.contract(*contract_id);
-                    c.name.to_string()
-                }
+                hir::ItemId::Contract(_) => "address".to_string(),
                 _ => "unknown".to_string(),
             },
             hir::TypeKind::Err(_) => "error".to_string(),

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -1,8 +1,9 @@
 //! Statement lowering.
 
 use super::{LoopContext, Lowerer};
-use crate::mir::{FunctionBuilder, ValueId};
+use crate::mir::{BlockId, FunctionBuilder, MirType, Value, ValueId};
 use alloy_primitives::U256;
+use rustc_hash::FxHashMap;
 use solar_interface::{Symbol, kw};
 use solar_sema::hir::{self, StmtKind, yul as hir_yul};
 
@@ -113,20 +114,7 @@ impl<'gcx> Lowerer<'gcx> {
             hir_yul::StmtKind::Expr(expr) => {
                 let _ = self.lower_yul_expr(builder, expr);
             }
-            hir_yul::StmtKind::If(cond, body) => {
-                let then_block = builder.create_block();
-                let cont_block = builder.create_block();
-                let cond = self.lower_yul_expr(builder, cond);
-                builder.branch(cond, then_block, cont_block);
-
-                builder.switch_to_block(then_block);
-                self.lower_yul_block(builder, body);
-                if !builder.func().block(builder.current_block()).is_terminated() {
-                    builder.jump(cont_block);
-                }
-
-                builder.switch_to_block(cont_block);
-            }
+            hir_yul::StmtKind::If(cond, body) => self.lower_yul_if(builder, cond, body),
             hir_yul::StmtKind::VarDecl(names, init) => {
                 let value = init.map(|expr| self.lower_yul_expr(builder, expr));
                 for name in *names {
@@ -134,13 +122,51 @@ impl<'gcx> Lowerer<'gcx> {
                     self.declare_yul_variable(name.name, value);
                 }
             }
-            hir_yul::StmtKind::AssignMulti(_, _)
-            | hir_yul::StmtKind::For(_)
-            | hir_yul::StmtKind::Switch(_)
-            | hir_yul::StmtKind::Leave
-            | hir_yul::StmtKind::Break
-            | hir_yul::StmtKind::Continue
-            | hir_yul::StmtKind::FunctionDef(_) => {}
+            hir_yul::StmtKind::AssignMulti(_, _) => {
+                self.unsupported_yul_stmt(builder, stmt, "multiple assignment");
+            }
+            hir_yul::StmtKind::For(_) => self.unsupported_yul_stmt(builder, stmt, "for statement"),
+            hir_yul::StmtKind::Switch(_) => {
+                self.unsupported_yul_stmt(builder, stmt, "switch statement");
+            }
+            hir_yul::StmtKind::Leave => self.unsupported_yul_stmt(builder, stmt, "leave statement"),
+            hir_yul::StmtKind::Break => self.unsupported_yul_stmt(builder, stmt, "break statement"),
+            hir_yul::StmtKind::Continue => {
+                self.unsupported_yul_stmt(builder, stmt, "continue statement");
+            }
+            hir_yul::StmtKind::FunctionDef(_) => {
+                self.unsupported_yul_stmt(builder, stmt, "function definition");
+            }
+        }
+    }
+
+    fn lower_yul_if(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        cond: &hir_yul::Expr<'_>,
+        body: &hir_yul::Block<'_>,
+    ) {
+        let before_scopes = self.yul_scopes.clone();
+        let cond_block = builder.current_block();
+        let then_block = builder.create_block();
+        let cont_block = builder.create_block();
+        let cond = self.lower_yul_expr(builder, cond);
+        builder.branch(cond, then_block, cont_block);
+
+        builder.switch_to_block(then_block);
+        self.lower_yul_block(builder, body);
+        let then_exit = builder.current_block();
+        let then_reaches_cont = !builder.func().block(then_exit).is_terminated();
+        let then_scopes = self.yul_scopes.clone();
+        if then_reaches_cont {
+            builder.jump(cont_block);
+        }
+
+        builder.switch_to_block(cont_block);
+        if then_reaches_cont {
+            self.merge_yul_if_scopes(builder, cond_block, then_exit, before_scopes, then_scopes);
+        } else {
+            self.yul_scopes = before_scopes;
         }
     }
 
@@ -163,199 +189,214 @@ impl<'gcx> Lowerer<'gcx> {
     ) -> ValueId {
         let args: Vec<_> =
             call.arguments.iter().map(|arg| self.lower_yul_expr(builder, arg)).collect();
+        if let Some(expected) = Self::supported_yul_builtin_arity(call.name.name)
+            && args.len() != expected
+        {
+            self.gcx
+                .dcx()
+                .err(format!(
+                    "wrong number of arguments for Yul builtin `{}`: expected {}, found {}",
+                    call.name.name,
+                    expected,
+                    args.len()
+                ))
+                .span(call.name.span)
+                .emit();
+            return builder.imm_u64(0);
+        }
 
         match call.name.name {
             kw::Add => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.add(a, b)
             }
             kw::Sub => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.sub(a, b)
             }
             kw::Mul => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.mul(a, b)
             }
             kw::Div => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.div(a, b)
             }
             kw::Sdiv => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.sdiv(a, b)
             }
             kw::Mod => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.mod_(a, b)
             }
             kw::Smod => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.smod(a, b)
             }
             kw::Exp => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.exp(a, b)
             }
             kw::And => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.and(a, b)
             }
             kw::Or => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.or(a, b)
             }
             kw::Xor => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.xor(a, b)
             }
             kw::Not => {
-                let a = Self::yul_arg(builder, &args, 0);
+                let a = Self::yul_arg(&args, 0);
                 builder.not(a)
             }
             kw::Shl => {
-                let shift = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let shift = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.shl(shift, value)
             }
             kw::Shr => {
-                let shift = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let shift = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.shr(shift, value)
             }
             kw::Sar => {
-                let shift = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let shift = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.sar(shift, value)
             }
             kw::Lt => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.lt(a, b)
             }
             kw::Slt => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.slt(a, b)
             }
             kw::Gt => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.gt(a, b)
             }
             kw::Sgt => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.sgt(a, b)
             }
             kw::Eq => {
-                let a = Self::yul_arg(builder, &args, 0);
-                let b = Self::yul_arg(builder, &args, 1);
+                let a = Self::yul_arg(&args, 0);
+                let b = Self::yul_arg(&args, 1);
                 builder.eq(a, b)
             }
             kw::Iszero => {
-                let a = Self::yul_arg(builder, &args, 0);
+                let a = Self::yul_arg(&args, 0);
                 builder.iszero(a)
             }
             kw::Byte => {
-                let index = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let index = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 Self::lower_yul_byte(builder, index, value)
             }
             kw::Mload => {
-                let offset = Self::yul_arg(builder, &args, 0);
+                let offset = Self::yul_arg(&args, 0);
                 builder.mload(offset)
             }
             kw::Mstore => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let offset = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.mstore(offset, value);
                 builder.imm_u64(0)
             }
             kw::Mstore8 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let offset = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.mstore8(offset, value);
                 builder.imm_u64(0)
             }
             kw::Msize => builder.msize(),
             kw::Mcopy => {
-                let dest = Self::yul_arg(builder, &args, 0);
-                let src = Self::yul_arg(builder, &args, 1);
-                let len = Self::yul_arg(builder, &args, 2);
+                let dest = Self::yul_arg(&args, 0);
+                let src = Self::yul_arg(&args, 1);
+                let len = Self::yul_arg(&args, 2);
                 builder.mcopy(dest, src, len);
                 builder.imm_u64(0)
             }
             kw::Sload => {
-                let slot = Self::yul_arg(builder, &args, 0);
+                let slot = Self::yul_arg(&args, 0);
                 builder.sload(slot)
             }
             kw::Sstore => {
-                let slot = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let slot = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.sstore(slot, value);
                 builder.imm_u64(0)
             }
             kw::Tload => {
-                let slot = Self::yul_arg(builder, &args, 0);
+                let slot = Self::yul_arg(&args, 0);
                 builder.tload(slot)
             }
             kw::Tstore => {
-                let slot = Self::yul_arg(builder, &args, 0);
-                let value = Self::yul_arg(builder, &args, 1);
+                let slot = Self::yul_arg(&args, 0);
+                let value = Self::yul_arg(&args, 1);
                 builder.tstore(slot, value);
                 builder.imm_u64(0)
             }
             kw::Calldataload => {
-                let offset = Self::yul_arg(builder, &args, 0);
+                let offset = Self::yul_arg(&args, 0);
                 builder.calldataload(offset)
             }
             kw::Calldatasize => builder.calldatasize(),
             kw::Calldatacopy => {
-                let dest = Self::yul_arg(builder, &args, 0);
-                let offset = Self::yul_arg(builder, &args, 1);
-                let size = Self::yul_arg(builder, &args, 2);
+                let dest = Self::yul_arg(&args, 0);
+                let offset = Self::yul_arg(&args, 1);
+                let size = Self::yul_arg(&args, 2);
                 builder.calldatacopy(dest, offset, size);
                 builder.imm_u64(0)
             }
             kw::Extcodesize => {
-                let addr = Self::yul_arg(builder, &args, 0);
+                let addr = Self::yul_arg(&args, 0);
                 builder.extcodesize(addr)
             }
             kw::Extcodecopy => {
-                let addr = Self::yul_arg(builder, &args, 0);
-                let dest = Self::yul_arg(builder, &args, 1);
-                let offset = Self::yul_arg(builder, &args, 2);
-                let size = Self::yul_arg(builder, &args, 3);
+                let addr = Self::yul_arg(&args, 0);
+                let dest = Self::yul_arg(&args, 1);
+                let offset = Self::yul_arg(&args, 2);
+                let size = Self::yul_arg(&args, 3);
                 builder.extcodecopy(addr, dest, offset, size);
                 builder.imm_u64(0)
             }
             kw::Extcodehash => {
-                let addr = Self::yul_arg(builder, &args, 0);
+                let addr = Self::yul_arg(&args, 0);
                 builder.extcodehash(addr)
             }
             kw::Returndatasize => builder.returndatasize(),
             kw::Returndatacopy => {
-                let dest = Self::yul_arg(builder, &args, 0);
-                let offset = Self::yul_arg(builder, &args, 1);
-                let size = Self::yul_arg(builder, &args, 2);
+                let dest = Self::yul_arg(&args, 0);
+                let offset = Self::yul_arg(&args, 1);
+                let size = Self::yul_arg(&args, 2);
                 builder.returndatacopy(dest, offset, size);
                 builder.imm_u64(0)
             }
             kw::Address => builder.address(),
             kw::Balance => {
-                let addr = Self::yul_arg(builder, &args, 0);
+                let addr = Self::yul_arg(&args, 0);
                 builder.balance(addr)
             }
             kw::Selfbalance => builder.selfbalance(),
@@ -364,7 +405,7 @@ impl<'gcx> Lowerer<'gcx> {
             kw::Origin => builder.origin(),
             kw::Gasprice => builder.gasprice(),
             kw::Blockhash => {
-                let block_num = Self::yul_arg(builder, &args, 0);
+                let block_num = Self::yul_arg(&args, 0);
                 builder.blockhash(block_num)
             }
             kw::Coinbase => builder.coinbase(),
@@ -377,98 +418,98 @@ impl<'gcx> Lowerer<'gcx> {
             kw::Basefee => builder.basefee(),
             kw::Blobbasefee => builder.blobbasefee(),
             kw::Blobhash => {
-                let index = Self::yul_arg(builder, &args, 0);
+                let index = Self::yul_arg(&args, 0);
                 builder.blobhash(index)
             }
             kw::Keccak256 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
                 builder.keccak256(offset, size)
             }
             kw::Call => {
-                let gas = Self::yul_arg(builder, &args, 0);
-                let addr = Self::yul_arg(builder, &args, 1);
-                let value = Self::yul_arg(builder, &args, 2);
-                let args_offset = Self::yul_arg(builder, &args, 3);
-                let args_size = Self::yul_arg(builder, &args, 4);
-                let ret_offset = Self::yul_arg(builder, &args, 5);
-                let ret_size = Self::yul_arg(builder, &args, 6);
+                let gas = Self::yul_arg(&args, 0);
+                let addr = Self::yul_arg(&args, 1);
+                let value = Self::yul_arg(&args, 2);
+                let args_offset = Self::yul_arg(&args, 3);
+                let args_size = Self::yul_arg(&args, 4);
+                let ret_offset = Self::yul_arg(&args, 5);
+                let ret_size = Self::yul_arg(&args, 6);
                 builder.call(gas, addr, value, args_offset, args_size, ret_offset, ret_size)
             }
             kw::Staticcall => {
-                let gas = Self::yul_arg(builder, &args, 0);
-                let addr = Self::yul_arg(builder, &args, 1);
-                let args_offset = Self::yul_arg(builder, &args, 2);
-                let args_size = Self::yul_arg(builder, &args, 3);
-                let ret_offset = Self::yul_arg(builder, &args, 4);
-                let ret_size = Self::yul_arg(builder, &args, 5);
+                let gas = Self::yul_arg(&args, 0);
+                let addr = Self::yul_arg(&args, 1);
+                let args_offset = Self::yul_arg(&args, 2);
+                let args_size = Self::yul_arg(&args, 3);
+                let ret_offset = Self::yul_arg(&args, 4);
+                let ret_size = Self::yul_arg(&args, 5);
                 builder.staticcall(gas, addr, args_offset, args_size, ret_offset, ret_size)
             }
             kw::Delegatecall => {
-                let gas = Self::yul_arg(builder, &args, 0);
-                let addr = Self::yul_arg(builder, &args, 1);
-                let args_offset = Self::yul_arg(builder, &args, 2);
-                let args_size = Self::yul_arg(builder, &args, 3);
-                let ret_offset = Self::yul_arg(builder, &args, 4);
-                let ret_size = Self::yul_arg(builder, &args, 5);
+                let gas = Self::yul_arg(&args, 0);
+                let addr = Self::yul_arg(&args, 1);
+                let args_offset = Self::yul_arg(&args, 2);
+                let args_size = Self::yul_arg(&args, 3);
+                let ret_offset = Self::yul_arg(&args, 4);
+                let ret_size = Self::yul_arg(&args, 5);
                 builder.delegatecall(gas, addr, args_offset, args_size, ret_offset, ret_size)
             }
             kw::Create => {
-                let value = Self::yul_arg(builder, &args, 0);
-                let offset = Self::yul_arg(builder, &args, 1);
-                let size = Self::yul_arg(builder, &args, 2);
+                let value = Self::yul_arg(&args, 0);
+                let offset = Self::yul_arg(&args, 1);
+                let size = Self::yul_arg(&args, 2);
                 builder.create(value, offset, size)
             }
             kw::Create2 => {
-                let value = Self::yul_arg(builder, &args, 0);
-                let offset = Self::yul_arg(builder, &args, 1);
-                let size = Self::yul_arg(builder, &args, 2);
-                let salt = Self::yul_arg(builder, &args, 3);
+                let value = Self::yul_arg(&args, 0);
+                let offset = Self::yul_arg(&args, 1);
+                let size = Self::yul_arg(&args, 2);
+                let salt = Self::yul_arg(&args, 3);
                 builder.create2(value, offset, size, salt)
             }
             kw::Log0 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
                 builder.log0(offset, size);
                 builder.imm_u64(0)
             }
             kw::Log1 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
-                let topic1 = Self::yul_arg(builder, &args, 2);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
+                let topic1 = Self::yul_arg(&args, 2);
                 builder.log1(offset, size, topic1);
                 builder.imm_u64(0)
             }
             kw::Log2 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
-                let topic1 = Self::yul_arg(builder, &args, 2);
-                let topic2 = Self::yul_arg(builder, &args, 3);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
+                let topic1 = Self::yul_arg(&args, 2);
+                let topic2 = Self::yul_arg(&args, 3);
                 builder.log2(offset, size, topic1, topic2);
                 builder.imm_u64(0)
             }
             kw::Log3 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
-                let topic1 = Self::yul_arg(builder, &args, 2);
-                let topic2 = Self::yul_arg(builder, &args, 3);
-                let topic3 = Self::yul_arg(builder, &args, 4);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
+                let topic1 = Self::yul_arg(&args, 2);
+                let topic2 = Self::yul_arg(&args, 3);
+                let topic3 = Self::yul_arg(&args, 4);
                 builder.log3(offset, size, topic1, topic2, topic3);
                 builder.imm_u64(0)
             }
             kw::Log4 => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
-                let topic1 = Self::yul_arg(builder, &args, 2);
-                let topic2 = Self::yul_arg(builder, &args, 3);
-                let topic3 = Self::yul_arg(builder, &args, 4);
-                let topic4 = Self::yul_arg(builder, &args, 5);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
+                let topic1 = Self::yul_arg(&args, 2);
+                let topic2 = Self::yul_arg(&args, 3);
+                let topic3 = Self::yul_arg(&args, 4);
+                let topic4 = Self::yul_arg(&args, 5);
                 builder.log4(offset, size, topic1, topic2, topic3, topic4);
                 builder.imm_u64(0)
             }
             kw::Revert => {
-                let offset = Self::yul_arg(builder, &args, 0);
-                let size = Self::yul_arg(builder, &args, 1);
+                let offset = Self::yul_arg(&args, 0);
+                let size = Self::yul_arg(&args, 1);
                 builder.revert(offset, size);
                 builder.imm_u64(0)
             }
@@ -521,8 +562,128 @@ impl<'gcx> Lowerer<'gcx> {
         builder.select(in_range, byte, zero)
     }
 
-    fn yul_arg(builder: &mut FunctionBuilder<'_>, args: &[ValueId], index: usize) -> ValueId {
-        args.get(index).copied().unwrap_or_else(|| builder.imm_u64(0))
+    fn yul_arg(args: &[ValueId], index: usize) -> ValueId {
+        args[index]
+    }
+
+    fn supported_yul_builtin_arity(name: Symbol) -> Option<usize> {
+        Some(match name {
+            kw::Add
+            | kw::Sub
+            | kw::Mul
+            | kw::Div
+            | kw::Sdiv
+            | kw::Mod
+            | kw::Smod
+            | kw::Exp
+            | kw::And
+            | kw::Or
+            | kw::Xor
+            | kw::Shl
+            | kw::Shr
+            | kw::Sar
+            | kw::Lt
+            | kw::Slt
+            | kw::Gt
+            | kw::Sgt
+            | kw::Eq
+            | kw::Byte => 2,
+            kw::Not
+            | kw::Iszero
+            | kw::Mload
+            | kw::Sload
+            | kw::Tload
+            | kw::Calldataload
+            | kw::Extcodesize
+            | kw::Extcodehash
+            | kw::Balance
+            | kw::Blockhash
+            | kw::Blobhash
+            | kw::Pop => 1,
+            kw::Mstore
+            | kw::Mstore8
+            | kw::Sstore
+            | kw::Tstore
+            | kw::Keccak256
+            | kw::Log0
+            | kw::Revert => 2,
+            kw::Mcopy | kw::Calldatacopy | kw::Returndatacopy | kw::Create | kw::Log1 => 3,
+            kw::Extcodecopy | kw::Create2 | kw::Log2 => 4,
+            kw::Log3 => 5,
+            kw::Staticcall | kw::Delegatecall | kw::Log4 => 6,
+            kw::Call => 7,
+            kw::Msize
+            | kw::Calldatasize
+            | kw::Returndatasize
+            | kw::Address
+            | kw::Selfbalance
+            | kw::Caller
+            | kw::Callvalue
+            | kw::Origin
+            | kw::Gasprice
+            | kw::Coinbase
+            | kw::Timestamp
+            | kw::Number
+            | kw::Difficulty
+            | kw::Prevrandao
+            | kw::Gaslimit
+            | kw::Chainid
+            | kw::Gas
+            | kw::Basefee
+            | kw::Blobbasefee
+            | kw::Stop
+            | kw::Invalid => 0,
+            _ => return None,
+        })
+    }
+
+    fn unsupported_yul_stmt(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        stmt: &hir_yul::Stmt<'_>,
+        kind: &str,
+    ) {
+        self.gcx.dcx().err(format!("unsupported Yul {kind}")).span(stmt.span).emit();
+        builder.invalid();
+    }
+
+    fn merge_yul_if_scopes(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        false_pred: BlockId,
+        then_pred: BlockId,
+        before_scopes: Vec<FxHashMap<Symbol, ValueId>>,
+        then_scopes: Vec<FxHashMap<Symbol, ValueId>>,
+    ) {
+        self.yul_scopes = before_scopes;
+        if self.yul_scopes.len() != then_scopes.len() {
+            return;
+        }
+
+        for (scope_idx, then_scope) in then_scopes.iter().enumerate() {
+            for (&name, &then_value) in then_scope {
+                let Some(&before_value) = self.yul_scopes[scope_idx].get(&name) else {
+                    continue;
+                };
+                if before_value == then_value {
+                    continue;
+                }
+
+                let ty = Self::value_ty(builder, before_value);
+                let phi =
+                    builder.phi(ty, vec![(false_pred, before_value), (then_pred, then_value)]);
+                self.yul_scopes[scope_idx].insert(name, phi);
+            }
+        }
+    }
+
+    fn value_ty(builder: &FunctionBuilder<'_>, value: ValueId) -> MirType {
+        match builder.func().value(value) {
+            Value::Inst(inst) => {
+                builder.func().instruction(*inst).result_ty.unwrap_or(MirType::uint256())
+            }
+            value => value.ty(),
+        }
     }
 
     fn enter_yul_scope(&mut self) {
@@ -559,6 +720,14 @@ impl<'gcx> Lowerer<'gcx> {
         }
     }
 
+    fn undefined_yul_variable(&mut self, path: &hir_yul::Path<'_>, name: Symbol) {
+        self.gcx.dcx().err(format!("undefined Yul variable `{name}`")).span(path.span).emit();
+    }
+
+    fn unsupported_yul_path(&mut self, path: &hir_yul::Path<'_>, kind: &str) {
+        self.gcx.dcx().err(format!("unsupported Yul {kind}")).span(path.span).emit();
+    }
+
     fn lower_yul_path(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -573,9 +742,19 @@ impl<'gcx> Lowerer<'gcx> {
                 builder.imm_u64(slot)
             }
             hir_yul::PathRes::StorageOffset(_) => builder.imm_u64(0),
-            hir_yul::PathRes::YulVariable => Self::yul_path_symbol(path)
-                .and_then(|name| self.lookup_yul_variable(name))
-                .unwrap_or_else(|| builder.imm_u64(0)),
+            hir_yul::PathRes::YulVariable => {
+                let Some(name) = Self::yul_path_symbol(path) else {
+                    self.unsupported_yul_path(path, "path expression");
+                    return builder.imm_u64(0);
+                };
+                match self.lookup_yul_variable(name) {
+                    Some(value) => value,
+                    None => {
+                        self.undefined_yul_variable(path, name);
+                        builder.imm_u64(0)
+                    }
+                }
+            }
             hir_yul::PathRes::Err => builder.imm_u64(0),
         }
     }
@@ -610,8 +789,12 @@ impl<'gcx> Lowerer<'gcx> {
     ) {
         match path.res {
             hir_yul::PathRes::YulVariable => {
-                if let Some(name) = Self::yul_path_symbol(path) {
-                    self.assign_yul_variable(name, value);
+                let Some(name) = Self::yul_path_symbol(path) else {
+                    self.unsupported_yul_path(path, "assignment target");
+                    return;
+                };
+                if !self.assign_yul_variable(name, value) {
+                    self.undefined_yul_variable(path, name);
                 }
             }
             hir_yul::PathRes::SolidityVariable(var_id) => {

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -3,7 +3,7 @@
 use super::{LoopContext, Lowerer};
 use crate::mir::{FunctionBuilder, ValueId};
 use alloy_primitives::U256;
-use solar_interface::kw;
+use solar_interface::{Symbol, kw};
 use solar_sema::hir::{self, StmtKind, yul as hir_yul};
 
 impl<'gcx> Lowerer<'gcx> {
@@ -93,9 +93,14 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     fn lower_yul_block(&mut self, builder: &mut FunctionBuilder<'_>, block: &hir_yul::Block<'_>) {
+        self.enter_yul_scope();
         for stmt in block.stmts {
             self.lower_yul_stmt(builder, stmt);
+            if builder.func().block(builder.current_block()).is_terminated() {
+                break;
+            }
         }
+        self.exit_yul_scope();
     }
 
     fn lower_yul_stmt(&mut self, builder: &mut FunctionBuilder<'_>, stmt: &hir_yul::Stmt<'_>) {
@@ -122,8 +127,14 @@ impl<'gcx> Lowerer<'gcx> {
 
                 builder.switch_to_block(cont_block);
             }
-            hir_yul::StmtKind::VarDecl(_, _)
-            | hir_yul::StmtKind::AssignMulti(_, _)
+            hir_yul::StmtKind::VarDecl(names, init) => {
+                let value = init.map(|expr| self.lower_yul_expr(builder, expr));
+                for name in *names {
+                    let value = value.unwrap_or_else(|| builder.imm_u64(0));
+                    self.declare_yul_variable(name.name, value);
+                }
+            }
+            hir_yul::StmtKind::AssignMulti(_, _)
             | hir_yul::StmtKind::For(_)
             | hir_yul::StmtKind::Switch(_)
             | hir_yul::StmtKind::Leave
@@ -174,6 +185,26 @@ impl<'gcx> Lowerer<'gcx> {
                 let b = Self::yul_arg(builder, &args, 1);
                 builder.div(a, b)
             }
+            kw::Sdiv => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.sdiv(a, b)
+            }
+            kw::Mod => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.mod_(a, b)
+            }
+            kw::Smod => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.smod(a, b)
+            }
+            kw::Exp => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.exp(a, b)
+            }
             kw::And => {
                 let a = Self::yul_arg(builder, &args, 0);
                 let b = Self::yul_arg(builder, &args, 1);
@@ -203,15 +234,30 @@ impl<'gcx> Lowerer<'gcx> {
                 let value = Self::yul_arg(builder, &args, 1);
                 builder.shr(shift, value)
             }
+            kw::Sar => {
+                let shift = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.sar(shift, value)
+            }
             kw::Lt => {
                 let a = Self::yul_arg(builder, &args, 0);
                 let b = Self::yul_arg(builder, &args, 1);
                 builder.lt(a, b)
             }
+            kw::Slt => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.slt(a, b)
+            }
             kw::Gt => {
                 let a = Self::yul_arg(builder, &args, 0);
                 let b = Self::yul_arg(builder, &args, 1);
                 builder.gt(a, b)
+            }
+            kw::Sgt => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.sgt(a, b)
             }
             kw::Eq => {
                 let a = Self::yul_arg(builder, &args, 0);
@@ -222,12 +268,295 @@ impl<'gcx> Lowerer<'gcx> {
                 let a = Self::yul_arg(builder, &args, 0);
                 builder.iszero(a)
             }
-            _ => builder.imm_u64(0),
+            kw::Byte => {
+                let index = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                Self::lower_yul_byte(builder, index, value)
+            }
+            kw::Mload => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                builder.mload(offset)
+            }
+            kw::Mstore => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.mstore(offset, value);
+                builder.imm_u64(0)
+            }
+            kw::Mstore8 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.mstore8(offset, value);
+                builder.imm_u64(0)
+            }
+            kw::Msize => builder.msize(),
+            kw::Mcopy => {
+                let dest = Self::yul_arg(builder, &args, 0);
+                let src = Self::yul_arg(builder, &args, 1);
+                let len = Self::yul_arg(builder, &args, 2);
+                builder.mcopy(dest, src, len);
+                builder.imm_u64(0)
+            }
+            kw::Sload => {
+                let slot = Self::yul_arg(builder, &args, 0);
+                builder.sload(slot)
+            }
+            kw::Sstore => {
+                let slot = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.sstore(slot, value);
+                builder.imm_u64(0)
+            }
+            kw::Tload => {
+                let slot = Self::yul_arg(builder, &args, 0);
+                builder.tload(slot)
+            }
+            kw::Tstore => {
+                let slot = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.tstore(slot, value);
+                builder.imm_u64(0)
+            }
+            kw::Calldataload => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                builder.calldataload(offset)
+            }
+            kw::Calldatasize => builder.calldatasize(),
+            kw::Calldatacopy => {
+                let dest = Self::yul_arg(builder, &args, 0);
+                let offset = Self::yul_arg(builder, &args, 1);
+                let size = Self::yul_arg(builder, &args, 2);
+                builder.calldatacopy(dest, offset, size);
+                builder.imm_u64(0)
+            }
+            kw::Extcodesize => {
+                let addr = Self::yul_arg(builder, &args, 0);
+                builder.extcodesize(addr)
+            }
+            kw::Extcodecopy => {
+                let addr = Self::yul_arg(builder, &args, 0);
+                let dest = Self::yul_arg(builder, &args, 1);
+                let offset = Self::yul_arg(builder, &args, 2);
+                let size = Self::yul_arg(builder, &args, 3);
+                builder.extcodecopy(addr, dest, offset, size);
+                builder.imm_u64(0)
+            }
+            kw::Extcodehash => {
+                let addr = Self::yul_arg(builder, &args, 0);
+                builder.extcodehash(addr)
+            }
+            kw::Returndatasize => builder.returndatasize(),
+            kw::Returndatacopy => {
+                let dest = Self::yul_arg(builder, &args, 0);
+                let offset = Self::yul_arg(builder, &args, 1);
+                let size = Self::yul_arg(builder, &args, 2);
+                builder.returndatacopy(dest, offset, size);
+                builder.imm_u64(0)
+            }
+            kw::Address => builder.address(),
+            kw::Balance => {
+                let addr = Self::yul_arg(builder, &args, 0);
+                builder.balance(addr)
+            }
+            kw::Selfbalance => builder.selfbalance(),
+            kw::Caller => builder.caller(),
+            kw::Callvalue => builder.callvalue(),
+            kw::Origin => builder.origin(),
+            kw::Gasprice => builder.gasprice(),
+            kw::Blockhash => {
+                let block_num = Self::yul_arg(builder, &args, 0);
+                builder.blockhash(block_num)
+            }
+            kw::Coinbase => builder.coinbase(),
+            kw::Timestamp => builder.timestamp(),
+            kw::Number => builder.number(),
+            kw::Difficulty | kw::Prevrandao => builder.prevrandao(),
+            kw::Gaslimit => builder.gaslimit(),
+            kw::Chainid => builder.chainid(),
+            kw::Gas => builder.gas(),
+            kw::Basefee => builder.basefee(),
+            kw::Blobbasefee => builder.blobbasefee(),
+            kw::Blobhash => {
+                let index = Self::yul_arg(builder, &args, 0);
+                builder.blobhash(index)
+            }
+            kw::Keccak256 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                builder.keccak256(offset, size)
+            }
+            kw::Call => {
+                let gas = Self::yul_arg(builder, &args, 0);
+                let addr = Self::yul_arg(builder, &args, 1);
+                let value = Self::yul_arg(builder, &args, 2);
+                let args_offset = Self::yul_arg(builder, &args, 3);
+                let args_size = Self::yul_arg(builder, &args, 4);
+                let ret_offset = Self::yul_arg(builder, &args, 5);
+                let ret_size = Self::yul_arg(builder, &args, 6);
+                builder.call(gas, addr, value, args_offset, args_size, ret_offset, ret_size)
+            }
+            kw::Staticcall => {
+                let gas = Self::yul_arg(builder, &args, 0);
+                let addr = Self::yul_arg(builder, &args, 1);
+                let args_offset = Self::yul_arg(builder, &args, 2);
+                let args_size = Self::yul_arg(builder, &args, 3);
+                let ret_offset = Self::yul_arg(builder, &args, 4);
+                let ret_size = Self::yul_arg(builder, &args, 5);
+                builder.staticcall(gas, addr, args_offset, args_size, ret_offset, ret_size)
+            }
+            kw::Delegatecall => {
+                let gas = Self::yul_arg(builder, &args, 0);
+                let addr = Self::yul_arg(builder, &args, 1);
+                let args_offset = Self::yul_arg(builder, &args, 2);
+                let args_size = Self::yul_arg(builder, &args, 3);
+                let ret_offset = Self::yul_arg(builder, &args, 4);
+                let ret_size = Self::yul_arg(builder, &args, 5);
+                builder.delegatecall(gas, addr, args_offset, args_size, ret_offset, ret_size)
+            }
+            kw::Create => {
+                let value = Self::yul_arg(builder, &args, 0);
+                let offset = Self::yul_arg(builder, &args, 1);
+                let size = Self::yul_arg(builder, &args, 2);
+                builder.create(value, offset, size)
+            }
+            kw::Create2 => {
+                let value = Self::yul_arg(builder, &args, 0);
+                let offset = Self::yul_arg(builder, &args, 1);
+                let size = Self::yul_arg(builder, &args, 2);
+                let salt = Self::yul_arg(builder, &args, 3);
+                builder.create2(value, offset, size, salt)
+            }
+            kw::Log0 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                builder.log0(offset, size);
+                builder.imm_u64(0)
+            }
+            kw::Log1 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                let topic1 = Self::yul_arg(builder, &args, 2);
+                builder.log1(offset, size, topic1);
+                builder.imm_u64(0)
+            }
+            kw::Log2 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                let topic1 = Self::yul_arg(builder, &args, 2);
+                let topic2 = Self::yul_arg(builder, &args, 3);
+                builder.log2(offset, size, topic1, topic2);
+                builder.imm_u64(0)
+            }
+            kw::Log3 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                let topic1 = Self::yul_arg(builder, &args, 2);
+                let topic2 = Self::yul_arg(builder, &args, 3);
+                let topic3 = Self::yul_arg(builder, &args, 4);
+                builder.log3(offset, size, topic1, topic2, topic3);
+                builder.imm_u64(0)
+            }
+            kw::Log4 => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                let topic1 = Self::yul_arg(builder, &args, 2);
+                let topic2 = Self::yul_arg(builder, &args, 3);
+                let topic3 = Self::yul_arg(builder, &args, 4);
+                let topic4 = Self::yul_arg(builder, &args, 5);
+                builder.log4(offset, size, topic1, topic2, topic3, topic4);
+                builder.imm_u64(0)
+            }
+            kw::Revert => {
+                let offset = Self::yul_arg(builder, &args, 0);
+                let size = Self::yul_arg(builder, &args, 1);
+                builder.revert(offset, size);
+                builder.imm_u64(0)
+            }
+            kw::Stop => {
+                builder.stop();
+                builder.imm_u64(0)
+            }
+            kw::Invalid => {
+                builder.invalid();
+                builder.imm_u64(0)
+            }
+            kw::Pop => builder.imm_u64(0),
+            _ => {
+                let message = match call.res {
+                    hir_yul::CallRes::Builtin => {
+                        format!("unsupported Yul builtin `{}`", call.name.name)
+                    }
+                    hir_yul::CallRes::Function => {
+                        format!("unsupported Yul function `{}`", call.name.name)
+                    }
+                    hir_yul::CallRes::Unknown => {
+                        format!("undefined Yul function `{}`", call.name.name)
+                    }
+                };
+                self.gcx.dcx().err(message).span(call.name.span).emit();
+                builder.imm_u64(0)
+            }
         }
+    }
+
+    fn lower_yul_byte(
+        builder: &mut FunctionBuilder<'_>,
+        index: ValueId,
+        value: ValueId,
+    ) -> ValueId {
+        let in_range = {
+            let limit = builder.imm_u64(32);
+            builder.lt(index, limit)
+        };
+        let shift = {
+            let last = builder.imm_u64(31);
+            let byte_width = builder.imm_u64(8);
+            let from_right = builder.sub(last, index);
+            builder.mul(from_right, byte_width)
+        };
+        let shifted = builder.shr(shift, value);
+        let mask = builder.imm_u64(0xff);
+        let byte = builder.and(shifted, mask);
+        let zero = builder.imm_u64(0);
+        builder.select(in_range, byte, zero)
     }
 
     fn yul_arg(builder: &mut FunctionBuilder<'_>, args: &[ValueId], index: usize) -> ValueId {
         args.get(index).copied().unwrap_or_else(|| builder.imm_u64(0))
+    }
+
+    fn enter_yul_scope(&mut self) {
+        self.yul_scopes.push(Default::default());
+    }
+
+    fn exit_yul_scope(&mut self) {
+        self.yul_scopes.pop();
+    }
+
+    fn declare_yul_variable(&mut self, name: Symbol, value: ValueId) {
+        let scope = self.yul_scopes.last_mut().expect("missing Yul scope");
+        scope.insert(name, value);
+    }
+
+    fn lookup_yul_variable(&self, name: Symbol) -> Option<ValueId> {
+        self.yul_scopes.iter().rev().find_map(|scope| scope.get(&name).copied())
+    }
+
+    fn assign_yul_variable(&mut self, name: Symbol, value: ValueId) -> bool {
+        for scope in self.yul_scopes.iter_mut().rev() {
+            if let Some(local) = scope.get_mut(&name) {
+                *local = value;
+                return true;
+            }
+        }
+        false
+    }
+
+    fn yul_path_symbol(path: &hir_yul::Path<'_>) -> Option<Symbol> {
+        match path.segments {
+            [ident] => Some(ident.name),
+            _ => None,
+        }
     }
 
     fn lower_yul_path(
@@ -244,7 +573,10 @@ impl<'gcx> Lowerer<'gcx> {
                 builder.imm_u64(slot)
             }
             hir_yul::PathRes::StorageOffset(_) => builder.imm_u64(0),
-            hir_yul::PathRes::YulVariable | hir_yul::PathRes::Err => builder.imm_u64(0),
+            hir_yul::PathRes::YulVariable => Self::yul_path_symbol(path)
+                .and_then(|name| self.lookup_yul_variable(name))
+                .unwrap_or_else(|| builder.imm_u64(0)),
+            hir_yul::PathRes::Err => builder.imm_u64(0),
         }
     }
 
@@ -276,16 +608,26 @@ impl<'gcx> Lowerer<'gcx> {
         path: &hir_yul::Path<'_>,
         value: ValueId,
     ) {
-        if let hir_yul::PathRes::SolidityVariable(var_id) = path.res {
-            if let Some(offset) = self.get_local_memory_offset(&var_id) {
-                let offset_val = self.local_memory_addr(builder, offset);
-                builder.mstore(offset_val, value);
-            } else if let Some(local) = self.locals.get_mut(&var_id) {
-                *local = value;
-            } else if let Some(&slot) = self.storage_slots.get(&var_id) {
-                let slot_val = builder.imm_u64(slot);
-                builder.sstore(slot_val, value);
+        match path.res {
+            hir_yul::PathRes::YulVariable => {
+                if let Some(name) = Self::yul_path_symbol(path) {
+                    self.assign_yul_variable(name, value);
+                }
             }
+            hir_yul::PathRes::SolidityVariable(var_id) => {
+                if let Some(offset) = self.get_local_memory_offset(&var_id) {
+                    let offset_val = self.local_memory_addr(builder, offset);
+                    builder.mstore(offset_val, value);
+                } else if let Some(local) = self.locals.get_mut(&var_id) {
+                    *local = value;
+                } else if let Some(&slot) = self.storage_slots.get(&var_id) {
+                    let slot_val = builder.imm_u64(slot);
+                    builder.sstore(slot_val, value);
+                }
+            }
+            hir_yul::PathRes::StorageSlot(_)
+            | hir_yul::PathRes::StorageOffset(_)
+            | hir_yul::PathRes::Err => {}
         }
     }
 

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -116,6 +116,10 @@ impl<'gcx> Lowerer<'gcx> {
             }
             hir_yul::StmtKind::If(cond, body) => self.lower_yul_if(builder, cond, body),
             hir_yul::StmtKind::VarDecl(names, init) => {
+                if names.len() != 1 {
+                    self.unsupported_yul_stmt(builder, stmt, "multiple variable declaration");
+                    return;
+                }
                 let value = init.map(|expr| self.lower_yul_expr(builder, expr));
                 for name in *names {
                     let value = value.unwrap_or_else(|| builder.imm_u64(0));
@@ -808,9 +812,13 @@ impl<'gcx> Lowerer<'gcx> {
                     builder.sstore(slot_val, value);
                 }
             }
-            hir_yul::PathRes::StorageSlot(_)
-            | hir_yul::PathRes::StorageOffset(_)
-            | hir_yul::PathRes::Err => {}
+            hir_yul::PathRes::StorageSlot(_) => {
+                self.unsupported_yul_path(path, "storage slot assignment target");
+            }
+            hir_yul::PathRes::StorageOffset(_) => {
+                self.unsupported_yul_path(path, "storage offset assignment target");
+            }
+            hir_yul::PathRes::Err => {}
         }
     }
 

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -3,7 +3,8 @@
 use super::{LoopContext, Lowerer};
 use crate::mir::{FunctionBuilder, ValueId};
 use alloy_primitives::U256;
-use solar_sema::hir::{self, StmtKind};
+use solar_interface::kw;
+use solar_sema::hir::{self, StmtKind, yul as hir_yul};
 
 impl<'gcx> Lowerer<'gcx> {
     /// Lowers a block of statements.
@@ -83,7 +84,208 @@ impl<'gcx> Lowerer<'gcx> {
                 self.lower_block(builder, block);
             }
 
+            StmtKind::Assembly(assembly) => {
+                self.lower_yul_block(builder, &assembly.block);
+            }
+
             StmtKind::Err(_) => {}
+        }
+    }
+
+    fn lower_yul_block(&mut self, builder: &mut FunctionBuilder<'_>, block: &hir_yul::Block<'_>) {
+        for stmt in block.stmts {
+            self.lower_yul_stmt(builder, stmt);
+        }
+    }
+
+    fn lower_yul_stmt(&mut self, builder: &mut FunctionBuilder<'_>, stmt: &hir_yul::Stmt<'_>) {
+        match &stmt.kind {
+            hir_yul::StmtKind::Block(block) => self.lower_yul_block(builder, block),
+            hir_yul::StmtKind::AssignSingle(path, expr) => {
+                let value = self.lower_yul_expr(builder, expr);
+                self.assign_yul_path(builder, path, value);
+            }
+            hir_yul::StmtKind::Expr(expr) => {
+                let _ = self.lower_yul_expr(builder, expr);
+            }
+            hir_yul::StmtKind::If(cond, body) => {
+                let then_block = builder.create_block();
+                let cont_block = builder.create_block();
+                let cond = self.lower_yul_expr(builder, cond);
+                builder.branch(cond, then_block, cont_block);
+
+                builder.switch_to_block(then_block);
+                self.lower_yul_block(builder, body);
+                if !builder.func().block(builder.current_block()).is_terminated() {
+                    builder.jump(cont_block);
+                }
+
+                builder.switch_to_block(cont_block);
+            }
+            hir_yul::StmtKind::VarDecl(_, _)
+            | hir_yul::StmtKind::AssignMulti(_, _)
+            | hir_yul::StmtKind::For(_)
+            | hir_yul::StmtKind::Switch(_)
+            | hir_yul::StmtKind::Leave
+            | hir_yul::StmtKind::Break
+            | hir_yul::StmtKind::Continue
+            | hir_yul::StmtKind::FunctionDef(_) => {}
+        }
+    }
+
+    fn lower_yul_expr(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        expr: &hir_yul::Expr<'_>,
+    ) -> ValueId {
+        match &expr.kind {
+            hir_yul::ExprKind::Path(path) => self.lower_yul_path(builder, path),
+            hir_yul::ExprKind::Lit(lit) => self.lower_literal(builder, lit),
+            hir_yul::ExprKind::Call(call) => self.lower_yul_call(builder, call),
+        }
+    }
+
+    fn lower_yul_call(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        call: &hir_yul::ExprCall<'_>,
+    ) -> ValueId {
+        let args: Vec<_> =
+            call.arguments.iter().map(|arg| self.lower_yul_expr(builder, arg)).collect();
+
+        match call.name.name {
+            kw::Add => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.add(a, b)
+            }
+            kw::Sub => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.sub(a, b)
+            }
+            kw::Mul => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.mul(a, b)
+            }
+            kw::Div => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.div(a, b)
+            }
+            kw::And => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.and(a, b)
+            }
+            kw::Or => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.or(a, b)
+            }
+            kw::Xor => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.xor(a, b)
+            }
+            kw::Not => {
+                let a = Self::yul_arg(builder, &args, 0);
+                builder.not(a)
+            }
+            kw::Shl => {
+                let shift = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.shl(shift, value)
+            }
+            kw::Shr => {
+                let shift = Self::yul_arg(builder, &args, 0);
+                let value = Self::yul_arg(builder, &args, 1);
+                builder.shr(shift, value)
+            }
+            kw::Lt => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.lt(a, b)
+            }
+            kw::Gt => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.gt(a, b)
+            }
+            kw::Eq => {
+                let a = Self::yul_arg(builder, &args, 0);
+                let b = Self::yul_arg(builder, &args, 1);
+                builder.eq(a, b)
+            }
+            kw::Iszero => {
+                let a = Self::yul_arg(builder, &args, 0);
+                builder.iszero(a)
+            }
+            _ => builder.imm_u64(0),
+        }
+    }
+
+    fn yul_arg(builder: &mut FunctionBuilder<'_>, args: &[ValueId], index: usize) -> ValueId {
+        args.get(index).copied().unwrap_or_else(|| builder.imm_u64(0))
+    }
+
+    fn lower_yul_path(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        path: &hir_yul::Path<'_>,
+    ) -> ValueId {
+        match path.res {
+            hir_yul::PathRes::SolidityVariable(var_id) => {
+                self.lower_solidity_variable_by_id(builder, var_id)
+            }
+            hir_yul::PathRes::StorageSlot(var_id) => {
+                let slot = self.storage_slots.get(&var_id).copied().unwrap_or(0);
+                builder.imm_u64(slot)
+            }
+            hir_yul::PathRes::StorageOffset(_) => builder.imm_u64(0),
+            hir_yul::PathRes::YulVariable | hir_yul::PathRes::Err => builder.imm_u64(0),
+        }
+    }
+
+    fn lower_solidity_variable_by_id(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        var_id: hir::VariableId,
+    ) -> ValueId {
+        if let Some(&val) = self.locals.get(&var_id) {
+            return val;
+        }
+
+        if let Some(offset) = self.get_local_memory_offset(&var_id) {
+            let offset_val = self.local_memory_addr(builder, offset);
+            return builder.mload(offset_val);
+        }
+
+        if let Some(&slot) = self.storage_slots.get(&var_id) {
+            let slot_val = builder.imm_u64(slot);
+            return builder.sload(slot_val);
+        }
+
+        builder.imm_u64(0)
+    }
+
+    fn assign_yul_path(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        path: &hir_yul::Path<'_>,
+        value: ValueId,
+    ) {
+        if let hir_yul::PathRes::SolidityVariable(var_id) = path.res {
+            if let Some(offset) = self.get_local_memory_offset(&var_id) {
+                let offset_val = self.local_memory_addr(builder, offset);
+                builder.mstore(offset_val, value);
+            } else if let Some(local) = self.locals.get_mut(&var_id) {
+                *local = value;
+            } else if let Some(&slot) = self.storage_slots.get(&var_id) {
+                let slot_val = builder.imm_u64(slot);
+                builder.sstore(slot_val, value);
+            }
         }
     }
 
@@ -136,9 +338,8 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     fn memory_struct_size(&self, ty: &hir::Type<'_>) -> u64 {
-        if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &ty.kind {
-            let strukt = self.gcx.hir.strukt(*struct_id);
-            (strukt.fields.len().max(1) as u64) * 32
+        if matches!(ty.kind, hir::TypeKind::Custom(hir::ItemId::Struct(_))) {
+            self.calculate_memory_words_for_type(ty) * 32
         } else {
             32
         }
@@ -414,14 +615,7 @@ impl<'gcx> Lowerer<'gcx> {
                     && builder.func().is_public()
                 {
                     let struct_ptr = self.lower_expr(builder, expr);
-                    let strukt = self.gcx.hir.strukt(struct_id);
-                    let mut ret_vals = Vec::new();
-                    for i in 0..strukt.fields.len() {
-                        let offset = builder.imm_u64(i as u64 * 32);
-                        let field_ptr = builder.add(struct_ptr, offset);
-                        let field_val = builder.mload(field_ptr);
-                        ret_vals.push(field_val);
-                    }
+                    let ret_vals = self.load_struct_return_values(builder, struct_id, struct_ptr);
                     builder.ret(ret_vals);
                 } else {
                     let ret_val = self.lower_expr(builder, expr);

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -1,7 +1,7 @@
 //! Statement lowering.
 
 use super::{LoopContext, Lowerer};
-use crate::mir::FunctionBuilder;
+use crate::mir::{FunctionBuilder, ValueId};
 use alloy_primitives::U256;
 use solar_sema::hir::{self, StmtKind};
 
@@ -21,7 +21,7 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     /// Lowers a statement to MIR.
-    fn lower_stmt(&mut self, builder: &mut FunctionBuilder<'_>, stmt: &hir::Stmt<'_>) {
+    pub(super) fn lower_stmt(&mut self, builder: &mut FunctionBuilder<'_>, stmt: &hir::Stmt<'_>) {
         match &stmt.kind {
             StmtKind::DeclSingle(var_id) => {
                 self.lower_single_var_decl(builder, *var_id);
@@ -110,23 +110,9 @@ impl<'gcx> Lowerer<'gcx> {
             self.lower_expr(builder, init)
         } else if let hir::TypeKind::Custom(hir::ItemId::Struct(_)) = &var.ty.kind {
             // Struct without initializer: allocate memory and zero-initialize
-            let total_words = self.calculate_memory_words_for_type(&var.ty);
-            let struct_size = total_words * 32;
+            let struct_size = self.memory_struct_size(&var.ty);
             let struct_ptr = self.allocate_memory(builder, struct_size);
-
-            // Zero-initialize all fields
-            for i in 0..total_words {
-                let field_offset = i * 32;
-                if field_offset == 0 {
-                    let zero = builder.imm_u256(U256::ZERO);
-                    builder.mstore(struct_ptr, zero);
-                } else {
-                    let offset_val = builder.imm_u64(field_offset);
-                    let field_addr = builder.add(struct_ptr, offset_val);
-                    let zero = builder.imm_u256(U256::ZERO);
-                    builder.mstore(field_addr, zero);
-                }
-            }
+            self.zero_initialize_memory_value(builder, &var.ty, struct_ptr);
             struct_ptr
         } else {
             builder.imm_u256(U256::ZERO)
@@ -141,7 +127,7 @@ impl<'gcx> Lowerer<'gcx> {
 
         if needs_local_memory {
             let offset = self.alloc_local_memory(var_id);
-            let offset_val = builder.imm_u64(offset);
+            let offset_val = self.local_memory_addr(builder, offset);
             builder.mstore(offset_val, initial_value);
         } else {
             // Variable is never reassigned and not from external call - keep as SSA value
@@ -149,10 +135,67 @@ impl<'gcx> Lowerer<'gcx> {
         }
     }
 
+    fn memory_struct_size(&self, ty: &hir::Type<'_>) -> u64 {
+        if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &ty.kind {
+            let strukt = self.gcx.hir.strukt(*struct_id);
+            (strukt.fields.len().max(1) as u64) * 32
+        } else {
+            32
+        }
+    }
+
+    fn zero_initialize_memory_value(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: &hir::Type<'_>,
+        ptr: ValueId,
+    ) {
+        let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &ty.kind else {
+            let zero = builder.imm_u256(U256::ZERO);
+            builder.mstore(ptr, zero);
+            return;
+        };
+
+        let strukt = self.gcx.hir.strukt(*struct_id);
+        for (i, &field_id) in strukt.fields.iter().enumerate() {
+            let field = self.gcx.hir.variable(field_id);
+            let value = self.zero_memory_field_value(builder, &field.ty);
+            let field_offset = (i as u64) * 32;
+            if field_offset == 0 {
+                builder.mstore(ptr, value);
+            } else {
+                let offset_val = builder.imm_u64(field_offset);
+                let field_addr = builder.add(ptr, offset_val);
+                builder.mstore(field_addr, value);
+            }
+        }
+    }
+
+    fn zero_memory_field_value(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: &hir::Type<'_>,
+    ) -> ValueId {
+        match &ty.kind {
+            hir::TypeKind::Array(array) if array.size.is_none() => {
+                let ptr = self.allocate_memory(builder, 32);
+                let zero = builder.imm_u256(U256::ZERO);
+                builder.mstore(ptr, zero);
+                ptr
+            }
+            hir::TypeKind::Custom(hir::ItemId::Struct(_)) => {
+                let ptr = self.allocate_memory(builder, self.memory_struct_size(ty));
+                self.zero_initialize_memory_value(builder, ty, ptr);
+                ptr
+            }
+            _ => builder.imm_u256(U256::ZERO),
+        }
+    }
+
     /// Lowers a multi-variable declaration.
     /// For external calls with multiple returns, the return data is written to memory
     /// at offsets 0, 32, 64, etc. after the CALL instruction.
-    fn lower_multi_var_decl(
+    pub(super) fn lower_multi_var_decl(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         var_ids: &[Option<hir::VariableId>],
@@ -173,7 +216,7 @@ impl<'gcx> Lowerer<'gcx> {
                 };
                 // Allocate memory slot and store value
                 let offset = self.alloc_local_memory(*var_id);
-                let offset_val = builder.imm_u64(offset);
+                let offset_val = self.local_memory_addr(builder, offset);
                 builder.mstore(offset_val, val);
             }
         }
@@ -367,7 +410,9 @@ impl<'gcx> Lowerer<'gcx> {
             } else {
                 // Check if returning a memory struct - expand to individual fields
                 let struct_type = self.get_return_struct_type(expr);
-                if let Some(struct_id) = struct_type {
+                if let Some(struct_id) = struct_type
+                    && builder.func().is_public()
+                {
                     let struct_ptr = self.lower_expr(builder, expr);
                     let strukt = self.gcx.hir.strukt(struct_id);
                     let mut ret_vals = Vec::new();

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -1,7 +1,8 @@
 //! MIR function builder.
 
 use super::{
-    BlockId, Function, Immediate, InstKind, Instruction, MirType, Terminator, Value, ValueId,
+    BlockId, Function, FunctionId, Immediate, InstKind, Instruction, MirType, Terminator, Value,
+    ValueId,
 };
 use alloy_primitives::U256;
 use smallvec::SmallVec;
@@ -223,6 +224,27 @@ impl<'a> FunctionBuilder<'a> {
     /// Emits a calldatasize instruction.
     pub fn calldatasize(&mut self) -> ValueId {
         self.emit_inst(InstKind::CalldataSize, Some(MirType::uint256()))
+    }
+
+    /// Emits a calldatacopy instruction.
+    pub fn calldatacopy(&mut self, dest: ValueId, offset: ValueId, size: ValueId) -> ValueId {
+        self.emit_inst(InstKind::CalldataCopy(dest, offset, size), None)
+    }
+
+    /// Emits an internal function call.
+    pub fn internal_call(
+        &mut self,
+        function: FunctionId,
+        args: Vec<ValueId>,
+        result_ty: Option<MirType>,
+    ) -> ValueId {
+        let returns = usize::from(result_ty.is_some());
+        self.emit_inst(InstKind::InternalCall { function, args, returns }, result_ty)
+    }
+
+    /// Emits an address inside the current internal-call frame.
+    pub fn internal_frame_addr(&mut self, offset: u64) -> ValueId {
+        self.emit_inst(InstKind::InternalFrameAddr(offset), Some(MirType::MemPtr))
     }
 
     /// Emits a caller instruction.

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -196,6 +196,16 @@ impl<'a> FunctionBuilder<'a> {
         self.emit_inst(InstKind::MStore8(offset, value), None)
     }
 
+    /// Emits an msize instruction.
+    pub fn msize(&mut self) -> ValueId {
+        self.emit_inst(InstKind::MSize, Some(MirType::uint256()))
+    }
+
+    /// Emits an mcopy instruction.
+    pub fn mcopy(&mut self, dest: ValueId, src: ValueId, len: ValueId) -> ValueId {
+        self.emit_inst(InstKind::MCopy(dest, src, len), None)
+    }
+
     /// Emits an sload instruction.
     pub fn sload(&mut self, slot: ValueId) -> ValueId {
         self.emit_inst(InstKind::SLoad(slot), Some(MirType::uint256()))
@@ -231,6 +241,42 @@ impl<'a> FunctionBuilder<'a> {
         self.emit_inst(InstKind::CalldataCopy(dest, offset, size), None)
     }
 
+    /// Emits a codesize instruction.
+    pub fn codesize(&mut self) -> ValueId {
+        self.emit_inst(InstKind::CodeSize, Some(MirType::uint256()))
+    }
+
+    /// Emits an extcodesize instruction.
+    pub fn extcodesize(&mut self, addr: ValueId) -> ValueId {
+        self.emit_inst(InstKind::ExtCodeSize(addr), Some(MirType::uint256()))
+    }
+
+    /// Emits an extcodecopy instruction.
+    pub fn extcodecopy(
+        &mut self,
+        addr: ValueId,
+        dest: ValueId,
+        offset: ValueId,
+        size: ValueId,
+    ) -> ValueId {
+        self.emit_inst(InstKind::ExtCodeCopy(addr, dest, offset, size), None)
+    }
+
+    /// Emits an extcodehash instruction.
+    pub fn extcodehash(&mut self, addr: ValueId) -> ValueId {
+        self.emit_inst(InstKind::ExtCodeHash(addr), Some(MirType::uint256()))
+    }
+
+    /// Emits a returndatasize instruction.
+    pub fn returndatasize(&mut self) -> ValueId {
+        self.emit_inst(InstKind::ReturnDataSize, Some(MirType::uint256()))
+    }
+
+    /// Emits a returndatacopy instruction.
+    pub fn returndatacopy(&mut self, dest: ValueId, offset: ValueId, size: ValueId) -> ValueId {
+        self.emit_inst(InstKind::ReturnDataCopy(dest, offset, size), None)
+    }
+
     /// Emits an internal function call.
     pub fn internal_call(
         &mut self,
@@ -257,6 +303,51 @@ impl<'a> FunctionBuilder<'a> {
         self.emit_inst(InstKind::CallValue, Some(MirType::uint256()))
     }
 
+    /// Emits an origin instruction.
+    pub fn origin(&mut self) -> ValueId {
+        self.emit_inst(InstKind::Origin, Some(MirType::Address))
+    }
+
+    /// Emits a gasprice instruction.
+    pub fn gasprice(&mut self) -> ValueId {
+        self.emit_inst(InstKind::GasPrice, Some(MirType::uint256()))
+    }
+
+    /// Emits a blockhash instruction.
+    pub fn blockhash(&mut self, block_num: ValueId) -> ValueId {
+        self.emit_inst(InstKind::BlockHash(block_num), Some(MirType::FixedBytes(32)))
+    }
+
+    /// Emits a coinbase instruction.
+    pub fn coinbase(&mut self) -> ValueId {
+        self.emit_inst(InstKind::Coinbase, Some(MirType::Address))
+    }
+
+    /// Emits a timestamp instruction.
+    pub fn timestamp(&mut self) -> ValueId {
+        self.emit_inst(InstKind::Timestamp, Some(MirType::uint256()))
+    }
+
+    /// Emits a number instruction.
+    pub fn number(&mut self) -> ValueId {
+        self.emit_inst(InstKind::BlockNumber, Some(MirType::uint256()))
+    }
+
+    /// Emits a prevrandao instruction.
+    pub fn prevrandao(&mut self) -> ValueId {
+        self.emit_inst(InstKind::PrevRandao, Some(MirType::uint256()))
+    }
+
+    /// Emits a gaslimit instruction.
+    pub fn gaslimit(&mut self) -> ValueId {
+        self.emit_inst(InstKind::GasLimit, Some(MirType::uint256()))
+    }
+
+    /// Emits a chainid instruction.
+    pub fn chainid(&mut self) -> ValueId {
+        self.emit_inst(InstKind::ChainId, Some(MirType::uint256()))
+    }
+
     /// Emits an address instruction.
     pub fn address(&mut self) -> ValueId {
         self.emit_inst(InstKind::Address, Some(MirType::Address))
@@ -280,6 +371,21 @@ impl<'a> FunctionBuilder<'a> {
     /// Emits a keccak256 instruction.
     pub fn keccak256(&mut self, offset: ValueId, size: ValueId) -> ValueId {
         self.emit_inst(InstKind::Keccak256(offset, size), Some(MirType::bytes32()))
+    }
+
+    /// Emits a basefee instruction.
+    pub fn basefee(&mut self) -> ValueId {
+        self.emit_inst(InstKind::BaseFee, Some(MirType::uint256()))
+    }
+
+    /// Emits a blobbasefee instruction.
+    pub fn blobbasefee(&mut self) -> ValueId {
+        self.emit_inst(InstKind::BlobBaseFee, Some(MirType::uint256()))
+    }
+
+    /// Emits a blobhash instruction.
+    pub fn blobhash(&mut self, index: ValueId) -> ValueId {
+        self.emit_inst(InstKind::BlobHash(index), Some(MirType::FixedBytes(32)))
     }
 
     /// Emits a call instruction (external call).

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -506,7 +506,7 @@ impl<'a> FunctionBuilder<'a> {
 
     /// Emits a phi instruction.
     pub fn phi(&mut self, ty: MirType, incoming: Vec<(BlockId, ValueId)>) -> ValueId {
-        self.func.alloc_value(Value::Phi { ty, incoming })
+        self.emit_inst(InstKind::Phi(incoming), Some(ty))
     }
 
     /// Sets a jump terminator.

--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -388,6 +388,13 @@ fn format_inst_kind(kind: &InstKind, func: &Function) -> String {
                 fmt_val(*ret_size, func)
             )
         }
+        InstKind::InternalCall { function, args, returns } => {
+            let args: Vec<_> = args.iter().map(|arg| fmt_val(*arg, func)).collect();
+            let mut parts = vec![format!("fn{}", function.index()), returns.to_string()];
+            parts.extend(args);
+            format!("internal_call {}", parts.join(", "))
+        }
+        InstKind::InternalFrameAddr(offset) => format!("internal_frame_addr {offset}"),
 
         // Contract creation
         InstKind::Create(value, offset, size) => {

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -19,6 +19,8 @@ pub struct Function {
     pub params: Vec<MirType>,
     /// Return types.
     pub returns: Vec<MirType>,
+    /// Bytes reserved in the internal-call frame for local memory slots.
+    pub internal_frame_size: u64,
     /// All values in this function.
     pub values: IndexVec<ValueId, Value>,
     /// All instructions in this function.
@@ -42,6 +44,7 @@ impl Function {
             attributes: FunctionAttributes::default(),
             params: Vec::new(),
             returns: Vec::new(),
+            internal_frame_size: 0,
             values: IndexVec::new(),
             instructions: IndexVec::new(),
             blocks,

--- a/crates/codegen/src/mir/inst.rs
+++ b/crates/codegen/src/mir/inst.rs
@@ -1,6 +1,6 @@
 //! MIR instructions.
 
-use super::{BlockId, MirType, ValueId};
+use super::{BlockId, FunctionId, MirType, ValueId};
 use smallvec::{SmallVec, smallvec};
 use std::fmt;
 
@@ -113,6 +113,8 @@ pub enum InstKind {
     CalldataCopy(ValueId, ValueId, ValueId),
     /// Get calldata size: `calldatasize()`
     CalldataSize,
+    /// Address inside the current internal-call frame.
+    InternalFrameAddr(u64),
 
     // Code operations
     /// Get code size: `codesize()`
@@ -203,6 +205,8 @@ pub enum InstKind {
         ret_offset: ValueId,
         ret_size: ValueId,
     },
+    /// Internal function call lowered to a direct jump.
+    InternalCall { function: FunctionId, args: Vec<ValueId>, returns: usize },
 
     // Contract creation
     /// Create contract: `create(value, offset, size)`
@@ -353,6 +357,9 @@ impl InstKind {
                 out.push(*ret_offset);
                 out.push(*ret_size);
             }
+            Self::InternalCall { args, .. } => {
+                out.extend(args.iter().copied());
+            }
 
             // Phi node - operands are the incoming values
             Self::Phi(incoming) => {
@@ -364,6 +371,7 @@ impl InstKind {
             // Nullary operations - no operands
             Self::MSize
             | Self::CalldataSize
+            | Self::InternalFrameAddr(_)
             | Self::CodeSize
             | Self::ReturnDataSize
             | Self::Caller
@@ -455,6 +463,8 @@ impl InstKind {
             Self::DelegateCall { gas, addr, args_offset, args_size, ret_offset, ret_size } => {
                 smallvec![*gas, *addr, *args_offset, *args_size, *ret_offset, *ret_size]
             }
+            Self::InternalCall { args, .. } => args.iter().copied().collect(),
+            Self::InternalFrameAddr(_) => smallvec![],
 
             Self::MSize
             | Self::CalldataSize
@@ -527,6 +537,7 @@ impl InstKind {
             Self::ExtCodeHash(_) => "extcodehash",
             Self::ReturnDataSize => "returndatasize",
             Self::ReturnDataCopy(_, _, _) => "returndatacopy",
+            Self::InternalFrameAddr(_) => "internal_frame_addr",
             Self::Caller => "caller",
             Self::CallValue => "callvalue",
             Self::Origin => "origin",
@@ -549,6 +560,7 @@ impl InstKind {
             Self::Call { .. } => "call",
             Self::StaticCall { .. } => "staticcall",
             Self::DelegateCall { .. } => "delegatecall",
+            Self::InternalCall { .. } => "internal_call",
             Self::Create(_, _, _) => "create",
             Self::Create2(_, _, _, _) => "create2",
             Self::Log0(_, _) => "log0",
@@ -579,6 +591,7 @@ impl InstKind {
             | Self::Call { .. }
             | Self::StaticCall { .. }
             | Self::DelegateCall { .. }
+            | Self::InternalCall { .. }
             // Contract creation
             | Self::Create(_, _, _)
             | Self::Create2(_, _, _, _)

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -34,7 +34,8 @@
 //! [`module_to_text`]: super::module_to_text
 
 use super::{
-    BasicBlock, BlockId, Function, InstKind, Instruction, Module, Terminator, Value, ValueId,
+    BasicBlock, BlockId, Function, FunctionId, InstKind, Instruction, Module, Terminator, Value,
+    ValueId,
 };
 use crate::mir::{Immediate, MirType};
 use alloy_primitives::U256;
@@ -708,6 +709,17 @@ impl<'a> Parser<'a> {
         block_labels.get(&idx).copied().ok_or_else(|| self.error(format!("unknown block `{id}`")))
     }
 
+    fn parse_function_id(&mut self) -> Result<FunctionId, ParseError> {
+        self.skip_inline();
+        let id = self.parse_ident()?;
+        let rest = id
+            .strip_prefix("fn")
+            .ok_or_else(|| self.error(format!("expected `fnN`, got `{id}`")))?;
+        let idx: usize =
+            rest.parse().map_err(|_| self.error(format!("invalid function index `{id}`")))?;
+        Ok(FunctionId::from_usize(idx))
+    }
+
     /// Parses one instruction line (with optional `vN =` result) or a terminator.
     fn parse_instruction_or_terminator(
         &mut self,
@@ -1282,6 +1294,21 @@ impl<'a> Parser<'a> {
                     },
                     Some(MirType::uint256()),
                 )
+            }
+            "internal_call" => {
+                let function = self.parse_function_id()?;
+                comma!();
+                let returns = self.parse_uint_literal()?.to::<usize>();
+                let mut args = Vec::new();
+                while self.try_punct(',') {
+                    args.push(v!());
+                }
+                let result_ty = (returns > 0).then(MirType::uint256);
+                (InstKind::InternalCall { function, args, returns }, result_ty)
+            }
+            "internal_frame_addr" => {
+                let offset = self.parse_uint_literal()?.to::<u64>();
+                (InstKind::InternalFrameAddr(offset), Some(MirType::MemPtr))
             }
 
             // ----- create -----

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -359,6 +359,11 @@ impl CommonSubexprEliminator {
                 replace(ret_offset);
                 replace(ret_size);
             }
+            InstKind::InternalCall { args, .. } => {
+                for arg in args {
+                    replace(arg);
+                }
+            }
 
             InstKind::Phi(incoming) => {
                 for (_, val) in incoming {
@@ -369,6 +374,7 @@ impl CommonSubexprEliminator {
             // Nullary operations - no operands
             InstKind::MSize
             | InstKind::CalldataSize
+            | InstKind::InternalFrameAddr(_)
             | InstKind::CodeSize
             | InstKind::ReturnDataSize
             | InstKind::Caller

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -735,6 +735,11 @@ fn replace_inst_operands(kind: &mut InstKind, replacements: &FxHashMap<ValueId, 
             replace(ret_offset);
             replace(ret_size);
         }
+        InstKind::InternalCall { args, .. } => {
+            for arg in args {
+                replace(arg);
+            }
+        }
         InstKind::Phi(incoming) => {
             for (_, v) in incoming {
                 replace(v);
@@ -743,6 +748,7 @@ fn replace_inst_operands(kind: &mut InstKind, replacements: &FxHashMap<ValueId, 
         // Nullary instructions have no operands.
         InstKind::MSize
         | InstKind::CalldataSize
+        | InstKind::InternalFrameAddr(_)
         | InstKind::CodeSize
         | InstKind::ReturnDataSize
         | InstKind::Caller

--- a/crates/sema/src/ast_lowering/mod.rs
+++ b/crates/sema/src/ast_lowering/mod.rs
@@ -13,6 +13,7 @@ use solar_interface::{Session, diagnostics::DiagCtxt};
 mod lower;
 
 mod linearize;
+mod yul;
 
 pub(crate) mod resolve;
 pub(crate) use resolve::{Res, SymbolResolver};

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -820,44 +820,14 @@ impl<'gcx> ResolveContext<'gcx> {
     }
 
     pub(super) fn resolve_yul_solidity_var_id(&self, ident: Ident) -> Option<hir::VariableId> {
-        let decls = match self.resolver.resolve_name_raw(ident, &self.scopes) {
-            Some(decls) => decls,
-            None => {
-                self.dcx()
-                    .err(format!("undefined variable `{}`", ident.name))
-                    .span(ident.span)
-                    .emit();
-                return None;
-            }
-        };
+        let decls = self.resolver.resolve_name_raw(ident, &self.scopes)?;
 
-        let [decl] = decls else {
-            self.dcx().err(format!("ambiguous variable `{}`", ident.name)).span(ident.span).emit();
-            return None;
-        };
-
-        match decl.res {
+        let mut vars = decls.iter().filter_map(|decl| match decl.res {
             Res::Item(hir::ItemId::Variable(var_id)) => Some(var_id),
-            Res::Item(item) => {
-                self.dcx()
-                    .err(format!(
-                        "cannot access {} `{}` from assembly",
-                        item.description(),
-                        ident.name
-                    ))
-                    .span(ident.span)
-                    .emit();
-                None
-            }
-            Res::Builtin(_) | Res::Namespace(_) => {
-                self.dcx()
-                    .err(format!("cannot access `{}` from assembly", ident.name))
-                    .span(ident.span)
-                    .emit();
-                None
-            }
-            Res::Err(_) => None,
-        }
+            _ => None,
+        });
+        let var_id = vars.next()?;
+        vars.next().is_none().then_some(var_id)
     }
 
     /// Lowers the given statements by first entering a new scope.

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -819,6 +819,47 @@ impl<'gcx> ResolveContext<'gcx> {
         self.resolver.resolve_path_as(path, &self.scopes, description)
     }
 
+    pub(super) fn resolve_yul_solidity_var_id(&self, ident: Ident) -> Option<hir::VariableId> {
+        let decls = match self.resolver.resolve_name_raw(ident, &self.scopes) {
+            Some(decls) => decls,
+            None => {
+                self.dcx()
+                    .err(format!("undefined variable `{}`", ident.name))
+                    .span(ident.span)
+                    .emit();
+                return None;
+            }
+        };
+
+        let [decl] = decls else {
+            self.dcx().err(format!("ambiguous variable `{}`", ident.name)).span(ident.span).emit();
+            return None;
+        };
+
+        match decl.res {
+            Res::Item(hir::ItemId::Variable(var_id)) => Some(var_id),
+            Res::Item(item) => {
+                self.dcx()
+                    .err(format!(
+                        "cannot access {} `{}` from assembly",
+                        item.description(),
+                        ident.name
+                    ))
+                    .span(ident.span)
+                    .emit();
+                None
+            }
+            Res::Builtin(_) | Res::Namespace(_) => {
+                self.dcx()
+                    .err(format!("cannot access `{}` from assembly", ident.name))
+                    .span(ident.span)
+                    .emit();
+                None
+            }
+            Res::Err(_) => None,
+        }
+    }
+
     /// Lowers the given statements by first entering a new scope.
     fn lower_block(&mut self, block: &ast::Block<'_>) -> hir::Block<'gcx> {
         self.in_scope_if(!block.is_empty(), |this| this.lower_stmts(block.stmts, block.span))
@@ -851,10 +892,10 @@ impl<'gcx> ResolveContext<'gcx> {
                 })),
                 self.lower_expr(expr),
             ),
-            ast::StmtKind::Assembly(_) => hir::StmtKind::Err(
-                // self.dcx().err("assembly is not yet implemented").span(stmt.span).emit(),
-                ErrorGuaranteed::new_unchecked(),
-            ),
+            ast::StmtKind::Assembly(assembly) => {
+                let mut yul = super::yul::YulLoweringContext::new(self);
+                hir::StmtKind::Assembly(yul.lower_assembly(assembly))
+            }
             ast::StmtKind::Block(stmts) => hir::StmtKind::Block(self.lower_block(stmts)),
             ast::StmtKind::UncheckedBlock(stmts) => {
                 hir::StmtKind::UncheckedBlock(self.lower_block(stmts))

--- a/crates/sema/src/ast_lowering/yul.rs
+++ b/crates/sema/src/ast_lowering/yul.rs
@@ -174,13 +174,12 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
             ast::yul::ExprKind::Path(path) => hir_yul::ExprKind::Path(self.lower_path(path)),
 
             ast::yul::ExprKind::Call(call) => {
-                // Validate the call target exists (builtin or user-defined function).
-                self.validate_call_target(call.name);
+                let res = self.resolve_call_target(call.name);
                 let arguments = self
                     .rcx
                     .arena
                     .alloc_slice_fill_iter(call.arguments.iter().map(|e| self.lower_expr_full(e)));
-                hir_yul::ExprKind::Call(hir_yul::ExprCall { name: call.name, arguments })
+                hir_yul::ExprKind::Call(hir_yul::ExprCall { name: call.name, arguments, res })
             }
 
             ast::yul::ExprKind::Lit(lit) => hir_yul::ExprKind::Lit(self.lower_lit(lit)),
@@ -244,8 +243,16 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
         self.rcx.resolve_yul_solidity_var_id(ident)
     }
 
-    fn validate_call_target(&mut self, name: Ident) {
-        let _ = name.is_yul_evm_builtin() || self.lookup_yul_function(name.name).is_some();
+    fn resolve_call_target(&mut self, name: Ident) -> hir_yul::CallRes {
+        if name.is_yul_evm_builtin() {
+            return hir_yul::CallRes::Builtin;
+        }
+
+        if self.lookup_yul_function(name.name).is_some() {
+            return hir_yul::CallRes::Function;
+        }
+
+        hir_yul::CallRes::Unknown
     }
 
     fn lower_lit(&mut self, lit: &ast::Lit<'_>) -> &'gcx ast::Lit<'gcx> {

--- a/crates/sema/src/ast_lowering/yul.rs
+++ b/crates/sema/src/ast_lowering/yul.rs
@@ -1,6 +1,6 @@
 //! Yul AST to HIR lowering and variable resolution.
 
-use super::resolve::{ResolveContext, Res};
+use super::resolve::ResolveContext;
 use crate::hir::{self, yul as hir_yul};
 use solar_ast as ast;
 use solar_data_structures::map::FxIndexMap;
@@ -32,11 +32,8 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
         &mut self,
         asm: &ast::StmtAssembly<'_>,
     ) -> &'gcx hir_yul::StmtAssembly<'gcx> {
-        let dialect = asm.dialect.map(|d| d.value);
-        let flags = self
-            .rcx
-            .arena
-            .alloc_slice_fill_iter(asm.flags.iter().map(|f| f.value));
+        let dialect = asm.dialect.as_ref().map(|d| d.value);
+        let flags = self.rcx.arena.alloc_slice_fill_iter(asm.flags.iter().map(|f| f.value));
         let block = self.lower_block(&asm.block);
         self.rcx.arena.alloc(hir_yul::StmtAssembly { dialect, flags, block })
     }
@@ -70,7 +67,7 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
                 for name in names.iter() {
                     self.declare_variable(*name);
                 }
-                let names = self.rcx.arena.alloc_slice_copy(&**names);
+                let names = self.rcx.arena.alloc_slice_copy(names);
                 let init = init.as_ref().map(|e| self.lower_expr(e));
                 hir_yul::StmtKind::VarDecl(names, init)
             }
@@ -82,17 +79,13 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
             }
 
             ast::yul::StmtKind::AssignMulti(paths, expr) => {
-                let paths = self
-                    .rcx
-                    .arena
-                    .alloc_slice_fill_iter(paths.iter().map(|p| self.lower_path(p)));
+                let paths =
+                    self.rcx.arena.alloc_slice_fill_iter(paths.iter().map(|p| self.lower_path(p)));
                 let expr = self.lower_expr(expr);
                 hir_yul::StmtKind::AssignMulti(paths, expr)
             }
 
-            ast::yul::StmtKind::Expr(expr) => {
-                hir_yul::StmtKind::Expr(self.lower_expr(expr))
-            }
+            ast::yul::StmtKind::Expr(expr) => hir_yul::StmtKind::Expr(self.lower_expr(expr)),
 
             ast::yul::StmtKind::If(cond, body) => {
                 let cond = self.lower_expr(cond);
@@ -178,9 +171,7 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
 
     fn lower_expr_full(&mut self, expr: &ast::yul::Expr<'_>) -> hir_yul::Expr<'gcx> {
         let kind = match &expr.kind {
-            ast::yul::ExprKind::Path(path) => {
-                hir_yul::ExprKind::Path(self.lower_path(path))
-            }
+            ast::yul::ExprKind::Path(path) => hir_yul::ExprKind::Path(self.lower_path(path)),
 
             ast::yul::ExprKind::Call(call) => {
                 // Validate the call target exists (builtin or user-defined function).
@@ -222,12 +213,14 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
                 // Dotted path like x.slot or x.offset.
                 // First check if base is a Yul variable (not allowed with .slot/.offset).
                 if self.lookup_yul_variable(base.name).is_some() {
-                    self.rcx.dcx().err(format!(
-                        "Yul variable `{}` cannot have `.{}` suffix",
-                        base.name, suffix.name
-                    ))
-                    .span(path.span())
-                    .emit();
+                    self.rcx
+                        .dcx()
+                        .err(format!(
+                            "Yul variable `{}` cannot have `.{}` suffix",
+                            base.name, suffix.name
+                        ))
+                        .span(path.span())
+                        .emit();
                     return hir_yul::PathRes::Err;
                 }
 
@@ -237,12 +230,14 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
                         let var = self.rcx.hir.variable(var_id);
                         // Validate it's a storage variable.
                         if !var.is_state_variable() {
-                            self.rcx.dcx().err(format!(
-                                "`.{}` is only allowed on storage variables",
-                                suffix.name
-                            ))
-                            .span(suffix.span)
-                            .emit();
+                            self.rcx
+                                .dcx()
+                                .err(format!(
+                                    "`.{}` is only allowed on storage variables",
+                                    suffix.name
+                                ))
+                                .span(suffix.span)
+                                .emit();
                             return hir_yul::PathRes::Err;
                         }
 
@@ -252,12 +247,14 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
                         } else if suffix.name == sym::offset {
                             hir_yul::PathRes::StorageOffset(var_id)
                         } else {
-                            self.rcx.dcx().err(format!(
-                                "unknown suffix `.{}`; expected `.slot` or `.offset`",
-                                suffix.name
-                            ))
-                            .span(suffix.span)
-                            .emit();
+                            self.rcx
+                                .dcx()
+                                .err(format!(
+                                    "unknown suffix `.{}`; expected `.slot` or `.offset`",
+                                    suffix.name
+                                ))
+                                .span(suffix.span)
+                                .emit();
                             hir_yul::PathRes::Err
                         }
                     }
@@ -266,11 +263,7 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
             }
             _ => {
                 // Paths with more than 2 segments are not valid in Yul.
-                self.rcx
-                    .dcx()
-                    .err("invalid path in assembly")
-                    .span(path.span())
-                    .emit();
+                self.rcx.dcx().err("invalid path in assembly").span(path.span()).emit();
                 hir_yul::PathRes::Err
             }
         }
@@ -284,42 +277,7 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
     }
 
     fn resolve_solidity_var_id(&mut self, ident: Ident) -> Option<hir::VariableId> {
-        // Try to resolve in Solidity scopes.
-        let res = self.rcx.resolver.resolve_single(&ident, &self.rcx.scopes);
-        match res {
-            Ok(decl) => match decl.res {
-                Res::Item(hir::ItemId::Variable(var_id)) => Some(var_id),
-                Res::Item(item) => {
-                    self.rcx
-                        .dcx()
-                        .err(format!(
-                            "cannot access {} `{}` from assembly",
-                            item.description(),
-                            ident.name
-                        ))
-                        .span(ident.span)
-                        .emit();
-                    None
-                }
-                Res::Builtin(_) | Res::Namespace(_) => {
-                    self.rcx
-                        .dcx()
-                        .err(format!("cannot access `{}` from assembly", ident.name))
-                        .span(ident.span)
-                        .emit();
-                    None
-                }
-                Res::Err(_) => None,
-            },
-            Err(_) => {
-                self.rcx
-                    .dcx()
-                    .err(format!("undefined variable `{}`", ident.name))
-                    .span(ident.span)
-                    .emit();
-                None
-            }
-        }
+        self.rcx.resolve_yul_solidity_var_id(ident)
     }
 
     fn validate_call_target(&mut self, name: Ident) {
@@ -334,11 +292,7 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
         }
 
         // Not found.
-        self.rcx
-            .dcx()
-            .err(format!("undefined function `{}`", name.name))
-            .span(name.span)
-            .emit();
+        self.rcx.dcx().err(format!("undefined function `{}`", name.name)).span(name.span).emit();
     }
 
     fn lower_lit(&mut self, lit: &ast::Lit<'_>) -> &'gcx ast::Lit<'gcx> {

--- a/crates/sema/src/ast_lowering/yul.rs
+++ b/crates/sema/src/ast_lowering/yul.rs
@@ -207,73 +207,37 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
                 }
 
                 // Try Solidity resolution.
-                self.resolve_solidity_var(*ident)
+                self.resolve_solidity_var(*ident).unwrap_or(hir_yul::PathRes::YulVariable)
             }
             [base, suffix] => {
-                // Dotted path like x.slot or x.offset.
-                // First check if base is a Yul variable (not allowed with .slot/.offset).
+                if suffix.name != sym::slot && suffix.name != sym::offset {
+                    return hir_yul::PathRes::YulVariable;
+                }
+
                 if self.lookup_yul_variable(base.name).is_some() {
-                    self.rcx
-                        .dcx()
-                        .err(format!(
-                            "Yul variable `{}` cannot have `.{}` suffix",
-                            base.name, suffix.name
-                        ))
-                        .span(path.span())
-                        .emit();
-                    return hir_yul::PathRes::Err;
+                    return hir_yul::PathRes::YulVariable;
                 }
 
-                // Must be a Solidity variable.
-                match self.resolve_solidity_var_id(*base) {
-                    Some(var_id) => {
-                        let var = self.rcx.hir.variable(var_id);
-                        // Validate it's a storage variable.
-                        if !var.is_state_variable() {
-                            self.rcx
-                                .dcx()
-                                .err(format!(
-                                    "`.{}` is only allowed on storage variables",
-                                    suffix.name
-                                ))
-                                .span(suffix.span)
-                                .emit();
-                            return hir_yul::PathRes::Err;
-                        }
+                let Some(var_id) = self.resolve_solidity_var_id(*base) else {
+                    return hir_yul::PathRes::YulVariable;
+                };
+                let var = self.rcx.hir.variable(var_id);
+                if !var.is_state_variable() {
+                    return hir_yul::PathRes::YulVariable;
+                }
 
-                        // Check suffix.
-                        if suffix.name == sym::slot {
-                            hir_yul::PathRes::StorageSlot(var_id)
-                        } else if suffix.name == sym::offset {
-                            hir_yul::PathRes::StorageOffset(var_id)
-                        } else {
-                            self.rcx
-                                .dcx()
-                                .err(format!(
-                                    "unknown suffix `.{}`; expected `.slot` or `.offset`",
-                                    suffix.name
-                                ))
-                                .span(suffix.span)
-                                .emit();
-                            hir_yul::PathRes::Err
-                        }
-                    }
-                    None => hir_yul::PathRes::Err,
+                if suffix.name == sym::slot {
+                    hir_yul::PathRes::StorageSlot(var_id)
+                } else {
+                    hir_yul::PathRes::StorageOffset(var_id)
                 }
             }
-            _ => {
-                // Paths with more than 2 segments are not valid in Yul.
-                self.rcx.dcx().err("invalid path in assembly").span(path.span()).emit();
-                hir_yul::PathRes::Err
-            }
+            _ => hir_yul::PathRes::YulVariable,
         }
     }
 
-    fn resolve_solidity_var(&mut self, ident: Ident) -> hir_yul::PathRes {
-        match self.resolve_solidity_var_id(ident) {
-            Some(var_id) => hir_yul::PathRes::SolidityVariable(var_id),
-            None => hir_yul::PathRes::Err,
-        }
+    fn resolve_solidity_var(&mut self, ident: Ident) -> Option<hir_yul::PathRes> {
+        self.resolve_solidity_var_id(ident).map(hir_yul::PathRes::SolidityVariable)
     }
 
     fn resolve_solidity_var_id(&mut self, ident: Ident) -> Option<hir::VariableId> {
@@ -281,18 +245,7 @@ impl<'a, 'gcx> YulLoweringContext<'a, 'gcx> {
     }
 
     fn validate_call_target(&mut self, name: Ident) {
-        // Check if it's a Yul builtin.
-        if name.is_yul_evm_builtin() {
-            return;
-        }
-
-        // Check if it's a user-defined Yul function.
-        if self.lookup_yul_function(name.name).is_some() {
-            return;
-        }
-
-        // Not found.
-        self.rcx.dcx().err(format!("undefined function `{}`", name.name)).span(name.span).emit();
+        let _ = name.is_yul_evm_builtin() || self.lookup_yul_function(name.name).is_some();
     }
 
     fn lower_lit(&mut self, lit: &ast::Lit<'_>) -> &'gcx ast::Lit<'gcx> {

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -21,6 +21,7 @@ pub use ast::{
 
 mod visit;
 pub use visit::Visit;
+pub mod yul;
 
 /// HIR arena allocator.
 pub struct Arena {
@@ -1175,9 +1176,8 @@ pub struct Stmt<'hir> {
 /// A kind of statement.
 #[derive(Debug)]
 pub enum StmtKind<'hir> {
-    // TODO: Yul to HIR.
-    // /// An assembly block, with optional flags: `assembly "evmasm" (...) { ... }`.
-    // Assembly(StmtAssembly<'hir>),
+    /// An assembly block, with optional flags: `assembly "evmasm" (...) { ... }`.
+    Assembly(&'hir yul::StmtAssembly<'hir>),
     /// A single-variable declaration statement: `uint256 foo = 42;`.
     DeclSingle(VariableId),
 

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -252,6 +252,7 @@ pub trait Visit<'hir> {
                 }
             }
             StmtKind::Expr(expr) => self.visit_expr(expr)?,
+            StmtKind::Assembly(_) => {}
             StmtKind::Placeholder => {}
             StmtKind::Err(_guar) => {}
         }

--- a/crates/sema/src/hir/yul.rs
+++ b/crates/sema/src/hir/yul.rs
@@ -160,6 +160,18 @@ pub enum PathRes {
 pub struct ExprCall<'hir> {
     pub name: Ident,
     pub arguments: &'hir [Expr<'hir>],
+    pub res: CallRes,
+}
+
+/// Resolution of a Yul function call target.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallRes {
+    /// An EVM dialect builtin.
+    Builtin,
+    /// A user-defined Yul function.
+    Function,
+    /// An unresolved call target. Parser-only paths allow this.
+    Unknown,
 }
 
 /// An assembly block statement.

--- a/tests/ui/codegen/base_constructor.sol
+++ b/tests/ui/codegen/base_constructor.sol
@@ -1,0 +1,14 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract Base {
+    uint256 public value;
+
+    constructor(uint256 initialValue) {
+        value = initialValue;
+    }
+}
+
+contract Derived is Base {
+    constructor(uint256 initialValue) Base(initialValue) {}
+}

--- a/tests/ui/codegen/base_constructor.stdout
+++ b/tests/ui/codegen/base_constructor.stdout
@@ -1,0 +1,28 @@
+// === ROOT/tests/ui/codegen/base_constructor.sol:Base ===
+; module @Base
+fn @value() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+
+fn @_anonymous(arg0: u256) {
+  bb0 (entry):
+    v2 = sstore 0, arg0
+    stop
+}
+
+// === ROOT/tests/ui/codegen/base_constructor.sol:Derived ===
+; module @Derived
+fn @_anonymous(arg0: u256) {
+  bb0 (entry):
+    v2 = sstore 0, arg0
+    stop
+}
+
+fn @value() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+

--- a/tests/ui/codegen/function_call.stdout
+++ b/tests/ui/codegen/function_call.stdout
@@ -8,15 +8,15 @@ fn @double(arg0: u256) -> u256 {
 
 fn @quadruple(arg0: u256) -> u256 {
   bb0 (entry):
-    v1 = add arg0, arg0
-    v2 = add v1, v1
-    ret v2
+    v2 = add arg0, arg0
+    v4 = add v2, v2
+    ret v4
 }
 
 fn @sum_then_double(arg0: u256, arg1: u256) -> u256 {
   bb0 (entry):
     v2 = add arg0, arg1
-    v3 = add v2, v2
-    ret v3
+    v4 = add v2, v2
+    ret v4
 }
 

--- a/tests/ui/codegen/internal_void_call.sol
+++ b/tests/ui/codegen/internal_void_call.sol
@@ -1,0 +1,16 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract InternalVoidCall {
+    uint256 public value;
+
+    function set(uint256 newValue) public {
+        writeIfNonZero(newValue);
+    }
+
+    function writeIfNonZero(uint256 newValue) internal {
+        if (newValue != 0) {
+            value = newValue;
+        }
+    }
+}

--- a/tests/ui/codegen/internal_void_call.stdout
+++ b/tests/ui/codegen/internal_void_call.stdout
@@ -1,0 +1,32 @@
+// === ROOT/tests/ui/codegen/internal_void_call.sol:InternalVoidCall ===
+; module @InternalVoidCall
+fn @value() -> u256 {
+  bb0 (entry):
+    v1 = sload 0
+    ret v1
+}
+
+fn @set(arg0: u256) {
+  bb0 (entry):
+    v2 = eq arg0, 0
+    v3 = iszero v2
+    br v3, bb1, bb2
+  bb1:
+    v5 = sstore 0, arg0
+    jump bb2
+  bb2:
+    stop
+}
+
+fn @writeIfNonZero(arg0: u256) {
+  bb0 (entry):
+    v2 = eq arg0, 0
+    v3 = iszero v2
+    br v3, bb1, bb2
+  bb1:
+    v5 = sstore 0, arg0
+    jump bb2
+  bb2:
+    stop
+}
+

--- a/tests/ui/codegen/recursive.stdout
+++ b/tests/ui/codegen/recursive.stdout
@@ -9,12 +9,8 @@ fn @fact(arg0: u256) -> u256 {
     ret 1
   bb2:
     v6 = sub arg0, 1
-    v8 = gt v6, 1
-    v9 = iszero v8
-    br v9, bb3, bb4
-  bb3:
-    ret 1
-  bb4:
+    v9 = gt v6, 1
+    v10 = iszero v9
     v13 = sub v6, 1
     v15 = mul v6, 0
     v16 = mul arg0, v15
@@ -30,22 +26,14 @@ fn @fib(arg0: u256) -> u256 {
     ret arg0
   bb2:
     v5 = sub arg0, 1
-    v7 = gt v5, 1
-    v8 = iszero v7
-    br v8, bb3, bb4
-  bb3:
-    ret v5
-  bb4:
+    v8 = gt v5, 1
+    v9 = iszero v8
     v11 = sub v5, 1
     v14 = sub v5, 2
     v16 = add 0, 0
     v18 = sub arg0, 2
-    v20 = gt v18, 1
-    v21 = iszero v20
-    br v21, bb5, bb6
-  bb5:
-    ret v18
-  bb6:
+    v21 = gt v18, 1
+    v22 = iszero v21
     v24 = sub v18, 1
     v27 = sub v18, 2
     v29 = add 0, 0

--- a/tests/ui/codegen/type_conversion.sol
+++ b/tests/ui/codegen/type_conversion.sol
@@ -1,0 +1,16 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract TypeConversion {
+    function narrowAddress(address asset) public pure returns (uint16) {
+        return uint16(uint160(asset));
+    }
+
+    function narrowUint(uint256 value) public pure returns (uint16) {
+        return uint16(value);
+    }
+
+    function narrowSigned(int256 value) public pure returns (int8) {
+        return int8(value);
+    }
+}

--- a/tests/ui/codegen/type_conversion.stdout
+++ b/tests/ui/codegen/type_conversion.stdout
@@ -1,0 +1,25 @@
+// === ROOT/tests/ui/codegen/type_conversion.sol:TypeConversion ===
+; module @TypeConversion
+fn @narrowAddress(arg0: address) -> u16 {
+  bb0 (entry):
+    v3 = mstore 128, 0
+    v5 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
+    v7 = and v5, 0xffff
+    ret v7
+}
+
+fn @narrowUint(arg0: u256) -> u16 {
+  bb0 (entry):
+    v3 = mstore 128, 0
+    v5 = and arg0, 0xffff
+    ret v5
+}
+
+fn @narrowSigned(arg0: i256) -> i8 {
+  bb0 (entry):
+    v3 = mstore 128, 0
+    v5 = shl 248, arg0
+    v6 = sar 248, v5
+    ret v6
+}
+

--- a/tests/ui/codegen/type_conversion.stdout
+++ b/tests/ui/codegen/type_conversion.stdout
@@ -2,24 +2,21 @@
 ; module @TypeConversion
 fn @narrowAddress(arg0: address) -> u16 {
   bb0 (entry):
-    v3 = mstore 128, 0
-    v5 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
-    v7 = and v5, 0xffff
-    ret v7
+    v2 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
+    v4 = and v2, 0xffff
+    ret v4
 }
 
 fn @narrowUint(arg0: u256) -> u16 {
   bb0 (entry):
-    v3 = mstore 128, 0
-    v5 = and arg0, 0xffff
-    ret v5
+    v2 = and arg0, 0xffff
+    ret v2
 }
 
 fn @narrowSigned(arg0: i256) -> i8 {
   bb0 (entry):
-    v3 = mstore 128, 0
-    v5 = shl 248, arg0
-    v6 = sar 248, v5
-    ret v6
+    v2 = shl 248, arg0
+    v3 = sar 248, v2
+    ret v3
 }
 

--- a/tests/ui/codegen/yul_call_errors.sol
+++ b/tests/ui/codegen/yul_call_errors.sol
@@ -15,10 +15,28 @@ contract YulCallErrors {
 
     function unsupportedFunction() public pure returns (uint256 result) {
         assembly {
-            function id(x) -> y {
+            result := id(1) //~ ERROR: unsupported Yul function `id`
+            function id(x) -> y { //~ ERROR: unsupported Yul function definition
                 y := x
             }
-            result := id(1) //~ ERROR: unsupported Yul function `id`
+        }
+    }
+
+    function wrongArity() public pure {
+        assembly {
+            mstore(0x00) //~ ERROR: wrong number of arguments for Yul builtin `mstore`: expected 2, found 1
+        }
+    }
+
+    function unsupportedFor() public pure {
+        assembly {
+            for { } 1 { } { } //~ ERROR: unsupported Yul for statement
+        }
+    }
+
+    function undefinedVariable() public pure returns (uint256 result) {
+        assembly {
+            result := missing //~ ERROR: undefined Yul variable `missing`
         }
     }
 }

--- a/tests/ui/codegen/yul_call_errors.sol
+++ b/tests/ui/codegen/yul_call_errors.sol
@@ -1,6 +1,8 @@
 //@compile-flags: --emit=mir
 
 contract YulCallErrors {
+    uint256 storageValue;
+
     function unknownCall() public pure returns (uint256 result) {
         assembly {
             result := unknown_yul_call() //~ ERROR: undefined Yul function `unknown_yul_call`
@@ -37,6 +39,19 @@ contract YulCallErrors {
     function undefinedVariable() public pure returns (uint256 result) {
         assembly {
             result := missing //~ ERROR: undefined Yul variable `missing`
+        }
+    }
+
+    function unsupportedMultiVarDecl() public pure {
+        assembly {
+            let a, b := add(1, 2) //~ ERROR: unsupported Yul multiple variable declaration
+        }
+    }
+
+    function unsupportedSlotAssign() public {
+        assembly {
+            storageValue.slot := 1 //~ ERROR: unsupported Yul storage slot assignment target
+            storageValue.offset := 1 //~ ERROR: unsupported Yul storage offset assignment target
         }
     }
 }

--- a/tests/ui/codegen/yul_call_errors.sol
+++ b/tests/ui/codegen/yul_call_errors.sol
@@ -1,0 +1,24 @@
+//@compile-flags: --emit=mir
+
+contract YulCallErrors {
+    function unknownCall() public pure returns (uint256 result) {
+        assembly {
+            result := unknown_yul_call() //~ ERROR: undefined Yul function `unknown_yul_call`
+        }
+    }
+
+    function unsupportedBuiltin() public pure returns (uint256 result) {
+        assembly {
+            result := addmod(1, 2, 3) //~ ERROR: unsupported Yul builtin `addmod`
+        }
+    }
+
+    function unsupportedFunction() public pure returns (uint256 result) {
+        assembly {
+            function id(x) -> y {
+                y := x
+            }
+            result := id(1) //~ ERROR: unsupported Yul function `id`
+        }
+    }
+}

--- a/tests/ui/codegen/yul_call_errors.stderr
+++ b/tests/ui/codegen/yul_call_errors.stderr
@@ -1,0 +1,20 @@
+error: undefined Yul function `unknown_yul_call`
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             result := unknown_yul_call()
+   ╰╴                      ━━━━━━━━━━━━━━━━
+
+error: unsupported Yul builtin `addmod`
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             result := addmod(1, 2, 3)
+   ╰╴                      ━━━━━━
+
+error: unsupported Yul function `id`
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             result := id(1)
+   ╰╴                      ━━
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/codegen/yul_call_errors.stderr
+++ b/tests/ui/codegen/yul_call_errors.stderr
@@ -16,5 +16,31 @@ error: unsupported Yul function `id`
 LL │             result := id(1)
    ╰╴                      ━━
 
-error: aborting due to 3 previous errors
+error: unsupported Yul function definition
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │ ┏             function id(x) -> y {
+LL │ ┃                 y := x
+LL │ ┃             }
+   ╰╴┗━━━━━━━━━━━━━┛
+
+error: wrong number of arguments for Yul builtin `mstore`: expected 2, found 1
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             mstore(0x00)
+   ╰╴            ━━━━━━
+
+error: unsupported Yul for statement
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             for { } 1 { } { }
+   ╰╴            ━━━━━━━━━━━━━━━━━
+
+error: undefined Yul variable `missing`
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             result := missing
+   ╰╴                      ━━━━━━━
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/codegen/yul_call_errors.stderr
+++ b/tests/ui/codegen/yul_call_errors.stderr
@@ -42,5 +42,23 @@ error: undefined Yul variable `missing`
 LL │             result := missing
    ╰╴                      ━━━━━━━
 
-error: aborting due to 7 previous errors
+error: unsupported Yul multiple variable declaration
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             let a, b := add(1, 2)
+   ╰╴            ━━━━━━━━━━━━━━━━━━━━━
+
+error: unsupported Yul storage slot assignment target
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             storageValue.slot := 1
+   ╰╴            ━━━━━━━━━━━━━━━━━
+
+error: unsupported Yul storage offset assignment target
+   ╭▸ ROOT/tests/ui/codegen/yul_call_errors.sol:LL:CC
+   │
+LL │             storageValue.offset := 1
+   ╰╴            ━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/codegen/yul_local_phi.sol
+++ b/tests/ui/codegen/yul_local_phi.sol
@@ -1,0 +1,14 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract YulLocalPhi {
+    function branchLocal(uint256 flag) public pure returns (uint256 result) {
+        assembly {
+            let x := 1
+            if flag {
+                x := 2
+            }
+            result := x
+        }
+    }
+}

--- a/tests/ui/codegen/yul_local_phi.stdout
+++ b/tests/ui/codegen/yul_local_phi.stdout
@@ -1,0 +1,15 @@
+// === ROOT/tests/ui/codegen/yul_local_phi.sol:YulLocalPhi ===
+; module @YulLocalPhi
+fn @branchLocal(arg0: u256) -> u256 {
+  bb0 (entry):
+    v3 = mstore 128, 0
+    br arg0, bb1, bb2
+  bb1:
+    jump bb2
+  bb2:
+    v6 = phi [bb0: 1], [bb1: 2]
+    v8 = mstore 128, v6
+    v10 = mload 128
+    ret v10
+}
+

--- a/tests/ui/codegen/yul_low_level_builtins.sol
+++ b/tests/ui/codegen/yul_low_level_builtins.sol
@@ -1,0 +1,18 @@
+//@ignore-host: windows
+//@compile-flags: --emit=mir
+
+contract YulLowLevelBuiltins {
+    function safeCall(address token, bytes4 selector) public returns (bool success) {
+        assembly {
+            let fmp := mload(0x40)
+            mstore(0x00, selector)
+            success := call(gas(), token, 0, 0x00, 0x04, 0x00, 0x20)
+            if iszero(and(success, eq(mload(0x00), 1))) {
+                returndatacopy(fmp, 0x00, returndatasize())
+                revert(fmp, returndatasize())
+            }
+            success := and(success, gt(extcodesize(token), 0))
+            mstore(0x40, fmp)
+        }
+    }
+}

--- a/tests/ui/codegen/yul_low_level_builtins.stdout
+++ b/tests/ui/codegen/yul_low_level_builtins.stdout
@@ -1,0 +1,32 @@
+// === ROOT/tests/ui/codegen/yul_low_level_builtins.sol:YulLowLevelBuiltins ===
+; module @YulLowLevelBuiltins
+fn @safeCall(arg0: address, arg1: bytes4) -> bool {
+  bb0 (entry):
+    v4 = mstore 128, 0
+    v6 = mload 64
+    v8 = mstore 0, arg1
+    v10 = gas
+    v16 = call v10, arg0, 0, 0, 4, 0, 32
+    v18 = mstore 128, v16
+    v20 = mload 128
+    v22 = mload 0
+    v24 = eq v22, 1
+    v25 = and v20, v24
+    v26 = iszero v25
+    br v26, bb1, bb2
+  bb1:
+    v28 = returndatasize
+    v29 = returndatacopy v6, 0, v28
+    v31 = returndatasize
+    revert v6, v31
+  bb2:
+    v34 = mload 128
+    v35 = extcodesize arg0
+    v37 = gt v35, 0
+    v38 = and v34, v37
+    v40 = mstore 128, v38
+    v42 = mstore 64, v6
+    v45 = mload 128
+    ret v45
+}
+


### PR DESCRIPTION
Continue with fixing `codegen` to avoid mismatches in runtime comparing to `solc`.