### PR TITLE
fix(sema): follow up function member kinds

### DIFF
--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -93,6 +93,7 @@ impl<'gcx> ConstantEvaluator<'gcx> {
                 l.binop(r, bin_op.kind).map_err(Into::into)
             }
             // hir::ExprKind::Call(_, _) => unimplemented!(),
+            // hir::ExprKind::CallOptions(_, _) => unimplemented!(),
             // hir::ExprKind::Delete(_) => unimplemented!(),
             hir::ExprKind::Ident(res) => {
                 // Ignore invalid overloads since they will get correctly detected later.

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -799,15 +799,14 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
         functions
     }).filter_map(|f_id| {
         let f = gcx.hir.function(f_id);
-        let ty = gcx
-            .mk_ty_fn(TyFn {
-                kind: TyFnKind::External,
-                parameters: gcx.mk_item_tys(f.parameters),
-                returns: gcx.mk_item_tys(f.returns),
-                state_mutability: fn_state_mutability(TyFnKind::External, f.state_mutability),
-                function_id: Some(f_id),
-            })
-            .as_externally_callable_function(false, gcx);
+        let TyKind::Fn(fn_ty) = gcx.type_of_item(f_id.into()).kind else { unreachable!() };
+        let ty = gcx.mk_ty_fn(TyFn {
+            kind: TyFnKind::External,
+            parameters: fn_ty.parameters,
+            returns: fn_ty.returns,
+            state_mutability: f.state_mutability,
+            function_id: fn_ty.function_id,
+        }).as_externally_callable_function(false, gcx);
         let TyKind::Fn(ty_f) = ty.kind else { unreachable!() };
         let mut result = Ok(());
         for (var_id, ty) in f.variables().zip(ty_f.tys()) {

--- a/tests/ui/typeck/function_calls/call_options_standalone.sol
+++ b/tests/ui/typeck/function_calls/call_options_standalone.sol
@@ -7,6 +7,8 @@ contract CallOptionMembers {
     }
 
     function callOptionMembers() external returns (bool) {
+        // solc accepts call options as a valid function value here. We currently only support
+        // call options directly on calls.
         return this.g{gas: 42}.address == this.g.address && //~ ERROR: call options must be part of a call expression
             this.g{gas: 42}.selector == this.g.selector && //~ ERROR: call options must be part of a call expression
             this.h{gas: 42}.address == this.h.address && //~ ERROR: call options must be part of a call expression


### PR DESCRIPTION
Follow-up to #786, which was merged before these last fixes landed on the branch.

This keeps interface function collection tied to `type_of_item` so exported function types reuse the canonical item shape before applying the external interface kind. It also carries over the small evaluator comment for call-options expressions and documents the known divergence where solc accepts call options as a standalone function value but this compiler currently only supports them directly on calls.

