### PR TITLE
fix(sema): reject invalid using modifiers

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -389,7 +389,24 @@ impl<'gcx> ResolveContext<'gcx> {
                                 && func.contract.is_some_and(|c| {
                                     self.hir.contract(c).linearized_bases[1..].contains(&base)
                                 }) => {}
-                        hir::ItemId::Function(f) if self.hir.function(f).kind.is_modifier() => {}
+                        hir::ItemId::Function(f) if self.hir.function(f).kind.is_modifier() => {
+                            let modifier_contract = self.hir.function(f).contract;
+                            let allowed = func.contract.is_some_and(|current| {
+                                modifier_contract.is_some_and(|modifier_contract| {
+                                    self.hir
+                                        .contract(current)
+                                        .linearized_bases
+                                        .contains(&modifier_contract)
+                                })
+                            });
+                            if !allowed {
+                                self.dcx()
+                                    .err("can only use modifiers defined in the current contract or in base contracts")
+                                    .span(modifier.name.span())
+                                    .emit();
+                                continue;
+                            }
+                        }
                         _ => {
                             self.resolver.report_expected(
                                 expected,

--- a/tests/ui/resolve/library_modifier_via_using.sol
+++ b/tests/ui/resolve/library_modifier_via_using.sol
@@ -1,0 +1,13 @@
+// ported-from: test/libsolidity/syntaxTests/modifiers/library_via_using.sol
+
+library L {
+    modifier m() {
+        _;
+    }
+}
+
+contract C {
+    using L for *;
+
+    function f() L.m public {} //~ ERROR: can only use modifiers defined in the current contract or in base contracts
+}

--- a/tests/ui/resolve/library_modifier_via_using.stderr
+++ b/tests/ui/resolve/library_modifier_via_using.stderr
@@ -1,0 +1,8 @@
+error: can only use modifiers defined in the current contract or in base contracts
+   ╭▸ ROOT/tests/ui/resolve/library_modifier_via_using.sol:LL:CC
+   │
+LL │     function f() L.m public {}
+   ╰╴                 ━━━
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Rejects modifiers resolved through a library path unless the modifier belongs to the current contract or one of its bases.

This ports the upstream `library_via_using.sol` case as standalone resolver UI coverage, so the change is independent from the using-for semantic branch.
