### PR TITLE
refactor(diagnostics): outline builder mutation

### DIFF
--- a/crates/interface/src/diagnostics/builder.rs
+++ b/crates/interface/src/diagnostics/builder.rs
@@ -180,11 +180,6 @@ impl<'a, G: EmissionGuarantee> DiagBuilder<'a, G> {
         unsafe { std::ptr::drop_in_place(&mut this.diagnostic) };
         r
     }
-
-    #[inline(never)]
-    fn outline_mut(&mut self, f: impl FnOnce(&mut Self)) {
-        f(self);
-    }
 }
 
 /// Forwards methods to [`Diag`].
@@ -200,9 +195,12 @@ macro_rules! forward {
             #[doc = concat!("See [`Diag::", stringify!($n), "()`].")]
             #[inline]
             $vis fn $n(mut self, $($name: $ty),*) -> Self {
-                self.outline_mut(|this| {
+                #[inline(never)]
+                fn outlined<G: EmissionGuarantee>(this: &mut DiagBuilder<'_, G>, $($name: $ty),*) {
                     this.diagnostic.0.$n($($name),*);
-                });
+                }
+
+                outlined(&mut self, $($name),*);
                 self
             }
         )*

--- a/crates/interface/src/diagnostics/builder.rs
+++ b/crates/interface/src/diagnostics/builder.rs
@@ -180,6 +180,11 @@ impl<'a, G: EmissionGuarantee> DiagBuilder<'a, G> {
         unsafe { std::ptr::drop_in_place(&mut this.diagnostic) };
         r
     }
+
+    #[inline(never)]
+    fn outline_mut(&mut self, f: impl FnOnce(&mut Self)) {
+        f(self);
+    }
 }
 
 /// Forwards methods to [`Diag`].
@@ -193,9 +198,11 @@ macro_rules! forward {
         $(
             $(#[$attrs])*
             #[doc = concat!("See [`Diag::", stringify!($n), "()`].")]
-            #[inline(never)]
+            #[inline]
             $vis fn $n(mut self, $($name: $ty),*) -> Self {
-                self.diagnostic.0.$n($($name),*);
+                self.outline_mut(|this| {
+                    this.diagnostic.0.$n($($name),*);
+                });
                 self
             }
         )*


### PR DESCRIPTION
Forwarded diagnostic builder methods keep their chaining API, but their generated wrappers now inline only the ownership handoff and call a no-inline helper that mutates through `&mut self`. This keeps the cold diagnostic mutation outlined without forcing every forwarded method body to be shaped as `mut self -> Self`.
