### PR TITLE
refactor(sema): skip arena ty list interning

### DIFF
--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -7,6 +7,7 @@ use solar_data_structures::{Interned, map::FxBuildHasher};
 use std::{
     borrow::Borrow,
     hash::{BuildHasher, Hash},
+    mem,
 };
 
 type InternSet<T> = once_map::OnceMap<T, (), FxBuildHasher>;
@@ -37,6 +38,11 @@ impl<'gcx> Interner<'gcx> {
     ) -> &'gcx [Ty<'gcx>] {
         if tys.is_empty() {
             return &[];
+        }
+        if bump_contains_slice(bump, tys) {
+            // SAFETY: `tys` points into `bump`, which is owned by the global context and lives for
+            // `'gcx`.
+            return unsafe { solar_data_structures::trustme::decouple_lt(tys) };
         }
         self.ty_lists.intern_ref(tys, |tys| bump.alloc_slice_copy(tys))
     }
@@ -179,4 +185,41 @@ fn make_val<K>(_: &K) {}
 #[inline]
 fn with_result<K: Copy, V>(k: &K, _: &V) -> K {
     *k
+}
+
+#[inline]
+fn bump_contains_slice<T>(bump: &bumpalo::Bump, slice: &[T]) -> bool {
+    let len = mem::size_of_val(slice);
+    if len == 0 {
+        return false;
+    }
+
+    let start = slice.as_ptr().addr();
+    let Some(end) = start.checked_add(len) else { return false };
+
+    // SAFETY: The chunk data is not read, and the arena is not used during the iteration.
+    unsafe {
+        bump.iter_allocated_chunks_raw().any(|(ptr, len)| {
+            let chunk_start = ptr.addr();
+            let chunk_end = chunk_start + len;
+            chunk_start <= start && end <= chunk_end
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solar_ast::ElementaryType;
+
+    #[test]
+    fn intern_tys_returns_arena_slice() {
+        let bump = bumpalo::Bump::new();
+        let interner = Interner::new();
+        let ty = interner.intern_ty(&bump, TyKind::Elementary(ElementaryType::Bool));
+        let tys = bump.alloc_slice_copy(&[ty]);
+
+        let interned = interner.intern_tys(&bump, tys);
+        assert!(std::ptr::eq(interned, tys));
+    }
 }

--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -7,7 +7,6 @@ use solar_data_structures::{Interned, map::FxBuildHasher};
 use std::{
     borrow::Borrow,
     hash::{BuildHasher, Hash},
-    mem,
 };
 
 type InternSet<T> = once_map::OnceMap<T, (), FxBuildHasher>;
@@ -39,7 +38,7 @@ impl<'gcx> Interner<'gcx> {
         if tys.is_empty() {
             return &[];
         }
-        if bump_contains_slice(bump, tys) {
+        if bump_contains_ptr(bump, tys.as_ptr()) {
             debug_assert!(self.ty_lists.contains_key(tys));
             // SAFETY: `tys` points into `bump`, which is owned by the global context and lives for
             // `'gcx`.
@@ -189,21 +188,14 @@ fn with_result<K: Copy, V>(k: &K, _: &V) -> K {
 }
 
 #[inline]
-fn bump_contains_slice<T>(bump: &bumpalo::Bump, slice: &[T]) -> bool {
-    let len = mem::size_of_val(slice);
-    if len == 0 {
-        return false;
-    }
-
-    let start = slice.as_ptr().addr();
-    let Some(end) = start.checked_add(len) else { return false };
-
+fn bump_contains_ptr<T>(bump: &bumpalo::Bump, ptr: *const T) -> bool {
+    let addr = ptr.addr();
     // SAFETY: The chunk data is not read, and the arena is not used during the iteration.
     unsafe {
         bump.iter_allocated_chunks_raw().any(|(ptr, len)| {
             let chunk_start = ptr.addr();
             let chunk_end = chunk_start + len;
-            chunk_start <= start && end <= chunk_end
+            chunk_start <= addr && addr < chunk_end
         })
     }
 }

--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -189,13 +189,13 @@ fn with_result<K: Copy, V>(k: &K, _: &V) -> K {
 
 #[inline]
 fn bump_contains_ptr<T>(bump: &bumpalo::Bump, ptr: *const T) -> bool {
-    let addr = ptr.addr();
+    let ptr = ptr.cast::<u8>();
     // SAFETY: The chunk data is not read, and the arena is not used during the iteration.
     unsafe {
-        bump.iter_allocated_chunks_raw().any(|(ptr, len)| {
-            let chunk_start = ptr.addr();
-            let chunk_end = chunk_start + len;
-            chunk_start <= addr && addr < chunk_end
+        bump.iter_allocated_chunks_raw().any(|(chunk_start, len)| {
+            let chunk_start = chunk_start.cast_const();
+            let chunk_end = chunk_start.add(len);
+            chunk_start <= ptr && ptr < chunk_end
         })
     }
 }

--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -40,6 +40,7 @@ impl<'gcx> Interner<'gcx> {
             return &[];
         }
         if bump_contains_slice(bump, tys) {
+            debug_assert!(self.ty_lists.contains_key(tys));
             // SAFETY: `tys` points into `bump`, which is owned by the global context and lives for
             // `'gcx`.
             return unsafe { solar_data_structures::trustme::decouple_lt(tys) };
@@ -217,9 +218,9 @@ mod tests {
         let bump = bumpalo::Bump::new();
         let interner = Interner::new();
         let ty = interner.intern_ty(&bump, TyKind::Elementary(ElementaryType::Bool));
-        let tys = bump.alloc_slice_copy(&[ty]);
+        let tys = interner.intern_tys(&bump, &[ty]);
 
-        let interned = interner.intern_tys(&bump, tys);
-        assert!(std::ptr::eq(interned, tys));
+        let reinterned = interner.intern_tys(&bump, tys);
+        assert!(std::ptr::eq(reinterned, tys));
     }
 }


### PR DESCRIPTION
This skips the type-list interner lookup when the input slice already lives in the HIR arena. In that case the list can be returned directly with the global context lifetime instead of hashing and probing the intern map again.
