### PR TITLE
fix(sema): validate inline array literals

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1049,6 +1049,12 @@ impl<'gcx> Ty<'gcx> {
                 let tys = tys.iter().map(|ty| ty.mobile(gcx)).collect::<Option<Vec<_>>>()?;
                 gcx.mk_ty_tuple(gcx.mk_tys(&tys))
             }
+            TyKind::Error(..)
+            | TyKind::Event(..)
+            | TyKind::Module(..)
+            | TyKind::BuiltinModule(..)
+            | TyKind::Type(_)
+            | TyKind::Meta(_) => return None,
             // TODO: functions
             _ => self,
         })

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -131,7 +131,9 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
                 if let Some(common) = common {
                     // TODO: https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/analysis/TypeChecker.cpp#L1583
-                    self.gcx.mk_ty(TyKind::Array(common, U256::from(exprs.len())))
+                    self.gcx
+                        .mk_ty(TyKind::Array(common, U256::from(exprs.len())))
+                        .with_loc(self.gcx, DataLocation::Memory)
                 } else {
                     self.gcx.mk_ty_err(
                         self.dcx().err("cannot infer array element type").span(expr.span).emit(),

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -9,7 +9,11 @@ use solar_ast::{
     DataLocation, ElementaryType, Span, StateMutability, TypeSize, UserDefinableOperator,
 };
 use solar_data_structures::{Never, map::FxHashMap, pluralize, smallvec::SmallVec};
-use solar_interface::{Ident, Symbol, diagnostics::DiagCtxt, kw, sym};
+use solar_interface::{
+    Ident, Symbol,
+    diagnostics::{DiagCtxt, ErrorGuaranteed},
+    kw, sym,
+};
 use std::ops::ControlFlow;
 
 type ParamNames = SmallVec<[Option<Symbol>; 8]>;
@@ -121,19 +125,44 @@ impl<'gcx> TypeChecker<'gcx> {
         match expr.kind {
             hir::ExprKind::Array(exprs) => {
                 let mut common = expected.and_then(|arr| arr.base_type(self.gcx));
+                let mut guar: Option<ErrorGuaranteed> = None;
                 for (i, expr) in exprs.iter().enumerate() {
                     let expr_ty = self.check_expr(expr);
+                    if (i == 0 || common.is_some())
+                        && let None = expr_ty.mobile(self.gcx)
+                    {
+                        let g = self.dcx().err("invalid mobile type").span(expr.span).emit();
+                        guar.get_or_insert(g);
+                    }
                     if let Some(common_ty) = common {
                         common = common_ty.common_type(expr_ty, self.gcx);
                     } else if i == 0 {
                         common = expr_ty.mobile(self.gcx);
                     }
                 }
+                if let Some(guar) = guar {
+                    return self.gcx.mk_ty_err(guar);
+                }
                 if let Some(common) = common {
-                    // TODO: https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/analysis/TypeChecker.cpp#L1583
-                    self.gcx
-                        .mk_ty(TyKind::Array(common, U256::from(exprs.len())))
-                        .with_loc(self.gcx, DataLocation::Memory)
+                    if common.has_mapping(self.gcx) {
+                        let msg = format!(
+                            "type `{}` is only valid in storage because it contains a (nested) mapping",
+                            common.display(self.gcx),
+                        );
+                        self.gcx.mk_ty_err(self.dcx().err(msg).span(expr.span).emit())
+                    } else if !common.nameable() {
+                        self.gcx.mk_ty_err(
+                            self.dcx()
+                                .err("cannot infer nameable array element type")
+                                .span(expr.span)
+                                .help("add an explicit type conversion for the first element")
+                                .emit(),
+                        )
+                    } else {
+                        self.gcx
+                            .mk_ty(TyKind::Array(common, U256::from(exprs.len())))
+                            .with_loc(self.gcx, DataLocation::Memory)
+                    }
                 } else {
                     self.gcx.mk_ty_err(
                         self.dcx().err("cannot infer array element type").span(expr.span).emit(),

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -16,6 +16,11 @@ contract C {
         uint256[3] memory b = a;
     }
 
+    function fixedArrayLiteral() internal pure {
+        uint256[3] memory a = [uint256(1), uint256(2), uint256(3)];
+        sameFixedArray([uint256(1), uint256(2), uint256(3)]);
+    }
+
     // === Valid: explicit conversions preserve data locations ===
 
     function explicitMemoryArray(uint256[] memory a) internal pure returns (uint256[] memory) {

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -6,6 +6,7 @@
 
 contract C {
     uint256[] storageArr;
+    mapping(int256 => int256) mappingArrElement;
 
     // === Valid: same element type assignment ===
     function sameDynamicArray(uint256[] memory a) internal pure {
@@ -62,6 +63,19 @@ contract C {
     function explicitStorageToCalldata() external view {
         uint256[] storage a = storageArr;
         uint256[] calldata b = uint256[](a); //~ ERROR: mismatched types
+    }
+
+    // === Invalid: inline array element types must be mobile and nameable ===
+    function invalidMobileType() internal pure {
+        [uint256]; //~ ERROR: invalid mobile type
+    }
+
+    function unnamedTupleElement() internal pure {
+        [(uint256(1), uint256(2)), (uint256(3), uint256(4))]; //~ ERROR: cannot infer nameable array element type
+    }
+
+    function mappingElementType() internal view {
+        [mappingArrElement]; //~ ERROR: is only valid in storage because it contains a (nested) mapping
     }
 
     // === Invalid: different array lengths ===

--- a/tests/ui/typeck/implicit_array_conversions.stderr
+++ b/tests/ui/typeck/implicit_array_conversions.stderr
@@ -28,6 +28,26 @@ error: mismatched types
 LL │         uint256[] calldata b = uint256[](a);
    ╰╴                               ━━━━━━━━━━━━ expected `uint256[] calldata`, found `uint256[] storage`
 
+error: invalid mobile type
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         [uint256];
+   ╰╴         ━━━━━━━
+
+error: cannot infer nameable array element type
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         [(uint256(1), uint256(2)), (uint256(3), uint256(4))];
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: add an explicit type conversion for the first element
+
+error: type `mapping(int256 => int256) storage` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         [mappingArrElement];
+   ╰╴        ━━━━━━━━━━━━━━━━━━━
+
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
    │
@@ -70,5 +90,5 @@ error: mismatched types
 LL │         uint8[] memory b = a;
    ╰╴                           ━ expected `uint8[] memory`, found `uint256[] memory`
 
-error: aborting due to 12 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
Type array literals as memory fixed arrays so they can be passed to and assigned into memory array slots, matching solc for struct constructors such as G2Point([..], [..]).

This also validates inline array element types against solc’s checks: elements must have a mobile type, the deduced common element type must be nameable, and nested mapping element types remain storage-only.
