### PR TITLE
fix(sema): ignore index args for lvalues

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -311,7 +311,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 if let Some((index_ty, result_ty)) = self.index_types(ty) {
                     // Index expression.
                     if let Some(index) = index {
-                        let _ = self.expect_ty(index, index_ty);
+                        let _ = self.check_expr_outside_lvalue_context(index, Some(index_ty));
                     } else {
                         self.dcx().err("index expression cannot be omitted").span(expr.span).emit();
                     }
@@ -1365,6 +1365,17 @@ impl<'gcx> TypeChecker<'gcx> {
 
     fn check_expr_once(&mut self, expr: &'gcx hir::Expr<'gcx>) -> Ty<'gcx> {
         if let Some(&ty) = self.types.get(&expr.id) { ty } else { self.check_expr(expr) }
+    }
+
+    fn check_expr_outside_lvalue_context(
+        &mut self,
+        expr: &'gcx hir::Expr<'gcx>,
+        expected: Option<Ty<'gcx>>,
+    ) -> Ty<'gcx> {
+        let prev = self.lvalue_context.take();
+        let ty = self.check_expr_with(expr, expected);
+        self.lvalue_context = prev;
+        ty
     }
 
     #[must_use]

--- a/tests/ui/typeck/lvalue/valid_storage.sol
+++ b/tests/ui/typeck/lvalue/valid_storage.sol
@@ -5,6 +5,7 @@ contract Test {
     uint256 state;
     uint256[] dynamicArray;
     mapping(uint256 => uint256) map;
+    mapping(address => mapping(address => bool)) nestedMap;
     uint256 idx;
     
     function testStateVar() external {
@@ -20,6 +21,10 @@ contract Test {
     function testMapping() external {
         uint256 x = state;
         map[idx] = x;
+    }
+
+    function testNestedMapping() external {
+        nestedMap[msg.sender][address(this)] = true;
     }
     
     function testIncrement() external {


### PR DESCRIPTION
Check index arguments outside lvalue context so valid assignment targets like nested mapping entries are not rejected because the index expression itself is not assignable.
