### PR TITLE
fix(sema): allow tuple assignment holes

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -699,11 +699,11 @@ impl<'gcx> TypeChecker<'gcx> {
         for (i, (&lhs_component, &lhs_component_ty)) in
             lhs_components.iter().zip(lhs_types).enumerate()
         {
-            let Some(_) = lhs_component else { continue };
-            let Some(rhs_component) = rhs_components.and_then(|components| components[i]) else {
-                continue;
-            };
-            self.check_expected(rhs_component, rhs_types[i], lhs_component_ty);
+            if let Some(_) = lhs_component
+                && let Some(rhs_component) = rhs_components.and_then(|components| components[i])
+            {
+                self.check_expected(rhs_component, rhs_types[i], lhs_component_ty);
+            }
         }
     }
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -9,7 +9,11 @@ use solar_ast::{
     DataLocation, ElementaryType, Span, StateMutability, TypeSize, UserDefinableOperator,
 };
 use solar_data_structures::{Never, map::FxHashMap, pluralize, smallvec::SmallVec};
-use solar_interface::{Ident, Symbol, diagnostics::DiagCtxt, kw, sym};
+use solar_interface::{
+    Ident, Symbol,
+    diagnostics::{DiagCtxt, ErrorGuaranteed},
+    kw, sym,
+};
 use std::ops::ControlFlow;
 
 type ParamNames = SmallVec<[Option<Symbol>; 8]>;
@@ -149,7 +153,7 @@ impl<'gcx> TypeChecker<'gcx> {
                             .span(expr.span);
                         return self.gcx.mk_ty_err(err.emit());
                     }
-                    let _ = self.expect_ty(rhs, ty);
+                    self.check_tuple_assign_rhs(lhs, ty, rhs);
                     ty
                 } else if let Some(op) = op {
                     let rhs_ty = self.check_expr(rhs);
@@ -559,8 +563,9 @@ impl<'gcx> TypeChecker<'gcx> {
                             self.check_expr(expr)
                         };
                         if ty.is_unit() { empty_err(self, expr.span) } else { ty }
+                    } else if self.in_lvalue() {
+                        self.gcx.mk_ty_err(ErrorGuaranteed::new_unchecked())
                     } else {
-                        // TODO: allow lvalue empty tuple component with a placeholder type
                         empty_err(self, expr.span)
                     }
                 });
@@ -648,6 +653,57 @@ impl<'gcx> TypeChecker<'gcx> {
                 .err("types in storage containing (nested) mappings cannot be assigned to")
                 .span(expr.span)
                 .emit();
+        }
+    }
+
+    fn check_tuple_assign_rhs(
+        &mut self,
+        lhs: &'gcx hir::Expr<'gcx>,
+        lhs_ty: Ty<'gcx>,
+        rhs: &'gcx hir::Expr<'gcx>,
+    ) {
+        let hir::ExprKind::Tuple(lhs_components) = &lhs.kind else { return };
+        let lhs_types = if let TyKind::Tuple(types) = lhs_ty.kind {
+            types
+        } else {
+            std::slice::from_ref(&lhs_ty)
+        };
+
+        let rhs_ty = self.check_expr(rhs);
+        let rhs_types = if let TyKind::Tuple(types) = rhs_ty.kind {
+            types
+        } else {
+            std::slice::from_ref(&rhs_ty)
+        };
+
+        if lhs_components.len() != rhs_types.len() {
+            self.dcx()
+                .err("mismatched number of components")
+                .span(lhs.span)
+                .span_label(
+                    rhs.span,
+                    format!(
+                        "expected a tuple with {} element{}, found one with {} element{}",
+                        lhs_components.len(),
+                        pluralize!(lhs_components.len()),
+                        rhs_types.len(),
+                        pluralize!(rhs_types.len())
+                    ),
+                )
+                .emit();
+            return;
+        }
+
+        let rhs_components =
+            if let hir::ExprKind::Tuple(components) = &rhs.kind { Some(*components) } else { None };
+        for (i, (&lhs_component, &lhs_component_ty)) in
+            lhs_components.iter().zip(lhs_types).enumerate()
+        {
+            let Some(_) = lhs_component else { continue };
+            let Some(rhs_component) = rhs_components.and_then(|components| components[i]) else {
+                continue;
+            };
+            self.check_expected(rhs_component, rhs_types[i], lhs_component_ty);
         }
     }
 

--- a/tests/ui/typeck/lvalue/tuple.sol
+++ b/tests/ui/typeck/lvalue/tuple.sol
@@ -14,4 +14,10 @@ contract Test {
         (1, state) = (x, x); //~ ERROR: expression has to be an lvalue
         //~^ ERROR: mismatched types
     }
+
+    function testTupleHoleTypeMismatch() external {
+        uint256 x = state;
+        (x, ) = (true, 1); //~ ERROR: mismatched types
+        (, x) = (1, true); //~ ERROR: mismatched types
+    }
 }

--- a/tests/ui/typeck/lvalue/tuple.stderr
+++ b/tests/ui/typeck/lvalue/tuple.stderr
@@ -14,7 +14,19 @@ error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/lvalue/tuple.sol:LL:CC
    │
 LL │         (1, state) = (x, x);
-   ╰╴                     ━━━━━━ expected `tuple(int_literal[1],uint256)`, found `tuple(uint256,uint256)`
+   ╰╴                      ━ expected `int_literal[1]`, found `uint256`
 
-error: aborting due to 3 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/lvalue/tuple.sol:LL:CC
+   │
+LL │         (x, ) = (true, 1);
+   ╰╴                 ━━━━ expected `uint256`, found `bool`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/lvalue/tuple.sol:LL:CC
+   │
+LL │         (, x) = (1, true);
+   ╰╴                    ━━━━ expected `uint256`, found `bool`
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/typeck/lvalue/valid_memory.sol
+++ b/tests/ui/typeck/lvalue/valid_memory.sol
@@ -38,6 +38,12 @@ contract Test {
         uint256 z;
         (x, y, z) = (z, y, x);
     }
+
+    function testTupleAssignWithHoles() external pure {
+        uint256 x;
+        (x, ) = (1, true);
+        (, x) = (false, 2);
+    }
     
     function testFunctionParam(uint256 param) external pure {
         uint256 x;


### PR DESCRIPTION
Allows tuple assignment targets to omit components, so expressions like `(ok, ) = address(this).staticcall("")` type-check the assigned slots without requiring a concrete type for skipped positions.

This also makes tuple assignment diagnostics point at the mismatched RHS component rather than the whole RHS tuple.
