### PR TITLE
fix(sema): type yul address literals as words

### DIFF
--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -8,18 +8,21 @@ use solar_interface::{Ident, Symbol, diagnostics::ErrorGuaranteed, kw, sym};
 
 impl<'gcx> TypeChecker<'gcx> {
     pub(super) fn check_yul_lit(&self, lit: &'gcx hir::Lit<'gcx>) -> Ty<'gcx> {
-        if let LitKind::Str(_, s, _) = &lit.kind {
-            let len = s.as_byte_str().len();
-            return if len <= 32 {
-                self.gcx.types.uint(256)
-            } else {
-                self.gcx.mk_ty_err(
+        match &lit.kind {
+            LitKind::Str(_, s, _) => {
+                let len = s.as_byte_str().len();
+                if len <= 32 {
+                    return self.gcx.types.uint(256);
+                }
+                return self.gcx.mk_ty_err(
                     self.dcx()
                         .err(format!("string literal too long ({len} > 32)"))
                         .span(lit.span)
                         .emit(),
-                )
-            };
+                );
+            }
+            LitKind::Address(_) => return self.gcx.types.uint(256),
+            _ => {}
         }
 
         self.gcx.type_of_lit(lit)

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -70,6 +70,9 @@ contract C {
             pop(convertedConstant)
             pop("abc")
             pop(hex"1234")
+            let bitmask := 0xffffffffffffffffffffffffffffffffffffffff
+            pop(bitmask)
+            mstore(64, 0x000000000000378eDCD5B5B0A24f5342d8C10485)
             mstore(0, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef")
             mstore(32, hex"1234567890123456789012345678901234567890123456789012345678901234")
             storageRef.slot := state.slot


### PR DESCRIPTION
Treat parsed address literals inside inline assembly as Yul words instead of Solidity `address` values. Yul builtins such as `mstore`, `add`, and local variable declarations expect stack words, so 20-byte hex constants should type-check like other numeric Yul literals.
