### PR TITLE
fix(sema): prefer most derived call target

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1028,7 +1028,7 @@ impl<'gcx> TypeChecker<'gcx> {
             return Ok(res);
         }
 
-        let mut selected = WantOne::Zero;
+        let mut selected = SmallVec::<[_; 4]>::new();
         for &res in res {
             let ty = self.type_of_res(res);
             let Some((param_tys, param_names)) = self.call_candidate_params(ty) else {
@@ -1038,11 +1038,43 @@ impl<'gcx> TypeChecker<'gcx> {
                 selected.push(res);
             }
         }
-        match selected {
-            WantOne::Zero => Err(OverloadError::NotFound),
-            WantOne::One(res) => Ok(res),
-            WantOne::Many => Err(OverloadError::Ambiguous),
+        match selected.as_slice() {
+            [] => Err(OverloadError::NotFound),
+            [res] => Ok(*res),
+            selected => self.select_most_derived_function(selected).ok_or(OverloadError::Ambiguous),
         }
+    }
+
+    fn select_most_derived_function(&self, candidates: &[hir::Res]) -> Option<hir::Res> {
+        let contract = self.contract?;
+        let bases = self.gcx.hir.contract(contract).linearized_bases;
+
+        let mut selected = None;
+        let mut selected_depth = usize::MAX;
+        let mut parameter_types = None;
+        for &candidate in candidates {
+            let hir::Res::Item(hir::ItemId::Function(id)) = candidate else { return None };
+            let function = self.gcx.hir.function(id);
+            let depth = bases.iter().position(|&base| Some(base) == function.contract)?;
+            let params = self.gcx.item_parameter_types(id);
+            if let Some(parameter_types) = parameter_types {
+                if parameter_types != params {
+                    return None;
+                }
+            } else {
+                parameter_types = Some(params);
+            }
+
+            match depth.cmp(&selected_depth) {
+                std::cmp::Ordering::Less => {
+                    selected = Some(candidate);
+                    selected_depth = depth;
+                }
+                std::cmp::Ordering::Equal => return None,
+                std::cmp::Ordering::Greater => {}
+            }
+        }
+        selected
     }
 
     fn call_candidate_params(&self, ty: Ty<'gcx>) -> Option<CallCandidateParams<'gcx>> {

--- a/tests/ui/typeck/function_calls/call_checking.sol
+++ b/tests/ui/typeck/function_calls/call_checking.sol
@@ -142,3 +142,15 @@ contract CallChecking {
         //~| ERROR: mismatched types
     }
 }
+
+contract BaseCallTarget {
+    function ownerCheck() internal view virtual {}
+}
+
+contract DerivedCallTarget is BaseCallTarget {
+    function testMostDerivedCall() public view {
+        ownerCheck();
+    }
+
+    function ownerCheck() internal view virtual override {}
+}


### PR DESCRIPTION
When unqualified call resolution finds several matching function declarations with the same parameter types, prefer the declaration closest to the current contract in the linearized inheritance list.

This handles calls to internal functions overridden in the current contract while preserving ambiguity for ordinary overload matches with different parameter types.
