### PR TITLE
fix(sema): bind storage array methods

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -89,6 +89,10 @@ impl<'gcx> Member<'gcx> {
         Self::with_res(builtin.name(), ty, builtin)
     }
 
+    pub fn with_attached_builtin(builtin: Builtin, ty: Ty<'gcx>) -> Self {
+        Self { name: builtin.name(), ty, res: Some(builtin.into()), attached: true }
+    }
+
     pub fn of_builtin(gcx: Gcx<'gcx>, builtin: Builtin) -> Self {
         Self::new(builtin.name(), builtin.ty(gcx))
     }
@@ -190,15 +194,15 @@ fn reference<'gcx>(
             };
             vec![
                 Member::of_builtin(gcx, Builtin::ArrayLength),
-                Member::with_builtin(
+                Member::with_attached_builtin(
                     Builtin::ArrayPush0,
                     gcx.mk_builtin_fn(&[this, inner], SM::NonPayable, &[]),
                 ),
-                Member::with_builtin(
+                Member::with_attached_builtin(
                     Builtin::ArrayPush,
                     gcx.mk_builtin_fn(&[this], SM::NonPayable, &[inner]),
                 ),
-                Member::with_builtin(
+                Member::with_attached_builtin(
                     Builtin::ArrayPop,
                     gcx.mk_builtin_fn(&[this], SM::NonPayable, &[]),
                 ),

--- a/tests/ui/typeck/lvalue/valid_storage.sol
+++ b/tests/ui/typeck/lvalue/valid_storage.sol
@@ -16,6 +16,13 @@ contract Test {
         uint256 x = state;
         dynamicArray[idx] = x;
     }
+
+    function testStorageArrayMethods() external {
+        dynamicArray.push(1);
+        uint256 x = dynamicArray.push();
+        dynamicArray.pop();
+        x;
+    }
     
     function testMapping() external {
         uint256 x = state;


### PR DESCRIPTION
Marks storage array `push` and `pop` builtins as attached to their receiver, so calls like `data.push(1)`, `data.push()`, and `data.pop()` are checked against only the user-supplied arguments.
