### PR TITLE
fix(sema): reject oversized memory arrays

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1377,6 +1377,7 @@ impl<'gcx> TypeChecker<'gcx> {
         let var = self.gcx.hir.variable(id);
         let _ = self.visit_ty(&var.ty);
         let ty = self.gcx.type_of_item(id.into());
+        self.check_var_type_size(var, ty);
 
         if let Some(init) = var.initializer {
             if var.is_state_variable() && ty.has_mapping(self.gcx) {
@@ -1439,6 +1440,43 @@ impl<'gcx> TypeChecker<'gcx> {
         }
 
         ty
+    }
+
+    fn check_var_type_size(&self, var: &hir::Variable<'gcx>, ty: Ty<'gcx>) {
+        let Some(loc @ (DataLocation::Memory | DataLocation::Calldata)) = ty.loc() else {
+            return;
+        };
+        let Some(size) = self.ty_memory_static_size(ty.peel_refs()) else { return };
+        if size >= U256::from(u32::MAX) {
+            self.dcx().err(format!("type too large for {loc}")).span(var.ty.span).emit();
+        }
+    }
+
+    fn ty_memory_static_size(&self, ty: Ty<'gcx>) -> Option<U256> {
+        match ty.kind {
+            TyKind::Array(elem, len) => {
+                let elem_size = if elem.is_dynamically_sized() {
+                    U256::from(32)
+                } else {
+                    self.ty_memory_static_size(elem)?
+                };
+                len.checked_mul(elem_size)
+            }
+            TyKind::Struct(id) => {
+                let mut size = U256::ZERO;
+                for &field_ty in self.gcx.struct_field_types(id) {
+                    let field_size = if field_ty.is_dynamically_sized() {
+                        U256::from(32)
+                    } else {
+                        self.ty_memory_static_size(field_ty)?
+                    };
+                    size = size.checked_add(field_size)?;
+                }
+                Some(size)
+            }
+            TyKind::Ref(inner, _) => self.ty_memory_static_size(inner),
+            _ => Some(U256::from(32)),
+        }
     }
 
     fn check_decl(

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1443,11 +1443,10 @@ impl<'gcx> TypeChecker<'gcx> {
     }
 
     fn check_var_type_size(&self, var: &hir::Variable<'gcx>, ty: Ty<'gcx>) {
-        let Some(loc @ (DataLocation::Memory | DataLocation::Calldata)) = ty.loc() else {
-            return;
-        };
-        let Some(size) = self.ty_memory_static_size(ty.peel_refs()) else { return };
-        if size >= U256::from(u32::MAX) {
+        if let Some(loc @ (DataLocation::Memory | DataLocation::Calldata)) = ty.loc()
+            && let Some(size) = self.ty_memory_static_size(ty.peel_refs())
+            && size >= u32::MAX
+        {
             self.dcx().err(format!("type too large for {loc}")).span(var.ty.span).emit();
         }
     }

--- a/tests/ui/typeck/var_decl_rules.sol
+++ b/tests/ui/typeck/var_decl_rules.sol
@@ -45,6 +45,10 @@ contract C {
     // Calldata variable containing mapping is also invalid
     function g(WithMapping calldata w) internal {} //~ ERROR: is only valid in storage because it contains a (nested) mapping
 
+    // Fixed arrays that exceed the memory/calldata type-size limit are invalid
+    function tooLargeMemory(uint[85678901234] memory a) public pure {} //~ ERROR: type too large for memory
+    function tooLargeCalldata(uint[85678901234] calldata a) external pure {} //~ ERROR: type too large for calldata
+
     // Uninitialized storage mapping in local variable is invalid
     function h() internal {
         mapping(uint => uint) storage s; //~ ERROR: uninitialized mapping

--- a/tests/ui/typeck/var_decl_rules.sol
+++ b/tests/ui/typeck/var_decl_rules.sol
@@ -46,8 +46,12 @@ contract C {
     function g(WithMapping calldata w) internal {} //~ ERROR: is only valid in storage because it contains a (nested) mapping
 
     // Fixed arrays that exceed the memory/calldata type-size limit are invalid
+    function maxMemory(uint[134217727] memory a) public pure {}
     function tooLargeMemory(uint[85678901234] memory a) public pure {} //~ ERROR: type too large for memory
+    function justTooLargeMemory(uint[134217728] memory a) public pure {} //~ ERROR: type too large for memory
+    function maxCalldata(uint[134217727] calldata a) external pure {}
     function tooLargeCalldata(uint[85678901234] calldata a) external pure {} //~ ERROR: type too large for calldata
+    function justTooLargeCalldata(uint[134217728] calldata a) external pure {} //~ ERROR: type too large for calldata
 
     // Uninitialized storage mapping in local variable is invalid
     function h() internal {

--- a/tests/ui/typeck/var_decl_rules.stderr
+++ b/tests/ui/typeck/var_decl_rules.stderr
@@ -54,6 +54,18 @@ error: type `struct C.WithMapping calldata` is only valid in storage because it 
 LL │     function g(WithMapping calldata w) internal {}
    ╰╴               ━━━━━━━━━━━━━━━━━━━━━━
 
+error: type too large for memory
+   ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
+   │
+LL │     function tooLargeMemory(uint[85678901234] memory a) public pure {}
+   ╰╴                            ━━━━━━━━━━━━━━━━━
+
+error: type too large for calldata
+   ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
+   │
+LL │     function tooLargeCalldata(uint[85678901234] calldata a) external pure {}
+   ╰╴                              ━━━━━━━━━━━━━━━━━
+
 error: uninitialized mapping
    ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
    │
@@ -62,5 +74,5 @@ LL │         mapping(uint => uint) storage s;
    │
    ╰ note: mappings cannot be created dynamically, you have to assign them from a state variable
 
-error: aborting due to 10 previous errors
+error: aborting due to 12 previous errors
 

--- a/tests/ui/typeck/var_decl_rules.stderr
+++ b/tests/ui/typeck/var_decl_rules.stderr
@@ -60,11 +60,23 @@ error: type too large for memory
 LL │     function tooLargeMemory(uint[85678901234] memory a) public pure {}
    ╰╴                            ━━━━━━━━━━━━━━━━━
 
+error: type too large for memory
+   ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
+   │
+LL │     function justTooLargeMemory(uint[134217728] memory a) public pure {}
+   ╰╴                                ━━━━━━━━━━━━━━━
+
 error: type too large for calldata
    ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
    │
 LL │     function tooLargeCalldata(uint[85678901234] calldata a) external pure {}
    ╰╴                              ━━━━━━━━━━━━━━━━━
+
+error: type too large for calldata
+   ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
+   │
+LL │     function justTooLargeCalldata(uint[134217728] calldata a) external pure {}
+   ╰╴                                  ━━━━━━━━━━━━━━━
 
 error: uninitialized mapping
    ╭▸ ROOT/tests/ui/typeck/var_decl_rules.sol:LL:CC
@@ -74,5 +86,5 @@ LL │         mapping(uint => uint) storage s;
    │
    ╰ note: mappings cannot be created dynamically, you have to assign them from a state variable
 
-error: aborting due to 12 previous errors
+error: aborting due to 14 previous errors
 


### PR DESCRIPTION
Rejects fixed-size memory and calldata reference types whose static size reaches the `uint32::MAX` limit used by solc for memory/calldata type validation.

This catches oversized public/internal memory parameters and external calldata parameters during variable type checking.
