### PR TITLE
fix(sema): cast library names to address

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -943,6 +943,10 @@ impl<'gcx> Ty<'gcx> {
 
             // Contract -> address (always allowed)
             (Contract(_), Elementary(Address(false))) => Ok(()),
+            // Library type name -> address.
+            (Type(library), Elementary(Address(false))) if matches!(library.kind, Contract(id) if gcx.hir.contract(id).kind.is_library()) => {
+                Ok(())
+            }
 
             // Contract -> address payable (only if contract can receive ether)
             (Contract(contract_id), Elementary(Address(true))) => {

--- a/tests/ui/typeck/contract_address_conversions_explicit.sol
+++ b/tests/ui/typeck/contract_address_conversions_explicit.sol
@@ -14,6 +14,8 @@ contract WithNonPayableFallback {
     fallback() external {}
 }
 
+library Lib {}
+
 contract Test {
     function testContractToAddress(
         NoReceive c1,
@@ -53,5 +55,11 @@ contract Test {
         WithPayableFallback c6 = WithPayableFallback(paddr); // ok
         NoReceive c7 = NoReceive(paddr); // ok
         WithNonPayableFallback c8 = WithNonPayableFallback(paddr); // ok
+    }
+
+    function testLibraryTypeToAddress() public pure {
+        address a = address(Lib);
+        address b = address(type(Lib)); //~ ERROR: invalid explicit type conversion
+        a; b;
     }
 }

--- a/tests/ui/typeck/contract_address_conversions_explicit.sol
+++ b/tests/ui/typeck/contract_address_conversions_explicit.sol
@@ -14,6 +14,10 @@ contract WithNonPayableFallback {
     fallback() external {}
 }
 
+interface I {}
+
+abstract contract Abstract {}
+
 library Lib {}
 
 contract Test {
@@ -61,5 +65,12 @@ contract Test {
         address a = address(Lib);
         address b = address(type(Lib)); //~ ERROR: invalid explicit type conversion
         a; b;
+    }
+
+    function testContractTypeToAddress() public pure {
+        address a = address(NoReceive); //~ ERROR: invalid explicit type conversion
+        address b = address(I); //~ ERROR: invalid explicit type conversion
+        address c = address(Abstract); //~ ERROR: invalid explicit type conversion
+        a; b; c;
     }
 }

--- a/tests/ui/typeck/contract_address_conversions_explicit.stderr
+++ b/tests/ui/typeck/contract_address_conversions_explicit.stderr
@@ -28,5 +28,23 @@ error: invalid explicit type conversion
 LL │         address b = address(type(Lib));
    ╰╴                    ━━━━━━━━━━━━━━━━━━ cannot convert `type(library Lib)` to `address`
 
-error: aborting due to 5 previous errors
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/contract_address_conversions_explicit.sol:LL:CC
+   │
+LL │         address a = address(NoReceive);
+   ╰╴                    ━━━━━━━━━━━━━━━━━━ cannot convert `type(contract NoReceive)` to `address`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/contract_address_conversions_explicit.sol:LL:CC
+   │
+LL │         address b = address(I);
+   ╰╴                    ━━━━━━━━━━ cannot convert `type(contract I)` to `address`
+
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/contract_address_conversions_explicit.sol:LL:CC
+   │
+LL │         address c = address(Abstract);
+   ╰╴                    ━━━━━━━━━━━━━━━━━ cannot convert `type(contract Abstract)` to `address`
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/typeck/contract_address_conversions_explicit.stderr
+++ b/tests/ui/typeck/contract_address_conversions_explicit.stderr
@@ -22,5 +22,11 @@ error: invalid explicit type conversion
 LL │         WithPayableFallback c3 = WithPayableFallback(addr);
    ╰╴                                 ━━━━━━━━━━━━━━━━━━━━━━━━━ cannot convert non-payable `address` to `contract WithPayableFallback` because it has a receive function or payable fallback
 
-error: aborting due to 4 previous errors
+error: invalid explicit type conversion
+   ╭▸ ROOT/tests/ui/typeck/contract_address_conversions_explicit.sol:LL:CC
+   │
+LL │         address b = address(type(Lib));
+   ╰╴                    ━━━━━━━━━━━━━━━━━━ cannot convert `type(library Lib)` to `address`
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Allows explicit `address(L)` casts for library identifiers while keeping `address(type(L))` rejected.

Solc permits the direct library-name cast because it refers to the deployed library address; this adds that narrow conversion without broadening contract/interface/abstract type-name casts. Plain contract names still resolve through the type namespace as `type(contract ...)`, and remain rejected.
