### PR TITLE
fix(sema): expose scoped state vars

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -11,7 +11,11 @@ use solar_interface::Symbol;
 pub type MemberList<'gcx> = &'gcx [Member<'gcx>];
 pub(crate) type MemberListOwned<'gcx> = Vec<Member<'gcx>>;
 
-pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'gcx> {
+pub(crate) fn native_members<'gcx>(
+    gcx: Gcx<'gcx>,
+    ty: Ty<'gcx>,
+    current_contract: Option<hir::ContractId>,
+) -> MemberList<'gcx> {
     let expected_ref = || panic!("native_members: type {ty:?} should be wrapped in Ref");
     gcx.bump().alloc_vec(match ty.kind {
         TyKind::Elementary(elementary_type) => match elementary_type {
@@ -57,7 +61,7 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
             .unwrap_or_else(|| panic!("builtin module {builtin:?} has no inner builtins"))
             .map(|b| Member::of_builtin(gcx, b))
             .collect(),
-        TyKind::Type(ty) => type_type(gcx, ty),
+        TyKind::Type(ty) => type_type(gcx, ty, current_contract),
         TyKind::Meta(ty) => meta(gcx, ty),
         TyKind::Err(_guar) => Default::default(),
     })
@@ -213,9 +217,13 @@ fn reference<'gcx>(
 }
 
 // `Enum.Variant`, `Udvt.wrap`
-fn type_type<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberListOwned<'gcx> {
+fn type_type<'gcx>(
+    gcx: Gcx<'gcx>,
+    ty: Ty<'gcx>,
+    current_contract: Option<hir::ContractId>,
+) -> MemberListOwned<'gcx> {
     match ty.kind {
-        TyKind::Contract(id) => contract_type(gcx, id),
+        TyKind::Contract(id) => contract_type(gcx, id, current_contract),
         TyKind::Enum(id) => {
             gcx.hir.enumm(id).variants.iter().map(|v| Member::new(v.name, ty)).collect()
         }
@@ -237,9 +245,15 @@ fn type_type<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberListOwned<'gcx> {
     }
 }
 
-fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
+fn contract_type(
+    gcx: Gcx<'_>,
+    id: hir::ContractId,
+    current_contract: Option<hir::ContractId>,
+) -> MemberListOwned<'_> {
     let contract = gcx.hir.contract(id);
     let is_library = contract.kind.is_library();
+    let is_base_of_current = current_contract
+        .is_some_and(|current| gcx.hir.contract(current).linearized_bases.contains(&id));
     let functions = if is_library {
         Either::Left(contract.functions().filter(|&id| {
             let f = gcx.hir.function(id);
@@ -248,7 +262,7 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
     } else {
         Either::Right(gcx.interface_functions(id).iter().map(|f| f.id))
     };
-    functions
+    let mut members: MemberListOwned<'_> = functions
         .map(|id| {
             let item = hir::ItemId::from(id);
             let f = gcx.hir.function(id);
@@ -270,7 +284,20 @@ fn contract_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
             };
             Member::with_res(gcx.item_name(item).name, ty, item)
         })
-        .collect()
+        .collect();
+
+    if !is_library && is_base_of_current {
+        members.extend(contract.variables().filter_map(|id| {
+            let var = gcx.hir.variable(id);
+            if var.visibility.unwrap_or(Visibility::Internal) <= Visibility::Private {
+                return None;
+            }
+            let item = hir::ItemId::from(id);
+            Some(Member::with_res(gcx.item_name(item).name, gcx.type_of_item(item), item))
+        }));
+    }
+
+    members
 }
 
 // `type(T)`

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -713,7 +713,7 @@ impl<'gcx> Gcx<'gcx> {
         source: hir::SourceId,
         contract: Option<hir::ContractId>,
     ) -> impl Iterator<Item = members::Member<'gcx>> + 'gcx {
-        let native = self.native_members(ty);
+        let native = self.native_members((ty, contract));
         let attached = self.attached_functions(ty, source, contract);
         native.iter().copied().chain(attached)
     }
@@ -892,6 +892,8 @@ fn fn_state_mutability(kind: TyFnKind, state_mutability: StateMutability) -> Sta
         state_mutability
     }
 }
+
+type NativeMembersKey<'gcx> = (Ty<'gcx>, Option<hir::ContractId>);
 
 macro_rules! cached {
     ($($(#[$attr:meta])* $vis:vis fn $name:ident($gcx:ident: _, $key:ident : $key_type:ty) -> $value:ty $imp:block)*) => {
@@ -1178,8 +1180,9 @@ pub fn struct_recursiveness(gcx: _, id: hir::StructId) -> Recursiveness {
     }
 }
 
-fn native_members(gcx: _, ty: Ty<'gcx>) -> members::MemberList<'gcx> {
-    members::native_members(gcx, ty)
+fn native_members(gcx: _, key: NativeMembersKey<'gcx>) -> members::MemberList<'gcx> {
+    let (ty, contract) = key;
+    members::native_members(gcx, ty, contract)
 }
 }
 

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -6,6 +6,7 @@
 // ported-from: test/libsolidity/syntaxTests/abiEncoder/v2_call_to_v2_library_function_pointer_accepting_struct.sol
 // ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/assign_function_via_contract_name_to_var.sol
 // ported-from: test/libsolidity/semanticTests/functionTypes/stack_height_check_on_adding_gas_variable_to_function.sol
+// ported-from: test/libsolidity/semanticTests/various/state_variable_under_contract_name.sol
 
 type Pointer is uint256;
 
@@ -79,5 +80,19 @@ contract C {
 
     function eventLibraryFunctionIsSpecial() public {
         emit ExternalFunction(PointerLib.ping); //~ ERROR: mismatched types
+    }
+}
+
+contract StateVarScope {
+    uint256 stateVar = 42;
+
+    function getStateVar() public view returns (uint256 value) {
+        value = StateVarScope.stateVar;
+    }
+}
+
+contract OtherScope {
+    function getStateVar() public view returns (uint256 value) {
+        value = StateVarScope.stateVar; //~ ERROR: member `stateVar` not found
     }
 }

--- a/tests/ui/typeck/function_calls/type_members.stderr
+++ b/tests/ui/typeck/function_calls/type_members.stderr
@@ -34,5 +34,11 @@ error: mismatched types
 LL │         emit ExternalFunction(PointerLib.ping);
    ╰╴                              ━━━━━━━━━━━━━━━ expected `function () external`, found `function ()`
 
-error: aborting due to 6 previous errors
+error: member `stateVar` not found on type `type(contract StateVarScope)`
+   ╭▸ ROOT/tests/ui/typeck/function_calls/type_members.sol:LL:CC
+   │
+LL │         value = StateVarScope.stateVar;
+   ╰╴                              ━━━━━━━━
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Expose visible state variables on a contract type when the referenced contract is the current contract or one of its bases.

This matches solc for reads such as Scope.stateVar inside Scope while keeping internal state variables hidden from unrelated contract scopes.
