### PR TITLE
fix(sema): index calldata slices

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -340,7 +340,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 let ty = self.check_expr(lhs);
                 if !ty.is_sliceable() {
                     self.dcx().err("can only slice arrays").span(expr.span).emit();
-                } else if !ty.is_ref_at(DataLocation::Calldata) {
+                } else if !is_calldata_sliceable(ty) {
                     self.dcx().err("can only slice dynamic calldata arrays").span(expr.span).emit();
                 }
                 if let Some((_index_ty, _result_ty)) = self.index_types(ty) {
@@ -785,6 +785,7 @@ impl<'gcx> TypeChecker<'gcx> {
             TyKind::Array(element, _) | TyKind::DynArray(element) => {
                 (self.gcx.types.uint(256), element.with_loc_if_ref_opt(self.gcx, loc))
             }
+            TyKind::Slice(array) => (self.gcx.types.uint(256), array.base_type(self.gcx)?),
             TyKind::Elementary(ElementaryType::Bytes)
             | TyKind::Elementary(ElementaryType::FixedBytes(_)) => {
                 (self.gcx.types.uint(256), self.gcx.types.fixed_bytes(1))
@@ -1928,6 +1929,11 @@ fn valid_delete(ty: Ty<'_>) -> bool {
 
         _ => false,
     }
+}
+
+fn is_calldata_sliceable(ty: Ty<'_>) -> bool {
+    ty.is_ref_at(DataLocation::Calldata)
+        || matches!(ty.kind, TyKind::Slice(array) if array.data_stored_in(DataLocation::Calldata))
 }
 
 fn valid_unop(ty: Ty<'_>, op: hir::UnOpKind) -> bool {

--- a/tests/ui/typeck/implicit_slice.sol
+++ b/tests/ui/typeck/implicit_slice.sol
@@ -1,4 +1,5 @@
 //@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/syntaxTests/array/slice/calldata_dynamic_access.sol
 
 // Tests for array slice implicit conversions.
 // See: https://docs.soliditylang.org/en/latest/types.html#array-slices
@@ -17,6 +18,13 @@ contract C {
     // Slices can be implicitly converted to memory arrays of the same element type.
     function toMemory(uint256[] calldata data, uint256 start, uint256 end) external pure {
         uint256[] memory s = data[start:end];
+    }
+
+    function accessSlice(uint256[] calldata data) external pure {
+        data[1:2][0];
+        data[1:][0];
+        data[1:][1:2][0];
+        data[1:2][1:][0];
     }
 
     // Slices can only be created from calldata arrays.


### PR DESCRIPTION
Allow indexing calldata array slices and taking further slices from them by using the slice’s underlying calldata array type for index result inference.

This matches solc for expressions such as x[1:2][0] and nested calldata slice access.
