### PR TITLE
fix(sema): handle storage call lvalues

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -27,7 +27,7 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         },
         TyKind::StringLiteral(_utf8, _size) => Default::default(),
         TyKind::IntLiteral(..) => Default::default(),
-        TyKind::Ref(inner, loc) => reference(gcx, inner, loc),
+        TyKind::Ref(inner, loc) => reference(gcx, ty, inner, loc),
         TyKind::DynArray(_ty) => expected_ref(),
         TyKind::Array(_ty, _len) => expected_ref(),
         TyKind::Slice(_ty) => Default::default(),
@@ -166,7 +166,12 @@ fn function<'gcx>(gcx: Gcx<'gcx>, f: &'gcx TyFn<'gcx>) -> MemberListOwned<'gcx> 
     members
 }
 
-fn reference<'gcx>(gcx: Gcx<'gcx>, inner: Ty<'gcx>, loc: DataLocation) -> MemberListOwned<'gcx> {
+fn reference<'gcx>(
+    gcx: Gcx<'gcx>,
+    this: Ty<'gcx>,
+    inner: Ty<'gcx>,
+    loc: DataLocation,
+) -> MemberListOwned<'gcx> {
     match (&inner.kind, loc) {
         (&TyKind::Struct(id), _) => {
             let fields = gcx.hir.strukt(id).fields;
@@ -191,15 +196,15 @@ fn reference<'gcx>(gcx: Gcx<'gcx>, inner: Ty<'gcx>, loc: DataLocation) -> Member
                 Member::of_builtin(gcx, Builtin::ArrayLength),
                 Member::with_attached_builtin(
                     Builtin::ArrayPush0,
-                    gcx.mk_builtin_fn(&[], SM::NonPayable, &[inner]),
+                    gcx.mk_builtin_fn(&[this], SM::NonPayable, &[inner]),
                 ),
                 Member::with_attached_builtin(
                     Builtin::ArrayPush,
-                    gcx.mk_builtin_fn(&[inner], SM::NonPayable, &[]),
+                    gcx.mk_builtin_fn(&[this, inner], SM::NonPayable, &[]),
                 ),
                 Member::with_attached_builtin(
                     Builtin::ArrayPop,
-                    gcx.mk_builtin_fn(&[], SM::NonPayable, &[]),
+                    gcx.mk_builtin_fn(&[this], SM::NonPayable, &[]),
                 ),
             ]
         }

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -27,7 +27,7 @@ pub(crate) fn native_members<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberList<'
         },
         TyKind::StringLiteral(_utf8, _size) => Default::default(),
         TyKind::IntLiteral(..) => Default::default(),
-        TyKind::Ref(inner, loc) => reference(gcx, ty, inner, loc),
+        TyKind::Ref(inner, loc) => reference(gcx, inner, loc),
         TyKind::DynArray(_ty) => expected_ref(),
         TyKind::Array(_ty, _len) => expected_ref(),
         TyKind::Slice(_ty) => Default::default(),
@@ -162,12 +162,7 @@ fn function<'gcx>(gcx: Gcx<'gcx>, f: &'gcx TyFn<'gcx>) -> MemberListOwned<'gcx> 
     members
 }
 
-fn reference<'gcx>(
-    gcx: Gcx<'gcx>,
-    this: Ty<'gcx>,
-    inner: Ty<'gcx>,
-    loc: DataLocation,
-) -> MemberListOwned<'gcx> {
+fn reference<'gcx>(gcx: Gcx<'gcx>, inner: Ty<'gcx>, loc: DataLocation) -> MemberListOwned<'gcx> {
     match (&inner.kind, loc) {
         (&TyKind::Struct(id), _) => {
             let fields = gcx.hir.strukt(id).fields;
@@ -192,15 +187,15 @@ fn reference<'gcx>(
                 Member::of_builtin(gcx, Builtin::ArrayLength),
                 Member::with_builtin(
                     Builtin::ArrayPush0,
-                    gcx.mk_builtin_fn(&[this, inner], SM::NonPayable, &[]),
+                    gcx.mk_builtin_fn(&[], SM::NonPayable, &[inner]),
                 ),
                 Member::with_builtin(
                     Builtin::ArrayPush,
-                    gcx.mk_builtin_fn(&[this], SM::NonPayable, &[inner]),
+                    gcx.mk_builtin_fn(&[inner], SM::NonPayable, &[]),
                 ),
                 Member::with_builtin(
                     Builtin::ArrayPop,
-                    gcx.mk_builtin_fn(&[this], SM::NonPayable, &[]),
+                    gcx.mk_builtin_fn(&[], SM::NonPayable, &[]),
                 ),
             ]
         }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -295,10 +295,8 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 };
 
-                // For some reason, `ArrayPush0` is the only call that can be an lvalue.
-                if !(ty.loc() == Some(DataLocation::Storage)
-                    || self.member_builtins.get(&callee.id) == Some(&Builtin::ArrayPush0))
-                {
+                // No-argument storage array `.push()` is the only call that can be an lvalue.
+                if self.member_builtins.get(&callee.id) != Some(&Builtin::ArrayPush0) {
                     self.try_set_not_lvalue(NotLvalueReason::Generic);
                 }
 
@@ -330,7 +328,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 ty
             }
             hir::ExprKind::Index(lhs, index) => {
-                let ty = self.check_expr(lhs);
+                let ty = self.check_expr_outside_lvalue_context(lhs, None);
                 if ty.references_error() {
                     return ty;
                 }
@@ -395,7 +393,7 @@ impl<'gcx> TypeChecker<'gcx> {
             hir::ExprKind::Lit(lit) if self.in_yul => self.check_yul_lit(lit),
             hir::ExprKind::Lit(lit) => self.gcx.type_of_lit(lit),
             hir::ExprKind::Member(expr, ident) => {
-                let expr_ty = self.check_expr(expr);
+                let expr_ty = self.check_expr_outside_lvalue_context(expr, None);
                 if expr_ty.references_error() {
                     return expr_ty;
                 }
@@ -932,7 +930,7 @@ impl<'gcx> TypeChecker<'gcx> {
         ident: Ident,
         args: &hir::CallArgs<'gcx>,
     ) -> Ty<'gcx> {
-        let receiver_ty = self.check_expr(receiver);
+        let receiver_ty = self.check_expr_outside_lvalue_context(receiver, None);
         if let Err(e) = receiver_ty.error_reported() {
             let ty = self.gcx.mk_ty_err(e);
             self.register_ty(callee, ty);

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -30,6 +30,7 @@ struct TypeChecker<'gcx> {
     construction_context: u32,
 
     types: FxHashMap<hir::ExprId, Ty<'gcx>>,
+    member_builtins: FxHashMap<hir::ExprId, Builtin>,
 
     lvalue_context: Option<Result<(), NotLvalueReason>>,
 
@@ -61,6 +62,7 @@ impl<'gcx> TypeChecker<'gcx> {
             function: None,
             construction_context: 0,
             types: Default::default(),
+            member_builtins: Default::default(),
             lvalue_context: None,
             in_emit: false,
             in_revert: false,
@@ -201,8 +203,8 @@ impl<'gcx> TypeChecker<'gcx> {
                     None
                 };
 
-                // TODO: `array.push() = x;` is the only valid call lvalue
-                let is_array_push = false;
+                let is_array_push =
+                    self.member_builtins.get(&callee.id) == Some(&Builtin::ArrayPush0);
 
                 let ty = match callee_ty.kind {
                     TyKind::Fn(f) => {
@@ -914,6 +916,9 @@ impl<'gcx> TypeChecker<'gcx> {
         let ty = match self.select_member_call_overload(receiver_ty, &possible_members, args) {
             Ok(member) => {
                 self.check_library_self_call(member, ident.span);
+                if let Some(builtin) = member_builtin(member) {
+                    self.member_builtins.insert(callee.id, builtin);
+                }
                 self.member_call_ty(receiver_ty, member)
             }
             Err(e) => {
@@ -1511,7 +1516,7 @@ impl<'gcx> TypeChecker<'gcx> {
         let result = self.lvalue_context.unwrap();
         self.lvalue_context = prev;
 
-        if result.is_ok() && is_syntactic_lvalue(expr) {
+        if result.is_ok() && self.is_lvalue_expr(expr) {
             return ty;
         }
 
@@ -1550,6 +1555,37 @@ impl<'gcx> TypeChecker<'gcx> {
 
     fn in_lvalue(&self) -> bool {
         self.lvalue_context.is_some()
+    }
+
+    /// Returns `true` if the given expression can be an lvalue.
+    ///
+    /// If `false`, it cannot be an lvalue.
+    fn is_lvalue_expr(&self, expr: &hir::Expr<'_>) -> bool {
+        match expr.kind {
+            hir::ExprKind::Ident(_)
+            | hir::ExprKind::Index(..)
+            | hir::ExprKind::Member(..)
+            | hir::ExprKind::YulMember(..)
+            | hir::ExprKind::Tuple(..)
+            | hir::ExprKind::Err(_) => true,
+
+            hir::ExprKind::Call(callee, ..) => {
+                self.member_builtins.get(&callee.id) == Some(&Builtin::ArrayPush0)
+            }
+
+            hir::ExprKind::Array(_)
+            | hir::ExprKind::Assign(..)
+            | hir::ExprKind::Binary(..)
+            | hir::ExprKind::Delete(_)
+            | hir::ExprKind::Slice(..)
+            | hir::ExprKind::Lit(_)
+            | hir::ExprKind::Payable(_)
+            | hir::ExprKind::New(_)
+            | hir::ExprKind::Ternary(..)
+            | hir::ExprKind::TypeCall(_)
+            | hir::ExprKind::Type(_)
+            | hir::ExprKind::Unary(..) => false,
+        }
     }
 
     fn in_constructor_context(&self) -> bool {
@@ -1830,34 +1866,6 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
     }
 }
 
-/// Returns `true` if the given expression can be an lvalue.
-///
-/// If `false`, it cannot be an lvalue.
-fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
-    match expr.kind {
-        hir::ExprKind::Ident(_)
-        | hir::ExprKind::Index(..)
-        | hir::ExprKind::Member(..)
-        | hir::ExprKind::YulMember(..)
-        | hir::ExprKind::Tuple(..)
-        | hir::ExprKind::Err(_) => true,
-
-        hir::ExprKind::Array(_)
-        | hir::ExprKind::Assign(..)
-        | hir::ExprKind::Binary(..)
-        | hir::ExprKind::Call(..)
-        | hir::ExprKind::Delete(_)
-        | hir::ExprKind::Slice(..)
-        | hir::ExprKind::Lit(_)
-        | hir::ExprKind::Payable(_)
-        | hir::ExprKind::New(_)
-        | hir::ExprKind::Ternary(..)
-        | hir::ExprKind::TypeCall(_)
-        | hir::ExprKind::Type(_)
-        | hir::ExprKind::Unary(..) => false,
-    }
-}
-
 enum OverloadError {
     NotFound,
     Ambiguous,
@@ -1893,6 +1901,13 @@ impl<T> WantOne<T> {
             Self::Zero => Self::One(value),
             Self::One(_) | Self::Many => Self::Many,
         };
+    }
+}
+
+fn member_builtin(member: &members::Member<'_>) -> Option<Builtin> {
+    match member.res {
+        Some(hir::Res::Builtin(builtin)) => Some(builtin),
+        _ => None,
     }
 }
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -265,7 +265,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 };
 
-                if !is_array_push {
+                if !is_array_push && !is_storage_ref(ty) {
                     self.try_set_not_lvalue(NotLvalueReason::Generic);
                 }
 
@@ -1839,13 +1839,13 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         | hir::ExprKind::Index(..)
         | hir::ExprKind::Member(..)
         | hir::ExprKind::YulMember(..)
-        | hir::ExprKind::Call(..)
         | hir::ExprKind::Tuple(..)
         | hir::ExprKind::Err(_) => true,
 
         hir::ExprKind::Array(_)
         | hir::ExprKind::Assign(..)
         | hir::ExprKind::Binary(..)
+        | hir::ExprKind::Call(..)
         | hir::ExprKind::Delete(_)
         | hir::ExprKind::Slice(..)
         | hir::ExprKind::Lit(_)
@@ -1856,6 +1856,10 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         | hir::ExprKind::Type(_)
         | hir::ExprKind::Unary(..) => false,
     }
+}
+
+fn is_storage_ref(ty: Ty<'_>) -> bool {
+    matches!(ty.kind, TyKind::Ref(_, DataLocation::Storage))
 }
 
 enum OverloadError {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -234,9 +234,6 @@ impl<'gcx> TypeChecker<'gcx> {
                     None
                 };
 
-                let is_array_push =
-                    self.member_builtins.get(&callee.id) == Some(&Builtin::ArrayPush0);
-
                 let ty = match callee_ty.kind {
                     TyKind::Fn(f) => {
                         if f.is_declaration() {
@@ -298,7 +295,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 };
 
-                if !is_array_push && ty.loc() != Some(DataLocation::Storage) {
+                // For some reason, `ArrayPush0` is the only call that can be an lvalue.
+                if !(ty.loc() == Some(DataLocation::Storage)
+                    || self.member_builtins.get(&callee.id) == Some(&Builtin::ArrayPush0))
+                {
                     self.try_set_not_lvalue(NotLvalueReason::Generic);
                 }
 
@@ -948,7 +948,7 @@ impl<'gcx> TypeChecker<'gcx> {
         let ty = match self.select_member_call_overload(receiver_ty, &possible_members, args) {
             Ok(member) => {
                 self.check_library_self_call(member, ident.span);
-                if let Some(builtin) = member_builtin(member) {
+                if let Some(hir::Res::Builtin(builtin)) = member.res {
                     self.member_builtins.insert(callee.id, builtin);
                 }
                 self.member_call_ty(receiver_ty, member)
@@ -1976,13 +1976,6 @@ impl<T> WantOne<T> {
             Self::Zero => Self::One(value),
             Self::One(_) | Self::Many => Self::Many,
         };
-    }
-}
-
-fn member_builtin(member: &members::Member<'_>) -> Option<Builtin> {
-    match member.res {
-        Some(hir::Res::Builtin(builtin)) => Some(builtin),
-        _ => None,
     }
 }
 

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -443,6 +443,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         };
                         Some(reason)
                     }
+                    TyKind::Ref(inner, _) if matches!(inner.kind, TyKind::Struct(_)) => None,
                     TyKind::Type(ty)
                         if matches!(ty.kind, TyKind::Contract(_))
                             && possible_members.len() == 1
@@ -452,7 +453,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     {
                         Some(NotLvalueReason::Generic)
                     }
-                    _ => None,
+                    _ => Some(NotLvalueReason::Generic),
                 };
                 if let Some(reason) = not_lvalue_reason {
                     self.try_set_not_lvalue(reason);

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -265,7 +265,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 };
 
-                if !is_array_push && !is_storage_ref(ty) {
+                if !is_array_push && ty.loc() != Some(DataLocation::Storage) {
                     self.try_set_not_lvalue(NotLvalueReason::Generic);
                 }
 
@@ -1856,10 +1856,6 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         | hir::ExprKind::Type(_)
         | hir::ExprKind::Unary(..) => false,
     }
-}
-
-fn is_storage_ref(ty: Ty<'_>) -> bool {
-    matches!(ty.kind, TyKind::Ref(_, DataLocation::Storage))
 }
 
 enum OverloadError {

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -26,6 +26,8 @@ contract Test {
     function testCall() external {
         retArr() = arr; //~ ERROR: expression has to be an lvalue
         retArr()[0] = 1;
+        retArr().push() = 1;
+        retArr().push(1) = arr.pop(); //~ ERROR: expression has to be an lvalue
     }
 
     function testCallLvalue() external {

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -1,10 +1,19 @@
 //@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/syntaxTests/lvalues/functions.sol
+// ported-from: test/libsolidity/syntaxTests/metaTypes/codeIsNoLValue.sol
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/015_balance_invalid.sol
+// ported-from: test/libsolidity/syntaxTests/functionTypes/delete_function_type_invalid.sol
+// ported-from: test/libsolidity/syntaxTests/functionTypes/delete_external_function_type_invalid.sol
+// ported-from: test/libsolidity/smtCheckerTests/array_members/push_as_lhs_2d.sol
+// ported-from: test/libsolidity/smtCheckerTests/array_members/push_as_lhs_3d.sol
 
 contract Test {
     uint256 a;
     uint256 b;
     int256 c;
     uint256[] arr;
+    uint256[][] nested;
+    uint256[][][] deeplyNested;
     bytes data;
 
     function testBinaryOp() external {
@@ -32,10 +41,42 @@ contract Test {
 
     function testCallLvalue() external {
         arr.push() = 1;
+        nested.push().push() = 2;
+        deeplyNested.push().push().push() = 3;
         data.push() = 0x01;
         arr.push() = arr.pop(); //~ ERROR: mismatched types
         arr.push(1) = arr.pop(); //~ ERROR: expression has to be an lvalue
         data.push(0x01) = arr.pop(); //~ ERROR: expression has to be an lvalue
         arr.pop() = arr.pop(); //~ ERROR: expression has to be an lvalue
+    }
+
+    function testAddressMember() external {
+        address(0).balance = 7; //~ ERROR: expression has to be an lvalue
+    }
+}
+
+contract FunctionLvalues {
+    function f() internal {}
+
+    function g() internal {
+        g = f; //~ ERROR: expression has to be an lvalue
+    }
+
+    function h() external {}
+
+    function i() external {
+        this.i = this.h; //~ ERROR: expression has to be an lvalue
+    }
+
+    function testDelete() external {
+        delete f; //~ ERROR: expression has to be an lvalue
+        delete this.h; //~ ERROR: expression has to be an lvalue
+    }
+}
+
+contract MetaTypeMemberLvalues {
+    function f() public pure {
+        type(MetaTypeMemberLvalues).creationCode = new bytes(6); //~ ERROR: expression has to be an lvalue
+        type(MetaTypeMemberLvalues).runtimeCode = new bytes(6); //~ ERROR: expression has to be an lvalue
     }
 }

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -5,6 +5,7 @@ contract Test {
     uint256 b;
     int256 c;
     uint256[] arr;
+    bytes data;
 
     function testBinaryOp() external {
         (a + b) = a; //~ ERROR: expression has to be an lvalue
@@ -24,5 +25,14 @@ contract Test {
 
     function testCall() external {
         retArr() = arr; //~ ERROR: expression has to be an lvalue
+        retArr()[0] = 1;
+    }
+
+    function testCallLvalue() external {
+        arr.push() = 1;
+        data.push() = 0x01;
+        arr.push(1) = arr.pop(); //~ ERROR: expression has to be an lvalue
+        data.push(0x01) = arr.pop(); //~ ERROR: expression has to be an lvalue
+        arr.pop() = arr.pop(); //~ ERROR: expression has to be an lvalue
     }
 }

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -31,6 +31,7 @@ contract Test {
     function testCallLvalue() external {
         arr.push() = 1;
         data.push() = 0x01;
+        arr.push() = arr.pop(); //~ ERROR: mismatched types
         arr.push(1) = arr.pop(); //~ ERROR: expression has to be an lvalue
         data.push(0x01) = arr.pop(); //~ ERROR: expression has to be an lvalue
         arr.pop() = arr.pop(); //~ ERROR: expression has to be an lvalue

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -4,6 +4,7 @@ contract Test {
     uint256 a;
     uint256 b;
     int256 c;
+    uint256[] arr;
 
     function testBinaryOp() external {
         (a + b) = a; //~ ERROR: expression has to be an lvalue
@@ -15,5 +16,13 @@ contract Test {
 
     function testUnary() external {
         (-c) = c; //~ ERROR: expression has to be an lvalue
+    }
+
+    function retArr() internal returns (uint256[] storage r) {
+        r = arr;
+    }
+
+    function testCall() external {
+        retArr() = arr; //~ ERROR: expression has to be an lvalue
     }
 }

--- a/tests/ui/typeck/lvalue/expressions.stderr
+++ b/tests/ui/typeck/lvalue/expressions.stderr
@@ -22,6 +22,12 @@ error: expression has to be an lvalue
 LL │         retArr() = arr;
    ╰╴        ━━━━━━━━
 
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         arr.push() = arr.pop();
+   ╰╴                     ━━━━━━━━━ expected `uint256`, found `tuple()`
+
 error: expression has to be an lvalue
    ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
    │
@@ -40,5 +46,5 @@ error: expression has to be an lvalue
 LL │         arr.pop() = arr.pop();
    ╰╴        ━━━━━━━━━
 
-error: aborting due to 7 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/typeck/lvalue/expressions.stderr
+++ b/tests/ui/typeck/lvalue/expressions.stderr
@@ -52,5 +52,47 @@ error: expression has to be an lvalue
 LL │         arr.pop() = arr.pop();
    ╰╴        ━━━━━━━━━
 
-error: aborting due to 9 previous errors
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         address(0).balance = 7;
+   ╰╴        ━━━━━━━━━━━━━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         g = f;
+   ╰╴        ━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         this.i = this.h;
+   ╰╴        ━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         delete f;
+   ╰╴               ━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         delete this.h;
+   ╰╴               ━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         type(MetaTypeMemberLvalues).creationCode = new bytes(6);
+   ╰╴        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         type(MetaTypeMemberLvalues).runtimeCode = new bytes(6);
+   ╰╴        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 16 previous errors
 

--- a/tests/ui/typeck/lvalue/expressions.stderr
+++ b/tests/ui/typeck/lvalue/expressions.stderr
@@ -22,6 +22,12 @@ error: expression has to be an lvalue
 LL │         retArr() = arr;
    ╰╴        ━━━━━━━━
 
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         retArr().push(1) = arr.pop();
+   ╰╴        ━━━━━━━━━━━━━━━━
+
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
    │
@@ -46,5 +52,5 @@ error: expression has to be an lvalue
 LL │         arr.pop() = arr.pop();
    ╰╴        ━━━━━━━━━
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/typeck/lvalue/expressions.stderr
+++ b/tests/ui/typeck/lvalue/expressions.stderr
@@ -22,5 +22,23 @@ error: expression has to be an lvalue
 LL │         retArr() = arr;
    ╰╴        ━━━━━━━━
 
-error: aborting due to 4 previous errors
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         arr.push(1) = arr.pop();
+   ╰╴        ━━━━━━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         data.push(0x01) = arr.pop();
+   ╰╴        ━━━━━━━━━━━━━━━
+
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         arr.pop() = arr.pop();
+   ╰╴        ━━━━━━━━━
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/lvalue/expressions.stderr
+++ b/tests/ui/typeck/lvalue/expressions.stderr
@@ -16,5 +16,11 @@ error: expression has to be an lvalue
 LL │         (-c) = c;
    ╰╴         ━━
 
-error: aborting due to 3 previous errors
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         retArr() = arr;
+   ╰╴        ━━━━━━━━
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/lvalue/return_storage_ref.sol
+++ b/tests/ui/typeck/lvalue/return_storage_ref.sol
@@ -1,0 +1,25 @@
+//@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/semanticTests/functionCall/mapping_internal_return.sol
+
+contract Test {
+    mapping(uint8 => uint8) a;
+    mapping(uint8 => uint8) b;
+
+    function f() internal returns (mapping(uint8 => uint8) storage r) {
+        r = a;
+        r[1] = 42;
+        r = b;
+        r[1] = 84;
+    }
+
+    function g() public returns (uint8, uint8, uint8, uint8, uint8, uint8) {
+        f()[2] = 21;
+        return (a[0], a[1], a[2], b[0], b[1], b[2]);
+    }
+
+    function h() public returns (uint8, uint8, uint8, uint8, uint8, uint8) {
+        mapping(uint8 => uint8) storage m = f();
+        m[2] = 17;
+        return (a[0], a[1], a[2], b[0], b[1], b[2]);
+    }
+}

--- a/tests/ui/typeck/lvalue/tuple.sol
+++ b/tests/ui/typeck/lvalue/tuple.sol
@@ -1,8 +1,12 @@
 //@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/syntaxTests/array/bytes1_array_push_assign_multi.sol
+// ported-from: test/libsolidity/syntaxTests/tupleAssignments/assignments_to_tuple_and_non_tuple_expressions_of_tuple_types.sol
 
 contract Test {
     uint256 constant CONST = 1;
     uint256 state;
+    bytes1[] byteArray;
+    bytes1[] otherByteArray;
 
     function testTupleWithConstant() external {
         uint256 x = state;
@@ -13,5 +17,22 @@ contract Test {
         uint256 x = state;
         (1, state) = (x, x); //~ ERROR: expression has to be an lvalue
         //~^ ERROR: mismatched types
+    }
+
+    function tuplePushLvalues() external {
+        (byteArray.push(), byteArray.push()) = (bytes1(0), bytes1(0));
+        (((byteArray.push())), (byteArray.push())) = (bytes1(0), bytes1(0));
+        ((byteArray.push(), byteArray.push()), byteArray.push()) =
+            ((bytes1(0), bytes1(0)), bytes1(0));
+        (byteArray.push(), byteArray[0]) = (bytes1(0), bytes1(0));
+        bytes1[] storage local = byteArray;
+        (byteArray.push(), local.push()) = (bytes1(0), bytes1(0));
+        (byteArray.push(), otherByteArray.push()) = (bytes1(0), bytes1(0));
+    }
+
+    function returnsTuple() internal returns (uint256, uint256) {}
+
+    function testParenthesizedCallValues() public {
+        (returnsTuple()) = (uint256(1), uint256(1)); //~ ERROR: expression has to be an lvalue
     }
 }

--- a/tests/ui/typeck/lvalue/tuple.stderr
+++ b/tests/ui/typeck/lvalue/tuple.stderr
@@ -16,5 +16,11 @@ error: mismatched types
 LL │         (1, state) = (x, x);
    ╰╴                     ━━━━━━ expected `tuple(int_literal[1],uint256)`, found `tuple(uint256,uint256)`
 
-error: aborting due to 3 previous errors
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/tuple.sol:LL:CC
+   │
+LL │         (returnsTuple()) = (uint256(1), uint256(1));
+   ╰╴         ━━━━━━━━━━━━━━
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/lvalue/valid_memory.sol
+++ b/tests/ui/typeck/lvalue/valid_memory.sol
@@ -1,4 +1,5 @@
 //@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/syntaxTests/lvalues/valid_lvalues.sol
 // Valid lvalue assignments for memory variables
 
 struct S {
@@ -42,5 +43,17 @@ contract Test {
     function testFunctionParam(uint256 param) external pure {
         uint256 x;
         param = x;
+    }
+
+    function internalFunction() internal pure {}
+
+    function externalFunction() external pure {}
+
+    function testInternalFunctionParam(function() internal pure param) internal pure {
+        param = internalFunction;
+    }
+
+    function testExternalFunctionParam(function() external pure param) external view {
+        param = this.externalFunction;
     }
 }


### PR DESCRIPTION
Allows the two call-lvalue cases that match solc: function calls returning storage references can still be used as bases for indexing or member access like `f()[k] = v`, and empty storage array or bytes `.push()` calls are direct lvalues for assignments like `arr.push() = v`.

Other calls remain rejected as direct lvalues, including `push(value)`, `pop()`, and plain calls that return storage references. This follows solc's `ArrayPush` special case, where only the overload with no parameters is marked as an lvalue.
