### PR TITLE
fix(sema): allow indexing storage return values

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -265,7 +265,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 };
 
-                if !is_array_push {
+                if !is_array_push && !is_storage_ref(ty) {
                     self.try_set_not_lvalue(NotLvalueReason::Generic);
                 }
 
@@ -1839,13 +1839,13 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         | hir::ExprKind::Index(..)
         | hir::ExprKind::Member(..)
         | hir::ExprKind::YulMember(..)
-        | hir::ExprKind::Call(..)
         | hir::ExprKind::Tuple(..)
         | hir::ExprKind::Err(_) => true,
 
         hir::ExprKind::Array(_)
         | hir::ExprKind::Assign(..)
         | hir::ExprKind::Binary(..)
+        | hir::ExprKind::Call(..)
         | hir::ExprKind::Delete(_)
         | hir::ExprKind::Slice(..)
         | hir::ExprKind::Lit(_)
@@ -1856,6 +1856,10 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         | hir::ExprKind::Type(_)
         | hir::ExprKind::Unary(..) => false,
     }
+}
+
+fn is_storage_ref(ty: Ty<'_>) -> bool {
+    matches!(ty.kind, TyKind::Ref(_, DataLocation::Storage))
 }
 
 enum OverloadError {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -265,7 +265,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 };
 
-                if !is_array_push && !is_storage_ref(ty) {
+                if !is_array_push && ty.loc() != Some(DataLocation::Storage) {
                     self.try_set_not_lvalue(NotLvalueReason::Generic);
                 }
 
@@ -1856,10 +1856,6 @@ fn is_syntactic_lvalue(expr: &hir::Expr<'_>) -> bool {
         | hir::ExprKind::Type(_)
         | hir::ExprKind::Unary(..) => false,
     }
-}
-
-fn is_storage_ref(ty: Ty<'_>) -> bool {
-    matches!(ty.kind, TyKind::Ref(_, DataLocation::Storage))
 }
 
 enum OverloadError {

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -4,6 +4,7 @@ contract Test {
     uint256 a;
     uint256 b;
     int256 c;
+    uint256[] arr;
 
     function testBinaryOp() external {
         (a + b) = a; //~ ERROR: expression has to be an lvalue
@@ -15,5 +16,13 @@ contract Test {
 
     function testUnary() external {
         (-c) = c; //~ ERROR: expression has to be an lvalue
+    }
+
+    function retArr() internal returns (uint256[] storage r) {
+        r = arr;
+    }
+
+    function testCall() external {
+        retArr() = arr; //~ ERROR: expression has to be an lvalue
     }
 }

--- a/tests/ui/typeck/lvalue/expressions.stderr
+++ b/tests/ui/typeck/lvalue/expressions.stderr
@@ -16,5 +16,11 @@ error: expression has to be an lvalue
 LL │         (-c) = c;
    ╰╴         ━━
 
-error: aborting due to 3 previous errors
+error: expression has to be an lvalue
+   ╭▸ ROOT/tests/ui/typeck/lvalue/expressions.sol:LL:CC
+   │
+LL │         retArr() = arr;
+   ╰╴        ━━━━━━━━
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/lvalue/return_storage_ref.sol
+++ b/tests/ui/typeck/lvalue/return_storage_ref.sol
@@ -1,0 +1,25 @@
+//@compile-flags: -Ztypeck
+// ported-from: test/libsolidity/semanticTests/functionCall/mapping_internal_return.sol
+
+contract Test {
+    mapping(uint8 => uint8) a;
+    mapping(uint8 => uint8) b;
+
+    function f() internal returns (mapping(uint8 => uint8) storage r) {
+        r = a;
+        r[1] = 42;
+        r = b;
+        r[1] = 84;
+    }
+
+    function g() public returns (uint8, uint8, uint8, uint8, uint8, uint8) {
+        f()[2] = 21;
+        return (a[0], a[1], a[2], b[0], b[1], b[2]);
+    }
+
+    function h() public returns (uint8, uint8, uint8, uint8, uint8, uint8) {
+        mapping(uint8 => uint8) storage m = f();
+        m[2] = 17;
+        return (a[0], a[1], a[2], b[0], b[1], b[2]);
+    }
+}


### PR DESCRIPTION
Allows function calls that return storage references to stay usable as storage bases for subsequent indexing, so expressions like `f()[k] = v` type check when `f()` returns a storage mapping.

This mirrors solc's behavior for `test/libsolidity/semanticTests/functionCall/mapping_internal_return.sol`: the function call itself is not a general assignable lvalue, but the returned storage reference must not poison the lvalue state before the mapping index access is checked.
