### PR TITLE
refactor(sema): preintern error type

### DIFF
--- a/crates/sema/src/ty/common.rs
+++ b/crates/sema/src/ty/common.rs
@@ -1,8 +1,11 @@
 use super::{Interner, Ty, TyKind};
 use solar_ast::{DataLocation, ElementaryType, TypeSize};
+use solar_interface::diagnostics::ErrorGuaranteed;
 
 /// Pre-interned types.
 pub struct CommonTypes<'gcx> {
+    pub(crate) err: Ty<'gcx>,
+
     /// The unit type `()`, AKA empty tuple, void.
     #[doc(alias = "empty_tuple", alias = "void")]
     pub unit: Ty<'gcx>,
@@ -49,6 +52,8 @@ impl<'gcx> CommonTypes<'gcx> {
         let bytes = mk(Elementary(Bytes));
 
         Self {
+            err: mk(Err(ErrorGuaranteed::new_unchecked())),
+
             unit: mk(Tuple(&[])),
             // never: mk(Elementary(Never)),
             bool: mk(Elementary(Bool)),

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -443,7 +443,8 @@ impl<'gcx> Gcx<'gcx> {
         }
     }
 
-    pub(crate) fn mk_ty_err(self, _guar: ErrorGuaranteed) -> Ty<'gcx> {
+    #[inline]
+    pub fn mk_ty_err(self, _guar: ErrorGuaranteed) -> Ty<'gcx> {
         const { assert!(std::mem::size_of::<ErrorGuaranteed>() == 0) }
         self.types.err
     }

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -641,7 +641,7 @@ impl<'gcx> Gcx<'gcx> {
                 TyKind::Mapping(key, value)
             }
             hir::TypeKind::Custom(item) => return self.type_of_item_simple(item, ty.span),
-            hir::TypeKind::Err(guar) => TyKind::Err(guar),
+            hir::TypeKind::Err(guar) => return self.mk_ty_err(guar),
         };
         self.mk_ty(kind)
     }
@@ -1110,7 +1110,7 @@ pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
                 TyKind::Udvt(ty, id)
             } else {
                 let msg = "the underlying type of UDVTs must be an elementary value type";
-                TyKind::Err(gcx.dcx().err(msg).span(udvt.ty.span).emit())
+                return gcx.mk_ty_err(gcx.dcx().err(msg).span(udvt.ty.span).emit());
             }
         }
         hir::ItemId::Error(id) => {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -443,8 +443,9 @@ impl<'gcx> Gcx<'gcx> {
         }
     }
 
-    pub fn mk_ty_err(self, guar: ErrorGuaranteed) -> Ty<'gcx> {
-        Ty::new(self, TyKind::Err(guar))
+    pub(crate) fn mk_ty_err(self, _guar: ErrorGuaranteed) -> Ty<'gcx> {
+        const { assert!(std::mem::size_of::<ErrorGuaranteed>() == 0) }
+        self.types.err
     }
 
     /// Returns the source file with the given path, if it exists.


### PR DESCRIPTION
This makes `mk_ty_err` return a crate-private pre-interned error type from `CommonTypes` instead of going through the type interner for every reported type error. The method is now crate-private and has a compile-time assertion that `ErrorGuaranteed` remains a zero-sized type before the specific value is discarded.