### PR TITLE
refactor(sema): add linearized base helpers

### DIFF
--- a/crates/sema/src/ast_lowering/linearize.rs
+++ b/crates/sema/src/ast_lowering/linearize.rs
@@ -19,13 +19,18 @@ impl super::LoweringContext<'_> {
             for contract_id in source.items.iter().filter_map(hir::ItemId::as_contract) {
                 let _guard = debug_span!("linearize_contract", ?contract_id).entered();
                 self.linearize_contract(contract_id, &mut linearizer);
-                if linearizer.result.is_empty() {
+                if !self.hir.contract(contract_id).bases.is_empty() && linearizer.result.is_empty()
+                {
                     let msg = "linearization of inheritance graph impossible";
                     self.dcx().emit_err(self.hir.contract(contract_id).name.span, msg);
-                    // Always include the contract itself in the linearized bases.
-                    linearizer.result.push(contract_id);
                 }
-                let linearized_bases = &*self.arena.alloc_slice_copy(&linearizer.result);
+                let linearized_bases = if linearizer.result.first() == Some(&contract_id) {
+                    &linearizer.result[1..]
+                } else {
+                    &linearizer.result
+                };
+                debug_assert!(!linearized_bases.contains(&contract_id));
+                let linearized_bases = &*self.arena.alloc_slice_copy(linearized_bases);
                 self.hir.contracts[contract_id].linearized_bases = linearized_bases;
 
                 // Import inherited scopes.
@@ -92,7 +97,6 @@ impl super::LoweringContext<'_> {
         let contract = self.hir.contract(contract_id);
         if contract.bases.is_empty() {
             linearizer.result.clear();
-            linearizer.result.push(contract_id);
             return;
         }
 
@@ -101,13 +105,12 @@ impl super::LoweringContext<'_> {
         for &base_id in contract.bases {
             linearizer.insert(base_id);
             let base = self.hir.contract(base_id);
-            let base_bases = base.self_and_inherited_bases();
-            if base_bases.is_empty() {
+            if base.linearization_failed() {
                 let msg = "definition of base has to precede definition of derived contract";
                 self.dcx().emit_err(contract.name.span, msg);
                 continue;
             }
-            linearizer.insert_bases(base_bases);
+            linearizer.insert_self_and_bases(base_id, base.inherited_bases());
         }
         linearizer.insert(contract_id);
         linearizer.c3_merge();
@@ -135,8 +138,8 @@ impl<T: Copy + Eq + std::fmt::Debug> C3Linearizer<T> {
         self.to_merge.back_mut().unwrap().push_front(id);
     }
 
-    fn insert_bases(&mut self, ids: &[T]) {
-        self.to_merge.push_front(ids.iter().copied().collect());
+    fn insert_self_and_bases(&mut self, id: T, bases: &[T]) {
+        self.to_merge.push_front(std::iter::once(id).chain(bases.iter().copied()).collect());
     }
 
     fn c3_merge(&mut self) {

--- a/crates/sema/src/ast_lowering/linearize.rs
+++ b/crates/sema/src/ast_lowering/linearize.rs
@@ -31,7 +31,7 @@ impl super::LoweringContext<'_> {
                 // Import inherited scopes.
                 // https://github.com/argotorg/solidity/blob/2694190d1dbbc90b001aa76f8d7bd0794923c343/libsolidity/analysis/NameAndTypeResolver.cpp#L352
                 let _guard = debug_span!("import_inherited_scopes").entered();
-                for &base_id in &linearized_bases[1..] {
+                for &base_id in self.hir.contract(contract_id).inherited_bases() {
                     let (base_scope, contract_scope) = super::get_two_mut_idx(
                         &mut self.resolver.contract_scopes,
                         base_id,
@@ -101,7 +101,7 @@ impl super::LoweringContext<'_> {
         for &base_id in contract.bases {
             linearizer.insert(base_id);
             let base = self.hir.contract(base_id);
-            let base_bases = base.linearized_bases;
+            let base_bases = base.self_and_inherited_bases();
             if base_bases.is_empty() {
                 let msg = "definition of base has to precede definition of derived contract";
                 self.dcx().err(msg).span(contract.name.span).emit();

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -195,7 +195,7 @@ impl super::LoweringContext<'_> {
             let mut fallback = None;
             let mut receive = None;
 
-            for &base_id in self.hir.contract(contract_id).self_and_inherited_bases() {
+            for base_id in self.hir.contract_and_inherited_bases(contract_id) {
                 for function_id in self.hir.contract(base_id).functions() {
                     let func = self.hir.function(function_id);
                     let slot = match func.kind {
@@ -394,8 +394,7 @@ impl<'gcx> ResolveContext<'gcx> {
                             let allowed = func.contract.is_some_and(|current| {
                                 modifier_contract.is_some_and(|modifier_contract| {
                                     self.hir
-                                        .contract(current)
-                                        .is_or_inherits_from(modifier_contract)
+                                        .contract_is_or_inherits_from(current, modifier_contract)
                                 })
                             });
                             if !allowed {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -195,7 +195,7 @@ impl super::LoweringContext<'_> {
             let mut fallback = None;
             let mut receive = None;
 
-            for &base_id in self.hir.contract(contract_id).linearized_bases {
+            for &base_id in self.hir.contract(contract_id).self_and_inherited_bases() {
                 for function_id in self.hir.contract(base_id).functions() {
                     let func = self.hir.function(function_id);
                     let slot = match func.kind {
@@ -386,17 +386,16 @@ impl<'gcx> ResolveContext<'gcx> {
                     match id {
                         hir::ItemId::Contract(base)
                             if func.kind.is_constructor()
-                                && func.contract.is_some_and(|c| {
-                                    self.hir.contract(c).linearized_bases[1..].contains(&base)
-                                }) => {}
+                                && func
+                                    .contract
+                                    .is_some_and(|c| self.hir.contract(c).inherits_from(base)) => {}
                         hir::ItemId::Function(f) if self.hir.function(f).kind.is_modifier() => {
                             let modifier_contract = self.hir.function(f).contract;
                             let allowed = func.contract.is_some_and(|current| {
                                 modifier_contract.is_some_and(|modifier_contract| {
                                     self.hir
                                         .contract(current)
-                                        .linearized_bases
-                                        .contains(&modifier_contract)
+                                        .is_or_inherits_from(modifier_contract)
                                 })
                             });
                             if !allowed {
@@ -593,15 +592,14 @@ impl<'gcx> ResolveContext<'gcx> {
             return;
         }
 
-        let len = contract.linearized_bases.len() - 1;
+        let len = contract.inherited_bases().len();
         let base_args: &mut [Option<&'gcx hir::Modifier<'gcx>>] =
             self.arena.alloc_from_iter(std::iter::repeat_n(None, len));
         let mut resolve = |base: &'gcx hir::Modifier<'gcx>, is_ctor: bool| {
             let Some(base_id) = base.id.as_contract() else { return };
             let base_idx = contract
-                .linearized_bases
+                .inherited_bases()
                 .iter()
-                .skip(1)
                 .position(|&l| l == base_id)
                 .expect("base contract not found");
 
@@ -1932,7 +1930,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 continue;
             };
 
-            if !self.hir.contract(c).linearized_bases[1..].contains(&id) {
+            if !self.hir.contract(c).inherits_from(id) {
                 self.dcx()
                     .err(format!(
                         "invalid contract `{}` specified in override list",

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -269,16 +269,26 @@ impl<'hir> Hir<'hir> {
         &self,
         id: ContractId,
     ) -> impl Iterator<Item = ItemId> + Clone + use<'_, 'hir> {
-        self.contract(id)
-            .self_and_inherited_bases()
-            .iter()
-            .copied()
+        self.contract_and_inherited_bases(id)
             .flat_map(|base| self.contract(base).items.iter().copied())
     }
 
     /// Returns an iterator over all items in a contract, including inheritance.
     pub fn contract_items(&self, id: ContractId) -> impl Iterator<Item = Item<'_, 'hir>> + Clone {
         self.contract_item_ids(id).map(move |id| self.item(id))
+    }
+
+    /// Returns the contract itself followed by its inherited bases.
+    pub fn contract_and_inherited_bases(
+        &self,
+        id: ContractId,
+    ) -> impl Iterator<Item = ContractId> + Clone + use<'_, 'hir> {
+        std::iter::once(id).chain(self.contract(id).inherited_bases().iter().copied())
+    }
+
+    /// Returns `true` if `contract` is `base` or inherits from it.
+    pub fn contract_is_or_inherits_from(&self, contract: ContractId, base: ContractId) -> bool {
+        contract == base || self.contract(contract).inherits_from(base)
     }
 
     /// Creates a builder for constructing HIR nodes.
@@ -763,11 +773,10 @@ pub struct Contract<'hir> {
     pub bases: &'hir [ContractId],
     /// The base arguments, as declared in the source code.
     pub bases_args: &'hir [Modifier<'hir>],
-    /// The linearized contract bases.
+    /// The linearized inherited contract bases.
     ///
-    /// The first element is always the contract itself, followed by its bases in order of
-    /// inheritance. The bases may not be present if the inheritance linearization failed. See
-    /// [`Contract::linearization_failed`].
+    /// The contract itself is not stored in this list. The bases may not be present if the
+    /// inheritance linearization failed. See [`Contract::linearization_failed`].
     pub linearized_bases: &'hir [ContractId],
     /// The constructor base arguments (if any).
     ///
@@ -794,18 +803,12 @@ pub struct Contract<'hir> {
 impl Contract<'_> {
     /// Returns `true` if the inheritance linearization failed.
     pub fn linearization_failed(&self) -> bool {
-        self.linearized_bases.is_empty()
-            || (!self.bases.is_empty() && self.linearized_bases.len() == 1)
+        !self.bases.is_empty() && self.linearized_bases.is_empty()
     }
 
-    /// Returns the contract itself followed by its inherited bases.
-    pub fn self_and_inherited_bases(&self) -> &[ContractId] {
-        self.linearized_bases
-    }
-
-    /// Returns inherited bases, excluding the contract itself.
+    /// Returns inherited bases.
     pub fn inherited_bases(&self) -> &[ContractId] {
-        &self.linearized_bases[1..]
+        self.linearized_bases
     }
 
     /// Returns inherited bases with their resolved constructor arguments.
@@ -818,11 +821,6 @@ impl Contract<'_> {
     /// Returns `true` if this contract inherits from `base`.
     pub fn inherits_from(&self, base: ContractId) -> bool {
         self.inherited_bases().contains(&base)
-    }
-
-    /// Returns `true` if this contract is `base` or inherits from it.
-    pub fn is_or_inherits_from(&self, base: ContractId) -> bool {
-        self.self_and_inherited_bases().contains(&base)
     }
 
     /// Returns an iterator over functions declared in the contract.

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -270,7 +270,7 @@ impl<'hir> Hir<'hir> {
         id: ContractId,
     ) -> impl Iterator<Item = ItemId> + Clone + use<'_, 'hir> {
         self.contract(id)
-            .linearized_bases
+            .self_and_inherited_bases()
             .iter()
             .copied()
             .flat_map(|base| self.contract(base).items.iter().copied())
@@ -771,7 +771,7 @@ pub struct Contract<'hir> {
     pub linearized_bases: &'hir [ContractId],
     /// The constructor base arguments (if any).
     ///
-    /// The index maps to the position in `linearized_bases[1..]`.
+    /// The index maps to the position in `Contract::inherited_bases`.
     ///
     /// The reference points to either `bases_args` in the original contract, or `modifiers` in the
     /// constructor.
@@ -796,6 +796,33 @@ impl Contract<'_> {
     pub fn linearization_failed(&self) -> bool {
         self.linearized_bases.is_empty()
             || (!self.bases.is_empty() && self.linearized_bases.len() == 1)
+    }
+
+    /// Returns the contract itself followed by its inherited bases.
+    pub fn self_and_inherited_bases(&self) -> &[ContractId] {
+        self.linearized_bases
+    }
+
+    /// Returns inherited bases, excluding the contract itself.
+    pub fn inherited_bases(&self) -> &[ContractId] {
+        &self.linearized_bases[1..]
+    }
+
+    /// Returns inherited bases with their resolved constructor arguments.
+    pub fn inherited_bases_with_args(
+        &self,
+    ) -> impl Iterator<Item = (ContractId, Option<&Modifier<'_>>)> + Clone + use<'_> {
+        self.inherited_bases().iter().copied().zip(self.linearized_bases_args.iter().copied())
+    }
+
+    /// Returns `true` if this contract inherits from `base`.
+    pub fn inherits_from(&self, base: ContractId) -> bool {
+        self.inherited_bases().contains(&base)
+    }
+
+    /// Returns `true` if this contract is `base` or inherits from it.
+    pub fn is_or_inherits_from(&self, base: ContractId) -> bool {
+        self.self_and_inherited_bases().contains(&base)
     }
 
     /// Returns an iterator over functions declared in the contract.

--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -388,17 +388,16 @@ impl<'gcx> Resolver<'gcx> {
             _ => return None,
         };
 
-        if let Some(contract) = item_contract {
-            let linearized_bases = &self.gcx.hir.contract(contract).linearized_bases;
-            if !linearized_bases.contains(&contract_id) {
-                dcx.err(format!(
-                    "tag `@inheritdoc` references contract \"{}\", which is not a base of this contract",
-                    contract_ident.name
-                ))
-                .span(tag_span)
-                .emit();
-                return None;
-            }
+        if let Some(contract) = item_contract
+            && !self.gcx.hir.contract(contract).is_or_inherits_from(contract_id)
+        {
+            dcx.err(format!(
+                "tag `@inheritdoc` references contract \"{}\", which is not a base of this contract",
+                contract_ident.name
+            ))
+            .span(tag_span)
+            .emit();
+            return None;
         }
 
         if self.find_inherited_item(item_id, contract_id).is_none() {

--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -381,7 +381,7 @@ impl<'gcx> Resolver<'gcx> {
         };
 
         if let Some(contract) = item_contract
-            && !self.gcx.hir.contract(contract).is_or_inherits_from(contract_id)
+            && !self.gcx.hir.contract_is_or_inherits_from(contract, contract_id)
         {
             dcx.emit_err(tag_span, format!(
                 "tag `@inheritdoc` references contract \"{}\", which is not a base of this contract",

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -954,7 +954,7 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
     let mut inheritance_start = None;
     let mut signatures_seen = FxHashSet::default();
     let mut hash_collisions = FxHashMap::default();
-    let functions = c.linearized_bases.iter().flat_map(|&base| {
+    let functions = c.self_and_inherited_bases().iter().flat_map(|&base| {
         let b = gcx.hir.contract(base);
         let functions =
             b.functions().filter(|&f| gcx.hir.function(f).is_part_of_external_interface());

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -948,18 +948,13 @@ pub fn interface_id(gcx: _, id: hir::ContractId) -> Selector {
 /// The contract doesn't have to be an interface.
 pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'gcx> {
     let c = gcx.hir.contract(id);
-    let mut inheritance_start = None;
+    let inheritance_start =
+        c.functions().filter(|&f| gcx.hir.function(f).is_part_of_external_interface()).count();
     let mut signatures_seen = FxHashSet::default();
     let mut hash_collisions = FxHashMap::default();
-    let functions = c.self_and_inherited_bases().iter().flat_map(|&base| {
+    let functions = gcx.hir.contract_and_inherited_bases(id).flat_map(|base| {
         let b = gcx.hir.contract(base);
-        let functions =
-            b.functions().filter(|&f| gcx.hir.function(f).is_part_of_external_interface());
-        if base == id {
-            assert!(inheritance_start.is_none(), "duplicate self ID in linearized_bases");
-            inheritance_start = Some(functions.clone().count());
-        }
-        functions
+        b.functions().filter(|&f| gcx.hir.function(f).is_part_of_external_interface())
     }).filter_map(|f_id| {
         let f = gcx.hir.function(f_id);
         let TyKind::Fn(fn_ty) = gcx.type_of_item(f_id.into()).kind else { unreachable!() };
@@ -1029,7 +1024,6 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
     });
     let functions = gcx.bump().alloc_from_iter(functions);
     trace!("{}.interfaceFunctions.len() = {}", gcx.contract_fully_qualified_name(id), functions.len());
-    let inheritance_start = inheritance_start.expect("linearized_bases did not contain self ID");
     InterfaceFunctions { functions, inheritance_start }
 }
 

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -703,8 +703,7 @@ impl<'gcx> Ty<'gcx> {
 
             // Contract -> Base contract (inheritance check)
             (Contract(self_contract_id), Contract(other_contract_id)) => {
-                let self_contract = gcx.hir.contract(self_contract_id);
-                if self_contract.is_or_inherits_from(other_contract_id) {
+                if gcx.hir.contract_is_or_inherits_from(self_contract_id, other_contract_id) {
                     Ok(())
                 } else {
                     Result::Err(TyConvertError::NonDerivedContract)
@@ -933,8 +932,7 @@ impl<'gcx> Ty<'gcx> {
 
             // Contract -> Base contract (inheritance check)
             (Contract(self_contract_id), Contract(other_contract_id)) => {
-                let self_contract = gcx.hir.contract(self_contract_id);
-                if self_contract.is_or_inherits_from(other_contract_id) {
+                if gcx.hir.contract_is_or_inherits_from(self_contract_id, other_contract_id) {
                     Ok(())
                 } else {
                     Result::Err(TyConvertError::NonDerivedContract)

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -704,7 +704,7 @@ impl<'gcx> Ty<'gcx> {
             // Contract -> Base contract (inheritance check)
             (Contract(self_contract_id), Contract(other_contract_id)) => {
                 let self_contract = gcx.hir.contract(self_contract_id);
-                if self_contract.linearized_bases.contains(&other_contract_id) {
+                if self_contract.is_or_inherits_from(other_contract_id) {
                     Ok(())
                 } else {
                     Result::Err(TyConvertError::NonDerivedContract)
@@ -934,7 +934,7 @@ impl<'gcx> Ty<'gcx> {
             // Contract -> Base contract (inheritance check)
             (Contract(self_contract_id), Contract(other_contract_id)) => {
                 let self_contract = gcx.hir.contract(self_contract_id);
-                if self_contract.linearized_bases.contains(&other_contract_id) {
+                if self_contract.is_or_inherits_from(other_contract_id) {
                     Ok(())
                 } else {
                     Result::Err(TyConvertError::NonDerivedContract)

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1125,7 +1125,7 @@ impl<'gcx> TypeChecker<'gcx> {
 
     fn select_most_derived_function(&self, candidates: &[hir::Res]) -> Option<hir::Res> {
         let contract = self.contract?;
-        let bases = self.gcx.hir.contract(contract).self_and_inherited_bases();
+        let bases = self.gcx.hir.contract_and_inherited_bases(contract).collect::<Vec<_>>();
 
         let mut selected = None;
         let mut selected_depth = usize::MAX;

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1149,7 +1149,7 @@ impl<'gcx> TypeChecker<'gcx> {
 
     fn select_most_derived_function(&self, candidates: &[hir::Res]) -> Option<hir::Res> {
         let contract = self.contract?;
-        let bases = self.gcx.hir.contract(contract).linearized_bases;
+        let bases = self.gcx.hir.contract(contract).self_and_inherited_bases();
 
         let mut selected = None;
         let mut selected_depth = usize::MAX;
@@ -1846,9 +1846,7 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
         }
 
         // Check base constructor arguments
-        for (&base_id, modifier) in
-            contract.linearized_bases.iter().skip(1).zip(contract.linearized_bases_args.iter())
-        {
+        for (base_id, modifier) in contract.inherited_bases_with_args() {
             // Get constructor parameters if the base has a constructor
             let base_contract = self.gcx.hir.contract(base_id);
             if let Some(ctor_id) = base_contract.ctor {

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -290,7 +290,7 @@ impl<'gcx> OverrideGraph<'gcx> {
             }
         }
 
-        for &ancestor_id in &contract.linearized_bases[1..] {
+        for &ancestor_id in contract.inherited_bases() {
             if let Some(proxy) = self.find_matching_in_contract(ancestor_id) {
                 return Some(proxy);
             }
@@ -1039,7 +1039,7 @@ impl<'gcx> OverrideChecker<'gcx> {
 
         let mut unimplemented: Vec<(OverrideProxy, ContractId)> = Vec::new();
 
-        for &base_id in contract.linearized_bases.iter() {
+        for &base_id in contract.self_and_inherited_bases() {
             let base = self.gcx.hir.contract(base_id);
 
             for f_id in base.functions() {
@@ -1049,17 +1049,18 @@ impl<'gcx> OverrideChecker<'gcx> {
                 }
                 if f.body.is_none() {
                     let sig = self.signature(OverrideProxy::Function(f_id));
-                    let is_implemented = contract.linearized_bases.iter().any(|&impl_base_id| {
-                        let impl_base = self.gcx.hir.contract(impl_base_id);
-                        impl_base.functions().any(|impl_f_id| {
-                            let impl_f = self.gcx.hir.function(impl_f_id);
-                            if impl_f.body.is_none() || impl_f.name.is_none() {
-                                return false;
-                            }
-                            let impl_sig = self.signature(OverrideProxy::Function(impl_f_id));
-                            impl_sig == sig
-                        })
-                    });
+                    let is_implemented =
+                        contract.self_and_inherited_bases().iter().any(|&impl_base_id| {
+                            let impl_base = self.gcx.hir.contract(impl_base_id);
+                            impl_base.functions().any(|impl_f_id| {
+                                let impl_f = self.gcx.hir.function(impl_f_id);
+                                if impl_f.body.is_none() || impl_f.name.is_none() {
+                                    return false;
+                                }
+                                let impl_sig = self.signature(OverrideProxy::Function(impl_f_id));
+                                impl_sig == sig
+                            })
+                        });
                     if !is_implemented {
                         unimplemented.push((OverrideProxy::Function(f_id), base_id));
                     }

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -1039,7 +1039,7 @@ impl<'gcx> OverrideChecker<'gcx> {
 
         let mut unimplemented: Vec<(OverrideProxy, ContractId)> = Vec::new();
 
-        for &base_id in contract.self_and_inherited_bases() {
+        for base_id in self.gcx.hir.contract_and_inherited_bases(self.contract_id) {
             let base = self.gcx.hir.contract(base_id);
 
             for f_id in base.functions() {
@@ -1049,8 +1049,11 @@ impl<'gcx> OverrideChecker<'gcx> {
                 }
                 if f.body.is_none() {
                     let sig = self.signature(OverrideProxy::Function(f_id));
-                    let is_implemented =
-                        contract.self_and_inherited_bases().iter().any(|&impl_base_id| {
+                    let is_implemented = self
+                        .gcx
+                        .hir
+                        .contract_and_inherited_bases(self.contract_id)
+                        .any(|impl_base_id| {
                             let impl_base = self.gcx.hir.contract(impl_base_id);
                             impl_base.functions().any(|impl_f_id| {
                                 let impl_f = self.gcx.hir.function(impl_f_id);


### PR DESCRIPTION
This adds small helpers on `hir::Contract` for iterating over the contract itself, inherited bases, inherited bases with constructor arguments, and inheritance checks.

The obvious callsites now use those helpers instead of manually slicing or searching `linearized_bases`, keeping the self-at-index-zero invariant local to the HIR type.
