### PR TITLE
refactor: add diagnostic span helper

### DIFF
--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -3,7 +3,7 @@ use super::{
     ErrorGuaranteed, FatalAbort, HumanBufferEmitter, Level, MultiSpan, SilentEmitter,
     emitter::HumanEmitter,
 };
-use crate::{Result, SourceMap};
+use crate::{Result, SourceMap, Span};
 use anstream::ColorChoice;
 use solar_config::{ErrorFormat, Opts};
 use solar_data_structures::{map::FxHashSet, sync::Mutex};
@@ -380,8 +380,43 @@ impl DiagCtxt {
 
     /// Emits an error at `span` with the given `msg`.
     #[track_caller]
-    pub fn err_span(&self, msg: impl Into<DiagMsg>, span: impl Into<MultiSpan>) -> ErrorGuaranteed {
+    pub fn emit_err(&self, span: impl Into<MultiSpan>, msg: impl Into<DiagMsg>) -> ErrorGuaranteed {
         self.err(msg).span(span).emit()
+    }
+
+    /// Emits an error at `span` with an attached note.
+    #[track_caller]
+    pub fn emit_err_note(
+        &self,
+        span: impl Into<MultiSpan>,
+        msg: impl Into<DiagMsg>,
+        note: impl Into<DiagMsg>,
+    ) -> ErrorGuaranteed {
+        self.err(msg).span(span).note(note).emit()
+    }
+
+    /// Emits an error at `span` with an attached span note.
+    #[track_caller]
+    pub fn emit_err_span_note(
+        &self,
+        span: impl Into<MultiSpan>,
+        msg: impl Into<DiagMsg>,
+        note_span: impl Into<MultiSpan>,
+        note: impl Into<DiagMsg>,
+    ) -> ErrorGuaranteed {
+        self.err(msg).span(span).span_note(note_span, note).emit()
+    }
+
+    /// Emits an error at `span` with an attached span label.
+    #[track_caller]
+    pub fn emit_err_label(
+        &self,
+        span: impl Into<MultiSpan>,
+        msg: impl Into<DiagMsg>,
+        label_span: Span,
+        label: impl Into<DiagMsg>,
+    ) -> ErrorGuaranteed {
+        self.err(msg).span(span).span_label(label_span, label).emit()
     }
 
     /// Creates a builder at the `Warning` level with the given `msg`.

--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -1,6 +1,7 @@
 use super::{
     BugAbort, Diag, DiagBuilder, DiagMsg, DynEmitter, EmissionGuarantee, EmittedDiagnostics,
-    ErrorGuaranteed, FatalAbort, HumanBufferEmitter, Level, SilentEmitter, emitter::HumanEmitter,
+    ErrorGuaranteed, FatalAbort, HumanBufferEmitter, Level, MultiSpan, SilentEmitter,
+    emitter::HumanEmitter,
 };
 use crate::{Result, SourceMap};
 use anstream::ColorChoice;
@@ -375,6 +376,12 @@ impl DiagCtxt {
     #[track_caller]
     pub fn err(&self, msg: impl Into<DiagMsg>) -> DiagBuilder<'_, ErrorGuaranteed> {
         self.diag(Level::Error, msg)
+    }
+
+    /// Emits an error at `span` with the given `msg`.
+    #[track_caller]
+    pub fn err_span(&self, msg: impl Into<DiagMsg>, span: impl Into<MultiSpan>) -> ErrorGuaranteed {
+        self.err(msg).span(span).emit()
     }
 
     /// Creates a builder at the `Warning` level with the given `msg`.

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -131,7 +131,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                         } else {
                             "unterminated block comment"
                         };
-                        self.dcx().err_span(msg, self.new_span(start, self.pos));
+                        self.dcx().emit_err(self.new_span(start, self.pos), msg);
                     }
 
                     // Opening delimiter and closing delimiter are not included into the symbol.
@@ -295,7 +295,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if !terminated {
                     cold_path();
                     let span = self.new_span(start, end);
-                    let guar = self.dcx().err_span("unterminated string", span);
+                    let guar = self.dcx().emit_err(span, "unterminated string");
                     (TokenLitKind::Err(guar), self.symbol_from_to(start, end))
                 } else {
                     (kind.into(), self.cook_quoted(kind, start, end))
@@ -305,7 +305,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if empty_int {
                     cold_path();
                     let span = self.new_span(start, end);
-                    self.dcx().err_span("no valid digits found for number", span);
+                    self.dcx().emit_err(span, "no valid digits found for number");
                     (TokenLitKind::Integer, self.symbol_from_to(start, end))
                 } else {
                     if matches!(base, Base::Binary | Base::Octal) {
@@ -322,12 +322,12 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                                 let lo = start + BytePos::from_usize(i);
                                 let hi = lo + BytePos::from_usize(c.len_utf8());
                                 let span = self.new_span(lo, hi);
-                                self.dcx().err_span(msg, span);
+                                self.dcx().emit_err(span, msg);
                             }
                         }
                         */
                         let msg = format!("integers in base {base} are not supported");
-                        self.dcx().err_span(msg, self.new_span(start, end));
+                        self.dcx().emit_err(self.new_span(start, end), msg);
                     }
                     (TokenLitKind::Integer, self.symbol_from_to(start, end))
                 }
@@ -336,7 +336,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if empty_exponent {
                     cold_path();
                     let span = self.new_span(start, self.pos);
-                    self.dcx().err_span("expected at least one digit in exponent", span);
+                    self.dcx().emit_err(span, "expected at least one digit in exponent");
                 }
 
                 let unsupported_base =
@@ -344,7 +344,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if unsupported_base {
                     cold_path();
                     let msg = format!("{base} rational numbers are not supported");
-                    self.dcx().err_span(msg, self.new_span(start, end));
+                    self.dcx().emit_err(self.new_span(start, end), msg);
                 }
 
                 (TokenLitKind::Rational, self.symbol_from_to(start, end))

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -131,7 +131,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                         } else {
                             "unterminated block comment"
                         };
-                        self.dcx().err(msg).span(self.new_span(start, self.pos)).emit();
+                        self.dcx().err_span(msg, self.new_span(start, self.pos));
                     }
 
                     // Opening delimiter and closing delimiter are not included into the symbol.
@@ -295,7 +295,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if !terminated {
                     cold_path();
                     let span = self.new_span(start, end);
-                    let guar = self.dcx().err("unterminated string").span(span).emit();
+                    let guar = self.dcx().err_span("unterminated string", span);
                     (TokenLitKind::Err(guar), self.symbol_from_to(start, end))
                 } else {
                     (kind.into(), self.cook_quoted(kind, start, end))
@@ -305,7 +305,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if empty_int {
                     cold_path();
                     let span = self.new_span(start, end);
-                    self.dcx().err("no valid digits found for number").span(span).emit();
+                    self.dcx().err_span("no valid digits found for number", span);
                     (TokenLitKind::Integer, self.symbol_from_to(start, end))
                 } else {
                     if matches!(base, Base::Binary | Base::Octal) {
@@ -322,12 +322,12 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                                 let lo = start + BytePos::from_usize(i);
                                 let hi = lo + BytePos::from_usize(c.len_utf8());
                                 let span = self.new_span(lo, hi);
-                                self.dcx().err(msg).span(span).emit();
+                                self.dcx().err_span(msg, span);
                             }
                         }
                         */
                         let msg = format!("integers in base {base} are not supported");
-                        self.dcx().err(msg).span(self.new_span(start, end)).emit();
+                        self.dcx().err_span(msg, self.new_span(start, end));
                     }
                     (TokenLitKind::Integer, self.symbol_from_to(start, end))
                 }
@@ -336,7 +336,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if empty_exponent {
                     cold_path();
                     let span = self.new_span(start, self.pos);
-                    self.dcx().err("expected at least one digit in exponent").span(span).emit();
+                    self.dcx().err_span("expected at least one digit in exponent", span);
                 }
 
                 let unsupported_base =
@@ -344,7 +344,7 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                 if unsupported_base {
                     cold_path();
                     let msg = format!("{base} rational numbers are not supported");
-                    self.dcx().err(msg).span(self.new_span(start, end)).emit();
+                    self.dcx().err_span(msg, self.new_span(start, end));
                 }
 
                 (TokenLitKind::Rational, self.symbol_from_to(start, end))

--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -85,7 +85,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         with: Option<Box<'ast, Expr<'ast>>>,
     ) -> PResult<'sess, Box<'ast, Expr<'ast>>> {
         if with.is_none() && self.eat(TokenKind::BinOp(BinOpToken::Plus)) {
-            self.dcx().err_span("unary plus is not supported", self.prev_token.span);
+            self.dcx().emit_err(self.prev_token.span, "unary plus is not supported");
         }
 
         let lo = with.as_ref().map(|e| e.span).unwrap_or(self.token.span);
@@ -186,7 +186,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 && *payable
             {
                 let msg = "`address payable` cannot be used in an expression";
-                self.dcx().err_span(msg, ty.span);
+                self.dcx().emit_err(ty.span, msg);
                 *payable = false;
             }
             ExprKind::Type(ty)

--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -85,7 +85,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         with: Option<Box<'ast, Expr<'ast>>>,
     ) -> PResult<'sess, Box<'ast, Expr<'ast>>> {
         if with.is_none() && self.eat(TokenKind::BinOp(BinOpToken::Plus)) {
-            self.dcx().err("unary plus is not supported").span(self.prev_token.span).emit();
+            self.dcx().err_span("unary plus is not supported", self.prev_token.span);
         }
 
         let lo = with.as_ref().map(|e| e.span).unwrap_or(self.token.span);
@@ -186,7 +186,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 && *payable
             {
                 let msg = "`address payable` cannot be used in an expression";
-                self.dcx().err(msg).span(ty.span).emit();
+                self.dcx().err_span(msg, ty.span);
                 *payable = false;
             }
             ExprKind::Type(ty)

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -38,7 +38,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             if self.in_contract && !item.is_allowed_in_contract() {
                 let msg = format!("{}s are not allowed in contracts", item.description());
                 let (_, note) = get_msg_note(self);
-                self.dcx().err(msg).span(item.span).note(note).emit();
+                self.dcx().emit_err_note(item.span, msg, note);
             } else {
                 items.push(item);
             }
@@ -154,7 +154,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
         if !self.in_contract && !kind.allowed_in_global() {
             let msg = format!("{kind}s are not allowed in the global scope");
-            self.dcx().err_span(msg, lo.to(self.prev_token.span));
+            self.dcx().emit_err(lo.to(self.prev_token.span), msg);
         }
         // All function kinds are allowed in contracts.
 
@@ -198,7 +198,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             header.name = Some(ident);
         } else if self.token.is_non_reserved_ident(false) {
             let msg = "function names are not allowed here";
-            self.dcx().err_span(msg, self.token.span);
+            self.dcx().emit_err(self.token.span, msg);
             self.bump();
         }
 
@@ -221,16 +221,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let span = self.prev_token.span;
                 if let Some(prev) = header.visibility {
                     let msg = "visibility already specified";
-                    self.dcx()
-                        .err(msg)
-                        .span(span)
-                        .span_label(prev.span, "previous definition")
-                        .emit();
+                    self.dcx().emit_err_label(span, msg, prev.span, "previous definition");
                 } else {
                     let mut v = Some(visibility);
                     if !flags.contains(FunctionFlags::from_visibility(visibility)) {
                         let msg = visibility_error(visibility, flags.visibilities());
-                        self.dcx().err_span(msg, span);
+                        self.dcx().emit_err(span, msg);
                         // Set to the first valid visibility, if any.
                         v = flags.visibilities().into_iter().flatten().next();
                     }
@@ -240,17 +236,13 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let span = self.prev_token.span;
                 if let Some(prev) = header.state_mutability {
                     let msg = "state mutability already specified";
-                    self.dcx()
-                        .err(msg)
-                        .span(span)
-                        .span_label(prev.span, "previous definition")
-                        .emit();
+                    self.dcx().emit_err_label(span, msg, prev.span, "previous definition");
                 } else {
                     let mut sm = Some(state_mutability);
                     if !flags.contains(FunctionFlags::from_state_mutability(state_mutability)) {
                         let msg =
                             state_mutability_error(state_mutability, flags.state_mutabilities());
-                        self.dcx().err_span(msg, span);
+                        self.dcx().emit_err(span, msg);
                         // Set to the first valid state mutability, if any.
                         sm = flags.state_mutabilities().into_iter().flatten().next();
                     }
@@ -260,10 +252,10 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let span = self.prev_token.span;
                 if !flags.contains(FunctionFlags::VIRTUAL) {
                     let msg = "`virtual` is not allowed here";
-                    self.dcx().err_span(msg, span);
+                    self.dcx().emit_err(span, msg);
                 } else if let Some(prev) = header.virtual_ {
                     let msg = "virtual already specified";
-                    self.dcx().err(msg).span(span).span_label(prev, "previous definition").emit();
+                    self.dcx().emit_err_label(span, msg, prev, "previous definition");
                 } else {
                     header.virtual_ = Some(span);
                 }
@@ -272,14 +264,10 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let span = o.span;
                 if !flags.contains(FunctionFlags::OVERRIDE) {
                     let msg = "`override` is not allowed here";
-                    self.dcx().err_span(msg, span);
+                    self.dcx().emit_err(span, msg);
                 } else if let Some(prev) = &header.override_ {
                     let msg = "override already specified";
-                    self.dcx()
-                        .err(msg)
-                        .span(span)
-                        .span_label(prev.span, "previous definition")
-                        .emit();
+                    self.dcx().emit_err_label(span, msg, prev.span, "previous definition");
                 } else {
                     header.override_ = Some(o);
                 }
@@ -363,11 +351,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     let span = |bases: &[Modifier<'_>]| {
                         Span::join_first_last(bases.iter().map(|m| m.span()))
                     };
-                    self.dcx()
-                        .err(msg)
-                        .span(span(new_bases))
-                        .span_label(span(prev), "previous definition")
-                        .emit();
+                    self.dcx().emit_err_label(
+                        span(new_bases),
+                        msg,
+                        span(prev),
+                        "previous definition",
+                    );
                 } else if !new_bases.is_empty() {
                     bases = Some(new_bases);
                 }
@@ -375,11 +364,12 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let new_layout = self.parse_storage_layout_specifier()?;
                 if let Some(prev) = &layout {
                     let msg = "storage layout already specified";
-                    self.dcx()
-                        .err(msg)
-                        .span(new_layout.span)
-                        .span_label(prev.span, "previous definition")
-                        .emit();
+                    self.dcx().emit_err_label(
+                        new_layout.span,
+                        msg,
+                        prev.span,
+                        "previous definition",
+                    );
                 } else {
                     layout = Some(new_layout);
                 }
@@ -392,7 +382,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             && !kind.is_contract()
         {
             let msg = "storage layout is only allowed for contracts";
-            self.dcx().err_span(msg, layout.span);
+            self.dcx().emit_err(layout.span, msg);
         }
 
         self.expect(TokenKind::OpenDelim(Delimiter::Brace))?;
@@ -452,7 +442,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             }
             if !self.token.is_eof() && tokens.is_empty() {
                 let msg = "expected at least one token in pragma directive";
-                self.dcx().err_span(msg, self.prev_token.span);
+                self.dcx().emit_err(self.prev_token.span, msg);
             }
             PragmaTokens::Verbatim(self.alloc_vec(tokens))
         };
@@ -600,7 +590,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         };
         if path.value.as_str().is_empty() {
             let msg = "import path cannot be empty";
-            self.dcx().err_span(msg, path.span);
+            self.dcx().emit_err(path.span, msg);
         }
         self.expect_semi()?;
         Ok(ImportDirective { path, items })
@@ -717,7 +707,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         {
             let msg = "expected a state variable declaration";
             let note = "this style of fallback function has been removed; use the `fallback` or `receive` keywords instead";
-            self.dcx().err(msg).span(self.token.span).note(note).emit();
+            self.dcx().emit_err_note(self.token.span, msg, note);
             let _ = self.parse_block()?;
             return Ok(VariableDefinition {
                 span: lo.to(self.prev_token.span),
@@ -741,20 +731,20 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             if let Some(s) = self.parse_data_location() {
                 if !flags.contains(VarFlags::DATALOC) {
                     let msg = "data locations are not allowed here";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else if data_location.is_some() {
                     let msg = "data location already specified";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else {
                     data_location = Some(s);
                 }
             } else if let Some(v) = self.parse_visibility() {
                 if !flags.contains(VarFlags::from_visibility(v)) {
                     let msg = visibility_error(v, flags.visibilities());
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else if visibility.is_some() {
                     let msg = "visibility already specified";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else {
                     visibility = Some(v);
                 }
@@ -762,34 +752,34 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 // `CONSTANT_VAR` is special cased later.
                 if flags != VarFlags::CONSTANT_VAR && !flags.contains(VarFlags::from_varmut(m)) {
                     let msg = varmut_error(m, flags.varmuts());
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else if mutability.is_some() {
                     let msg = "mutability already specified";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else {
                     mutability = Some(m);
                 }
             } else if self.eat_keyword(kw::Indexed) {
                 if !flags.contains(VarFlags::INDEXED) {
                     let msg = "`indexed` is not allowed here";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else if indexed {
                     let msg = "`indexed` already specified";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else {
                     indexed = true;
                 }
             } else if self.eat_keyword(kw::Virtual) {
                 let msg = "`virtual` is not allowed here";
-                self.dcx().err_span(msg, self.prev_token.span);
+                self.dcx().emit_err(self.prev_token.span, msg);
             } else if self.eat_keyword(kw::Override) {
                 let o = self.parse_override()?;
                 if !flags.contains(VarFlags::OVERRIDE) {
                     let msg = "`override` is not allowed here";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else if override_.is_some() {
                     let msg = "override already specified";
-                    self.dcx().err_span(msg, self.prev_token.span);
+                    self.dcx().emit_err(self.prev_token.span, msg);
                 } else {
                     override_ = Some(o);
                 }
@@ -825,11 +815,11 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
         if mutability == Some(VarMut::Constant) && initializer.is_none() {
             let msg = "constant variable must be initialized";
-            self.dcx().err_span(msg, span);
+            self.dcx().emit_err(span, msg);
         }
         if flags == VarFlags::CONSTANT_VAR && mutability != Some(VarMut::Constant) {
             let msg = "only constant variables are allowed at file level";
-            self.dcx().err_span(msg, span);
+            self.dcx().emit_err(span, msg);
         }
 
         Ok(VariableDefinition {
@@ -1000,7 +990,7 @@ impl<'p, 'sess, 'ast> SemverVersionParser<'p, 'sess, 'ast> {
     }
 
     fn emit_err(&self, msg: impl Into<DiagMsg>) {
-        self.p.dcx().err_span(msg, self.current_span());
+        self.p.dcx().emit_err(self.current_span(), msg);
     }
 
     fn parse(mut self) -> SemverVersion {

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -154,7 +154,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
         if !self.in_contract && !kind.allowed_in_global() {
             let msg = format!("{kind}s are not allowed in the global scope");
-            self.dcx().err(msg).span(lo.to(self.prev_token.span)).emit();
+            self.dcx().err_span(msg, lo.to(self.prev_token.span));
         }
         // All function kinds are allowed in contracts.
 
@@ -198,7 +198,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             header.name = Some(ident);
         } else if self.token.is_non_reserved_ident(false) {
             let msg = "function names are not allowed here";
-            self.dcx().err(msg).span(self.token.span).emit();
+            self.dcx().err_span(msg, self.token.span);
             self.bump();
         }
 
@@ -230,7 +230,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     let mut v = Some(visibility);
                     if !flags.contains(FunctionFlags::from_visibility(visibility)) {
                         let msg = visibility_error(visibility, flags.visibilities());
-                        self.dcx().err(msg).span(span).emit();
+                        self.dcx().err_span(msg, span);
                         // Set to the first valid visibility, if any.
                         v = flags.visibilities().into_iter().flatten().next();
                     }
@@ -250,7 +250,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                     if !flags.contains(FunctionFlags::from_state_mutability(state_mutability)) {
                         let msg =
                             state_mutability_error(state_mutability, flags.state_mutabilities());
-                        self.dcx().err(msg).span(span).emit();
+                        self.dcx().err_span(msg, span);
                         // Set to the first valid state mutability, if any.
                         sm = flags.state_mutabilities().into_iter().flatten().next();
                     }
@@ -260,7 +260,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let span = self.prev_token.span;
                 if !flags.contains(FunctionFlags::VIRTUAL) {
                     let msg = "`virtual` is not allowed here";
-                    self.dcx().err(msg).span(span).emit();
+                    self.dcx().err_span(msg, span);
                 } else if let Some(prev) = header.virtual_ {
                     let msg = "virtual already specified";
                     self.dcx().err(msg).span(span).span_label(prev, "previous definition").emit();
@@ -272,7 +272,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let span = o.span;
                 if !flags.contains(FunctionFlags::OVERRIDE) {
                     let msg = "`override` is not allowed here";
-                    self.dcx().err(msg).span(span).emit();
+                    self.dcx().err_span(msg, span);
                 } else if let Some(prev) = &header.override_ {
                     let msg = "override already specified";
                     self.dcx()
@@ -392,7 +392,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             && !kind.is_contract()
         {
             let msg = "storage layout is only allowed for contracts";
-            self.dcx().err(msg).span(layout.span).emit();
+            self.dcx().err_span(msg, layout.span);
         }
 
         self.expect(TokenKind::OpenDelim(Delimiter::Brace))?;
@@ -452,7 +452,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             }
             if !self.token.is_eof() && tokens.is_empty() {
                 let msg = "expected at least one token in pragma directive";
-                self.dcx().err(msg).span(self.prev_token.span).emit();
+                self.dcx().err_span(msg, self.prev_token.span);
             }
             PragmaTokens::Verbatim(self.alloc_vec(tokens))
         };
@@ -600,7 +600,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         };
         if path.value.as_str().is_empty() {
             let msg = "import path cannot be empty";
-            self.dcx().err(msg).span(path.span).emit();
+            self.dcx().err_span(msg, path.span);
         }
         self.expect_semi()?;
         Ok(ImportDirective { path, items })
@@ -741,20 +741,20 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             if let Some(s) = self.parse_data_location() {
                 if !flags.contains(VarFlags::DATALOC) {
                     let msg = "data locations are not allowed here";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else if data_location.is_some() {
                     let msg = "data location already specified";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else {
                     data_location = Some(s);
                 }
             } else if let Some(v) = self.parse_visibility() {
                 if !flags.contains(VarFlags::from_visibility(v)) {
                     let msg = visibility_error(v, flags.visibilities());
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else if visibility.is_some() {
                     let msg = "visibility already specified";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else {
                     visibility = Some(v);
                 }
@@ -762,34 +762,34 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 // `CONSTANT_VAR` is special cased later.
                 if flags != VarFlags::CONSTANT_VAR && !flags.contains(VarFlags::from_varmut(m)) {
                     let msg = varmut_error(m, flags.varmuts());
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else if mutability.is_some() {
                     let msg = "mutability already specified";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else {
                     mutability = Some(m);
                 }
             } else if self.eat_keyword(kw::Indexed) {
                 if !flags.contains(VarFlags::INDEXED) {
                     let msg = "`indexed` is not allowed here";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else if indexed {
                     let msg = "`indexed` already specified";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else {
                     indexed = true;
                 }
             } else if self.eat_keyword(kw::Virtual) {
                 let msg = "`virtual` is not allowed here";
-                self.dcx().err(msg).span(self.prev_token.span).emit();
+                self.dcx().err_span(msg, self.prev_token.span);
             } else if self.eat_keyword(kw::Override) {
                 let o = self.parse_override()?;
                 if !flags.contains(VarFlags::OVERRIDE) {
                     let msg = "`override` is not allowed here";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else if override_.is_some() {
                     let msg = "override already specified";
-                    self.dcx().err(msg).span(self.prev_token.span).emit();
+                    self.dcx().err_span(msg, self.prev_token.span);
                 } else {
                     override_ = Some(o);
                 }
@@ -825,11 +825,11 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
         if mutability == Some(VarMut::Constant) && initializer.is_none() {
             let msg = "constant variable must be initialized";
-            self.dcx().err(msg).span(span).emit();
+            self.dcx().err_span(msg, span);
         }
         if flags == VarFlags::CONSTANT_VAR && mutability != Some(VarMut::Constant) {
             let msg = "only constant variables are allowed at file level";
-            self.dcx().err(msg).span(span).emit();
+            self.dcx().err_span(msg, span);
         }
 
         Ok(VariableDefinition {
@@ -1000,7 +1000,7 @@ impl<'p, 'sess, 'ast> SemverVersionParser<'p, 'sess, 'ast> {
     }
 
     fn emit_err(&self, msg: impl Into<DiagMsg>) {
-        self.p.dcx().err(msg).span(self.current_span()).emit();
+        self.p.dcx().err_span(msg, self.current_span());
     }
 
     fn parse(mut self) -> SemverVersion {

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -54,7 +54,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     pub(super) fn expect_no_subdenomination(&mut self) {
         if let Some(_sub) = self.parse_subdenomination() {
             let span = self.prev_token.span;
-            self.dcx().err("subdenominations aren't allowed here").span(span).emit();
+            self.dcx().err_span("subdenominations aren't allowed here", span);
         }
     }
 
@@ -99,7 +99,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         if slot.is_some() {
             *slot = None;
             let msg = "sub-denominations are only allowed on number and rational literals";
-            self.dcx().err(msg).span(span).emit();
+            self.dcx().err_span(msg, span);
         }
     }
 

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -54,7 +54,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     pub(super) fn expect_no_subdenomination(&mut self) {
         if let Some(_sub) = self.parse_subdenomination() {
             let span = self.prev_token.span;
-            self.dcx().err_span("subdenominations aren't allowed here", span);
+            self.dcx().emit_err(span, "subdenominations aren't allowed here");
         }
     }
 
@@ -99,7 +99,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         if slot.is_some() {
             *slot = None;
             let msg = "sub-denominations are only allowed on number and rational literals";
-            self.dcx().err_span(msg, span);
+            self.dcx().emit_err(span, msg);
         }
     }
 

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -696,7 +696,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             }
             if !sep.trailing_sep_allowed && trailing {
                 let msg = format!("trailing `{sep_kind}` separator is not allowed");
-                self.dcx().err(msg).span(self.prev_token.span).emit();
+                self.dcx().err_span(msg, self.prev_token.span);
             }
         }
 

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -696,7 +696,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             }
             if !sep.trailing_sep_allowed && trailing {
                 let msg = format!("trailing `{sep_kind}` separator is not allowed");
-                self.dcx().err_span(msg, self.prev_token.span);
+                self.dcx().emit_err(self.prev_token.span, msg);
             }
         }
 

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -465,7 +465,7 @@ impl<'ast> IndexAccessedPath<'ast> {
                 IndexKind::Index(expr) => expr,
                 IndexKind::Range(l, r) => {
                     let msg = "expected array length, got range expression";
-                    parser.dcx().err_span(msg, span);
+                    parser.dcx().emit_err(span, msg);
                     l.or(r)
                 }
             };

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -465,7 +465,7 @@ impl<'ast> IndexAccessedPath<'ast> {
                 IndexKind::Index(expr) => expr,
                 IndexKind::Range(l, r) => {
                     let msg = "expected array length, got range expression";
-                    parser.dcx().err(msg).span(span).emit();
+                    parser.dcx().err_span(msg, span);
                     l.or(r)
                 }
             };

--- a/crates/parse/src/parser/ty.rs
+++ b/crates/parse/src/parser/ty.rs
@@ -102,13 +102,13 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 } else {
                     "only address types can have state mutability"
                 };
-                self.dcx().err(msg).span(id.span.to(self.prev_token.span)).emit();
+                self.dcx().err_span(msg, id.span.to(self.prev_token.span));
             }
         }
 
         // TODO: Move to type checking.
         // if matches!(ty, ElementaryType::Fixed(..) | ElementaryType::UFixed(..)) {
-        //     self.dcx().err("`fixed` types are not yet supported").span(id.span).emit();
+        //     self.dcx().err_span("`fixed` types are not yet supported", id.span);
         // }
 
         Ok(ty)

--- a/crates/parse/src/parser/ty.rs
+++ b/crates/parse/src/parser/ty.rs
@@ -102,13 +102,13 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 } else {
                     "only address types can have state mutability"
                 };
-                self.dcx().err_span(msg, id.span.to(self.prev_token.span));
+                self.dcx().emit_err(id.span.to(self.prev_token.span), msg);
             }
         }
 
         // TODO: Move to type checking.
         // if matches!(ty, ElementaryType::Fixed(..) | ElementaryType::UFixed(..)) {
-        //     self.dcx().err_span("`fixed` types are not yet supported", id.span);
+        //     self.dcx().emit_err(id.span, "`fixed` types are not yet supported");
         // }
 
         Ok(ty)

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -229,7 +229,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         if cases.is_empty() {
             let span = lo.to(self.prev_token.span);
             if default_case.is_none() {
-                self.dcx().err("`switch` statement has no cases").span(span).emit();
+                self.dcx().err_span("`switch` statement has no cases", span);
             } else {
                 self.dcx()
                     .warn("`switch` statement has only a default case")
@@ -309,7 +309,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     #[track_caller]
     fn expect_single_ident_path(&mut self, path: AstPath<'_>) -> Ident {
         if path.segments().len() > 1 {
-            self.dcx().err("fully-qualified paths aren't allowed here").span(path.span()).emit();
+            self.dcx().err_span("fully-qualified paths aren't allowed here", path.span());
         }
         *path.last()
     }

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -229,7 +229,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         if cases.is_empty() {
             let span = lo.to(self.prev_token.span);
             if default_case.is_none() {
-                self.dcx().err_span("`switch` statement has no cases", span);
+                self.dcx().emit_err(span, "`switch` statement has no cases");
             } else {
                 self.dcx()
                     .warn("`switch` statement has only a default case")
@@ -309,7 +309,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     #[track_caller]
     fn expect_single_ident_path(&mut self, path: AstPath<'_>) -> Ident {
         if path.segments().len() > 1 {
-            self.dcx().err_span("fully-qualified paths aren't allowed here", path.span());
+            self.dcx().emit_err(path.span(), "fully-qualified paths aren't allowed here");
         }
         *path.last()
     }

--- a/crates/sema/src/ast_lowering/linearize.rs
+++ b/crates/sema/src/ast_lowering/linearize.rs
@@ -21,7 +21,7 @@ impl super::LoweringContext<'_> {
                 self.linearize_contract(contract_id, &mut linearizer);
                 if linearizer.result.is_empty() {
                     let msg = "linearization of inheritance graph impossible";
-                    self.dcx().err_span(msg, self.hir.contract(contract_id).name.span);
+                    self.dcx().emit_err(self.hir.contract(contract_id).name.span, msg);
                     // Always include the contract itself in the linearized bases.
                     linearizer.result.push(contract_id);
                 }
@@ -104,7 +104,7 @@ impl super::LoweringContext<'_> {
             let base_bases = base.linearized_bases;
             if base_bases.is_empty() {
                 let msg = "definition of base has to precede definition of derived contract";
-                self.dcx().err_span(msg, contract.name.span);
+                self.dcx().emit_err(contract.name.span, msg);
                 continue;
             }
             linearizer.insert_bases(base_bases);

--- a/crates/sema/src/ast_lowering/linearize.rs
+++ b/crates/sema/src/ast_lowering/linearize.rs
@@ -21,7 +21,7 @@ impl super::LoweringContext<'_> {
                 self.linearize_contract(contract_id, &mut linearizer);
                 if linearizer.result.is_empty() {
                     let msg = "linearization of inheritance graph impossible";
-                    self.dcx().err(msg).span(self.hir.contract(contract_id).name.span).emit();
+                    self.dcx().err_span(msg, self.hir.contract(contract_id).name.span);
                     // Always include the contract itself in the linearized bases.
                     linearizer.result.push(contract_id);
                 }
@@ -104,7 +104,7 @@ impl super::LoweringContext<'_> {
             let base_bases = base.linearized_bases;
             if base_bases.is_empty() {
                 let msg = "definition of base has to precede definition of derived contract";
-                self.dcx().err(msg).span(contract.name.span).emit();
+                self.dcx().err_span(msg, contract.name.span);
                 continue;
             }
             linearizer.insert_bases(base_bases);

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -106,7 +106,7 @@ impl super::LoweringContext<'_> {
                                         .source_map()
                                         .filename_for_diagnostics(&source.file.name)
                                 );
-                                let guar = self.sess.dcx.err(msg).span(import.span).emit();
+                                let guar = self.sess.dcx.err_span(msg, import.span);
                                 let _ = source_scope.declare_res(
                                     self.sess,
                                     &self.hir,
@@ -179,7 +179,7 @@ impl super::LoweringContext<'_> {
                 };
                 if base_id == contract_id {
                     let msg = "contracts cannot inherit from themselves";
-                    self.dcx().err(msg).span(name.span()).emit();
+                    self.dcx().err_span(msg, name.span());
                     continue;
                 }
                 bases.push(base_id);
@@ -400,10 +400,7 @@ impl<'gcx> ResolveContext<'gcx> {
                                 })
                             });
                             if !allowed {
-                                self.dcx()
-                                    .err("can only use modifiers defined in the current contract or in base contracts")
-                                    .span(modifier.name.span())
-                                    .emit();
+                                self.dcx().err_span("can only use modifiers defined in the current contract or in base contracts", modifier.name.span());
                                 continue;
                             }
                         }
@@ -540,7 +537,7 @@ impl<'gcx> ResolveContext<'gcx> {
             return hir::UsingEntryKind::Err(guar);
         }
         if functions.len() != 1 || saw_non_function {
-            let guar = self.dcx().err("expected function name").span(path.span()).emit();
+            let guar = self.dcx().err_span("expected function name", path.span());
             return hir::UsingEntryKind::Err(guar);
         }
         hir::UsingEntryKind::Functions(self.arena.alloc_smallvec(functions))
@@ -1052,9 +1049,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 sym::memory_dash_safe => {
                     if memory_safe {
                         self.dcx()
-                            .err("inline assembly marked memory-safe multiple times")
-                            .span(span)
-                            .emit();
+                            .err_span("inline assembly marked memory-safe multiple times", span);
                     }
                     memory_safe = true;
                 }
@@ -1412,7 +1407,7 @@ impl<'gcx> ResolveContext<'gcx> {
             return Ok(self.arena.alloc_as_slice(Res::Builtin(builtin)));
         }
         if name.name.as_str().starts_with("verbatim_") {
-            return Err(self.dcx().err("unsupported verbatim builtin").span(name.span).emit());
+            return Err(self.dcx().err_span("unsupported verbatim builtin", name.span));
         }
         Err(self.resolver.emit_resolver_error()(ResolverError::new(
             name,
@@ -1767,7 +1762,7 @@ impl<'gcx> ResolveContext<'gcx> {
                     break 'b hir::ExprKind::Payable(self.lower_expr(arg));
                 }
                 let msg = "expected exactly one unnamed argument";
-                let guar = self.sess.dcx.err(msg).span(expr.span).emit();
+                let guar = self.sess.dcx.err_span(msg, expr.span);
                 hir::ExprKind::Err(guar)
             }
             ast::ExprKind::Ternary(cond, then, r#else) => hir::ExprKind::Ternary(
@@ -2052,7 +2047,7 @@ impl<'gcx> SymbolResolver<'gcx> {
     }
 
     fn emit_resolver_error(&self) -> impl Fn(ResolverError) -> ErrorGuaranteed + '_ {
-        move |e| self.dcx.err(e.format()).span(e.span()).emit()
+        move |e| self.dcx.err_span(e.format(), e.span())
     }
 
     fn resolve_path(
@@ -2128,7 +2123,7 @@ impl<'gcx> SymbolResolver<'gcx> {
     }
 
     fn report_expected(&self, expected: &str, found: &str, span: Span) -> ErrorGuaranteed {
-        self.dcx.err(format!("expected {expected}, found {found}")).span(span).emit()
+        self.dcx.err_span(format!("expected {expected}, found {found}"), span)
     }
 }
 

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -106,7 +106,7 @@ impl super::LoweringContext<'_> {
                                         .source_map()
                                         .filename_for_diagnostics(&source.file.name)
                                 );
-                                let guar = self.sess.dcx.err_span(msg, import.span);
+                                let guar = self.sess.dcx.emit_err(import.span, msg);
                                 let _ = source_scope.declare_res(
                                     self.sess,
                                     &self.hir,
@@ -179,7 +179,7 @@ impl super::LoweringContext<'_> {
                 };
                 if base_id == contract_id {
                     let msg = "contracts cannot inherit from themselves";
-                    self.dcx().err_span(msg, name.span());
+                    self.dcx().emit_err(name.span(), msg);
                     continue;
                 }
                 bases.push(base_id);
@@ -213,7 +213,7 @@ impl super::LoweringContext<'_> {
                         let msg = format!("{} function already declared", func.kind);
                         let note = "previous declaration here";
                         let prev_span = self.hir.function(prev).span;
-                        self.dcx().err(msg).span(func.span).span_note(prev_span, note).emit();
+                        self.dcx().emit_err_span_note(func.span, msg, prev_span, note);
                     } else {
                         *slot = Some(function_id);
                     }
@@ -400,7 +400,7 @@ impl<'gcx> ResolveContext<'gcx> {
                                 })
                             });
                             if !allowed {
-                                self.dcx().err_span("can only use modifiers defined in the current contract or in base contracts", modifier.name.span());
+                                self.dcx().emit_err(modifier.name.span(), "can only use modifiers defined in the current contract or in base contracts");
                                 continue;
                             }
                         }
@@ -537,7 +537,7 @@ impl<'gcx> ResolveContext<'gcx> {
             return hir::UsingEntryKind::Err(guar);
         }
         if functions.len() != 1 || saw_non_function {
-            let guar = self.dcx().err_span("expected function name", path.span());
+            let guar = self.dcx().emit_err(path.span(), "expected function name");
             return hir::UsingEntryKind::Err(guar);
         }
         hir::UsingEntryKind::Functions(self.arena.alloc_smallvec(functions))
@@ -608,9 +608,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 // So we use `is_dummy` here instead of `is_empty`.
                 self.sess
                     .dcx
-                    .err("modifier-style base constructor call without arguments")
-                    .span(base.span)
-                    .emit();
+                    .emit_err(base.span, "modifier-style base constructor call without arguments");
             }
             let prev = &mut base_args[base_idx];
             if let Some(prev) = prev {
@@ -824,7 +822,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 [] => {
                     let msg = "getter must return at least one value";
                     let note = "the struct has all its members omitted, therefore the getter cannot return any values";
-                    self.dcx().err(msg).span(span).span_note(ret_ty.span, note).emit();
+                    self.dcx().emit_err_span_note(span, msg, ret_ty.span, note);
                     Some(&[])
                 }
                 // `return <expr>;`
@@ -1049,7 +1047,7 @@ impl<'gcx> ResolveContext<'gcx> {
                 sym::memory_dash_safe => {
                     if memory_safe {
                         self.dcx()
-                            .err_span("inline assembly marked memory-safe multiple times", span);
+                            .emit_err(span, "inline assembly marked memory-safe multiple times");
                     }
                     memory_safe = true;
                 }
@@ -1407,7 +1405,7 @@ impl<'gcx> ResolveContext<'gcx> {
             return Ok(self.arena.alloc_as_slice(Res::Builtin(builtin)));
         }
         if name.name.as_str().starts_with("verbatim_") {
-            return Err(self.dcx().err_span("unsupported verbatim builtin", name.span));
+            return Err(self.dcx().emit_err(name.span, "unsupported verbatim builtin"));
         }
         Err(self.resolver.emit_resolver_error()(ResolverError::new(
             name,
@@ -1721,14 +1719,12 @@ impl<'gcx> ResolveContext<'gcx> {
                 let callee = self.lower_expr(callee);
                 let _options = self.lower_named_args(options);
                 let options_span = callee.span.shrink_to_hi().with_hi(expr.span.hi());
-                hir::ExprKind::Err(
-                    self.sess
-                        .dcx
-                        .err("call options must be part of a call expression")
-                        .span(options_span)
-                        .span_note(expr.span, "this expression is not a function call expression")
-                        .emit(),
-                )
+                hir::ExprKind::Err(self.sess.dcx.emit_err_span_note(
+                    options_span,
+                    "call options must be part of a call expression",
+                    expr.span,
+                    "this expression is not a function call expression",
+                ))
             }
             ast::ExprKind::Delete(expr) => hir::ExprKind::Delete(self.lower_expr(expr)),
             ast::ExprKind::Ident(name) => {
@@ -1762,7 +1758,7 @@ impl<'gcx> ResolveContext<'gcx> {
                     break 'b hir::ExprKind::Payable(self.lower_expr(arg));
                 }
                 let msg = "expected exactly one unnamed argument";
-                let guar = self.sess.dcx.err_span(msg, expr.span);
+                let guar = self.sess.dcx.emit_err(expr.span, msg);
                 hir::ExprKind::Err(guar)
             }
             ast::ExprKind::Ternary(cond, then, r#else) => hir::ExprKind::Ternary(
@@ -2047,7 +2043,7 @@ impl<'gcx> SymbolResolver<'gcx> {
     }
 
     fn emit_resolver_error(&self) -> impl Fn(ResolverError) -> ErrorGuaranteed + '_ {
-        move |e| self.dcx.err_span(e.format(), e.span())
+        move |e| self.dcx.emit_err(e.span(), e.format())
     }
 
     fn resolve_path(
@@ -2123,7 +2119,7 @@ impl<'gcx> SymbolResolver<'gcx> {
     }
 
     fn report_expected(&self, expected: &str, found: &str, span: Span) -> ErrorGuaranteed {
-        self.dcx.err_span(format!("expected {expected}, found {found}"), span)
+        self.dcx.emit_err(span, format!("expected {expected}, found {found}"))
     }
 }
 

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -116,7 +116,7 @@ impl<'sess> AstValidator<'sess, '_> {
         }
 
         if let ast::SubDenomination::Time(ast::TimeSubDenomination::Years) = denom {
-            self.dcx().err_span("using \"years\" as a unit denomination is deprecated", lit.span);
+            self.dcx().emit_err(lit.span, "using \"years\" as a unit denomination is deprecated");
         }
     }
 
@@ -150,7 +150,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
     ) -> ControlFlow<Self::BreakValue> {
         let ast::ItemStruct { name, fields, .. } = item;
         if fields.is_empty() {
-            self.dcx().err_span("structs must have at least one field", name.span);
+            self.dcx().emit_err(name.span, "structs must have at least one field");
         }
         ControlFlow::Continue(())
     }
@@ -161,10 +161,10 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
     ) -> ControlFlow<Self::BreakValue> {
         let ast::ItemEnum { name, variants } = enum_;
         if variants.is_empty() {
-            self.dcx().err_span("enum must have at least one variant", name.span);
+            self.dcx().emit_err(name.span, "enum must have at least one variant");
         }
         if variants.len() > 256 {
-            self.dcx().err_span("enum cannot have more than 256 variants", name.span);
+            self.dcx().emit_err(name.span, "enum cannot have more than 256 variants");
         }
         ControlFlow::Continue(())
     }
@@ -177,7 +177,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             ast::PragmaTokens::Version(name, _version) => {
                 if name.name != sym::solidity {
                     let msg = "only `solidity` is supported as a version pragma";
-                    self.dcx().err_span(msg, name.span);
+                    self.dcx().emit_err(name.span, msg);
                 }
             }
             ast::PragmaTokens::Custom(name, value) => {
@@ -189,15 +189,15 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
                     ("experimental", Some("SMTChecker")) => {}
                     ("experimental", Some("solidity")) => {
                         let msg = "experimental solidity features are not supported";
-                        self.dcx().err_span(msg, self.item_span);
+                        self.dcx().emit_err(self.item_span, msg);
                     }
                     _ => {
-                        self.dcx().err_span("unknown pragma", self.item_span);
+                        self.dcx().emit_err(self.item_span, "unknown pragma");
                     }
                 }
             }
             ast::PragmaTokens::Verbatim(_) => {
-                self.dcx().err_span("unknown pragma", self.item_span);
+                self.dcx().emit_err(self.item_span, "unknown pragma");
             }
         }
         ControlFlow::Continue(())
@@ -218,7 +218,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             }
             ast::StmtKind::UncheckedBlock(_block) => {
                 if self.in_unchecked_block {
-                    self.dcx().err_span("`unchecked` blocks cannot be nested", stmt.span);
+                    self.dcx().emit_err(stmt.span, "`unchecked` blocks cannot be nested");
                 }
 
                 let prev = self.in_unchecked_block;
@@ -230,15 +230,15 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             ast::StmtKind::Placeholder => {
                 self.placeholder_count += 1;
                 if !self.function_kind.is_some_and(|k| k.is_modifier()) {
-                    self.dcx().err_span(
-                        "placeholder statements can only be used in modifiers",
+                    self.dcx().emit_err(
                         stmt.span,
+                        "placeholder statements can only be used in modifiers",
                     );
                 }
                 if self.in_unchecked_block {
-                    self.dcx().err_span(
-                        "placeholder statements cannot be used inside unchecked blocks",
+                    self.dcx().emit_err(
                         stmt.span,
+                        "placeholder statements cannot be used inside unchecked blocks",
                     );
                 }
             }
@@ -256,14 +256,14 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
 
         if contract.kind.is_library() {
             if !contract.bases.is_empty() {
-                self.dcx().err_span("library is not allowed to inherit", contract.name.span);
+                self.dcx().emit_err(contract.name.span, "library is not allowed to inherit");
             }
             for item in contract.body.iter() {
                 if let ast::ItemKind::Variable(var) = &item.kind
                     && !var.mutability.is_some_and(|m| m.is_constant())
                 {
                     self.dcx()
-                        .err_span("library cannot have non-constant state variable", var.span);
+                        .emit_err(var.span, "library cannot have non-constant state variable");
                 }
             }
         }
@@ -292,11 +292,11 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             }
             if contract.kind.is_interface() && !func.header.modifiers.is_empty() {
                 self.dcx()
-                    .err_span("functions in interfaces cannot have modifiers", self.item_span);
+                    .emit_err(self.item_span, "functions in interfaces cannot have modifiers");
             } else if !func.is_implemented() && !func.header.modifiers.is_empty() {
-                self.dcx().err_span(
-                    "functions without implementation cannot have modifiers",
+                self.dcx().emit_err(
                     self.item_span,
+                    "functions without implementation cannot have modifiers",
                 );
             }
         }
@@ -304,7 +304,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
         if func.kind.is_receive() {
             if self.contract.is_some_and(|c| c.kind.is_library()) {
                 self.dcx()
-                    .err_span("libraries cannot have receive ether functions", self.item_span);
+                    .emit_err(self.item_span, "libraries cannot have receive ether functions");
             }
 
             if !func.header.state_mutability().is_payable() {
@@ -317,7 +317,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
 
             if !func.header.parameters.is_empty() {
                 self.dcx()
-                    .err_span("receive ether function cannot take parameters", self.item_span);
+                    .emit_err(self.item_span, "receive ether function cannot take parameters");
             }
         }
 
@@ -340,7 +340,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
 
         if self.contract.is_none() && func.kind.is_function() {
             if !func.is_implemented() {
-                self.dcx().err_span("free functions must be implemented", self.item_span);
+                self.dcx().emit_err(self.item_span, "free functions must be implemented");
             }
             if let Some(visibility) = func.header.visibility {
                 self.dcx()
@@ -361,7 +361,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
                 && let Some(func_name) = func.header.name
             {
                 self.dcx()
-                    .err_span("modifier must have a `_;` placeholder statement", func_name.span);
+                    .emit_err(func_name.span, "modifier must have a `_;` placeholder statement");
             }
         }
         r
@@ -374,30 +374,30 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
         let ast::UsingDirective { ref list, ref ty, global } = *using;
         let with_ty = ty.is_some();
         if self.contract.is_none() && !with_ty {
-            self.dcx().err_span(
-                "the type has to be specified explicitly at file level (cannot use `*`)",
+            self.dcx().emit_err(
                 self.item_span,
+                "the type has to be specified explicitly at file level (cannot use `*`)",
             );
         }
         if self.contract.is_some() && !with_ty && matches!(list, ast::UsingList::Multiple(_)) {
-            self.dcx().err_span(
-                "the type has to be specified explicitly when attaching specific functions",
+            self.dcx().emit_err(
                 self.item_span,
+                "the type has to be specified explicitly when attaching specific functions",
             );
         }
         if global && !with_ty {
             self.dcx()
-                .err_span("can only globally attach functions to specific types", self.item_span);
+                .emit_err(self.item_span, "can only globally attach functions to specific types");
         }
         if global && self.contract.is_some() {
-            self.dcx().err_span("`global` can only be used at file level", self.item_span);
+            self.dcx().emit_err(self.item_span, "`global` can only be used at file level");
         }
         if !global && let ast::UsingList::Multiple(paths) = list {
             for (path, operator) in paths.iter() {
                 if operator.is_some() {
-                    self.dcx().err_span(
-                        "operators can only be defined in a global `using for` directive",
+                    self.dcx().emit_err(
                         path.span(),
+                        "operators can only be defined in a global `using for` directive",
                     );
                 }
             }
@@ -405,9 +405,9 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
         if let Some(contract) = self.contract
             && contract.kind.is_interface()
         {
-            self.dcx().err_span(
-                "the `using for` directive is not allowed inside interfaces",
+            self.dcx().emit_err(
                 self.item_span,
+                "the `using for` directive is not allowed inside interfaces",
             );
         }
         self.walk_using_directive(using)

--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -116,10 +116,7 @@ impl<'sess> AstValidator<'sess, '_> {
         }
 
         if let ast::SubDenomination::Time(ast::TimeSubDenomination::Years) = denom {
-            self.dcx()
-                .err("using \"years\" as a unit denomination is deprecated")
-                .span(lit.span)
-                .emit();
+            self.dcx().err_span("using \"years\" as a unit denomination is deprecated", lit.span);
         }
     }
 
@@ -153,7 +150,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
     ) -> ControlFlow<Self::BreakValue> {
         let ast::ItemStruct { name, fields, .. } = item;
         if fields.is_empty() {
-            self.dcx().err("structs must have at least one field").span(name.span).emit();
+            self.dcx().err_span("structs must have at least one field", name.span);
         }
         ControlFlow::Continue(())
     }
@@ -164,10 +161,10 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
     ) -> ControlFlow<Self::BreakValue> {
         let ast::ItemEnum { name, variants } = enum_;
         if variants.is_empty() {
-            self.dcx().err("enum must have at least one variant").span(name.span).emit();
+            self.dcx().err_span("enum must have at least one variant", name.span);
         }
         if variants.len() > 256 {
-            self.dcx().err("enum cannot have more than 256 variants").span(name.span).emit();
+            self.dcx().err_span("enum cannot have more than 256 variants", name.span);
         }
         ControlFlow::Continue(())
     }
@@ -180,7 +177,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             ast::PragmaTokens::Version(name, _version) => {
                 if name.name != sym::solidity {
                     let msg = "only `solidity` is supported as a version pragma";
-                    self.dcx().err(msg).span(name.span).emit();
+                    self.dcx().err_span(msg, name.span);
                 }
             }
             ast::PragmaTokens::Custom(name, value) => {
@@ -192,15 +189,15 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
                     ("experimental", Some("SMTChecker")) => {}
                     ("experimental", Some("solidity")) => {
                         let msg = "experimental solidity features are not supported";
-                        self.dcx().err(msg).span(self.item_span).emit();
+                        self.dcx().err_span(msg, self.item_span);
                     }
                     _ => {
-                        self.dcx().err("unknown pragma").span(self.item_span).emit();
+                        self.dcx().err_span("unknown pragma", self.item_span);
                     }
                 }
             }
             ast::PragmaTokens::Verbatim(_) => {
-                self.dcx().err("unknown pragma").span(self.item_span).emit();
+                self.dcx().err_span("unknown pragma", self.item_span);
             }
         }
         ControlFlow::Continue(())
@@ -221,7 +218,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             }
             ast::StmtKind::UncheckedBlock(_block) => {
                 if self.in_unchecked_block {
-                    self.dcx().err("`unchecked` blocks cannot be nested").span(stmt.span).emit();
+                    self.dcx().err_span("`unchecked` blocks cannot be nested", stmt.span);
                 }
 
                 let prev = self.in_unchecked_block;
@@ -233,16 +230,16 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             ast::StmtKind::Placeholder => {
                 self.placeholder_count += 1;
                 if !self.function_kind.is_some_and(|k| k.is_modifier()) {
-                    self.dcx()
-                        .err("placeholder statements can only be used in modifiers")
-                        .span(stmt.span)
-                        .emit();
+                    self.dcx().err_span(
+                        "placeholder statements can only be used in modifiers",
+                        stmt.span,
+                    );
                 }
                 if self.in_unchecked_block {
-                    self.dcx()
-                        .err("placeholder statements cannot be used inside unchecked blocks")
-                        .span(stmt.span)
-                        .emit();
+                    self.dcx().err_span(
+                        "placeholder statements cannot be used inside unchecked blocks",
+                        stmt.span,
+                    );
                 }
             }
             _ => {}
@@ -259,16 +256,14 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
 
         if contract.kind.is_library() {
             if !contract.bases.is_empty() {
-                self.dcx().err("library is not allowed to inherit").span(contract.name.span).emit();
+                self.dcx().err_span("library is not allowed to inherit", contract.name.span);
             }
             for item in contract.body.iter() {
                 if let ast::ItemKind::Variable(var) = &item.kind
                     && !var.mutability.is_some_and(|m| m.is_constant())
                 {
                     self.dcx()
-                        .err("library cannot have non-constant state variable")
-                        .span(var.span)
-                        .emit();
+                        .err_span("library cannot have non-constant state variable", var.span);
                 }
             }
         }
@@ -297,23 +292,19 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             }
             if contract.kind.is_interface() && !func.header.modifiers.is_empty() {
                 self.dcx()
-                    .err("functions in interfaces cannot have modifiers")
-                    .span(self.item_span)
-                    .emit();
+                    .err_span("functions in interfaces cannot have modifiers", self.item_span);
             } else if !func.is_implemented() && !func.header.modifiers.is_empty() {
-                self.dcx()
-                    .err("functions without implementation cannot have modifiers")
-                    .span(self.item_span)
-                    .emit();
+                self.dcx().err_span(
+                    "functions without implementation cannot have modifiers",
+                    self.item_span,
+                );
             }
         }
 
         if func.kind.is_receive() {
             if self.contract.is_some_and(|c| c.kind.is_library()) {
                 self.dcx()
-                    .err("libraries cannot have receive ether functions")
-                    .span(self.item_span)
-                    .emit();
+                    .err_span("libraries cannot have receive ether functions", self.item_span);
             }
 
             if !func.header.state_mutability().is_payable() {
@@ -326,9 +317,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
 
             if !func.header.parameters.is_empty() {
                 self.dcx()
-                    .err("receive ether function cannot take parameters")
-                    .span(self.item_span)
-                    .emit();
+                    .err_span("receive ether function cannot take parameters", self.item_span);
             }
         }
 
@@ -351,7 +340,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
 
         if self.contract.is_none() && func.kind.is_function() {
             if !func.is_implemented() {
-                self.dcx().err("free functions must be implemented").span(self.item_span).emit();
+                self.dcx().err_span("free functions must be implemented", self.item_span);
             }
             if let Some(visibility) = func.header.visibility {
                 self.dcx()
@@ -372,9 +361,7 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
                 && let Some(func_name) = func.header.name
             {
                 self.dcx()
-                    .err("modifier must have a `_;` placeholder statement")
-                    .span(func_name.span)
-                    .emit();
+                    .err_span("modifier must have a `_;` placeholder statement", func_name.span);
             }
         }
         r
@@ -387,43 +374,41 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
         let ast::UsingDirective { ref list, ref ty, global } = *using;
         let with_ty = ty.is_some();
         if self.contract.is_none() && !with_ty {
-            self.dcx()
-                .err("the type has to be specified explicitly at file level (cannot use `*`)")
-                .span(self.item_span)
-                .emit();
+            self.dcx().err_span(
+                "the type has to be specified explicitly at file level (cannot use `*`)",
+                self.item_span,
+            );
         }
         if self.contract.is_some() && !with_ty && matches!(list, ast::UsingList::Multiple(_)) {
-            self.dcx()
-                .err("the type has to be specified explicitly when attaching specific functions")
-                .span(self.item_span)
-                .emit();
+            self.dcx().err_span(
+                "the type has to be specified explicitly when attaching specific functions",
+                self.item_span,
+            );
         }
         if global && !with_ty {
             self.dcx()
-                .err("can only globally attach functions to specific types")
-                .span(self.item_span)
-                .emit();
+                .err_span("can only globally attach functions to specific types", self.item_span);
         }
         if global && self.contract.is_some() {
-            self.dcx().err("`global` can only be used at file level").span(self.item_span).emit();
+            self.dcx().err_span("`global` can only be used at file level", self.item_span);
         }
         if !global && let ast::UsingList::Multiple(paths) = list {
             for (path, operator) in paths.iter() {
                 if operator.is_some() {
-                    self.dcx()
-                        .err("operators can only be defined in a global `using for` directive")
-                        .span(path.span())
-                        .emit();
+                    self.dcx().err_span(
+                        "operators can only be defined in a global `using for` directive",
+                        path.span(),
+                    );
                 }
             }
         }
         if let Some(contract) = self.contract
             && contract.kind.is_interface()
         {
-            self.dcx()
-                .err("the `using for` directive is not allowed inside interfaces")
-                .span(self.item_span)
-                .emit();
+            self.dcx().err_span(
+                "the `using for` directive is not allowed inside interfaces",
+                self.item_span,
+            );
         }
         self.walk_using_directive(using)
     }

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -17,11 +17,11 @@ pub fn eval_array_len(gcx: Gcx<'_>, size: &hir::Expr<'_>) -> Result<U256, ErrorG
         Ok(int) => {
             let Some(int) = int.as_u256() else {
                 let msg = "array length cannot be negative";
-                return Err(gcx.dcx().err_span(msg, size.span));
+                return Err(gcx.dcx().emit_err(size.span, msg));
             };
             if int.is_zero() {
                 let msg = "array length must be greater than zero";
-                Err(gcx.dcx().err_span(msg, size.span))
+                Err(gcx.dcx().emit_err(size.span, msg))
             } else {
                 Ok(int)
             }
@@ -77,7 +77,7 @@ impl<'gcx> ConstantEvaluator<'gcx> {
             _ => {
                 let msg = format!("failed to evaluate constant: {}", err.kind.msg());
                 let label = "evaluation of constant value failed here";
-                self.gcx.dcx().err(msg).span(expr.span).span_label(err.span, label).emit()
+                self.gcx.dcx().emit_err_label(expr.span, msg, err.span, label)
             }
         }
     }

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -17,11 +17,11 @@ pub fn eval_array_len(gcx: Gcx<'_>, size: &hir::Expr<'_>) -> Result<U256, ErrorG
         Ok(int) => {
             let Some(int) = int.as_u256() else {
                 let msg = "array length cannot be negative";
-                return Err(gcx.dcx().err(msg).span(size.span).emit());
+                return Err(gcx.dcx().err_span(msg, size.span));
             };
             if int.is_zero() {
                 let msg = "array length must be greater than zero";
-                Err(gcx.dcx().err(msg).span(size.span).emit())
+                Err(gcx.dcx().err_span(msg, size.span))
             } else {
                 Ok(int)
             }

--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -209,14 +209,13 @@ impl<'gcx> Resolver<'gcx> {
                         if params.contains(&name.name) {
                             local_tags.push(*natspec);
                         } else {
-                            self.gcx
-                                .dcx()
-                                .err(format!(
+                            self.gcx.dcx().emit_err(
+                                tag_span,
+                                format!(
                                     "tag `@param` references non-existent parameter '{}'",
                                     name.name
-                                ))
-                                .span(tag_span)
-                                .emit();
+                                ),
+                            );
                         };
                     }
                     NatSpecKind::Return { .. } => {
@@ -244,14 +243,12 @@ impl<'gcx> Resolver<'gcx> {
                         };
 
                         let return_valid = if state.return_count > return_count {
-                            self.gcx.dcx().err(format!(
+                            self.gcx.dcx().emit_err(tag_span, format!(
                                 "too many `@return` tags: function has {} return value{}, found {}",
                                 return_count,
                                 if return_count == 1 { "" } else { "s" },
                                 state.return_count
-                            ))
-                            .span(tag_span)
-                            .emit();
+                            ));
                             false
                         } else {
                             true
@@ -284,21 +281,19 @@ impl<'gcx> Resolver<'gcx> {
             natspec.content_start as usize,
             natspec.content_end as usize,
         ) else {
-            self.gcx
-                .dcx()
-                .err("tag `@return` does not contain the name of its return parameter")
-                .span(natspec.span)
-                .emit();
+            self.gcx.dcx().emit_err(
+                natspec.span,
+                "tag `@return` does not contain the name of its return parameter",
+            );
             return None;
         };
 
         let name = Symbol::intern(name);
         if !rets.iter().any(|&id| self.gcx.hir.variable(id).name.is_some_and(|n| n.name == name)) {
-            self.gcx
-                .dcx()
-                .err(format!("tag `@return` references non-existent return parameter '{name}'"))
-                .span(natspec.span)
-                .emit();
+            self.gcx.dcx().emit_err(
+                natspec.span,
+                format!("tag `@return` references non-existent return parameter '{name}'"),
+            );
             return None;
         }
 
@@ -311,26 +306,22 @@ impl<'gcx> Resolver<'gcx> {
     #[cold]
     fn emit_forbidden_tag_error(&self, tag_name: &str, tag_span: Span, item_id: hir::ItemId) {
         let item_desc = self.gcx.hir.item(item_id).description();
-        self.gcx
-            .dcx()
-            .err(format!("tag `{tag_name}` not valid for {item_desc}s"))
-            .span(tag_span)
-            .emit();
+        self.gcx.dcx().emit_err(tag_span, format!("tag `{tag_name}` not valid for {item_desc}s"));
     }
 
     #[cold]
     fn emit_duplicate_tag_error(&self, tag_name: &str, tag_span: Span) {
-        self.gcx.dcx().err_span(format!("tag {tag_name} can only be given once"), tag_span);
+        self.gcx.dcx().emit_err(tag_span, format!("tag {tag_name} can only be given once"));
     }
 
     #[cold]
     fn emit_duplicate_param_error(&self, param_name: Symbol, tag_span: Span, prev_span: Span) {
-        self.gcx
-            .dcx()
-            .err(format!("duplicate documentation for parameter '{param_name}'"))
-            .span(tag_span)
-            .span_note(prev_span, "previously documented here")
-            .emit();
+        self.gcx.dcx().emit_err_span_note(
+            tag_span,
+            format!("duplicate documentation for parameter '{param_name}'"),
+            prev_span,
+            "previously documented here",
+        );
     }
 
     /// Helper to validate tags that can only be defined once.
@@ -373,12 +364,13 @@ impl<'gcx> Resolver<'gcx> {
         let contract_id = self.gcx.natspec_contract_in_source(cache_key);
 
         let Some(contract_id) = contract_id else {
-            dcx.err(format!(
-                "tag `@inheritdoc` references inexistent contract \"{}\"",
-                contract_ident.name
-            ))
-            .span(tag_span)
-            .emit();
+            dcx.emit_err(
+                tag_span,
+                format!(
+                    "tag `@inheritdoc` references inexistent contract \"{}\"",
+                    contract_ident.name
+                ),
+            );
             return None;
         };
 
@@ -391,23 +383,19 @@ impl<'gcx> Resolver<'gcx> {
         if let Some(contract) = item_contract {
             let linearized_bases = &self.gcx.hir.contract(contract).linearized_bases;
             if !linearized_bases.contains(&contract_id) {
-                dcx.err(format!(
+                dcx.emit_err(tag_span, format!(
                     "tag `@inheritdoc` references contract \"{}\", which is not a base of this contract",
                     contract_ident.name
-                ))
-                .span(tag_span)
-                .emit();
+                ));
                 return None;
             }
         }
 
         if self.find_inherited_item(item_id, contract_id).is_none() {
-            dcx.err(format!(
+            dcx.emit_err(tag_span, format!(
                 "tag `@inheritdoc` references contract \"{}\", but the contract does not contain a matching item that can be inherited",
                 contract_ident.name
-            ))
-            .span(tag_span)
-            .emit();
+            ));
             return None;
         }
 

--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -320,7 +320,7 @@ impl<'gcx> Resolver<'gcx> {
 
     #[cold]
     fn emit_duplicate_tag_error(&self, tag_name: &str, tag_span: Span) {
-        self.gcx.dcx().err(format!("tag {tag_name} can only be given once")).span(tag_span).emit();
+        self.gcx.dcx().err_span(format!("tag {tag_name} can only be given once"), tag_span);
     }
 
     #[cold]

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -361,7 +361,7 @@ impl<'gcx> ParsingContext<'gcx> {
             return None;
         }
         let Some(path) = path_from_bytes(&path_bytes[..]) else {
-            self.dcx().err("import path is not a valid UTF-8 string").span(span).emit();
+            self.dcx().err_span("import path is not a valid UTF-8 string", span);
             return None;
         };
         self.file_resolver

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -361,7 +361,7 @@ impl<'gcx> ParsingContext<'gcx> {
             return None;
         }
         let Some(path) = path_from_bytes(&path_bytes[..]) else {
-            self.dcx().err_span("import path is not a valid UTF-8 string", span);
+            self.dcx().emit_err(span, "import path is not a valid UTF-8 string");
             return None;
         };
         self.file_resolver

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -662,7 +662,7 @@ impl<'gcx> Gcx<'gcx> {
             | hir::ItemId::Udvt(_) => self.type_of_item(id),
             _ => {
                 let msg = "name has to refer to a valid user-defined type";
-                self.mk_ty_err(self.dcx().err_span(msg, span))
+                self.mk_ty_err(self.dcx().emit_err(span, msg))
             }
         }
     }
@@ -693,12 +693,12 @@ impl<'gcx> Gcx<'gcx> {
                 )
                 .unwrap_or_else(|| {
                     self.mk_ty_err(
-                        self.dcx().err_span("integer literal is greater than 2**256", lit.span),
+                        self.dcx().emit_err(lit.span, "integer literal is greater than 2**256"),
                     )
                 })
             }
             solar_ast::LitKind::Rational(_) => {
-                self.mk_ty_err(self.dcx().err_span("rational literals are not supported", lit.span))
+                self.mk_ty_err(self.dcx().emit_err(lit.span, "rational literals are not supported"))
             }
             solar_ast::LitKind::Address(_) => self.types.address,
             solar_ast::LitKind::Bool(_) => self.types.bool,
@@ -998,7 +998,7 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                     format!("this type cannot be parameter or return type of a public {kind}")
                 };
                 let span = gcx.hir.variable(var_id).ty.span;
-                result = Err(gcx.dcx().err_span(msg, span));
+                result = Err(gcx.dcx().emit_err(span, msg));
             }
         }
         if result.is_err() {
@@ -1107,7 +1107,7 @@ pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
                 TyKind::Udvt(ty, id)
             } else {
                 let msg = "the underlying type of UDVTs must be an elementary value type";
-                return gcx.mk_ty_err(gcx.dcx().err_span(msg, udvt.ty.span));
+                return gcx.mk_ty_err(gcx.dcx().emit_err(udvt.ty.span, msg));
             }
         }
         hir::ItemId::Error(id) => {
@@ -1133,7 +1133,7 @@ pub fn struct_recursiveness(gcx: _, id: hir::StructId) -> Recursiveness {
         let s = gcx.hir.strukt(id);
 
         if cd.depth() >= 256 {
-            let guar = gcx.dcx().err_span("struct is too deeply nested", s.span);
+            let guar = gcx.dcx().emit_err(s.span, "struct is too deeply nested");
             return CycleDetectorResult::Break(Either::Left(guar));
         }
 
@@ -1172,7 +1172,7 @@ pub fn struct_recursiveness(gcx: _, id: hir::StructId) -> Recursiveness {
         CycleDetectorResult::Break(Either::Left(guar)) => Recursiveness::Infinite(guar),
         CycleDetectorResult::Break(Either::Right(())) => Recursiveness::Recursive,
         CycleDetectorResult::Cycle(id) => Recursiveness::Infinite(
-            gcx.dcx().err_span("recursive struct definition", gcx.item_span(id))
+            gcx.dcx().emit_err(gcx.item_span(id), "recursive struct definition")
         ),
     }
 }
@@ -1272,12 +1272,12 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
             Some(Transient) => {
                 if mut_specified {
                     let msg = "transient cannot be used as data location for constant or immutable variables";
-                    gcx.dcx().err_span(msg, var.span);
+                    gcx.dcx().emit_err(var.span, msg);
                 }
                 if var.initializer.is_some() {
                     let msg =
                         "initialization of transient storage state variables is not supported";
-                    gcx.dcx().err_span(msg, var.span);
+                    gcx.dcx().emit_err(var.span, msg);
                 }
                 Transient
             }

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -662,7 +662,7 @@ impl<'gcx> Gcx<'gcx> {
             | hir::ItemId::Udvt(_) => self.type_of_item(id),
             _ => {
                 let msg = "name has to refer to a valid user-defined type";
-                self.mk_ty_err(self.dcx().err(msg).span(span).emit())
+                self.mk_ty_err(self.dcx().err_span(msg, span))
             }
         }
     }
@@ -693,16 +693,13 @@ impl<'gcx> Gcx<'gcx> {
                 )
                 .unwrap_or_else(|| {
                     self.mk_ty_err(
-                        self.dcx()
-                            .err("integer literal is greater than 2**256")
-                            .span(lit.span)
-                            .emit(),
+                        self.dcx().err_span("integer literal is greater than 2**256", lit.span),
                     )
                 })
             }
-            solar_ast::LitKind::Rational(_) => self.mk_ty_err(
-                self.dcx().err("rational literals are not supported").span(lit.span).emit(),
-            ),
+            solar_ast::LitKind::Rational(_) => {
+                self.mk_ty_err(self.dcx().err_span("rational literals are not supported", lit.span))
+            }
             solar_ast::LitKind::Address(_) => self.types.address,
             solar_ast::LitKind::Bool(_) => self.types.bool,
             &solar_ast::LitKind::Err(guar) => self.mk_ty_err(guar),
@@ -1001,7 +998,7 @@ pub fn interface_functions(gcx: _, id: hir::ContractId) -> InterfaceFunctions<'g
                     format!("this type cannot be parameter or return type of a public {kind}")
                 };
                 let span = gcx.hir.variable(var_id).ty.span;
-                result = Err(gcx.dcx().err(msg).span(span).emit());
+                result = Err(gcx.dcx().err_span(msg, span));
             }
         }
         if result.is_err() {
@@ -1110,7 +1107,7 @@ pub fn type_of_item(gcx: _, id: hir::ItemId) -> Ty<'gcx> {
                 TyKind::Udvt(ty, id)
             } else {
                 let msg = "the underlying type of UDVTs must be an elementary value type";
-                return gcx.mk_ty_err(gcx.dcx().err(msg).span(udvt.ty.span).emit());
+                return gcx.mk_ty_err(gcx.dcx().err_span(msg, udvt.ty.span));
             }
         }
         hir::ItemId::Error(id) => {
@@ -1136,7 +1133,7 @@ pub fn struct_recursiveness(gcx: _, id: hir::StructId) -> Recursiveness {
         let s = gcx.hir.strukt(id);
 
         if cd.depth() >= 256 {
-            let guar = gcx.dcx().err("struct is too deeply nested").span(s.span).emit();
+            let guar = gcx.dcx().err_span("struct is too deeply nested", s.span);
             return CycleDetectorResult::Break(Either::Left(guar));
         }
 
@@ -1175,7 +1172,7 @@ pub fn struct_recursiveness(gcx: _, id: hir::StructId) -> Recursiveness {
         CycleDetectorResult::Break(Either::Left(guar)) => Recursiveness::Infinite(guar),
         CycleDetectorResult::Break(Either::Right(())) => Recursiveness::Recursive,
         CycleDetectorResult::Cycle(id) => Recursiveness::Infinite(
-            gcx.dcx().err("recursive struct definition").span(gcx.item_span(id)).emit()
+            gcx.dcx().err_span("recursive struct definition", gcx.item_span(id))
         ),
     }
 }
@@ -1275,12 +1272,12 @@ fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) 
             Some(Transient) => {
                 if mut_specified {
                     let msg = "transient cannot be used as data location for constant or immutable variables";
-                    gcx.dcx().err(msg).span(var.span).emit();
+                    gcx.dcx().err_span(msg, var.span);
                 }
                 if var.initializer.is_some() {
                     let msg =
                         "initialization of transient storage state variables is not supported";
-                    gcx.dcx().err(msg).span(var.span).emit();
+                    gcx.dcx().err_span(msg, var.span);
                 }
                 Transient
             }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -82,10 +82,7 @@ impl<'gcx> TypeChecker<'gcx> {
         match ConstantEvaluator::new(self.gcx).eval(slot) {
             Ok(value) => {
                 if value.as_u256().is_none() {
-                    self.dcx()
-                        .err("base slot of storage layout evaluates to a value outside the range of type `uint256`")
-                        .span(slot.span)
-                        .emit();
+                    self.dcx().err_span("base slot of storage layout evaluates to a value outside the range of type `uint256`", slot.span);
                 }
             }
             Err(_err) => {}
@@ -147,7 +144,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     if (i == 0 || common.is_some())
                         && let None = expr_ty.mobile(self.gcx)
                     {
-                        let g = self.dcx().err("invalid mobile type").span(expr.span).emit();
+                        let g = self.dcx().err_span("invalid mobile type", expr.span);
                         guar.get_or_insert(g);
                     }
                     if let Some(common_ty) = common {
@@ -165,7 +162,7 @@ impl<'gcx> TypeChecker<'gcx> {
                             "type `{}` is only valid in storage because it contains a (nested) mapping",
                             common.display(self.gcx),
                         );
-                        self.gcx.mk_ty_err(self.dcx().err(msg).span(expr.span).emit())
+                        self.gcx.mk_ty_err(self.dcx().err_span(msg, expr.span))
                     } else if !common.nameable() {
                         self.gcx.mk_ty_err(
                             self.dcx()
@@ -181,7 +178,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 } else {
                     self.gcx.mk_ty_err(
-                        self.dcx().err("cannot infer array element type").span(expr.span).emit(),
+                        self.dcx().err_span("cannot infer array element type", expr.span),
                     )
                 }
             }
@@ -251,12 +248,10 @@ impl<'gcx> TypeChecker<'gcx> {
                 let ty = match callee_ty.kind {
                     TyKind::Fn(f) => {
                         if f.is_declaration() {
-                            return self.gcx.mk_ty_err(
-                                self.dcx()
-                                    .err("cannot call function via contract type name")
-                                    .span(expr.span)
-                                    .emit(),
-                            );
+                            return self.gcx.mk_ty_err(self.dcx().err_span(
+                                "cannot call function via contract type name",
+                                expr.span,
+                            ));
                         }
                         let param_names = if let Some(struct_id) = struct_id {
                             Some(self.get_struct_field_names(struct_id))
@@ -270,10 +265,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     TyKind::Type(to) => self.check_explicit_cast(expr.span, to, args),
                     TyKind::Event(param_tys, id) => {
                         if !self.in_emit {
-                            self.dcx()
-                                .err("event invocations have to be prefixed by `emit`")
-                                .span(expr.span)
-                                .emit();
+                            self.dcx().err_span(
+                                "event invocations have to be prefixed by `emit`",
+                                expr.span,
+                            );
                         }
                         // Clear context so nested calls in args are not considered in emit/revert.
                         self.in_emit = false;
@@ -286,10 +281,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     TyKind::Error(param_tys, id) => {
                         // TODO: Also allow in require(condition, MyError(...)).
                         if !self.in_revert {
-                            self.dcx()
-                                .err("errors can only be used with revert statements")
-                                .span(expr.span)
-                                .emit();
+                            self.dcx().err_span(
+                                "errors can only be used with revert statements",
+                                expr.span,
+                            );
                         }
                         // Clear context so nested calls in args are not considered in emit/revert.
                         self.in_emit = false;
@@ -358,7 +353,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     if let Some(index) = index {
                         let _ = self.check_expr_outside_lvalue_context(index, Some(index_ty));
                     } else {
-                        self.dcx().err("index expression cannot be omitted").span(expr.span).emit();
+                        self.dcx().err_span("index expression cannot be omitted", expr.span);
                     }
                     result_ty
                 } else if let TyKind::Type(elem_ty) = ty.kind {
@@ -378,15 +373,15 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.gcx.mk_ty(TyKind::Type(self.gcx.mk_ty(arr)))
                 } else {
                     let msg = format!("cannot index into {}", ty.display(self.gcx));
-                    self.gcx.mk_ty_err(self.dcx().err(msg).span(expr.span).emit())
+                    self.gcx.mk_ty_err(self.dcx().err_span(msg, expr.span))
                 }
             }
             hir::ExprKind::Slice(lhs, start, end) => {
                 let ty = self.check_expr(lhs);
                 if !ty.is_sliceable() {
-                    self.dcx().err("can only slice arrays").span(expr.span).emit();
+                    self.dcx().err_span("can only slice arrays", expr.span);
                 } else if !is_calldata_sliceable(ty) {
-                    self.dcx().err("can only slice dynamic calldata arrays").span(expr.span).emit();
+                    self.dcx().err_span("can only slice dynamic calldata arrays", expr.span);
                 }
                 if let Some((_index_ty, _result_ty)) = self.index_types(ty) {
                     if let Some(start) = start {
@@ -401,7 +396,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         self.gcx.mk_ty(TyKind::Slice(ty))
                     }
                 } else {
-                    self.gcx.mk_ty_err(self.dcx().err("cannot index").span(expr.span).emit())
+                    self.gcx.mk_ty_err(self.dcx().err_span("cannot index", expr.span))
                 }
             }
             hir::ExprKind::Lit(lit) if self.in_yul => self.check_yul_lit(lit),
@@ -482,7 +477,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         let c = self.gcx.hir.contract(id);
                         if !c.kind.is_contract() {
                             let msg = format!("cannot instantiate {}s", c.kind);
-                            self.gcx.mk_ty_err(self.dcx().err(msg).span(hir_ty.span).emit())
+                            self.gcx.mk_ty_err(self.dcx().err_span(msg, hir_ty.span))
                         } else {
                             let mut parameters: &[Ty<'_>] = &[];
                             let mut sm = hir::StateMutability::NonPayable;
@@ -512,17 +507,11 @@ impl<'gcx> TypeChecker<'gcx> {
                     _ if ty.is_array_like() => {
                         if ty.has_mapping(self.gcx) {
                             self.gcx.mk_ty_err(
-                                self.dcx()
-                                    .err("cannot instantiate mappings")
-                                    .span(hir_ty.span)
-                                    .emit(),
+                                self.dcx().err_span("cannot instantiate mappings", hir_ty.span),
                             )
                         } else if ty.contains_library(self.gcx) {
                             self.gcx.mk_ty_err(
-                                self.dcx()
-                                    .err("invalid use of a library name")
-                                    .span(hir_ty.span)
-                                    .emit(),
+                                self.dcx().err_span("invalid use of a library name", hir_ty.span),
                             )
                         } else {
                             let ty = ty.with_loc(self.gcx, DataLocation::Memory);
@@ -535,10 +524,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                     TyKind::Err(_) => ty,
                     _ => self.gcx.mk_ty_err(
-                        self.dcx()
-                            .err("expected contract or dynamic array type")
-                            .span(hir_ty.span)
-                            .emit(),
+                        self.dcx().err_span("expected contract or dynamic array type", hir_ty.span),
                     ),
                 }
             }
@@ -579,12 +565,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     (true_ty, false_ty) => {
                         let mut guar = None;
                         if true_ty.is_none() {
-                            guar =
-                                Some(self.dcx().err("invalid true type").span(true_.span).emit());
+                            guar = Some(self.dcx().err_span("invalid true type", true_.span));
                         }
                         if false_ty.is_none() {
-                            guar =
-                                Some(self.dcx().err("invalid false type").span(false_.span).emit());
+                            guar = Some(self.dcx().err_span("invalid false type", false_.span));
                         }
                         true_ty.or(false_ty).unwrap_or_else(|| self.gcx.mk_ty_err(guar.unwrap()))
                     }
@@ -595,7 +579,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 let mut tys = exprs.iter().map(|&expr_opt| {
                     let empty_err = |this: &Self, span| {
                         this.gcx.mk_ty_err(
-                            this.dcx().err("tuple components cannot be empty").span(span).emit(),
+                            this.dcx().err_span("tuple components cannot be empty", span),
                         )
                     };
                     if let Some(expr) = expr_opt {
@@ -622,7 +606,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 if valid_meta_type(ty) {
                     self.gcx.mk_ty(TyKind::Meta(ty))
                 } else {
-                    self.gcx.mk_ty_err(self.dcx().err("invalid type").span(hir_ty.span).emit())
+                    self.gcx.mk_ty_err(self.dcx().err_span("invalid type", hir_ty.span))
                 }
             }
             hir::ExprKind::Type(ref ty) => {
@@ -675,7 +659,7 @@ impl<'gcx> TypeChecker<'gcx> {
         // https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/analysis/TypeChecker.cpp#L1421
         if let hir::ExprKind::Tuple(components) = &expr.kind {
             if components.is_empty() {
-                self.dcx().err("empty tuple on the left hand side").span(expr.span).emit();
+                self.dcx().err_span("empty tuple on the left hand side", expr.span);
                 return;
             }
             let types =
@@ -691,10 +675,10 @@ impl<'gcx> TypeChecker<'gcx> {
         // Types containing mappings cannot be assigned to, unless the lvalue is a local/return
         // variable (local storage pointers are OK).
         if ty.has_mapping(self.gcx) && !self.is_local_or_return_variable(expr) {
-            self.dcx()
-                .err("types in storage containing (nested) mappings cannot be assigned to")
-                .span(expr.span)
-                .emit();
+            self.dcx().err_span(
+                "types in storage containing (nested) mappings cannot be assigned to",
+                expr.span,
+            );
         }
     }
 
@@ -862,14 +846,14 @@ impl<'gcx> TypeChecker<'gcx> {
                 };
                 Some(self.fn_call_return_type(function_ty.returns))
             }
-            WantOne::Many => Some(
-                self.gcx.mk_ty_err(
-                    self.dcx()
-                        .err("user-defined operator has more than one matching definition")
-                        .span(span)
-                        .emit(),
-                ),
-            ),
+            WantOne::Many => {
+                Some(self.gcx.mk_ty_err(
+                    self.dcx().err_span(
+                        "user-defined operator has more than one matching definition",
+                        span,
+                    ),
+                ))
+            }
         }
     }
 
@@ -902,7 +886,7 @@ impl<'gcx> TypeChecker<'gcx> {
     ) -> Ty<'gcx> {
         let WantOne::One(from_expr) = args.exprs().collect::<WantOne<_>>() else {
             return self.gcx.mk_ty_err(
-                self.dcx().err("expected exactly one unnamed argument").span(args.span).emit(),
+                self.dcx().err_span("expected exactly one unnamed argument", args.span),
             );
         };
         let from = self.check_expr(from_expr);
@@ -978,10 +962,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 if let Some(names) = param_names {
                     self.check_named_call_args(call_span, args.span, named_args, param_tys, names);
                 } else {
-                    self.dcx()
-                        .err("named arguments cannot be used for functions that take arbitrary parameters")
-                        .span(args.span)
-                        .emit();
+                    self.dcx().err_span("named arguments cannot be used for functions that take arbitrary parameters", args.span);
                     for arg in named_args {
                         let _ = self.check_expr(&arg.value);
                     }
@@ -1037,7 +1018,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         )
                     }
                 };
-                self.gcx.mk_ty_err(self.dcx().err(msg).span(ident.span).emit())
+                self.gcx.mk_ty_err(self.dcx().err_span(msg, ident.span))
             }
         };
         self.register_ty(callee, ty);
@@ -1068,7 +1049,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     OverloadError::NotFound => "no matching declarations found",
                     OverloadError::Ambiguous => "no unique declarations found",
                 };
-                hir::Res::Err(self.dcx().err(msg).span(callee.span).emit())
+                hir::Res::Err(self.dcx().err_span(msg, callee.span))
             }
         };
         let ty = self.type_of_res(res);
@@ -1088,10 +1069,7 @@ impl<'gcx> TypeChecker<'gcx> {
         if function.contract == Some(contract_id)
             && function.visibility >= solar_ast::Visibility::Public
         {
-            self.dcx()
-                .err("libraries cannot call their own functions externally")
-                .span(span)
-                .emit();
+            self.dcx().err_span("libraries cannot call their own functions externally", span);
         }
     }
 
@@ -1304,20 +1282,14 @@ impl<'gcx> TypeChecker<'gcx> {
                 let _ = self.check_expr(&opt.value);
             }
             if !ty.references_error() {
-                self.dcx()
-                    .err("function call options can only be set on external function calls or contract creations")
-                    .span(span)
-                    .emit();
+                self.dcx().err_span("function call options can only be set on external function calls or contract creations", span);
             }
             return ty;
         };
 
         let creation = f.is_creation();
         if !creation && !f.is_external() && !f.is_bare_call() {
-            self.dcx()
-                .err("function call options can only be set on external function calls or contract creations")
-                .span(span)
-                .emit();
+            self.dcx().err_span("function call options can only be set on external function calls or contract creations", span);
         }
 
         let mut gas_set = false;
@@ -1328,10 +1300,10 @@ impl<'gcx> TypeChecker<'gcx> {
             let duplicate = match name {
                 kw::Gas => {
                     if creation {
-                        self.dcx()
-                            .err("function call option `gas` cannot be used with `new`")
-                            .span(opt.name.span)
-                            .emit();
+                        self.dcx().err_span(
+                            "function call option `gas` cannot be used with `new`",
+                            opt.name.span,
+                        );
                     } else {
                         let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
                     }
@@ -1340,14 +1312,10 @@ impl<'gcx> TypeChecker<'gcx> {
                 sym::value => {
                     if f.kind == TyFnKind::BareDelegateCall {
                         self.dcx()
-                            .err("cannot set option `value` for delegatecall")
-                            .span(opt.name.span)
-                            .emit();
+                            .err_span("cannot set option `value` for delegatecall", opt.name.span);
                     } else if f.kind == TyFnKind::BareStaticCall {
                         self.dcx()
-                            .err("cannot set option `value` for staticcall")
-                            .span(opt.name.span)
-                            .emit();
+                            .err_span("cannot set option `value` for staticcall", opt.name.span);
                     } else if f.state_mutability != StateMutability::Payable {
                         let msg = if creation
                             && let Some(ret) = f.returns.first()
@@ -1360,17 +1328,17 @@ impl<'gcx> TypeChecker<'gcx> {
                         } else {
                             "cannot set option `value` on a non-payable function type".to_string()
                         };
-                        self.dcx().err(msg).span(opt.name.span).emit();
+                        self.dcx().err_span(msg, opt.name.span);
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
                     std::mem::replace(&mut value_set, true)
                 }
                 sym::salt => {
                     if !creation {
-                        self.dcx()
-                            .err("function call option `salt` can only be used with `new`")
-                            .span(opt.name.span)
-                            .emit();
+                        self.dcx().err_span(
+                            "function call option `salt` can only be used with `new`",
+                            opt.name.span,
+                        );
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.fixed_bytes(32));
                     std::mem::replace(&mut salt_set, true)
@@ -1525,10 +1493,10 @@ impl<'gcx> TypeChecker<'gcx> {
 
         if let Some(init) = var.initializer {
             if var.is_state_variable() && ty.has_mapping(self.gcx) {
-                self.dcx()
-                    .err("types in storage containing (nested) mappings cannot be assigned to")
-                    .span(var.span)
-                    .emit();
+                self.dcx().err_span(
+                    "types in storage containing (nested) mappings cannot be assigned to",
+                    var.span,
+                );
             } else if expect {
                 let _ = if var.is_state_variable() {
                     self.with_construction_context(|this| this.expect_ty(init, ty))
@@ -1540,18 +1508,15 @@ impl<'gcx> TypeChecker<'gcx> {
 
         if var.is_immutable() {
             if !ty.is_value_type() {
-                self.dcx()
-                    .err("immutable variables cannot have a non-value type")
-                    .span(var.span)
-                    .emit();
+                self.dcx().err_span("immutable variables cannot have a non-value type", var.span);
             }
             if let TyKind::Fn(f) = ty.kind
                 && f.is_external()
             {
-                self.dcx()
-                    .err("immutable variables of external function type are not yet supported")
-                    .span(var.span)
-                    .emit();
+                self.dcx().err_span(
+                    "immutable variables of external function type are not yet supported",
+                    var.span,
+                );
             }
         }
 
@@ -1644,7 +1609,7 @@ impl<'gcx> TypeChecker<'gcx> {
             ty.kind,
             TyKind::Elementary(_) | TyKind::Udvt(_, _) | TyKind::Contract(_) | TyKind::Enum(_)
         ) {
-            self.dcx().err("only elementary types, user defined value types, contract types or enums are allowed as mapping keys.").span(key.span).emit();
+            self.dcx().err_span("only elementary types, user defined value types, contract types or enums are allowed as mapping keys.", key.span);
         }
         ty
     }
@@ -1752,7 +1717,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     OverloadError::NotFound => "no matching declarations found",
                     OverloadError::Ambiguous => "no unique declarations found",
                 };
-                hir::Res::Err(self.dcx().err(msg).span(span).emit())
+                hir::Res::Err(self.dcx().err_span(msg, span))
             }
         }
     }
@@ -1964,18 +1929,15 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     match stmt.kind {
                         hir::StmtKind::Emit(_) => {
                             if !matches!(callee_ty.kind, TyKind::Event(..)) {
-                                self.dcx()
-                                    .err("expression has to be an event invocation")
-                                    .span(callee.span)
-                                    .emit();
+                                self.dcx().err_span(
+                                    "expression has to be an event invocation",
+                                    callee.span,
+                                );
                             }
                         }
                         hir::StmtKind::Revert(_) => {
                             if !matches!(callee_ty.kind, TyKind::Error(..)) {
-                                self.dcx()
-                                    .err("expression has to be an error")
-                                    .span(callee.span)
-                                    .emit();
+                                self.dcx().err_span("expression has to be an error", callee.span);
                             }
                         }
                         _ => unreachable!(),
@@ -1997,10 +1959,10 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     && !ty.is_unit()
                     && !ty.references_error()
                 {
-                    self.dcx()
-                        .err("inline assembly expression statements cannot return values")
-                        .span(expr.span)
-                        .emit();
+                    self.dcx().err_span(
+                        "inline assembly expression statements cannot return values",
+                        expr.span,
+                    );
                 }
                 return ControlFlow::Continue(());
             }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -82,7 +82,7 @@ impl<'gcx> TypeChecker<'gcx> {
         match ConstantEvaluator::new(self.gcx).eval(slot) {
             Ok(value) => {
                 if value.as_u256().is_none() {
-                    self.dcx().err_span("base slot of storage layout evaluates to a value outside the range of type `uint256`", slot.span);
+                    self.dcx().emit_err(slot.span, "base slot of storage layout evaluates to a value outside the range of type `uint256`");
                 }
             }
             Err(_err) => {}
@@ -144,7 +144,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     if (i == 0 || common.is_some())
                         && let None = expr_ty.mobile(self.gcx)
                     {
-                        let g = self.dcx().err_span("invalid mobile type", expr.span);
+                        let g = self.dcx().emit_err(expr.span, "invalid mobile type");
                         guar.get_or_insert(g);
                     }
                     if let Some(common_ty) = common {
@@ -162,7 +162,7 @@ impl<'gcx> TypeChecker<'gcx> {
                             "type `{}` is only valid in storage because it contains a (nested) mapping",
                             common.display(self.gcx),
                         );
-                        self.gcx.mk_ty_err(self.dcx().err_span(msg, expr.span))
+                        self.gcx.mk_ty_err(self.dcx().emit_err(expr.span, msg))
                     } else if !common.nameable() {
                         self.gcx.mk_ty_err(
                             self.dcx()
@@ -178,7 +178,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                 } else {
                     self.gcx.mk_ty_err(
-                        self.dcx().err_span("cannot infer array element type", expr.span),
+                        self.dcx().emit_err(expr.span, "cannot infer array element type"),
                     )
                 }
             }
@@ -248,9 +248,9 @@ impl<'gcx> TypeChecker<'gcx> {
                 let ty = match callee_ty.kind {
                     TyKind::Fn(f) => {
                         if f.is_declaration() {
-                            return self.gcx.mk_ty_err(self.dcx().err_span(
-                                "cannot call function via contract type name",
+                            return self.gcx.mk_ty_err(self.dcx().emit_err(
                                 expr.span,
+                                "cannot call function via contract type name",
                             ));
                         }
                         let param_names = if let Some(struct_id) = struct_id {
@@ -265,9 +265,9 @@ impl<'gcx> TypeChecker<'gcx> {
                     TyKind::Type(to) => self.check_explicit_cast(expr.span, to, args),
                     TyKind::Event(param_tys, id) => {
                         if !self.in_emit {
-                            self.dcx().err_span(
-                                "event invocations have to be prefixed by `emit`",
+                            self.dcx().emit_err(
                                 expr.span,
+                                "event invocations have to be prefixed by `emit`",
                             );
                         }
                         // Clear context so nested calls in args are not considered in emit/revert.
@@ -281,9 +281,9 @@ impl<'gcx> TypeChecker<'gcx> {
                     TyKind::Error(param_tys, id) => {
                         // TODO: Also allow in require(condition, MyError(...)).
                         if !self.in_revert {
-                            self.dcx().err_span(
-                                "errors can only be used with revert statements",
+                            self.dcx().emit_err(
                                 expr.span,
+                                "errors can only be used with revert statements",
                             );
                         }
                         // Clear context so nested calls in args are not considered in emit/revert.
@@ -353,7 +353,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     if let Some(index) = index {
                         let _ = self.check_expr_outside_lvalue_context(index, Some(index_ty));
                     } else {
-                        self.dcx().err_span("index expression cannot be omitted", expr.span);
+                        self.dcx().emit_err(expr.span, "index expression cannot be omitted");
                     }
                     result_ty
                 } else if let TyKind::Type(elem_ty) = ty.kind {
@@ -373,15 +373,15 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.gcx.mk_ty(TyKind::Type(self.gcx.mk_ty(arr)))
                 } else {
                     let msg = format!("cannot index into {}", ty.display(self.gcx));
-                    self.gcx.mk_ty_err(self.dcx().err_span(msg, expr.span))
+                    self.gcx.mk_ty_err(self.dcx().emit_err(expr.span, msg))
                 }
             }
             hir::ExprKind::Slice(lhs, start, end) => {
                 let ty = self.check_expr(lhs);
                 if !ty.is_sliceable() {
-                    self.dcx().err_span("can only slice arrays", expr.span);
+                    self.dcx().emit_err(expr.span, "can only slice arrays");
                 } else if !is_calldata_sliceable(ty) {
-                    self.dcx().err_span("can only slice dynamic calldata arrays", expr.span);
+                    self.dcx().emit_err(expr.span, "can only slice dynamic calldata arrays");
                 }
                 if let Some((_index_ty, _result_ty)) = self.index_types(ty) {
                     if let Some(start) = start {
@@ -396,7 +396,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         self.gcx.mk_ty(TyKind::Slice(ty))
                     }
                 } else {
-                    self.gcx.mk_ty_err(self.dcx().err_span("cannot index", expr.span))
+                    self.gcx.mk_ty_err(self.dcx().emit_err(expr.span, "cannot index"))
                 }
             }
             hir::ExprKind::Lit(lit) if self.in_yul => self.check_yul_lit(lit),
@@ -477,7 +477,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         let c = self.gcx.hir.contract(id);
                         if !c.kind.is_contract() {
                             let msg = format!("cannot instantiate {}s", c.kind);
-                            self.gcx.mk_ty_err(self.dcx().err_span(msg, hir_ty.span))
+                            self.gcx.mk_ty_err(self.dcx().emit_err(hir_ty.span, msg))
                         } else {
                             let mut parameters: &[Ty<'_>] = &[];
                             let mut sm = hir::StateMutability::NonPayable;
@@ -507,11 +507,11 @@ impl<'gcx> TypeChecker<'gcx> {
                     _ if ty.is_array_like() => {
                         if ty.has_mapping(self.gcx) {
                             self.gcx.mk_ty_err(
-                                self.dcx().err_span("cannot instantiate mappings", hir_ty.span),
+                                self.dcx().emit_err(hir_ty.span, "cannot instantiate mappings"),
                             )
                         } else if ty.contains_library(self.gcx) {
                             self.gcx.mk_ty_err(
-                                self.dcx().err_span("invalid use of a library name", hir_ty.span),
+                                self.dcx().emit_err(hir_ty.span, "invalid use of a library name"),
                             )
                         } else {
                             let ty = ty.with_loc(self.gcx, DataLocation::Memory);
@@ -524,7 +524,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     }
                     TyKind::Err(_) => ty,
                     _ => self.gcx.mk_ty_err(
-                        self.dcx().err_span("expected contract or dynamic array type", hir_ty.span),
+                        self.dcx().emit_err(hir_ty.span, "expected contract or dynamic array type"),
                     ),
                 }
             }
@@ -565,10 +565,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     (true_ty, false_ty) => {
                         let mut guar = None;
                         if true_ty.is_none() {
-                            guar = Some(self.dcx().err_span("invalid true type", true_.span));
+                            guar = Some(self.dcx().emit_err(true_.span, "invalid true type"));
                         }
                         if false_ty.is_none() {
-                            guar = Some(self.dcx().err_span("invalid false type", false_.span));
+                            guar = Some(self.dcx().emit_err(false_.span, "invalid false type"));
                         }
                         true_ty.or(false_ty).unwrap_or_else(|| self.gcx.mk_ty_err(guar.unwrap()))
                     }
@@ -579,7 +579,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 let mut tys = exprs.iter().map(|&expr_opt| {
                     let empty_err = |this: &Self, span| {
                         this.gcx.mk_ty_err(
-                            this.dcx().err_span("tuple components cannot be empty", span),
+                            this.dcx().emit_err(span, "tuple components cannot be empty"),
                         )
                     };
                     if let Some(expr) = expr_opt {
@@ -606,7 +606,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 if valid_meta_type(ty) {
                     self.gcx.mk_ty(TyKind::Meta(ty))
                 } else {
-                    self.gcx.mk_ty_err(self.dcx().err_span("invalid type", hir_ty.span))
+                    self.gcx.mk_ty_err(self.dcx().emit_err(hir_ty.span, "invalid type"))
                 }
             }
             hir::ExprKind::Type(ref ty) => {
@@ -659,7 +659,7 @@ impl<'gcx> TypeChecker<'gcx> {
         // https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/analysis/TypeChecker.cpp#L1421
         if let hir::ExprKind::Tuple(components) = &expr.kind {
             if components.is_empty() {
-                self.dcx().err_span("empty tuple on the left hand side", expr.span);
+                self.dcx().emit_err(expr.span, "empty tuple on the left hand side");
                 return;
             }
             let types =
@@ -675,9 +675,9 @@ impl<'gcx> TypeChecker<'gcx> {
         // Types containing mappings cannot be assigned to, unless the lvalue is a local/return
         // variable (local storage pointers are OK).
         if ty.has_mapping(self.gcx) && !self.is_local_or_return_variable(expr) {
-            self.dcx().err_span(
-                "types in storage containing (nested) mappings cannot be assigned to",
+            self.dcx().emit_err(
                 expr.span,
+                "types in storage containing (nested) mappings cannot be assigned to",
             );
         }
     }
@@ -703,20 +703,18 @@ impl<'gcx> TypeChecker<'gcx> {
         };
 
         if lhs_components.len() != rhs_types.len() {
-            self.dcx()
-                .err("mismatched number of components")
-                .span(lhs.span)
-                .span_label(
-                    rhs.span,
-                    format!(
-                        "expected a tuple with {} element{}, found one with {} element{}",
-                        lhs_components.len(),
-                        pluralize!(lhs_components.len()),
-                        rhs_types.len(),
-                        pluralize!(rhs_types.len())
-                    ),
-                )
-                .emit();
+            self.dcx().emit_err_label(
+                lhs.span,
+                "mismatched number of components",
+                rhs.span,
+                format!(
+                    "expected a tuple with {} element{}, found one with {} element{}",
+                    lhs_components.len(),
+                    pluralize!(lhs_components.len()),
+                    rhs_types.len(),
+                    pluralize!(rhs_types.len())
+                ),
+            );
             return;
         }
 
@@ -848,9 +846,9 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             WantOne::Many => {
                 Some(self.gcx.mk_ty_err(
-                    self.dcx().err_span(
-                        "user-defined operator has more than one matching definition",
+                    self.dcx().emit_err(
                         span,
+                        "user-defined operator has more than one matching definition",
                     ),
                 ))
             }
@@ -886,7 +884,7 @@ impl<'gcx> TypeChecker<'gcx> {
     ) -> Ty<'gcx> {
         let WantOne::One(from_expr) = args.exprs().collect::<WantOne<_>>() else {
             return self.gcx.mk_ty_err(
-                self.dcx().err_span("expected exactly one unnamed argument", args.span),
+                self.dcx().emit_err(args.span, "expected exactly one unnamed argument"),
             );
         };
         let from = self.check_expr(from_expr);
@@ -962,7 +960,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 if let Some(names) = param_names {
                     self.check_named_call_args(call_span, args.span, named_args, param_tys, names);
                 } else {
-                    self.dcx().err_span("named arguments cannot be used for functions that take arbitrary parameters", args.span);
+                    self.dcx().emit_err(args.span, "named arguments cannot be used for functions that take arbitrary parameters");
                     for arg in named_args {
                         let _ = self.check_expr(&arg.value);
                     }
@@ -1018,7 +1016,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         )
                     }
                 };
-                self.gcx.mk_ty_err(self.dcx().err_span(msg, ident.span))
+                self.gcx.mk_ty_err(self.dcx().emit_err(ident.span, msg))
             }
         };
         self.register_ty(callee, ty);
@@ -1049,7 +1047,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     OverloadError::NotFound => "no matching declarations found",
                     OverloadError::Ambiguous => "no unique declarations found",
                 };
-                hir::Res::Err(self.dcx().err_span(msg, callee.span))
+                hir::Res::Err(self.dcx().emit_err(callee.span, msg))
             }
         };
         let ty = self.type_of_res(res);
@@ -1069,7 +1067,7 @@ impl<'gcx> TypeChecker<'gcx> {
         if function.contract == Some(contract_id)
             && function.visibility >= solar_ast::Visibility::Public
         {
-            self.dcx().err_span("libraries cannot call their own functions externally", span);
+            self.dcx().emit_err(span, "libraries cannot call their own functions externally");
         }
     }
 
@@ -1282,14 +1280,14 @@ impl<'gcx> TypeChecker<'gcx> {
                 let _ = self.check_expr(&opt.value);
             }
             if !ty.references_error() {
-                self.dcx().err_span("function call options can only be set on external function calls or contract creations", span);
+                self.dcx().emit_err(span, "function call options can only be set on external function calls or contract creations");
             }
             return ty;
         };
 
         let creation = f.is_creation();
         if !creation && !f.is_external() && !f.is_bare_call() {
-            self.dcx().err_span("function call options can only be set on external function calls or contract creations", span);
+            self.dcx().emit_err(span, "function call options can only be set on external function calls or contract creations");
         }
 
         let mut gas_set = false;
@@ -1300,9 +1298,9 @@ impl<'gcx> TypeChecker<'gcx> {
             let duplicate = match name {
                 kw::Gas => {
                     if creation {
-                        self.dcx().err_span(
-                            "function call option `gas` cannot be used with `new`",
+                        self.dcx().emit_err(
                             opt.name.span,
+                            "function call option `gas` cannot be used with `new`",
                         );
                     } else {
                         let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
@@ -1312,10 +1310,10 @@ impl<'gcx> TypeChecker<'gcx> {
                 sym::value => {
                     if f.kind == TyFnKind::BareDelegateCall {
                         self.dcx()
-                            .err_span("cannot set option `value` for delegatecall", opt.name.span);
+                            .emit_err(opt.name.span, "cannot set option `value` for delegatecall");
                     } else if f.kind == TyFnKind::BareStaticCall {
                         self.dcx()
-                            .err_span("cannot set option `value` for staticcall", opt.name.span);
+                            .emit_err(opt.name.span, "cannot set option `value` for staticcall");
                     } else if f.state_mutability != StateMutability::Payable {
                         let msg = if creation
                             && let Some(ret) = f.returns.first()
@@ -1328,35 +1326,29 @@ impl<'gcx> TypeChecker<'gcx> {
                         } else {
                             "cannot set option `value` on a non-payable function type".to_string()
                         };
-                        self.dcx().err_span(msg, opt.name.span);
+                        self.dcx().emit_err(opt.name.span, msg);
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.uint(256));
                     std::mem::replace(&mut value_set, true)
                 }
                 sym::salt => {
                     if !creation {
-                        self.dcx().err_span(
-                            "function call option `salt` can only be used with `new`",
+                        self.dcx().emit_err(
                             opt.name.span,
+                            "function call option `salt` can only be used with `new`",
                         );
                     }
                     let _ = self.expect_ty(&opt.value, self.gcx.types.fixed_bytes(32));
                     std::mem::replace(&mut salt_set, true)
                 }
                 _ => {
-                    self.dcx()
-                        .err(format!("unknown call option `{name}`"))
-                        .span(opt.name.span)
-                        .emit();
+                    self.dcx().emit_err(opt.name.span, format!("unknown call option `{name}`"));
                     let _ = self.check_expr(&opt.value);
                     false
                 }
             };
             if duplicate {
-                self.dcx()
-                    .err(format!("duplicate call option `{name}`"))
-                    .span(opt.name.span)
-                    .emit();
+                self.dcx().emit_err(opt.name.span, format!("duplicate call option `{name}`"));
             }
         }
 
@@ -1371,23 +1363,21 @@ impl<'gcx> TypeChecker<'gcx> {
         param_tys: &[Ty<'gcx>],
     ) {
         if exprs.len() != param_tys.len() {
-            self.dcx()
-                .err(format!(
+            self.dcx().emit_err_label(
+                call_span,
+                format!(
                     "wrong argument count for function call: {} arguments given but expected {}",
                     exprs.len(),
                     param_tys.len()
-                ))
-                .span(call_span)
-                .span_label(
-                    args_span,
-                    format!(
-                        "expected {} argument{}, found {}",
-                        param_tys.len(),
-                        pluralize!(param_tys.len()),
-                        exprs.len()
-                    ),
-                )
-                .emit();
+                ),
+                args_span,
+                format!(
+                    "expected {} argument{}, found {}",
+                    param_tys.len(),
+                    pluralize!(param_tys.len()),
+                    exprs.len()
+                ),
+            );
         }
 
         let count = std::cmp::min(exprs.len(), param_tys.len());
@@ -1411,23 +1401,21 @@ impl<'gcx> TypeChecker<'gcx> {
         debug_assert_eq!(param_tys.len(), param_names.len());
 
         if named_args.len() != param_tys.len() {
-            self.dcx()
-                .err(format!(
+            self.dcx().emit_err_label(
+                call_span,
+                format!(
                     "wrong argument count for function call: {} arguments given but expected {}",
                     named_args.len(),
                     param_tys.len()
-                ))
-                .span(call_span)
-                .span_label(
-                    args_span,
-                    format!(
-                        "expected {} argument{}, found {}",
-                        param_tys.len(),
-                        pluralize!(param_tys.len()),
-                        named_args.len()
-                    ),
-                )
-                .emit();
+                ),
+                args_span,
+                format!(
+                    "expected {} argument{}, found {}",
+                    param_tys.len(),
+                    pluralize!(param_tys.len()),
+                    named_args.len()
+                ),
+            );
         }
 
         let mut seen_names: SmallVec<[solar_interface::Symbol; 8]> = SmallVec::new();
@@ -1437,9 +1425,7 @@ impl<'gcx> TypeChecker<'gcx> {
 
             if seen_names.contains(&arg_name) {
                 self.dcx()
-                    .err(format!("duplicate named argument `{arg_name}`"))
-                    .span(arg.name.span)
-                    .emit();
+                    .emit_err(arg.name.span, format!("duplicate named argument `{arg_name}`"));
                 let _ = self.check_expr_once(&arg.value);
                 continue;
             }
@@ -1453,12 +1439,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.check_expected(&arg.value, actual, param_tys[idx]);
                 }
                 None => {
-                    self.dcx()
-                        .err(format!(
-                            "named argument `{arg_name}` does not match function declaration"
-                        ))
-                        .span(arg.name.span)
-                        .emit();
+                    self.dcx().emit_err(
+                        arg.name.span,
+                        format!("named argument `{arg_name}` does not match function declaration"),
+                    );
                     let _ = self.check_expr_once(&arg.value);
                 }
             }
@@ -1493,9 +1477,9 @@ impl<'gcx> TypeChecker<'gcx> {
 
         if let Some(init) = var.initializer {
             if var.is_state_variable() && ty.has_mapping(self.gcx) {
-                self.dcx().err_span(
-                    "types in storage containing (nested) mappings cannot be assigned to",
+                self.dcx().emit_err(
                     var.span,
+                    "types in storage containing (nested) mappings cannot be assigned to",
                 );
             } else if expect {
                 let _ = if var.is_state_variable() {
@@ -1508,14 +1492,14 @@ impl<'gcx> TypeChecker<'gcx> {
 
         if var.is_immutable() {
             if !ty.is_value_type() {
-                self.dcx().err_span("immutable variables cannot have a non-value type", var.span);
+                self.dcx().emit_err(var.span, "immutable variables cannot have a non-value type");
             }
             if let TyKind::Fn(f) = ty.kind
                 && f.is_external()
             {
-                self.dcx().err_span(
-                    "immutable variables of external function type are not yet supported",
+                self.dcx().emit_err(
                     var.span,
+                    "immutable variables of external function type are not yet supported",
                 );
             }
         }
@@ -1527,13 +1511,13 @@ impl<'gcx> TypeChecker<'gcx> {
             )
             && ty.has_mapping(self.gcx)
         {
-            self.dcx()
-                .err(format!(
+            self.dcx().emit_err(
+                var.span,
+                format!(
                     "type `{}` is only valid in storage because it contains a (nested) mapping",
                     ty.display(self.gcx)
-                ))
-                .span(var.span)
-                .emit();
+                ),
+            );
         }
 
         // Uninitialized local mapping variables are invalid (error 4182).
@@ -1573,20 +1557,18 @@ impl<'gcx> TypeChecker<'gcx> {
 
         debug_assert!(!decls.is_empty());
         if value_types.len() != decls.len() {
-            self.dcx()
-                .err("mismatched number of components")
-                .span(span)
-                .span_label(
-                    init.span,
-                    format!(
-                        "expected a tuple with {} element{}, found one with {} element{}",
-                        decls.len(),
-                        pluralize!(decls.len()),
-                        value_types.len(),
-                        pluralize!(value_types.len())
-                    ),
-                )
-                .emit();
+            self.dcx().emit_err_label(
+                span,
+                "mismatched number of components",
+                init.span,
+                format!(
+                    "expected a tuple with {} element{}, found one with {} element{}",
+                    decls.len(),
+                    pluralize!(decls.len()),
+                    value_types.len(),
+                    pluralize!(value_types.len())
+                ),
+            );
         }
 
         let exprs = if let hir::ExprKind::Tuple(exprs) = init.kind {
@@ -1609,7 +1591,7 @@ impl<'gcx> TypeChecker<'gcx> {
             ty.kind,
             TyKind::Elementary(_) | TyKind::Udvt(_, _) | TyKind::Contract(_) | TyKind::Enum(_)
         ) {
-            self.dcx().err_span("only elementary types, user defined value types, contract types or enums are allowed as mapping keys.", key.span);
+            self.dcx().emit_err(key.span, "only elementary types, user defined value types, contract types or enums are allowed as mapping keys.");
         }
         ty
     }
@@ -1717,7 +1699,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     OverloadError::NotFound => "no matching declarations found",
                     OverloadError::Ambiguous => "no unique declarations found",
                 };
-                hir::Res::Err(self.dcx().err_span(msg, span))
+                hir::Res::Err(self.dcx().emit_err(span, msg))
             }
         }
     }
@@ -1822,14 +1804,11 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                 if let Some(modifier) = modifier {
                     let arg_count = modifier.args.exprs().len();
                     if arg_count != ctor_param_types.len() {
-                        self.dcx()
-                            .err(format!(
-                                "wrong number of arguments for base constructor: expected {}, found {}",
-                                ctor_param_types.len(),
-                                arg_count
-                            ))
-                            .span(modifier.span)
-                            .emit();
+                        self.dcx().emit_err(modifier.span, format!(
+                            "wrong number of arguments for base constructor: expected {}, found {}",
+                            ctor_param_types.len(),
+                            arg_count
+                        ));
                     } else {
                         for (arg_expr, expected_arg_ty) in
                             modifier.args.exprs().zip(ctor_param_types.iter())
@@ -1929,15 +1908,15 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     match stmt.kind {
                         hir::StmtKind::Emit(_) => {
                             if !matches!(callee_ty.kind, TyKind::Event(..)) {
-                                self.dcx().err_span(
-                                    "expression has to be an event invocation",
+                                self.dcx().emit_err(
                                     callee.span,
+                                    "expression has to be an event invocation",
                                 );
                             }
                         }
                         hir::StmtKind::Revert(_) => {
                             if !matches!(callee_ty.kind, TyKind::Error(..)) {
-                                self.dcx().err_span("expression has to be an error", callee.span);
+                                self.dcx().emit_err(callee.span, "expression has to be an error");
                             }
                         }
                         _ => unreachable!(),
@@ -1959,9 +1938,9 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                     && !ty.is_unit()
                     && !ty.references_error()
                 {
-                    self.dcx().err_span(
-                        "inline assembly expression statements cannot return values",
+                    self.dcx().emit_err(
                         expr.span,
+                        "inline assembly expression statements cannot return values",
                     );
                 }
                 return ControlFlow::Continue(());

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -15,10 +15,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     return self.gcx.types.uint(256);
                 }
                 return self.gcx.mk_ty_err(
-                    self.dcx()
-                        .err(format!("string literal too long ({len} > 32)"))
-                        .span(lit.span)
-                        .emit(),
+                    self.dcx().emit_err(lit.span, format!("string literal too long ({len} > 32)")),
                 );
             }
             LitKind::Address(_) => return self.gcx.types.uint(256),
@@ -48,16 +45,12 @@ impl<'gcx> TypeChecker<'gcx> {
             if self.in_lvalue() {
                 return Err(self
                     .dcx()
-                    .err("only local variables can be assigned to in inline assembly")
-                    .span(span)
-                    .emit());
+                    .emit_err(span, "only local variables can be assigned to in inline assembly"));
             }
             if let hir::ItemId::Function(_) = item {
                 return Err(self
                     .dcx()
-                    .err("access to functions is not allowed in inline assembly")
-                    .span(span)
-                    .emit());
+                    .emit_err(span, "access to functions is not allowed in inline assembly"));
             }
             return Ok(false);
         };
@@ -66,17 +59,13 @@ impl<'gcx> TypeChecker<'gcx> {
         if var.is_immutable() {
             return Err(self
                 .dcx()
-                .err("assembly access to immutable variables is not supported")
-                .span(span)
-                .emit());
+                .emit_err(span, "assembly access to immutable variables is not supported"));
         }
 
         if var.is_constant() && !self.in_lvalue() && !ty.is_value_type() {
             return Err(self
                 .dcx()
-                .err("only direct number constants are supported in inline assembly")
-                .span(span)
-                .emit());
+                .emit_err(span, "only direct number constants are supported in inline assembly"));
         }
 
         if var.is_state_variable() && !var.is_constant() {
@@ -109,9 +98,7 @@ impl<'gcx> TypeChecker<'gcx> {
         if matches!(ty.kind, TyKind::Fn(f) if f.is_external()) {
             return Err(self
                 .dcx()
-                .err("only types that use one stack slot are supported")
-                .span(span)
-                .emit());
+                .emit_err(span, "only types that use one stack slot are supported"));
         }
 
         Ok(true)
@@ -169,34 +156,26 @@ impl<'gcx> TypeChecker<'gcx> {
             Ok(()) => return self.gcx.types.uint(256),
             Err(ErrorKind::NonVariable) => self
                 .dcx()
-                .err("inline assembly suffixes can only be used with variables")
-                .span(member.span)
-                .emit(),
+                .emit_err(member.span, "inline assembly suffixes can only be used with variables"),
             Err(ErrorKind::Immutable) => self
                 .dcx()
-                .err("assembly access to immutable variables is not supported")
-                .span(expr.span)
-                .emit(),
-            Err(ErrorKind::UnsupportedBase) => self
-                .dcx()
-                .err(format!("suffix `.{member}` is not supported by this variable or type"))
-                .span(member.span)
-                .emit(),
+                .emit_err(expr.span, "assembly access to immutable variables is not supported"),
+            Err(ErrorKind::UnsupportedBase) => self.dcx().emit_err(
+                member.span,
+                format!("suffix `.{member}` is not supported by this variable or type"),
+            ),
             Err(ErrorKind::UnsupportedMember(member_set)) => {
-                self.dcx().err_span(member_set.unsupported_member_message(), member.span)
+                self.dcx().emit_err(member.span, member_set.unsupported_member_message())
             }
-            Err(ErrorKind::NonExternalFunction) => self
-                .dcx()
-                .err("only external function pointer variables support `.selector` and `.address`")
-                .span(member.span)
-                .emit(),
+            Err(ErrorKind::NonExternalFunction) => self.dcx().emit_err(
+                member.span,
+                "only external function pointer variables support `.selector` and `.address`",
+            ),
             Err(ErrorKind::Assignment(YulMemberAssignmentError::StateVariable)) => self
                 .dcx()
-                .err("state variables cannot be assigned to in inline assembly")
-                .span(expr.span)
-                .emit(),
+                .emit_err(expr.span, "state variables cannot be assigned to in inline assembly"),
             Err(ErrorKind::Assignment(YulMemberAssignmentError::StorageOffset)) => {
-                self.dcx().err_span("only `.slot` can be assigned to", member.span)
+                self.dcx().emit_err(member.span, "only `.slot` can be assigned to")
             }
         };
 

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -183,7 +183,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 .span(member.span)
                 .emit(),
             Err(ErrorKind::UnsupportedMember(member_set)) => {
-                self.dcx().err(member_set.unsupported_member_message()).span(member.span).emit()
+                self.dcx().err_span(member_set.unsupported_member_message(), member.span)
             }
             Err(ErrorKind::NonExternalFunction) => self
                 .dcx()
@@ -196,7 +196,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 .span(expr.span)
                 .emit(),
             Err(ErrorKind::Assignment(YulMemberAssignmentError::StorageOffset)) => {
-                self.dcx().err("only `.slot` can be assigned to").span(member.span).emit()
+                self.dcx().err_span("only `.slot` can be assigned to", member.span)
             }
         };
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -56,10 +56,10 @@ fn check_using_directive<'gcx>(gcx: Gcx<'gcx>, using: &'gcx hir::UsingDirective<
         match ty.same_source_file_level_user_type(gcx, using.source) {
             Ok(()) => {}
             Err(SameSourceFileLevelUserTypeError::NotUserDefined) => {
-                gcx.dcx().err_span("can only use `global` with user-defined types", using.span);
+                gcx.dcx().emit_err(using.span, "can only use `global` with user-defined types");
             }
             Err(SameSourceFileLevelUserTypeError::NotSameSourceFileLevel) => {
-                gcx.dcx().err_span("can only use `global` with types defined in the same source unit at file level", using.span);
+                gcx.dcx().emit_err(using.span, "can only use `global` with types defined in the same source unit at file level");
             }
         }
     }
@@ -69,7 +69,7 @@ fn check_using_directive<'gcx>(gcx: Gcx<'gcx>, using: &'gcx hir::UsingDirective<
         && let TyKind::Contract(id) = ty.kind
         && gcx.hir.contract(id).kind.is_library()
     {
-        gcx.dcx().err_span("invalid use of library name", using.span);
+        gcx.dcx().emit_err(using.span, "invalid use of library name");
     }
 
     for entry in using.entries {
@@ -104,31 +104,28 @@ fn check_using_function<'gcx>(
     let is_library_function =
         function.contract.is_some_and(|id| gcx.hir.contract(id).kind.is_library());
     if !function.is_free() && !is_library_function {
-        gcx.dcx().err_span("only file-level functions and library functions can be attached to a type in a `using` statement", entry.span);
+        gcx.dcx().emit_err(entry.span, "only file-level functions and library functions can be attached to a type in a `using` statement");
     }
 
     let TyKind::Fn(function_ty) = gcx.type_of_item(function_id.into()).kind else { unreachable!() };
     if function_ty.parameters.is_empty() {
-        gcx.dcx()
-            .err(format!(
+        gcx.dcx().emit_err_span_note(
+            entry.span,
+            format!(
                 "function `{}` does not have any parameters and therefore cannot be attached",
                 gcx.item_name(function_id).as_str()
-            ))
-            .span(entry.span)
-            .span_note(function.span, "function defined here")
-            .emit();
+            ),
+            function.span,
+            "function defined here",
+        );
         return;
     }
 
     if function.visibility == Visibility::Private && function.contract != using.contract {
-        gcx.dcx()
-            .err(format!(
-                "function `{}` is private and therefore cannot be attached to a type outside of the library where it is defined",
-                gcx.item_name(function_id).as_str()
-            ))
-            .span(entry.span)
-            .span_note(function.span, "function defined here")
-            .emit();
+        gcx.dcx().emit_err_span_note(entry.span, format!(
+            "function `{}` is private and therefore cannot be attached to a type outside of the library where it is defined",
+            gcx.item_name(function_id).as_str()
+        ), function.span, "function defined here");
     }
 
     if let Some(using_ty) = using_ty {
@@ -323,7 +320,7 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     if contract.kind.is_library() {
         if let Some(receive) = contract.receive {
             gcx.dcx()
-                .err_span("libraries cannot have receive ether functions", gcx.item_span(receive));
+                .emit_err(gcx.item_span(receive), "libraries cannot have receive ether functions");
         }
         return;
     }
@@ -331,9 +328,9 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
         let f = gcx.hir.function(receive);
         // Check visibility
         if f.visibility != Visibility::External {
-            gcx.dcx().err_span(
-                "receive ether function must be defined as `external`",
+            gcx.dcx().emit_err(
                 gcx.item_span(receive),
+                "receive ether function must be defined as `external`",
             );
         }
 
@@ -349,13 +346,13 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
         // Check parameters
         if !f.parameters.is_empty() {
             gcx.dcx()
-                .err_span("receive ether function cannot take parameters", gcx.item_span(receive));
+                .emit_err(gcx.item_span(receive), "receive ether function cannot take parameters");
         }
 
         // Check return values
         if !f.returns.is_empty() {
             gcx.dcx()
-                .err_span("receive ether function cannot return values", gcx.item_span(receive));
+                .emit_err(gcx.item_span(receive), "receive ether function cannot return values");
         }
     }
 }
@@ -366,7 +363,7 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 fn check_storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let span = gcx.hir.contract(contract_id).name.span;
     let Some(total_size) = storage_size_upper_bound(gcx, contract_id) else {
-        gcx.dcx().err_span("contract requires too much storage", span);
+        gcx.dcx().emit_err(span, "contract requires too much storage");
         return;
     };
 
@@ -459,7 +456,7 @@ impl<'gcx> BreakContinueChecker<'gcx> {
     fn check_break_continue(&self, span: Span, kind: &str) {
         if self.loop_depth == 0 {
             let msg = format!("`{kind}` outside of a loop");
-            self.gcx.sess.dcx.err_span(msg, span);
+            self.gcx.sess.dcx.emit_err(span, msg);
         }
     }
 }

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -56,16 +56,10 @@ fn check_using_directive<'gcx>(gcx: Gcx<'gcx>, using: &'gcx hir::UsingDirective<
         match ty.same_source_file_level_user_type(gcx, using.source) {
             Ok(()) => {}
             Err(SameSourceFileLevelUserTypeError::NotUserDefined) => {
-                gcx.dcx()
-                    .err("can only use `global` with user-defined types")
-                    .span(using.span)
-                    .emit();
+                gcx.dcx().err_span("can only use `global` with user-defined types", using.span);
             }
             Err(SameSourceFileLevelUserTypeError::NotSameSourceFileLevel) => {
-                gcx.dcx()
-                    .err("can only use `global` with types defined in the same source unit at file level")
-                    .span(using.span)
-                    .emit();
+                gcx.dcx().err_span("can only use `global` with types defined in the same source unit at file level", using.span);
             }
         }
     }
@@ -75,7 +69,7 @@ fn check_using_directive<'gcx>(gcx: Gcx<'gcx>, using: &'gcx hir::UsingDirective<
         && let TyKind::Contract(id) = ty.kind
         && gcx.hir.contract(id).kind.is_library()
     {
-        gcx.dcx().err("invalid use of library name").span(using.span).emit();
+        gcx.dcx().err_span("invalid use of library name", using.span);
     }
 
     for entry in using.entries {
@@ -110,10 +104,7 @@ fn check_using_function<'gcx>(
     let is_library_function =
         function.contract.is_some_and(|id| gcx.hir.contract(id).kind.is_library());
     if !function.is_free() && !is_library_function {
-        gcx.dcx()
-            .err("only file-level functions and library functions can be attached to a type in a `using` statement")
-            .span(entry.span)
-            .emit();
+        gcx.dcx().err_span("only file-level functions and library functions can be attached to a type in a `using` statement", entry.span);
     }
 
     let TyKind::Fn(function_ty) = gcx.type_of_item(function_id.into()).kind else { unreachable!() };
@@ -332,9 +323,7 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     if contract.kind.is_library() {
         if let Some(receive) = contract.receive {
             gcx.dcx()
-                .err("libraries cannot have receive ether functions")
-                .span(gcx.item_span(receive))
-                .emit();
+                .err_span("libraries cannot have receive ether functions", gcx.item_span(receive));
         }
         return;
     }
@@ -342,10 +331,10 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
         let f = gcx.hir.function(receive);
         // Check visibility
         if f.visibility != Visibility::External {
-            gcx.dcx()
-                .err("receive ether function must be defined as `external`")
-                .span(gcx.item_span(receive))
-                .emit();
+            gcx.dcx().err_span(
+                "receive ether function must be defined as `external`",
+                gcx.item_span(receive),
+            );
         }
 
         // Check state mutability
@@ -360,17 +349,13 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
         // Check parameters
         if !f.parameters.is_empty() {
             gcx.dcx()
-                .err("receive ether function cannot take parameters")
-                .span(gcx.item_span(receive))
-                .emit();
+                .err_span("receive ether function cannot take parameters", gcx.item_span(receive));
         }
 
         // Check return values
         if !f.returns.is_empty() {
             gcx.dcx()
-                .err("receive ether function cannot return values")
-                .span(gcx.item_span(receive))
-                .emit();
+                .err_span("receive ether function cannot return values", gcx.item_span(receive));
         }
     }
 }
@@ -381,7 +366,7 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 fn check_storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let span = gcx.hir.contract(contract_id).name.span;
     let Some(total_size) = storage_size_upper_bound(gcx, contract_id) else {
-        gcx.dcx().err("contract requires too much storage").span(span).emit();
+        gcx.dcx().err_span("contract requires too much storage", span);
         return;
     };
 
@@ -474,7 +459,7 @@ impl<'gcx> BreakContinueChecker<'gcx> {
     fn check_break_continue(&self, span: Span, kind: &str) {
         if self.loop_depth == 0 {
             let msg = format!("`{kind}` outside of a loop");
-            self.gcx.sess.dcx.err(msg).span(span).emit();
+            self.gcx.sess.dcx.err_span(msg, span);
         }
     }
 }

--- a/crates/sema/src/typeck/udvt.rs
+++ b/crates/sema/src/typeck/udvt.rs
@@ -26,9 +26,7 @@ pub(super) fn check_using_operator<'gcx>(
     let Some(using_ty) = using_ty else { return };
     let TyKind::Udvt(_, _) = using_ty.kind else {
         gcx.dcx()
-            .err("operators can only be implemented for user-defined value types")
-            .span(entry.span)
-            .emit();
+            .err_span("operators can only be implemented for user-defined value types", entry.span);
         return;
     };
 

--- a/crates/sema/src/typeck/udvt.rs
+++ b/crates/sema/src/typeck/udvt.rs
@@ -16,17 +16,18 @@ pub(super) fn check_using_operator<'gcx>(
     let function = gcx.hir.function(function_id);
 
     if function_ty.state_mutability != StateMutability::Pure || !function.is_free() {
-        gcx.dcx()
-            .err("only pure free functions can be used to define operators")
-            .span(entry.span)
-            .span_note(function.span, "function defined here")
-            .emit();
+        gcx.dcx().emit_err_span_note(
+            entry.span,
+            "only pure free functions can be used to define operators",
+            function.span,
+            "function defined here",
+        );
     }
 
     let Some(using_ty) = using_ty else { return };
     let TyKind::Udvt(_, _) = using_ty.kind else {
         gcx.dcx()
-            .err_span("operators can only be implemented for user-defined value types", entry.span);
+            .emit_err(entry.span, "operators can only be implemented for user-defined value types");
         return;
     };
 
@@ -93,14 +94,11 @@ pub(super) fn check_using_operator<'gcx>(
             &mut |_| matches += 1,
         );
         if matches >= 2 {
-            gcx.dcx()
-                .err(format!(
-                    "user-defined {} operator `{}` has more than one definition matching the operand type visible in the current scope",
-                    if params.len() == 1 { "unary" } else { "binary" },
-                    op.to_str()
-                ))
-                .span(entry.span)
-                .emit();
+            gcx.dcx().emit_err(entry.span, format!(
+                "user-defined {} operator `{}` has more than one definition matching the operand type visible in the current scope",
+                if params.len() == 1 { "unary" } else { "binary" },
+                op.to_str()
+            ));
         }
     }
 }


### PR DESCRIPTION
This adds `DiagCtxt::emit_err(span, msg)` for the common error-with-span emission pattern, with the span first to match the callsite flow.

It also adds focused helpers for the common one-note, one-span-note, and one-span-label builder chains, then applies those helpers across straightforward parser and semantic-analysis callsites. More complex diagnostics stay on the builder API.
