### PR TITLE
feat(sema): warn on local state shadowing

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1589,10 +1589,38 @@ impl<'gcx> ResolveContext<'gcx> {
         self.hir.variables[id].initializer = self.lower_expr_opt(var.initializer.as_deref());
         let mut guar = Ok(());
         if let Some(name) = var.name {
+            if kind == hir::VarKind::Statement {
+                self.warn_if_local_shadows_state_variable(name);
+            }
             let res = Res::Item(hir::ItemId::Variable(id));
             guar = self.scopes.current_scope().declare_res(self.lcx.sess, &self.lcx.hir, name, res);
         }
         (id, guar)
+    }
+
+    fn warn_if_local_shadows_state_variable(&self, name: Ident) {
+        if self.scopes.scopes.iter().rev().any(|scope| scope.resolve(name).is_some()) {
+            return;
+        }
+        let Some(contract) = self.scopes.contract else { return };
+        let Some(decls) = self.resolver.contract_scopes[contract].resolve(name) else {
+            return;
+        };
+        let Some(previous) = decls.iter().find(|decl| {
+            matches!(
+                decl.res,
+                Res::Item(hir::ItemId::Variable(id)) if self.hir.variable(id).is_state_variable()
+            )
+        }) else {
+            return;
+        };
+
+        self.dcx()
+            .warn("this declaration shadows an existing declaration")
+            .code(error_code!(2519))
+            .span(name.span)
+            .span_note(previous.span, "shadowed declaration is here")
+            .emit();
     }
 
     /// Desugars a `while`, `do while`, or `for` loop into a `loop` HIR statement.

--- a/tests/ui/resolve/shadow_state_variable.sol
+++ b/tests/ui/resolve/shadow_state_variable.sol
@@ -1,0 +1,13 @@
+contract C {
+    uint256 value;
+
+    function f() public {
+        uint32 value; //~ WARN: this declaration shadows an existing declaration
+        value = 2;
+    }
+
+    function g(uint256 value) public {
+        uint32 value;
+        value = 2;
+    }
+}

--- a/tests/ui/resolve/shadow_state_variable.stderr
+++ b/tests/ui/resolve/shadow_state_variable.stderr
@@ -1,0 +1,12 @@
+warning[2519]: this declaration shadows an existing declaration
+   ╭▸ ROOT/tests/ui/resolve/shadow_state_variable.sol:LL:CC
+   │
+LL │         uint32 value;
+   │                ━━━━━
+   ╰╴
+note: shadowed declaration is here
+   ╭▸ ROOT/tests/ui/resolve/shadow_state_variable.sol:LL:CC
+   │
+LL │     uint256 value;
+   ╰╴            ━━━━━
+

--- a/tests/ui/typeck/implicit_slice.sol
+++ b/tests/ui/typeck/implicit_slice.sol
@@ -7,17 +7,18 @@ contract C {
     // Array slices are implicitly convertible to arrays of their underlying type.
     function ok(uint256[] calldata data, uint256 start, uint256 end) external pure {
         // Take a slice and implicitly convert it to the underlying type.
-        uint256[] calldata s = data[start:end];
+        uint256[] calldata s = data[start:end]; //~ WARN: this declaration shadows
     }
 
     // Slices cannot be implicitly converted to a different element type.
     function wrongElementType(uint256[] calldata data, uint256 start, uint256 end) external pure {
         uint128[] calldata s = data[start:end]; //~ ERROR: mismatched types
+        //~^ WARN: this declaration shadows
     }
 
     // Slices can be implicitly converted to memory arrays of the same element type.
     function toMemory(uint256[] calldata data, uint256 start, uint256 end) external pure {
-        uint256[] memory s = data[start:end];
+        uint256[] memory s = data[start:end]; //~ WARN: this declaration shadows
     }
 
     function accessSlice(uint256[] calldata data) external pure {
@@ -30,6 +31,7 @@ contract C {
     // Slices can only be created from calldata arrays.
     function notCalldata(uint256[] memory data, uint256 start, uint256 end) external pure {
         uint256[] memory s = data[start:end]; //~ ERROR: can only slice dynamic calldata arrays
+        //~^ WARN: this declaration shadows
     }
 
     // Slices cannot be converted to a single element.

--- a/tests/ui/typeck/implicit_slice.stderr
+++ b/tests/ui/typeck/implicit_slice.stderr
@@ -1,3 +1,51 @@
+warning[2519]: this declaration shadows an existing declaration
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │         uint256[] calldata s = data[start:end];
+   │                            ━
+   ╰╴
+note: shadowed declaration is here
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │     uint256[] s;
+   ╰╴              ━
+
+warning[2519]: this declaration shadows an existing declaration
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │         uint128[] calldata s = data[start:end];
+   │                            ━
+   ╰╴
+note: shadowed declaration is here
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │     uint256[] s;
+   ╰╴              ━
+
+warning[2519]: this declaration shadows an existing declaration
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │         uint256[] memory s = data[start:end];
+   │                          ━
+   ╰╴
+note: shadowed declaration is here
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │     uint256[] s;
+   ╰╴              ━
+
+warning[2519]: this declaration shadows an existing declaration
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │         uint256[] memory s = data[start:end];
+   │                          ━
+   ╰╴
+note: shadowed declaration is here
+   ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
+   │
+LL │     uint256[] s;
+   ╰╴              ━
+
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/implicit_slice.sol:LL:CC
    │
@@ -22,5 +70,5 @@ error: mismatched types
 LL │         t = data[start:end];
    ╰╴            ━━━━━━━━━━━━━━━ expected `uint256[] storage`, found `uint256[] calldata slice`
 
-error: aborting due to 4 previous errors
+error: aborting due to 4 previous errors; 4 warnings emitted
 


### PR DESCRIPTION
This adds the narrow solc-compatible shadowing warning for statement-local variables that shadow state variables.

The warning is emitted during lowering only when no existing local scope already resolves the name, keeping the rule focused on the state-variable case without expanding into broader shadowing diagnostics.
