### PR TITLE
feat(parser): add import callback

### DIFF
--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -4,7 +4,7 @@ use solar_ast::{token::*, *};
 
 use solar_interface::kw;
 
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses an expression.
     #[inline]
     pub fn parse_expr(&mut self) -> PResult<'sess, Box<'ast, Expr<'ast>>> {

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -5,44 +5,15 @@ use smallvec::SmallVec;
 use solar_ast::{token::*, *};
 use solar_interface::{Ident, Span, Spanned, diagnostics::DiagMsg, error_code, kw, sym};
 
-type ImportCallback<'a, 'ast> = &'a mut dyn FnMut(ItemId, Span, &ImportDirective<'ast>);
-
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a source unit.
     #[instrument(level = "debug", skip_all)]
     pub fn parse_file(&mut self) -> PResult<'sess, SourceUnit<'ast>> {
-        self.parse_file_with_import_callback(|_, _, _| {})
-    }
-
-    /// Parses a source unit and calls `import_callback` for each parsed import directive.
-    #[instrument(level = "debug", skip_all)]
-    pub fn parse_file_with_import_callback(
-        &mut self,
-        import_callback: impl FnMut(ItemId, Span, &ImportDirective<'ast>),
-    ) -> PResult<'sess, SourceUnit<'ast>> {
-        self.parse_source_items(TokenKind::Eof, import_callback).map(SourceUnit::new)
-    }
-
-    /// Parses a list of source unit items until the given token is encountered.
-    fn parse_source_items(
-        &mut self,
-        end: TokenKind,
-        mut import_callback: impl FnMut(ItemId, Span, &ImportDirective<'ast>),
-    ) -> PResult<'sess, BoxSlice<'ast, Item<'ast>>> {
-        self.parse_items_inner(end, Some(&mut import_callback))
+        self.parse_items(TokenKind::Eof).map(SourceUnit::new)
     }
 
     /// Parses a list of items until the given token is encountered.
     fn parse_items(&mut self, end: TokenKind) -> PResult<'sess, BoxSlice<'ast, Item<'ast>>> {
-        self.parse_items_inner(end, None)
-    }
-
-    /// Parses a list of items until the given token is encountered.
-    fn parse_items_inner(
-        &mut self,
-        end: TokenKind,
-        mut import_callback: Option<ImportCallback<'_, 'ast>>,
-    ) -> PResult<'sess, BoxSlice<'ast, Item<'ast>>> {
         let get_msg_note = |this: &mut Self| {
             let (prefix, list, link);
             if this.in_contract {
@@ -69,7 +40,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let (_, note) = get_msg_note(self);
                 self.dcx().emit_err_note(item.span, msg, note);
             } else {
-                if let Some(callback) = &mut import_callback
+                if let Some(callback) = &mut self.import_callback
                     && let ItemKind::Import(import) = &item.kind
                 {
                     callback(ItemId::new(items.len()), item.span, import);
@@ -1012,14 +983,14 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     }
 }
 
-struct SemverVersionParser<'p, 'sess, 'ast> {
-    p: &'p mut Parser<'sess, 'ast>,
+struct SemverVersionParser<'p, 'sess, 'ast, 'cb> {
+    p: &'p mut Parser<'sess, 'ast, 'cb>,
     bumps: u32,
     pos_inside: u32,
 }
 
-impl<'p, 'sess, 'ast> SemverVersionParser<'p, 'sess, 'ast> {
-    fn new(p: &'p mut Parser<'sess, 'ast>) -> Self {
+impl<'p, 'sess, 'ast, 'cb> SemverVersionParser<'p, 'sess, 'ast, 'cb> {
+    fn new(p: &'p mut Parser<'sess, 'ast, 'cb>) -> Self {
         Self { p, bumps: 0, pos_inside: 0 }
     }
 

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -5,15 +5,44 @@ use smallvec::SmallVec;
 use solar_ast::{token::*, *};
 use solar_interface::{Ident, Span, Spanned, diagnostics::DiagMsg, error_code, kw, sym};
 
+type ImportCallback<'a, 'ast> = &'a mut dyn FnMut(ItemId, Span, &ImportDirective<'ast>);
+
 impl<'sess, 'ast> Parser<'sess, 'ast> {
     /// Parses a source unit.
     #[instrument(level = "debug", skip_all)]
     pub fn parse_file(&mut self) -> PResult<'sess, SourceUnit<'ast>> {
-        self.parse_items(TokenKind::Eof).map(SourceUnit::new)
+        self.parse_file_with_import_callback(|_, _, _| {})
+    }
+
+    /// Parses a source unit and calls `import_callback` for each parsed import directive.
+    #[instrument(level = "debug", skip_all)]
+    pub fn parse_file_with_import_callback(
+        &mut self,
+        import_callback: impl FnMut(ItemId, Span, &ImportDirective<'ast>),
+    ) -> PResult<'sess, SourceUnit<'ast>> {
+        self.parse_source_items(TokenKind::Eof, import_callback).map(SourceUnit::new)
+    }
+
+    /// Parses a list of source unit items until the given token is encountered.
+    fn parse_source_items(
+        &mut self,
+        end: TokenKind,
+        mut import_callback: impl FnMut(ItemId, Span, &ImportDirective<'ast>),
+    ) -> PResult<'sess, BoxSlice<'ast, Item<'ast>>> {
+        self.parse_items_inner(end, Some(&mut import_callback))
     }
 
     /// Parses a list of items until the given token is encountered.
     fn parse_items(&mut self, end: TokenKind) -> PResult<'sess, BoxSlice<'ast, Item<'ast>>> {
+        self.parse_items_inner(end, None)
+    }
+
+    /// Parses a list of items until the given token is encountered.
+    fn parse_items_inner(
+        &mut self,
+        end: TokenKind,
+        mut import_callback: Option<ImportCallback<'_, 'ast>>,
+    ) -> PResult<'sess, BoxSlice<'ast, Item<'ast>>> {
         let get_msg_note = |this: &mut Self| {
             let (prefix, list, link);
             if this.in_contract {
@@ -40,6 +69,11 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 let (_, note) = get_msg_note(self);
                 self.dcx().emit_err_note(item.span, msg, note);
             } else {
+                if let Some(callback) = &mut import_callback
+                    && let ItemKind::Import(import) = &item.kind
+                {
+                    callback(ItemId::new(items.len()), item.span, import);
+                }
                 items.push(item);
             }
         }

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -43,7 +43,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
                 if let Some(callback) = &mut self.import_callback
                     && let ItemKind::Import(import) = &item.kind
                 {
-                    callback(ItemId::new(items.len()), item.span, &import.path);
+                    callback(ItemId::new(items.len()), item.span, import);
                 }
                 items.push(item);
             }

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -43,7 +43,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
                 if let Some(callback) = &mut self.import_callback
                     && let ItemKind::Import(import) = &item.kind
                 {
-                    callback(ItemId::new(items.len()), item.span, import);
+                    callback(ItemId::new(items.len()), item.span, import.path.clone());
                 }
                 items.push(item);
             }

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -43,7 +43,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
                 if let Some(callback) = &mut self.import_callback
                     && let ItemKind::Import(import) = &item.kind
                 {
-                    callback(ItemId::new(items.len()), item.span, import.path.clone());
+                    callback(ItemId::new(items.len()), item.span, &import.path);
                 }
                 items.push(item);
             }

--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -7,7 +7,7 @@ use solar_ast::{token::*, *};
 use solar_interface::{ByteSymbol, Session, Symbol, diagnostics::ErrorGuaranteed, kw};
 use std::{borrow::Cow, fmt};
 
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a literal with an optional subdenomination.
     ///
     /// Note that the subdenomination gets applied to the literal directly, and is returned just for

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -22,8 +22,6 @@ mod yul;
 /// Maximum allowed recursive descent depth for selected parser entry points.
 const PARSER_RECURSION_LIMIT: usize = 128;
 
-type ImportCallback<'cb> = dyn FnMut(ast::ItemId, Span, &ast::StrLit) + 'cb;
-
 /// Solidity and Yul parser.
 ///
 /// # Examples
@@ -63,7 +61,8 @@ pub struct Parser<'sess, 'ast, 'cb> {
     /// Current recursion depth for recursive parsing operations.
     recursion_depth: usize,
     /// Callback invoked after a top-level import directive is parsed.
-    import_callback: Option<std::boxed::Box<ImportCallback<'cb>>>,
+    #[allow(clippy::type_complexity)]
+    import_callback: Option<std::boxed::Box<dyn FnMut(ast::ItemId, Span, &ast::StrLit) + 'cb>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -62,7 +62,8 @@ pub struct Parser<'sess, 'ast, 'cb> {
     recursion_depth: usize,
     /// Callback invoked after a top-level import directive is parsed.
     #[allow(clippy::type_complexity)]
-    import_callback: Option<std::boxed::Box<dyn FnMut(ast::ItemId, Span, &ast::StrLit) + 'cb>>,
+    import_callback:
+        Option<std::boxed::Box<dyn FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>) + 'cb>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -165,7 +166,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Sets the import callback.
     pub fn set_import_callback(
         &mut self,
-        import_callback: impl FnMut(ast::ItemId, Span, &ast::StrLit) + 'cb,
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>) + 'cb,
     ) {
         self.import_callback = Some(std::boxed::Box::new(import_callback));
     }
@@ -1242,8 +1243,8 @@ import * as B from "b.sol";
                 Parser::from_source_code(&sess, &arena, "test.sol".to_string().into(), src)
                     .expect("failed to create parser");
 
-            parser.set_import_callback(|id, span, path| {
-                imports.push((id, span, path.value.as_str().to_string()));
+            parser.set_import_callback(|id, span, import| {
+                imports.push((id, span, import.path.value.as_str().to_string()));
             });
             let ast = parser.parse_file().expect("failed to parse file");
             drop(parser);

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -31,7 +31,7 @@ const PARSER_RECURSION_LIMIT: usize = 128;
 /// # fn main() {}
 #[doc = include_str!("../../doc-examples/parser.rs")]
 /// ```
-type ImportCallback<'cb, 'ast> = dyn FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>) + 'cb;
+type ImportCallback<'cb> = dyn FnMut(ast::ItemId, Span, ast::StrLit) + 'cb;
 
 pub struct Parser<'sess, 'ast, 'cb> {
     /// The parser session.
@@ -63,7 +63,7 @@ pub struct Parser<'sess, 'ast, 'cb> {
     /// Current recursion depth for recursive parsing operations.
     recursion_depth: usize,
     /// Callback invoked after a top-level import directive is parsed.
-    import_callback: Option<std::boxed::Box<ImportCallback<'cb, 'ast>>>,
+    import_callback: Option<std::boxed::Box<ImportCallback<'cb>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -166,7 +166,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Sets the import callback.
     pub fn set_import_callback(
         &mut self,
-        import_callback: impl FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>) + 'cb,
+        import_callback: impl FnMut(ast::ItemId, Span, ast::StrLit) + 'cb,
     ) {
         self.import_callback = Some(std::boxed::Box::new(import_callback));
     }
@@ -1243,8 +1243,8 @@ import * as B from "b.sol";
                 Parser::from_source_code(&sess, &arena, "test.sol".to_string().into(), src)
                     .expect("failed to create parser");
 
-            parser.set_import_callback(|id, span, import| {
-                imports.push((id, span, import.path.value.as_str().to_string()));
+            parser.set_import_callback(|id, span, path| {
+                imports.push((id, span, path.value.as_str().to_string()));
             });
             let ast = parser.parse_file().expect("failed to parse file");
             drop(parser);

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -22,6 +22,8 @@ mod yul;
 /// Maximum allowed recursive descent depth for selected parser entry points.
 const PARSER_RECURSION_LIMIT: usize = 128;
 
+type ImportCallback<'cb> = dyn FnMut(ast::ItemId, Span, &ast::StrLit) + 'cb;
+
 /// Solidity and Yul parser.
 ///
 /// # Examples
@@ -31,8 +33,6 @@ const PARSER_RECURSION_LIMIT: usize = 128;
 /// # fn main() {}
 #[doc = include_str!("../../doc-examples/parser.rs")]
 /// ```
-type ImportCallback<'cb> = dyn FnMut(ast::ItemId, Span, ast::StrLit) + 'cb;
-
 pub struct Parser<'sess, 'ast, 'cb> {
     /// The parser session.
     pub sess: &'sess Session,
@@ -166,7 +166,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Sets the import callback.
     pub fn set_import_callback(
         &mut self,
-        import_callback: impl FnMut(ast::ItemId, Span, ast::StrLit) + 'cb,
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::StrLit) + 'cb,
     ) {
         self.import_callback = Some(std::boxed::Box::new(import_callback));
     }

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -1214,6 +1214,42 @@ mod tests {
     }
 
     #[test]
+    fn parse_file_import_callback() {
+        let src = r#"
+import "a.sol";
+contract C {}
+import * as B from "b.sol";
+"#;
+
+        let sess =
+            Session::builder().with_buffer_emitter(Default::default()).single_threaded().build();
+        sess.enter_sequential(|| {
+            let arena = ast::Arena::new();
+            let mut parser =
+                Parser::from_source_code(&sess, &arena, "test.sol".to_string().into(), src)
+                    .expect("failed to create parser");
+            let mut imports = Vec::new();
+
+            let ast = parser
+                .parse_file_with_import_callback(|id, span, import| {
+                    imports.push((id, span, import.path.value.as_str().to_string()));
+                })
+                .expect("failed to parse file");
+
+            assert_eq!(ast.items.len(), 3);
+            assert_eq!(imports.len(), 2);
+            assert_eq!(imports[0].0, ast::ItemId::new(0));
+            assert_eq!(imports[0].2, "a.sol");
+            assert_eq!(imports[1].0, ast::ItemId::new(2));
+            assert_eq!(imports[1].2, "b.sol");
+            assert_eq!(
+                sess.source_map().span_to_snippet(imports[0].1).unwrap(),
+                r#"import "a.sol";"#
+            );
+        });
+    }
+
+    #[test]
     fn parse_natspec_line_cmnts() {
         let src = r#"
 /// @title MyContract

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -31,7 +31,9 @@ const PARSER_RECURSION_LIMIT: usize = 128;
 /// # fn main() {}
 #[doc = include_str!("../../doc-examples/parser.rs")]
 /// ```
-pub struct Parser<'sess, 'ast> {
+type ImportCallback<'cb, 'ast> = dyn FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>) + 'cb;
+
+pub struct Parser<'sess, 'ast, 'cb> {
     /// The parser session.
     pub sess: &'sess Session,
     /// The arena where the AST nodes are allocated.
@@ -60,6 +62,8 @@ pub struct Parser<'sess, 'ast> {
 
     /// Current recursion depth for recursive parsing operations.
     recursion_depth: usize,
+    /// Callback invoked after a top-level import directive is parsed.
+    import_callback: Option<std::boxed::Box<ImportCallback<'cb, 'ast>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -137,7 +141,7 @@ pub enum Recovered {
     Yes,
 }
 
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Creates a new parser.
     pub fn new(sess: &'sess Session, arena: &'ast ast::Arena, tokens: Vec<Token>) -> Self {
         assert!(sess.is_entered(), "session should be entered before parsing");
@@ -153,9 +157,18 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             in_yul: false,
             in_contract: false,
             recursion_depth: 0,
+            import_callback: None,
         };
         parser.bump();
         parser
+    }
+
+    /// Sets the import callback.
+    pub fn set_import_callback(
+        &mut self,
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>) + 'cb,
+    ) {
+        self.import_callback = Some(std::boxed::Box::new(import_callback));
     }
 
     /// Creates a new parser from a source code string.
@@ -847,7 +860,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 }
 
 /// Common parsing methods.
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Provides a spanned parser.
     #[track_caller]
     pub fn parse_spanned<T>(
@@ -1225,16 +1238,16 @@ import * as B from "b.sol";
             Session::builder().with_buffer_emitter(Default::default()).single_threaded().build();
         sess.enter_sequential(|| {
             let arena = ast::Arena::new();
+            let mut imports = Vec::new();
             let mut parser =
                 Parser::from_source_code(&sess, &arena, "test.sol".to_string().into(), src)
                     .expect("failed to create parser");
-            let mut imports = Vec::new();
 
-            let ast = parser
-                .parse_file_with_import_callback(|id, span, import| {
-                    imports.push((id, span, import.path.value.as_str().to_string()));
-                })
-                .expect("failed to parse file");
+            parser.set_import_callback(|id, span, import| {
+                imports.push((id, span, import.path.value.as_str().to_string()));
+            });
+            let ast = parser.parse_file().expect("failed to parse file");
+            drop(parser);
 
             assert_eq!(ast.items.len(), 3);
             assert_eq!(imports.len(), 2);

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -5,7 +5,7 @@ use solar_ast::{token::*, *};
 use solar_data_structures::CollectAndApply;
 use solar_interface::{Ident, Span, SpannedOption, kw, sym};
 
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a statement.
     #[instrument(level = "trace", skip_all)]
     pub fn parse_stmt(&mut self) -> PResult<'sess, Stmt<'ast>> {
@@ -437,7 +437,7 @@ struct IndexAccessedPath<'ast> {
 }
 
 impl<'ast> IndexAccessedPath<'ast> {
-    fn into_ty(self, parser: &mut Parser<'_, 'ast>) -> Option<Type<'ast>> {
+    fn into_ty(self, parser: &mut Parser<'_, 'ast, '_>) -> Option<Type<'ast>> {
         // https://github.com/argotorg/solidity/blob/194b114664c7daebc2ff68af3c573272f5d28913/libsolidity/parsing/Parser.cpp#L2617
         let mut path = self.path.into_iter();
         let first = path.next()?;
@@ -477,7 +477,7 @@ impl<'ast> IndexAccessedPath<'ast> {
         Some(ty)
     }
 
-    fn into_expr(self, parser: &mut Parser<'_, 'ast>) -> Option<Box<'ast, Expr<'ast>>> {
+    fn into_expr(self, parser: &mut Parser<'_, 'ast, '_>) -> Option<Box<'ast, Expr<'ast>>> {
         // https://github.com/argotorg/solidity/blob/194b114664c7daebc2ff68af3c573272f5d28913/libsolidity/parsing/Parser.cpp#L2658
         let mut path = self.path.into_iter();
 

--- a/crates/parse/src/parser/ty.rs
+++ b/crates/parse/src/parser/ty.rs
@@ -4,7 +4,7 @@ use solar_ast::{token::*, *};
 use solar_interface::kw;
 use std::{fmt, ops::RangeInclusive};
 
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a type.
     #[instrument(level = "trace", skip_all)]
     pub fn parse_type(&mut self) -> PResult<'sess, Type<'ast>> {

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -6,7 +6,7 @@ use solar_ast::{
 };
 use solar_interface::{Ident, error_code, kw, sym};
 
-impl<'sess, 'ast> Parser<'sess, 'ast> {
+impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a Yul object or plain block.
     ///
     /// The plain block gets returned as a Yul object named "object", with a single `code` block.

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -16,8 +16,6 @@ use solar_parse::{Lexer, Parser, unescape};
 use std::{fmt, path::Path, sync::Arc};
 use thread_local::ThreadLocal;
 
-type ParseImportCallback<'a> = &'a mut dyn FnMut(ast::ItemId, Span, &ast::StrLit);
-
 /// Builder for parsing sources into a [`Compiler`](crate::Compiler).
 ///
 /// Created from [`CompilerRef::parse`](crate::CompilerRef::parse).
@@ -238,18 +236,13 @@ impl<'gcx> ParsingContext<'gcx> {
             let file = source.file.clone();
             let parent = parent_path(&file);
             let mut imports = Vec::new();
-            let mut import_callback = |item_id, _, path: &ast::StrLit| {
+            let ast = self.parse_one(&file, arena, |item_id, _, path| {
                 let _guard = debug_span!("resolve_import").entered();
                 let Some(import_file) = self.resolve_import_path(path, parent) else {
                     return;
                 };
                 imports.push((item_id, import_file));
-            };
-            let ast = self.parse_one(
-                &file,
-                arena,
-                self.resolve_imports.then_some(&mut import_callback as ParseImportCallback<'_>),
-            );
+            });
             if ast.is_some() {
                 for (import_item_id, import_file) in imports {
                     sources.add_import(id, import_item_id, import_file, false);
@@ -300,7 +293,7 @@ impl<'gcx> ParsingContext<'gcx> {
     ) {
         let mut imports = Vec::new();
         let parent = parent_path(&file);
-        let mut import_callback = |item_id, _, path: &ast::StrLit| {
+        let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, path| {
             let _guard = debug_span!("resolve_import").entered();
             let Some(import_file) = self.resolve_import_path(path, parent) else {
                 return;
@@ -314,12 +307,7 @@ impl<'gcx> ParsingContext<'gcx> {
             if is_new {
                 self.spawn_parse_job(lock, import_id, import_file, arenas, scope);
             }
-        };
-        let ast = self.parse_one(
-            &file,
-            arenas.get_or_default(),
-            self.resolve_imports.then_some(&mut import_callback as ParseImportCallback<'_>),
-        );
+        });
 
         // Set AST and add imports.
         let _guard = debug_span!("add_imports").entered();
@@ -339,14 +327,12 @@ impl<'gcx> ParsingContext<'gcx> {
         &self,
         file: &SourceFile,
         arena: &'ast ast::Arena,
-        import_callback: Option<ParseImportCallback<'_>>,
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::StrLit),
     ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);
-        if let Some(import_callback) = import_callback {
-            parser.set_import_callback(move |item_id, span, path| {
-                import_callback(item_id, span, path);
-            });
+        if self.resolve_imports {
+            parser.set_import_callback(import_callback);
         }
         if self.sess.opts.language.is_yul() {
             let _file = parser.parse_yul_file_object().map_err(|e| e.emit());

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -283,23 +283,39 @@ impl<'gcx> ParsingContext<'gcx> {
         arenas: &'ast ThreadLocal<ast::Arena>,
         scope: &rayon::Scope<'scope>,
     ) {
-        // Parse and resolve imports.
-        let ast = self.parse_one(&file, arenas.get_or_default());
-        let imports = {
-            let _guard = debug_span!("resolve_imports").entered();
-            self.resolve_imports(&file, ast.as_ref()).collect::<Vec<_>>()
-        };
+        let mut imports = Vec::new();
+        let parent = parent_path(&file);
+        let ast = self.parse_one_with_import_callback(
+            &file,
+            arenas.get_or_default(),
+            |item_id, _, import| {
+                if !self.resolve_imports {
+                    return;
+                }
+                let _guard = debug_span!("resolve_import").entered();
+                let Some(import_file) = self.resolve_import_directive(import, parent) else {
+                    return;
+                };
+                imports.push((item_id, import_file.clone()));
 
-        // Set AST, add imports and recursively spawn jobs for parsing them if necessary.
+                let (import_id, is_new) = {
+                    let sources = &mut *lock.lock();
+                    sources.get_or_insert_file(import_file.clone())
+                };
+                if is_new {
+                    self.spawn_parse_job(lock, import_id, import_file, arenas, scope);
+                }
+            },
+        );
+
+        // Set AST and add imports.
         let _guard = debug_span!("add_imports").entered();
         let sources = &mut *lock.lock();
         assert!(sources[id].ast.is_none());
         sources[id].ast = ast;
-        for (import_item_id, import_file) in imports {
-            let (import_id, is_new) =
-                sources.add_import(id, import_item_id, import_file.clone(), false);
-            if is_new {
-                self.spawn_parse_job(lock, import_id, import_file, arenas, scope);
+        if sources[id].ast.is_some() {
+            for (import_item_id, import_file) in imports {
+                sources.add_import(id, import_item_id, import_file, false);
             }
         }
     }
@@ -311,13 +327,24 @@ impl<'gcx> ParsingContext<'gcx> {
         file: &SourceFile,
         arena: &'ast ast::Arena,
     ) -> Option<ast::SourceUnit<'ast>> {
+        self.parse_one_with_import_callback(file, arena, |_, _, _| {})
+    }
+
+    /// Parses a single file, calling `import_callback` for every parsed import directive.
+    #[instrument(level = "debug", skip_all, fields(file = %file.name.display()))]
+    fn parse_one_with_import_callback<'ast>(
+        &self,
+        file: &SourceFile,
+        arena: &'ast ast::Arena,
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>),
+    ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);
         if self.sess.opts.language.is_yul() {
             let _file = parser.parse_yul_file_object().map_err(|e| e.emit());
             None
         } else {
-            parser.parse_file().map_err(|e| e.emit()).ok()
+            parser.parse_file_with_import_callback(import_callback).map_err(|e| e.emit()).ok()
         }
     }
 
@@ -328,10 +355,7 @@ impl<'gcx> ParsingContext<'gcx> {
         file: &SourceFile,
         ast: Option<&ast::SourceUnit<'_>>,
     ) -> impl Iterator<Item = (ast::ItemId, Arc<SourceFile>)> {
-        let parent = match &file.name {
-            FileName::Real(path) => Some(path.as_path()),
-            FileName::Stdin | FileName::Custom(_) => None,
-        };
+        let parent = parent_path(file);
         let items =
             ast.filter(|_| self.resolve_imports).map(|ast| &ast.items[..]).unwrap_or_default();
         items
@@ -396,6 +420,13 @@ impl Drop for ParsingContext<'_> {
         // This used to be a call to `bug` but it can be hit legitimately for example when there is
         // an error returned with `?` in between calls to `parse`.
         warn!("`ParsingContext::parse` not called");
+    }
+}
+
+fn parent_path(file: &SourceFile) -> Option<&Path> {
+    match &file.name {
+        FileName::Real(path) => Some(path.as_path()),
+        FileName::Stdin | FileName::Custom(_) => None,
     }
 }
 

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -235,18 +235,16 @@ impl<'gcx> ParsingContext<'gcx> {
 
             let file = source.file.clone();
             let parent = parent_path(&file);
-            let mut imports = Vec::new();
+            let imports_len = sources[id].imports.len();
             let ast = self.parse_one(&file, arena, |item_id, _, path| {
                 let _guard = debug_span!("resolve_import").entered();
                 let Some(import_file) = self.resolve_import_path(path, parent) else {
                     return;
                 };
-                imports.push((item_id, import_file));
+                sources.add_import(id, item_id, import_file, false);
             });
-            if ast.is_some() {
-                for (import_item_id, import_file) in imports {
-                    sources.add_import(id, import_item_id, import_file, false);
-                }
+            if ast.is_none() {
+                sources[id].imports.truncate(imports_len);
             }
             sources[id].ast = ast;
         }

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -236,9 +236,9 @@ impl<'gcx> ParsingContext<'gcx> {
             let file = source.file.clone();
             let parent = parent_path(&file);
             let imports_len = sources[id].imports.len();
-            let ast = self.parse_one(&file, arena, |item_id, _, path| {
+            let ast = self.parse_one(&file, arena, |item_id, _, import| {
                 let _guard = debug_span!("resolve_import").entered();
-                let Some(import_file) = self.resolve_import_path(path, parent) else {
+                let Some(import_file) = self.resolve_import_directive(import, parent) else {
                     return;
                 };
                 sources.add_import(id, item_id, import_file, false);
@@ -291,9 +291,9 @@ impl<'gcx> ParsingContext<'gcx> {
     ) {
         let mut imports = Vec::new();
         let parent = parent_path(&file);
-        let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, path| {
+        let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, import| {
             let _guard = debug_span!("resolve_import").entered();
-            let Some(import_file) = self.resolve_import_path(path, parent) else {
+            let Some(import_file) = self.resolve_import_directive(import, parent) else {
                 return;
             };
             imports.push((item_id, import_file.clone()));
@@ -325,7 +325,7 @@ impl<'gcx> ParsingContext<'gcx> {
         &self,
         file: &SourceFile,
         arena: &'ast ast::Arena,
-        import_callback: impl FnMut(ast::ItemId, Span, &ast::StrLit),
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>),
     ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -16,6 +16,8 @@ use solar_parse::{Lexer, Parser, unescape};
 use std::{fmt, path::Path, sync::Arc};
 use thread_local::ThreadLocal;
 
+type ParseImportCallback<'a> = &'a mut dyn FnMut(ast::ItemId, Span, &ast::StrLit);
+
 /// Builder for parsing sources into a [`Compiler`](crate::Compiler).
 ///
 /// Created from [`CompilerRef::parse`](crate::CompilerRef::parse).
@@ -236,16 +238,18 @@ impl<'gcx> ParsingContext<'gcx> {
             let file = source.file.clone();
             let parent = parent_path(&file);
             let mut imports = Vec::new();
-            let ast = self.parse_one(&file, arena, |item_id, _, path| {
-                if !self.resolve_imports {
-                    return;
-                }
+            let mut import_callback = |item_id, _, path: &ast::StrLit| {
                 let _guard = debug_span!("resolve_import").entered();
                 let Some(import_file) = self.resolve_import_path(path, parent) else {
                     return;
                 };
                 imports.push((item_id, import_file));
-            });
+            };
+            let ast = self.parse_one(
+                &file,
+                arena,
+                self.resolve_imports.then_some(&mut import_callback as ParseImportCallback<'_>),
+            );
             if ast.is_some() {
                 for (import_item_id, import_file) in imports {
                     sources.add_import(id, import_item_id, import_file, false);
@@ -296,10 +300,7 @@ impl<'gcx> ParsingContext<'gcx> {
     ) {
         let mut imports = Vec::new();
         let parent = parent_path(&file);
-        let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, path| {
-            if !self.resolve_imports {
-                return;
-            }
+        let mut import_callback = |item_id, _, path: &ast::StrLit| {
             let _guard = debug_span!("resolve_import").entered();
             let Some(import_file) = self.resolve_import_path(path, parent) else {
                 return;
@@ -313,7 +314,12 @@ impl<'gcx> ParsingContext<'gcx> {
             if is_new {
                 self.spawn_parse_job(lock, import_id, import_file, arenas, scope);
             }
-        });
+        };
+        let ast = self.parse_one(
+            &file,
+            arenas.get_or_default(),
+            self.resolve_imports.then_some(&mut import_callback as ParseImportCallback<'_>),
+        );
 
         // Set AST and add imports.
         let _guard = debug_span!("add_imports").entered();
@@ -333,11 +339,15 @@ impl<'gcx> ParsingContext<'gcx> {
         &self,
         file: &SourceFile,
         arena: &'ast ast::Arena,
-        import_callback: impl FnMut(ast::ItemId, Span, &ast::StrLit),
+        import_callback: Option<ParseImportCallback<'_>>,
     ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);
-        parser.set_import_callback(import_callback);
+        if let Some(import_callback) = import_callback {
+            parser.set_import_callback(move |item_id, span, path| {
+                import_callback(item_id, span, path);
+            });
+        }
         if self.sess.opts.language.is_yul() {
             let _file = parser.parse_yul_file_object().map_err(|e| e.emit());
             None

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -236,7 +236,7 @@ impl<'gcx> ParsingContext<'gcx> {
             let file = source.file.clone();
             let parent = parent_path(&file);
             let mut imports = Vec::new();
-            let ast = self.parse_one_with_import_callback(&file, arena, |item_id, _, path| {
+            let ast = self.parse_one(&file, arena, |item_id, _, path| {
                 if !self.resolve_imports {
                     return;
                 }
@@ -296,28 +296,24 @@ impl<'gcx> ParsingContext<'gcx> {
     ) {
         let mut imports = Vec::new();
         let parent = parent_path(&file);
-        let ast = self.parse_one_with_import_callback(
-            &file,
-            arenas.get_or_default(),
-            |item_id, _, path| {
-                if !self.resolve_imports {
-                    return;
-                }
-                let _guard = debug_span!("resolve_import").entered();
-                let Some(import_file) = self.resolve_import_path(path, parent) else {
-                    return;
-                };
-                imports.push((item_id, import_file.clone()));
+        let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, path| {
+            if !self.resolve_imports {
+                return;
+            }
+            let _guard = debug_span!("resolve_import").entered();
+            let Some(import_file) = self.resolve_import_path(path, parent) else {
+                return;
+            };
+            imports.push((item_id, import_file.clone()));
 
-                let (import_id, is_new) = {
-                    let sources = &mut *lock.lock();
-                    sources.get_or_insert_file(import_file.clone())
-                };
-                if is_new {
-                    self.spawn_parse_job(lock, import_id, import_file, arenas, scope);
-                }
-            },
-        );
+            let (import_id, is_new) = {
+                let sources = &mut *lock.lock();
+                sources.get_or_insert_file(import_file.clone())
+            };
+            if is_new {
+                self.spawn_parse_job(lock, import_id, import_file, arenas, scope);
+            }
+        });
 
         // Set AST and add imports.
         let _guard = debug_span!("add_imports").entered();
@@ -333,11 +329,11 @@ impl<'gcx> ParsingContext<'gcx> {
 
     /// Parses a single file, calling `import_callback` for every parsed import directive.
     #[instrument(level = "debug", skip_all, fields(file = %file.name.display()))]
-    fn parse_one_with_import_callback<'ast>(
+    fn parse_one<'ast>(
         &self,
         file: &SourceFile,
         arena: &'ast ast::Arena,
-        import_callback: impl FnMut(ast::ItemId, Span, ast::StrLit),
+        import_callback: impl FnMut(ast::ItemId, Span, &ast::StrLit),
     ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);
@@ -379,12 +375,12 @@ impl<'gcx> ParsingContext<'gcx> {
         import: &ast::ImportDirective<'_>,
         parent: Option<&Path>,
     ) -> Option<Arc<SourceFile>> {
-        self.resolve_import_path(import.path.clone(), parent)
+        self.resolve_import_path(&import.path, parent)
     }
 
     fn resolve_import_path(
         &self,
-        import_path: ast::StrLit,
+        import_path: &ast::StrLit,
         parent: Option<&Path>,
     ) -> Option<Arc<SourceFile>> {
         let span = import_path.span;

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -233,12 +233,23 @@ impl<'gcx> ParsingContext<'gcx> {
                 continue;
             }
 
-            let ast = self.parse_one(&source.file, arena);
-            let _guard = debug_span!("resolve_imports").entered();
-            for (import_item_id, import_file) in
-                self.resolve_imports(&source.file.clone(), ast.as_ref())
-            {
-                sources.add_import(id, import_item_id, import_file, false);
+            let file = source.file.clone();
+            let parent = parent_path(&file);
+            let mut imports = Vec::new();
+            let ast = self.parse_one_with_import_callback(&file, arena, |item_id, _, path| {
+                if !self.resolve_imports {
+                    return;
+                }
+                let _guard = debug_span!("resolve_import").entered();
+                let Some(import_file) = self.resolve_import_path(path, parent) else {
+                    return;
+                };
+                imports.push((item_id, import_file));
+            });
+            if ast.is_some() {
+                for (import_item_id, import_file) in imports {
+                    sources.add_import(id, import_item_id, import_file, false);
+                }
             }
             sources[id].ast = ast;
         }
@@ -288,12 +299,12 @@ impl<'gcx> ParsingContext<'gcx> {
         let ast = self.parse_one_with_import_callback(
             &file,
             arenas.get_or_default(),
-            |item_id, _, import| {
+            |item_id, _, path| {
                 if !self.resolve_imports {
                     return;
                 }
                 let _guard = debug_span!("resolve_import").entered();
-                let Some(import_file) = self.resolve_import_directive(import, parent) else {
+                let Some(import_file) = self.resolve_import_path(path, parent) else {
                     return;
                 };
                 imports.push((item_id, import_file.clone()));
@@ -320,23 +331,13 @@ impl<'gcx> ParsingContext<'gcx> {
         }
     }
 
-    /// Parses a single file.
-    #[instrument(level = "debug", skip_all, fields(file = %file.name.display()))]
-    fn parse_one<'ast>(
-        &self,
-        file: &SourceFile,
-        arena: &'ast ast::Arena,
-    ) -> Option<ast::SourceUnit<'ast>> {
-        self.parse_one_with_import_callback(file, arena, |_, _, _| {})
-    }
-
     /// Parses a single file, calling `import_callback` for every parsed import directive.
     #[instrument(level = "debug", skip_all, fields(file = %file.name.display()))]
     fn parse_one_with_import_callback<'ast>(
         &self,
         file: &SourceFile,
         arena: &'ast ast::Arena,
-        import_callback: impl FnMut(ast::ItemId, Span, &ast::ImportDirective<'ast>),
+        import_callback: impl FnMut(ast::ItemId, Span, ast::StrLit),
     ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);
@@ -378,8 +379,16 @@ impl<'gcx> ParsingContext<'gcx> {
         import: &ast::ImportDirective<'_>,
         parent: Option<&Path>,
     ) -> Option<Arc<SourceFile>> {
-        let span = import.path.span;
-        let path_str = import.path.value.as_str();
+        self.resolve_import_path(import.path.clone(), parent)
+    }
+
+    fn resolve_import_path(
+        &self,
+        import_path: ast::StrLit,
+        parent: Option<&Path>,
+    ) -> Option<Arc<SourceFile>> {
+        let span = import_path.span;
+        let path_str = import_path.value.as_str();
         let (path_bytes, any_error) =
             unescape::parse_string_literal(path_str, unescape::StrKind::Str, span, self.sess);
         if any_error {

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -340,11 +340,12 @@ impl<'gcx> ParsingContext<'gcx> {
     ) -> Option<ast::SourceUnit<'ast>> {
         let lexer = Lexer::from_source_file(self.sess, file);
         let mut parser = Parser::from_lexer(arena, lexer);
+        parser.set_import_callback(import_callback);
         if self.sess.opts.language.is_yul() {
             let _file = parser.parse_yul_file_object().map_err(|e| e.emit());
             None
         } else {
-            parser.parse_file_with_import_callback(import_callback).map_err(|e| e.emit()).ok()
+            parser.parse_file().map_err(|e| e.emit()).ok()
         }
     }
 

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -327,7 +327,7 @@ impl<'gcx> ParsingContext<'gcx> {
         }
     }
 
-    /// Parses a single file, calling `import_callback` for every parsed import directive.
+    /// Parses a single file.
     #[instrument(level = "debug", skip_all, fields(file = %file.name.display()))]
     fn parse_one<'ast>(
         &self,

--- a/tests/ui/resolve/auxiliary/parallel_import_a.sol
+++ b/tests/ui/resolve/auxiliary/parallel_import_a.sol
@@ -1,0 +1,5 @@
+import {shared} from "./parallel_import_shared.sol";
+
+function a() pure returns (uint256) {
+    return shared();
+}

--- a/tests/ui/resolve/auxiliary/parallel_import_b.sol
+++ b/tests/ui/resolve/auxiliary/parallel_import_b.sol
@@ -1,0 +1,5 @@
+import {shared} from "./parallel_import_shared.sol";
+
+function b() pure returns (uint256) {
+    return shared() + 1;
+}

--- a/tests/ui/resolve/auxiliary/parallel_import_c.sol
+++ b/tests/ui/resolve/auxiliary/parallel_import_c.sol
@@ -1,0 +1,6 @@
+import {a} from "./parallel_import_a.sol";
+import {b} from "./parallel_import_b.sol";
+
+function c() pure returns (uint256) {
+    return a() + b();
+}

--- a/tests/ui/resolve/auxiliary/parallel_import_shared.sol
+++ b/tests/ui/resolve/auxiliary/parallel_import_shared.sol
@@ -1,0 +1,3 @@
+function shared() pure returns (uint256) {
+    return 1;
+}

--- a/tests/ui/resolve/parallel_import_smoke.sol
+++ b/tests/ui/resolve/parallel_import_smoke.sol
@@ -1,0 +1,11 @@
+//@compile-flags: -j8
+
+import "./auxiliary/parallel_import_a.sol" as A;
+import "./auxiliary/parallel_import_b.sol" as B;
+import "./auxiliary/parallel_import_c.sol" as C;
+
+contract ParallelImportSmoke {
+    function f() external pure returns (uint256) {
+        return A.a() + B.b() + C.c();
+    }
+}

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -205,6 +205,13 @@ fn per_file_config(config: &mut ui_test::Config, file: &Spanned<Vec<u8>>, cfg: M
         Spanned::dummy(is_check_fail || has_annotations).into();
     let code = if is_check_fail || (has_annotations && src.contains("ERROR:")) { 1 } else { 0 };
     config.comment_defaults.base().exit_status = Spanned::dummy(code).into();
+
+    if src.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("//@compile-flags:") && (line.contains("-j") || line.contains("--threads"))
+    }) {
+        config.program.args.retain(|arg| arg != "-j1");
+    }
 }
 
 // For solc tests, we can't expect errors normally since we have different diagnostics.


### PR DESCRIPTION
This adds a parser-owned import callback configured through a setter. The callback is invoked for each top-level import path with the final item ID and import span, so callers can resolve imports while parsing instead of walking the completed AST first.

The sema parse path uses this callback to perform import resolution. In parallel parsing, newly discovered imported sources are inserted and scheduled immediately, while dependency edges are still attached after the parent AST succeeds.

On Solady at 92539ab, benchmarking only the top-level `src/Milady.sol` input plus remappings from `forge re` (`forge-std/=test/utils/forge-std/`) reaches 73 Solidity files through 99 import edges. With the default `-j8` parallel parser and `--stop-after parsing`, 100 hyperfine runs measured main at 9.6 ms ± 0.3 ms and this branch at 8.5 ms ± 0.3 ms, a 1.14x ± 0.05 speedup.
