### PR TITLE
fix(sema): expose inherited function selectors

### DIFF
--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -426,6 +426,25 @@ fn super_type(gcx: Gcx<'_>, id: hir::ContractId) -> MemberListOwned<'_> {
     members
 }
 
+pub(crate) fn internal_function_members_in_context<'gcx>(
+    gcx: Gcx<'gcx>,
+    id: hir::FunctionId,
+    current_contract: hir::ContractId,
+) -> MemberListOwned<'gcx> {
+    // Solc exposes `.selector` on internal function types only from a derived contract scope.
+    let function = gcx.hir.function(id);
+    let Some(defining_contract) = function.contract else {
+        return MemberListOwned::default();
+    };
+    if current_contract == defining_contract
+        || !function.is_part_of_external_interface()
+        || !gcx.hir.contract(current_contract).linearized_bases.contains(&defining_contract)
+    {
+        return MemberListOwned::default();
+    }
+    Member::of_builtins(gcx, [Builtin::FunctionSelector])
+}
+
 // `type(T)`
 fn meta<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> MemberListOwned<'gcx> {
     match ty.kind {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -724,15 +724,23 @@ impl<'gcx> Gcx<'gcx> {
         current_contract: Option<hir::ContractId>,
     ) -> Option<members::MemberList<'gcx>> {
         let current_contract = current_contract?;
-        let TyKind::Type(ty) = ty.kind else { return None };
-        let TyKind::Contract(id) = ty.kind else { return None };
-        let contract = self.hir.contract(id);
-        if contract.kind.is_library()
-            || !self.hir.contract(current_contract).linearized_bases.contains(&id)
-        {
-            return None;
+        match ty.kind {
+            TyKind::Type(ty) => {
+                let TyKind::Contract(id) = ty.kind else { return None };
+                let contract = self.hir.contract(id);
+                if contract.kind.is_library()
+                    || !self.hir.contract(current_contract).linearized_bases.contains(&id)
+                {
+                    return None;
+                }
+                Some(self.contract_type_members_in_context((id, current_contract)))
+            }
+            TyKind::Fn(f) if f.kind == TyFnKind::Internal => {
+                let id = f.function_id?;
+                Some(self.internal_function_members_in_context((id, current_contract)))
+            }
+            _ => None,
         }
-        Some(self.contract_type_members_in_context((id, current_contract)))
     }
 
     pub(crate) fn for_each_user_operator(
@@ -1221,6 +1229,14 @@ fn contract_type_members_in_context(
 ) -> members::MemberList<'gcx> {
     let (id, current_contract) = key;
     members::contract_type_members_in_context(gcx, id, current_contract)
+}
+
+fn internal_function_members_in_context(
+    gcx: _,
+    key: (hir::FunctionId, hir::ContractId)
+) -> members::MemberList<'gcx> {
+    let (id, current_contract) = key;
+    gcx.bump().alloc_vec(members::internal_function_members_in_context(gcx, id, current_contract))
 }
 }
 

--- a/tests/ui/typeck/function_calls/contract_type_base_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_base_members.sol
@@ -1,5 +1,7 @@
 //@compile-flags: -Ztypeck
 
+// ported-from: test/libsolidity/semanticTests/functionTypes/selector_1.sol
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/484_function_types_selector_1.sol
 // ported-from: test/libsolidity/syntaxTests/inheritance/override/override_implemented_and_unimplemented_with_implemented_call_via_contract.sol
 
 contract Base {
@@ -14,9 +16,21 @@ contract Base {
     function externalBase(uint256 value) external pure returns (uint256) {
         return value;
     }
+
+    function ownPublicFunctionSelector() public pure returns (bytes4) {
+        return publicBase.selector; //~ ERROR: member `selector` not found
+    }
 }
 
 contract Derived is Base {
+    function inheritedPublicFunctionSelector() public pure returns (bytes4) {
+        return publicBase.selector;
+    }
+
+    function inheritedInternalFunctionSelector() public pure returns (bytes4) {
+        return internalBase.selector; //~ ERROR: member `selector` not found
+    }
+
     function selfTypePublicFunctionSelector() public pure returns (bytes4) {
         return Derived.baseTypePublicFunction.selector; //~ ERROR: member `selector` not found
     }

--- a/tests/ui/typeck/function_calls/contract_type_base_members.stderr
+++ b/tests/ui/typeck/function_calls/contract_type_base_members.stderr
@@ -1,3 +1,15 @@
+error: member `selector` not found on type `function (uint256) pure returns (uint256)`
+   ╭▸ ROOT/tests/ui/typeck/function_calls/contract_type_base_members.sol:LL:CC
+   │
+LL │         return publicBase.selector;
+   ╰╴                          ━━━━━━━━
+
+error: member `selector` not found on type `function (uint256) pure returns (uint256)`
+   ╭▸ ROOT/tests/ui/typeck/function_calls/contract_type_base_members.sol:LL:CC
+   │
+LL │         return internalBase.selector;
+   ╰╴                            ━━━━━━━━
+
 error: member `selector` not found on type `function () pure returns (uint256)`
    ╭▸ ROOT/tests/ui/typeck/function_calls/contract_type_base_members.sol:LL:CC
    │
@@ -16,5 +28,5 @@ error: cannot call function via contract type name
 LL │         AbstractBase.abstractBaseFunction();
    ╰╴        ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This matches solc's context-sensitive selector lookup for function names inherited from a base contract. An unqualified inherited public function name in a derived contract can expose `.selector`, while a function defined on the current contract and inherited internal functions still do not.

The behavior is covered with ports from `semanticTests/functionTypes/selector_1.sol` and `syntaxTests/nameAndTypeResolution/484_function_types_selector_1.sol`. I also checked nearby solc behavior: inherited external functions are not available by unqualified name, inherited internal functions do not expose `.selector`, and an override in the current contract does not expose `.selector` through the unqualified function name.
