### PR TITLE
fix(sema): allow struct NatSpec params

### DIFF
--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -38,9 +38,8 @@ bitflags::bitflags! {
 impl TagPermissions {
     fn from_item_id(item_id: hir::ItemId) -> Self {
         match item_id {
-            hir::ItemId::Contract(_) | hir::ItemId::Struct(_) | hir::ItemId::Enum(_) => {
-                Self::TITLE_AUTHOR | Self::RETURN
-            }
+            hir::ItemId::Contract(_) | hir::ItemId::Enum(_) => Self::TITLE_AUTHOR | Self::RETURN,
+            hir::ItemId::Struct(_) => Self::TITLE_AUTHOR | Self::PARAM | Self::RETURN,
             hir::ItemId::Function(_) => Self::PARAM | Self::INHERITDOC | Self::RETURN,
             hir::ItemId::Variable(_) => Self::INHERITDOC | Self::RETURN,
             hir::ItemId::Event(_) => Self::PARAM,
@@ -220,6 +219,11 @@ impl<'gcx> Resolver<'gcx> {
                     NatSpecKind::Param { name } => {
                         if !permissions.contains(TagPermissions::PARAM) {
                             self.emit_forbidden_tag_error("@param", tag_span, item_id);
+                            continue;
+                        }
+
+                        if matches!(item_id, hir::ItemId::Struct(_)) {
+                            local_tags.push(*natspec);
                             continue;
                         }
 

--- a/tests/ui/natspec/tag_sema.sol
+++ b/tests/ui/natspec/tag_sema.sol
@@ -23,6 +23,8 @@ contract ValidItems {
     /// @title User information
     /// @notice Contains user data
     /// @dev Stored in mapping
+    /// @param addr User address
+    /// @param balance User balance
     struct User {
         address addr;
         uint balance;
@@ -100,4 +102,13 @@ contract InvalidParamName {
     /// @param y Invalid parameter name
     //~^ ERROR: tag `@param` references non-existent parameter 'y'
     function foo(uint x) public {}
+}
+
+contract StructParamDocs {
+    /// @param value Valid field name
+    /// @param value Duplicate struct field docs are accepted for solc compatibility
+    /// @param missing Unknown struct field docs are accepted for solc compatibility
+    struct User {
+        uint value;
+    }
 }


### PR DESCRIPTION
This aligns with what `solc` does.

Without this, `solar` can not compile contracts like `one-step-proof` by `nitro`, or some `lilweb3` contracts from https://github.com/walnuthq/solidity-compiler-benchmarks.