### PR TITLE
feat(sema): add implicit tuple conversions

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1397,29 +1397,3 @@ impl TyFlags {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::Compiler;
-    use solar_interface::{ColorChoice, Session};
-
-    #[test]
-    fn tuple_implicit_conversions_are_element_wise() {
-        let sess =
-            Session::builder().with_buffer_emitter(ColorChoice::Never).single_threaded().build();
-        let compiler = Compiler::new(sess);
-
-        compiler.enter_sequential(|compiler| {
-            let gcx = compiler.gcx();
-            let from = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address_payable, gcx.types.uint(8)]));
-            let to = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address, gcx.types.uint(256)]));
-            assert!(from.try_convert_implicit_to(to, gcx).is_ok());
-
-            let narrowed = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address, gcx.types.uint(8)]));
-            assert!(to.try_convert_implicit_to(narrowed, gcx).is_err());
-
-            let shorter = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address]));
-            assert!(from.try_convert_implicit_to(shorter, gcx).is_err());
-        });
-    }
-}

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -844,6 +844,18 @@ impl<'gcx> Ty<'gcx> {
                 if mutability_ok { Ok(()) } else { Result::Err(TyConvertError::Incompatible) }
             }
 
+            // Tuple conversions: element-wise implicit conversion with same length.
+            // See: <https://docs.soliditylang.org/en/latest/types.html#tuple-types>
+            (Tuple(from_tys), Tuple(to_tys)) => {
+                if from_tys.len() != to_tys.len() {
+                    return Result::Err(TyConvertError::Incompatible);
+                }
+                for (&from_ty, &to_ty) in std::iter::zip(from_tys, to_tys) {
+                    from_ty.try_convert_implicit_to(to_ty, gcx)?;
+                }
+                Ok(())
+            }
+
             _ => Result::Err(TyConvertError::Incompatible),
         }
     }
@@ -1383,5 +1395,31 @@ impl TyFlags {
         for &ty in tys {
             self.add_ty(ty);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Compiler;
+    use solar_interface::{ColorChoice, Session};
+
+    #[test]
+    fn tuple_implicit_conversions_are_element_wise() {
+        let sess =
+            Session::builder().with_buffer_emitter(ColorChoice::Never).single_threaded().build();
+        let compiler = Compiler::new(sess);
+
+        compiler.enter_sequential(|compiler| {
+            let gcx = compiler.gcx();
+            let from = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address_payable, gcx.types.uint(8)]));
+            let to = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address, gcx.types.uint(256)]));
+            assert!(from.try_convert_implicit_to(to, gcx).is_ok());
+
+            let narrowed = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address, gcx.types.uint(8)]));
+            assert!(to.try_convert_implicit_to(narrowed, gcx).is_err());
+
+            let shorter = gcx.mk_ty_tuple(gcx.mk_tys(&[gcx.types.address]));
+            assert!(from.try_convert_implicit_to(shorter, gcx).is_err());
+        });
     }
 }

--- a/tests/ui/typeck/implicit_tuple_conversions.sol
+++ b/tests/ui/typeck/implicit_tuple_conversions.sol
@@ -14,6 +14,10 @@ contract C {
         (uint256 x, uint256 y, uint256 z) = (a, b, c);
     }
 
+    function tupleConditionalCommonType(address payable a, uint8 b, address c, uint256 d, bool cond) public pure {
+        (address x, uint256 y) = cond ? (a, b) : (c, d);
+    }
+
     // === Invalid: tuple type mismatch ===
     function tupleTypeMismatch(uint256 a, address b) public pure {
         (address x, uint256 y) = (
@@ -41,5 +45,10 @@ contract C {
     // === Invalid: tuple length mismatch ===
     function tupleLengthMismatch(uint256 a, uint256 b) public pure {
         (uint256 x, uint256 y, uint256 z) = (a, b); //~ ERROR: mismatched number of components
+    }
+
+    // === Invalid: no common tuple type ===
+    function tupleConditionalNoCommonType(address payable a, uint256 b, address c, uint8 d, bool cond) public pure {
+        cond ? (a, b) : (c, d); //~ ERROR: incompatible conditional types
     }
 }

--- a/tests/ui/typeck/implicit_tuple_conversions.stderr
+++ b/tests/ui/typeck/implicit_tuple_conversions.stderr
@@ -36,5 +36,11 @@ LL │         (uint256 x, uint256 y, uint256 z) = (a, b);
    │                                             │
    ╰╴                                            expected a tuple with 3 elements, found one with 2 elements
 
-error: aborting due to 6 previous errors
+error: incompatible conditional types
+   ╭▸ ROOT/tests/ui/typeck/implicit_tuple_conversions.sol:LL:CC
+   │
+LL │         cond ? (a, b) : (c, d);
+   ╰╴        ━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
This pulls the implicit tuple conversion rule out of the codegen branch so it can land independently.

The rule matches solc's TupleType::isImplicitlyConvertibleTo: tuple types convert only at the same arity, and each source component must be implicitly convertible to the corresponding target component. Coverage lives in the existing implicit tuple conversions UI test, including a conditional tuple common-type case that fails without the conversion rule.
