### PR TITLE
feat: expose expr types after typeck

### DIFF
--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -12,7 +12,6 @@ use solar_data_structures::{
     fmt::{from_fn, or_list},
     map::{FxBuildHasher, FxHashMap, FxHashSet},
     smallvec::SmallVec,
-    sync::RwLock,
     trustme,
 };
 use solar_interface::{
@@ -26,7 +25,7 @@ use std::{
     hash::Hash,
     ops::ControlFlow,
     sync::{
-        Arc,
+        Arc, OnceLock,
         atomic::{AtomicUsize, Ordering},
     },
 };
@@ -226,7 +225,7 @@ pub struct GlobalCtxt<'gcx> {
     stage: AtomicCompilerStage,
 
     pub types: CommonTypes<'gcx>,
-    expr_types: RwLock<FxHashMap<hir::ExprId, Ty<'gcx>>>,
+    expr_types: OnceLock<FxHashMap<hir::ExprId, Ty<'gcx>>>,
 
     pub(crate) ast_arenas: ThreadLocal<ast::Arena>,
     pub(crate) hir_arenas: ThreadLocal<hir::Arena>,
@@ -399,24 +398,12 @@ impl<'gcx> Gcx<'gcx> {
     /// when `-Ztypeck` is enabled.
     #[inline]
     pub fn type_of_expr(self, id: hir::ExprId) -> Option<Ty<'gcx>> {
-        self.expr_types.read().get(&id).copied()
+        self.expr_types.get()?.get(&id).copied()
     }
 
-    pub(crate) fn register_expr_types(
-        self,
-        types: impl IntoIterator<Item = (hir::ExprId, Ty<'gcx>)>,
-    ) {
-        let mut expr_types = self.expr_types.write();
-        for (id, ty) in types {
-            if let Some(prev_ty) = expr_types.insert(id, ty) {
-                self.dcx()
-                    .bug(format!(
-                        "expression {id:?} already has type {}; tried to register {}",
-                        prev_ty.display(self),
-                        ty.display(self),
-                    ))
-                    .emit();
-            }
+    pub(crate) fn set_expr_types(self, types: FxHashMap<hir::ExprId, Ty<'gcx>>) {
+        if self.expr_types.set(types).is_err() {
+            self.dcx().bug("expression types are already initialized").emit();
         }
     }
 

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -12,6 +12,7 @@ use solar_data_structures::{
     fmt::{from_fn, or_list},
     map::{FxBuildHasher, FxHashMap, FxHashSet},
     smallvec::SmallVec,
+    sync::RwLock,
     trustme,
 };
 use solar_interface::{
@@ -225,6 +226,7 @@ pub struct GlobalCtxt<'gcx> {
     stage: AtomicCompilerStage,
 
     pub types: CommonTypes<'gcx>,
+    expr_types: RwLock<FxHashMap<hir::ExprId, Ty<'gcx>>>,
 
     pub(crate) ast_arenas: ThreadLocal<ast::Arena>,
     pub(crate) hir_arenas: ThreadLocal<hir::Arena>,
@@ -258,6 +260,7 @@ impl<'gcx> GlobalCtxt<'gcx> {
                 &interner,
                 unsafe { trustme::decouple_lt(&hir_arenas) }.get_or_default().bump(),
             ),
+            expr_types: Default::default(),
 
             ast_arenas: ThreadLocal::new(),
             hir_arenas,
@@ -388,6 +391,33 @@ impl<'gcx> Gcx<'gcx> {
 
     pub fn mk_ty_fn(self, ptr: TyFn<'gcx>) -> Ty<'gcx> {
         self.mk_ty(TyKind::Fn(self.interner.intern_ty_fn(self.bump(), ptr)))
+    }
+
+    /// Returns the type inferred for the given expression, if available.
+    ///
+    /// Expression types are populated by the experimental type checker, which currently only runs
+    /// when `-Ztypeck` is enabled.
+    #[inline]
+    pub fn type_of_expr(self, id: hir::ExprId) -> Option<Ty<'gcx>> {
+        self.expr_types.read().get(&id).copied()
+    }
+
+    pub(crate) fn register_expr_types(
+        self,
+        types: impl IntoIterator<Item = (hir::ExprId, Ty<'gcx>)>,
+    ) {
+        let mut expr_types = self.expr_types.write();
+        for (id, ty) in types {
+            if let Some(prev_ty) = expr_types.insert(id, ty) {
+                self.dcx()
+                    .bug(format!(
+                        "expression {id:?} already has type {}; tried to register {}",
+                        prev_ty.display(self),
+                        ty.display(self),
+                    ))
+                    .emit();
+            }
+        }
     }
 
     pub fn mk_ty_variadic(self) -> Ty<'gcx> {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -45,6 +45,7 @@ enum AbiDecodeArg {
 pub(super) fn check(gcx: Gcx<'_>, source: hir::SourceId) {
     let mut checker = TypeChecker::new(gcx, source);
     let _ = checker.visit_nested_source(source);
+    gcx.register_expr_types(checker.types);
 }
 
 struct TypeChecker<'gcx> {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -42,10 +42,13 @@ enum AbiDecodeArg {
     Types,
 }
 
-pub(super) fn check(gcx: Gcx<'_>, source: hir::SourceId) {
+pub(super) fn check<'gcx>(
+    gcx: Gcx<'gcx>,
+    source: hir::SourceId,
+) -> FxHashMap<hir::ExprId, Ty<'gcx>> {
     let mut checker = TypeChecker::new(gcx, source);
     let _ = checker.visit_nested_source(source);
-    gcx.register_expr_types(checker.types);
+    checker.types
 }
 
 struct TypeChecker<'gcx> {

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -499,3 +499,84 @@ impl<'gcx> Visit<'gcx> for BreakContinueChecker<'gcx> {
         ControlFlow::Continue(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Compiler, hir::ExprKind};
+    use solar_interface::{
+        Session,
+        config::{Opts, UnstableOpts},
+    };
+    use std::path::PathBuf;
+
+    const SOURCE: &str = r#"
+contract C {
+    function f(uint256 x) public pure returns (uint256) {
+        return x + 1;
+    }
+}
+"#;
+
+    struct FirstBinaryExpr<'hir> {
+        hir: &'hir hir::Hir<'hir>,
+    }
+
+    impl<'hir> Visit<'hir> for FirstBinaryExpr<'hir> {
+        type BreakValue = &'hir hir::Expr<'hir>;
+
+        fn hir(&self) -> &'hir hir::Hir<'hir> {
+            self.hir
+        }
+
+        fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+            if matches!(expr.kind, ExprKind::Binary(..)) {
+                ControlFlow::Break(expr)
+            } else {
+                self.walk_expr(expr)
+            }
+        }
+    }
+
+    fn binary_expr_type(typeck: bool) -> Option<String> {
+        let sess = Session::builder()
+            .opts(Opts {
+                unstable: UnstableOpts { typeck, ..Default::default() },
+                ..Default::default()
+            })
+            .with_test_emitter()
+            .build();
+        let mut compiler = Compiler::new(sess);
+
+        compiler.enter_mut(|c| {
+            let mut pcx = c.parse();
+            let file =
+                c.sess().source_map().new_source_file(PathBuf::from("test.sol"), SOURCE).unwrap();
+            pcx.add_file(file);
+            pcx.parse();
+
+            assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
+            assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
+        });
+
+        compiler.enter(|c| {
+            let gcx = c.gcx();
+            let source = gcx.hir.source_ids().next().unwrap();
+            let mut visitor = FirstBinaryExpr { hir: &gcx.hir };
+            let ControlFlow::Break(expr) = visitor.visit_nested_source(source) else {
+                panic!("missing binary expression")
+            };
+            gcx.type_of_expr(expr.id).map(|ty| ty.display(gcx).to_string())
+        })
+    }
+
+    #[test]
+    fn expression_types_are_available_after_typeck() {
+        assert_eq!(binary_expr_type(true).as_deref(), Some("uint256"));
+    }
+
+    #[test]
+    fn expression_types_are_empty_without_typeck() {
+        assert_eq!(binary_expr_type(false), None);
+    }
+}

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -19,32 +19,68 @@ mod override_checker;
 mod udvt;
 
 pub(crate) fn check(gcx: Gcx<'_>) {
-    parallel!(
-        gcx.sess,
-        gcx.hir.par_contract_ids().for_each(|id| {
-            check_duplicate_definitions(gcx, &gcx.symbol_resolver.contract_scopes[id]);
-            check_storage_size_upper_bound(gcx, id);
-            check_payable_fallback_without_receive(gcx, id);
-            check_external_type_clashes(gcx, id);
-            check_receive_function(gcx, id);
-            for using in gcx.hir.contract(id).usings {
-                check_using_directive(gcx, using);
-            }
-            check_unimplemented_functions(gcx, id);
-            override_checker::check(gcx, id);
-        }),
-        gcx.hir.par_source_ids().for_each(|id| {
-            check_duplicate_definitions(gcx, &gcx.symbol_resolver.source_scopes[id]);
-            check_break_continue(gcx, id);
-            for using in gcx.hir.source(id).usings {
-                check_using_directive(gcx, using);
-            }
-            if gcx.sess.opts.unstable.typeck {
-                // TODO: Parallelize more.
-                checker::check(gcx, id);
-            }
-        }),
-    );
+    let mut expr_types = None;
+    parallel!(gcx.sess, gcx.hir.par_contract_ids().for_each(|id| check_contract(gcx, id)), {
+        if gcx.sess.opts.unstable.typeck {
+            expr_types = Some(
+                gcx.hir
+                    .par_source_ids()
+                    .map(|id| {
+                        check_source(gcx, id);
+                        // TODO: Parallelize more.
+                        checker::check(gcx, id)
+                    })
+                    .reduce(FxHashMap::default, |mut a, b| {
+                        merge_expr_types(gcx, &mut a, b);
+                        a
+                    }),
+            );
+        } else {
+            gcx.hir.par_source_ids().for_each(|id| check_source(gcx, id));
+        }
+    },);
+    if let Some(expr_types) = expr_types {
+        gcx.set_expr_types(expr_types);
+    }
+}
+
+fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
+    check_duplicate_definitions(gcx, &gcx.symbol_resolver.contract_scopes[id]);
+    check_storage_size_upper_bound(gcx, id);
+    check_payable_fallback_without_receive(gcx, id);
+    check_external_type_clashes(gcx, id);
+    check_receive_function(gcx, id);
+    for using in gcx.hir.contract(id).usings {
+        check_using_directive(gcx, using);
+    }
+    check_unimplemented_functions(gcx, id);
+    override_checker::check(gcx, id);
+}
+
+fn check_source(gcx: Gcx<'_>, id: hir::SourceId) {
+    check_duplicate_definitions(gcx, &gcx.symbol_resolver.source_scopes[id]);
+    check_break_continue(gcx, id);
+    for using in gcx.hir.source(id).usings {
+        check_using_directive(gcx, using);
+    }
+}
+
+fn merge_expr_types<'gcx>(
+    gcx: Gcx<'gcx>,
+    expr_types: &mut FxHashMap<hir::ExprId, Ty<'gcx>>,
+    new_expr_types: FxHashMap<hir::ExprId, Ty<'gcx>>,
+) {
+    for (id, ty) in new_expr_types {
+        if let Some(prev_ty) = expr_types.insert(id, ty) {
+            gcx.dcx()
+                .bug(format!(
+                    "expression {id:?} already has type {}; tried to register {}",
+                    prev_ty.display(gcx),
+                    ty.display(gcx),
+                ))
+                .emit();
+        }
+    }
 }
 
 fn check_using_directive<'gcx>(gcx: Gcx<'gcx>, using: &'gcx hir::UsingDirective<'gcx>) {
@@ -517,6 +553,13 @@ contract C {
     }
 }
 "#;
+    const SECOND_SOURCE: &str = r#"
+contract D {
+    function g(uint256 x) public pure returns (uint256) {
+        return x * 2;
+    }
+}
+"#;
 
     struct FirstBinaryExpr<'hir> {
         hir: &'hir hir::Hir<'hir>,
@@ -538,7 +581,7 @@ contract C {
         }
     }
 
-    fn binary_expr_type(typeck: bool) -> Option<String> {
+    fn binary_expr_types(typeck: bool) -> Vec<Option<String>> {
         let sess = Session::builder()
             .opts(Opts {
                 unstable: UnstableOpts { typeck, ..Default::default() },
@@ -553,6 +596,12 @@ contract C {
             let file =
                 c.sess().source_map().new_source_file(PathBuf::from("test.sol"), SOURCE).unwrap();
             pcx.add_file(file);
+            let file = c
+                .sess()
+                .source_map()
+                .new_source_file(PathBuf::from("second.sol"), SECOND_SOURCE)
+                .unwrap();
+            pcx.add_file(file);
             pcx.parse();
 
             assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
@@ -561,22 +610,26 @@ contract C {
 
         compiler.enter(|c| {
             let gcx = c.gcx();
-            let source = gcx.hir.source_ids().next().unwrap();
-            let mut visitor = FirstBinaryExpr { hir: &gcx.hir };
-            let ControlFlow::Break(expr) = visitor.visit_nested_source(source) else {
-                panic!("missing binary expression")
-            };
-            gcx.type_of_expr(expr.id).map(|ty| ty.display(gcx).to_string())
+            gcx.hir
+                .source_ids()
+                .map(|source| {
+                    let mut visitor = FirstBinaryExpr { hir: &gcx.hir };
+                    let ControlFlow::Break(expr) = visitor.visit_nested_source(source) else {
+                        panic!("missing binary expression")
+                    };
+                    gcx.type_of_expr(expr.id).map(|ty| ty.display(gcx).to_string())
+                })
+                .collect()
         })
     }
 
     #[test]
     fn expression_types_are_available_after_typeck() {
-        assert_eq!(binary_expr_type(true).as_deref(), Some("uint256"));
+        assert_eq!(binary_expr_types(true), [Some("uint256".to_string()), Some("uint256".into())]);
     }
 
     #[test]
     fn expression_types_are_empty_without_typeck() {
-        assert_eq!(binary_expr_type(false), None);
+        assert_eq!(binary_expr_types(false), [None, None]);
     }
 }


### PR DESCRIPTION
Expose expr types after typeck, useful in Foundry for chisel and linter.