### PR TITLE
feat: continue after frontend errors

### DIFF
--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -301,26 +301,6 @@ impl<'ast> Visit<'ast> for AstValidator<'_, 'ast> {
             }
         }
 
-        if func.kind.is_receive() {
-            if self.contract.is_some_and(|c| c.kind.is_library()) {
-                self.dcx()
-                    .emit_err(self.item_span, "libraries cannot have receive ether functions");
-            }
-
-            if !func.header.state_mutability().is_payable() {
-                self.dcx()
-                    .err("receive ether function must be payable")
-                    .span(self.item_span)
-                    .help("add `payable` state mutability")
-                    .emit();
-            }
-
-            if !func.header.parameters.is_empty() {
-                self.dcx()
-                    .emit_err(self.item_span, "receive ether function cannot take parameters");
-            }
-        }
-
         if func.header.visibility.is_none()
             && let Some(contract) = self.contract
             && let Some(suggested_visibility) = if func.kind.is_function() {

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -119,6 +119,7 @@ fn analysis(gcx: Gcx<'_>) -> Result<ControlFlow<()>> {
         }
         natspec::validate_item_docs(gcx, id);
     });
+
     typeck::check(gcx);
 
     if !gcx.sess.opts.emit.is_empty() {

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -89,8 +89,6 @@ pub(crate) fn lower(compiler: &mut CompilerRef<'_>) -> Result<ControlFlow<()>> {
         });
     });
 
-    gcx.sess.dcx.has_errors()?;
-
     ast_lowering::lower(compiler.gcx_mut());
 
     Ok(ControlFlow::Continue(()))
@@ -121,14 +119,10 @@ fn analysis(gcx: Gcx<'_>) -> Result<ControlFlow<()>> {
         }
         natspec::validate_item_docs(gcx, id);
     });
-    gcx.sess.dcx.has_errors()?;
-
     typeck::check(gcx);
-    gcx.sess.dcx.has_errors()?;
 
     if !gcx.sess.opts.emit.is_empty() {
         emit::emit(gcx);
-        gcx.sess.dcx.has_errors()?;
     }
 
     Ok(ControlFlow::Continue(()))

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -212,25 +212,12 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
                 self.print(ty)?;
                 write!(self.buf, "[{len}]")
             }
-            TyKind::Err(_) => {
-                assert!(
-                    self.gcx.dcx().has_errors().is_err(),
-                    "trying to print error type and no error has been emitted"
-                );
-                self.buf.write_str("<error>")
-            }
-            TyKind::Mapping(..) => {
-                assert!(
-                    self.gcx.dcx().has_errors().is_err(),
-                    "trying to print mapping type as ABI and no error has been emitted"
-                );
-                self.buf.write_str("<mapping>")
-            }
 
             TyKind::Slice(..)
             | TyKind::StringLiteral(..)
             | TyKind::IntLiteral(..)
             | TyKind::Tuple(_)
+            | TyKind::Mapping(..)
             | TyKind::Super(_)
             | TyKind::Error(..)
             | TyKind::Event(..)
@@ -238,7 +225,14 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
             | TyKind::BuiltinModule(_)
             | TyKind::Variadic
             | TyKind::Type(_)
-            | TyKind::Meta(_) => panic!("printing unsupported type as ABI: {ty:?}"),
+            | TyKind::Meta(_)
+            | TyKind::Err(_) => {
+                assert!(
+                    self.gcx.dcx().has_errors().is_err(),
+                    "printing unsupported type as ABI: {ty:?}"
+                );
+                self.buf.write_str("<error>")
+            }
         }
     }
 

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -219,12 +219,18 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
                 );
                 self.buf.write_str("<error>")
             }
+            TyKind::Mapping(..) => {
+                assert!(
+                    self.gcx.dcx().has_errors().is_err(),
+                    "trying to print mapping type as ABI and no error has been emitted"
+                );
+                self.buf.write_str("<mapping>")
+            }
 
             TyKind::Slice(..)
             | TyKind::StringLiteral(..)
             | TyKind::IntLiteral(..)
             | TyKind::Tuple(_)
-            | TyKind::Mapping(..)
             | TyKind::Super(_)
             | TyKind::Error(..)
             | TyKind::Event(..)

--- a/crates/sema/src/ty/print.rs
+++ b/crates/sema/src/ty/print.rs
@@ -212,6 +212,13 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
                 self.print(ty)?;
                 write!(self.buf, "[{len}]")
             }
+            TyKind::Err(_) => {
+                assert!(
+                    self.gcx.dcx().has_errors().is_err(),
+                    "trying to print error type and no error has been emitted"
+                );
+                self.buf.write_str("<error>")
+            }
 
             TyKind::Slice(..)
             | TyKind::StringLiteral(..)
@@ -225,8 +232,7 @@ impl<'gcx, W: fmt::Write> TyAbiPrinter<'gcx, W> {
             | TyKind::BuiltinModule(_)
             | TyKind::Variadic
             | TyKind::Type(_)
-            | TyKind::Meta(_)
-            | TyKind::Err(_) => panic!("printing unsupported type as ABI: {ty:?}"),
+            | TyKind::Meta(_) => panic!("printing unsupported type as ABI: {ty:?}"),
         }
     }
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -11,7 +11,7 @@ use solar_data_structures::{
     map::{FxHashMap, FxHashSet},
     parallel,
 };
-use solar_interface::{Span, error_code};
+use solar_interface::{Span, diagnostics::ErrorGuaranteed, error_code};
 use std::ops::ControlFlow;
 
 mod checker;
@@ -373,9 +373,13 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 /// Reference: <https://github.com/argotorg/solidity/blob/03e2739809769ae0c8d236a883aadc900da60536/libsolidity/analysis/ContractLevelChecker.cpp#L556C1-L570C2>
 fn check_storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let span = gcx.hir.contract(contract_id).name.span;
-    let Some(total_size) = storage_size_upper_bound(gcx, contract_id) else {
-        gcx.dcx().emit_err(span, "contract requires too much storage");
-        return;
+    let total_size = match storage_size_upper_bound(gcx, contract_id) {
+        Ok(Some(total_size)) => total_size,
+        Ok(None) => {
+            gcx.dcx().emit_err(span, "contract requires too much storage");
+            return;
+        }
+        Err(_) => return,
     };
 
     if gcx.sess.opts.unstable.print_max_storage_sizes {
@@ -387,7 +391,10 @@ fn check_storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     }
 }
 
-fn storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) -> Option<U256> {
+fn storage_size_upper_bound(
+    gcx: Gcx<'_>,
+    contract_id: hir::ContractId,
+) -> Result<Option<U256>, ErrorGuaranteed> {
     let mut total_size = U256::ZERO;
     for item_id in gcx.hir.contract_item_ids(contract_id) {
         // Skip constant and immutable variables
@@ -395,13 +402,15 @@ fn storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) -> Optio
             && !(var.is_constant() || var.is_immutable())
         {
             let ty = gcx.type_of_item(item_id);
-            total_size = total_size.checked_add(ty_storage_size_upper_bound(ty, gcx)?)?;
+            let Some(size) = ty_storage_size_upper_bound(ty, gcx)? else { return Ok(None) };
+            let Some(size) = total_size.checked_add(size) else { return Ok(None) };
+            total_size = size;
         }
     }
-    Some(total_size)
+    Ok(Some(total_size))
 }
 
-fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Option<U256> {
+fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Result<Option<U256>, ErrorGuaranteed> {
     match ty.kind {
         TyKind::Elementary(..)
         | TyKind::StringLiteral(..)
@@ -412,22 +421,28 @@ fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Option<U256> {
         | TyKind::Udvt(..)
         | TyKind::Enum(..)
         | TyKind::Fn(..)
-        | TyKind::DynArray(..) => Some(U256::from(1)),
+        | TyKind::DynArray(..) => Ok(Some(U256::from(1))),
         TyKind::Ref(ty, _) => ty_storage_size_upper_bound(ty, gcx),
         TyKind::Array(ty, uint) => {
             // https://github.com/argotorg/solidity/blob/03e2739809769ae0c8d236a883aadc900da60536/libsolidity/ast/Types.cpp#L1800C1-L1806C2
-            let elem_size = ty_storage_size_upper_bound(ty, gcx)?;
-            uint.checked_mul(elem_size)
+            let Some(elem_size) = ty_storage_size_upper_bound(ty, gcx)? else { return Ok(None) };
+            Ok(uint.checked_mul(elem_size))
         }
         TyKind::Struct(struct_id) => {
             // https://github.com/argotorg/solidity/blob/03e2739809769ae0c8d236a883aadc900da60536/libsolidity/ast/Types.cpp#L2303C1-L2309C2
             let mut total_size = U256::from(1);
             for t in gcx.struct_field_types(struct_id) {
-                let size_contribution = ty_storage_size_upper_bound(*t, gcx)?;
-                total_size = total_size.checked_add(size_contribution)?;
+                let Some(size_contribution) = ty_storage_size_upper_bound(*t, gcx)? else {
+                    return Ok(None);
+                };
+                let Some(size) = total_size.checked_add(size_contribution) else {
+                    return Ok(None);
+                };
+                total_size = size;
             }
-            Some(total_size)
+            Ok(Some(total_size))
         }
+        TyKind::Err(guar) => Err(guar),
 
         TyKind::Slice(..)
         | TyKind::Type(..)
@@ -437,7 +452,6 @@ fn ty_storage_size_upper_bound(ty: Ty<'_>, gcx: Gcx<'_>) -> Option<U256> {
         | TyKind::Variadic
         | TyKind::Event(..)
         | TyKind::Meta(..)
-        | TyKind::Err(..)
         | TyKind::Error(..) => {
             unreachable!()
         }

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_primitives::{B256, U256};
 use rayon::prelude::*;
-use solar_ast::{DataLocation, Visibility};
+use solar_ast::{DataLocation, StateMutability, Visibility};
 use solar_data_structures::{
     Never,
     map::{FxHashMap, FxHashSet},
@@ -352,8 +352,17 @@ fn check_unimplemented_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let contract = gcx.hir.contract(contract_id);
 
+    // Libraries cannot have receive functions
+    if contract.kind.is_library() {
+        if let Some(receive) = contract.receive {
+            gcx.dcx()
+                .emit_err(gcx.item_span(receive), "libraries cannot have receive ether functions");
+        }
+        return;
+    }
     if let Some(receive) = contract.receive {
         let f = gcx.hir.function(receive);
+        // Check visibility
         if f.visibility != Visibility::External {
             gcx.dcx().emit_err(
                 gcx.item_span(receive),
@@ -361,6 +370,22 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
             );
         }
 
+        // Check state mutability
+        if f.state_mutability != StateMutability::Payable {
+            gcx.dcx()
+                .err("receive ether function must be payable")
+                .span(gcx.item_span(receive))
+                .help("add `payable` state mutability")
+                .emit();
+        }
+
+        // Check parameters
+        if !f.parameters.is_empty() {
+            gcx.dcx()
+                .emit_err(gcx.item_span(receive), "receive ether function cannot take parameters");
+        }
+
+        // Check return values
         if !f.returns.is_empty() {
             gcx.dcx()
                 .emit_err(gcx.item_span(receive), "receive ether function cannot return values");

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_primitives::{B256, U256};
 use rayon::prelude::*;
-use solar_ast::{DataLocation, StateMutability, Visibility};
+use solar_ast::{DataLocation, Visibility};
 use solar_data_structures::{
     Never,
     map::{FxHashMap, FxHashSet},
@@ -352,17 +352,8 @@ fn check_unimplemented_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let contract = gcx.hir.contract(contract_id);
 
-    // Libraries cannot have receive functions
-    if contract.kind.is_library() {
-        if let Some(receive) = contract.receive {
-            gcx.dcx()
-                .emit_err(gcx.item_span(receive), "libraries cannot have receive ether functions");
-        }
-        return;
-    }
     if let Some(receive) = contract.receive {
         let f = gcx.hir.function(receive);
-        // Check visibility
         if f.visibility != Visibility::External {
             gcx.dcx().emit_err(
                 gcx.item_span(receive),
@@ -370,22 +361,6 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
             );
         }
 
-        // Check state mutability
-        if f.state_mutability != StateMutability::Payable {
-            gcx.dcx()
-                .err("receive ether function must be payable")
-                .span(gcx.item_span(receive))
-                .help("add `payable` state mutability")
-                .emit();
-        }
-
-        // Check parameters
-        if !f.parameters.is_empty() {
-            gcx.dcx()
-                .emit_err(gcx.item_span(receive), "receive ether function cannot take parameters");
-        }
-
-        // Check return values
         if !f.returns.is_empty() {
             gcx.dcx()
                 .emit_err(gcx.item_span(receive), "receive ether function cannot return values");

--- a/tests/ui/lexer/string_escapes_crlf.sol
+++ b/tests/ui/lexer/string_escapes_crlf.sol
@@ -3,8 +3,10 @@
 // Escaped - OK
 string constant s = "\
 ";
+//~v ERROR: identifier `s` already declared
 string constant s = unicode"\
 ";
+//~v ERROR: identifier `s` already declared
 bytes constant s = hex"\
 ";
 //~^^ ERROR: invalid hex digit
@@ -13,12 +15,14 @@ bytes constant s = hex"\
 // 3x for \\, \r, \n
 
 // Escaped, but can only escape one newline
+//~v ERROR: identifier `s` already declared
 string constant s = "\
 
 "; //~^ ERROR: cannot skip multiple lines
 string constant s = unicode"\
 
 "; //~^ ERROR: cannot skip multiple lines
+//~^^^ ERROR: identifier `s` already declared
 bytes constant s = hex"\
 
 ";
@@ -27,15 +31,19 @@ bytes constant s = hex"\
 //~| ERROR: invalid hex digit
 //~^^^^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
+//~^^^^^^^^ ERROR: identifier `s` already declared
 // 5x for \\, \r, \n, \r, \n
 
 // Unescaped
+//~v ERROR: identifier `s` already declared
 string constant s = "
 "; //~^ ERROR: unescaped newline
 string constant s = unicode"
 "; //~^ ERROR: unescaped newline
+//~^^ ERROR: identifier `s` already declared
 bytes constant s = hex"
 ";
 //~^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
+//~^^^^ ERROR: identifier `s` already declared
 // 2x for \r, \n

--- a/tests/ui/lexer/string_escapes_crlf.sol
+++ b/tests/ui/lexer/string_escapes_crlf.sol
@@ -1,13 +1,11 @@
 //@ignore-host: windows
 
 // Escaped - OK
-string constant s = "\
+string constant s1 = "\
 ";
-//~v ERROR: identifier `s` already declared
-string constant s = unicode"\
+string constant s2 = unicode"\
 ";
-//~v ERROR: identifier `s` already declared
-bytes constant s = hex"\
+bytes constant b1 = hex"\
 ";
 //~^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
@@ -15,15 +13,13 @@ bytes constant s = hex"\
 // 3x for \\, \r, \n
 
 // Escaped, but can only escape one newline
-//~v ERROR: identifier `s` already declared
-string constant s = "\
+string constant s3 = "\
 
 "; //~^ ERROR: cannot skip multiple lines
-string constant s = unicode"\
+string constant s4 = unicode"\
 
 "; //~^ ERROR: cannot skip multiple lines
-//~^^^ ERROR: identifier `s` already declared
-bytes constant s = hex"\
+bytes constant b2 = hex"\
 
 ";
 //~^^^ ERROR: invalid hex digit
@@ -31,19 +27,15 @@ bytes constant s = hex"\
 //~| ERROR: invalid hex digit
 //~^^^^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
-//~^^^^^^^^ ERROR: identifier `s` already declared
 // 5x for \\, \r, \n, \r, \n
 
 // Unescaped
-//~v ERROR: identifier `s` already declared
-string constant s = "
+string constant s5 = "
 "; //~^ ERROR: unescaped newline
-string constant s = unicode"
+string constant s6 = unicode"
 "; //~^ ERROR: unescaped newline
-//~^^ ERROR: identifier `s` already declared
-bytes constant s = hex"
+bytes constant b3 = hex"
 ";
 //~^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
-//~^^^^ ERROR: identifier `s` already declared
 // 2x for \r, \n

--- a/tests/ui/lexer/string_escapes_crlf.stderr
+++ b/tests/ui/lexer/string_escapes_crlf.stderr
@@ -95,5 +95,101 @@ LL │   bytes constant s = hex"
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: aborting due to 14 previous errors
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = unicode"\
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ bytes constant s = hex"\
+   │                ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = unicode"\
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ bytes constant s = hex"\
+   │                ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = unicode"
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ bytes constant s = hex"
+   │                ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: aborting due to 22 previous errors
 

--- a/tests/ui/lexer/string_escapes_crlf.stderr
+++ b/tests/ui/lexer/string_escapes_crlf.stderr
@@ -1,20 +1,20 @@
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │ bytes constant s = hex"\
-   ╰╴                       ━
-
-error: invalid hex digit
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"\
+LL │ bytes constant b1 = hex"\
    ╰╴                        ━
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │   bytes constant s = hex"\
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │ bytes constant b1 = hex"\
+   ╰╴                         ━
+
+error: invalid hex digit
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │   bytes constant b1 = hex"\
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
@@ -35,20 +35,20 @@ LL │ ┃ ";
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │ bytes constant s = hex"\
-   ╰╴                       ━
-
-error: invalid hex digit
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"\
+LL │ bytes constant b2 = hex"\
    ╰╴                        ━
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │   bytes constant s = hex"\
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │ bytes constant b2 = hex"\
+   ╰╴                         ━
+
+error: invalid hex digit
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
+   │
+LL │   bytes constant b2 = hex"\
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃
    ╰╴┗━┛
 
@@ -68,128 +68,32 @@ LL │ ┃ ";
 error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │   string constant s = "
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   string constant s5 = "
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
 error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │   string constant s = unicode"
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   string constant s6 = unicode"
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │ bytes constant s = hex"
-   ╰╴                       ━
+LL │ bytes constant b3 = hex"
+   ╰╴                        ━
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
-LL │   bytes constant s = hex"
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   bytes constant b3 = hex"
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = unicode"\
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"\
-   │                ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = unicode"\
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"\
-   │                ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = unicode"
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"
-   │                ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: aborting due to 22 previous errors
+error: aborting due to 14 previous errors
 

--- a/tests/ui/lexer/string_escapes_lf.sol
+++ b/tests/ui/lexer/string_escapes_lf.sol
@@ -1,8 +1,10 @@
 // Escaped - OK
 string constant s = "\
 ";
+//~v ERROR: identifier `s` already declared
 string constant s = unicode"\
 ";
+//~v ERROR: identifier `s` already declared
 bytes constant s = hex"\
 ";
 //~^^ ERROR: invalid hex digit
@@ -10,26 +12,32 @@ bytes constant s = hex"\
 // 2 for \\, \n
 
 // Escaped, but can only escape one newline
+//~v ERROR: identifier `s` already declared
 string constant s = "\
 
 "; //~^ ERROR: cannot skip multiple lines
 string constant s = unicode"\
 
 "; //~^ ERROR: cannot skip multiple lines
+//~^^^ ERROR: identifier `s` already declared
 bytes constant s = hex"\
 
 ";
 //~^^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
 //~^^^^ ERROR: invalid hex digit
+//~^^^^^^ ERROR: identifier `s` already declared
 // 3x for \\, \n, \n
 
 // Unescaped
+//~v ERROR: identifier `s` already declared
 string constant s = "
 "; //~^ ERROR: unescaped newline
 string constant s = unicode"
 "; //~^ ERROR: unescaped newline
+//~^^ ERROR: identifier `s` already declared
 bytes constant s = hex"
 ";
 //~^^ ERROR: invalid hex digit
+//~^^^ ERROR: identifier `s` already declared
 // 1x for \n

--- a/tests/ui/lexer/string_escapes_lf.sol
+++ b/tests/ui/lexer/string_escapes_lf.sol
@@ -1,43 +1,35 @@
 // Escaped - OK
-string constant s = "\
+string constant s1 = "\
 ";
-//~v ERROR: identifier `s` already declared
-string constant s = unicode"\
+string constant s2 = unicode"\
 ";
-//~v ERROR: identifier `s` already declared
-bytes constant s = hex"\
+bytes constant b1 = hex"\
 ";
 //~^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
 // 2 for \\, \n
 
 // Escaped, but can only escape one newline
-//~v ERROR: identifier `s` already declared
-string constant s = "\
+string constant s3 = "\
 
 "; //~^ ERROR: cannot skip multiple lines
-string constant s = unicode"\
+string constant s4 = unicode"\
 
 "; //~^ ERROR: cannot skip multiple lines
-//~^^^ ERROR: identifier `s` already declared
-bytes constant s = hex"\
+bytes constant b2 = hex"\
 
 ";
 //~^^^ ERROR: invalid hex digit
 //~| ERROR: invalid hex digit
 //~^^^^ ERROR: invalid hex digit
-//~^^^^^^ ERROR: identifier `s` already declared
 // 3x for \\, \n, \n
 
 // Unescaped
-//~v ERROR: identifier `s` already declared
-string constant s = "
+string constant s5 = "
 "; //~^ ERROR: unescaped newline
-string constant s = unicode"
+string constant s6 = unicode"
 "; //~^ ERROR: unescaped newline
-//~^^ ERROR: identifier `s` already declared
-bytes constant s = hex"
+bytes constant b3 = hex"
 ";
 //~^^ ERROR: invalid hex digit
-//~^^^ ERROR: identifier `s` already declared
 // 1x for \n

--- a/tests/ui/lexer/string_escapes_lf.stderr
+++ b/tests/ui/lexer/string_escapes_lf.stderr
@@ -1,14 +1,14 @@
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │ bytes constant s = hex"\
-   ╰╴                       ━
+LL │ bytes constant b1 = hex"\
+   ╰╴                        ━
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │   bytes constant s = hex"\
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   bytes constant b1 = hex"\
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
@@ -29,14 +29,14 @@ LL │ ┃ ";
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │ bytes constant s = hex"\
-   ╰╴                       ━
+LL │ bytes constant b2 = hex"\
+   ╰╴                        ━
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │   bytes constant s = hex"\
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   bytes constant b2 = hex"\
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃
    ╰╴┗━┛
 
@@ -50,122 +50,26 @@ LL │ ┃ ";
 error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │   string constant s = "
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   string constant s5 = "
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
 error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │   string constant s = unicode"
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   string constant s6 = unicode"
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
 error: invalid hex digit
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
-LL │   bytes constant s = hex"
-   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━┛
+LL │   bytes constant b3 = hex"
+   │ ┏━━━━━━━━━━━━━━━━━━━━━━━━━┛
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = unicode"\
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"\
-   │                ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = unicode"\
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"\
-   │                ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = unicode"
-   │                 ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: identifier `s` already declared
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ bytes constant s = hex"
-   │                ━
-   ╰╴
-note: previous declaration declared here
-   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
-   │
-LL │ string constant s = "\
-   ╰╴                ━
-
-error: aborting due to 18 previous errors
+error: aborting due to 10 previous errors
 

--- a/tests/ui/lexer/string_escapes_lf.stderr
+++ b/tests/ui/lexer/string_escapes_lf.stderr
@@ -71,5 +71,101 @@ LL │   bytes constant s = hex"
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: aborting due to 10 previous errors
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = unicode"\
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ bytes constant s = hex"\
+   │                ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = unicode"\
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ bytes constant s = hex"\
+   │                ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = unicode"
+   │                 ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: identifier `s` already declared
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ bytes constant s = hex"
+   │                ━
+   ╰╴
+note: previous declaration declared here
+   ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
+   │
+LL │ string constant s = "\
+   ╰╴                ━
+
+error: aborting due to 18 previous errors
 

--- a/tests/ui/parser/already_specified.sol
+++ b/tests/ui/parser/already_specified.sol
@@ -1,10 +1,10 @@
 contract C
-    is A
+    is A //~ ERROR: unresolved symbol `A`
     is B //~ ERROR: base contracts already specified
     layout at 0
     layout at 1 //~ ERROR: storage layout already specified
 {
-    function f()
+    function f() //~ ERROR: Function has override specified but does not override anything
     public
     private //~ ERROR: visibility already specified
 
@@ -18,7 +18,7 @@ contract C
     override //~ ERROR: override already specified
     {}
 
-    uint
+    uint //~ ERROR: public state variable has override specified but does not override anything
     public
     private //~ ERROR: visibility already specified
 

--- a/tests/ui/parser/already_specified.stderr
+++ b/tests/ui/parser/already_specified.stderr
@@ -70,5 +70,33 @@ error: override already specified
 LL │     override
    ╰╴    ━━━━━━━━
 
-error: aborting due to 10 previous errors
+error: unresolved symbol `A`
+   ╭▸ ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   │
+LL │     is A
+   ╰╴       ━
+
+error[7792]: Function has override specified but does not override anything
+   ╭▸ ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   │
+LL │ ┏     function f()
+LL │ ┃     public
+LL │ ┃     private
+   ‡ ┃
+LL │ ┃     override
+LL │ ┃     {}
+   ╰╴┗━━━━━━┛
+
+error[7792]: public state variable has override specified but does not override anything
+   ╭▸ ROOT/tests/ui/parser/already_specified.sol:LL:CC
+   │
+LL │ ┏     uint
+LL │ ┃     public
+LL │ ┃     private
+   ‡ ┃
+LL │ ┃     override
+LL │ ┃     x = 0;
+   ╰╴┗━━━━━━━━━━┛
+
+error: aborting due to 13 previous errors
 

--- a/tests/ui/parser/using.sol
+++ b/tests/ui/parser/using.sol
@@ -1,14 +1,12 @@
 using {f} for * global; //~ ERROR: can only globally attach functions to specific types
 //~^ ERROR: the type has to be specified explicitly at file level (cannot use `*`)
-//~| ERROR: expected function name
-function f(uint) pure {} //~ ERROR: function with same name and parameter types declared twice
+function f(uint) pure {}
 
 contract C {
     using {f} for uint global; //~ ERROR: `global` can only be used at file level
-    //~^ ERROR: expected function name
-    //~| ERROR: can only use `global` with user-defined types
+    //~^ ERROR: can only use `global` with user-defined types
 }
-function f(uint) pure {}
+function f2(uint) pure {}
 
 interface I2 {
     using L for int; //~ ERROR: the `using for` directive is not allowed inside interfaces

--- a/tests/ui/parser/using.sol
+++ b/tests/ui/parser/using.sol
@@ -1,13 +1,17 @@
 using {f} for * global; //~ ERROR: can only globally attach functions to specific types
 //~^ ERROR: the type has to be specified explicitly at file level (cannot use `*`)
-function f(uint) pure {}
+//~| ERROR: expected function name
+function f(uint) pure {} //~ ERROR: function with same name and parameter types declared twice
 
 contract C {
     using {f} for uint global; //~ ERROR: `global` can only be used at file level
+    //~^ ERROR: expected function name
+    //~| ERROR: can only use `global` with user-defined types
 }
 function f(uint) pure {}
 
 interface I2 {
     using L for int; //~ ERROR: the `using for` directive is not allowed inside interfaces
+    //~^ ERROR: unresolved symbol `L`
     function g() external;
 }

--- a/tests/ui/parser/using.stderr
+++ b/tests/ui/parser/using.stderr
@@ -22,35 +22,11 @@ error: the `using for` directive is not allowed inside interfaces
 LL │     using L for int;
    ╰╴    ━━━━━━━━━━━━━━━━
 
-error: expected function name
-   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
-   │
-LL │ using {f} for * global;
-   ╰╴       ━
-
-error: expected function name
-   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
-   │
-LL │     using {f} for uint global;
-   ╰╴           ━
-
 error: unresolved symbol `L`
    ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
    │
 LL │     using L for int;
    ╰╴          ━
-
-error: function with same name and parameter types declared twice
-   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
-   │
-LL │ function f(uint) pure {}
-   │          ━
-   ╰╴
-note: other declaration
-   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
-   │
-LL │ function f(uint) pure {}
-   ╰╴         ━
 
 error: can only use `global` with user-defined types
    ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
@@ -58,5 +34,5 @@ error: can only use `global` with user-defined types
 LL │     using {f} for uint global;
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 9 previous errors
+error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/using.stderr
+++ b/tests/ui/parser/using.stderr
@@ -22,5 +22,41 @@ error: the `using for` directive is not allowed inside interfaces
 LL │     using L for int;
    ╰╴    ━━━━━━━━━━━━━━━━
 
-error: aborting due to 4 previous errors
+error: expected function name
+   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
+   │
+LL │ using {f} for * global;
+   ╰╴       ━
+
+error: expected function name
+   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
+   │
+LL │     using {f} for uint global;
+   ╰╴           ━
+
+error: unresolved symbol `L`
+   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
+   │
+LL │     using L for int;
+   ╰╴          ━
+
+error: function with same name and parameter types declared twice
+   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
+   │
+LL │ function f(uint) pure {}
+   │          ━
+   ╰╴
+note: other declaration
+   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
+   │
+LL │ function f(uint) pure {}
+   ╰╴         ━
+
+error: can only use `global` with user-defined types
+   ╭▸ ROOT/tests/ui/parser/using.sol:LL:CC
+   │
+LL │     using {f} for uint global;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/parser/yul/bare_evm_builtin.sol
+++ b/tests/ui/parser/yul/bare_evm_builtin.sol
@@ -3,8 +3,11 @@ contract C {
     function f() external view returns (uint id, address a, uint g) {
         assembly {
             id := chainid //~ ERROR: builtin function `chainid` must be called
+            //~^ ERROR: unresolved symbol `chainid`
             a := caller //~ ERROR: builtin function `caller` must be called
+            //~^ ERROR: unresolved symbol `caller`
             g := gas //~ ERROR: builtin function `gas` must be called
+            //~^ ERROR: unresolved symbol `gas`
         }
     }
 }

--- a/tests/ui/parser/yul/bare_evm_builtin.stderr
+++ b/tests/ui/parser/yul/bare_evm_builtin.stderr
@@ -16,5 +16,23 @@ error: builtin function `gas` must be called
 LL │             g := gas
    ╰╴                 ━━━
 
-error: aborting due to 3 previous errors
+error: unresolved symbol `chainid`
+   ╭▸ ROOT/tests/ui/parser/yul/bare_evm_builtin.sol:LL:CC
+   │
+LL │             id := chainid
+   ╰╴                  ━━━━━━━
+
+error: unresolved symbol `caller`
+   ╭▸ ROOT/tests/ui/parser/yul/bare_evm_builtin.sol:LL:CC
+   │
+LL │             a := caller
+   ╰╴                 ━━━━━━
+
+error: unresolved symbol `gas`
+   ╭▸ ROOT/tests/ui/parser/yul/bare_evm_builtin.sol:LL:CC
+   │
+LL │             g := gas
+   ╰╴                 ━━━
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/parser/yul/kws_err.sol
+++ b/tests/ui/parser/yul/kws_err.sol
@@ -3,9 +3,13 @@ contract C {
         assembly {
             number := 0
             //~^ ERROR: expected identifier, found Yul EVM builtin keyword `number`
+            //~| ERROR: unresolved symbol `number`
             number, number := some_call()
             //~^ ERROR: expected identifier, found Yul EVM builtin keyword `number`
             //~| ERROR: expected identifier, found Yul EVM builtin keyword `number`
+            //~| ERROR: unresolved symbol `number`
+            //~| ERROR: unresolved symbol `number`
+            //~| ERROR: unresolved symbol `some_call`
             let number := 0
             //~^ ERROR: expected identifier, found Yul EVM builtin keyword `number`
         }

--- a/tests/ui/parser/yul/kws_err.stderr
+++ b/tests/ui/parser/yul/kws_err.stderr
@@ -22,5 +22,29 @@ error: expected identifier, found Yul EVM builtin keyword `number`
 LL │             let number := 0
    ╰╴                ━━━━━━
 
-error: aborting due to 4 previous errors
+error: unresolved symbol `number`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_err.sol:LL:CC
+   │
+LL │             number := 0
+   ╰╴            ━━━━━━
+
+error: unresolved symbol `number`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_err.sol:LL:CC
+   │
+LL │             number, number := some_call()
+   ╰╴            ━━━━━━
+
+error: unresolved symbol `number`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_err.sol:LL:CC
+   │
+LL │             number, number := some_call()
+   ╰╴                    ━━━━━━
+
+error: unresolved symbol `some_call`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_err.sol:LL:CC
+   │
+LL │             number, number := some_call()
+   ╰╴                              ━━━━━━━━━
+
+error: aborting due to 8 previous errors
 

--- a/tests/ui/resolve/func_visibility.sol
+++ b/tests/ui/resolve/func_visibility.sol
@@ -16,6 +16,7 @@ contract U3 {
 
 contract U4 {
     receive() payable {} //~ERROR: no visibility specified
+    //~^ ERROR: receive ether function must be defined as `external`
 }
 
 contract U5 {

--- a/tests/ui/resolve/func_visibility.stderr
+++ b/tests/ui/resolve/func_visibility.stderr
@@ -44,5 +44,11 @@ error: free functions must be implemented
 LL │ function xyz();
    ╰╴━━━━━━━━━━━━━━━
 
-error: aborting due to 6 previous errors
+error: receive ether function must be defined as `external`
+   ╭▸ ROOT/tests/ui/resolve/func_visibility.sol:LL:CC
+   │
+LL │     receive() payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/resolve/inheritance_conflicts.sol
+++ b/tests/ui/resolve/inheritance_conflicts.sol
@@ -1,9 +1,12 @@
 contract A {
-    uint public x = 0;
+    uint public x = 0; //~ ERROR: cannot override non-virtual function
+    //~^ ERROR: cannot override public state variable
 }
 
 contract B is A {
     uint public x = 1; //~ ERROR: identifier `x` already declared
+    //~^ ERROR: overriding public state variable is missing `override` specifier
+    //~| ERROR: overriding public state variable is missing `override` specifier
 }
 
 contract AA {
@@ -14,4 +17,4 @@ contract BB {
     uint public y = 3; //~ ERROR: identifier `y` already declared
 }
 
-contract CC is AA, BB {}
+contract CC is AA, BB {} //~ ERROR: derived contract must override function `y`

--- a/tests/ui/resolve/inheritance_conflicts.stderr
+++ b/tests/ui/resolve/inheritance_conflicts.stderr
@@ -22,5 +22,67 @@ note: previous declaration declared here
 LL │     uint public y = 2;
    ╰╴                ━
 
-error: aborting due to 2 previous errors
+error[9456]: overriding public state variable is missing `override` specifier
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 1;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: overridden function is here
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 0;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰ help: add `override` to the function signature
+
+error[4334]: cannot override non-virtual function
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 0;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: overriding public state variable is here
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 1;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰ help: add `virtual` to the base function to allow overriding
+
+error[9456]: overriding public state variable is missing `override` specifier
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 1;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: overridden public state variable is here
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 0;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰ help: add `override` to the function signature
+
+error[1452]: cannot override public state variable
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 0;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: overriding public state variable is here
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │     uint public x = 1;
+   │     ━━━━━━━━━━━━━━━━━━
+   ╰ help: change the inheritance layout or rename the functions
+
+error[6480]: derived contract must override function `y`
+   ╭▸ ROOT/tests/ui/resolve/inheritance_conflicts.sol:LL:CC
+   │
+LL │ contract CC is AA, BB {}
+   │          ━━
+   │
+   ├ note: two or more base classes define function with same name and parameter types
+   ├ note: defined in: `AA`, `BB`
+   ╰ help: since one of the bases defines a public state variable which cannot be overridden, change the inheritance layout or rename the functions
+
+error: aborting due to 7 previous errors
 

--- a/tests/ui/standard-json/no-io-import.jsonc
+++ b/tests/ui/standard-json/no-io-import.jsonc
@@ -1,5 +1,6 @@
 // CHECK: "errors": [
 // CHECK: "message": "file tests/ui/standard-json/auxiliary/on-disk.sol not found"
+// CHECK: "message": "unresolved symbol `OnDisk`"
 // CHECK-NOT: "contracts"
 {
   "language": "Solidity",

--- a/tests/ui/standard-json/no-io-import.stdout
+++ b/tests/ui/standard-json/no-io-import.stdout
@@ -13,6 +13,20 @@
       "errorCode": null,
       "message": "file tests/ui/standard-json/auxiliary/on-disk.sol not found",
       "formattedMessage": "error: file tests/ui/standard-json/auxiliary/on-disk.sol not found\n   ╭▸ A.sol:LL:CC\n   │\nLL │ import \"tests/ui/standard-json/auxiliary/on-disk.sol\"; contract A is OnDisk {}\n   ╰╴       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"
+    },
+    {
+      "sourceLocation": {
+        "file": "A.sol",
+        "start": 69,
+        "end": 75
+      },
+      "secondarySourceLocations": [],
+      "type": "Exception",
+      "component": "general",
+      "severity": "error",
+      "errorCode": null,
+      "message": "unresolved symbol `OnDisk`",
+      "formattedMessage": "error: unresolved symbol `OnDisk`\n   ╭▸ A.sol:LL:CC\n   │\nLL │ import \"tests/ui/standard-json/auxiliary/on-disk.sol\"; contract A is OnDisk {}\n   ╰╴                                                                     ━━━━━━\n\n"
     }
   ],
   "sources": {

--- a/tests/ui/using-for/imports/imported_duplicate_operator.sol
+++ b/tests/ui/using-for/imports/imported_duplicate_operator.sol
@@ -8,3 +8,4 @@ function add2(Int a, Int b) pure returns (Int) {
 }
 
 using {add2 as +} for Int; //~ ERROR: operators can only be defined in a global
+//~^ ERROR: user-defined binary operator `+` has more than one definition

--- a/tests/ui/using-for/imports/imported_duplicate_operator.stderr
+++ b/tests/ui/using-for/imports/imported_duplicate_operator.stderr
@@ -4,5 +4,11 @@ error: operators can only be defined in a global `using for` directive
 LL │ using {add2 as +} for Int;
    ╰╴       ━━━━
 
-error: aborting due to 1 previous error
+error: user-defined binary operator `+` has more than one definition matching the operand type visible in the current scope
+   ╭▸ ROOT/tests/ui/using-for/imports/imported_duplicate_operator.sol:LL:CC
+   │
+LL │ using {add2 as +} for Int;
+   ╰╴       ━━━━
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/using-for/imports/imported_non_global_operator_definition.sol
+++ b/tests/ui/using-for/imports/imported_non_global_operator_definition.sol
@@ -8,10 +8,10 @@ import {DefinedInt} from "./auxiliary/defined_non_global_operator.sol";
 
 contract C {
     function binary(DefinedInt a, DefinedInt b) public pure returns (DefinedInt) {
-        return a + b;
+        return a + b; //~ ERROR: cannot apply builtin operator `+`
     }
 
     function unary(DefinedInt a) public pure returns (DefinedInt) {
-        return -a;
+        return -a; //~ ERROR: cannot apply unary operator `-`
     }
 }

--- a/tests/ui/using-for/imports/imported_non_global_operator_definition.stderr
+++ b/tests/ui/using-for/imports/imported_non_global_operator_definition.stderr
@@ -10,5 +10,19 @@ error: operators can only be defined in a global `using for` directive
 LL │ using {add as +, neg as -} for DefinedInt;
    ╰╴                 ━━━
 
-error: aborting due to 2 previous errors
+error: cannot apply builtin operator `+` to `DefinedInt` and `DefinedInt`
+   ╭▸ ROOT/tests/ui/using-for/imports/imported_non_global_operator_definition.sol:LL:CC
+   │
+LL │         return a + b;
+   │                ┬ ━ ─ DefinedInt
+   │                │
+   ╰╴               DefinedInt
+
+error: cannot apply unary operator `-` to `DefinedInt`
+   ╭▸ ROOT/tests/ui/using-for/imports/imported_non_global_operator_definition.sol:LL:CC
+   │
+LL │         return -a;
+   ╰╴               ━━
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/using-for/imports/transitive_non_global_operator.sol
+++ b/tests/ui/using-for/imports/transitive_non_global_operator.sol
@@ -11,10 +11,10 @@ import "./auxiliary/non_global_right.sol";
 
 contract C {
     function binary(TransitiveInt a, TransitiveInt b) public pure returns (TransitiveInt) {
-        return a + b;
+        return a + b; //~ ERROR: cannot apply builtin operator `+`
     }
 
     function unary(TransitiveInt a) public pure returns (TransitiveInt) {
-        return -a;
+        return -a; //~ ERROR: cannot apply unary operator `-`
     }
 }

--- a/tests/ui/using-for/imports/transitive_non_global_operator.stderr
+++ b/tests/ui/using-for/imports/transitive_non_global_operator.stderr
@@ -22,5 +22,19 @@ error: operators can only be defined in a global `using for` directive
 LL │ using {addRight as +, negRight as -} for TransitiveInt;
    ╰╴                      ━━━━━━━━
 
-error: aborting due to 4 previous errors
+error: cannot apply builtin operator `+` to `TransitiveInt` and `TransitiveInt`
+   ╭▸ ROOT/tests/ui/using-for/imports/transitive_non_global_operator.sol:LL:CC
+   │
+LL │         return a + b;
+   │                ┬ ━ ─ TransitiveInt
+   │                │
+   ╰╴               TransitiveInt
+
+error: cannot apply unary operator `-` to `TransitiveInt`
+   ╭▸ ROOT/tests/ui/using-for/imports/transitive_non_global_operator.sol:LL:CC
+   │
+LL │         return -a;
+   ╰╴               ━━
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/using-for/operators/contract_scope_duplicates.sol
+++ b/tests/ui/using-for/operators/contract_scope_duplicates.sol
@@ -15,8 +15,9 @@ function add2(Int a, Int b) pure returns (Int) {
 
 contract C {
     using {add2 as +} for Int; //~ ERROR: operators can only be defined in a global
+    //~^ ERROR: user-defined binary operator `+` has more than one definition
 
     function f(Int a, Int b) public pure returns (Int) {
-        return a + b;
+        return a + b; //~ ERROR: user-defined operator has more than one matching definition
     }
 }

--- a/tests/ui/using-for/operators/contract_scope_duplicates.stderr
+++ b/tests/ui/using-for/operators/contract_scope_duplicates.stderr
@@ -4,5 +4,17 @@ error: operators can only be defined in a global `using for` directive
 LL │     using {add2 as +} for Int;
    ╰╴           ━━━━
 
-error: aborting due to 1 previous error
+error: user-defined operator has more than one matching definition
+   ╭▸ ROOT/tests/ui/using-for/operators/contract_scope_duplicates.sol:LL:CC
+   │
+LL │         return a + b;
+   ╰╴                 ━
+
+error: user-defined binary operator `+` has more than one definition matching the operand type visible in the current scope
+   ╭▸ ROOT/tests/ui/using-for/operators/contract_scope_duplicates.sol:LL:CC
+   │
+LL │     using {add2 as +} for Int;
+   ╰╴           ━━━━
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/using-for/operators/contract_scope_not_inherited.sol
+++ b/tests/ui/using-for/operators/contract_scope_not_inherited.sol
@@ -29,6 +29,6 @@ contract Derived is Base {
 
 contract OnlyInherited is Base {
     function h(Int a, Int b) public pure returns (Int) {
-        return a + b;
+        return a + b; //~ ERROR: cannot apply builtin operator `+`
     }
 }

--- a/tests/ui/using-for/operators/contract_scope_not_inherited.stderr
+++ b/tests/ui/using-for/operators/contract_scope_not_inherited.stderr
@@ -10,5 +10,13 @@ error: operators can only be defined in a global `using for` directive
 LL │     using {add2 as +} for Int;
    ╰╴           ━━━━
 
-error: aborting due to 2 previous errors
+error: cannot apply builtin operator `+` to `Int` and `Int`
+   ╭▸ ROOT/tests/ui/using-for/operators/contract_scope_not_inherited.sol:LL:CC
+   │
+LL │         return a + b;
+   │                ┬ ━ ─ Int
+   │                │
+   ╰╴               Int
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/yul_lowering/yul_function_scope.sol
+++ b/tests/ui/yul_lowering/yul_function_scope.sol
@@ -11,6 +11,7 @@ contract C {
 
         assembly {
             x, y := pair(1) //~ ERROR: unresolved symbol
+            //~^ ERROR: mismatched number of components
         }
     }
 

--- a/tests/ui/yul_lowering/yul_function_scope.stderr
+++ b/tests/ui/yul_lowering/yul_function_scope.stderr
@@ -40,5 +40,11 @@ error: unresolved symbol `a`
 LL │                     r := a
    ╰╴                         ━
 
-error: aborting due to 7 previous errors
+error: mismatched number of components
+   ╭▸ ROOT/tests/ui/yul_lowering/yul_function_scope.sol:LL:CC
+   │
+LL │             x, y := pair(1)
+   ╰╴            ━━━━    ─────── expected a tuple with 2 elements, found one with 1 element
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
This removes the frontend driver's intermediate diagnostic gates so lowering, type validation, type checking, and emit can continue after earlier diagnostics when recovered state is available.

The UI updates record additional diagnostics now produced by later phases. Where that surfaced incidental duplicate-name diagnostics in tests that were not exercising duplicate declarations, the fixtures were adjusted to use unique helper names so the snapshots stay focused.

Recovery follow-ups keep complete receive validation in typeck while avoiding duplicate receive diagnostics, skip the storage-size overflow check on error types, and make ABI type printing tolerate already-reported unsupported types.
