### PR TITLE
fix: add codes to warnings

### DIFF
--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -1,9 +1,6 @@
 //! Utility functions used by the Solar CLI.
 
 use solar_interface::diagnostics::DiagCtxt;
-#[cfg(not(feature = "tracing"))]
-use solar_interface::diagnostics::DiagId;
-#[cfg(feature = "tracing")]
 use std::io;
 
 #[cfg(feature = "tracing")]
@@ -77,15 +74,14 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogDestination {
 pub fn init_logger(dst: LogDestination) -> impl Sized {
     #[cfg(not(feature = "tracing"))]
     {
-        let _ = dst;
         if std::env::var_os("RUST_LOG").is_some() {
             let msg = "`RUST_LOG` is set, but \"tracing\" support was not enabled at compile time";
-            DiagCtxt::new_early().warn(msg).code(DiagId::new_str("solar-tracing-disabled")).emit();
+            DiagCtxt::new_early().warn(msg).emit();
         }
         if std::env::var_os("SOLAR_PROFILE").is_some() {
             let msg =
                 "`SOLAR_PROFILE` is set, but \"tracing\" support was not enabled at compile time";
-            DiagCtxt::new_early().warn(msg).code(DiagId::new_str("solar-tracing-disabled")).emit();
+            DiagCtxt::new_early().warn(msg).emit();
         }
     }
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -1,6 +1,9 @@
 //! Utility functions used by the Solar CLI.
 
 use solar_interface::diagnostics::DiagCtxt;
+#[cfg(not(feature = "tracing"))]
+use solar_interface::diagnostics::DiagId;
+#[cfg(feature = "tracing")]
 use std::io;
 
 #[cfg(feature = "tracing")]
@@ -74,14 +77,15 @@ impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogDestination {
 pub fn init_logger(dst: LogDestination) -> impl Sized {
     #[cfg(not(feature = "tracing"))]
     {
+        let _ = dst;
         if std::env::var_os("RUST_LOG").is_some() {
             let msg = "`RUST_LOG` is set, but \"tracing\" support was not enabled at compile time";
-            DiagCtxt::new_early().warn(msg).emit();
+            DiagCtxt::new_early().warn(msg).code(DiagId::new_str("solar-tracing-disabled")).emit();
         }
         if std::env::var_os("SOLAR_PROFILE").is_some() {
             let msg =
                 "`SOLAR_PROFILE` is set, but \"tracing\" support was not enabled at compile time";
-            DiagCtxt::new_early().warn(msg).emit();
+            DiagCtxt::new_early().warn(msg).code(DiagId::new_str("solar-tracing-disabled")).emit();
         }
     }
 

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -8,6 +8,7 @@ use solar_data_structures::{BumpExt, fmt::or_list};
 use solar_interface::{
     BytePos, Ident, Result, Session, Span, Symbol,
     diagnostics::DiagCtxt,
+    error_code,
     source_map::{FileName, SourceFile},
 };
 use std::{fmt, path::Path};
@@ -1170,6 +1171,7 @@ fn parse_natspec(
                         if !in_yul {
                             dcx
                                 .warn(format!("invalid natspec tag '@{tag}', custom tags must use format '@custom:name'"))
+                                .code(error_code!(6546))
                                 .span(comment_span)
                                 .emit();
                         }

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1054,7 +1054,12 @@ impl<'gcx> ResolveContext<'gcx> {
                     }
                     memory_safe = true;
                 }
-                _ => self.dcx().warn("unknown inline assembly flag").span(span).emit(),
+                _ => self
+                    .dcx()
+                    .warn("unknown inline assembly flag")
+                    .code(error_code!(4430))
+                    .span(span)
+                    .emit(),
             }
         }
 

--- a/tests/ui/natspec/natspec.stderr
+++ b/tests/ui/natspec/natspec.stderr
@@ -1,10 +1,10 @@
-warning: invalid natspec tag '@invalid', custom tags must use format '@custom:name'
+warning[6546]: invalid natspec tag '@invalid', custom tags must use format '@custom:name'
    ╭▸ ROOT/tests/ui/natspec/natspec.sol:LL:CC
    │
 LL │ /// @invalid This is not a valid tag
    ╰╴━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-warning: invalid natspec tag '@customwrong', custom tags must use format '@custom:name'
+warning[6546]: invalid natspec tag '@customwrong', custom tags must use format '@custom:name'
    ╭▸ ROOT/tests/ui/natspec/natspec.sol:LL:CC
    │
 LL │ /// @customwrong Should use colon format

--- a/tests/ui/natspec/tag_syntax.stderr
+++ b/tests/ui/natspec/tag_syntax.stderr
@@ -1,10 +1,10 @@
-warning: invalid natspec tag '@invalid', custom tags must use format '@custom:name'
+warning[6546]: invalid natspec tag '@invalid', custom tags must use format '@custom:name'
    ╭▸ ROOT/tests/ui/natspec/tag_syntax.sol:LL:CC
    │
 LL │ /// @invalid This is not a valid tag
    ╰╴━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-warning: invalid natspec tag '@customwrong', custom tags must use format '@custom:name'
+warning[6546]: invalid natspec tag '@customwrong', custom tags must use format '@custom:name'
    ╭▸ ROOT/tests/ui/natspec/tag_syntax.sol:LL:CC
    │
 LL │ /// @customwrong Should use colon format

--- a/tests/ui/typeck/assembly_flags.stderr
+++ b/tests/ui/typeck/assembly_flags.stderr
@@ -4,7 +4,7 @@ error: inline assembly marked memory-safe multiple times
 LL │         assembly ("memory-safe", "memory-safe") {
    ╰╴                                 ━━━━━━━━━━━━━
 
-warning: unknown inline assembly flag
+warning[4430]: unknown inline assembly flag
    ╭▸ ROOT/tests/ui/typeck/assembly_flags.sol:LL:CC
    │
 LL │         assembly ("unknown-flag") {


### PR DESCRIPTION
Adds solc-compatible diagnostic IDs to warning-level diagnostics that were previously rendered without codes. This covers invalid NatSpec tags and unknown inline assembly flags, matching the integer IDs used by solc.
