### PR TITLE
fix: suppress missing import cascades

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1,8 +1,9 @@
 use crate::{builtins::Builtin, hir};
 use alloy_primitives::U256;
 use solar_ast as ast;
+use solar_ast::visit::Visit as _;
 use solar_data_structures::{
-    BumpExt,
+    BumpExt, Never,
     index::{Idx, IndexVec},
     map::{FxHashMap, FxIndexMap, IndexEntry},
     smallvec::SmallVec,
@@ -12,7 +13,7 @@ use solar_interface::{
     diagnostics::{DiagCtxt, ErrorGuaranteed},
     error_code, sym,
 };
-use std::fmt;
+use std::{fmt, ops::ControlFlow};
 
 pub(crate) use crate::hir::Res;
 
@@ -116,6 +117,22 @@ impl super::LoweringContext<'_> {
                             }
                         }
                     }
+                }
+            }
+            if let Some(ast) = &self.sources[source_id].ast {
+                for &(item_id, guar) in &self.sources[source_id].failed_imports {
+                    let import_item = &ast.items[item_id];
+                    let ast::ItemKind::Import(import) = &import_item.kind else { unreachable!() };
+                    let source_scope = &mut self.resolver.source_scopes[source_id];
+                    declare_failed_import(
+                        self.sess,
+                        &self.hir,
+                        &self.resolver.global_builtin_scope,
+                        source_scope,
+                        ast,
+                        import,
+                        guar,
+                    );
                 }
             }
         }
@@ -227,6 +244,77 @@ impl super::LoweringContext<'_> {
             c.fallback = fallback;
             c.receive = receive;
         }
+    }
+}
+
+fn declare_failed_import<'ast>(
+    sess: &Session,
+    hir: &hir::Hir<'_>,
+    builtin_scope: &Declarations,
+    source_scope: &mut Declarations,
+    ast: &'ast ast::SourceUnit<'ast>,
+    import: &ast::ImportDirective<'ast>,
+    guar: ErrorGuaranteed,
+) {
+    match import.items {
+        ast::ImportItems::Plain(Some(alias)) | ast::ImportItems::Glob(alias) => {
+            declare_import_error_name(sess, hir, builtin_scope, source_scope, alias, guar);
+        }
+        ast::ImportItems::Aliases(ref aliases) => {
+            for &(import, alias) in aliases.iter() {
+                declare_import_error_name(
+                    sess,
+                    hir,
+                    builtin_scope,
+                    source_scope,
+                    alias.unwrap_or(import),
+                    guar,
+                );
+            }
+        }
+        ast::ImportItems::Plain(None) => {
+            let mut collector = FailedImportPathCollector { names: Vec::new() };
+            let _: ControlFlow<Never> = collector.visit_source_unit(ast);
+            for name in collector.names {
+                declare_import_error_name(sess, hir, builtin_scope, source_scope, name, guar);
+            }
+        }
+    }
+}
+
+fn declare_import_error_name(
+    sess: &Session,
+    hir: &hir::Hir<'_>,
+    builtin_scope: &Declarations,
+    source_scope: &mut Declarations,
+    name: Ident,
+    guar: ErrorGuaranteed,
+) {
+    if source_scope.resolve(name).is_none() && builtin_scope.resolve(name).is_none() {
+        let _ = source_scope.declare_res(sess, hir, name, Res::Err(guar));
+    }
+}
+
+struct FailedImportPathCollector {
+    names: Vec<Ident>,
+}
+
+impl<'ast> ast::visit::Visit<'ast> for FailedImportPathCollector {
+    type BreakValue = Never;
+
+    fn visit_import_directive(
+        &mut self,
+        _import: &'ast ast::ImportDirective<'ast>,
+    ) -> ControlFlow<Self::BreakValue> {
+        ControlFlow::Continue(())
+    }
+
+    fn visit_path(&mut self, path: &'ast ast::PathSlice) -> ControlFlow<Self::BreakValue> {
+        let name = *path.first();
+        if !self.names.iter().any(|ident| ident.name == name.name) {
+            self.names.push(name);
+        }
+        ControlFlow::Continue(())
     }
 }
 

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1,9 +1,8 @@
 use crate::{builtins::Builtin, hir};
 use alloy_primitives::U256;
 use solar_ast as ast;
-use solar_ast::visit::Visit as _;
 use solar_data_structures::{
-    BumpExt, Never,
+    BumpExt,
     index::{Idx, IndexVec},
     map::{FxHashMap, FxIndexMap, IndexEntry},
     smallvec::SmallVec,
@@ -13,7 +12,7 @@ use solar_interface::{
     diagnostics::{DiagCtxt, ErrorGuaranteed},
     error_code, sym,
 };
-use std::{fmt, ops::ControlFlow};
+use std::fmt;
 
 pub(crate) use crate::hir::Res;
 
@@ -49,6 +48,37 @@ impl super::LoweringContext<'_> {
             for &(item_id, import_id) in source.imports {
                 let import_item = &self.sources[source_id].ast.as_ref().unwrap().items[item_id];
                 let ast::ItemKind::Import(import) = &import_item.kind else { unreachable!() };
+                let import_id = match import_id {
+                    Ok(import_id) => import_id,
+                    Err(guar) => {
+                        let source_scope = &mut self.resolver.source_scopes[source_id];
+                        match import.items {
+                            ast::ImportItems::Plain(Some(alias))
+                            | ast::ImportItems::Glob(alias) => {
+                                let _ = source_scope.declare_res(
+                                    self.sess,
+                                    &self.hir,
+                                    alias,
+                                    Res::Err(guar),
+                                );
+                            }
+                            ast::ImportItems::Aliases(ref aliases) => {
+                                for &(import, alias) in aliases.iter() {
+                                    let _ = source_scope.declare_res(
+                                        self.sess,
+                                        &self.hir,
+                                        alias.unwrap_or(import),
+                                        Res::Err(guar),
+                                    );
+                                }
+                            }
+                            ast::ImportItems::Plain(None) => {
+                                source_scope.declare_import_error(guar);
+                            }
+                        }
+                        continue;
+                    }
+                };
                 let (source_scope, import_scope) = if source_id != import_id {
                     let (a, b) = super::get_two_mut_idx(
                         &mut self.resolver.source_scopes,
@@ -117,22 +147,6 @@ impl super::LoweringContext<'_> {
                             }
                         }
                     }
-                }
-            }
-            if let Some(ast) = &self.sources[source_id].ast {
-                for &(item_id, guar) in &self.sources[source_id].failed_imports {
-                    let import_item = &ast.items[item_id];
-                    let ast::ItemKind::Import(import) = &import_item.kind else { unreachable!() };
-                    let source_scope = &mut self.resolver.source_scopes[source_id];
-                    declare_failed_import(
-                        self.sess,
-                        &self.hir,
-                        &self.resolver.global_builtin_scope,
-                        source_scope,
-                        ast,
-                        import,
-                        guar,
-                    );
                 }
             }
         }
@@ -244,77 +258,6 @@ impl super::LoweringContext<'_> {
             c.fallback = fallback;
             c.receive = receive;
         }
-    }
-}
-
-fn declare_failed_import<'ast>(
-    sess: &Session,
-    hir: &hir::Hir<'_>,
-    builtin_scope: &Declarations,
-    source_scope: &mut Declarations,
-    ast: &'ast ast::SourceUnit<'ast>,
-    import: &ast::ImportDirective<'ast>,
-    guar: ErrorGuaranteed,
-) {
-    match import.items {
-        ast::ImportItems::Plain(Some(alias)) | ast::ImportItems::Glob(alias) => {
-            declare_import_error_name(sess, hir, builtin_scope, source_scope, alias, guar);
-        }
-        ast::ImportItems::Aliases(ref aliases) => {
-            for &(import, alias) in aliases.iter() {
-                declare_import_error_name(
-                    sess,
-                    hir,
-                    builtin_scope,
-                    source_scope,
-                    alias.unwrap_or(import),
-                    guar,
-                );
-            }
-        }
-        ast::ImportItems::Plain(None) => {
-            let mut collector = FailedImportPathCollector { names: Vec::new() };
-            let _: ControlFlow<Never> = collector.visit_source_unit(ast);
-            for name in collector.names {
-                declare_import_error_name(sess, hir, builtin_scope, source_scope, name, guar);
-            }
-        }
-    }
-}
-
-fn declare_import_error_name(
-    sess: &Session,
-    hir: &hir::Hir<'_>,
-    builtin_scope: &Declarations,
-    source_scope: &mut Declarations,
-    name: Ident,
-    guar: ErrorGuaranteed,
-) {
-    if source_scope.resolve(name).is_none() && builtin_scope.resolve(name).is_none() {
-        let _ = source_scope.declare_res(sess, hir, name, Res::Err(guar));
-    }
-}
-
-struct FailedImportPathCollector {
-    names: Vec<Ident>,
-}
-
-impl<'ast> ast::visit::Visit<'ast> for FailedImportPathCollector {
-    type BreakValue = Never;
-
-    fn visit_import_directive(
-        &mut self,
-        _import: &'ast ast::ImportDirective<'ast>,
-    ) -> ControlFlow<Self::BreakValue> {
-        ControlFlow::Continue(())
-    }
-
-    fn visit_path(&mut self, path: &'ast ast::PathSlice) -> ControlFlow<Self::BreakValue> {
-        let name = *path.first();
-        if !self.names.iter().any(|ident| ident.name == name.name) {
-            self.names.push(name);
-        }
-        ControlFlow::Continue(())
     }
 }
 
@@ -2186,7 +2129,11 @@ impl<'gcx> SymbolResolver<'gcx> {
         name: Ident,
         scopes: &'a SymbolResolverScopes,
     ) -> Option<&'a [Declaration]> {
-        scopes.get(self).find_map(move |scope| scope.resolve(name))
+        let mut scopes = scopes.get(self);
+        scopes
+            .clone()
+            .find_map(move |scope| scope.resolve(name))
+            .or_else(|| scopes.find_map(Declarations::import_error))
     }
 
     fn resolve_name_non_local<'a>(
@@ -2194,9 +2141,11 @@ impl<'gcx> SymbolResolver<'gcx> {
         name: Ident,
         scopes: &'a SymbolResolverScopes,
     ) -> Result<&'a [Declaration], ResolverError> {
+        let mut scopes = scopes.get_non_local(self);
         scopes
-            .get_non_local(self)
+            .clone()
             .find_map(move |scope| scope.resolve(name))
+            .or_else(|| scopes.find_map(Declarations::import_error))
             .ok_or_else(|| ResolverError::new(name, ResolverErrorKind::Unresolved))
     }
 
@@ -2286,6 +2235,7 @@ impl SymbolResolverScopes {
 
 pub(crate) struct Declarations {
     declarations: FxIndexMap<Symbol, DeclarationsInner>,
+    import_error: Option<Declaration>,
 }
 
 impl fmt::Debug for Declarations {
@@ -2313,7 +2263,10 @@ impl Declarations {
     }
 
     pub(crate) fn with_capacity(capacity: usize) -> Self {
-        Self { declarations: FxIndexMap::with_capacity_and_hasher(capacity, Default::default()) }
+        Self {
+            declarations: FxIndexMap::with_capacity_and_hasher(capacity, Default::default()),
+            import_error: None,
+        }
     }
 
     pub(crate) fn reserve(&mut self, additional: usize) {
@@ -2322,6 +2275,7 @@ impl Declarations {
 
     pub(crate) fn clear(&mut self) {
         self.declarations.clear();
+        self.import_error = None;
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -2338,6 +2292,14 @@ impl Declarations {
 
     pub(crate) fn resolve_cloned(&self, name: Ident) -> Option<DeclarationsInner> {
         self.declarations.get(&name.name).cloned()
+    }
+
+    pub(crate) fn declare_import_error(&mut self, guar: ErrorGuaranteed) {
+        self.import_error.get_or_insert(Declaration { res: Res::Err(guar), span: Span::DUMMY });
+    }
+
+    fn import_error(&self) -> Option<&[Declaration]> {
+        self.import_error.as_ref().map(std::slice::from_ref)
     }
 
     /// Declares `name => decl` without checking for conflicts.

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -468,7 +468,7 @@ pub struct Source<'hir> {
     ///
     /// Note that the source IDs may not be unique, as multiple imports may resolve to the same
     /// source.
-    pub imports: &'hir [(ast::ItemId, SourceId)],
+    pub imports: &'hir [(ast::ItemId, Result<SourceId, ErrorGuaranteed>)],
     /// The source items.
     pub items: &'hir [ItemId],
     /// The source-level `using for` directives.

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -175,13 +175,18 @@ impl<'gcx> ParsingContext<'gcx> {
         for id in sources.indices() {
             let source = &mut sources[id];
             let ast = source.ast.take();
-            for (import_item_id, import_file) in
+            for (import_item_id, import_result) in
                 self.resolve_imports(&source.file.clone(), ast.as_ref())
             {
-                let (_import_id, is_new) =
-                    sources.add_import(id, import_item_id, import_file, true);
-                if is_new {
-                    any_new = true;
+                match import_result {
+                    Ok(import_file) => {
+                        let (_import_id, is_new) =
+                            sources.add_import(id, import_item_id, import_file, true);
+                        if is_new {
+                            any_new = true;
+                        }
+                    }
+                    Err(guar) => sources.add_failed_import(id, import_item_id, guar, true),
                 }
             }
             sources[id].ast = ast;
@@ -257,15 +262,19 @@ impl<'gcx> ParsingContext<'gcx> {
             let file = source.file.clone();
             let parent = parent_path(&file);
             let imports_len = sources[id].imports.len();
+            let failed_imports_len = sources[id].failed_imports.len();
             let ast = self.parse_one(&file, arena, |item_id, _, import| {
                 let _guard = debug_span!("resolve_import").entered();
-                let Some(import_file) = self.resolve_import_directive(import, parent) else {
-                    return;
-                };
-                sources.add_import(id, item_id, import_file, false);
+                match self.resolve_import_directive(import, parent) {
+                    Ok(import_file) => {
+                        sources.add_import(id, item_id, import_file, false);
+                    }
+                    Err(guar) => sources.add_failed_import(id, item_id, guar, false),
+                }
             });
             if ast.is_none() {
                 sources[id].imports.truncate(imports_len);
+                sources[id].failed_imports.truncate(failed_imports_len);
             }
             sources[id].ast = ast;
         }
@@ -311,11 +320,16 @@ impl<'gcx> ParsingContext<'gcx> {
         scope: &rayon::Scope<'scope>,
     ) {
         let mut imports = Vec::new();
+        let mut failed_imports = Vec::new();
         let parent = parent_path(&file);
         let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, import| {
             let _guard = debug_span!("resolve_import").entered();
-            let Some(import_file) = self.resolve_import_directive(import, parent) else {
-                return;
+            let import_file = match self.resolve_import_directive(import, parent) {
+                Ok(import_file) => import_file,
+                Err(guar) => {
+                    failed_imports.push((item_id, guar));
+                    return;
+                }
             };
             imports.push((item_id, import_file.clone()));
 
@@ -337,6 +351,7 @@ impl<'gcx> ParsingContext<'gcx> {
             for (import_item_id, import_file) in imports {
                 sources.add_import(id, import_item_id, import_file, false);
             }
+            sources[id].failed_imports.extend(failed_imports);
         }
     }
 
@@ -361,35 +376,34 @@ impl<'gcx> ParsingContext<'gcx> {
         }
     }
 
-    /// Resolves the imports of the given file, returning an iterator over all the imported files
-    /// that were successfully resolved.
+    /// Resolves the imports of the given file.
     fn resolve_imports(
         &self,
         file: &SourceFile,
         ast: Option<&ast::SourceUnit<'_>>,
-    ) -> impl Iterator<Item = (ast::ItemId, Arc<SourceFile>)> {
+    ) -> impl Iterator<Item = (ast::ItemId, Result<Arc<SourceFile>, ErrorGuaranteed>)> {
         let parent = parent_path(file);
         let items =
             ast.filter(|_| self.resolve_imports).map(|ast| &ast.items[..]).unwrap_or_default();
-        items
-            .iter_enumerated()
-            .filter_map(move |(id, item)| self.resolve_import(item, parent).map(|file| (id, file)))
+        items.iter_enumerated().filter_map(move |(id, item)| {
+            self.resolve_import(item, parent).map(|result| (id, result))
+        })
     }
 
     fn resolve_import(
         &self,
         item: &ast::Item<'_>,
         parent: Option<&Path>,
-    ) -> Option<Arc<SourceFile>> {
+    ) -> Option<Result<Arc<SourceFile>, ErrorGuaranteed>> {
         let ast::ItemKind::Import(import) = &item.kind else { return None };
-        self.resolve_import_directive(import, parent)
+        Some(self.resolve_import_directive(import, parent))
     }
 
     fn resolve_import_directive(
         &self,
         import: &ast::ImportDirective<'_>,
         parent: Option<&Path>,
-    ) -> Option<Arc<SourceFile>> {
+    ) -> Result<Arc<SourceFile>, ErrorGuaranteed> {
         self.resolve_import_path(&import.path, parent)
     }
 
@@ -397,22 +411,20 @@ impl<'gcx> ParsingContext<'gcx> {
         &self,
         import_path: &ast::StrLit,
         parent: Option<&Path>,
-    ) -> Option<Arc<SourceFile>> {
+    ) -> Result<Arc<SourceFile>, ErrorGuaranteed> {
         let span = import_path.span;
         let path_str = import_path.value.as_str();
         let (path_bytes, any_error) =
             unescape::parse_string_literal(path_str, unescape::StrKind::Str, span, self.sess);
         if any_error {
-            return None;
+            return Err(self.dcx().has_errors().expect_err("string literal parsing emitted error"));
         }
         let Some(path) = path_from_bytes(&path_bytes[..]) else {
-            self.dcx().emit_err(span, "import path is not a valid UTF-8 string");
-            return None;
+            return Err(self.dcx().emit_err(span, "import path is not a valid UTF-8 string"));
         };
         self.file_resolver
             .resolve_file(path, parent)
             .map_err(self.map_resolve_error_with(Some(span)))
-            .ok()
     }
 
     fn map_resolve_error(&self) -> impl FnOnce(ResolveError) -> ErrorGuaranteed {
@@ -567,6 +579,20 @@ impl<'ast> Sources<'ast> {
         ret
     }
 
+    fn add_failed_import(
+        &mut self,
+        current: SourceId,
+        import_item_id: ast::ItemId,
+        guar: ErrorGuaranteed,
+        check_dup: bool,
+    ) {
+        let failed_imports = &mut self.sources[current].failed_imports;
+        if check_dup && failed_imports.iter().any(|&(id, _)| id == import_item_id) {
+            return;
+        }
+        failed_imports.push((import_item_id, guar));
+    }
+
     /// Asserts that all sources are unique.
     fn assert_unique(&self) {
         if self.sources.len() <= 1 {
@@ -662,6 +688,8 @@ pub struct Source<'ast> {
     /// Note that the source IDs may not be unique, as multiple imports may resolve to the same
     /// source.
     pub imports: Vec<(ast::ItemId, SourceId)>,
+    /// The individual imports that failed to resolve.
+    pub failed_imports: Vec<(ast::ItemId, ErrorGuaranteed)>,
     /// The AST.
     ///
     /// `None` if:
@@ -677,6 +705,7 @@ impl fmt::Debug for Source<'_> {
         f.debug_struct("Source")
             .field("file", &self.file.name)
             .field("imports", &self.imports)
+            .field("failed_imports", &self.failed_imports)
             .field("ast", &self.ast)
             .finish()
     }
@@ -685,7 +714,7 @@ impl fmt::Debug for Source<'_> {
 impl Source<'_> {
     /// Creates a new empty source.
     pub fn new(file: Arc<SourceFile>) -> Self {
-        Self { file, ast: None, imports: Vec::new() }
+        Self { file, ast: None, imports: Vec::new(), failed_imports: Vec::new() }
     }
 
     fn count_contracts(&self) -> usize {

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -186,7 +186,7 @@ impl<'gcx> ParsingContext<'gcx> {
                             any_new = true;
                         }
                     }
-                    Err(guar) => sources.add_failed_import(id, import_item_id, guar, true),
+                    Err(guar) => sources.add_import_error(id, import_item_id, guar, true),
                 }
             }
             sources[id].ast = ast;
@@ -262,19 +262,17 @@ impl<'gcx> ParsingContext<'gcx> {
             let file = source.file.clone();
             let parent = parent_path(&file);
             let imports_len = sources[id].imports.len();
-            let failed_imports_len = sources[id].failed_imports.len();
             let ast = self.parse_one(&file, arena, |item_id, _, import| {
                 let _guard = debug_span!("resolve_import").entered();
                 match self.resolve_import_directive(import, parent) {
                     Ok(import_file) => {
                         sources.add_import(id, item_id, import_file, false);
                     }
-                    Err(guar) => sources.add_failed_import(id, item_id, guar, false),
+                    Err(guar) => sources.add_import_error(id, item_id, guar, false),
                 }
             });
             if ast.is_none() {
                 sources[id].imports.truncate(imports_len);
-                sources[id].failed_imports.truncate(failed_imports_len);
             }
             sources[id].ast = ast;
         }
@@ -320,18 +318,17 @@ impl<'gcx> ParsingContext<'gcx> {
         scope: &rayon::Scope<'scope>,
     ) {
         let mut imports = Vec::new();
-        let mut failed_imports = Vec::new();
         let parent = parent_path(&file);
         let ast = self.parse_one(&file, arenas.get_or_default(), |item_id, _, import| {
             let _guard = debug_span!("resolve_import").entered();
             let import_file = match self.resolve_import_directive(import, parent) {
                 Ok(import_file) => import_file,
                 Err(guar) => {
-                    failed_imports.push((item_id, guar));
+                    imports.push((item_id, Err(guar)));
                     return;
                 }
             };
-            imports.push((item_id, import_file.clone()));
+            imports.push((item_id, Ok(import_file.clone())));
 
             let (import_id, is_new) = {
                 let sources = &mut *lock.lock();
@@ -349,9 +346,13 @@ impl<'gcx> ParsingContext<'gcx> {
         sources[id].ast = ast;
         if sources[id].ast.is_some() {
             for (import_item_id, import_file) in imports {
-                sources.add_import(id, import_item_id, import_file, false);
+                match import_file {
+                    Ok(import_file) => {
+                        sources.add_import(id, import_item_id, import_file, false);
+                    }
+                    Err(guar) => sources.add_import_error(id, import_item_id, guar, false),
+                }
             }
-            sources[id].failed_imports.extend(failed_imports);
         }
     }
 
@@ -569,7 +570,7 @@ impl<'ast> Sources<'ast> {
         let (import_id, new) = ret;
 
         let current = &mut self.sources[current].imports;
-        let value = (import_item_id, import_id);
+        let value = (import_item_id, Ok(import_id));
         if check_dup && current.contains(&value) {
             assert!(!new, "duplicate import but source is new?");
             return ret;
@@ -579,18 +580,19 @@ impl<'ast> Sources<'ast> {
         ret
     }
 
-    fn add_failed_import(
+    fn add_import_error(
         &mut self,
         current: SourceId,
         import_item_id: ast::ItemId,
         guar: ErrorGuaranteed,
         check_dup: bool,
     ) {
-        let failed_imports = &mut self.sources[current].failed_imports;
-        if check_dup && failed_imports.iter().any(|&(id, _)| id == import_item_id) {
+        let imports = &mut self.sources[current].imports;
+        let value = (import_item_id, Err(guar));
+        if check_dup && imports.contains(&value) {
             return;
         }
-        failed_imports.push((import_item_id, guar));
+        imports.push(value);
     }
 
     /// Asserts that all sources are unique.
@@ -632,7 +634,9 @@ impl<'ast> Sources<'ast> {
         debug_span!("remap_state").in_scope(|| {
             for source in &mut self.sources {
                 for (_, import) in &mut source.imports {
-                    *import = map[*import];
+                    if let Ok(import) = import {
+                        *import = map[*import];
+                    }
                 }
             }
 
@@ -657,7 +661,9 @@ impl<'ast> Sources<'ast> {
             return;
         }
         for &(_, import_id) in &self.sources[id].imports {
-            self.topo_order(import_id, order, map, seen);
+            if let Ok(import_id) = import_id {
+                self.topo_order(import_id, order, map, seen);
+            }
         }
         map[id] = order.push(id);
     }
@@ -687,9 +693,7 @@ pub struct Source<'ast> {
     ///
     /// Note that the source IDs may not be unique, as multiple imports may resolve to the same
     /// source.
-    pub imports: Vec<(ast::ItemId, SourceId)>,
-    /// The individual imports that failed to resolve.
-    pub failed_imports: Vec<(ast::ItemId, ErrorGuaranteed)>,
+    pub imports: Vec<(ast::ItemId, Result<SourceId, ErrorGuaranteed>)>,
     /// The AST.
     ///
     /// `None` if:
@@ -705,7 +709,6 @@ impl fmt::Debug for Source<'_> {
         f.debug_struct("Source")
             .field("file", &self.file.name)
             .field("imports", &self.imports)
-            .field("failed_imports", &self.failed_imports)
             .field("ast", &self.ast)
             .finish()
     }
@@ -714,7 +717,7 @@ impl fmt::Debug for Source<'_> {
 impl Source<'_> {
     /// Creates a new empty source.
     pub fn new(file: Arc<SourceFile>) -> Self {
-        Self { file, ast: None, imports: Vec::new(), failed_imports: Vec::new() }
+        Self { file, ast: None, imports: Vec::new() }
     }
 
     fn count_contracts(&self) -> usize {
@@ -778,7 +781,7 @@ mod tests {
                 (cid, PathBuf::from("c.sol")),
             ];
 
-            sources[aid].imports.push((ItemId::new(0), cid));
+            sources[aid].imports.push((ItemId::new(0), Ok(cid)));
 
             for (id, path) in &files {
                 assert_eq!(sources[*id].file.name, FileName::Real(path.clone()));

--- a/tests/ui/standard-json/no-io-import.jsonc
+++ b/tests/ui/standard-json/no-io-import.jsonc
@@ -1,6 +1,5 @@
 // CHECK: "errors": [
 // CHECK: "message": "file tests/ui/standard-json/auxiliary/on-disk.sol not found"
-// CHECK: "message": "unresolved symbol `OnDisk`"
 // CHECK-NOT: "contracts"
 {
   "language": "Solidity",

--- a/tests/ui/standard-json/no-io-import.stdout
+++ b/tests/ui/standard-json/no-io-import.stdout
@@ -13,20 +13,6 @@
       "errorCode": null,
       "message": "file tests/ui/standard-json/auxiliary/on-disk.sol not found",
       "formattedMessage": "error: file tests/ui/standard-json/auxiliary/on-disk.sol not found\n   ╭▸ A.sol:LL:CC\n   │\nLL │ import \"tests/ui/standard-json/auxiliary/on-disk.sol\"; contract A is OnDisk {}\n   ╰╴       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n"
-    },
-    {
-      "sourceLocation": {
-        "file": "A.sol",
-        "start": 69,
-        "end": 75
-      },
-      "secondarySourceLocations": [],
-      "type": "Exception",
-      "component": "general",
-      "severity": "error",
-      "errorCode": null,
-      "message": "unresolved symbol `OnDisk`",
-      "formattedMessage": "error: unresolved symbol `OnDisk`\n   ╭▸ A.sol:LL:CC\n   │\nLL │ import \"tests/ui/standard-json/auxiliary/on-disk.sol\"; contract A is OnDisk {}\n   ╰╴                                                                     ━━━━━━\n\n"
     }
   ],
   "sources": {


### PR DESCRIPTION
Stacked on #838.

This changes source import edges to store `Result<SourceId, ErrorGuaranteed>` instead of dropping imports that failed to resolve. Lowering can then declare `Res::Err` placeholders for failed explicit import aliases and install an error fallback for failed plain imports, preventing cascaded diagnostics such as the extra unresolved `OnDisk` error after the import path has already failed.
