### PR TITLE
Replace bumpalo with stumpalo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,7 +2983,6 @@ name = "solar-ast"
 version = "0.1.8"
 dependencies = [
  "alloy-primitives",
- "bumpalo",
  "either",
  "num-rational",
  "semver 1.0.28",
@@ -2986,6 +2991,7 @@ dependencies = [
  "solar-interface",
  "solar-macros",
  "strum 0.28.0",
+ "stumpalo",
 ]
 
 [[package]]
@@ -3058,13 +3064,13 @@ dependencies = [
 name = "solar-data-structures"
 version = "0.1.8"
 dependencies = [
- "bumpalo",
  "indexmap",
  "oxc_index",
  "parking_lot",
  "rayon",
  "rustc-hash",
  "smallvec",
+ "stumpalo",
 ]
 
 [[package]]
@@ -3119,7 +3125,6 @@ version = "0.1.8"
 dependencies = [
  "alloy-primitives",
  "bitflags",
- "bumpalo",
  "itertools 0.14.0",
  "memchr",
  "num-bigint",
@@ -3131,6 +3136,7 @@ dependencies = [
  "solar-ast",
  "solar-data-structures",
  "solar-interface",
+ "stumpalo",
  "tracing",
 ]
 
@@ -3141,7 +3147,6 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "bitflags",
- "bumpalo",
  "derive_more",
  "either",
  "num-bigint",
@@ -3158,6 +3163,7 @@ dependencies = [
  "solar-macros",
  "solar-parse",
  "strum 0.28.0",
+ "stumpalo",
  "thread_local",
  "tracing",
 ]
@@ -3276,6 +3282,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "stumpalo"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e131fe8c9f91240d07788578b0ae965045ee033a4441f234b1cb30ff2a69c58e"
+dependencies = [
+ "readme-rustdocifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ tempfile = "3.9"
 
 # misc
 bitflags = "2.4"
-bumpalo = "3.14"
+stumpalo = "0.1.4"
 cfg-if = "1.0"
 either = "1"
 oxc_index = { version = "4.1", features = ["nonmax"] }

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -29,7 +29,7 @@ solar-interface.workspace = true
 solar-macros.workspace = true
 
 alloy-primitives.workspace = true
-bumpalo = { workspace = true, features = ["std", "boxed"] }
+stumpalo = { workspace = true, features = ["std"] }
 either.workspace = true
 semver.workspace = true
 num-rational.workspace = true

--- a/crates/ast/src/ast/mod.rs
+++ b/crates/ast/src/ast/mod.rs
@@ -1,6 +1,6 @@
 //! Solidity AST.
 
-use solar_data_structures::{BumpExt, ThinSlice, index::IndexSlice, newtype_index};
+use solar_data_structures::{ArenaExt, ThinSlice, index::IndexSlice, newtype_index};
 use std::fmt;
 
 pub use crate::token::CommentKind;

--- a/crates/ast/src/ast/mod.rs
+++ b/crates/ast/src/ast/mod.rs
@@ -44,9 +44,7 @@ pub struct Arena {
     bump: stumpalo::Arena,
 }
 
-// SAFETY: Solar stores AST arenas in `thread_local::ThreadLocal`, so each arena is only mutated by
-// its owning thread. References allocated from an arena may be read by other threads after parsing,
-// but the arena itself is not concurrently allocated from across threads.
+// SAFETY: `stumpalo::Arena` is Send, but the crate does not mark it as such yet.
 unsafe impl Send for Arena {}
 
 impl Arena {

--- a/crates/ast/src/ast/mod.rs
+++ b/crates/ast/src/ast/mod.rs
@@ -41,22 +41,27 @@ pub type BoxSlice<'ast, T> = Box<'ast, ThinSlice<T>>;
 
 /// AST arena allocator.
 pub struct Arena {
-    bump: bumpalo::Bump,
+    bump: stumpalo::Arena,
 }
+
+// SAFETY: Solar stores AST arenas in `thread_local::ThreadLocal`, so each arena is only mutated by
+// its owning thread. References allocated from an arena may be read by other threads after parsing,
+// but the arena itself is not concurrently allocated from across threads.
+unsafe impl Send for Arena {}
 
 impl Arena {
     /// Creates a new AST arena.
     pub fn new() -> Self {
-        Self { bump: bumpalo::Bump::new() }
+        Self { bump: stumpalo::Arena::new() }
     }
 
     /// Returns a reference to the arena's bump allocator.
-    pub fn bump(&self) -> &bumpalo::Bump {
+    pub fn bump(&self) -> &stumpalo::Arena {
         &self.bump
     }
 
     /// Returns a mutable reference to the arena's bump allocator.
-    pub fn bump_mut(&mut self) -> &mut bumpalo::Bump {
+    pub fn bump_mut(&mut self) -> &mut stumpalo::Arena {
         &mut self.bump
     }
 
@@ -78,7 +83,7 @@ impl Default for Arena {
 }
 
 impl std::ops::Deref for Arena {
-    type Target = bumpalo::Bump;
+    type Target = stumpalo::Arena;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/crates/ast/src/ast/path.rs
+++ b/crates/ast/src/ast/path.rs
@@ -1,5 +1,5 @@
 use crate::BoxSlice;
-use solar_data_structures::{BumpExt, smallvec::SmallVec};
+use solar_data_structures::{ArenaExt, smallvec::SmallVec};
 use solar_interface::{Ident, Span, Symbol};
 use std::{cmp::Ordering, fmt};
 use stumpalo::Arena;

--- a/crates/ast/src/ast/path.rs
+++ b/crates/ast/src/ast/path.rs
@@ -1,8 +1,8 @@
 use crate::BoxSlice;
-use bumpalo::Bump;
 use solar_data_structures::{BumpExt, smallvec::SmallVec};
 use solar_interface::{Ident, Span, Symbol};
 use std::{cmp::Ordering, fmt};
+use stumpalo::Arena;
 
 /// A boxed [`PathSlice`].
 #[derive(Debug)]
@@ -57,7 +57,7 @@ impl std::hash::Hash for AstPath<'_> {
 impl<'ast> AstPath<'ast> {
     /// Creates a new path from a slice of segments by allocating them on the given arena.
     #[inline]
-    pub fn new_in(arena: &'ast Bump, segments: &[Ident]) -> Self {
+    pub fn new_in(arena: &'ast Arena, segments: &[Ident]) -> Self {
         Self(arena.alloc_thin_slice_copy((), segments))
     }
 

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -6,8 +6,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Convenience re-exports.
-pub use bumpalo;
 pub use solar_interface as interface;
+pub use stumpalo;
 
 mod ast;
 pub use ast::*;

--- a/crates/data-structures/Cargo.toml
+++ b/crates/data-structures/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = [
 workspace = true
 
 [dependencies]
-bumpalo.workspace = true
+stumpalo.workspace = true
 oxc_index.workspace = true
 indexmap.workspace = true
 parking_lot.workspace = true

--- a/crates/data-structures/src/arena_ext.rs
+++ b/crates/data-structures/src/arena_ext.rs
@@ -4,7 +4,7 @@ use stumpalo::Arena;
 
 /// Extension trait for [`Arena`].
 #[expect(clippy::mut_from_ref)] // Arena.
-pub trait BumpExt {
+pub trait ArenaExt {
     /// Returns the number of bytes currently in use.
     fn used_bytes(&self) -> usize;
 
@@ -91,7 +91,7 @@ pub trait BumpExt {
     ) -> &'a mut RawThinSlice<H, T>;
 }
 
-impl BumpExt for Arena {
+impl ArenaExt for Arena {
     fn used_bytes(&self) -> usize {
         self.allocated_bytes().saturating_sub(self.chunk_capacity())
     }

--- a/crates/data-structures/src/bump_ext.rs
+++ b/crates/data-structures/src/bump_ext.rs
@@ -1,8 +1,8 @@
 use crate::RawThinSlice;
-use bumpalo::Bump;
 use smallvec::SmallVec;
+use stumpalo::Arena;
 
-/// Extension trait for [`Bump`].
+/// Extension trait for [`Arena`].
 #[expect(clippy::mut_from_ref)] // Arena.
 pub trait BumpExt {
     /// Returns the number of bytes currently in use.
@@ -18,27 +18,27 @@ pub trait BumpExt {
 
     /// Allocates a vector of items on the arena.
     ///
-    /// NOTE: This method does not drop the values, so you likely want to wrap the result in a
-    /// [`bumpalo::boxed::Box`] if `T: Drop`.
+    /// NOTE: This method does not drop the values, so you likely want to wrap the result in an
+    /// owning arena wrapper if `T: Drop`.
     fn alloc_vec<T>(&self, values: Vec<T>) -> &mut [T];
 
     /// Allocates a `SmallVector` of items on the arena.
     ///
-    /// NOTE: This method does not drop the values, so you likely want to wrap the result in a
-    /// [`bumpalo::boxed::Box`] if `T: Drop`.
+    /// NOTE: This method does not drop the values, so you likely want to wrap the result in an
+    /// owning arena wrapper if `T: Drop`.
     fn alloc_smallvec<A: smallvec::Array>(&self, values: SmallVec<A>) -> &mut [A::Item];
 
     /// Allocates an array of items on the arena.
     ///
-    /// NOTE: This method does not drop the values, so you likely want to wrap the result in a
-    /// [`bumpalo::boxed::Box`] if `T: Drop`.
+    /// NOTE: This method does not drop the values, so you likely want to wrap the result in an
+    /// owning arena wrapper if `T: Drop`.
     fn alloc_array<T, const N: usize>(&self, values: [T; N]) -> &mut [T];
 
     /// Allocates a slice of items on the arena and copies them in.
     ///
     /// # Safety
     ///
-    /// If `T: Drop`, the resulting slice must not be wrapped in [`bumpalo::boxed::Box`], unless
+    /// If `T: Drop`, the resulting slice must not be wrapped in an owning arena wrapper, unless
     /// ownership is moved as well, such as through [`alloc_vec`](Self::alloc_vec) and the other
     /// methods in this trait.
     unsafe fn alloc_slice_unchecked<'a, T>(&'a self, slice: &[T]) -> &'a mut [T];
@@ -72,7 +72,7 @@ pub trait BumpExt {
         values: [T; N],
     ) -> &mut RawThinSlice<H, T>;
 
-    /// See [`alloc_slice_copy`](Bump::alloc_slice_copy).
+    /// See [`alloc_slice_copy`](Arena::alloc_slice_copy).
     fn alloc_thin_slice_copy<'a, H, T: Copy>(
         &'a self,
         header: H,
@@ -91,10 +91,9 @@ pub trait BumpExt {
     ) -> &'a mut RawThinSlice<H, T>;
 }
 
-impl BumpExt for Bump {
+impl BumpExt for Arena {
     fn used_bytes(&self) -> usize {
-        // SAFETY: The data is not read, and the arena is not used during the iteration.
-        unsafe { self.iter_allocated_chunks_raw().map(|(_ptr, len)| len).sum::<usize>() }
+        self.allocated_bytes().saturating_sub(self.chunk_capacity())
     }
 
     #[inline]
@@ -153,13 +152,7 @@ impl BumpExt for Bump {
 
     #[inline]
     unsafe fn alloc_slice_unchecked<'a, T>(&'a self, src: &[T]) -> &'a mut [T] {
-        // Copied from `alloc_slice_copy`.
-        let layout = std::alloc::Layout::for_value(src);
-        let dst = self.alloc_layout(layout).cast::<T>();
-        unsafe {
-            std::ptr::copy_nonoverlapping(src.as_ptr(), dst.as_ptr(), src.len());
-            std::slice::from_raw_parts_mut(dst.as_ptr(), src.len())
-        }
+        self.alloc_slice_fill_with(src.len(), |i| unsafe { std::ptr::read(src.as_ptr().add(i)) })
     }
 
     #[inline]
@@ -253,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_alloc_vec() {
-        let bump = Bump::new();
+        let bump = Arena::new();
         let vec = vec![DropBomb::new(1), DropBomb::new(2), DropBomb::new(3)];
         let other_vec = vec![DropBomb::new(1), DropBomb::new(2), DropBomb::new(3)];
         let slice = bump.alloc_vec(vec);
@@ -268,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_alloc_vec_thin() {
-        let bump = Bump::new();
+        let bump = Arena::new();
         let vec = vec![DropBomb::new(1), DropBomb::new(2), DropBomb::new(3)];
         let other_vec = vec![DropBomb::new(1), DropBomb::new(2), DropBomb::new(3)];
         let raw_slice = bump.alloc_vec_thin(69usize, vec);
@@ -285,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_alloc_thin_empty() {
-        let bump = Bump::new();
+        let bump = Arena::new();
         let data = Vec::<&'static str>::new();
         let raw_slice = bump.alloc_vec_thin(69usize, data);
         assert_eq!(*raw_slice.header(), 69usize);

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -18,8 +18,8 @@ pub mod map;
 pub mod sync;
 pub mod trustme;
 
-mod bump_ext;
-pub use bump_ext::BumpExt;
+mod arena_ext;
+pub use arena_ext::ArenaExt;
 
 mod collect;
 pub use collect::CollectAndApply;

--- a/crates/data-structures/src/thin_slice.rs
+++ b/crates/data-structures/src/thin_slice.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, fmt};
+use std::{alloc::Layout, fmt, mem::MaybeUninit};
 use stumpalo::Arena;
 
 // Modified from [`rustc_middle::ty::List`](https://github.com/rust-lang/rust/blob/a2db9280539229a3b8a084a09886670a57bc7e9c/compiler/rustc_middle/src/ty/list.rs#L15).
@@ -76,7 +76,8 @@ impl<H, T> RawThinSlice<H, T> {
             .unwrap();
         assert!(layout.align() <= align_of::<u128>());
         let words = layout.size().div_ceil(size_of::<u128>());
-        arena.alloc_slice_fill_with(words, |_| 0u128).as_mut_ptr() as *mut Self
+        arena.alloc_slice_fill_with(words, |_| MaybeUninit::<u128>::uninit()).as_mut_ptr()
+            as *mut Self
     }
 
     /// Initializes a list by copying the contents of `slice` into it.

--- a/crates/data-structures/src/thin_slice.rs
+++ b/crates/data-structures/src/thin_slice.rs
@@ -1,5 +1,5 @@
-use bumpalo::Bump;
 use std::{alloc::Layout, fmt};
+use stumpalo::Arena;
 
 // Modified from [`rustc_middle::ty::List`](https://github.com/rust-lang/rust/blob/a2db9280539229a3b8a084a09886670a57bc7e9c/compiler/rustc_middle/src/ty/list.rs#L15).
 
@@ -48,7 +48,7 @@ impl<H, T> RawThinSlice<H, T> {
     /// Allocates a list from `arena` and copies the contents of `slice` into it.
     #[inline]
     #[expect(clippy::mut_from_ref)] // Arena.
-    pub(super) fn from_arena<'a>(arena: &'a Bump, header: H, slice: &[T]) -> &'a mut Self {
+    pub(super) fn from_arena<'a>(arena: &'a Arena, header: H, slice: &[T]) -> &'a mut Self {
         let mem = Self::alloc_from_arena(arena, slice.len());
         // SAFETY: `mem` comes from `alloc_from_arena`.
         unsafe { Self::init(mem, header, slice) }
@@ -58,7 +58,7 @@ impl<H, T> RawThinSlice<H, T> {
     #[inline]
     #[expect(clippy::mut_from_ref)] // Arena.
     pub(super) fn from_arena_with(
-        arena: &Bump,
+        arena: &Arena,
         header: H,
         len: usize,
         f: impl FnMut(usize) -> T,
@@ -70,11 +70,13 @@ impl<H, T> RawThinSlice<H, T> {
 
     /// Allocates a list from `arena`.
     #[inline]
-    fn alloc_from_arena(arena: &Bump, len: usize) -> *mut Self {
+    fn alloc_from_arena(arena: &Arena, len: usize) -> *mut Self {
         let (layout, _offset) = Layout::new::<ThinSliceSkeleton<H, T>>()
             .extend(Layout::array::<T>(len).unwrap())
             .unwrap();
-        arena.alloc_layout(layout).as_ptr() as *mut Self
+        assert!(layout.align() <= align_of::<u128>());
+        let words = layout.size().next_multiple_of(size_of::<u128>()) / size_of::<u128>();
+        arena.alloc_slice_fill_with(words, |_| 0u128).as_mut_ptr() as *mut Self
     }
 
     /// Initializes a list by copying the contents of `slice` into it.

--- a/crates/data-structures/src/thin_slice.rs
+++ b/crates/data-structures/src/thin_slice.rs
@@ -75,7 +75,7 @@ impl<H, T> RawThinSlice<H, T> {
             .extend(Layout::array::<T>(len).unwrap())
             .unwrap();
         assert!(layout.align() <= align_of::<u128>());
-        let words = layout.size().next_multiple_of(size_of::<u128>()) / size_of::<u128>();
+        let words = layout.size().div_ceil(size_of::<u128>());
         arena.alloc_slice_fill_with(words, |_| 0u128).as_mut_ptr() as *mut Self
     }
 

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -30,7 +30,7 @@ solar-interface.workspace = true
 
 alloy-primitives.workspace = true
 bitflags.workspace = true
-bumpalo.workspace = true
+stumpalo.workspace = true
 itertools.workspace = true
 memchr.workspace = true
 num-bigint.workspace = true

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -22,9 +22,9 @@ mod parser;
 pub use parser::{Parser, Recovered};
 
 // Convenience re-exports.
-pub use bumpalo;
 pub use solar_ast::{self as ast, token};
 pub use solar_interface as interface;
+pub use stumpalo;
 
 /// Parser error type.
 pub type PErr<'a> = DiagBuilder<'a, ErrorGuaranteed>;

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -4,7 +4,7 @@ use solar_ast::{
     self as ast, AstPath, Box, BoxSlice, DocComment, DocComments,
     token::{Delimiter, Token, TokenKind},
 };
-use solar_data_structures::{BumpExt, fmt::or_list};
+use solar_data_structures::{ArenaExt, fmt::or_list};
 use solar_interface::{
     BytePos, Ident, Result, Session, Span, Symbol,
     diagnostics::DiagCtxt,

--- a/crates/sema/Cargo.toml
+++ b/crates/sema/Cargo.toml
@@ -28,7 +28,7 @@ paste.workspace = true
 strum.workspace = true
 
 alloy-primitives.workspace = true
-bumpalo.workspace = true
+stumpalo.workspace = true
 either.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true

--- a/crates/sema/src/ast_lowering/lower.rs
+++ b/crates/sema/src/ast_lowering/lower.rs
@@ -1,7 +1,7 @@
 use crate::hir::{self, ContractId, SourceId};
 use solar_ast as ast;
 use solar_ast::visit::Visit;
-use solar_data_structures::{BumpExt, Never, smallvec::SmallVec};
+use solar_data_structures::{ArenaExt, Never, smallvec::SmallVec};
 use std::ops::ControlFlow;
 
 impl<'gcx> super::LoweringContext<'gcx> {

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -2,7 +2,7 @@ use crate::{builtins::Builtin, hir};
 use alloy_primitives::U256;
 use solar_ast as ast;
 use solar_data_structures::{
-    BumpExt,
+    ArenaExt,
     index::{Idx, IndexVec},
     map::{FxHashMap, FxIndexMap, IndexEntry},
     smallvec::SmallVec,

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -4,7 +4,7 @@ use crate::{
     ty::{Gcx, Ty, TyFn, TyFnKind, TyKind},
 };
 use solar_ast::{DataLocation, ElementaryType, StateMutability as SM, Visibility};
-use solar_data_structures::BumpExt;
+use solar_data_structures::ArenaExt;
 use solar_interface::Symbol;
 
 pub type MemberList<'gcx> = &'gcx [Member<'gcx>];

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -24,22 +24,26 @@ pub use visit::Visit;
 
 /// HIR arena allocator.
 pub struct Arena {
-    bump: bumpalo::Bump,
+    bump: stumpalo::Arena,
 }
+
+// SAFETY: HIR arenas are owned by the semantic context and allocation happens during construction.
+// Cross-thread users only read already allocated HIR data through shared references.
+unsafe impl Send for Arena {}
 
 impl Arena {
     /// Creates a new AST arena.
     pub fn new() -> Self {
-        Self { bump: bumpalo::Bump::new() }
+        Self { bump: stumpalo::Arena::new() }
     }
 
     /// Returns a reference to the arena's bump allocator.
-    pub fn bump(&self) -> &bumpalo::Bump {
+    pub fn bump(&self) -> &stumpalo::Arena {
         &self.bump
     }
 
     /// Returns a mutable reference to the arena's bump allocator.
-    pub fn bump_mut(&mut self) -> &mut bumpalo::Bump {
+    pub fn bump_mut(&mut self) -> &mut stumpalo::Arena {
         &mut self.bump
     }
 
@@ -61,7 +65,7 @@ impl Default for Arena {
 }
 
 impl std::ops::Deref for Arena {
-    type Target = bumpalo::Bump;
+    type Target = stumpalo::Arena;
 
     #[inline]
     fn deref(&self) -> &Self::Target {
@@ -283,7 +287,7 @@ impl<'hir> Hir<'hir> {
 
     /// Creates a builder for constructing HIR nodes.
     pub fn builder<'id>(
-        arena: &'hir bumpalo::Bump,
+        arena: &'hir stumpalo::Arena,
         next_id: &'id IdCounter,
     ) -> HirBuilder<'hir, 'id> {
         HirBuilder::new(arena, next_id)
@@ -326,13 +330,13 @@ impl IdCounter {
 
 /// A builder for constructing HIR nodes.
 pub struct HirBuilder<'hir, 'id> {
-    arena: &'hir bumpalo::Bump,
+    arena: &'hir stumpalo::Arena,
     next_id: &'id IdCounter,
 }
 
 impl<'hir, 'id> HirBuilder<'hir, 'id> {
     /// Creates a new HIR builder.
-    pub fn new(arena: &'hir bumpalo::Bump, next_id: &'id IdCounter) -> Self {
+    pub fn new(arena: &'hir stumpalo::Arena, next_id: &'id IdCounter) -> Self {
         Self { arena, next_id }
     }
 

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -27,8 +27,7 @@ pub struct Arena {
     bump: stumpalo::Arena,
 }
 
-// SAFETY: HIR arenas are owned by the semantic context and allocation happens during construction.
-// Cross-thread users only read already allocated HIR data through shared references.
+// SAFETY: `stumpalo::Arena` is Send, but the crate does not mark it as such yet.
 unsafe impl Send for Arena {}
 
 impl Arena {

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -6,7 +6,7 @@ use either::Either;
 use rayon::prelude::*;
 use solar_ast as ast;
 use solar_data_structures::{
-    BumpExt,
+    ArenaExt,
     index::{Idx, IndexVec},
     newtype_index,
 };

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -15,9 +15,9 @@ use std::ops::ControlFlow;
 
 // Convenience re-exports.
 pub use ::thread_local;
-pub use bumpalo;
 pub use solar_ast as ast;
 pub use solar_interface as interface;
+pub use stumpalo;
 
 mod ast_lowering;
 mod ast_passes;

--- a/crates/sema/src/ty/common.rs
+++ b/crates/sema/src/ty/common.rs
@@ -35,7 +35,7 @@ pub struct CommonTypes<'gcx> {
 impl<'gcx> CommonTypes<'gcx> {
     #[instrument(name = "new_common_types", level = "debug", skip_all)]
     #[inline]
-    pub(super) fn new(interner: &Interner<'gcx>, bump: &'gcx bumpalo::Bump) -> Self {
+    pub(super) fn new(interner: &Interner<'gcx>, bump: &'gcx stumpalo::Arena) -> Self {
         use ElementaryType::*;
         use TyKind::*;
         use std::array::from_fn;

--- a/crates/sema/src/ty/interner.rs
+++ b/crates/sema/src/ty/interner.rs
@@ -23,7 +23,7 @@ impl<'gcx> Interner<'gcx> {
         Self::default()
     }
 
-    pub(super) fn intern_ty(&self, bump: &'gcx bumpalo::Bump, kind: TyKind<'gcx>) -> Ty<'gcx> {
+    pub(super) fn intern_ty(&self, bump: &'gcx stumpalo::Arena, kind: TyKind<'gcx>) -> Ty<'gcx> {
         Ty(Interned::new_unchecked(
             self.tys
                 .intern(kind, |kind| bump.alloc(TyData { flags: TyFlags::calculate(&kind), kind })),
@@ -32,7 +32,7 @@ impl<'gcx> Interner<'gcx> {
 
     pub(super) fn intern_tys(
         &self,
-        bump: &'gcx bumpalo::Bump,
+        bump: &'gcx stumpalo::Arena,
         tys: &[Ty<'gcx>],
     ) -> &'gcx [Ty<'gcx>] {
         if tys.is_empty() {
@@ -43,7 +43,7 @@ impl<'gcx> Interner<'gcx> {
 
     pub(super) fn intern_ty_iter(
         &self,
-        bump: &'gcx bumpalo::Bump,
+        bump: &'gcx stumpalo::Arena,
         tys: impl Iterator<Item = Ty<'gcx>>,
     ) -> &'gcx [Ty<'gcx>] {
         solar_data_structures::CollectAndApply::collect_and_apply(tys, |tys| {
@@ -53,7 +53,7 @@ impl<'gcx> Interner<'gcx> {
 
     pub(super) fn intern_ty_fn(
         &self,
-        bump: &'gcx bumpalo::Bump,
+        bump: &'gcx stumpalo::Arena,
         ptr: TyFn<'gcx>,
     ) -> &'gcx TyFn<'gcx> {
         self.fns.intern(ptr, |ptr| bump.alloc(ptr))

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -332,7 +332,7 @@ impl<'gcx> Gcx<'gcx> {
         self.hir_arenas.get_or_default()
     }
 
-    pub fn bump(self) -> &'gcx bumpalo::Bump {
+    pub fn bump(self) -> &'gcx stumpalo::Arena {
         self.arena().bump()
     }
 

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -8,7 +8,7 @@ use alloy_primitives::{B256, Selector, U256, keccak256};
 use either::Either;
 use solar_ast::{DataLocation, StateMutability, TypeSize, UserDefinableOperator, Visibility};
 use solar_data_structures::{
-    BumpExt,
+    ArenaExt,
     fmt::{from_fn, or_list},
     map::{FxBuildHasher, FxHashMap, FxHashSet},
     smallvec::SmallVec,


### PR DESCRIPTION
## Summary
- replace Solar workspace uses of bumpalo with stumpalo
- adapt arena extension helpers to stumpalo public allocation APIs
- keep Solar arena wrappers Send for existing thread-local parallel parsing/typechecking flows

## Tests
- cargo test -p solar-data-structures bump_ext --lib
- cargo check --workspace

Prompted by: @DaniPopes