### PR TITLE
test: update ui test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ fn visit_expr(&mut self, expr: &'ast Expr) -> ControlFlow<Self::BreakValue> {
 ### UI Test Annotations
 
 ```solidity
-//@compile-flags: --emit=abi
+//@ compile-flags: --emit=abi
 contract Test {
     uint x; //~ ERROR: message here
     //~^ NOTE: note about previous line
@@ -69,12 +69,12 @@ Use `^` or `v` to point to lines above/below.
 
 Common file-level UI directives:
 
-- `//@compile-flags: ...`: Pass extra compiler flags for this test.
+- `//@ compile-flags: ...`: Pass extra compiler flags for this test.
 - `//@ error-in-other-file: ...`: Expect a diagnostic with this text in an
   imported/auxiliary source.
-- `// check-fail`: Mark the test as expected to fail even if no inline
+- `//@ check-fail`: Mark the test as expected to fail even if no inline
   diagnostic annotation appears in the primary file.
-- `//@ignore-host: windows`: Skip a test on a specific host.
+- `//@ ignore-host: windows`: Skip a test on a specific host.
 - `//@[name] compile-flags: ...`: Define revision-specific flags for tests with
   multiple revisions.
 
@@ -89,8 +89,8 @@ update imports accordingly.
 Add attribution using:
 `// ported-from: test/libsolidity/.../name.sol`. Use one line per upstream file.
 Do not add a full stop or other trailing punctuation after the path.
-Place these after initial UI metadata directives such as `//@compile-flags`,
-`//@ error-in-other-file`, and `// check-fail`; if the file has no UI metadata,
+Place these after initial UI metadata directives such as `//@ compile-flags`,
+`//@ error-in-other-file`, and `//@ check-fail`; if the file has no UI metadata,
 put the attribution at the top.
 Only add attribution if you're actually porting the semantics of the test 1-1 from Solc, not just "covering the error message". Renames are OK.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ Here's a simple example to show how to write a "UI" integration test (`tests/ui`
 
 ```rust
 // Directives
-//@compile-flags: --flag
+//@ compile-flags: --flag
 
 // Annotations specify the errors that the compiler is expected to emit.
 // These are `//~`, one of HELP, NOTE, WARN, ERROR, and a colon (`:`),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,13 +2669,13 @@ dependencies = [
 
 [[package]]
 name = "rustfix"
-version = "0.8.7"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fa69b198d894d84e23afde8e9ab2af4400b2cba20d6bf2b428a8b01c222c5a"
+checksum = "602c6a9fecd66c254d55f3fce9e63e738e71fc3ed2693e69eb2453bb6d7bdcc7"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -3173,13 +3173,15 @@ dependencies = [
 
 [[package]]
 name = "spanned"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4b0c055fde758f086eb4a6e73410247df8a3837fd606d2caeeaf72aa566d"
+checksum = "118662960e1508d35b4162b0f0e41828e6d8e3c7c07da7d959c18e803528d1a2"
 dependencies = [
+ "annotate-snippets 0.11.5",
  "anyhow",
  "bstr",
  "color-eyre",
+ "colored 3.1.1",
 ]
 
 [[package]]
@@ -3663,10 +3665,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 [[package]]
 name = "ui_test"
 version = "0.30.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8811281d587a786747c0c49245925016c07767bc996305bdd34d5ce076786a"
+source = "git+https://github.com/DaniPopes/ui_test?branch=fork#cc87c902788e9ca0b75cb7b209a3c499744452a4"
 dependencies = [
- "annotate-snippets 0.11.5",
+ "annotate-snippets 0.12.16",
  "anyhow",
  "bstr",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,3 +182,4 @@ unicode-width = "0.2"
 vergen = { package = "vergen-gitcl", version = "10.0.0-beta.5" }
 
 [patch.crates-io]
+ui_test = { git = "https://github.com/DaniPopes/ui_test", branch = "fork" }

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ ignore = [
     "RUSTSEC-2024-0436",
     # `bincode` is unmaintained - unused
     "RUSTSEC-2025-0141",
+    # `proc-macro-error2` is unmaintained - transitive dependency
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]
@@ -44,6 +46,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-git = [
     # Used only for testing.
+    "https://github.com/DaniPopes/ui_test",
     "https://github.com/oli-obk/ui_test",
     # Used only for benchmarks.
     "https://github.com/DaniPopes/codspeed-rust",

--- a/tests/ui/abi/basic.sol
+++ b/tests/ui/abi/basic.sol
@@ -1,5 +1,5 @@
-//@ignore-host: windows
-//@compile-flags: --emit=abi,hashes --pretty-json
+//@ ignore-host: windows
+//@ compile-flags: --emit=abi,hashes --pretty-json
 
 struct S1 {
     uint x;

--- a/tests/ui/abi/contract_special_functions.sol
+++ b/tests/ui/abi/contract_special_functions.sol
@@ -1,5 +1,5 @@
-//@ignore-host: windows
-//@compile-flags: --emit=abi,hashes --pretty-json
+//@ ignore-host: windows
+//@ compile-flags: --emit=abi,hashes --pretty-json
 
 // Abstract contracts don't emit constructors.
 abstract contract A {

--- a/tests/ui/abi/getters.sol
+++ b/tests/ui/abi/getters.sol
@@ -1,5 +1,5 @@
-//@ignore-host: windows
-//@compile-flags: --emit=abi,hashes --pretty-json
+//@ ignore-host: windows
+//@ compile-flags: --emit=abi,hashes --pretty-json
 
 contract C {
     int public simple;

--- a/tests/ui/abi/mapping_getters.sol
+++ b/tests/ui/abi/mapping_getters.sol
@@ -1,5 +1,5 @@
-//@ignore-host: windows
-//@compile-flags: --emit=abi,hashes --pretty-json
+//@ ignore-host: windows
+//@ compile-flags: --emit=abi,hashes --pretty-json
 
 contract C {
     struct Data {

--- a/tests/ui/cli/non_existant_file.sol
+++ b/tests/ui/cli/non_existant_file.sol
@@ -1,3 +1,3 @@
 //@ compile-flags: doesnotexist.sol
 //@ error-in-other-file: file doesnotexist.sol not found
-// check-fail
+//@ check-fail

--- a/tests/ui/lexer/string_escapes_crlf.sol
+++ b/tests/ui/lexer/string_escapes_crlf.sol
@@ -1,4 +1,4 @@
-//@ignore-host: windows
+//@ ignore-host: windows
 
 // Escaped - OK
 string constant s1 = "\

--- a/tests/ui/natspec/inheritdoc/merge_tags.sol
+++ b/tests/ui/natspec/inheritdoc/merge_tags.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zprint-natspec
+//@ compile-flags: -Zprint-natspec
 
 contract Base {
     /// @notice Base function notice

--- a/tests/ui/natspec/inheritdoc/overload_signature.sol
+++ b/tests/ui/natspec/inheritdoc/overload_signature.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zprint-natspec
+//@ compile-flags: -Zprint-natspec
 
 contract OverloadBase {
     /// @notice address overload

--- a/tests/ui/natspec/inheritdoc/public_variable_getters.sol
+++ b/tests/ui/natspec/inheritdoc/public_variable_getters.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zprint-natspec
+//@ compile-flags: -Zprint-natspec
 
 interface Base {
     /// @notice Base factory notice

--- a/tests/ui/natspec/tag_returns_resolved.sol
+++ b/tests/ui/natspec/tag_returns_resolved.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zprint-natspec
+//@ compile-flags: -Zprint-natspec
 
 contract ReturnDocs {
     /// @return the value

--- a/tests/ui/natspec/tag_variables_resolved.sol
+++ b/tests/ui/natspec/tag_variables_resolved.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zprint-natspec
+//@ compile-flags: -Zprint-natspec
 
 contract VariableDocs {
     /// @return The number of decimals

--- a/tests/ui/parser/import_invalid_token.sol
+++ b/tests/ui/parser/import_invalid_token.sol
@@ -1,4 +1,4 @@
 //@ error-in-other-file: unknown start of token: #
-// check-fail
+//@ check-fail
 
 import "./auxiliary/invalid_token.sol";

--- a/tests/ui/parser/no_unknown_prefix.sol
+++ b/tests/ui/parser/no_unknown_prefix.sol
@@ -1,4 +1,4 @@
-//@compile-flags: --stop-after parsing -Zno-resolve-imports
+//@ compile-flags: --stop-after parsing -Zno-resolve-imports
 
 // This used to fail with an "unknown string prefix" error.
 

--- a/tests/ui/parser/span_visitor.sol
+++ b/tests/ui/parser/span_visitor.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zspan-visitor
+//@ compile-flags: -Zspan-visitor
 
 /// @title SpanVisitorTest
 /// @author solar contributors

--- a/tests/ui/resolve/parallel_import_smoke.sol
+++ b/tests/ui/resolve/parallel_import_smoke.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -j8
+//@ compile-flags: -j8
 
 import "./auxiliary/parallel_import_a.sol" as A;
 import "./auxiliary/parallel_import_b.sol" as B;

--- a/tests/ui/typeck/address_conversions_explicit.sol
+++ b/tests/ui/typeck/address_conversions_explicit.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 contract C {
     function f(
         address a,

--- a/tests/ui/typeck/bytes_string_explicit_conversions.sol
+++ b/tests/ui/typeck/bytes_string_explicit_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract BytesStringTests {
     // Valid: string literal -> bytes memory.

--- a/tests/ui/typeck/contract_address_conversions_explicit.sol
+++ b/tests/ui/typeck/contract_address_conversions_explicit.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract NoReceive {}
 

--- a/tests/ui/typeck/contract_type_members.sol
+++ b/tests/ui/typeck/contract_type_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 library LibraryTypes {
     uint256 constant BASE = 1;

--- a/tests/ui/typeck/contract_type_members_public_vars.sol
+++ b/tests/ui/typeck/contract_type_members_public_vars.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract PublicStateVarBase {
     uint256 public baseVar = 42;

--- a/tests/ui/typeck/explicit_dynamic_bytes_conversion.sol
+++ b/tests/ui/typeck/explicit_dynamic_bytes_conversion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 contract C {
     function f(bytes memory a0) public pure {
         // Valid conversion

--- a/tests/ui/typeck/explicit_enum_conversion.sol
+++ b/tests/ui/typeck/explicit_enum_conversion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 contract C {
     enum TrafficLight {
         Red,

--- a/tests/ui/typeck/fixed_bytes_conversions.sol
+++ b/tests/ui/typeck/fixed_bytes_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     // Valid: implicit FixedBytes widening and same-size conversion.

--- a/tests/ui/typeck/function_calls/abi_decode.sol
+++ b/tests/ui/typeck/function_calls/abi_decode.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     struct Unsupported {

--- a/tests/ui/typeck/function_calls/abi_encode_call_args.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_call_args.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f1(int256 value) public {

--- a/tests/ui/typeck/function_calls/abi_encode_call_conversions.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_call_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 interface Target {
     function takesMemoryFunction(function(string memory) external callback) external;

--- a/tests/ui/typeck/function_calls/abi_encode_call_function_kinds.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_call_function_kinds.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 library Lib {
     function externalTarget(uint256 value) external {

--- a/tests/ui/typeck/function_calls/abi_encode_packed.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_packed.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     struct S {

--- a/tests/ui/typeck/function_calls/call_checking.sol
+++ b/tests/ui/typeck/function_calls/call_checking.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract CallChecking {
     event E(uint a, bytes32 b);

--- a/tests/ui/typeck/function_calls/contract_type_base_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_base_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // ported-from: test/libsolidity/semanticTests/functionTypes/selector_1.sol
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/484_function_types_selector_1.sol

--- a/tests/ui/typeck/function_calls/contract_type_interface_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_interface_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // ported-from: test/libsolidity/smtCheckerTests/function_selector/function_selector_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/assign_function_via_contract_name_to_var.sol

--- a/tests/ui/typeck/function_calls/contract_type_state_var_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_state_var_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // ported-from: test/libsolidity/semanticTests/various/state_variable_under_contract_name.sol
 

--- a/tests/ui/typeck/function_calls/declaration_function_calls.sol
+++ b/tests/ui/typeck/function_calls/declaration_function_calls.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/call_function_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/freeFunctions/free_call_via_contract_type.sol
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/145_external_base_visibility.sol

--- a/tests/ui/typeck/function_calls/enum_value_not_callable.sol
+++ b/tests/ui/typeck/function_calls/enum_value_not_callable.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     enum ActionChoices { GoLeft, GoRight }

--- a/tests/ui/typeck/function_calls/event_error/emit_non_event.sol
+++ b/tests/ui/typeck/function_calls/event_error/emit_non_event.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/emit/emit_non_event.sol
 
 contract EmitNonEvent {

--- a/tests/ui/typeck/function_calls/event_error/error_used_elsewhere.sol
+++ b/tests/ui/typeck/function_calls/event_error/error_used_elsewhere.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/revertStatement/error_used_elsewhere.sol
 
 contract ErrorUsedElsewhere {

--- a/tests/ui/typeck/function_calls/event_error/event_without_emit.sol
+++ b/tests/ui/typeck/function_calls/event_error/event_without_emit.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/events/event_without_emit_deprecated.sol
 // ported-from: test/libsolidity/syntaxTests/events/multiple_event_without_emit.sol
 

--- a/tests/ui/typeck/function_calls/event_error/nested_contexts.sol
+++ b/tests/ui/typeck/function_calls/event_error/nested_contexts.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract EventErrorNestedContexts {
     event MyEvent(uint a, bytes32 b);

--- a/tests/ui/typeck/function_calls/event_error/require_custom_error.sol
+++ b/tests/ui/typeck/function_calls/event_error/require_custom_error.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract RequireCustomError {
     error EmptyError();

--- a/tests/ui/typeck/function_calls/event_error/revert_event.sol
+++ b/tests/ui/typeck/function_calls/event_error/revert_event.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/revertStatement/revert_event.sol
 
 contract RevertEvent {

--- a/tests/ui/typeck/function_calls/int_not_callable.sol
+++ b/tests/ui/typeck/function_calls/int_not_callable.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f() public {

--- a/tests/ui/typeck/function_calls/low_level_call_options.sol
+++ b/tests/ui/typeck/function_calls/low_level_call_options.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/functionCalls/calloptions_on_delegatecall.sol
 // ported-from: test/libsolidity/syntaxTests/functionCalls/calloptions_on_staticcall.sol
 // ported-from: test/libsolidity/smtCheckerTests/external_calls/external_call_with_gas_1.sol

--- a/tests/ui/typeck/function_calls/named_arguments_duplicate_parameter.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_duplicate_parameter.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract test {
     function a(uint a, uint b) public returns (uint r) {

--- a/tests/ui/typeck/function_calls/named_arguments_in_any_order.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_in_any_order.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f(uint u, bytes32 s, bool b) internal {}

--- a/tests/ui/typeck/function_calls/named_arguments_invalid_name.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_invalid_name.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract test {
     function f(uint a, bool b, bytes32 c, uint d, bool e) public returns (uint r) {

--- a/tests/ui/typeck/function_calls/named_arguments_wrong_count.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_wrong_count.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract test {
     function a(uint a, uint b) public returns (uint r) {

--- a/tests/ui/typeck/function_calls/new/abstract_contract.sol
+++ b/tests/ui/typeck/function_calls/new/abstract_contract.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/029_create_abstract_contract.sol
 
 abstract contract A {

--- a/tests/ui/typeck/function_calls/new/dynamic_array_arguments.sol
+++ b/tests/ui/typeck/function_calls/new/dynamic_array_arguments.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/invalidArgs/creating_memory_array.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/new/interface.sol
+++ b/tests/ui/typeck/function_calls/new/interface.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/523_reject_interface_creation.sol
 
 interface I {}

--- a/tests/ui/typeck/function_calls/new/library.sol
+++ b/tests/ui/typeck/function_calls/new/library.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/functionCalls/new_library.sol
 
 library L {}

--- a/tests/ui/typeck/function_calls/new/library_array.sol
+++ b/tests/ui/typeck/function_calls/new/library_array.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/library_array.sol
 
 library L {}

--- a/tests/ui/typeck/function_calls/new/non_array.sol
+++ b/tests/ui/typeck/function_calls/new/non_array.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/265_new_for_non_array.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/new/nonpayable_call_options.sol
+++ b/tests/ui/typeck/function_calls/new/nonpayable_call_options.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/constructor/nonpayable_new.sol
 
 contract NonPayableA1 {

--- a/tests/ui/typeck/function_calls/new/payable_call_options.sol
+++ b/tests/ui/typeck/function_calls/new/payable_call_options.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/constructor/payable_new.sol
 
 contract PayableA1 {}

--- a/tests/ui/typeck/function_calls/new/static_array.sol
+++ b/tests/ui/typeck/function_calls/new/static_array.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/new_no_parentheses.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/overloads.sol
+++ b/tests/ui/typeck/function_calls/overloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/freeFunctions/overloads.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/libraries/library_function_selectors.sol
 // ported-from: test/libsolidity/smtCheckerTests/function_selector/function_selector_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/external_library_function_to_external_function_type.sol

--- a/tests/ui/typeck/function_calls/variadic.sol
+++ b/tests/ui/typeck/function_calls/variadic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 interface Target {
     function none() external;

--- a/tests/ui/typeck/function_ptr_comparisons.sol
+++ b/tests/ui/typeck/function_ptr_comparisons.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/functionTypes/comparison_operators_for_external_functions.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_1.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_2.sol

--- a/tests/ui/typeck/function_ptr_mutability_conversions.sol
+++ b/tests/ui/typeck/function_ptr_mutability_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/conversion/function_type_nonpayable_payable.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/function_type_nonpayable_pure.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/function_type_nonpayable_view.sol

--- a/tests/ui/typeck/implicit_address.sol
+++ b/tests/ui/typeck/implicit_address.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 function f() {
     address payable e = 0x14aF3198B9Dd911fc828434f8D97df0C0Ff979Ee; //~ ERROR: mismatched types
 

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // Tests for implicit array conversions.
 // Arrays require exactly the same element type - no widening allowed.

--- a/tests/ui/typeck/implicit_contract_conversions.sol
+++ b/tests/ui/typeck/implicit_contract_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 pragma solidity ^0.8.0;
 
 contract Base {}

--- a/tests/ui/typeck/implicit_fixed_bytes.sol
+++ b/tests/ui/typeck/implicit_fixed_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // Tests for implicit FixedBytes width conversions.
 // See: https://docs.soliditylang.org/en/latest/types.html#implicit-conversions

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // Tests for implicit function pointer conversions.
 // Function pointers require exact parameter/return types.

--- a/tests/ui/typeck/implicit_int_literal.sol
+++ b/tests/ui/typeck/implicit_int_literal.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 function f() {
     // === Non-negative literals to uint ===
     // Value must fit in the unsigned range [0, 2^N - 1]

--- a/tests/ui/typeck/implicit_integer_width.sol
+++ b/tests/ui/typeck/implicit_integer_width.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // Tests for implicit integer width conversions.
 // See: https://docs.soliditylang.org/en/latest/types.html#implicit-conversions

--- a/tests/ui/typeck/implicit_slice.sol
+++ b/tests/ui/typeck/implicit_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/slice/calldata_dynamic_access.sol
 
 // Tests for array slice implicit conversions.

--- a/tests/ui/typeck/implicit_tuple_conversions.sol
+++ b/tests/ui/typeck/implicit_tuple_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // Tests for implicit tuple conversions.
 // Tuple assignments check element-wise type matching.

--- a/tests/ui/typeck/integer_explicit_conversions.sol
+++ b/tests/ui/typeck/integer_explicit_conversions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract IntegerConversions {
     // Int <-> Int (any size - only width changes)

--- a/tests/ui/typeck/internal_fn_public_interface.sol
+++ b/tests/ui/typeck/internal_fn_public_interface.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     // Internal function type as public state variable - should error.

--- a/tests/ui/typeck/library_mappings.sol
+++ b/tests/ui/typeck/library_mappings.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/lvalues/library_mapping.sol
 
 contract L {

--- a/tests/ui/typeck/literal_bytes_implicit_conversion.sol
+++ b/tests/ui/typeck/literal_bytes_implicit_conversion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 contract C {
     function f() public pure {
         // --- Valid: literal to fixed-size bytes (equal size) ---

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // Tests for data location coercion rules.
 // See: https://docs.soliditylang.org/en/latest/types.html#data-location-and-assignment-behaviour

--- a/tests/ui/typeck/lvalue/address_balance.sol
+++ b/tests/ui/typeck/lvalue/address_balance.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/015_balance_invalid.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/array_length.sol
+++ b/tests/ui/typeck/lvalue/array_length.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract Test {
     uint256[] dynamicArray;

--- a/tests/ui/typeck/lvalue/calldata_array.sol
+++ b/tests/ui/typeck/lvalue/calldata_array.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract Test {
     uint256 state;

--- a/tests/ui/typeck/lvalue/calldata_struct.sol
+++ b/tests/ui/typeck/lvalue/calldata_struct.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 struct S {
     uint256 x;

--- a/tests/ui/typeck/lvalue/constant.sol
+++ b/tests/ui/typeck/lvalue/constant.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract Test {
     uint256 constant CONST = 1;

--- a/tests/ui/typeck/lvalue/delete_function_type.sol
+++ b/tests/ui/typeck/lvalue/delete_function_type.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/functionTypes/delete_function_type_invalid.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/delete_external_function_type_invalid.sol
 

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract Test {
     uint256 a;

--- a/tests/ui/typeck/lvalue/fixed_bytes.sol
+++ b/tests/ui/typeck/lvalue/fixed_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract Test {
     bytes32 fixedBytes;

--- a/tests/ui/typeck/lvalue/function_lvalues.sol
+++ b/tests/ui/typeck/lvalue/function_lvalues.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/lvalues/functions.sol
 
 contract FunctionLvalues {

--- a/tests/ui/typeck/lvalue/immutable.sol
+++ b/tests/ui/typeck/lvalue/immutable.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/immutable/variable_declaration_value.sol
 // ported-from: test/libsolidity/semanticTests/immutable/multiple_initializations.sol
 // ported-from: test/libsolidity/syntaxTests/immutable/ctor_initialization_tuple.sol

--- a/tests/ui/typeck/lvalue/literals.sol
+++ b/tests/ui/typeck/lvalue/literals.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // TODO: `mismatched types` errors on integer literals are a current limitation of solar
 
 contract Test {

--- a/tests/ui/typeck/lvalue/metatype_code.sol
+++ b/tests/ui/typeck/lvalue/metatype_code.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/metaTypes/codeIsNoLValue.sol
 
 contract MetaTypeMemberLvalues {

--- a/tests/ui/typeck/lvalue/push_as_lhs.sol
+++ b/tests/ui/typeck/lvalue/push_as_lhs.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/smtCheckerTests/array_members/push_as_lhs_2d.sol
 // ported-from: test/libsolidity/smtCheckerTests/array_members/push_as_lhs_3d.sol
 

--- a/tests/ui/typeck/lvalue/return_storage_ref.sol
+++ b/tests/ui/typeck/lvalue/return_storage_ref.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/functionCall/mapping_internal_return.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/tuple_assignments.sol
+++ b/tests/ui/typeck/lvalue/tuple_assignments.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/tupleAssignments/assignments_to_tuple_and_non_tuple_expressions_of_tuple_types.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/tuple_push.sol
+++ b/tests/ui/typeck/lvalue/tuple_push.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/bytes1_array_push_assign_multi.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/valid_calldata.sol
+++ b/tests/ui/typeck/lvalue/valid_calldata.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // Valid operations on calldata (reading is allowed)
 
 struct S {

--- a/tests/ui/typeck/lvalue/valid_memory.sol
+++ b/tests/ui/typeck/lvalue/valid_memory.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/lvalues/valid_lvalues.sol
 // Valid lvalue assignments for memory variables
 

--- a/tests/ui/typeck/lvalue/valid_storage.sol
+++ b/tests/ui/typeck/lvalue/valid_storage.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // Valid lvalue assignments for storage variables
 
 contract Test {

--- a/tests/ui/typeck/mapping_assignment.sol
+++ b/tests/ui/typeck/mapping_assignment.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     mapping(uint => uint) a;

--- a/tests/ui/typeck/mapping_key_type_check.sol
+++ b/tests/ui/typeck/mapping_key_type_check.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 type U is int;
 enum E {
     A,

--- a/tests/ui/typeck/new_dynamic_arrays.sol
+++ b/tests/ui/typeck/new_dynamic_arrays.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     struct S {

--- a/tests/ui/typeck/pow_associativity.sol
+++ b/tests/ui/typeck/pow_associativity.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 function test() pure {
     uint[2**3**2] memory a;

--- a/tests/ui/typeck/storage_layout_base_slot_negative.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_negative.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_underflow_value.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/negative_number.sol
 

--- a/tests/ui/typeck/storage_layout_base_slot_overflow.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_overflow.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/intermediate_operation_out_of_range.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_value.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_bitwise_negation_literal.sol

--- a/tests/ui/typeck/storage_layout_base_slot_unsupported.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_unsupported.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_attached_library_function.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/string.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/hex_string.sol

--- a/tests/ui/typeck/storage_layout_base_slot_valid.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_valid.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/simple_layout.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/literal_with_underscore.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/rational_number_without_fractional_part.sol

--- a/tests/ui/typeck/super/calls.sol
+++ b/tests/ui/typeck/super/calls.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // ported-from: test/libsolidity/semanticTests/various/super.sol
 // ported-from: test/libsolidity/semanticTests/various/super_parentheses.sol

--- a/tests/ui/typeck/super/conversion.sol
+++ b/tests/ui/typeck/super/conversion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // ported-from: test/libsolidity/syntaxTests/conversion/convert_to_super_empty.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/convert_to_super_nonempty.sol

--- a/tests/ui/typeck/super/linearized_bases.sol
+++ b/tests/ui/typeck/super/linearized_bases.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract A {
     function fromA() public virtual returns (uint256) {

--- a/tests/ui/typeck/super/member_access.sol
+++ b/tests/ui/typeck/super/member_access.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/065_super_excludes_current_contract.sol
 // ported-from: test/libsolidity/syntaxTests/inheritance/super_on_external.sol

--- a/tests/ui/typeck/var_decl_rules.sol
+++ b/tests/ui/typeck/var_decl_rules.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     // Immutable with non-value type (array)

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 type U256 is uint256;
 type Word is bytes32;

--- a/tests/ui/using-for/attached_free_functions.sol
+++ b/tests/ui/using-for/attached_free_functions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/free_functions_individual.sol
 // ported-from: test/libsolidity/semanticTests/using/free_function_multi.sol
 // ported-from: test/libsolidity/semanticTests/using/library_functions_inside_contract.sol

--- a/tests/ui/using-for/attached_function_members.sol
+++ b/tests/ui/using-for/attached_function_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_function_attached_but_not_called.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/assign_attached_library_function.sol
 // ported-from: test/libsolidity/semanticTests/libraries/internal_library_function_attached_to_internal_function_type.sol

--- a/tests/ui/using-for/global/defined_elsewhere.sol
+++ b/tests/ui/using-for/global/defined_elsewhere.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_for_type_defined_elsewhere.sol
 
 library L {

--- a/tests/ui/using-for/global/directives.sol
+++ b/tests/ui/using-for/global/directives.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_working.sol
 
 import {S, U} from "./auxiliary/global_directives.sol";

--- a/tests/ui/using-for/global/imported_type_global.sol
+++ b/tests/ui/using-for/global/imported_type_global.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_for_type_from_other_file.sol
 
 import {ImportedS, ImportedU} from "./auxiliary/imported_types.sol";

--- a/tests/ui/using-for/global/invalid_global_targets.sol
+++ b/tests/ui/using-for/global/invalid_global_targets.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_for_non_user_defined.sol
 // ported-from: test/libsolidity/syntaxTests/using/global_library_for_builtin.sol
 // ported-from: test/libsolidity/syntaxTests/using/global_library_for_interface.sol

--- a/tests/ui/using-for/global/invalid_operator_targets.sol
+++ b/tests/ui/using-for/global/invalid_operator_targets.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/defining_operator_for_enum.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/defining_operator_for_struct.sol
 

--- a/tests/ui/using-for/global/library.sol
+++ b/tests/ui/using-for/global/library.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/using_global_all_the_types.sol
 
 import {E, S, T} from "./auxiliary/global_library.sol";

--- a/tests/ui/using-for/global/library_invisible.sol
+++ b/tests/ui/using-for/global/library_invisible.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/using_global_invisible.sol
 
 import {C} from "./auxiliary/global_invisible_mid.sol";

--- a/tests/ui/using-for/global_local_clash.sol
+++ b/tests/ui/using-for/global_local_clash.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_local_clash.sol
 
 import {S, f1 as f, gen} from "./auxiliary/imported_aliases_and_clashes.sol";

--- a/tests/ui/using-for/imported_functions.sol
+++ b/tests/ui/using-for/imported_functions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/imported_functions.sol
 
 import {inc as aliasedInc} from "./auxiliary/imported_aliases_and_clashes.sol";

--- a/tests/ui/using-for/imports/file_level_using_not_imported.sol
+++ b/tests/ui/using-for/imports/file_level_using_not_imported.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/file_level_inactive_after_import.sol
 
 import "./auxiliary/file_level_using.sol";

--- a/tests/ui/using-for/imports/imported_duplicate_operator.sol
+++ b/tests/ui/using-for/imports/imported_duplicate_operator.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_different_functions_global_and_non_global_different_files.sol
 
 import {Int} from "./auxiliary/transitive_base.sol";

--- a/tests/ui/using-for/imports/imported_global_operator.sol
+++ b/tests/ui/using-for/imports/imported_global_operator.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported.sol
 
 import {Int} from "./auxiliary/imported_using.sol";

--- a/tests/ui/using-for/imports/imported_members.sol
+++ b/tests/ui/using-for/imports/imported_members.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/module_2.sol
 // ported-from: test/libsolidity/syntaxTests/using/library_import_as.sol
 

--- a/tests/ui/using-for/imports/imported_non_global_operator.sol
+++ b/tests/ui/using-for/imports/imported_non_global_operator.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported_non_global.sol
 
 import {ImportedInt} from "./auxiliary/non_global_operator.sol";

--- a/tests/ui/using-for/imports/imported_non_global_operator_definition.sol
+++ b/tests/ui/using-for/imports/imported_non_global_operator_definition.sol
@@ -1,7 +1,7 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
-// check-fail
+//@ check-fail
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported_non_global.sol
 
 import {DefinedInt} from "./auxiliary/defined_non_global_operator.sol";

--- a/tests/ui/using-for/imports/module_alias.sol
+++ b/tests/ui/using-for/imports/module_alias.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/module_3.sol
 
 import "./auxiliary/imported_using.sol" as M;

--- a/tests/ui/using-for/imports/transitive_global_operator.sol
+++ b/tests/ui/using-for/imports/transitive_global_operator.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported.sol
 
 import "./auxiliary/transitive_mid.sol";

--- a/tests/ui/using-for/imports/transitive_global_operator_wrong_source.sol
+++ b/tests/ui/using-for/imports/transitive_global_operator_wrong_source.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 //@ error-in-other-file: can only use `global` with types defined in the same source unit at file level
 //@ error-in-other-file: can only use `global` with types defined in the same source unit at file level
 //@ error-in-other-file: can only use `global` with types defined in the same source unit at file level

--- a/tests/ui/using-for/imports/transitive_non_global_operator.sol
+++ b/tests/ui/using-for/imports/transitive_non_global_operator.sol
@@ -1,9 +1,9 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
-// check-fail
+//@ check-fail
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported_transitively_non_global.sol
 
 import "./auxiliary/non_global_left.sol";

--- a/tests/ui/using-for/invalid/contract_directive.sol
+++ b/tests/ui/using-for/invalid/contract_directive.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_contract_err.sol
 
 contract NotLibrary {

--- a/tests/ui/using-for/invalid/free_no_parameters.sol
+++ b/tests/ui/using-for/invalid/free_no_parameters.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_free_no_parameters_err.sol
 
 function zero() pure returns (uint256) {

--- a/tests/ui/using-for/invalid/implicit_conversion.sol
+++ b/tests/ui/using-for/invalid/implicit_conversion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/free_functions_implicit_conversion_err.sol
 
 struct S {

--- a/tests/ui/using-for/invalid/library_for_library.sol
+++ b/tests/ui/using-for/invalid/library_for_library.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_library_for_library.sol
 
 library L {}

--- a/tests/ui/using-for/invalid/non_function.sol
+++ b/tests/ui/using-for/invalid/non_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_non_function.sol
 
 contract C {

--- a/tests/ui/using-for/invalid/private_library_function.sol
+++ b/tests/ui/using-for/invalid/private_library_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/private_library_function_outside_scope.sol
 
 library L {

--- a/tests/ui/using-for/invalid/unbraced_function.sol
+++ b/tests/ui/using-for/invalid/unbraced_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/function_name_without_braces_inside_contract_err.sol
 
 function id256(uint256 x) pure returns (uint256) {

--- a/tests/ui/using-for/libraries/self_call.sol
+++ b/tests/ui/using-for/libraries/self_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_attached_at_file_level_used_inside_library.sol
 
 library L {

--- a/tests/ui/using-for/libraries/visibility.sol
+++ b/tests/ui/using-for/libraries/visibility.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_at_file_level.sol
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 // ported-from: test/libsolidity/syntaxTests/using/private_library_function_inside_scope.sol

--- a/tests/ui/using-for/locations/calldata_receiver.sol
+++ b/tests/ui/using-for/locations/calldata_receiver.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/bound_calldata_parameter_accepting_calldata.sol
 
 struct S {

--- a/tests/ui/using-for/locations/calldata_rejects_memory.sol
+++ b/tests/ui/using-for/locations/calldata_rejects_memory.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/bound_calldata_parameter_not_accepting_memory.sol
 
 library L {

--- a/tests/ui/using-for/locations/reference_types.sol
+++ b/tests/ui/using-for/locations/reference_types.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/free_reference_type.sol
 
 function memoryHead(uint256[] memory x) pure returns (uint256) {

--- a/tests/ui/using-for/methods.sol
+++ b/tests/ui/using-for/methods.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_free_functions.sol
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 // ported-from: test/libsolidity/syntaxTests/using/global_working.sol

--- a/tests/ui/using-for/operators.sol
+++ b/tests/ui/using-for/operators.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/contract_scope_duplicates.sol
+++ b/tests/ui/using-for/operators/contract_scope_duplicates.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_on_file_and_contract_level.sol
 
 type Int is int256;

--- a/tests/ui/using-for/operators/contract_scope_not_inherited.sol
+++ b/tests/ui/using-for/operators/contract_scope_not_inherited.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/using_for_with_operator_at_contract_level_in_base_contract.sol
 
 type Int is int256;

--- a/tests/ui/using-for/operators/duplicate_distinct_functions.sol
+++ b/tests/ui/using-for/operators/duplicate_distinct_functions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_different_functions_same_directive.sol
 
 type Int is int256;

--- a/tests/ui/using-for/operators/duplicate_same_directive.sol
+++ b/tests/ui/using-for/operators/duplicate_same_directive.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_different_functions_same_directive.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/duplicate_same_function.sol
+++ b/tests/ui/using-for/operators/duplicate_same_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_same_function_same_directive.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_same_function_separate_directives.sol
 

--- a/tests/ui/using-for/operators/implicit_conversion_failures.sol
+++ b/tests/ui/using-for/operators/implicit_conversion_failures.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_with_implicit_conversion.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/imported_global.sol
+++ b/tests/ui/using-for/operators/imported_global.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported.sol
 
 import {Int} from "./auxiliary/operator_imported.sol";

--- a/tests/ui/using-for/operators/invalid_event_implementor.sol
+++ b/tests/ui/using-for/operators/invalid_event_implementor.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_event.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/invalid_implementors.sol
+++ b/tests/ui/using-for/operators/invalid_implementors.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_contract_function_at_file_level.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_library_function_at_file_level.sol
 

--- a/tests/ui/using-for/operators/non_pure_definition.sol
+++ b/tests/ui/using-for/operators/non_pure_definition.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_non_pure_function.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/operator_definition_matrix.sol
+++ b/tests/ui/using-for/operators/operator_definition_matrix.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_no_parameters_binary.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_two_parameters_unary.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_and_returning_types_not_matching_using_for.sol

--- a/tests/ui/using-for/operators/operator_not_method.sol
+++ b/tests/ui/using-for/operators/operator_not_method.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_as_attached_function_via_function_name.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/type_mismatch_definitions.sol
+++ b/tests/ui/using-for/operators/type_mismatch_definitions.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_and_returning_types_not_matching_using_for.sol
 
 type Int is int256;

--- a/tests/ui/using-for/overloads/ambiguous_library_member.sol
+++ b/tests/ui/using-for/overloads/ambiguous_library_member.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 
 library L {

--- a/tests/ui/using-for/overloads/braced_free_overload_rejected.sol
+++ b/tests/ui/using-for/overloads/braced_free_overload_rejected.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/free_functions_non_unique_err.sol
 // ported-from: test/libsolidity/syntaxTests/using/free_overloads.sol
 

--- a/tests/ui/using-for/overloads/library_member_overloads.sol
+++ b/tests/ui/using-for/overloads/library_member_overloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 
 library L {

--- a/tests/ui/using-for/paths/super_qualified_function.sol
+++ b/tests/ui/using-for/paths/super_qualified_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/function_from_base_contract_qualified_with_super.sol
 
 contract C {

--- a/tests/ui/using-for/paths/this_qualified_function.sol
+++ b/tests/ui/using-for/paths/this_qualified_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/external_function_qualified_with_this.sol
 
 contract C {

--- a/tests/ui/yul_lowering/arithmetic.sol
+++ b/tests/ui/yul_lowering/arithmetic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f(uint256 a, uint256 b) public returns (uint256 x) {

--- a/tests/ui/yul_lowering/break_continue.sol
+++ b/tests/ui/yul_lowering/break_continue.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function ok(uint256 n) public returns (uint256 x) {

--- a/tests/ui/yul_lowering/builtins.sol
+++ b/tests/ui/yul_lowering/builtins.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f() public returns (uint256 x) {

--- a/tests/ui/yul_lowering/control_flow.sol
+++ b/tests/ui/yul_lowering/control_flow.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f(uint256 n) public returns (uint256 x) {

--- a/tests/ui/yul_lowering/dialect_helpers.sol
+++ b/tests/ui/yul_lowering/dialect_helpers.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f() public returns (uint256 x, uint256 y) {

--- a/tests/ui/yul_lowering/for_loop_scope.sol
+++ b/tests/ui/yul_lowering/for_loop_scope.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function init_visible(uint256 n) public returns (uint256 x) {

--- a/tests/ui/yul_lowering/solc_for_statement_2.sol
+++ b/tests/ui/yul_lowering/solc_for_statement_2.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libyul/yulSyntaxTests/for_statement_2.yul
 
 contract C {

--- a/tests/ui/yul_lowering/solc_inline_assembly_instructions_allowed.sol
+++ b/tests/ui/yul_lowering/solc_inline_assembly_instructions_allowed.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/viewPureChecker/inline_assembly_instructions_allowed.sol
 
 contract C {

--- a/tests/ui/yul_lowering/yul_call_non_function.sol
+++ b/tests/ui/yul_lowering/yul_call_non_function.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function helper(uint256 a) internal pure returns (uint256) {

--- a/tests/ui/yul_lowering/yul_function_resolution.sol
+++ b/tests/ui/yul_lowering/yul_function_resolution.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f() public returns (uint256 x) {

--- a/tests/ui/yul_lowering/yul_function_scope.sol
+++ b/tests/ui/yul_lowering/yul_function_scope.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Ztypeck
+//@ compile-flags: -Ztypeck
 
 contract C {
     function f() public returns (uint256 x, uint256 y) {

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -44,21 +44,25 @@ pub fn run_tests(cmd: &'static Path) -> Result<()> {
 
     let tmp_dir = tempfile::tempdir()?;
     let tmp_dir = &*Box::leak(tmp_dir.path().to_path_buf().into_boxed_path());
-    for &mode in modes {
-        let cfg = MyConfig::<'static> { mode, tmp_dir };
-        let config = config(cmd, &args, mode);
+    let configs = modes.iter().copied().map(|mode| config(cmd, &args, mode)).collect();
 
-        let text_emitter: Box<dyn ui_test::status_emitter::StatusEmitter> = args.format.into();
-        let gha_emitter = ui_test::status_emitter::Gha { name: mode.to_string(), group: true };
-        let status_emitter = (text_emitter, gha_emitter);
+    let text_emitter: Box<dyn ui_test::status_emitter::StatusEmitter> = args.format.into();
+    let gha_name = if modes.len() == 1 { modes[0].to_string() } else { "ui-tests".to_string() };
+    let gha_emitter = ui_test::status_emitter::Gha { name: gha_name, group: true };
+    let status_emitter = (text_emitter, gha_emitter);
 
-        ui_test::run_tests_generic(
-            vec![config],
-            move |path, config| file_filter(path, config, cfg),
-            move |config, contents| per_file_config(config, contents, cfg),
-            status_emitter,
-        )?;
-    }
+    ui_test::run_tests_generic(
+        configs,
+        move |path, config| {
+            let cfg = MyConfig::<'static> { mode: mode_from_config(config), tmp_dir };
+            file_filter(path, config, cfg)
+        },
+        move |config, contents| {
+            let cfg = MyConfig::<'static> { mode: mode_from_config(config), tmp_dir };
+            per_file_config(config, contents, cfg)
+        },
+        status_emitter,
+    )?;
 
     Ok(())
 }
@@ -90,7 +94,7 @@ FileCheck "$2" < "$out"
 "#;
 
     let mut config = ui_test::Config {
-        // `host` and `target` are used for `//@ignore-...` comments.
+        // `host` and `target` are used for `//@ ignore-...` comments.
         host: Some(get_host().to_string()),
         target: None,
         root_dir: tests_root,
@@ -198,6 +202,18 @@ fn get_host() -> &'static str {
     })
 }
 
+fn mode_from_config(config: &ui_test::Config) -> Mode {
+    if config.program.program == Path::new("sh") {
+        Mode::StandardJson
+    } else if config.root_dir.ends_with("testdata/solidity/test/libyul") {
+        Mode::SolcYul
+    } else if config.root_dir.ends_with("testdata/solidity/test") {
+        Mode::SolcSolidity
+    } else {
+        Mode::Ui
+    }
+}
+
 fn file_filter(path: &Path, config: &ui_test::Config, cfg: MyConfig<'_>) -> Option<bool> {
     match cfg.mode {
         Mode::StandardJson => {
@@ -236,16 +252,15 @@ fn per_file_config(config: &mut ui_test::Config, file: &Spanned<Vec<u8>>, cfg: M
 
     assert_eq!(config.comment_start, "//");
     let has_annotations = src.contains("//~");
-    // TODO: https://github.com/oli-obk/ui_test/issues/341
-    let is_check_fail = src.contains("check-fail");
-    config.comment_defaults.base().require_annotations =
-        Spanned::dummy(is_check_fail || has_annotations).into();
-    let code = if is_check_fail || (has_annotations && src.contains("ERROR:")) { 1 } else { 0 };
+    config.comment_defaults.base().require_annotations = Spanned::dummy(has_annotations).into();
+    let code = if has_annotations && src.contains("ERROR:") { 1 } else { 0 };
     config.comment_defaults.base().exit_status = Spanned::dummy(code).into();
 
     if src.lines().any(|line| {
         let line = line.trim_start();
-        line.starts_with("//@compile-flags:") && (line.contains("-j") || line.contains("--threads"))
+        line.starts_with("//@")
+            && line.contains("compile-flags")
+            && (line.contains("-j") || line.contains("--threads"))
     }) {
         config.program.args.retain(|arg| arg != "-j1");
     }


### PR DESCRIPTION
This updates the UI test harness to run the configured modes in a single `ui_test` invocation, so filtering and scheduling apply across the whole set consistently. The per-mode behavior is still derived from each config before file filtering and per-file setup.

It also switches to the forked `ui_test` branch with native `//@ check-fail` support, removes the local `check-fail` workaround, and normalizes UI metadata comments to use a space after `//@` while leaving revision-specific directives unchanged.
