### PR TITLE
fix(bench): preserve single-threaded session

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -294,8 +294,8 @@ impl Compiler for Solar {
 fn session() -> Session {
     Session::builder()
         .with_stderr_emitter_and_color(solar::parse::interface::ColorChoice::Always)
-        .single_threaded()
         .opts(solar::config::Opts {
+            threads: solar::config::Threads::resolve(1),
             unstable: solar::config::UnstableOpts {
                 typeck: true,
                 codegen: true,


### PR DESCRIPTION
Keep the benchmark session single-threaded after installing the codegen/typeck options.

The codegen merge added an explicit `opts(...)` call after `single_threaded()`, which replaced the whole option set and restored the default thread count. Move `single_threaded()` after `opts(...)` so the Criterion benchmarks keep their intended one-thread configuration while still enabling the codegen-related flags.
