### PR TITLE
feat(codegen): cost-model load PRE insertions

### DIFF
--- a/crates/codegen/src/transform/indvar_simplify.rs
+++ b/crates/codegen/src/transform/indvar_simplify.rs
@@ -187,7 +187,7 @@ impl IndVarSimplifier {
         let AffineExpr { base, constant, terms } = scev.get(value)?.clone();
         let base = base?;
         let [term] = terms.as_slice() else { return None };
-        if term.value != iv_value || term.scale <= 1 {
+        if term.value != iv_value || term.scale <= 0 {
             return None;
         }
         if constant < 0 {

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -214,14 +214,96 @@ impl KeySet {
 /// inserting copies of `kind` at the end of the `insertions` predecessors.
 struct Candidate {
     target: BlockId,
-    inst: InstId,
     key: LoadKey,
-    result: ValueId,
     result_ty: MirType,
     kind: InstKind,
     metadata: InstructionMetadata,
+    loads: Vec<(InstId, ValueId)>,
     incoming: Vec<(BlockId, ValueId)>,
     insertions: Vec<BlockId>,
+}
+
+/// A small static profitability model for load PRE insertions.
+///
+/// The model intentionally works in approximate dynamic path cost rather than
+/// MIR instruction count: a join-block reload executes on every predecessor
+/// path, while a compensating load only executes on the paths where the value
+/// was unavailable.
+#[derive(Clone, Copy, Debug, Default)]
+struct LoadPreCostModel;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LoadPreCost {
+    saved: i64,
+    inserted: i64,
+    phi: i64,
+    operands: i64,
+}
+
+impl LoadPreCost {
+    const fn is_profitable(self) -> bool {
+        self.saved > self.inserted + self.phi + self.operands
+    }
+}
+
+struct LoadPreCostInput<'a> {
+    func: &'a Function,
+    key: LoadKey,
+    kind: &'a InstKind,
+    predecessors: &'a [BlockId],
+    loads: &'a [(InstId, ValueId)],
+    insertions: &'a [BlockId],
+    loop_carried: bool,
+    needs_phi: bool,
+}
+
+impl LoadPreCostModel {
+    const MEMORY_READ: i64 = 3;
+    const STORAGE_READ: i64 = 100;
+    const TRANSIENT_READ: i64 = 100;
+    const KECCAK_BASE: i64 = 30;
+    const KECCAK_WORD: i64 = 6;
+    const NON_LOOP_PHI_EDGE_COPY: i64 = 3;
+    const CROSS_BLOCK_OPERAND: i64 = 3;
+
+    fn estimate(&self, input: LoadPreCostInput<'_>) -> LoadPreCost {
+        let read = Self::read_cost(input.key);
+        let saved = read * input.loads.len() as i64 * input.predecessors.len() as i64;
+        let inserted = read * input.insertions.len() as i64;
+        let phi = if !input.needs_phi || input.loop_carried {
+            0
+        } else {
+            Self::NON_LOOP_PHI_EDGE_COPY * input.predecessors.len() as i64
+        };
+        let operands = Self::inserted_operand_cost(input.func, input.kind, input.insertions);
+        LoadPreCost { saved, inserted, phi, operands }
+    }
+
+    const fn read_cost(key: LoadKey) -> i64 {
+        match key {
+            LoadKey::Storage(_) => Self::STORAGE_READ,
+            LoadKey::Transient(_) => Self::TRANSIENT_READ,
+            LoadKey::Memory(_) => Self::MEMORY_READ,
+            LoadKey::Keccak(_, size) => match size {
+                KeccakSize::Const(size) => {
+                    Self::KECCAK_BASE + Self::KECCAK_WORD * size.div_ceil(32) as i64
+                }
+                KeccakSize::Dyn(_) => Self::KECCAK_BASE + Self::KECCAK_WORD * 2,
+            },
+        }
+    }
+
+    fn inserted_operand_cost(func: &Function, kind: &InstKind, insertions: &[BlockId]) -> i64 {
+        if insertions.is_empty() {
+            return 0;
+        }
+        let cross_block_operands = kind
+            .operands()
+            .into_iter()
+            .filter(|&value| matches!(func.value(value), Value::Inst(_) | Value::Undef(_)))
+            .count();
+        Self::CROSS_BLOCK_OPERAND * cross_block_operands as i64 * insertions.len() as i64
+    }
 }
 
 /// Per-round analysis shared by candidate collection.
@@ -481,7 +563,7 @@ impl LoadRedundancyEliminator {
                 }
                 modified_blocks.insert(candidate.target);
                 modified_blocks.extend(candidate.insertions.iter().copied());
-                eliminated_values.insert(candidate.result);
+                eliminated_values.extend(candidate.loads.iter().map(|&(_, value)| value));
                 batch.push(candidate);
             }
         }
@@ -500,6 +582,7 @@ impl LoadRedundancyEliminator {
         modified_blocks.contains(&candidate.target)
             || candidate.insertions.iter().any(|block| modified_blocks.contains(block))
             || candidate.incoming.iter().any(|(_, value)| eliminated_values.contains(value))
+            || candidate.loads.iter().any(|&(_, value)| eliminated_values.contains(&value))
             || (!candidate.insertions.is_empty()
                 && candidate
                     .kind
@@ -560,6 +643,50 @@ impl LoadRedundancyEliminator {
         found
     }
 
+    fn same_key_loads_in_target(
+        func: &Function,
+        analysis: &Analysis,
+        target: BlockId,
+        first_inst: InstId,
+        key: LoadKey,
+    ) -> Vec<(InstId, ValueId)> {
+        let mut loads = Vec::new();
+        let mut past_first = false;
+
+        for &inst_id in &func.blocks[target].instructions {
+            if inst_id == first_inst {
+                past_first = true;
+            }
+            if !past_first {
+                continue;
+            }
+
+            if inst_id != first_inst {
+                let kind = &func.instructions[inst_id].kind;
+                if matches!(kind, InstKind::Gas) {
+                    break;
+                }
+                if matches!(kind, InstKind::MSize)
+                    && matches!(key, LoadKey::Memory(_) | LoadKey::Keccak(_, _))
+                {
+                    break;
+                }
+                if kind.has_side_effects() && Self::inst_kills_key(func, inst_id, key) {
+                    break;
+                }
+            }
+
+            if let Some((load_key, GenSource::LoadResult)) = Self::gen_key_value(func, inst_id)
+                && load_key == key
+                && let Some(&value) = analysis.inst_results.get(&inst_id)
+            {
+                loads.push((inst_id, value));
+            }
+        }
+
+        loads
+    }
+
     fn candidate_for_load(
         &self,
         func: &Function,
@@ -573,6 +700,10 @@ impl LoadRedundancyEliminator {
         let result = *cx.analysis.inst_results.get(&inst)?;
         let result_ty = instruction.result_ty?;
         let key = cx.analysis.keys[key_idx];
+        let loads = Self::same_key_loads_in_target(func, cx.analysis, target, inst, key);
+        if loads.is_empty() {
+            return None;
+        }
 
         let mut incoming = Vec::with_capacity(predecessors.len());
         let mut insertions = Vec::new();
@@ -601,41 +732,50 @@ impl LoadRedundancyEliminator {
 
         let loop_carried =
             Self::is_loop_carried_rewrite(&cx.analysis.dominators, target, &incoming, &insertions);
-        // Memory reads are only 3 gas, so a diamond phi is still not worth
-        // the extra block-edge work. Loop-carried memory PRE is different:
-        // the entry load runs once while the eliminated header reload would
-        // run on every iteration, and the backend can now keep canonical loop
-        // phis stack-resident.
-        if matches!(key, LoadKey::Memory(_)) && !loop_carried {
+        let needs_phi = !insertions.is_empty()
+            || incoming.first().is_none_or(|&(_, first)| {
+                first == result || incoming.iter().any(|&(_, value)| value != first)
+            });
+        let model = LoadPreCostModel;
+        let cost = model.estimate(LoadPreCostInput {
+            func,
+            key,
+            kind: &instruction.kind,
+            predecessors,
+            loads: &loads,
+            insertions: &insertions,
+            loop_carried,
+            needs_phi,
+        });
+        if !cost.is_profitable() {
             return None;
         }
 
         if !insertions.is_empty() {
-            // The backend lowers phis through spill slots, so an insertion
-            // always lengthens its own path by the phi copies while the
-            // savings land on the other paths. Static counts cannot weigh
-            // execution frequencies, so only loop-carried availability is
-            // accepted: the value arrives over backedges (predecessors the
-            // join dominates) and the compensating loads sit on the entry
-            // edges, running once per loop entry while every iteration drops
-            // a full load.
-            let insertion_profitable = incoming
+            // Insertions must be structurally safe; profitability is decided
+            // by `LoadPreCostModel` above.
+            let loop_insertion = incoming
                 .iter()
                 .all(|&(pred, _)| cx.analysis.dominators.dominates(target, pred))
                 && insertions.iter().all(|&pred| !cx.analysis.dominators.dominates(target, pred));
-            if !insertion_profitable || insertions.len() > incoming.len() {
+            let diamond_insertion = Self::is_non_cyclic_diamond_insertion(
+                &cx.analysis.dominators,
+                target,
+                &incoming,
+                &insertions,
+            );
+            if !(loop_insertion || diamond_insertion) || insertions.len() > incoming.len() {
                 return None;
             }
         }
 
         Some(Candidate {
             target,
-            inst,
             key,
-            result,
             result_ty,
             kind: instruction.kind.clone(),
             metadata: instruction.metadata.clone(),
+            loads,
             incoming,
             insertions,
         })
@@ -653,6 +793,18 @@ impl LoadRedundancyEliminator {
             || !insertions.is_empty();
         has_backedge_incoming
             && has_entry_edge
+            && insertions.iter().all(|&pred| !dominators.dominates(target, pred))
+    }
+
+    fn is_non_cyclic_diamond_insertion(
+        dominators: &DominatorTree,
+        target: BlockId,
+        incoming: &[(BlockId, ValueId)],
+        insertions: &[BlockId],
+    ) -> bool {
+        !incoming.is_empty()
+            && !insertions.is_empty()
+            && incoming.iter().all(|&(pred, _)| !dominators.dominates(target, pred))
             && insertions.iter().all(|&pred| !dominators.dominates(target, pred))
     }
 
@@ -723,17 +875,8 @@ impl LoadRedundancyEliminator {
         eliminated_keys: &mut FxHashSet<(LoadKey, BlockId)>,
         inserted_insts: &mut FxHashSet<InstId>,
     ) {
-        let Candidate {
-            target,
-            inst,
-            key,
-            result,
-            result_ty,
-            kind,
-            metadata,
-            mut incoming,
-            insertions,
-        } = candidate;
+        let Candidate { target, key, result_ty, kind, metadata, loads, mut incoming, insertions } =
+            candidate;
 
         eliminated_keys.insert((key, target));
 
@@ -755,10 +898,11 @@ impl LoadRedundancyEliminator {
         // A fully-available key whose predecessors all locate the same value
         // needs no phi: that value's def dominates every predecessor and
         // therefore the join itself.
+        let first_result = loads[0].1;
         let replacement = match incoming.first() {
             Some(&(_, first))
                 if fully_available
-                    && first != result
+                    && first != first_result
                     && incoming.iter().all(|&(_, value)| value == first) =>
             {
                 first
@@ -779,9 +923,12 @@ impl LoadRedundancyEliminator {
             }
         };
 
-        Self::replace_uses(func, result, replacement);
-        func.blocks[target].instructions.retain(|&inst_id| inst_id != inst);
-        self.stats.loads_eliminated += 1;
+        for &(_, load_result) in &loads {
+            Self::replace_uses(func, load_result, replacement);
+        }
+        let load_insts: FxHashSet<InstId> = loads.iter().map(|&(inst_id, _)| inst_id).collect();
+        func.blocks[target].instructions.retain(|&inst_id| !load_insts.contains(&inst_id));
+        self.stats.loads_eliminated += loads.len();
     }
 
     // ----- Keys, gens, and kills -----

--- a/crates/codegen/src/transform/loop_opt.rs
+++ b/crates/codegen/src/transform/loop_opt.rs
@@ -430,6 +430,8 @@ impl LoopOptimizer {
         self.licm_profit(func, inst_id) >= self.config.min_licm_profit
             || (self.loop_has_known_multiple_iterations(ctx.loop_data)
                 && self.is_affine_address_base_used_in_loop(func, inst_id, ctx))
+            || (self.inst_dominates_loop_backedges(func, inst_id, ctx.loop_data, ctx.analyzer)
+                && self.is_affine_address_base_used_in_loop(func, inst_id, ctx))
     }
 
     fn loop_has_known_multiple_iterations(&self, loop_data: &Loop) -> bool {
@@ -445,6 +447,24 @@ impl LoopOptimizer {
             }
         }
         false
+    }
+
+    fn inst_dominates_loop_backedges(
+        &self,
+        func: &Function,
+        inst_id: InstId,
+        loop_data: &Loop,
+        analyzer: &LoopAnalyzer,
+    ) -> bool {
+        let Some(inst_block) = loop_data
+            .blocks
+            .iter()
+            .copied()
+            .find(|&block| func.blocks[block].instructions.contains(&inst_id))
+        else {
+            return false;
+        };
+        loop_data.back_edges.iter().all(|&latch| analyzer.dominates(inst_block, latch))
     }
 
     fn loop_may_mutate_memory_range(

--- a/tests/ui/codegen/mir/indvar_simplify.mir
+++ b/tests/ui/codegen/mir/indvar_simplify.mir
@@ -34,3 +34,19 @@ fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
   bb3:
     ret 0
 }
+
+fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    v1 = phi [bb0: 0], [bb2: v5]
+    v2 = lt v1, 4
+    br v2, bb2, bb3
+  bb2:
+    v3 = add arg0, v1
+    mstore8 v3, v1
+    v5 = add v1, 1
+    jump bb1
+  bb3:
+    ret 0
+}

--- a/tests/ui/codegen/mir/indvar_simplify.stdout
+++ b/tests/ui/codegen/mir/indvar_simplify.stdout
@@ -39,3 +39,21 @@ fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
   bb3:
     ret 0
 }
+
+fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    v3 = phi [bb0: 0], [bb2: v2]
+    v9 = phi [bb0: arg0], [bb2: v11]
+    v5 = lt v3, 4
+    br v5, bb2, bb3
+  bb2:
+    v6 = add arg0, v3
+    mstore8 v9, v3
+    v2 = add v3, 1
+    v11 = add v9, 1
+    jump bb1
+  bb3:
+    ret 0
+}

--- a/tests/ui/codegen/mir/licm_v2.mir
+++ b/tests/ui/codegen/mir/licm_v2.mir
@@ -68,3 +68,21 @@ fn @hoist_affine_memory_base(arg0: u256) -> u256 {
   bb3:
     ret 0
 }
+
+fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    v1 = phi [bb0: 0], [bb2: v7]
+    v2 = lt v1, arg1
+    br v2, bb2, bb3
+  bb2:
+    v3 = add arg0, 32
+    v4 = mul v1, 32
+    v5 = add v3, v4
+    mstore v5, v1
+    v7 = add v1, 1
+    jump bb1
+  bb3:
+    ret 0
+}

--- a/tests/ui/codegen/mir/licm_v2.stdout
+++ b/tests/ui/codegen/mir/licm_v2.stdout
@@ -38,13 +38,13 @@ fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
 
 fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
   bb0 (entry):
+    v3 = add arg0, 1
+    v6 = add arg0, 2
     jump bb1
   bb1:
     br arg1, bb2, bb3
   bb2:
-    v3 = add arg0, 1
     v4 = sload v3 !metadata(storage=offset(arg0, 1))
-    v6 = add arg0, 2
     sstore v6, 9 !metadata(storage=offset(arg0, 2))
     jump bb1
   bb3:
@@ -64,6 +64,24 @@ fn @hoist_affine_memory_base(arg0: u256) -> u256 {
     v10 = add v7, v9
     mstore v10, v3
     v2 = add v3, 1
+    jump bb1
+  bb3:
+    ret 0
+}
+
+fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    v7 = add arg0, 32
+    jump bb1
+  bb1:
+    v4 = phi [bb0: 0], [bb2: v3]
+    v5 = lt v4, arg1
+    br v5, bb2, bb3
+  bb2:
+    v9 = mul v4, 32
+    v10 = add v7, v9
+    mstore v10, v4
+    v3 = add v4, 1
     jump bb1
   bb3:
     ret 0

--- a/tests/ui/codegen/mir/load_pre.mir
+++ b/tests/ui/codegen/mir/load_pre.mir
@@ -1,10 +1,9 @@
 //@compile-flags: --pass load-pre
 // Basic storage shapes: a join reload of a slot loaded in both arms becomes a
 // phi; an sstore in one arm forwards its stored value into the phi. A load
-// available on one diamond arm only is NOT compensated on the other arm:
-// the backend's spill-slot phi copies lengthen the inserted path while the
-// savings land elsewhere, and static counts cannot weigh path frequencies,
-// so insertion is reserved for loop-carried availability (load_pre_loop.mir).
+// available on one diamond arm only is compensated on the other arm for
+// expensive storage/transient/keccak keys; cheap memory keys keep the stricter
+// loop-carried-only policy (load_pre_memory.mir).
 ; module @LoadPre
 fn @full_diamond(arg0: bool) -> u256 {
   bb0 (entry):
@@ -34,7 +33,7 @@ fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
     ret v3
 }
 
-fn @partial_no_insert_diamond(arg0: bool) -> u256 {
+fn @partial_insert_diamond(arg0: bool) -> u256 {
   bb0 (entry):
     br arg0, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/load_pre.stdout
+++ b/tests/ui/codegen/mir/load_pre.stdout
@@ -28,17 +28,18 @@ fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
     ret v7
 }
 
-fn @partial_no_insert_diamond(arg0: bool) -> u256 {
+fn @partial_insert_diamond(arg0: bool) -> u256 {
   bb0 (entry):
     br arg0, bb1, bb2
   bb1:
     v2 = sload 5
     jump bb3
   bb2:
+    v5 = sload 5
     jump bb3
   bb3:
-    v4 = sload 5
-    ret v4
+    v6 = phi [bb1: v2], [bb2: v5]
+    ret v6
 }
 
 fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {

--- a/tests/ui/codegen/mir/load_pre_clobbers.mir
+++ b/tests/ui/codegen/mir/load_pre_clobbers.mir
@@ -1,10 +1,9 @@
 //@compile-flags: --pass load-pre
-// Kill behavior: a may-aliasing sstore or a call in an arm blocks the
-// rewrite; staticcall preserves storage so the join reload reuses the
-// dominating load directly; a clobbering diamond arm gets no compensating
-// load (insertion is reserved for loop-carried availability, and the phi
-// spill copies would lengthen the arm for no saving on it); gas() above the
-// join load blocks the rewrite in all spaces.
+// Kill behavior: a may-aliasing sstore or a call in an arm blocks reuse across
+// that edge; staticcall preserves storage so the join reload reuses the
+// dominating load directly; a clobbering diamond arm may be compensated, but
+// the inserted load must stay after the clobber; gas() above the join load
+// blocks the rewrite in all spaces.
 ; module @LoadPreClobbers
 fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
   bb0 (entry):
@@ -54,7 +53,7 @@ fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
     ret v1
 }
 
-fn @clobbered_arm_no_insert(arg0: bool, arg1: u256) -> u256 {
+fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
   bb0 (entry):
     br arg0, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/load_pre_clobbers.stdout
+++ b/tests/ui/codegen/mir/load_pre_clobbers.stdout
@@ -47,19 +47,20 @@ fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
     ret v3
 }
 
-fn @clobbered_arm_no_insert(arg0: bool, arg1: u256) -> u256 {
+fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
   bb0 (entry):
     br arg0, bb1, bb2
   bb1:
     v3 = sload 5
     sstore arg1, 7
+    v9 = sload 5
     jump bb3
   bb2:
     v6 = sload 5
     jump bb3
   bb3:
-    v8 = sload 5
-    ret v8
+    v10 = phi [bb1: v9], [bb2: v6]
+    ret v10
 }
 
 fn @gas_blocks_rewrite(arg0: bool) -> u256 {

--- a/tests/ui/codegen/mir/load_pre_memory.mir
+++ b/tests/ui/codegen/mir/load_pre_memory.mir
@@ -1,7 +1,8 @@
 //@compile-flags: --pass load-pre
-// Memory diamond shapes stay rejected: a 3-gas MLOAD does not pay for a
-// merge phi. Loop-carried memory reloads are profitable now that canonical
-// loop phis can stay stack-resident in the EVM backend.
+// Memory diamonds are cost-model gated: a single 3-gas MLOAD does not pay for
+// a merge phi, but repeated same-key join reloads can amortize the insertion.
+// Loop-carried memory reloads are profitable now that canonical loop phis can
+// stay stack-resident in the EVM backend.
 ; module @LoadPreMemory
 fn @mload_full_diamond(arg0: bool) -> u256 {
   bb0 (entry):
@@ -58,6 +59,21 @@ fn @mload_partial_rejected(arg0: bool) -> u256 {
   bb3:
     v2 = mload 128
     ret v2
+}
+
+fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
+  bb0 (entry):
+    br arg0, bb1, bb2
+  bb1:
+    v1 = mload 128
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    v2 = mload 128
+    v3 = mload 128
+    v4 = add v2, v3
+    ret v4
 }
 
 fn @mload_partial_two_available(arg0: u256) -> u256 {

--- a/tests/ui/codegen/mir/load_pre_memory.stdout
+++ b/tests/ui/codegen/mir/load_pre_memory.stdout
@@ -57,6 +57,21 @@ fn @mload_partial_rejected(arg0: bool) -> u256 {
     ret v4
 }
 
+fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
+  bb0 (entry):
+    br arg0, bb1, bb2
+  bb1:
+    v2 = mload 128
+    jump bb3
+  bb2:
+    v8 = mload 128
+    jump bb3
+  bb3:
+    v9 = phi [bb1: v2], [bb2: v8]
+    v7 = add v9, v9
+    ret v7
+}
+
 fn @mload_partial_two_available(arg0: u256) -> u256 {
   bb0 (entry):
     switch arg0, default bb3, [1 => bb1, 2 => bb2]


### PR DESCRIPTION
Adds a small MIR cost model for load-PRE/loop opts so we only insert extra work when it is expected to pay off.

- enables profitable memory load-PRE cases
- opens selected indvar/LICM patterns after stack-resident loop values
- keeps cheap diamond insertions gated when the spill/phi cost would outweigh the load


It goes after https://github.com/paradigmxyz/solar/pull/862