### PR TITLE
refactor: add shared bitset data structures

### DIFF
--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -12,114 +12,11 @@
 
 use crate::mir::{BlockId, Function, InstId, Terminator, Value, ValueId};
 use smallvec::SmallVec;
-use solar_data_structures::map::FxHashMap;
+use solar_data_structures::{bit_set::GrowableBitSet, map::FxHashMap};
 use std::collections::VecDeque;
 
 /// A dense bitset for tracking live values.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct LiveSet {
-    /// Bit vector where bit i indicates whether value i is live.
-    bits: Vec<u64>,
-}
-
-impl LiveSet {
-    /// Creates a new empty live set with capacity for `n` values.
-    #[must_use]
-    pub fn with_capacity(n: usize) -> Self {
-        let words = n.div_ceil(64);
-        Self { bits: vec![0; words] }
-    }
-
-    /// Returns true if the value is in the set.
-    #[must_use]
-    pub fn contains(&self, val: ValueId) -> bool {
-        let idx = val.index();
-        let word = idx / 64;
-        let bit = idx % 64;
-        word < self.bits.len() && (self.bits[word] & (1u64 << bit)) != 0
-    }
-
-    /// Adds a value to the set. Returns true if the value was not already present.
-    pub fn insert(&mut self, val: ValueId) -> bool {
-        let idx = val.index();
-        let word = idx / 64;
-        let bit = idx % 64;
-        if word >= self.bits.len() {
-            self.bits.resize(word + 1, 0);
-        }
-        let mask = 1u64 << bit;
-        let was_absent = (self.bits[word] & mask) == 0;
-        self.bits[word] |= mask;
-        was_absent
-    }
-
-    /// Removes a value from the set.
-    pub fn remove(&mut self, val: ValueId) {
-        let idx = val.index();
-        let word = idx / 64;
-        let bit = idx % 64;
-        if word < self.bits.len() {
-            self.bits[word] &= !(1u64 << bit);
-        }
-    }
-
-    /// Sets `self = self - other`, returning true if this set changed.
-    pub fn subtract(&mut self, other: &Self) -> bool {
-        let mut changed = false;
-        for (i, &word) in other.bits.iter().enumerate() {
-            if i < self.bits.len() {
-                let old = self.bits[i];
-                self.bits[i] &= !word;
-                if self.bits[i] != old {
-                    changed = true;
-                }
-            }
-        }
-        changed
-    }
-
-    /// Unions this set with another, returning true if this set changed.
-    pub fn union_with(&mut self, other: &Self) -> bool {
-        let mut changed = false;
-        if self.bits.len() < other.bits.len() {
-            self.bits.resize(other.bits.len(), 0);
-        }
-        for (i, &word) in other.bits.iter().enumerate() {
-            let old = self.bits[i];
-            self.bits[i] |= word;
-            if self.bits[i] != old {
-                changed = true;
-            }
-        }
-        changed
-    }
-
-    /// Returns an iterator over all values in the set.
-    pub fn iter(&self) -> impl Iterator<Item = ValueId> + '_ {
-        self.bits.iter().enumerate().flat_map(|(word_idx, &word)| {
-            (0..64).filter_map(move |bit| {
-                if (word & (1u64 << bit)) != 0 {
-                    Some(ValueId::from_usize(word_idx * 64 + bit))
-                } else {
-                    None
-                }
-            })
-        })
-    }
-
-    /// Returns the number of live values.
-    #[must_use]
-    pub fn count(&self) -> usize {
-        self.bits.iter().map(|w| w.count_ones() as usize).sum()
-    }
-
-    /// Clears the set.
-    pub fn clear(&mut self) {
-        for word in &mut self.bits {
-            *word = 0;
-        }
-    }
-}
+pub type LiveSet = GrowableBitSet<ValueId>;
 
 /// Per-instruction liveness information.
 #[derive(Clone, Debug)]
@@ -235,7 +132,7 @@ impl Liveness {
             let successors =
                 block.terminator.as_ref().map(Terminator::successors).unwrap_or_default();
             for succ in successors {
-                new_live_out.union_with(&block_liveness[succ.index()].live_in);
+                new_live_out.union(&block_liveness[succ.index()].live_in);
             }
 
             // live_in = use ∪ (live_out - def)
@@ -454,14 +351,14 @@ mod tests {
         set2.insert(ValueId::from_usize(2));
         set2.insert(ValueId::from_usize(3));
 
-        assert!(set1.union_with(&set2));
+        assert!(set1.union(&set2));
         assert!(set1.contains(ValueId::from_usize(1)));
         assert!(set1.contains(ValueId::from_usize(2)));
         assert!(set1.contains(ValueId::from_usize(3)));
         assert_eq!(set1.count(), 3);
 
         // Union again should not change
-        assert!(!set1.union_with(&set2));
+        assert!(!set1.union(&set2));
     }
 
     #[test]

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -82,7 +82,11 @@ use crate::{
     utils::repair_reachability_phis,
 };
 use alloy_primitives::U256;
-use solar_data_structures::map::{FxHashMap, FxHashSet};
+use solar_data_structures::{
+    bit_set::DenseBitSet,
+    map::{FxHashMap, FxHashSet},
+    newtype_index,
+};
 
 /// Statistics for load PRE.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -153,60 +157,49 @@ enum GenSource {
     Stored(ValueId),
 }
 
+newtype_index! {
+    struct KeyIdx;
+}
+
 /// A dense bitset over key-universe indices.
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct KeySet {
-    bits: Vec<u64>,
-}
+struct KeySet(DenseBitSet<KeyIdx>);
 
 impl KeySet {
     fn empty(len: usize) -> Self {
-        Self { bits: vec![0; len.div_ceil(64)] }
+        Self(DenseBitSet::new_empty(len))
     }
 
     fn full(len: usize) -> Self {
-        let mut bits = vec![!0u64; len.div_ceil(64)];
-        let rem = len % 64;
-        if rem != 0
-            && let Some(last) = bits.last_mut()
-        {
-            *last = (1u64 << rem) - 1;
-        }
-        Self { bits }
+        Self(DenseBitSet::new_filled(len))
     }
 
     fn insert(&mut self, idx: usize) {
-        self.bits[idx / 64] |= 1 << (idx % 64);
+        self.0.insert(KeyIdx::from_usize(idx));
     }
 
     fn remove(&mut self, idx: usize) {
-        self.bits[idx / 64] &= !(1 << (idx % 64));
+        self.0.remove(KeyIdx::from_usize(idx));
     }
 
     fn contains(&self, idx: usize) -> bool {
-        self.bits[idx / 64] & (1 << (idx % 64)) != 0
+        self.0.contains(KeyIdx::from_usize(idx))
     }
 
     fn is_empty(&self) -> bool {
-        self.bits.iter().all(|word| *word == 0)
+        self.0.is_empty()
     }
 
     fn intersect_with(&mut self, other: &Self) {
-        for (word, other) in self.bits.iter_mut().zip(&other.bits) {
-            *word &= other;
-        }
+        self.0.intersect(&other.0);
     }
 
     fn subtract(&mut self, other: &Self) {
-        for (word, other) in self.bits.iter_mut().zip(&other.bits) {
-            *word &= !other;
-        }
+        self.0.subtract(&other.0);
     }
 
     fn union_with(&mut self, other: &Self) {
-        for (word, other) in self.bits.iter_mut().zip(&other.bits) {
-            *word |= other;
-        }
+        self.0.union(&other.0);
     }
 }
 

--- a/crates/data-structures/src/bit_set.rs
+++ b/crates/data-structures/src/bit_set.rs
@@ -1,29 +1,79 @@
-//! Indexed bitsets.
-//!
-//! Adapted from `rustc_index::bit_set`.
+#![allow(
+    clippy::let_and_return,
+    clippy::needless_range_loop,
+    clippy::to_string_trait_impl,
+    clippy::use_self
+)]
 
 use std::{
-    fmt, iter,
+    fmt,
+    hash::Hash,
+    iter,
     marker::PhantomData,
     ops::{Bound, Range, RangeBounds},
+    rc::Rc,
     slice,
 };
 
-use crate::index::Idx;
+use Chunk::*;
+
+pub trait Idx: Copy + 'static + Ord + fmt::Debug + Hash {
+    fn new(index: usize) -> Self;
+    fn index(self) -> usize;
+}
+
+impl Idx for usize {
+    #[inline]
+    fn new(index: usize) -> Self {
+        index
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        self
+    }
+}
+
+impl Idx for u32 {
+    #[inline]
+    fn new(index: usize) -> Self {
+        Self::try_from(index).unwrap()
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        self as usize
+    }
+}
+
+#[cfg(test)]
+mod tests;
 
 type Word = u64;
 const WORD_BYTES: usize = size_of::<Word>();
 const WORD_BITS: usize = WORD_BYTES * 8;
 
-/// Bitwise set relations.
+// The choice of chunk size has some trade-offs.
+//
+// A big chunk size tends to favour cases where many large `ChunkedBitSet`s are
+// present, because they require fewer `Chunk`s, reducing the number of
+// allocations and reducing peak memory usage. Also, fewer chunk operations are
+// required, though more of them might be `Mixed`.
+//
+// A small chunk size tends to favour cases where many small `ChunkedBitSet`s
+// are present, because less space is wasted at the end of the final chunk (if
+// it's not full).
+const CHUNK_WORDS: usize = 32;
+const CHUNK_BITS: usize = CHUNK_WORDS * WORD_BITS; // 2048 bits
+
+/// ChunkSize is small to keep `Chunk` small. The static assertion ensures it's
+/// not too small.
+type ChunkSize = u16;
+const _: () = assert!(CHUNK_BITS <= ChunkSize::MAX as usize);
+
 pub trait BitRelations<Rhs> {
-    /// Sets `self = self | other`, returning true if this set changed.
     fn union(&mut self, other: &Rhs) -> bool;
-
-    /// Sets `self = self - other`, returning true if this set changed.
     fn subtract(&mut self, other: &Rhs) -> bool;
-
-    /// Sets `self = self & other`, returning true if this set changed.
     fn intersect(&mut self, other: &Rhs) -> bool;
 }
 
@@ -32,6 +82,7 @@ fn inclusive_start_end<T: Idx>(
     range: impl RangeBounds<T>,
     domain: usize,
 ) -> Option<(usize, usize)> {
+    // Both start and end are inclusive.
     let start = match range.start_bound().cloned() {
         Bound::Included(start) => start.index(),
         Bound::Excluded(start) => start.index() + 1,
@@ -51,7 +102,8 @@ fn inclusive_start_end<T: Idx>(
 
 macro_rules! bit_relations_inherent_impls {
     () => {
-        /// Sets `self = self | other`, returning true if this set changed.
+        /// Sets `self = self | other` and returns `true` if `self` changed
+        /// (i.e., if new bits were added).
         pub fn union<Rhs>(&mut self, other: &Rhs) -> bool
         where
             Self: BitRelations<Rhs>,
@@ -59,7 +111,8 @@ macro_rules! bit_relations_inherent_impls {
             <Self as BitRelations<Rhs>>::union(self, other)
         }
 
-        /// Sets `self = self - other`, returning true if this set changed.
+        /// Sets `self = self - other` and returns `true` if `self` changed.
+        /// (i.e., if any bits were removed).
         pub fn subtract<Rhs>(&mut self, other: &Rhs) -> bool
         where
             Self: BitRelations<Rhs>,
@@ -67,7 +120,8 @@ macro_rules! bit_relations_inherent_impls {
             <Self as BitRelations<Rhs>>::subtract(self, other)
         }
 
-        /// Sets `self = self & other`, returning true if this set changed.
+        /// Sets `self = self & other` and return `true` if `self` changed.
+        /// (i.e., if any bits were removed).
         pub fn intersect<Rhs>(&mut self, other: &Rhs) -> bool
         where
             Self: BitRelations<Rhs>,
@@ -79,9 +133,20 @@ macro_rules! bit_relations_inherent_impls {
 
 /// A fixed-size bitset type with a dense representation.
 ///
-/// `T` is an index type. All operations that involve an element panic if the
-/// element is equal to or greater than the domain size. Operations that involve
-/// two bitsets panic if their domain sizes differ.
+/// Note 1: Since this bitset is dense, if your domain is big, and/or relatively
+/// homogeneous (for example, with long runs of bits set or unset), then it may
+/// be preferable to instead use a [MixedBitSet], or an
+/// [IntervalSet](crate::interval::IntervalSet). They should be more suited to
+/// sparse, or highly-compressible, domains.
+///
+/// Note 2: Use [`GrowableBitSet`] if you need support for resizing after creation.
+///
+/// `T` is an index type, typically a newtyped `usize` wrapper, but it can also
+/// just be `usize`.
+///
+/// All operations that involve an element will panic if the element is equal
+/// to or greater than the domain size. All operations that involve two bitsets
+/// will panic if the bitsets have differing domain sizes.
 #[derive(Eq, PartialEq, Hash)]
 pub struct DenseBitSet<T> {
     domain_size: usize,
@@ -91,45 +156,46 @@ pub struct DenseBitSet<T> {
 
 impl<T> DenseBitSet<T> {
     /// Gets the domain size.
-    #[inline]
-    pub const fn domain_size(&self) -> usize {
+    pub fn domain_size(&self) -> usize {
         self.domain_size
     }
 }
 
 impl<T: Idx> DenseBitSet<T> {
-    /// Creates a new, empty bitset with the given domain size.
+    /// Creates a new, empty bitset with a given `domain_size`.
     #[inline]
-    pub fn new_empty(domain_size: usize) -> Self {
-        Self { domain_size, words: vec![0; num_words(domain_size)], marker: PhantomData }
+    pub fn new_empty(domain_size: usize) -> DenseBitSet<T> {
+        let num_words = num_words(domain_size);
+        DenseBitSet { domain_size, words: vec![0; num_words], marker: PhantomData }
     }
 
-    /// Creates a new, filled bitset with the given domain size.
+    /// Creates a new, filled bitset with a given `domain_size`.
     #[inline]
-    pub fn new_filled(domain_size: usize) -> Self {
+    pub fn new_filled(domain_size: usize) -> DenseBitSet<T> {
+        let num_words = num_words(domain_size);
         let mut result =
-            Self { domain_size, words: vec![!0; num_words(domain_size)], marker: PhantomData };
+            DenseBitSet { domain_size, words: vec![!0; num_words], marker: PhantomData };
         result.clear_excess_bits();
         result
     }
 
-    /// Clears all elements.
+    /// Clear all elements.
     #[inline]
     pub fn clear(&mut self) {
         self.words.fill(0);
     }
 
+    /// Clear excess bits in the final word.
     fn clear_excess_bits(&mut self) {
         clear_excess_bits_in_final_word(self.domain_size, &mut self.words);
     }
 
-    /// Counts the number of set bits.
-    #[inline]
+    /// Count the number of set bits in the set.
     pub fn count(&self) -> usize {
         count_ones(&self.words)
     }
 
-    /// Returns true if the set contains `elem`.
+    /// Returns `true` if `self` contains `elem`.
     #[inline]
     pub fn contains(&self, elem: T) -> bool {
         assert!(elem.index() < self.domain_size);
@@ -137,20 +203,20 @@ impl<T: Idx> DenseBitSet<T> {
         (self.words[word_index] & mask) != 0
     }
 
-    /// Returns true if this set is a non-strict superset of `other`.
+    /// Is `self` is a (non-strict) superset of `other`?
     #[inline]
-    pub fn superset(&self, other: &Self) -> bool {
+    pub fn superset(&self, other: &DenseBitSet<T>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         self.words.iter().zip(&other.words).all(|(a, b)| (a & b) == *b)
     }
 
-    /// Returns true if the set is empty.
+    /// Is the set empty?
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.words.iter().all(|word| *word == 0)
+        self.words.iter().all(|a| *a == 0)
     }
 
-    /// Inserts `elem`, returning true if this set changed.
+    /// Insert `elem`. Returns whether the set has changed.
     #[inline]
     pub fn insert(&mut self, elem: T) -> bool {
         assert!(
@@ -160,99 +226,114 @@ impl<T: Idx> DenseBitSet<T> {
             self.domain_size,
         );
         let (word_index, mask) = word_index_and_mask(elem);
-        let word = self.words[word_index];
+        let word_ref = &mut self.words[word_index];
+        let word = *word_ref;
         let new_word = word | mask;
-        self.words[word_index] = new_word;
+        *word_ref = new_word;
         new_word != word
     }
 
-    /// Inserts each element in `elems`.
     #[inline]
     pub fn insert_range(&mut self, elems: impl RangeBounds<T>) {
         let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
             return;
         };
 
-        let (start_word_index, start_mask) = word_index_and_mask_usize(start);
-        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
+        let (start_word_index, start_mask) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
 
+        // Set all words in between start and end (exclusively of both).
         for word_index in (start_word_index + 1)..end_word_index {
             self.words[word_index] = !0;
         }
 
         if start_word_index != end_word_index {
+            // Start and end are in different words, so we handle each in turn.
+            //
+            // We set all leading bits. This includes the start_mask bit.
             self.words[start_word_index] |= !(start_mask - 1);
+            // And all trailing bits (i.e. from 0..=end) in the end word,
+            // including the end.
             self.words[end_word_index] |= end_mask | (end_mask - 1);
         } else {
             self.words[start_word_index] |= end_mask | (end_mask - start_mask);
         }
     }
 
-    /// Inserts all elements in the domain.
+    /// Sets all bits to true.
     pub fn insert_all(&mut self) {
         self.words.fill(!0);
         self.clear_excess_bits();
     }
 
-    /// Returns true if any bit in `elems` is set.
+    /// Checks whether any bit in the given range is a 1.
     #[inline]
     pub fn contains_any(&self, elems: impl RangeBounds<T>) -> bool {
         let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
             return false;
         };
-        let (start_word_index, start_mask) = word_index_and_mask_usize(start);
-        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
+        let (start_word_index, start_mask) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
 
         if start_word_index == end_word_index {
             self.words[start_word_index] & (end_mask | (end_mask - start_mask)) != 0
-        } else if self.words[start_word_index] & !(start_mask - 1) != 0 {
-            true
         } else {
+            if self.words[start_word_index] & !(start_mask - 1) != 0 {
+                return true;
+            }
+
             let remaining = start_word_index + 1..end_word_index;
-            remaining.start <= remaining.end
-                && (self.words[remaining].iter().any(|&word| word != 0)
-                    || self.words[end_word_index] & (end_mask | (end_mask - 1)) != 0)
+            if remaining.start <= remaining.end {
+                self.words[remaining].iter().any(|&w| w != 0)
+                    || self.words[end_word_index] & (end_mask | (end_mask - 1)) != 0
+            } else {
+                false
+            }
         }
     }
 
-    /// Removes `elem`, returning true if this set changed.
+    /// Returns `true` if the set has changed.
     #[inline]
     pub fn remove(&mut self, elem: T) -> bool {
         assert!(elem.index() < self.domain_size);
         let (word_index, mask) = word_index_and_mask(elem);
-        let word = self.words[word_index];
+        let word_ref = &mut self.words[word_index];
+        let word = *word_ref;
         let new_word = word & !mask;
-        self.words[word_index] = new_word;
+        *word_ref = new_word;
         new_word != word
     }
 
-    /// Iterates over the indices of set bits in sorted order.
+    /// Iterates over the indices of set bits in a sorted order.
     #[inline]
     pub fn iter(&self) -> BitIter<'_, T> {
         BitIter::new(&self.words)
     }
 
-    /// Returns the last set bit in `range`.
     pub fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
         let (start, end) = inclusive_start_end(range, self.domain_size)?;
-        let (start_word_index, _) = word_index_and_mask_usize(start);
-        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
+        let (start_word_index, _) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
 
         let end_word = self.words[end_word_index] & (end_mask | (end_mask - 1));
         if end_word != 0 {
             let pos = max_bit(end_word) + WORD_BITS * end_word_index;
             if start <= pos {
-                return Some(T::from_usize(pos));
+                return Some(T::new(pos));
             }
         }
 
+        // We exclude end_word_index from the range here, because we don't want
+        // to limit ourselves to *just* the last word: the bits set it in may be
+        // after `end`, so it may not work out.
         if let Some(offset) =
-            self.words[start_word_index..end_word_index].iter().rposition(|&word| word != 0)
+            self.words[start_word_index..end_word_index].iter().rposition(|&w| w != 0)
         {
             let word_idx = start_word_index + offset;
-            let pos = max_bit(self.words[word_idx]) + WORD_BITS * word_idx;
+            let start_word = self.words[word_idx];
+            let pos = max_bit(start_word) + WORD_BITS * word_idx;
             if start <= pos {
-                return Some(T::from_usize(pos));
+                return Some(T::new(pos));
             }
         }
 
@@ -262,28 +343,37 @@ impl<T: Idx> DenseBitSet<T> {
     bit_relations_inherent_impls! {}
 
     /// Sets `self = self | !other`.
-    pub fn union_not(&mut self, other: &Self) {
+    ///
+    /// FIXME: Incorporate this into [`BitRelations`] and fill out
+    /// implementations for other bitset types, if needed.
+    pub fn union_not(&mut self, other: &DenseBitSet<T>) {
         assert_eq!(self.domain_size, other.domain_size);
+
+        // FIXME(Zalathar): If we were to forcibly _set_ all excess bits before
+        // the bitwise update, and then clear them again afterwards, we could
+        // quickly and accurately detect whether the update changed anything.
+        // But that's only worth doing if there's an actual use-case.
+
         update_words(&mut self.words, &other.words, |a, b| a | !b);
+        // The bitwise update `a | !b` can result in the last word containing
+        // out-of-domain bits, so we need to clear them.
         self.clear_excess_bits();
     }
 }
 
-impl<T: Idx> BitRelations<Self> for DenseBitSet<T> {
-    #[inline]
-    fn union(&mut self, other: &Self) -> bool {
+// dense REL dense
+impl<T: Idx> BitRelations<DenseBitSet<T>> for DenseBitSet<T> {
+    fn union(&mut self, other: &DenseBitSet<T>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a | b)
     }
 
-    #[inline]
-    fn subtract(&mut self, other: &Self) -> bool {
+    fn subtract(&mut self, other: &DenseBitSet<T>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a & !b)
     }
 
-    #[inline]
-    fn intersect(&mut self, other: &Self) -> bool {
+    fn intersect(&mut self, other: &DenseBitSet<T>) -> bool {
         assert_eq!(self.domain_size, other.domain_size);
         update_words(&mut self.words, &other.words, |a, b| a & b)
     }
@@ -297,7 +387,11 @@ impl<T: Idx> From<GrowableBitSet<T>> for DenseBitSet<T> {
 
 impl<T> Clone for DenseBitSet<T> {
     fn clone(&self) -> Self {
-        Self { domain_size: self.domain_size, words: self.words.clone(), marker: PhantomData }
+        DenseBitSet {
+            domain_size: self.domain_size,
+            words: self.words.clone(),
+            marker: PhantomData,
+        }
     }
 
     fn clone_from(&mut self, from: &Self) {
@@ -312,18 +406,66 @@ impl<T: Idx> fmt::Debug for DenseBitSet<T> {
     }
 }
 
-/// Iterator over the set bits in a bitset.
+impl<T: Idx> ToString for DenseBitSet<T> {
+    fn to_string(&self) -> String {
+        let mut result = String::new();
+        let mut sep = '[';
+
+        // Note: this is a little endian printout of bytes.
+
+        // i tracks how many bits we have printed so far.
+        let mut i = 0;
+        for word in &self.words {
+            let mut word = *word;
+            for _ in 0..WORD_BYTES {
+                // for each byte in `word`:
+                let remain = self.domain_size - i;
+                // If less than a byte remains, then mask just that many bits.
+                let mask = if remain <= 8 { (1 << remain) - 1 } else { 0xFF };
+                assert!(mask <= 0xFF);
+                let byte = word & mask;
+
+                result.push_str(&format!("{sep}{byte:02x}"));
+
+                if remain <= 8 {
+                    break;
+                }
+                word >>= 8;
+                i += 8;
+                sep = '-';
+            }
+            sep = '|';
+        }
+        result.push(']');
+
+        result
+    }
+}
+
 pub struct BitIter<'a, T: Idx> {
+    /// A copy of the current word, but with any already-visited bits cleared.
+    /// (This lets us use `trailing_zeros()` to find the next set bit.) When it
+    /// is reduced to 0, we move onto the next word.
     word: Word,
+
+    /// The offset (measured in bits) of the current word.
     offset: usize,
+
+    /// Underlying iterator over the words.
     iter: slice::Iter<'a, Word>,
+
     marker: PhantomData<T>,
 }
 
 impl<'a, T: Idx> BitIter<'a, T> {
     #[inline]
-    fn new(words: &'a [Word]) -> Self {
-        Self {
+    fn new(words: &'a [Word]) -> BitIter<'a, T> {
+        // We initialize `word` and `offset` to degenerate values. On the first
+        // call to `next()` we will fall through to getting the first word from
+        // `iter`, which sets `word` to the first word (if there is one) and
+        // `offset` to 0. Doing it this way saves us from having to maintain
+        // additional state about whether we have started.
+        BitIter {
             word: 0,
             offset: usize::MAX - (WORD_BITS - 1),
             iter: words.iter(),
@@ -332,37 +474,865 @@ impl<'a, T: Idx> BitIter<'a, T> {
     }
 }
 
-impl<T: Idx> Iterator for BitIter<'_, T> {
+impl<'a, T: Idx> Iterator for BitIter<'a, T> {
     type Item = T;
-
     fn next(&mut self) -> Option<T> {
         loop {
             if self.word != 0 {
+                // Get the position of the next set bit in the current word,
+                // then clear the bit.
                 let bit_pos = self.word.trailing_zeros() as usize;
                 self.word ^= 1 << bit_pos;
-                return Some(T::from_usize(bit_pos + self.offset));
+                return Some(T::new(bit_pos + self.offset));
             }
 
+            // Move onto the next word. `wrapping_add()` is needed to handle
+            // the degenerate initial value given to `offset` in `new()`.
             self.word = *self.iter.next()?;
             self.offset = self.offset.wrapping_add(WORD_BITS);
         }
     }
 }
 
+/// A fixed-size bitset type with a partially dense, partially sparse
+/// representation. The bitset is broken into chunks, and chunks that are all
+/// zeros or all ones are represented and handled very efficiently.
+///
+/// This type is especially efficient for sets that typically have a large
+/// `domain_size` with significant stretches of all zeros or all ones, and also
+/// some stretches with lots of 0s and 1s mixed in a way that causes trouble
+/// for `IntervalSet`.
+///
+/// Best used via `MixedBitSet`, rather than directly, because `MixedBitSet`
+/// has better performance for small bitsets.
+///
+/// `T` is an index type, typically a newtyped `usize` wrapper, but it can also
+/// just be `usize`.
+///
+/// All operations that involve an element will panic if the element is equal
+/// to or greater than the domain size. All operations that involve two bitsets
+/// will panic if the bitsets have differing domain sizes.
+#[derive(PartialEq, Eq)]
+pub struct ChunkedBitSet<T> {
+    domain_size: usize,
+
+    /// The chunks. Each one contains exactly CHUNK_BITS values, except the
+    /// last one which contains 1..=CHUNK_BITS values.
+    chunks: Box<[Chunk]>,
+
+    marker: PhantomData<T>,
+}
+
+// NOTE: The chunk domain size is stored in each variant because it keeps the
+// size of `Chunk` smaller than if it were stored outside the variants.
+// We have also tried computing it on the fly, but that was slightly more
+// complex and slower than storing it. See #145480 and #147802.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Chunk {
+    /// A chunk that is all zeros; we don't represent the zeros explicitly.
+    Zeros { chunk_domain_size: ChunkSize },
+
+    /// A chunk that is all ones; we don't represent the ones explicitly.
+    Ones { chunk_domain_size: ChunkSize },
+
+    /// A chunk that has a mix of zeros and ones, which are represented
+    /// explicitly and densely. It never has all zeros or all ones.
+    ///
+    /// If this is the final chunk there may be excess, unused words. This
+    /// turns out to be both simpler and have better performance than
+    /// allocating the minimum number of words, largely because we avoid having
+    /// to store the length, which would make this type larger. These excess
+    /// words are always zero, as are any excess bits in the final in-use word.
+    ///
+    /// The words are within an `Rc` because it's surprisingly common to
+    /// duplicate an entire chunk, e.g. in `ChunkedBitSet::clone_from()`, or
+    /// when a `Mixed` chunk is union'd into a `Zeros` chunk. When we do need
+    /// to modify a chunk we use `Rc::make_mut`.
+    Mixed {
+        chunk_domain_size: ChunkSize,
+        /// Count of set bits (1s) in this chunk's words.
+        ///
+        /// Invariant: `0 < ones_count < chunk_domain_size`.
+        ///
+        /// Tracking this separately allows individual insert/remove calls to
+        /// know that the chunk has become all-zeroes or all-ones, in O(1) time.
+        ones_count: ChunkSize,
+        words: Rc<[Word; CHUNK_WORDS]>,
+    },
+}
+
+// This type is used a lot. Make sure it doesn't unintentionally get bigger.
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<Chunk>() == 16);
+
+impl<T> ChunkedBitSet<T> {
+    pub fn domain_size(&self) -> usize {
+        self.domain_size
+    }
+
+    #[cfg(test)]
+    fn assert_valid(&self) {
+        if self.domain_size == 0 {
+            assert!(self.chunks.is_empty());
+            return;
+        }
+
+        assert!((self.chunks.len() - 1) * CHUNK_BITS <= self.domain_size);
+        assert!(self.chunks.len() * CHUNK_BITS >= self.domain_size);
+        for chunk in self.chunks.iter() {
+            chunk.assert_valid();
+        }
+    }
+}
+
+impl<T: Idx> ChunkedBitSet<T> {
+    /// Creates a new bitset with a given `domain_size` and chunk kind.
+    fn new(domain_size: usize, is_empty: bool) -> Self {
+        let chunks = if domain_size == 0 {
+            Box::new([])
+        } else {
+            let num_chunks = domain_size.index().div_ceil(CHUNK_BITS);
+            let mut last_chunk_domain_size = domain_size % CHUNK_BITS;
+            if last_chunk_domain_size == 0 {
+                last_chunk_domain_size = CHUNK_BITS;
+            };
+
+            // All the chunks are the same except the last one which might have a different
+            // `chunk_domain_size`.
+            let (normal_chunk, final_chunk) = if is_empty {
+                (
+                    Zeros { chunk_domain_size: CHUNK_BITS as ChunkSize },
+                    Zeros { chunk_domain_size: last_chunk_domain_size as ChunkSize },
+                )
+            } else {
+                (
+                    Ones { chunk_domain_size: CHUNK_BITS as ChunkSize },
+                    Ones { chunk_domain_size: last_chunk_domain_size as ChunkSize },
+                )
+            };
+            let mut chunks = vec![normal_chunk; num_chunks].into_boxed_slice();
+            *chunks.as_mut().last_mut().unwrap() = final_chunk;
+            chunks
+        };
+        ChunkedBitSet { domain_size, chunks, marker: PhantomData }
+    }
+
+    /// Creates a new, empty bitset with a given `domain_size`.
+    #[inline]
+    pub fn new_empty(domain_size: usize) -> Self {
+        ChunkedBitSet::new(domain_size, /* is_empty */ true)
+    }
+
+    /// Creates a new, filled bitset with a given `domain_size`.
+    #[inline]
+    pub fn new_filled(domain_size: usize) -> Self {
+        ChunkedBitSet::new(domain_size, /* is_empty */ false)
+    }
+
+    pub fn clear(&mut self) {
+        // Not the most efficient implementation, but this function isn't hot.
+        *self = ChunkedBitSet::new_empty(self.domain_size);
+    }
+
+    #[cfg(test)]
+    fn chunks(&self) -> &[Chunk] {
+        &self.chunks
+    }
+
+    /// Count the number of bits in the set.
+    pub fn count(&self) -> usize {
+        self.chunks.iter().map(|chunk| chunk.count()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.chunks.iter().all(|chunk| matches!(chunk, Zeros { .. }))
+    }
+
+    /// Returns `true` if `self` contains `elem`.
+    #[inline]
+    pub fn contains(&self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let chunk = &self.chunks[chunk_index(elem)];
+        match &chunk {
+            Zeros { .. } => false,
+            Ones { .. } => true,
+            Mixed { words, .. } => {
+                let (word_index, mask) = chunk_word_index_and_mask(elem);
+                (words[word_index] & mask) != 0
+            }
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> ChunkedBitIter<'_, T> {
+        ChunkedBitIter::new(self)
+    }
+
+    /// Insert `elem`. Returns whether the set has changed.
+    pub fn insert(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let chunk_index = chunk_index(elem);
+        let chunk = &mut self.chunks[chunk_index];
+        match *chunk {
+            Zeros { chunk_domain_size } => {
+                if chunk_domain_size > 1 {
+                    let mut words = {
+                        // We take some effort to avoid copying the words.
+                        let words = Rc::<[Word; CHUNK_WORDS]>::new([0; CHUNK_WORDS]);
+                        words
+                    };
+                    let words_ref = Rc::get_mut(&mut words).unwrap();
+
+                    let (word_index, mask) = chunk_word_index_and_mask(elem);
+                    words_ref[word_index] |= mask;
+                    *chunk = Mixed { chunk_domain_size, ones_count: 1, words };
+                } else {
+                    *chunk = Ones { chunk_domain_size };
+                }
+                true
+            }
+            Ones { .. } => false,
+            Mixed { chunk_domain_size, ref mut ones_count, ref mut words } => {
+                // We skip all the work if the bit is already set.
+                let (word_index, mask) = chunk_word_index_and_mask(elem);
+                if (words[word_index] & mask) == 0 {
+                    *ones_count += 1;
+                    if *ones_count < chunk_domain_size {
+                        let words = Rc::make_mut(words);
+                        words[word_index] |= mask;
+                    } else {
+                        *chunk = Ones { chunk_domain_size };
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Sets all bits to true.
+    pub fn insert_all(&mut self) {
+        // Not the most efficient implementation, but this function isn't hot.
+        *self = ChunkedBitSet::new_filled(self.domain_size);
+    }
+
+    /// Returns `true` if the set has changed.
+    pub fn remove(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let chunk_index = chunk_index(elem);
+        let chunk = &mut self.chunks[chunk_index];
+        match *chunk {
+            Zeros { .. } => false,
+            Ones { chunk_domain_size } => {
+                if chunk_domain_size > 1 {
+                    let mut words = {
+                        // We take some effort to avoid copying the words.
+                        let words = Rc::<[Word; CHUNK_WORDS]>::new([0; CHUNK_WORDS]);
+                        words
+                    };
+                    let words_ref = Rc::get_mut(&mut words).unwrap();
+
+                    // Set only the bits in use.
+                    let num_words = num_words(chunk_domain_size as usize);
+                    words_ref[..num_words].fill(!0);
+                    clear_excess_bits_in_final_word(
+                        chunk_domain_size as usize,
+                        &mut words_ref[..num_words],
+                    );
+                    let (word_index, mask) = chunk_word_index_and_mask(elem);
+                    words_ref[word_index] &= !mask;
+                    *chunk = Mixed { chunk_domain_size, ones_count: chunk_domain_size - 1, words };
+                } else {
+                    *chunk = Zeros { chunk_domain_size };
+                }
+                true
+            }
+            Mixed { chunk_domain_size, ref mut ones_count, ref mut words } => {
+                // We skip all the work if the bit is already clear.
+                let (word_index, mask) = chunk_word_index_and_mask(elem);
+                if (words[word_index] & mask) != 0 {
+                    *ones_count -= 1;
+                    if *ones_count > 0 {
+                        let words = Rc::make_mut(words);
+                        words[word_index] &= !mask;
+                    } else {
+                        *chunk = Zeros { chunk_domain_size }
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn chunk_iter(&self, chunk_index: usize) -> ChunkIter<'_> {
+        match self.chunks.get(chunk_index) {
+            Some(Zeros { .. }) => ChunkIter::Zeros,
+            Some(Ones { chunk_domain_size }) => ChunkIter::Ones(0..*chunk_domain_size as usize),
+            Some(Mixed { chunk_domain_size, words, .. }) => {
+                let num_words = num_words(*chunk_domain_size as usize);
+                ChunkIter::Mixed(BitIter::new(&words[0..num_words]))
+            }
+            None => ChunkIter::Finished,
+        }
+    }
+
+    bit_relations_inherent_impls! {}
+}
+
+impl<T: Idx> BitRelations<ChunkedBitSet<T>> for ChunkedBitSet<T> {
+    fn union(&mut self, other: &ChunkedBitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+
+        let mut changed = false;
+        for (mut self_chunk, other_chunk) in self.chunks.iter_mut().zip(other.chunks.iter()) {
+            match (&mut self_chunk, &other_chunk) {
+                (_, Zeros { .. }) | (Ones { .. }, _) => {}
+                (Zeros { .. }, _) | (Mixed { .. }, Ones { .. }) => {
+                    // `other_chunk` fully overwrites `self_chunk`
+                    *self_chunk = other_chunk.clone();
+                    changed = true;
+                }
+                (
+                    Mixed {
+                        chunk_domain_size,
+                        ones_count: self_chunk_ones_count,
+                        words: self_chunk_words,
+                    },
+                    Mixed { words: other_chunk_words, .. },
+                ) => {
+                    // First check if the operation would change
+                    // `self_chunk.words`. If not, we can avoid allocating some
+                    // words, and this happens often enough that it's a
+                    // performance win. Also, we only need to operate on the
+                    // in-use words, hence the slicing.
+                    let num_words = num_words(*chunk_domain_size as usize);
+
+                    // If both sides are the same, nothing will change. This
+                    // case is very common and it's a pretty fast check, so
+                    // it's a performance win to do it.
+                    if self_chunk_words[0..num_words] == other_chunk_words[0..num_words] {
+                        continue;
+                    }
+
+                    // Do a more precise "will anything change?" test. Also a
+                    // performance win.
+                    let op = |a, b| a | b;
+                    if !would_modify_words(
+                        &self_chunk_words[0..num_words],
+                        &other_chunk_words[0..num_words],
+                        op,
+                    ) {
+                        continue;
+                    }
+
+                    // If we reach here, `self_chunk_words` is definitely changing.
+                    let self_chunk_words = Rc::make_mut(self_chunk_words);
+                    let has_changed = update_words(
+                        &mut self_chunk_words[0..num_words],
+                        &other_chunk_words[0..num_words],
+                        op,
+                    );
+                    debug_assert!(has_changed);
+                    *self_chunk_ones_count =
+                        count_ones(&self_chunk_words[0..num_words]) as ChunkSize;
+                    if *self_chunk_ones_count == *chunk_domain_size {
+                        *self_chunk = Ones { chunk_domain_size: *chunk_domain_size };
+                    }
+                    changed = true;
+                }
+            }
+        }
+        changed
+    }
+
+    fn subtract(&mut self, other: &ChunkedBitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+
+        let mut changed = false;
+        for (mut self_chunk, other_chunk) in self.chunks.iter_mut().zip(other.chunks.iter()) {
+            match (&mut self_chunk, &other_chunk) {
+                (Zeros { .. }, _) | (_, Zeros { .. }) => {}
+                (Ones { chunk_domain_size } | Mixed { chunk_domain_size, .. }, Ones { .. }) => {
+                    changed = true;
+                    *self_chunk = Zeros { chunk_domain_size: *chunk_domain_size };
+                }
+                (
+                    Ones { chunk_domain_size },
+                    Mixed { ones_count: other_chunk_ones_count, words: other_chunk_words, .. },
+                ) => {
+                    changed = true;
+                    let num_words = num_words(*chunk_domain_size as usize);
+                    debug_assert!(num_words > 0 && num_words <= CHUNK_WORDS);
+                    // Set `self_chunk_words` to `other_chunk_words`, then invert all bits and
+                    // clear any excess bits in the final word.
+                    let mut self_chunk_words = **other_chunk_words;
+                    for word in self_chunk_words[0..num_words].iter_mut() {
+                        *word = !*word;
+                    }
+                    clear_excess_bits_in_final_word(
+                        *chunk_domain_size as usize,
+                        &mut self_chunk_words[..num_words],
+                    );
+                    let self_chunk_ones_count = *chunk_domain_size - *other_chunk_ones_count;
+                    debug_assert_eq!(
+                        self_chunk_ones_count,
+                        count_ones(&self_chunk_words[0..num_words]) as ChunkSize
+                    );
+                    *self_chunk = Mixed {
+                        chunk_domain_size: *chunk_domain_size,
+                        ones_count: self_chunk_ones_count,
+                        words: Rc::new(self_chunk_words),
+                    };
+                }
+                (
+                    Mixed {
+                        chunk_domain_size,
+                        ones_count: self_chunk_ones_count,
+                        words: self_chunk_words,
+                    },
+                    Mixed { words: other_chunk_words, .. },
+                ) => {
+                    // See `ChunkedBitSet::union` for details on what is happening here.
+                    let num_words = num_words(*chunk_domain_size as usize);
+                    let op = |a: Word, b: Word| a & !b;
+                    if !would_modify_words(
+                        &self_chunk_words[0..num_words],
+                        &other_chunk_words[0..num_words],
+                        op,
+                    ) {
+                        continue;
+                    }
+
+                    let self_chunk_words = Rc::make_mut(self_chunk_words);
+                    let has_changed = update_words(
+                        &mut self_chunk_words[0..num_words],
+                        &other_chunk_words[0..num_words],
+                        op,
+                    );
+                    debug_assert!(has_changed);
+                    *self_chunk_ones_count =
+                        count_ones(&self_chunk_words[0..num_words]) as ChunkSize;
+                    if *self_chunk_ones_count == 0 {
+                        *self_chunk = Zeros { chunk_domain_size: *chunk_domain_size };
+                    }
+                    changed = true;
+                }
+            }
+        }
+        changed
+    }
+
+    fn intersect(&mut self, other: &ChunkedBitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+
+        let mut changed = false;
+        for (mut self_chunk, other_chunk) in self.chunks.iter_mut().zip(other.chunks.iter()) {
+            match (&mut self_chunk, &other_chunk) {
+                (Zeros { .. }, _) | (_, Ones { .. }) => {}
+                (Ones { .. }, Zeros { .. } | Mixed { .. }) | (Mixed { .. }, Zeros { .. }) => {
+                    changed = true;
+                    *self_chunk = other_chunk.clone();
+                }
+                (
+                    Mixed {
+                        chunk_domain_size,
+                        ones_count: self_chunk_ones_count,
+                        words: self_chunk_words,
+                    },
+                    Mixed { words: other_chunk_words, .. },
+                ) => {
+                    // See `ChunkedBitSet::union` for details on what is happening here.
+                    let num_words = num_words(*chunk_domain_size as usize);
+                    let op = |a, b| a & b;
+                    if !would_modify_words(
+                        &self_chunk_words[0..num_words],
+                        &other_chunk_words[0..num_words],
+                        op,
+                    ) {
+                        continue;
+                    }
+
+                    let self_chunk_words = Rc::make_mut(self_chunk_words);
+                    let has_changed = update_words(
+                        &mut self_chunk_words[0..num_words],
+                        &other_chunk_words[0..num_words],
+                        op,
+                    );
+                    debug_assert!(has_changed);
+                    *self_chunk_ones_count =
+                        count_ones(&self_chunk_words[0..num_words]) as ChunkSize;
+                    if *self_chunk_ones_count == 0 {
+                        *self_chunk = Zeros { chunk_domain_size: *chunk_domain_size };
+                    }
+                    changed = true;
+                }
+            }
+        }
+
+        changed
+    }
+}
+
+impl<T> Clone for ChunkedBitSet<T> {
+    fn clone(&self) -> Self {
+        ChunkedBitSet {
+            domain_size: self.domain_size,
+            chunks: self.chunks.clone(),
+            marker: PhantomData,
+        }
+    }
+
+    /// WARNING: this implementation of clone_from will panic if the two
+    /// bitsets have different domain sizes. This constraint is not inherent to
+    /// `clone_from`, but it works with the existing call sites and allows a
+    /// faster implementation, which is important because this function is hot.
+    fn clone_from(&mut self, from: &Self) {
+        assert_eq!(self.domain_size, from.domain_size);
+        debug_assert_eq!(self.chunks.len(), from.chunks.len());
+
+        self.chunks.clone_from(&from.chunks)
+    }
+}
+
+pub struct ChunkedBitIter<'a, T: Idx> {
+    bit_set: &'a ChunkedBitSet<T>,
+
+    // The index of the current chunk.
+    chunk_index: usize,
+
+    // The sub-iterator for the current chunk.
+    chunk_iter: ChunkIter<'a>,
+}
+
+impl<'a, T: Idx> ChunkedBitIter<'a, T> {
+    #[inline]
+    fn new(bit_set: &'a ChunkedBitSet<T>) -> ChunkedBitIter<'a, T> {
+        ChunkedBitIter { bit_set, chunk_index: 0, chunk_iter: bit_set.chunk_iter(0) }
+    }
+}
+
+impl<'a, T: Idx> Iterator for ChunkedBitIter<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            match &mut self.chunk_iter {
+                ChunkIter::Zeros => {}
+                ChunkIter::Ones(iter) => {
+                    if let Some(next) = iter.next() {
+                        return Some(T::new(next + self.chunk_index * CHUNK_BITS));
+                    }
+                }
+                ChunkIter::Mixed(iter) => {
+                    if let Some(next) = iter.next() {
+                        return Some(T::new(next + self.chunk_index * CHUNK_BITS));
+                    }
+                }
+                ChunkIter::Finished => return None,
+            }
+            self.chunk_index += 1;
+            self.chunk_iter = self.bit_set.chunk_iter(self.chunk_index);
+        }
+    }
+}
+
+impl Chunk {
+    #[cfg(test)]
+    fn assert_valid(&self) {
+        match *self {
+            Zeros { chunk_domain_size } | Ones { chunk_domain_size } => {
+                assert!(chunk_domain_size as usize <= CHUNK_BITS);
+            }
+            Mixed { chunk_domain_size, ones_count, ref words } => {
+                assert!(chunk_domain_size as usize <= CHUNK_BITS);
+                assert!(0 < ones_count && ones_count < chunk_domain_size);
+
+                // Check the number of set bits matches `count`.
+                assert_eq!(count_ones(words.as_slice()) as ChunkSize, ones_count);
+
+                // Check the not-in-use words are all zeroed.
+                let num_words = num_words(chunk_domain_size as usize);
+                if num_words < CHUNK_WORDS {
+                    assert_eq!(count_ones(&words[num_words..]) as ChunkSize, 0);
+                }
+            }
+        }
+    }
+
+    /// Count the number of 1s in the chunk.
+    fn count(&self) -> usize {
+        match *self {
+            Zeros { .. } => 0,
+            Ones { chunk_domain_size } => chunk_domain_size as usize,
+            Mixed { ones_count, .. } => usize::from(ones_count),
+        }
+    }
+}
+
+enum ChunkIter<'a> {
+    Zeros,
+    Ones(Range<usize>),
+    Mixed(BitIter<'a, usize>),
+    Finished,
+}
+
+impl<T: Idx> fmt::Debug for ChunkedBitSet<T> {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
+        w.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// Sets `lhs[i] = op(lhs[i], rhs[i])` for each index `i` in both
+/// slices. The slices must have the same length.
+///
+/// Returns true if at least one bit in `lhs` was changed.
+///
+/// ## Warning
+/// Some bitwise operations (e.g. union-not, xor) can set output bits that were
+/// unset in in both inputs. If this happens in the last word/chunk of a bitset,
+/// it can cause the bitset to contain out-of-domain values, which need to
+/// be cleared with `clear_excess_bits_in_final_word`. This also makes the
+/// "changed" return value unreliable, because the change might have only
+/// affected excess bits.
+#[inline]
+fn update_words<Op>(lhs: &mut [Word], rhs: &[Word], op: Op) -> bool
+where
+    Op: Fn(Word, Word) -> Word,
+{
+    assert_eq!(lhs.len(), rhs.len());
+    let mut changed = 0;
+    for (lhs_slot, &rhs_val) in iter::zip(lhs, rhs) {
+        let old_val = *lhs_slot;
+        let new_val = op(old_val, rhs_val);
+        *lhs_slot = new_val;
+        // This is essentially equivalent to a != with changed being a bool, but
+        // in practice this code gets auto-vectorized by the compiler for most
+        // operators. Using != here causes us to generate quite poor code as the
+        // compiler tries to go back to a boolean on each loop iteration.
+        changed |= old_val ^ new_val;
+    }
+    changed != 0
+}
+
+/// Returns true if a call to [`update_words`] would modify `lhs`, i.e.
+/// `lhs[i] != op(lhs[i], rhs[i])` for some `i`.
+#[inline]
+fn would_modify_words<Op>(lhs: &[Word], rhs: &[Word], op: Op) -> bool
+where
+    Op: Fn(Word, Word) -> Word,
+{
+    assert_eq!(lhs.len(), rhs.len());
+
+    // To make codegen more vectorizer-friendly, we traverse each slice in larger
+    // "subchunks", and only consider an early return at subchunk boundaries.
+    // These subchunks are smaller than full `ChunkedBitSet` chunks, so that
+    // we still have some chance of stopping early.
+    const SUBCHUNK_LEN: usize = 64 / size_of::<Word>();
+    let (lhs_chunks, lhs_tail) = lhs.as_chunks::<SUBCHUNK_LEN>();
+    let (rhs_chunks, rhs_tail) = rhs.as_chunks::<SUBCHUNK_LEN>();
+
+    let would_modify_subchunk = |lhs_chunk: &[Word], rhs_chunk: &[Word]| {
+        let mut changed = 0;
+        for (&old_val, &rhs_val) in iter::zip(lhs_chunk, rhs_chunk) {
+            let new_val = op(old_val, rhs_val);
+            // Set `changed` to a non-zero value if any bits changed.
+            // This gives better SIMD codegen than using an actual boolean.
+            changed |= old_val ^ new_val;
+        }
+        changed != 0
+    };
+
+    for (lhs_chunk, rhs_chunk) in iter::zip(lhs_chunks, rhs_chunks) {
+        if would_modify_subchunk(lhs_chunk, rhs_chunk) {
+            return true;
+        }
+    }
+    would_modify_subchunk(lhs_tail, rhs_tail)
+}
+
+/// A bitset with a mixed representation, using `DenseBitSet` for small and
+/// medium bitsets, and `ChunkedBitSet` for large bitsets, i.e. those with
+/// enough bits for at least two chunks. This is a good choice for many bitsets
+/// that can have large domain sizes (e.g. 5000+).
+///
+/// `T` is an index type, typically a newtyped `usize` wrapper, but it can also
+/// just be `usize`.
+///
+/// All operations that involve an element will panic if the element is equal
+/// to or greater than the domain size. All operations that involve two bitsets
+/// will panic if the bitsets have differing domain sizes.
+#[derive(PartialEq, Eq)]
+pub enum MixedBitSet<T> {
+    Small(DenseBitSet<T>),
+    Large(ChunkedBitSet<T>),
+}
+
+impl<T> MixedBitSet<T> {
+    pub fn domain_size(&self) -> usize {
+        match self {
+            MixedBitSet::Small(set) => set.domain_size(),
+            MixedBitSet::Large(set) => set.domain_size(),
+        }
+    }
+}
+
+impl<T: Idx> MixedBitSet<T> {
+    #[inline]
+    pub fn new_empty(domain_size: usize) -> MixedBitSet<T> {
+        if domain_size <= CHUNK_BITS {
+            MixedBitSet::Small(DenseBitSet::new_empty(domain_size))
+        } else {
+            MixedBitSet::Large(ChunkedBitSet::new_empty(domain_size))
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            MixedBitSet::Small(set) => set.is_empty(),
+            MixedBitSet::Large(set) => set.is_empty(),
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, elem: T) -> bool {
+        match self {
+            MixedBitSet::Small(set) => set.contains(elem),
+            MixedBitSet::Large(set) => set.contains(elem),
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, elem: T) -> bool {
+        match self {
+            MixedBitSet::Small(set) => set.insert(elem),
+            MixedBitSet::Large(set) => set.insert(elem),
+        }
+    }
+
+    pub fn insert_all(&mut self) {
+        match self {
+            MixedBitSet::Small(set) => set.insert_all(),
+            MixedBitSet::Large(set) => set.insert_all(),
+        }
+    }
+
+    #[inline]
+    pub fn remove(&mut self, elem: T) -> bool {
+        match self {
+            MixedBitSet::Small(set) => set.remove(elem),
+            MixedBitSet::Large(set) => set.remove(elem),
+        }
+    }
+
+    pub fn iter(&self) -> MixedBitIter<'_, T> {
+        match self {
+            MixedBitSet::Small(set) => MixedBitIter::Small(set.iter()),
+            MixedBitSet::Large(set) => MixedBitIter::Large(set.iter()),
+        }
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        match self {
+            MixedBitSet::Small(set) => set.clear(),
+            MixedBitSet::Large(set) => set.clear(),
+        }
+    }
+
+    bit_relations_inherent_impls! {}
+}
+
+impl<T> Clone for MixedBitSet<T> {
+    fn clone(&self) -> Self {
+        match self {
+            MixedBitSet::Small(set) => MixedBitSet::Small(set.clone()),
+            MixedBitSet::Large(set) => MixedBitSet::Large(set.clone()),
+        }
+    }
+
+    /// WARNING: this implementation of clone_from may panic if the two
+    /// bitsets have different domain sizes. This constraint is not inherent to
+    /// `clone_from`, but it works with the existing call sites and allows a
+    /// faster implementation, which is important because this function is hot.
+    fn clone_from(&mut self, from: &Self) {
+        match (self, from) {
+            (MixedBitSet::Small(set), MixedBitSet::Small(from)) => set.clone_from(from),
+            (MixedBitSet::Large(set), MixedBitSet::Large(from)) => set.clone_from(from),
+            _ => panic!("MixedBitSet size mismatch"),
+        }
+    }
+}
+
+impl<T: Idx> BitRelations<MixedBitSet<T>> for MixedBitSet<T> {
+    fn union(&mut self, other: &MixedBitSet<T>) -> bool {
+        match (self, other) {
+            (MixedBitSet::Small(set), MixedBitSet::Small(other)) => set.union(other),
+            (MixedBitSet::Large(set), MixedBitSet::Large(other)) => set.union(other),
+            _ => panic!("MixedBitSet size mismatch"),
+        }
+    }
+
+    fn subtract(&mut self, other: &MixedBitSet<T>) -> bool {
+        match (self, other) {
+            (MixedBitSet::Small(set), MixedBitSet::Small(other)) => set.subtract(other),
+            (MixedBitSet::Large(set), MixedBitSet::Large(other)) => set.subtract(other),
+            _ => panic!("MixedBitSet size mismatch"),
+        }
+    }
+
+    fn intersect(&mut self, _other: &MixedBitSet<T>) -> bool {
+        unimplemented!("implement if/when necessary");
+    }
+}
+
+impl<T: Idx> fmt::Debug for MixedBitSet<T> {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MixedBitSet::Small(set) => set.fmt(w),
+            MixedBitSet::Large(set) => set.fmt(w),
+        }
+    }
+}
+
+pub enum MixedBitIter<'a, T: Idx> {
+    Small(BitIter<'a, T>),
+    Large(ChunkedBitIter<'a, T>),
+}
+
+impl<'a, T: Idx> Iterator for MixedBitIter<'a, T> {
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        match self {
+            MixedBitIter::Small(iter) => iter.next(),
+            MixedBitIter::Large(iter) => iter.next(),
+        }
+    }
+}
+
 /// A resizable bitset type with a dense representation.
-#[derive(Clone, Debug, Eq, PartialEq)]
+///
+/// `T` is an index type, typically a newtyped `usize` wrapper, but it can also
+/// just be `usize`.
+///
+/// All operations that involve an element will panic if the element is equal
+/// to or greater than the domain size.
+#[derive(Clone, Debug, PartialEq)]
 pub struct GrowableBitSet<T: Idx> {
     bit_set: DenseBitSet<T>,
 }
 
 impl<T: Idx> Default for GrowableBitSet<T> {
     fn default() -> Self {
-        Self::new_empty()
+        GrowableBitSet::new_empty()
     }
 }
 
 impl<T: Idx> GrowableBitSet<T> {
-    /// Ensures that the set can hold at least `min_domain_size` elements.
+    /// Ensure that the set can hold at least `min_domain_size` elements.
     pub fn ensure(&mut self, min_domain_size: usize) {
         if self.bit_set.domain_size < min_domain_size {
             self.bit_set.domain_size = min_domain_size;
@@ -370,82 +1340,72 @@ impl<T: Idx> GrowableBitSet<T> {
 
         let min_num_words = num_words(min_domain_size);
         if self.bit_set.words.len() < min_num_words {
-            self.bit_set.words.resize(min_num_words, 0);
+            self.bit_set.words.resize(min_num_words, 0)
         }
     }
 
-    /// Creates a new, empty growable bitset.
-    pub fn new_empty() -> Self {
-        Self { bit_set: DenseBitSet::new_empty(0) }
+    pub fn new_empty() -> GrowableBitSet<T> {
+        GrowableBitSet { bit_set: DenseBitSet::new_empty(0) }
     }
 
-    /// Creates a new, empty growable bitset with the given capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self { bit_set: DenseBitSet::new_empty(capacity) }
+    pub fn with_capacity(capacity: usize) -> GrowableBitSet<T> {
+        GrowableBitSet { bit_set: DenseBitSet::new_empty(capacity) }
     }
 
-    /// Inserts `elem`, returning true if this set changed.
+    /// Returns `true` if the set has changed.
     #[inline]
     pub fn insert(&mut self, elem: T) -> bool {
         self.ensure(elem.index() + 1);
         self.bit_set.insert(elem)
     }
 
-    /// Inserts each element in `elems`.
     #[inline]
     pub fn insert_range(&mut self, elems: Range<T>) {
         self.ensure(elems.end.index());
         self.bit_set.insert_range(elems);
     }
 
-    /// Removes `elem`, returning true if this set changed.
+    /// Returns `true` if the set has changed.
     #[inline]
     pub fn remove(&mut self, elem: T) -> bool {
         self.ensure(elem.index() + 1);
         self.bit_set.remove(elem)
     }
 
-    /// Clears all elements.
     #[inline]
     pub fn clear(&mut self) {
         self.bit_set.clear();
     }
 
-    /// Counts the number of set bits.
     #[inline]
     pub fn count(&self) -> usize {
         self.bit_set.count()
     }
 
-    /// Returns true if the set is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.bit_set.is_empty()
     }
 
-    /// Returns true if the set contains `elem`.
     #[inline]
     pub fn contains(&self, elem: T) -> bool {
         let (word_index, mask) = word_index_and_mask(elem);
         self.bit_set.words.get(word_index).is_some_and(|word| (word & mask) != 0)
     }
 
-    /// Returns true if any bit in `elems` is set.
     #[inline]
     pub fn contains_any(&self, elems: Range<T>) -> bool {
         elems.start.index() < self.bit_set.domain_size
-            && self.bit_set.contains_any(
-                elems.start..T::from_usize(elems.end.index().min(self.bit_set.domain_size)),
-            )
+            && self
+                .bit_set
+                .contains_any(elems.start..T::new(elems.end.index().min(self.bit_set.domain_size)))
     }
 
-    /// Iterates over the indices of set bits in sorted order.
     #[inline]
     pub fn iter(&self) -> BitIter<'_, T> {
         self.bit_set.iter()
     }
 
-    /// Counts the number of set bits.
     #[inline]
     pub fn len(&self) -> usize {
         self.bit_set.count()
@@ -461,19 +1421,16 @@ impl<T: Idx> From<DenseBitSet<T>> for GrowableBitSet<T> {
 }
 
 impl<T: Idx> BitRelations<Self> for GrowableBitSet<T> {
-    #[inline]
     fn union(&mut self, other: &Self) -> bool {
         self.ensure(other.bit_set.domain_size);
         update_words(&mut self.bit_set.words, &other.bit_set.words, |a, b| a | b)
     }
 
-    #[inline]
     fn subtract(&mut self, other: &Self) -> bool {
         let len = self.bit_set.words.len().min(other.bit_set.words.len());
         update_words(&mut self.bit_set.words[..len], &other.bit_set.words[..len], |a, b| a & !b)
     }
 
-    #[inline]
     fn intersect(&mut self, other: &Self) -> bool {
         let len = self.bit_set.words.len().min(other.bit_set.words.len());
         let changed =
@@ -484,37 +1441,380 @@ impl<T: Idx> BitRelations<Self> for GrowableBitSet<T> {
     }
 }
 
-#[inline]
-fn update_words<Op>(lhs: &mut [Word], rhs: &[Word], op: Op) -> bool
-where
-    Op: Fn(Word, Word) -> Word,
-{
-    assert_eq!(lhs.len(), rhs.len());
-    let mut changed = 0;
-    for (lhs_slot, &rhs_val) in iter::zip(lhs, rhs) {
-        let old_val = *lhs_slot;
-        let new_val = op(old_val, rhs_val);
-        *lhs_slot = new_val;
-        changed |= old_val ^ new_val;
+/// A fixed-size 2D bit matrix type with a dense representation.
+///
+/// `R` and `C` are index types used to identify rows and columns respectively;
+/// typically newtyped `usize` wrappers, but they can also just be `usize`.
+///
+/// All operations that involve a row and/or column index will panic if the
+/// index exceeds the relevant bound.
+#[derive(Clone, Eq, PartialEq, Hash)]
+pub struct BitMatrix<R: Idx, C: Idx> {
+    num_rows: usize,
+    num_columns: usize,
+    words: Vec<Word>,
+    marker: PhantomData<(R, C)>,
+}
+
+impl<R: Idx, C: Idx> BitMatrix<R, C> {
+    /// Creates a new `rows x columns` matrix, initially empty.
+    pub fn new(num_rows: usize, num_columns: usize) -> BitMatrix<R, C> {
+        // For every element, we need one bit for every other
+        // element. Round up to an even number of words.
+        let words_per_row = num_words(num_columns);
+        BitMatrix {
+            num_rows,
+            num_columns,
+            words: vec![0; num_rows * words_per_row],
+            marker: PhantomData,
+        }
     }
-    changed != 0
+
+    /// Creates a new matrix, with `row` used as the value for every row.
+    pub fn from_row_n(row: &DenseBitSet<C>, num_rows: usize) -> BitMatrix<R, C> {
+        let num_columns = row.domain_size();
+        let words_per_row = num_words(num_columns);
+        assert_eq!(words_per_row, row.words.len());
+        BitMatrix {
+            num_rows,
+            num_columns,
+            words: iter::repeat_n(&row.words, num_rows).flatten().cloned().collect(),
+            marker: PhantomData,
+        }
+    }
+
+    pub fn rows(&self) -> impl Iterator<Item = R> {
+        (0..self.num_rows).map(R::new)
+    }
+
+    /// The range of bits for a given row.
+    fn range(&self, row: R) -> (usize, usize) {
+        let words_per_row = num_words(self.num_columns);
+        let start = row.index() * words_per_row;
+        (start, start + words_per_row)
+    }
+
+    /// Sets the cell at `(row, column)` to true. Put another way, insert
+    /// `column` to the bitset for `row`.
+    ///
+    /// Returns `true` if this changed the matrix.
+    pub fn insert(&mut self, row: R, column: C) -> bool {
+        assert!(row.index() < self.num_rows && column.index() < self.num_columns);
+        let (start, _) = self.range(row);
+        let (word_index, mask) = word_index_and_mask(column);
+        let words = &mut self.words[..];
+        let word = words[start + word_index];
+        let new_word = word | mask;
+        words[start + word_index] = new_word;
+        word != new_word
+    }
+
+    /// Do the bits from `row` contain `column`? Put another way, is
+    /// the matrix cell at `(row, column)` true?  Put yet another way,
+    /// if the matrix represents (transitive) reachability, can
+    /// `row` reach `column`?
+    pub fn contains(&self, row: R, column: C) -> bool {
+        assert!(row.index() < self.num_rows && column.index() < self.num_columns);
+        let (start, _) = self.range(row);
+        let (word_index, mask) = word_index_and_mask(column);
+        (self.words[start + word_index] & mask) != 0
+    }
+
+    /// Returns those indices that are true in rows `a` and `b`. This
+    /// is an *O*(*n*) operation where *n* is the number of elements
+    /// (somewhat independent from the actual size of the
+    /// intersection, in particular).
+    pub fn intersect_rows(&self, row1: R, row2: R) -> Vec<C> {
+        assert!(row1.index() < self.num_rows && row2.index() < self.num_rows);
+        let (row1_start, row1_end) = self.range(row1);
+        let (row2_start, row2_end) = self.range(row2);
+        let mut result = Vec::with_capacity(self.num_columns);
+        for (base, (i, j)) in (row1_start..row1_end).zip(row2_start..row2_end).enumerate() {
+            let mut v = self.words[i] & self.words[j];
+            for bit in 0..WORD_BITS {
+                if v == 0 {
+                    break;
+                }
+                if v & 0x1 != 0 {
+                    result.push(C::new(base * WORD_BITS + bit));
+                }
+                v >>= 1;
+            }
+        }
+        result
+    }
+
+    /// Adds the bits from row `read` to the bits from row `write`, and
+    /// returns `true` if anything changed.
+    ///
+    /// This is used when computing transitive reachability because if
+    /// you have an edge `write -> read`, because in that case
+    /// `write` can reach everything that `read` can (and
+    /// potentially more).
+    pub fn union_rows(&mut self, read: R, write: R) -> bool {
+        assert!(read.index() < self.num_rows && write.index() < self.num_rows);
+        let (read_start, read_end) = self.range(read);
+        let (write_start, write_end) = self.range(write);
+        let words = &mut self.words[..];
+        let mut changed = 0;
+        for (read_index, write_index) in iter::zip(read_start..read_end, write_start..write_end) {
+            let word = words[write_index];
+            let new_word = word | words[read_index];
+            words[write_index] = new_word;
+            // See `bitwise` for the rationale.
+            changed |= word ^ new_word;
+        }
+        changed != 0
+    }
+
+    /// Adds the bits from `with` to the bits from row `write`, and
+    /// returns `true` if anything changed.
+    pub fn union_row_with(&mut self, with: &DenseBitSet<C>, write: R) -> bool {
+        assert!(write.index() < self.num_rows);
+        assert_eq!(with.domain_size(), self.num_columns);
+        let (write_start, write_end) = self.range(write);
+        update_words(&mut self.words[write_start..write_end], &with.words, |a, b| a | b)
+    }
+
+    /// Sets every cell in `row` to true.
+    pub fn insert_all_into_row(&mut self, row: R) {
+        assert!(row.index() < self.num_rows);
+        let (start, end) = self.range(row);
+        let words = &mut self.words[..];
+        for index in start..end {
+            words[index] = !0;
+        }
+        clear_excess_bits_in_final_word(self.num_columns, &mut self.words[..end]);
+    }
+
+    /// Gets a slice of the underlying words.
+    pub fn words(&self) -> &[Word] {
+        &self.words
+    }
+
+    /// Iterates through all the columns set to true in a given row of
+    /// the matrix.
+    pub fn iter(&self, row: R) -> BitIter<'_, C> {
+        assert!(row.index() < self.num_rows);
+        let (start, end) = self.range(row);
+        BitIter::new(&self.words[start..end])
+    }
+
+    /// Returns the number of elements in `row`.
+    pub fn count(&self, row: R) -> usize {
+        let (start, end) = self.range(row);
+        count_ones(&self.words[start..end])
+    }
+}
+
+impl<R: Idx, C: Idx> fmt::Debug for BitMatrix<R, C> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        /// Forces its contents to print in regular mode instead of alternate mode.
+        struct OneLinePrinter<T>(T);
+        impl<T: fmt::Debug> fmt::Debug for OneLinePrinter<T> {
+            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(fmt, "{:?}", self.0)
+            }
+        }
+
+        write!(fmt, "BitMatrix({}x{}) ", self.num_rows, self.num_columns)?;
+        let items = self.rows().flat_map(|r| self.iter(r).map(move |c| (r, c)));
+        fmt.debug_set().entries(items.map(OneLinePrinter)).finish()
+    }
+}
+
+/// A fixed-column-size, variable-row-size 2D bit matrix with a moderately
+/// sparse representation.
+///
+/// Initially, every row has no explicit representation. If any bit within a row
+/// is set, the entire row is instantiated as `Some(<DenseBitSet>)`.
+/// Furthermore, any previously uninstantiated rows prior to it will be
+/// instantiated as `None`. Those prior rows may themselves become fully
+/// instantiated later on if any of their bits are set.
+///
+/// `R` and `C` are index types used to identify rows and columns respectively;
+/// typically newtyped `usize` wrappers, but they can also just be `usize`.
+#[derive(Clone, Debug)]
+pub struct SparseBitMatrix<R, C>
+where
+    R: Idx,
+    C: Idx,
+{
+    num_columns: usize,
+    rows: Vec<Option<DenseBitSet<C>>>,
+    marker: PhantomData<R>,
+}
+
+impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
+    /// Creates a new empty sparse bit matrix with no rows or columns.
+    pub fn new(num_columns: usize) -> Self {
+        Self { num_columns, rows: Vec::new(), marker: PhantomData }
+    }
+
+    fn ensure_row(&mut self, row: R) -> &mut DenseBitSet<C> {
+        // Instantiate any missing rows up to and including row `row` with an empty `DenseBitSet`.
+        // Then replace row `row` with a full `DenseBitSet` if necessary.
+        let row = row.index();
+        if self.rows.len() <= row {
+            self.rows.resize_with(row + 1, || None);
+        }
+        self.rows[row].get_or_insert_with(|| DenseBitSet::new_empty(self.num_columns))
+    }
+
+    /// Sets the cell at `(row, column)` to true. Put another way, insert
+    /// `column` to the bitset for `row`.
+    ///
+    /// Returns `true` if this changed the matrix.
+    pub fn insert(&mut self, row: R, column: C) -> bool {
+        self.ensure_row(row).insert(column)
+    }
+
+    /// Sets the cell at `(row, column)` to false. Put another way, delete
+    /// `column` from the bitset for `row`. Has no effect if `row` does not
+    /// exist.
+    ///
+    /// Returns `true` if this changed the matrix.
+    pub fn remove(&mut self, row: R, column: C) -> bool {
+        match self.rows.get_mut(row.index()) {
+            Some(Some(row)) => row.remove(column),
+            _ => false,
+        }
+    }
+
+    /// Sets all columns at `row` to false. Has no effect if `row` does
+    /// not exist.
+    pub fn clear(&mut self, row: R) {
+        if let Some(Some(row)) = self.rows.get_mut(row.index()) {
+            row.clear();
+        }
+    }
+
+    /// Do the bits from `row` contain `column`? Put another way, is
+    /// the matrix cell at `(row, column)` true?  Put yet another way,
+    /// if the matrix represents (transitive) reachability, can
+    /// `row` reach `column`?
+    pub fn contains(&self, row: R, column: C) -> bool {
+        self.row(row).is_some_and(|r| r.contains(column))
+    }
+
+    /// Adds the bits from row `read` to the bits from row `write`, and
+    /// returns `true` if anything changed.
+    ///
+    /// This is used when computing transitive reachability because if
+    /// you have an edge `write -> read`, because in that case
+    /// `write` can reach everything that `read` can (and
+    /// potentially more).
+    pub fn union_rows(&mut self, read: R, write: R) -> bool {
+        if read == write || self.row(read).is_none() {
+            return false;
+        }
+
+        self.ensure_row(write);
+        let Some((read_row, write_row)) = pick2_mut(&mut self.rows, read.index(), write.index())
+        else {
+            unreachable!()
+        };
+        let (Some(read_row), Some(write_row)) = (read_row.as_ref(), write_row.as_mut()) else {
+            unreachable!()
+        };
+        write_row.union(read_row)
+    }
+
+    /// Insert all bits in the given row.
+    pub fn insert_all_into_row(&mut self, row: R) {
+        self.ensure_row(row).insert_all();
+    }
+
+    pub fn rows(&self) -> impl Iterator<Item = R> {
+        (0..self.rows.len()).map(R::new)
+    }
+
+    /// Iterates through all the columns set to true in a given row of
+    /// the matrix.
+    pub fn iter(&self, row: R) -> impl Iterator<Item = C> {
+        self.row(row).into_iter().flat_map(|r| r.iter())
+    }
+
+    pub fn row(&self, row: R) -> Option<&DenseBitSet<C>> {
+        self.rows.get(row.index())?.as_ref()
+    }
+
+    /// Intersects `row` with `set`. `set` can be either `DenseBitSet` or
+    /// `ChunkedBitSet`. Has no effect if `row` does not exist.
+    ///
+    /// Returns true if the row was changed.
+    pub fn intersect_row<Set>(&mut self, row: R, set: &Set) -> bool
+    where
+        DenseBitSet<C>: BitRelations<Set>,
+    {
+        match self.rows.get_mut(row.index()) {
+            Some(Some(row)) => row.intersect(set),
+            _ => false,
+        }
+    }
+
+    /// Subtracts `set` from `row`. `set` can be either `DenseBitSet` or
+    /// `ChunkedBitSet`. Has no effect if `row` does not exist.
+    ///
+    /// Returns true if the row was changed.
+    pub fn subtract_row<Set>(&mut self, row: R, set: &Set) -> bool
+    where
+        DenseBitSet<C>: BitRelations<Set>,
+    {
+        match self.rows.get_mut(row.index()) {
+            Some(Some(row)) => row.subtract(set),
+            _ => false,
+        }
+    }
+
+    /// Unions `row` with `set`. `set` can be either `DenseBitSet` or
+    /// `ChunkedBitSet`.
+    ///
+    /// Returns true if the row was changed.
+    pub fn union_row<Set>(&mut self, row: R, set: &Set) -> bool
+    where
+        DenseBitSet<C>: BitRelations<Set>,
+    {
+        self.ensure_row(row).union(set)
+    }
 }
 
 #[inline]
-fn num_words(domain_size: usize) -> usize {
-    domain_size.div_ceil(WORD_BITS)
+fn num_words<T: Idx>(domain_size: T) -> usize {
+    domain_size.index().div_ceil(WORD_BITS)
 }
 
 #[inline]
 fn word_index_and_mask<T: Idx>(elem: T) -> (usize, Word) {
-    word_index_and_mask_usize(elem.index())
-}
-
-#[inline]
-fn word_index_and_mask_usize(elem: usize) -> (usize, Word) {
+    let elem = elem.index();
     let word_index = elem / WORD_BITS;
     let mask = 1 << (elem % WORD_BITS);
     (word_index, mask)
+}
+
+#[inline]
+fn chunk_index<T: Idx>(elem: T) -> usize {
+    elem.index() / CHUNK_BITS
+}
+
+#[inline]
+fn chunk_word_index_and_mask<T: Idx>(elem: T) -> (usize, Word) {
+    let chunk_elem = elem.index() % CHUNK_BITS;
+    word_index_and_mask(chunk_elem)
+}
+
+fn pick2_mut<T>(slice: &mut [T], idx_1: usize, idx_2: usize) -> Option<(&mut T, &mut T)> {
+    if idx_1 == idx_2 || idx_1 >= slice.len() || idx_2 >= slice.len() {
+        return None;
+    }
+
+    if idx_1 < idx_2 {
+        let (left, right) = slice.split_at_mut(idx_2);
+        Some((&mut left[idx_1], &mut right[0]))
+    } else {
+        let (left, right) = slice.split_at_mut(idx_1);
+        Some((&mut right[0], &mut left[idx_2]))
+    }
 }
 
 fn clear_excess_bits_in_final_word(domain_size: usize, words: &mut [Word]) {
@@ -533,58 +1833,4 @@ fn max_bit(word: Word) -> usize {
 #[inline]
 fn count_ones(words: &[Word]) -> usize {
     words.iter().map(|word| word.count_ones() as usize).sum()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::newtype_index;
-
-    newtype_index! {
-        struct TestIdx;
-    }
-
-    #[test]
-    fn dense_insert_remove_iter() {
-        let _ = TestIdx::MAX;
-        let mut set = DenseBitSet::<TestIdx>::new_empty(130);
-        for idx in [0, 1, 63, 64, 129] {
-            assert!(set.insert(TestIdx::from_usize(idx)));
-        }
-        assert!(!set.insert(TestIdx::from_usize(64)));
-        assert!(set.contains(TestIdx::from_usize(129)));
-        assert_eq!(set.count(), 5);
-
-        assert!(set.remove(TestIdx::from_usize(1)));
-        assert!(!set.contains(TestIdx::from_usize(1)));
-
-        let values: Vec<_> = set.iter().map(Idx::index).collect();
-        assert_eq!(values, [0, 63, 64, 129]);
-    }
-
-    #[test]
-    fn dense_relations() {
-        let mut left = DenseBitSet::<TestIdx>::new_empty(100);
-        let mut right = DenseBitSet::<TestIdx>::new_empty(100);
-        left.insert(TestIdx::from_usize(1));
-        left.insert(TestIdx::from_usize(3));
-        right.insert(TestIdx::from_usize(3));
-        right.insert(TestIdx::from_usize(5));
-
-        assert!(left.union(&right));
-        assert!(!left.union(&right));
-        assert_eq!(left.iter().map(Idx::index).collect::<Vec<_>>(), [1, 3, 5]);
-
-        assert!(left.subtract(&right));
-        assert_eq!(left.iter().map(Idx::index).collect::<Vec<_>>(), [1]);
-    }
-
-    #[test]
-    fn growable_extends_on_insert() {
-        let mut set = GrowableBitSet::<TestIdx>::new_empty();
-        assert!(set.insert(TestIdx::from_usize(250)));
-        assert!(set.contains(TestIdx::from_usize(250)));
-        assert!(!set.contains(TestIdx::from_usize(249)));
-        assert_eq!(set.count(), 1);
-    }
 }

--- a/crates/data-structures/src/bit_set.rs
+++ b/crates/data-structures/src/bit_set.rs
@@ -1,0 +1,590 @@
+//! Indexed bitsets.
+//!
+//! Adapted from `rustc_index::bit_set`.
+
+use std::{
+    fmt, iter,
+    marker::PhantomData,
+    ops::{Bound, Range, RangeBounds},
+    slice,
+};
+
+use crate::index::Idx;
+
+type Word = u64;
+const WORD_BYTES: usize = size_of::<Word>();
+const WORD_BITS: usize = WORD_BYTES * 8;
+
+/// Bitwise set relations.
+pub trait BitRelations<Rhs> {
+    /// Sets `self = self | other`, returning true if this set changed.
+    fn union(&mut self, other: &Rhs) -> bool;
+
+    /// Sets `self = self - other`, returning true if this set changed.
+    fn subtract(&mut self, other: &Rhs) -> bool;
+
+    /// Sets `self = self & other`, returning true if this set changed.
+    fn intersect(&mut self, other: &Rhs) -> bool;
+}
+
+#[inline]
+fn inclusive_start_end<T: Idx>(
+    range: impl RangeBounds<T>,
+    domain: usize,
+) -> Option<(usize, usize)> {
+    let start = match range.start_bound().cloned() {
+        Bound::Included(start) => start.index(),
+        Bound::Excluded(start) => start.index() + 1,
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound().cloned() {
+        Bound::Included(end) => end.index(),
+        Bound::Excluded(end) => end.index().checked_sub(1)?,
+        Bound::Unbounded => domain - 1,
+    };
+    assert!(end < domain);
+    if start > end {
+        return None;
+    }
+    Some((start, end))
+}
+
+macro_rules! bit_relations_inherent_impls {
+    () => {
+        /// Sets `self = self | other`, returning true if this set changed.
+        pub fn union<Rhs>(&mut self, other: &Rhs) -> bool
+        where
+            Self: BitRelations<Rhs>,
+        {
+            <Self as BitRelations<Rhs>>::union(self, other)
+        }
+
+        /// Sets `self = self - other`, returning true if this set changed.
+        pub fn subtract<Rhs>(&mut self, other: &Rhs) -> bool
+        where
+            Self: BitRelations<Rhs>,
+        {
+            <Self as BitRelations<Rhs>>::subtract(self, other)
+        }
+
+        /// Sets `self = self & other`, returning true if this set changed.
+        pub fn intersect<Rhs>(&mut self, other: &Rhs) -> bool
+        where
+            Self: BitRelations<Rhs>,
+        {
+            <Self as BitRelations<Rhs>>::intersect(self, other)
+        }
+    };
+}
+
+/// A fixed-size bitset type with a dense representation.
+///
+/// `T` is an index type. All operations that involve an element panic if the
+/// element is equal to or greater than the domain size. Operations that involve
+/// two bitsets panic if their domain sizes differ.
+#[derive(Eq, PartialEq, Hash)]
+pub struct DenseBitSet<T> {
+    domain_size: usize,
+    words: Vec<Word>,
+    marker: PhantomData<T>,
+}
+
+impl<T> DenseBitSet<T> {
+    /// Gets the domain size.
+    #[inline]
+    pub const fn domain_size(&self) -> usize {
+        self.domain_size
+    }
+}
+
+impl<T: Idx> DenseBitSet<T> {
+    /// Creates a new, empty bitset with the given domain size.
+    #[inline]
+    pub fn new_empty(domain_size: usize) -> Self {
+        Self { domain_size, words: vec![0; num_words(domain_size)], marker: PhantomData }
+    }
+
+    /// Creates a new, filled bitset with the given domain size.
+    #[inline]
+    pub fn new_filled(domain_size: usize) -> Self {
+        let mut result =
+            Self { domain_size, words: vec![!0; num_words(domain_size)], marker: PhantomData };
+        result.clear_excess_bits();
+        result
+    }
+
+    /// Clears all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.words.fill(0);
+    }
+
+    fn clear_excess_bits(&mut self) {
+        clear_excess_bits_in_final_word(self.domain_size, &mut self.words);
+    }
+
+    /// Counts the number of set bits.
+    #[inline]
+    pub fn count(&self) -> usize {
+        count_ones(&self.words)
+    }
+
+    /// Returns true if the set contains `elem`.
+    #[inline]
+    pub fn contains(&self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let (word_index, mask) = word_index_and_mask(elem);
+        (self.words[word_index] & mask) != 0
+    }
+
+    /// Returns true if this set is a non-strict superset of `other`.
+    #[inline]
+    pub fn superset(&self, other: &Self) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        self.words.iter().zip(&other.words).all(|(a, b)| (a & b) == *b)
+    }
+
+    /// Returns true if the set is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.words.iter().all(|word| *word == 0)
+    }
+
+    /// Inserts `elem`, returning true if this set changed.
+    #[inline]
+    pub fn insert(&mut self, elem: T) -> bool {
+        assert!(
+            elem.index() < self.domain_size,
+            "inserting element at index {} but domain size is {}",
+            elem.index(),
+            self.domain_size,
+        );
+        let (word_index, mask) = word_index_and_mask(elem);
+        let word = self.words[word_index];
+        let new_word = word | mask;
+        self.words[word_index] = new_word;
+        new_word != word
+    }
+
+    /// Inserts each element in `elems`.
+    #[inline]
+    pub fn insert_range(&mut self, elems: impl RangeBounds<T>) {
+        let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
+            return;
+        };
+
+        let (start_word_index, start_mask) = word_index_and_mask_usize(start);
+        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
+
+        for word_index in (start_word_index + 1)..end_word_index {
+            self.words[word_index] = !0;
+        }
+
+        if start_word_index != end_word_index {
+            self.words[start_word_index] |= !(start_mask - 1);
+            self.words[end_word_index] |= end_mask | (end_mask - 1);
+        } else {
+            self.words[start_word_index] |= end_mask | (end_mask - start_mask);
+        }
+    }
+
+    /// Inserts all elements in the domain.
+    pub fn insert_all(&mut self) {
+        self.words.fill(!0);
+        self.clear_excess_bits();
+    }
+
+    /// Returns true if any bit in `elems` is set.
+    #[inline]
+    pub fn contains_any(&self, elems: impl RangeBounds<T>) -> bool {
+        let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
+            return false;
+        };
+        let (start_word_index, start_mask) = word_index_and_mask_usize(start);
+        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
+
+        if start_word_index == end_word_index {
+            self.words[start_word_index] & (end_mask | (end_mask - start_mask)) != 0
+        } else if self.words[start_word_index] & !(start_mask - 1) != 0 {
+            true
+        } else {
+            let remaining = start_word_index + 1..end_word_index;
+            remaining.start <= remaining.end
+                && (self.words[remaining].iter().any(|&word| word != 0)
+                    || self.words[end_word_index] & (end_mask | (end_mask - 1)) != 0)
+        }
+    }
+
+    /// Removes `elem`, returning true if this set changed.
+    #[inline]
+    pub fn remove(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let (word_index, mask) = word_index_and_mask(elem);
+        let word = self.words[word_index];
+        let new_word = word & !mask;
+        self.words[word_index] = new_word;
+        new_word != word
+    }
+
+    /// Iterates over the indices of set bits in sorted order.
+    #[inline]
+    pub fn iter(&self) -> BitIter<'_, T> {
+        BitIter::new(&self.words)
+    }
+
+    /// Returns the last set bit in `range`.
+    pub fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
+        let (start, end) = inclusive_start_end(range, self.domain_size)?;
+        let (start_word_index, _) = word_index_and_mask_usize(start);
+        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
+
+        let end_word = self.words[end_word_index] & (end_mask | (end_mask - 1));
+        if end_word != 0 {
+            let pos = max_bit(end_word) + WORD_BITS * end_word_index;
+            if start <= pos {
+                return Some(T::from_usize(pos));
+            }
+        }
+
+        if let Some(offset) =
+            self.words[start_word_index..end_word_index].iter().rposition(|&word| word != 0)
+        {
+            let word_idx = start_word_index + offset;
+            let pos = max_bit(self.words[word_idx]) + WORD_BITS * word_idx;
+            if start <= pos {
+                return Some(T::from_usize(pos));
+            }
+        }
+
+        None
+    }
+
+    bit_relations_inherent_impls! {}
+
+    /// Sets `self = self | !other`.
+    pub fn union_not(&mut self, other: &Self) {
+        assert_eq!(self.domain_size, other.domain_size);
+        update_words(&mut self.words, &other.words, |a, b| a | !b);
+        self.clear_excess_bits();
+    }
+}
+
+impl<T: Idx> BitRelations<Self> for DenseBitSet<T> {
+    #[inline]
+    fn union(&mut self, other: &Self) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        update_words(&mut self.words, &other.words, |a, b| a | b)
+    }
+
+    #[inline]
+    fn subtract(&mut self, other: &Self) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        update_words(&mut self.words, &other.words, |a, b| a & !b)
+    }
+
+    #[inline]
+    fn intersect(&mut self, other: &Self) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        update_words(&mut self.words, &other.words, |a, b| a & b)
+    }
+}
+
+impl<T: Idx> From<GrowableBitSet<T>> for DenseBitSet<T> {
+    fn from(bit_set: GrowableBitSet<T>) -> Self {
+        bit_set.bit_set
+    }
+}
+
+impl<T> Clone for DenseBitSet<T> {
+    fn clone(&self) -> Self {
+        Self { domain_size: self.domain_size, words: self.words.clone(), marker: PhantomData }
+    }
+
+    fn clone_from(&mut self, from: &Self) {
+        self.domain_size = from.domain_size;
+        self.words.clone_from(&from.words);
+    }
+}
+
+impl<T: Idx> fmt::Debug for DenseBitSet<T> {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
+        w.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// Iterator over the set bits in a bitset.
+pub struct BitIter<'a, T: Idx> {
+    word: Word,
+    offset: usize,
+    iter: slice::Iter<'a, Word>,
+    marker: PhantomData<T>,
+}
+
+impl<'a, T: Idx> BitIter<'a, T> {
+    #[inline]
+    fn new(words: &'a [Word]) -> Self {
+        Self {
+            word: 0,
+            offset: usize::MAX - (WORD_BITS - 1),
+            iter: words.iter(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Idx> Iterator for BitIter<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            if self.word != 0 {
+                let bit_pos = self.word.trailing_zeros() as usize;
+                self.word ^= 1 << bit_pos;
+                return Some(T::from_usize(bit_pos + self.offset));
+            }
+
+            self.word = *self.iter.next()?;
+            self.offset = self.offset.wrapping_add(WORD_BITS);
+        }
+    }
+}
+
+/// A resizable bitset type with a dense representation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GrowableBitSet<T: Idx> {
+    bit_set: DenseBitSet<T>,
+}
+
+impl<T: Idx> Default for GrowableBitSet<T> {
+    fn default() -> Self {
+        Self::new_empty()
+    }
+}
+
+impl<T: Idx> GrowableBitSet<T> {
+    /// Ensures that the set can hold at least `min_domain_size` elements.
+    pub fn ensure(&mut self, min_domain_size: usize) {
+        if self.bit_set.domain_size < min_domain_size {
+            self.bit_set.domain_size = min_domain_size;
+        }
+
+        let min_num_words = num_words(min_domain_size);
+        if self.bit_set.words.len() < min_num_words {
+            self.bit_set.words.resize(min_num_words, 0);
+        }
+    }
+
+    /// Creates a new, empty growable bitset.
+    pub fn new_empty() -> Self {
+        Self { bit_set: DenseBitSet::new_empty(0) }
+    }
+
+    /// Creates a new, empty growable bitset with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { bit_set: DenseBitSet::new_empty(capacity) }
+    }
+
+    /// Inserts `elem`, returning true if this set changed.
+    #[inline]
+    pub fn insert(&mut self, elem: T) -> bool {
+        self.ensure(elem.index() + 1);
+        self.bit_set.insert(elem)
+    }
+
+    /// Inserts each element in `elems`.
+    #[inline]
+    pub fn insert_range(&mut self, elems: Range<T>) {
+        self.ensure(elems.end.index());
+        self.bit_set.insert_range(elems);
+    }
+
+    /// Removes `elem`, returning true if this set changed.
+    #[inline]
+    pub fn remove(&mut self, elem: T) -> bool {
+        self.ensure(elem.index() + 1);
+        self.bit_set.remove(elem)
+    }
+
+    /// Clears all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.bit_set.clear();
+    }
+
+    /// Counts the number of set bits.
+    #[inline]
+    pub fn count(&self) -> usize {
+        self.bit_set.count()
+    }
+
+    /// Returns true if the set is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bit_set.is_empty()
+    }
+
+    /// Returns true if the set contains `elem`.
+    #[inline]
+    pub fn contains(&self, elem: T) -> bool {
+        let (word_index, mask) = word_index_and_mask(elem);
+        self.bit_set.words.get(word_index).is_some_and(|word| (word & mask) != 0)
+    }
+
+    /// Returns true if any bit in `elems` is set.
+    #[inline]
+    pub fn contains_any(&self, elems: Range<T>) -> bool {
+        elems.start.index() < self.bit_set.domain_size
+            && self.bit_set.contains_any(
+                elems.start..T::from_usize(elems.end.index().min(self.bit_set.domain_size)),
+            )
+    }
+
+    /// Iterates over the indices of set bits in sorted order.
+    #[inline]
+    pub fn iter(&self) -> BitIter<'_, T> {
+        self.bit_set.iter()
+    }
+
+    /// Counts the number of set bits.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.bit_set.count()
+    }
+
+    bit_relations_inherent_impls! {}
+}
+
+impl<T: Idx> From<DenseBitSet<T>> for GrowableBitSet<T> {
+    fn from(bit_set: DenseBitSet<T>) -> Self {
+        Self { bit_set }
+    }
+}
+
+impl<T: Idx> BitRelations<Self> for GrowableBitSet<T> {
+    #[inline]
+    fn union(&mut self, other: &Self) -> bool {
+        self.ensure(other.bit_set.domain_size);
+        update_words(&mut self.bit_set.words, &other.bit_set.words, |a, b| a | b)
+    }
+
+    #[inline]
+    fn subtract(&mut self, other: &Self) -> bool {
+        let len = self.bit_set.words.len().min(other.bit_set.words.len());
+        update_words(&mut self.bit_set.words[..len], &other.bit_set.words[..len], |a, b| a & !b)
+    }
+
+    #[inline]
+    fn intersect(&mut self, other: &Self) -> bool {
+        let len = self.bit_set.words.len().min(other.bit_set.words.len());
+        let changed =
+            update_words(&mut self.bit_set.words[..len], &other.bit_set.words[..len], |a, b| a & b);
+        let truncated = self.bit_set.words[len..].iter().any(|word| *word != 0);
+        self.bit_set.words[len..].fill(0);
+        changed || truncated
+    }
+}
+
+#[inline]
+fn update_words<Op>(lhs: &mut [Word], rhs: &[Word], op: Op) -> bool
+where
+    Op: Fn(Word, Word) -> Word,
+{
+    assert_eq!(lhs.len(), rhs.len());
+    let mut changed = 0;
+    for (lhs_slot, &rhs_val) in iter::zip(lhs, rhs) {
+        let old_val = *lhs_slot;
+        let new_val = op(old_val, rhs_val);
+        *lhs_slot = new_val;
+        changed |= old_val ^ new_val;
+    }
+    changed != 0
+}
+
+#[inline]
+fn num_words(domain_size: usize) -> usize {
+    domain_size.div_ceil(WORD_BITS)
+}
+
+#[inline]
+fn word_index_and_mask<T: Idx>(elem: T) -> (usize, Word) {
+    word_index_and_mask_usize(elem.index())
+}
+
+#[inline]
+fn word_index_and_mask_usize(elem: usize) -> (usize, Word) {
+    let word_index = elem / WORD_BITS;
+    let mask = 1 << (elem % WORD_BITS);
+    (word_index, mask)
+}
+
+fn clear_excess_bits_in_final_word(domain_size: usize, words: &mut [Word]) {
+    let num_bits_in_final_word = domain_size % WORD_BITS;
+    if num_bits_in_final_word > 0 {
+        let mask = (1 << num_bits_in_final_word) - 1;
+        words[words.len() - 1] &= mask;
+    }
+}
+
+#[inline]
+fn max_bit(word: Word) -> usize {
+    WORD_BITS - 1 - word.leading_zeros() as usize
+}
+
+#[inline]
+fn count_ones(words: &[Word]) -> usize {
+    words.iter().map(|word| word.count_ones() as usize).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::newtype_index;
+
+    newtype_index! {
+        struct TestIdx;
+    }
+
+    #[test]
+    fn dense_insert_remove_iter() {
+        let _ = TestIdx::MAX;
+        let mut set = DenseBitSet::<TestIdx>::new_empty(130);
+        for idx in [0, 1, 63, 64, 129] {
+            assert!(set.insert(TestIdx::from_usize(idx)));
+        }
+        assert!(!set.insert(TestIdx::from_usize(64)));
+        assert!(set.contains(TestIdx::from_usize(129)));
+        assert_eq!(set.count(), 5);
+
+        assert!(set.remove(TestIdx::from_usize(1)));
+        assert!(!set.contains(TestIdx::from_usize(1)));
+
+        let values: Vec<_> = set.iter().map(Idx::index).collect();
+        assert_eq!(values, [0, 63, 64, 129]);
+    }
+
+    #[test]
+    fn dense_relations() {
+        let mut left = DenseBitSet::<TestIdx>::new_empty(100);
+        let mut right = DenseBitSet::<TestIdx>::new_empty(100);
+        left.insert(TestIdx::from_usize(1));
+        left.insert(TestIdx::from_usize(3));
+        right.insert(TestIdx::from_usize(3));
+        right.insert(TestIdx::from_usize(5));
+
+        assert!(left.union(&right));
+        assert!(!left.union(&right));
+        assert_eq!(left.iter().map(Idx::index).collect::<Vec<_>>(), [1, 3, 5]);
+
+        assert!(left.subtract(&right));
+        assert_eq!(left.iter().map(Idx::index).collect::<Vec<_>>(), [1]);
+    }
+
+    #[test]
+    fn growable_extends_on_insert() {
+        let mut set = GrowableBitSet::<TestIdx>::new_empty();
+        assert!(set.insert(TestIdx::from_usize(250)));
+        assert!(set.contains(TestIdx::from_usize(250)));
+        assert!(!set.contains(TestIdx::from_usize(249)));
+        assert_eq!(set.count(), 1);
+    }
+}

--- a/crates/data-structures/src/bit_set.rs
+++ b/crates/data-structures/src/bit_set.rs
@@ -6,9 +6,7 @@
 )]
 
 use std::{
-    fmt,
-    hash::Hash,
-    iter,
+    fmt, iter,
     marker::PhantomData,
     ops::{Bound, Range, RangeBounds},
     rc::Rc,
@@ -17,34 +15,7 @@ use std::{
 
 use Chunk::*;
 
-pub trait Idx: Copy + 'static + Ord + fmt::Debug + Hash {
-    fn new(index: usize) -> Self;
-    fn index(self) -> usize;
-}
-
-impl Idx for usize {
-    #[inline]
-    fn new(index: usize) -> Self {
-        index
-    }
-
-    #[inline]
-    fn index(self) -> usize {
-        self
-    }
-}
-
-impl Idx for u32 {
-    #[inline]
-    fn new(index: usize) -> Self {
-        Self::try_from(index).unwrap()
-    }
-
-    #[inline]
-    fn index(self) -> usize {
-        self as usize
-    }
-}
+use crate::index::Idx;
 
 #[cfg(test)]
 mod tests;
@@ -239,8 +210,8 @@ impl<T: Idx> DenseBitSet<T> {
             return;
         };
 
-        let (start_word_index, start_mask) = word_index_and_mask(start);
-        let (end_word_index, end_mask) = word_index_and_mask(end);
+        let (start_word_index, start_mask) = word_index_and_mask_usize(start);
+        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
 
         // Set all words in between start and end (exclusively of both).
         for word_index in (start_word_index + 1)..end_word_index {
@@ -272,8 +243,8 @@ impl<T: Idx> DenseBitSet<T> {
         let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
             return false;
         };
-        let (start_word_index, start_mask) = word_index_and_mask(start);
-        let (end_word_index, end_mask) = word_index_and_mask(end);
+        let (start_word_index, start_mask) = word_index_and_mask_usize(start);
+        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
 
         if start_word_index == end_word_index {
             self.words[start_word_index] & (end_mask | (end_mask - start_mask)) != 0
@@ -312,14 +283,14 @@ impl<T: Idx> DenseBitSet<T> {
 
     pub fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
         let (start, end) = inclusive_start_end(range, self.domain_size)?;
-        let (start_word_index, _) = word_index_and_mask(start);
-        let (end_word_index, end_mask) = word_index_and_mask(end);
+        let (start_word_index, _) = word_index_and_mask_usize(start);
+        let (end_word_index, end_mask) = word_index_and_mask_usize(end);
 
         let end_word = self.words[end_word_index] & (end_mask | (end_mask - 1));
         if end_word != 0 {
             let pos = max_bit(end_word) + WORD_BITS * end_word_index;
             if start <= pos {
-                return Some(T::new(pos));
+                return Some(T::from_usize(pos));
             }
         }
 
@@ -333,7 +304,7 @@ impl<T: Idx> DenseBitSet<T> {
             let start_word = self.words[word_idx];
             let pos = max_bit(start_word) + WORD_BITS * word_idx;
             if start <= pos {
-                return Some(T::new(pos));
+                return Some(T::from_usize(pos));
             }
         }
 
@@ -483,7 +454,7 @@ impl<'a, T: Idx> Iterator for BitIter<'a, T> {
                 // then clear the bit.
                 let bit_pos = self.word.trailing_zeros() as usize;
                 self.word ^= 1 << bit_pos;
-                return Some(T::new(bit_pos + self.offset));
+                return Some(T::from_usize(bit_pos + self.offset));
             }
 
             // Move onto the next word. `wrapping_add()` is needed to handle
@@ -591,7 +562,7 @@ impl<T: Idx> ChunkedBitSet<T> {
         let chunks = if domain_size == 0 {
             Box::new([])
         } else {
-            let num_chunks = domain_size.index().div_ceil(CHUNK_BITS);
+            let num_chunks = domain_size.div_ceil(CHUNK_BITS);
             let mut last_chunk_domain_size = domain_size % CHUNK_BITS;
             if last_chunk_domain_size == 0 {
                 last_chunk_domain_size = CHUNK_BITS;
@@ -1023,12 +994,12 @@ impl<'a, T: Idx> Iterator for ChunkedBitIter<'a, T> {
                 ChunkIter::Zeros => {}
                 ChunkIter::Ones(iter) => {
                     if let Some(next) = iter.next() {
-                        return Some(T::new(next + self.chunk_index * CHUNK_BITS));
+                        return Some(T::from_usize(next + self.chunk_index * CHUNK_BITS));
                     }
                 }
                 ChunkIter::Mixed(iter) => {
                     if let Some(next) = iter.next() {
-                        return Some(T::new(next + self.chunk_index * CHUNK_BITS));
+                        return Some(T::from_usize(next.index() + self.chunk_index * CHUNK_BITS));
                     }
                 }
                 ChunkIter::Finished => return None,
@@ -1075,8 +1046,23 @@ impl Chunk {
 enum ChunkIter<'a> {
     Zeros,
     Ones(Range<usize>),
-    Mixed(BitIter<'a, usize>),
+    Mixed(BitIter<'a, ChunkBitIdx>),
     Finished,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+struct ChunkBitIdx(usize);
+
+impl Idx for ChunkBitIdx {
+    const MAX: usize = usize::MAX;
+
+    unsafe fn from_usize_unchecked(idx: usize) -> Self {
+        Self(idx)
+    }
+
+    fn index(self) -> usize {
+        self.0
+    }
 }
 
 impl<T: Idx> fmt::Debug for ChunkedBitSet<T> {
@@ -1396,9 +1382,9 @@ impl<T: Idx> GrowableBitSet<T> {
     #[inline]
     pub fn contains_any(&self, elems: Range<T>) -> bool {
         elems.start.index() < self.bit_set.domain_size
-            && self
-                .bit_set
-                .contains_any(elems.start..T::new(elems.end.index().min(self.bit_set.domain_size)))
+            && self.bit_set.contains_any(
+                elems.start..T::from_usize(elems.end.index().min(self.bit_set.domain_size)),
+            )
     }
 
     #[inline]
@@ -1484,7 +1470,7 @@ impl<R: Idx, C: Idx> BitMatrix<R, C> {
     }
 
     pub fn rows(&self) -> impl Iterator<Item = R> {
-        (0..self.num_rows).map(R::new)
+        (0..self.num_rows).map(R::from_usize)
     }
 
     /// The range of bits for a given row.
@@ -1536,7 +1522,7 @@ impl<R: Idx, C: Idx> BitMatrix<R, C> {
                     break;
                 }
                 if v & 0x1 != 0 {
-                    result.push(C::new(base * WORD_BITS + bit));
+                    result.push(C::from_usize(base * WORD_BITS + bit));
                 }
                 v >>= 1;
             }
@@ -1726,7 +1712,7 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
     }
 
     pub fn rows(&self) -> impl Iterator<Item = R> {
-        (0..self.rows.len()).map(R::new)
+        (0..self.rows.len()).map(R::from_usize)
     }
 
     /// Iterates through all the columns set to true in a given row of
@@ -1780,13 +1766,17 @@ impl<R: Idx, C: Idx> SparseBitMatrix<R, C> {
 }
 
 #[inline]
-fn num_words<T: Idx>(domain_size: T) -> usize {
-    domain_size.index().div_ceil(WORD_BITS)
+fn num_words(domain_size: usize) -> usize {
+    domain_size.div_ceil(WORD_BITS)
 }
 
 #[inline]
 fn word_index_and_mask<T: Idx>(elem: T) -> (usize, Word) {
-    let elem = elem.index();
+    word_index_and_mask_usize(elem.index())
+}
+
+#[inline]
+fn word_index_and_mask_usize(elem: usize) -> (usize, Word) {
     let word_index = elem / WORD_BITS;
     let mask = 1 << (elem % WORD_BITS);
     (word_index, mask)
@@ -1800,7 +1790,7 @@ fn chunk_index<T: Idx>(elem: T) -> usize {
 #[inline]
 fn chunk_word_index_and_mask<T: Idx>(elem: T) -> (usize, Word) {
     let chunk_elem = elem.index() % CHUNK_BITS;
-    word_index_and_mask(chunk_elem)
+    word_index_and_mask_usize(chunk_elem)
 }
 
 fn pick2_mut<T>(slice: &mut [T], idx_1: usize, idx_2: usize) -> Option<(&mut T, &mut T)> {

--- a/crates/data-structures/src/bit_set.rs
+++ b/crates/data-structures/src/bit_set.rs
@@ -107,7 +107,7 @@ macro_rules! bit_relations_inherent_impls {
 /// Note 1: Since this bitset is dense, if your domain is big, and/or relatively
 /// homogeneous (for example, with long runs of bits set or unset), then it may
 /// be preferable to instead use a [MixedBitSet], or an
-/// [IntervalSet](crate::interval::IntervalSet). They should be more suited to
+/// `IntervalSet`. They should be more suited to
 /// sparse, or highly-compressible, domains.
 ///
 /// Note 2: Use [`GrowableBitSet`] if you need support for resizing after creation.

--- a/crates/data-structures/src/bit_set/tests.rs
+++ b/crates/data-structures/src/bit_set/tests.rs
@@ -1,0 +1,1011 @@
+#![allow(
+    clippy::type_complexity,
+    clippy::uninlined_format_args,
+    clippy::use_self,
+    clippy::while_let_on_iterator
+)]
+
+use super::*;
+
+#[test]
+fn test_new_filled() {
+    for i in 0..128 {
+        let idx_buf = DenseBitSet::new_filled(i);
+        let elems: Vec<usize> = idx_buf.iter().collect();
+        let expected: Vec<usize> = (0..i).collect();
+        assert_eq!(elems, expected);
+    }
+}
+
+#[test]
+fn bitset_iter_works() {
+    let mut bitset: DenseBitSet<usize> = DenseBitSet::new_empty(100);
+    bitset.insert(1);
+    bitset.insert(10);
+    bitset.insert(19);
+    bitset.insert(62);
+    bitset.insert(63);
+    bitset.insert(64);
+    bitset.insert(65);
+    bitset.insert(66);
+    bitset.insert(99);
+    assert_eq!(bitset.iter().collect::<Vec<_>>(), [1, 10, 19, 62, 63, 64, 65, 66, 99]);
+}
+
+#[test]
+fn bitset_iter_works_2() {
+    let mut bitset: DenseBitSet<usize> = DenseBitSet::new_empty(320);
+    bitset.insert(0);
+    bitset.insert(127);
+    bitset.insert(191);
+    bitset.insert(255);
+    bitset.insert(319);
+    assert_eq!(bitset.iter().collect::<Vec<_>>(), [0, 127, 191, 255, 319]);
+}
+
+#[test]
+fn bitset_clone_from() {
+    let mut a: DenseBitSet<usize> = DenseBitSet::new_empty(10);
+    a.insert(4);
+    a.insert(7);
+    a.insert(9);
+
+    let mut b = DenseBitSet::new_empty(2);
+    b.clone_from(&a);
+    assert_eq!(b.domain_size(), 10);
+    assert_eq!(b.iter().collect::<Vec<_>>(), [4, 7, 9]);
+
+    b.clone_from(&DenseBitSet::new_empty(40));
+    assert_eq!(b.domain_size(), 40);
+    assert_eq!(b.iter().collect::<Vec<_>>(), []);
+}
+
+#[test]
+fn union_two_sets() {
+    let mut set1: DenseBitSet<usize> = DenseBitSet::new_empty(65);
+    let mut set2: DenseBitSet<usize> = DenseBitSet::new_empty(65);
+    assert!(set1.insert(3));
+    assert!(!set1.insert(3));
+    assert!(set2.insert(5));
+    assert!(set2.insert(64));
+    assert!(set1.union(&set2));
+    assert!(!set1.union(&set2));
+    assert!(set1.contains(3));
+    assert!(!set1.contains(4));
+    assert!(set1.contains(5));
+    assert!(!set1.contains(63));
+    assert!(set1.contains(64));
+}
+
+#[test]
+fn union_not() {
+    let mut a = DenseBitSet::<usize>::new_empty(100);
+    let mut b = DenseBitSet::<usize>::new_empty(100);
+
+    a.insert(3);
+    a.insert(5);
+    a.insert(80);
+    a.insert(81);
+
+    b.insert(5); // Already in `a`.
+    b.insert(7);
+    b.insert(63);
+    b.insert(81); // Already in `a`.
+    b.insert(90);
+
+    a.union_not(&b);
+
+    // After union-not, `a` should contain all values in the domain, except for
+    // the ones that are in `b` and were _not_ already in `a`.
+    assert_eq!(
+        a.iter().collect::<Vec<_>>(),
+        (0usize..100).filter(|&x| !matches!(x, 7 | 63 | 90)).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn chunked_bitset() {
+    let mut b0 = ChunkedBitSet::<usize>::new_empty(0);
+    let b0b = b0.clone();
+    assert_eq!(b0, ChunkedBitSet { domain_size: 0, chunks: Box::new([]), marker: PhantomData });
+
+    // There are no valid insert/remove/contains operations on a 0-domain
+    // bitset, but we can test `union`.
+    b0.assert_valid();
+    assert!(!b0.union(&b0b));
+    assert_eq!(b0.chunks(), vec![]);
+    assert_eq!(b0.count(), 0);
+    b0.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b1 = ChunkedBitSet::<usize>::new_empty(1);
+    assert_eq!(
+        b1,
+        ChunkedBitSet {
+            domain_size: 1,
+            chunks: Box::new([Zeros { chunk_domain_size: 1 }]),
+            marker: PhantomData
+        }
+    );
+
+    b1.assert_valid();
+    assert!(!b1.contains(0));
+    assert_eq!(b1.count(), 0);
+    assert!(b1.insert(0));
+    assert!(b1.contains(0));
+    assert_eq!(b1.count(), 1);
+    assert_eq!(b1.chunks(), [Ones { chunk_domain_size: 1 }]);
+    assert!(!b1.insert(0));
+    assert!(b1.remove(0));
+    assert!(!b1.contains(0));
+    assert_eq!(b1.count(), 0);
+    assert_eq!(b1.chunks(), [Zeros { chunk_domain_size: 1 }]);
+    b1.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b100 = ChunkedBitSet::<usize>::new_filled(100);
+    assert_eq!(
+        b100,
+        ChunkedBitSet {
+            domain_size: 100,
+            chunks: Box::new([Ones { chunk_domain_size: 100 }]),
+            marker: PhantomData
+        }
+    );
+
+    b100.assert_valid();
+    for i in 0..100 {
+        assert!(b100.contains(i));
+    }
+    assert_eq!(b100.count(), 100);
+    assert!(b100.remove(3));
+    assert!(b100.insert(3));
+    assert_eq!(b100.chunks(), vec![Ones { chunk_domain_size: 100 }]);
+    assert!(
+        b100.remove(20) && b100.remove(30) && b100.remove(40) && b100.remove(99) && b100.insert(30)
+    );
+    assert_eq!(b100.count(), 97);
+    assert!(!b100.contains(20) && b100.contains(30) && !b100.contains(99) && b100.contains(50));
+    assert_eq!(
+        b100.chunks(),
+        vec![Mixed {
+            chunk_domain_size: 100,
+            ones_count: 97,
+            words: Rc::new([
+                0b11111111_11111111_11111110_11111111_11111111_11101111_11111111_11111111,
+                0b00000000_00000000_00000000_00000111_11111111_11111111_11111111_11111111,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ])
+        }],
+    );
+    b100.assert_valid();
+    let mut num_removed = 0;
+    for i in 0..100 {
+        if b100.remove(i) {
+            num_removed += 1;
+        }
+    }
+    assert_eq!(num_removed, 97);
+    assert_eq!(b100.chunks(), vec![Zeros { chunk_domain_size: 100 }]);
+    b100.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b2548 = ChunkedBitSet::<usize>::new_empty(2548);
+    assert_eq!(
+        b2548,
+        ChunkedBitSet {
+            domain_size: 2548,
+            chunks: Box::new([Zeros { chunk_domain_size: 2048 }, Zeros { chunk_domain_size: 500 }]),
+            marker: PhantomData
+        }
+    );
+
+    b2548.assert_valid();
+    b2548.insert(14);
+    b2548.remove(14);
+    assert_eq!(
+        b2548.chunks(),
+        vec![Zeros { chunk_domain_size: 2048 }, Zeros { chunk_domain_size: 500 }]
+    );
+    b2548.insert_all();
+    for i in 0..2548 {
+        assert!(b2548.contains(i));
+    }
+    assert_eq!(b2548.count(), 2548);
+    assert_eq!(
+        b2548.chunks(),
+        vec![Ones { chunk_domain_size: 2048 }, Ones { chunk_domain_size: 500 }]
+    );
+    b2548.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b4096 = ChunkedBitSet::<usize>::new_empty(4096);
+    assert_eq!(
+        b4096,
+        ChunkedBitSet {
+            domain_size: 4096,
+            chunks: Box::new([
+                Zeros { chunk_domain_size: 2048 },
+                Zeros { chunk_domain_size: 2048 }
+            ]),
+            marker: PhantomData
+        }
+    );
+
+    b4096.assert_valid();
+    for i in 0..4096 {
+        assert!(!b4096.contains(i));
+    }
+    assert!(b4096.insert(0) && b4096.insert(4095) && !b4096.insert(4095));
+    assert!(
+        b4096.contains(0) && !b4096.contains(2047) && !b4096.contains(2048) && b4096.contains(4095)
+    );
+    assert_eq!(
+        b4096.chunks(),
+        vec![
+            Mixed {
+                chunk_domain_size: 2048,
+                ones_count: 1,
+                words: Rc::new([
+                    1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0
+                ])
+            },
+            Mixed {
+                chunk_domain_size: 2048,
+                ones_count: 1,
+                words: Rc::new([
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0x8000_0000_0000_0000
+                ])
+            },
+        ],
+    );
+    assert_eq!(b4096.count(), 2);
+    b4096.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b10000 = ChunkedBitSet::<usize>::new_empty(10000);
+    assert_eq!(
+        b10000,
+        ChunkedBitSet {
+            domain_size: 10000,
+            chunks: Box::new([
+                Zeros { chunk_domain_size: 2048 },
+                Zeros { chunk_domain_size: 2048 },
+                Zeros { chunk_domain_size: 2048 },
+                Zeros { chunk_domain_size: 2048 },
+                Zeros { chunk_domain_size: 1808 }
+            ]),
+            marker: PhantomData,
+        }
+    );
+
+    b10000.assert_valid();
+    assert!(b10000.insert(3000) && b10000.insert(5000));
+    assert_eq!(
+        b10000.chunks(),
+        vec![
+            Zeros { chunk_domain_size: 2048 },
+            Mixed {
+                chunk_domain_size: 2048,
+                ones_count: 1,
+                words: Rc::new([
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0x0100_0000_0000_0000,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ])
+            },
+            Mixed {
+                chunk_domain_size: 2048,
+                ones_count: 1,
+                words: Rc::new([
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0,
+                ])
+            },
+            Zeros { chunk_domain_size: 2048 },
+            Zeros { chunk_domain_size: 1808 },
+        ],
+    );
+    let mut b10000b = ChunkedBitSet::<usize>::new_empty(10000);
+    b10000b.clone_from(&b10000);
+    assert_eq!(b10000, b10000b);
+    for i in 6000..7000 {
+        b10000b.insert(i);
+    }
+    assert_eq!(b10000b.count(), 1002);
+    b10000b.assert_valid();
+    b10000b.clone_from(&b10000);
+    assert_eq!(b10000b.count(), 2);
+    for i in 2000..8000 {
+        b10000b.insert(i);
+    }
+    b10000.union(&b10000b);
+    assert_eq!(b10000.count(), 6000);
+    b10000.union(&b10000b);
+    assert_eq!(b10000.count(), 6000);
+    b10000.assert_valid();
+    b10000b.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b64 = ChunkedBitSet::<usize>::new_filled(64);
+
+    let mut b64b = ChunkedBitSet::<usize>::new_empty(64);
+    b64b.insert(0);
+
+    b64.subtract(&b64b);
+    assert!(!b64.contains(0));
+    assert!(b64.contains(10));
+    assert!(b64.contains(50));
+    assert!(b64.contains(63));
+    assert_eq!(
+        b64.chunks(),
+        vec![Mixed {
+            chunk_domain_size: 64,
+            ones_count: 63,
+            words: Rc::new([
+                0xfffffffffffffffe,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ])
+        },],
+    );
+}
+
+/// Additional helper methods for testing.
+impl ChunkedBitSet<usize> {
+    /// Creates a new `ChunkedBitSet` containing all `i` for which `fill_fn(i)` is true.
+    fn fill_with(domain_size: usize, fill_fn: impl Fn(usize) -> bool) -> Self {
+        let mut this = ChunkedBitSet::new_empty(domain_size);
+        for i in 0..domain_size {
+            if fill_fn(i) {
+                this.insert(i);
+            }
+        }
+        this
+    }
+
+    /// Asserts that for each `i` in `0..self.domain_size()`, `self.contains(i) == expected_fn(i)`.
+    #[track_caller]
+    fn assert_filled_with(&self, expected_fn: impl Fn(usize) -> bool) {
+        for i in 0..self.domain_size() {
+            let expected = expected_fn(i);
+            assert_eq!(self.contains(i), expected, "i = {i}");
+        }
+    }
+}
+
+#[test]
+fn chunked_bulk_ops() {
+    struct ChunkedBulkOp {
+        name: &'static str,
+        op_fn: fn(&mut ChunkedBitSet<usize>, &ChunkedBitSet<usize>) -> bool,
+        spec_fn: fn(fn(usize) -> bool, fn(usize) -> bool, usize) -> bool,
+    }
+    let ops = &[
+        ChunkedBulkOp {
+            name: "union",
+            op_fn: ChunkedBitSet::union,
+            spec_fn: |fizz, buzz, i| fizz(i) || buzz(i),
+        },
+        ChunkedBulkOp {
+            name: "subtract",
+            op_fn: ChunkedBitSet::subtract,
+            spec_fn: |fizz, buzz, i| fizz(i) && !buzz(i),
+        },
+        ChunkedBulkOp {
+            name: "intersect",
+            op_fn: ChunkedBitSet::intersect,
+            spec_fn: |fizz, buzz, i| fizz(i) && buzz(i),
+        },
+    ];
+
+    let domain_sizes = [
+        CHUNK_BITS / 7, // Smaller than a full chunk.
+        CHUNK_BITS,
+        (CHUNK_BITS + CHUNK_BITS / 7), // Larger than a full chunk.
+    ];
+
+    for ChunkedBulkOp { name, op_fn, spec_fn } in ops {
+        for domain_size in domain_sizes {
+            // If false, use different values for LHS and RHS, to test "fizz op buzz".
+            // If true, use identical values, to test "fizz op fizz".
+            for identical in [false, true] {
+                // If false, make a clone of LHS before doing the op.
+                // This covers optimizations that depend on whether chunk words are shared or not.
+                for unique in [false, true] {
+                    // Print the current test case, so that we can see which one failed.
+                    println!(
+                        "Testing op={name}, domain_size={domain_size}, identical={identical}, unique={unique} ..."
+                    );
+
+                    let fizz_fn = |i| i % 3 == 0;
+                    let buzz_fn = if identical { fizz_fn } else { |i| i % 5 == 0 };
+
+                    // Check that `fizz op buzz` gives the expected results.
+                    chunked_bulk_ops_test_inner(
+                        domain_size,
+                        unique,
+                        fizz_fn,
+                        buzz_fn,
+                        op_fn,
+                        |i| spec_fn(fizz_fn, buzz_fn, i),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn chunked_bulk_ops_test_inner(
+    domain_size: usize,
+    unique: bool,
+    fizz_fn: impl Fn(usize) -> bool + Copy,
+    buzz_fn: impl Fn(usize) -> bool + Copy,
+    op_fn: impl Fn(&mut ChunkedBitSet<usize>, &ChunkedBitSet<usize>) -> bool,
+    expected_fn: impl Fn(usize) -> bool + Copy,
+) {
+    // Create two bitsets, "fizz" (LHS) and "buzz" (RHS).
+    let mut fizz = ChunkedBitSet::fill_with(domain_size, fizz_fn);
+    let buzz = ChunkedBitSet::fill_with(domain_size, buzz_fn);
+
+    // If requested, clone `fizz` so that its word Rcs are not uniquely-owned.
+    let _cloned = (!unique).then(|| fizz.clone());
+
+    // Perform the op (e.g. union/subtract/intersect), and verify that the
+    // mutated LHS contains exactly the expected values.
+    let changed = op_fn(&mut fizz, &buzz);
+    fizz.assert_filled_with(expected_fn);
+
+    // Verify that the "changed" return value is correct.
+    let should_change = (0..domain_size).any(|i| fizz_fn(i) != expected_fn(i));
+    assert_eq!(changed, should_change);
+}
+
+fn with_elements_chunked(elements: &[usize], domain_size: usize) -> ChunkedBitSet<usize> {
+    let mut s = ChunkedBitSet::new_empty(domain_size);
+    for &e in elements {
+        assert!(s.insert(e));
+    }
+    s
+}
+
+#[test]
+fn chunked_bitset_iter() {
+    fn check_iter(bit: &ChunkedBitSet<usize>, vec: &Vec<usize>) {
+        // Test collecting via both `.next()` and `.fold()` calls, to make sure both are correct
+        let mut collect_next = Vec::new();
+        let mut bit_iter = bit.iter();
+        while let Some(item) = bit_iter.next() {
+            collect_next.push(item);
+        }
+        assert_eq!(vec, &collect_next);
+
+        let collect_fold = bit.iter().fold(Vec::new(), |mut v, item| {
+            v.push(item);
+            v
+        });
+        assert_eq!(vec, &collect_fold);
+    }
+
+    // Empty
+    let vec: Vec<usize> = Vec::new();
+    let bit = with_elements_chunked(&vec, 9000);
+    check_iter(&bit, &vec);
+
+    // Filled
+    let n = 10000;
+    let vec: Vec<usize> = (0..n).collect();
+    let bit = with_elements_chunked(&vec, n);
+    check_iter(&bit, &vec);
+
+    // Filled with trailing zeros
+    let n = 10000;
+    let vec: Vec<usize> = (0..n).collect();
+    let bit = with_elements_chunked(&vec, 2 * n);
+    check_iter(&bit, &vec);
+
+    // Mixed
+    let n = 12345;
+    let vec: Vec<usize> = vec![0, 1, 2, 2010, 2047, 2099, 6000, 6002, 6004];
+    let bit = with_elements_chunked(&vec, n);
+    check_iter(&bit, &vec);
+}
+
+#[test]
+fn grow() {
+    let mut set: GrowableBitSet<usize> = GrowableBitSet::with_capacity(65);
+    for index in 0..65 {
+        assert!(set.insert(index));
+        assert!(!set.insert(index));
+    }
+    set.ensure(128);
+
+    // Check if the bits set before growing are still set
+    for index in 0..65 {
+        assert!(set.contains(index));
+    }
+
+    // Check if the new bits are all un-set
+    for index in 65..128 {
+        assert!(!set.contains(index));
+    }
+
+    // Check that we can set all new bits without running out of bounds
+    for index in 65..128 {
+        assert!(set.insert(index));
+        assert!(!set.insert(index));
+    }
+}
+
+#[test]
+fn matrix_intersection() {
+    let mut matrix: BitMatrix<usize, usize> = BitMatrix::new(200, 200);
+
+    // (*) Elements reachable from both 2 and 65.
+
+    matrix.insert(2, 3);
+    matrix.insert(2, 6);
+    matrix.insert(2, 10); // (*)
+    matrix.insert(2, 64); // (*)
+    matrix.insert(2, 65);
+    matrix.insert(2, 130);
+    matrix.insert(2, 160); // (*)
+
+    matrix.insert(64, 133);
+
+    matrix.insert(65, 2);
+    matrix.insert(65, 8);
+    matrix.insert(65, 10); // (*)
+    matrix.insert(65, 64); // (*)
+    matrix.insert(65, 68);
+    matrix.insert(65, 133);
+    matrix.insert(65, 160); // (*)
+
+    let intersection = matrix.intersect_rows(2, 64);
+    assert!(intersection.is_empty());
+
+    let intersection = matrix.intersect_rows(2, 65);
+    assert_eq!(intersection, &[10, 64, 160]);
+}
+
+#[test]
+fn matrix_iter() {
+    let mut matrix: BitMatrix<usize, usize> = BitMatrix::new(64, 100);
+    matrix.insert(3, 22);
+    matrix.insert(3, 75);
+    matrix.insert(2, 99);
+    matrix.insert(4, 0);
+    matrix.union_rows(3, 5);
+    matrix.insert_all_into_row(6);
+
+    let expected = [99];
+    let mut iter = expected.iter();
+    for i in matrix.iter(2) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    let expected = [22, 75];
+    let mut iter = expected.iter();
+    assert_eq!(matrix.count(3), expected.len());
+    for i in matrix.iter(3) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    let expected = [0];
+    let mut iter = expected.iter();
+    assert_eq!(matrix.count(4), expected.len());
+    for i in matrix.iter(4) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    let expected = [22, 75];
+    let mut iter = expected.iter();
+    assert_eq!(matrix.count(5), expected.len());
+    for i in matrix.iter(5) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    assert_eq!(matrix.count(6), 100);
+    let mut count = 0;
+    for (idx, i) in matrix.iter(6).enumerate() {
+        assert_eq!(idx, i);
+        count += 1;
+    }
+    assert_eq!(count, 100);
+
+    if let Some(i) = matrix.iter(7).next() {
+        panic!("expected no elements in row, but contains element {:?}", i);
+    }
+}
+
+#[test]
+fn sparse_matrix_iter() {
+    let mut matrix: SparseBitMatrix<usize, usize> = SparseBitMatrix::new(100);
+    matrix.insert(3, 22);
+    matrix.insert(3, 75);
+    matrix.insert(2, 99);
+    matrix.insert(4, 0);
+    matrix.union_rows(3, 5);
+
+    let expected = [99];
+    let mut iter = expected.iter();
+    for i in matrix.iter(2) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    let expected = [22, 75];
+    let mut iter = expected.iter();
+    for i in matrix.iter(3) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    let expected = [0];
+    let mut iter = expected.iter();
+    for i in matrix.iter(4) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+
+    let expected = [22, 75];
+    let mut iter = expected.iter();
+    for i in matrix.iter(5) {
+        let j = *iter.next().unwrap();
+        assert_eq!(i, j);
+    }
+    assert!(iter.next().is_none());
+}
+
+#[test]
+fn sparse_matrix_operations() {
+    let mut matrix: SparseBitMatrix<usize, usize> = SparseBitMatrix::new(100);
+    matrix.insert(3, 22);
+    matrix.insert(3, 75);
+    matrix.insert(2, 99);
+    matrix.insert(4, 0);
+
+    let mut disjoint: DenseBitSet<usize> = DenseBitSet::new_empty(100);
+    disjoint.insert(33);
+
+    let mut superset = DenseBitSet::new_empty(100);
+    superset.insert(22);
+    superset.insert(75);
+    superset.insert(33);
+
+    let mut subset = DenseBitSet::new_empty(100);
+    subset.insert(22);
+
+    // SparseBitMatrix::remove
+    {
+        let mut matrix = matrix.clone();
+        matrix.remove(3, 22);
+        assert!(!matrix.row(3).unwrap().contains(22));
+        matrix.remove(0, 0);
+        assert!(matrix.row(0).is_none());
+    }
+
+    // SparseBitMatrix::clear
+    {
+        let mut matrix = matrix.clone();
+        matrix.clear(3);
+        assert!(!matrix.row(3).unwrap().contains(75));
+        matrix.clear(0);
+        assert!(matrix.row(0).is_none());
+    }
+
+    // SparseBitMatrix::intersect_row
+    {
+        let mut matrix = matrix.clone();
+        assert!(!matrix.intersect_row(3, &superset));
+        assert!(matrix.intersect_row(3, &subset));
+        matrix.intersect_row(0, &disjoint);
+        assert!(matrix.row(0).is_none());
+    }
+
+    // SparseBitMatrix::subtract_row
+    {
+        let mut matrix = matrix.clone();
+        assert!(!matrix.subtract_row(3, &disjoint));
+        assert!(matrix.subtract_row(3, &subset));
+        assert!(matrix.subtract_row(3, &superset));
+        matrix.intersect_row(0, &disjoint);
+        assert!(matrix.row(0).is_none());
+    }
+
+    // SparseBitMatrix::union_row
+    {
+        let mut matrix = matrix.clone();
+        assert!(!matrix.union_row(3, &subset));
+        assert!(matrix.union_row(3, &disjoint));
+        matrix.union_row(0, &disjoint);
+        assert!(matrix.row(0).is_some());
+    }
+}
+
+#[test]
+fn dense_insert_range() {
+    #[track_caller]
+    fn check<R>(domain: usize, range: R)
+    where
+        R: RangeBounds<usize> + Clone + IntoIterator<Item = usize> + std::fmt::Debug,
+    {
+        let mut set = DenseBitSet::new_empty(domain);
+        set.insert_range(range.clone());
+        for i in set.iter() {
+            assert!(range.contains(&i));
+        }
+        for i in range.clone() {
+            assert!(set.contains(i), "{} in {:?}, inserted {:?}", i, set, range);
+        }
+    }
+    check(300, 10..10);
+    check(300, WORD_BITS..WORD_BITS * 2);
+    check(300, WORD_BITS - 1..WORD_BITS * 2);
+    check(300, WORD_BITS - 1..WORD_BITS);
+    check(300, 10..100);
+    check(300, 10..30);
+    check(300, 0..5);
+    check(300, 0..250);
+    check(300, 200..250);
+
+    check(300, 10..=10);
+    check(300, WORD_BITS..=WORD_BITS * 2);
+    check(300, WORD_BITS - 1..=WORD_BITS * 2);
+    check(300, WORD_BITS - 1..=WORD_BITS);
+    check(300, 10..=100);
+    check(300, 10..=30);
+    check(300, 0..=5);
+    check(300, 0..=250);
+    check(300, 200..=250);
+
+    for i in 0..WORD_BITS * 2 {
+        for j in i..WORD_BITS * 2 {
+            check(WORD_BITS * 2, i..j);
+            check(WORD_BITS * 2, i..=j);
+            check(300, i..j);
+            check(300, i..=j);
+        }
+    }
+}
+
+#[test]
+fn dense_last_set_before() {
+    fn easy(set: &DenseBitSet<usize>, needle: impl RangeBounds<usize>) -> Option<usize> {
+        let mut last_leq = None;
+        for e in set.iter() {
+            if needle.contains(&e) {
+                last_leq = Some(e);
+            }
+        }
+        last_leq
+    }
+
+    #[track_caller]
+    fn cmp(set: &DenseBitSet<usize>, needle: impl RangeBounds<usize> + Clone + std::fmt::Debug) {
+        assert_eq!(
+            set.last_set_in(needle.clone()),
+            easy(set, needle.clone()),
+            "{:?} in {:?}",
+            needle,
+            set
+        );
+    }
+    let mut set = DenseBitSet::new_empty(300);
+    cmp(&set, 50..=50);
+    set.insert(WORD_BITS);
+    cmp(&set, WORD_BITS..=WORD_BITS);
+    set.insert(WORD_BITS - 1);
+    cmp(&set, 0..=WORD_BITS - 1);
+    cmp(&set, 0..=5);
+    cmp(&set, 10..100);
+    set.insert(100);
+    cmp(&set, 100..110);
+    cmp(&set, 99..100);
+    cmp(&set, 99..=100);
+
+    for i in 0..=WORD_BITS * 2 {
+        for j in i..=WORD_BITS * 2 {
+            for k in 0..WORD_BITS * 2 {
+                let mut set = DenseBitSet::new_empty(300);
+                cmp(&set, i..j);
+                cmp(&set, i..=j);
+                set.insert(k);
+                cmp(&set, i..j);
+                cmp(&set, i..=j);
+            }
+        }
+    }
+}
+
+#[test]
+fn dense_contains_any() {
+    let mut set: DenseBitSet<usize> = DenseBitSet::new_empty(300);
+    assert!(!set.contains_any(0..300));
+    set.insert_range(10..20);
+    set.insert_range(60..70);
+    set.insert_range(150..=250);
+
+    assert!(set.contains_any(0..30));
+    assert!(set.contains_any(5..100));
+    assert!(set.contains_any(250..255));
+
+    assert!(!set.contains_any(20..59));
+    assert!(!set.contains_any(256..290));
+
+    set.insert(22);
+    assert!(set.contains_any(20..59));
+}
+
+#[cfg(any())]
+#[bench]
+fn bench_insert(b: &mut test::Bencher) {
+    let mut bs = DenseBitSet::new_filled(99999usize);
+    b.iter(|| {
+        std::hint::black_box(bs.insert(std::hint::black_box(100u32)));
+    });
+}
+
+#[cfg(any())]
+#[bench]
+fn bench_remove(b: &mut test::Bencher) {
+    let mut bs = DenseBitSet::new_filled(99999usize);
+    b.iter(|| {
+        std::hint::black_box(bs.remove(std::hint::black_box(100u32)));
+    });
+}
+
+#[cfg(any())]
+#[bench]
+fn bench_iter(b: &mut test::Bencher) {
+    let bs = DenseBitSet::new_filled(99999usize);
+    b.iter(|| {
+        bs.iter().map(|b: usize| std::hint::black_box(b)).for_each(drop);
+    });
+}
+
+#[cfg(any())]
+#[bench]
+fn bench_intersect(b: &mut test::Bencher) {
+    let mut ba: DenseBitSet<u32> = DenseBitSet::new_filled(99999usize);
+    let bb = DenseBitSet::new_filled(99999usize);
+    b.iter(|| {
+        ba.intersect(std::hint::black_box(&bb));
+    });
+}

--- a/crates/data-structures/src/bit_set/tests.rs
+++ b/crates/data-structures/src/bit_set/tests.rs
@@ -6,12 +6,33 @@
 )]
 
 use super::*;
+use crate::{index::Idx, newtype_index};
+
+newtype_index! {
+    struct TestIdx;
+}
+
+fn idx(index: usize) -> TestIdx {
+    TestIdx::from_usize(index)
+}
+
+fn idx_range(range: std::ops::Range<usize>) -> std::ops::Range<TestIdx> {
+    idx(range.start)..idx(range.end)
+}
+
+fn idx_range_inclusive(
+    range: std::ops::RangeInclusive<usize>,
+) -> std::ops::RangeInclusive<TestIdx> {
+    let (start, end) = range.into_inner();
+    idx(start)..=idx(end)
+}
 
 #[test]
 fn test_new_filled() {
+    let _ = TestIdx::MAX;
     for i in 0..128 {
-        let idx_buf = DenseBitSet::new_filled(i);
-        let elems: Vec<usize> = idx_buf.iter().collect();
+        let idx_buf = DenseBitSet::<TestIdx>::new_filled(i);
+        let elems: Vec<usize> = idx_buf.iter().map(Idx::index).collect();
         let expected: Vec<usize> = (0..i).collect();
         assert_eq!(elems, expected);
     }
@@ -19,93 +40,96 @@ fn test_new_filled() {
 
 #[test]
 fn bitset_iter_works() {
-    let mut bitset: DenseBitSet<usize> = DenseBitSet::new_empty(100);
-    bitset.insert(1);
-    bitset.insert(10);
-    bitset.insert(19);
-    bitset.insert(62);
-    bitset.insert(63);
-    bitset.insert(64);
-    bitset.insert(65);
-    bitset.insert(66);
-    bitset.insert(99);
-    assert_eq!(bitset.iter().collect::<Vec<_>>(), [1, 10, 19, 62, 63, 64, 65, 66, 99]);
+    let mut bitset: DenseBitSet<TestIdx> = DenseBitSet::new_empty(100);
+    bitset.insert(idx(1));
+    bitset.insert(idx(10));
+    bitset.insert(idx(19));
+    bitset.insert(idx(62));
+    bitset.insert(idx(63));
+    bitset.insert(idx(64));
+    bitset.insert(idx(65));
+    bitset.insert(idx(66));
+    bitset.insert(idx(99));
+    assert_eq!(
+        bitset.iter().map(Idx::index).collect::<Vec<_>>(),
+        [1, 10, 19, 62, 63, 64, 65, 66, 99]
+    );
 }
 
 #[test]
 fn bitset_iter_works_2() {
-    let mut bitset: DenseBitSet<usize> = DenseBitSet::new_empty(320);
-    bitset.insert(0);
-    bitset.insert(127);
-    bitset.insert(191);
-    bitset.insert(255);
-    bitset.insert(319);
-    assert_eq!(bitset.iter().collect::<Vec<_>>(), [0, 127, 191, 255, 319]);
+    let mut bitset: DenseBitSet<TestIdx> = DenseBitSet::new_empty(320);
+    bitset.insert(idx(0));
+    bitset.insert(idx(127));
+    bitset.insert(idx(191));
+    bitset.insert(idx(255));
+    bitset.insert(idx(319));
+    assert_eq!(bitset.iter().map(Idx::index).collect::<Vec<_>>(), [0, 127, 191, 255, 319]);
 }
 
 #[test]
 fn bitset_clone_from() {
-    let mut a: DenseBitSet<usize> = DenseBitSet::new_empty(10);
-    a.insert(4);
-    a.insert(7);
-    a.insert(9);
+    let mut a: DenseBitSet<TestIdx> = DenseBitSet::new_empty(10);
+    a.insert(idx(4));
+    a.insert(idx(7));
+    a.insert(idx(9));
 
     let mut b = DenseBitSet::new_empty(2);
     b.clone_from(&a);
     assert_eq!(b.domain_size(), 10);
-    assert_eq!(b.iter().collect::<Vec<_>>(), [4, 7, 9]);
+    assert_eq!(b.iter().map(Idx::index).collect::<Vec<_>>(), [4, 7, 9]);
 
     b.clone_from(&DenseBitSet::new_empty(40));
     assert_eq!(b.domain_size(), 40);
-    assert_eq!(b.iter().collect::<Vec<_>>(), []);
+    assert_eq!(b.iter().map(Idx::index).collect::<Vec<_>>(), Vec::<usize>::new());
 }
 
 #[test]
 fn union_two_sets() {
-    let mut set1: DenseBitSet<usize> = DenseBitSet::new_empty(65);
-    let mut set2: DenseBitSet<usize> = DenseBitSet::new_empty(65);
-    assert!(set1.insert(3));
-    assert!(!set1.insert(3));
-    assert!(set2.insert(5));
-    assert!(set2.insert(64));
+    let mut set1: DenseBitSet<TestIdx> = DenseBitSet::new_empty(65);
+    let mut set2: DenseBitSet<TestIdx> = DenseBitSet::new_empty(65);
+    assert!(set1.insert(idx(3)));
+    assert!(!set1.insert(idx(3)));
+    assert!(set2.insert(idx(5)));
+    assert!(set2.insert(idx(64)));
     assert!(set1.union(&set2));
     assert!(!set1.union(&set2));
-    assert!(set1.contains(3));
-    assert!(!set1.contains(4));
-    assert!(set1.contains(5));
-    assert!(!set1.contains(63));
-    assert!(set1.contains(64));
+    assert!(set1.contains(idx(3)));
+    assert!(!set1.contains(idx(4)));
+    assert!(set1.contains(idx(5)));
+    assert!(!set1.contains(idx(63)));
+    assert!(set1.contains(idx(64)));
 }
 
 #[test]
 fn union_not() {
-    let mut a = DenseBitSet::<usize>::new_empty(100);
-    let mut b = DenseBitSet::<usize>::new_empty(100);
+    let mut a = DenseBitSet::<TestIdx>::new_empty(100);
+    let mut b = DenseBitSet::<TestIdx>::new_empty(100);
 
-    a.insert(3);
-    a.insert(5);
-    a.insert(80);
-    a.insert(81);
+    a.insert(idx(3));
+    a.insert(idx(5));
+    a.insert(idx(80));
+    a.insert(idx(81));
 
-    b.insert(5); // Already in `a`.
-    b.insert(7);
-    b.insert(63);
-    b.insert(81); // Already in `a`.
-    b.insert(90);
+    b.insert(idx(5)); // Already in `a`.
+    b.insert(idx(7));
+    b.insert(idx(63));
+    b.insert(idx(81)); // Already in `a`.
+    b.insert(idx(90));
 
     a.union_not(&b);
 
     // After union-not, `a` should contain all values in the domain, except for
     // the ones that are in `b` and were _not_ already in `a`.
     assert_eq!(
-        a.iter().collect::<Vec<_>>(),
+        a.iter().map(Idx::index).collect::<Vec<_>>(),
         (0usize..100).filter(|&x| !matches!(x, 7 | 63 | 90)).collect::<Vec<_>>(),
     );
 }
 
 #[test]
 fn chunked_bitset() {
-    let mut b0 = ChunkedBitSet::<usize>::new_empty(0);
+    let mut b0 = ChunkedBitSet::<TestIdx>::new_empty(0);
     let b0b = b0.clone();
     assert_eq!(b0, ChunkedBitSet { domain_size: 0, chunks: Box::new([]), marker: PhantomData });
 
@@ -119,7 +143,7 @@ fn chunked_bitset() {
 
     //-----------------------------------------------------------------------
 
-    let mut b1 = ChunkedBitSet::<usize>::new_empty(1);
+    let mut b1 = ChunkedBitSet::<TestIdx>::new_empty(1);
     assert_eq!(
         b1,
         ChunkedBitSet {
@@ -130,22 +154,22 @@ fn chunked_bitset() {
     );
 
     b1.assert_valid();
-    assert!(!b1.contains(0));
+    assert!(!b1.contains(idx(0)));
     assert_eq!(b1.count(), 0);
-    assert!(b1.insert(0));
-    assert!(b1.contains(0));
+    assert!(b1.insert(idx(0)));
+    assert!(b1.contains(idx(0)));
     assert_eq!(b1.count(), 1);
     assert_eq!(b1.chunks(), [Ones { chunk_domain_size: 1 }]);
-    assert!(!b1.insert(0));
-    assert!(b1.remove(0));
-    assert!(!b1.contains(0));
+    assert!(!b1.insert(idx(0)));
+    assert!(b1.remove(idx(0)));
+    assert!(!b1.contains(idx(0)));
     assert_eq!(b1.count(), 0);
     assert_eq!(b1.chunks(), [Zeros { chunk_domain_size: 1 }]);
     b1.assert_valid();
 
     //-----------------------------------------------------------------------
 
-    let mut b100 = ChunkedBitSet::<usize>::new_filled(100);
+    let mut b100 = ChunkedBitSet::<TestIdx>::new_filled(100);
     assert_eq!(
         b100,
         ChunkedBitSet {
@@ -157,17 +181,26 @@ fn chunked_bitset() {
 
     b100.assert_valid();
     for i in 0..100 {
-        assert!(b100.contains(i));
+        assert!(b100.contains(idx(i)));
     }
     assert_eq!(b100.count(), 100);
-    assert!(b100.remove(3));
-    assert!(b100.insert(3));
+    assert!(b100.remove(idx(3)));
+    assert!(b100.insert(idx(3)));
     assert_eq!(b100.chunks(), vec![Ones { chunk_domain_size: 100 }]);
     assert!(
-        b100.remove(20) && b100.remove(30) && b100.remove(40) && b100.remove(99) && b100.insert(30)
+        b100.remove(idx(20))
+            && b100.remove(idx(30))
+            && b100.remove(idx(40))
+            && b100.remove(idx(99))
+            && b100.insert(idx(30))
     );
     assert_eq!(b100.count(), 97);
-    assert!(!b100.contains(20) && b100.contains(30) && !b100.contains(99) && b100.contains(50));
+    assert!(
+        !b100.contains(idx(20))
+            && b100.contains(idx(30))
+            && !b100.contains(idx(99))
+            && b100.contains(idx(50))
+    );
     assert_eq!(
         b100.chunks(),
         vec![Mixed {
@@ -212,7 +245,7 @@ fn chunked_bitset() {
     b100.assert_valid();
     let mut num_removed = 0;
     for i in 0..100 {
-        if b100.remove(i) {
+        if b100.remove(idx(i)) {
             num_removed += 1;
         }
     }
@@ -222,7 +255,7 @@ fn chunked_bitset() {
 
     //-----------------------------------------------------------------------
 
-    let mut b2548 = ChunkedBitSet::<usize>::new_empty(2548);
+    let mut b2548 = ChunkedBitSet::<TestIdx>::new_empty(2548);
     assert_eq!(
         b2548,
         ChunkedBitSet {
@@ -233,15 +266,15 @@ fn chunked_bitset() {
     );
 
     b2548.assert_valid();
-    b2548.insert(14);
-    b2548.remove(14);
+    b2548.insert(idx(14));
+    b2548.remove(idx(14));
     assert_eq!(
         b2548.chunks(),
         vec![Zeros { chunk_domain_size: 2048 }, Zeros { chunk_domain_size: 500 }]
     );
     b2548.insert_all();
     for i in 0..2548 {
-        assert!(b2548.contains(i));
+        assert!(b2548.contains(idx(i)));
     }
     assert_eq!(b2548.count(), 2548);
     assert_eq!(
@@ -252,7 +285,7 @@ fn chunked_bitset() {
 
     //-----------------------------------------------------------------------
 
-    let mut b4096 = ChunkedBitSet::<usize>::new_empty(4096);
+    let mut b4096 = ChunkedBitSet::<TestIdx>::new_empty(4096);
     assert_eq!(
         b4096,
         ChunkedBitSet {
@@ -267,11 +300,14 @@ fn chunked_bitset() {
 
     b4096.assert_valid();
     for i in 0..4096 {
-        assert!(!b4096.contains(i));
+        assert!(!b4096.contains(idx(i)));
     }
-    assert!(b4096.insert(0) && b4096.insert(4095) && !b4096.insert(4095));
+    assert!(b4096.insert(idx(0)) && b4096.insert(idx(4095)) && !b4096.insert(idx(4095)));
     assert!(
-        b4096.contains(0) && !b4096.contains(2047) && !b4096.contains(2048) && b4096.contains(4095)
+        b4096.contains(idx(0))
+            && !b4096.contains(idx(2047))
+            && !b4096.contains(idx(2048))
+            && b4096.contains(idx(4095))
     );
     assert_eq!(
         b4096.chunks(),
@@ -329,7 +365,7 @@ fn chunked_bitset() {
 
     //-----------------------------------------------------------------------
 
-    let mut b10000 = ChunkedBitSet::<usize>::new_empty(10000);
+    let mut b10000 = ChunkedBitSet::<TestIdx>::new_empty(10000);
     assert_eq!(
         b10000,
         ChunkedBitSet {
@@ -346,7 +382,7 @@ fn chunked_bitset() {
     );
 
     b10000.assert_valid();
-    assert!(b10000.insert(3000) && b10000.insert(5000));
+    assert!(b10000.insert(idx(3000)) && b10000.insert(idx(5000)));
     assert_eq!(
         b10000.chunks(),
         vec![
@@ -401,18 +437,18 @@ fn chunked_bitset() {
             Zeros { chunk_domain_size: 1808 },
         ],
     );
-    let mut b10000b = ChunkedBitSet::<usize>::new_empty(10000);
+    let mut b10000b = ChunkedBitSet::<TestIdx>::new_empty(10000);
     b10000b.clone_from(&b10000);
     assert_eq!(b10000, b10000b);
     for i in 6000..7000 {
-        b10000b.insert(i);
+        b10000b.insert(idx(i));
     }
     assert_eq!(b10000b.count(), 1002);
     b10000b.assert_valid();
     b10000b.clone_from(&b10000);
     assert_eq!(b10000b.count(), 2);
     for i in 2000..8000 {
-        b10000b.insert(i);
+        b10000b.insert(idx(i));
     }
     b10000.union(&b10000b);
     assert_eq!(b10000.count(), 6000);
@@ -423,16 +459,16 @@ fn chunked_bitset() {
 
     //-----------------------------------------------------------------------
 
-    let mut b64 = ChunkedBitSet::<usize>::new_filled(64);
+    let mut b64 = ChunkedBitSet::<TestIdx>::new_filled(64);
 
-    let mut b64b = ChunkedBitSet::<usize>::new_empty(64);
-    b64b.insert(0);
+    let mut b64b = ChunkedBitSet::<TestIdx>::new_empty(64);
+    b64b.insert(idx(0));
 
     b64.subtract(&b64b);
-    assert!(!b64.contains(0));
-    assert!(b64.contains(10));
-    assert!(b64.contains(50));
-    assert!(b64.contains(63));
+    assert!(!b64.contains(idx(0)));
+    assert!(b64.contains(idx(10)));
+    assert!(b64.contains(idx(50)));
+    assert!(b64.contains(idx(63)));
     assert_eq!(
         b64.chunks(),
         vec![Mixed {
@@ -477,24 +513,25 @@ fn chunked_bitset() {
 }
 
 /// Additional helper methods for testing.
-impl ChunkedBitSet<usize> {
+impl ChunkedBitSet<TestIdx> {
     /// Creates a new `ChunkedBitSet` containing all `i` for which `fill_fn(i)` is true.
     fn fill_with(domain_size: usize, fill_fn: impl Fn(usize) -> bool) -> Self {
         let mut this = ChunkedBitSet::new_empty(domain_size);
         for i in 0..domain_size {
             if fill_fn(i) {
-                this.insert(i);
+                this.insert(idx(i));
             }
         }
         this
     }
 
-    /// Asserts that for each `i` in `0..self.domain_size()`, `self.contains(i) == expected_fn(i)`.
+    /// Asserts that for each `i` in `0..self.domain_size()`, `self.contains(idx(i)) ==
+    /// expected_fn(i)`.
     #[track_caller]
     fn assert_filled_with(&self, expected_fn: impl Fn(usize) -> bool) {
         for i in 0..self.domain_size() {
             let expected = expected_fn(i);
-            assert_eq!(self.contains(i), expected, "i = {i}");
+            assert_eq!(self.contains(idx(i)), expected, "i = {i}");
         }
     }
 }
@@ -503,7 +540,7 @@ impl ChunkedBitSet<usize> {
 fn chunked_bulk_ops() {
     struct ChunkedBulkOp {
         name: &'static str,
-        op_fn: fn(&mut ChunkedBitSet<usize>, &ChunkedBitSet<usize>) -> bool,
+        op_fn: fn(&mut ChunkedBitSet<TestIdx>, &ChunkedBitSet<TestIdx>) -> bool,
         spec_fn: fn(fn(usize) -> bool, fn(usize) -> bool, usize) -> bool,
     }
     let ops = &[
@@ -566,7 +603,7 @@ fn chunked_bulk_ops_test_inner(
     unique: bool,
     fizz_fn: impl Fn(usize) -> bool + Copy,
     buzz_fn: impl Fn(usize) -> bool + Copy,
-    op_fn: impl Fn(&mut ChunkedBitSet<usize>, &ChunkedBitSet<usize>) -> bool,
+    op_fn: impl Fn(&mut ChunkedBitSet<TestIdx>, &ChunkedBitSet<TestIdx>) -> bool,
     expected_fn: impl Fn(usize) -> bool + Copy,
 ) {
     // Create two bitsets, "fizz" (LHS) and "buzz" (RHS).
@@ -586,17 +623,17 @@ fn chunked_bulk_ops_test_inner(
     assert_eq!(changed, should_change);
 }
 
-fn with_elements_chunked(elements: &[usize], domain_size: usize) -> ChunkedBitSet<usize> {
+fn with_elements_chunked(elements: &[usize], domain_size: usize) -> ChunkedBitSet<TestIdx> {
     let mut s = ChunkedBitSet::new_empty(domain_size);
     for &e in elements {
-        assert!(s.insert(e));
+        assert!(s.insert(idx(e)));
     }
     s
 }
 
 #[test]
 fn chunked_bitset_iter() {
-    fn check_iter(bit: &ChunkedBitSet<usize>, vec: &Vec<usize>) {
+    fn check_iter(bit: &ChunkedBitSet<TestIdx>, vec: &Vec<usize>) {
         // Test collecting via both `.next()` and `.fold()` calls, to make sure both are correct
         let mut collect_next = Vec::new();
         let mut bit_iter = bit.iter();
@@ -638,74 +675,74 @@ fn chunked_bitset_iter() {
 
 #[test]
 fn grow() {
-    let mut set: GrowableBitSet<usize> = GrowableBitSet::with_capacity(65);
+    let mut set: GrowableBitSet<TestIdx> = GrowableBitSet::with_capacity(65);
     for index in 0..65 {
-        assert!(set.insert(index));
-        assert!(!set.insert(index));
+        assert!(set.insert(idx(index)));
+        assert!(!set.insert(idx(index)));
     }
     set.ensure(128);
 
     // Check if the bits set before growing are still set
     for index in 0..65 {
-        assert!(set.contains(index));
+        assert!(set.contains(idx(index)));
     }
 
     // Check if the new bits are all un-set
     for index in 65..128 {
-        assert!(!set.contains(index));
+        assert!(!set.contains(idx(index)));
     }
 
     // Check that we can set all new bits without running out of bounds
     for index in 65..128 {
-        assert!(set.insert(index));
-        assert!(!set.insert(index));
+        assert!(set.insert(idx(index)));
+        assert!(!set.insert(idx(index)));
     }
 }
 
 #[test]
 fn matrix_intersection() {
-    let mut matrix: BitMatrix<usize, usize> = BitMatrix::new(200, 200);
+    let mut matrix: BitMatrix<TestIdx, TestIdx> = BitMatrix::new(200, 200);
 
     // (*) Elements reachable from both 2 and 65.
 
-    matrix.insert(2, 3);
-    matrix.insert(2, 6);
-    matrix.insert(2, 10); // (*)
-    matrix.insert(2, 64); // (*)
-    matrix.insert(2, 65);
-    matrix.insert(2, 130);
-    matrix.insert(2, 160); // (*)
+    matrix.insert(idx(2), idx(3));
+    matrix.insert(idx(2), idx(6));
+    matrix.insert(idx(2), idx(10)); // (*)
+    matrix.insert(idx(2), idx(64)); // (*)
+    matrix.insert(idx(2), idx(65));
+    matrix.insert(idx(2), idx(130));
+    matrix.insert(idx(2), idx(160)); // (*)
 
-    matrix.insert(64, 133);
+    matrix.insert(idx(64), idx(133));
 
-    matrix.insert(65, 2);
-    matrix.insert(65, 8);
-    matrix.insert(65, 10); // (*)
-    matrix.insert(65, 64); // (*)
-    matrix.insert(65, 68);
-    matrix.insert(65, 133);
-    matrix.insert(65, 160); // (*)
+    matrix.insert(idx(65), idx(2));
+    matrix.insert(idx(65), idx(8));
+    matrix.insert(idx(65), idx(10)); // (*)
+    matrix.insert(idx(65), idx(64)); // (*)
+    matrix.insert(idx(65), idx(68));
+    matrix.insert(idx(65), idx(133));
+    matrix.insert(idx(65), idx(160)); // (*)
 
-    let intersection = matrix.intersect_rows(2, 64);
+    let intersection = matrix.intersect_rows(idx(2), idx(64));
     assert!(intersection.is_empty());
 
-    let intersection = matrix.intersect_rows(2, 65);
+    let intersection = matrix.intersect_rows(idx(2), idx(65));
     assert_eq!(intersection, &[10, 64, 160]);
 }
 
 #[test]
 fn matrix_iter() {
-    let mut matrix: BitMatrix<usize, usize> = BitMatrix::new(64, 100);
-    matrix.insert(3, 22);
-    matrix.insert(3, 75);
-    matrix.insert(2, 99);
-    matrix.insert(4, 0);
-    matrix.union_rows(3, 5);
-    matrix.insert_all_into_row(6);
+    let mut matrix: BitMatrix<TestIdx, TestIdx> = BitMatrix::new(64, 100);
+    matrix.insert(idx(3), idx(22));
+    matrix.insert(idx(3), idx(75));
+    matrix.insert(idx(2), idx(99));
+    matrix.insert(idx(4), idx(0));
+    matrix.union_rows(idx(3), idx(5));
+    matrix.insert_all_into_row(idx(6));
 
     let expected = [99];
     let mut iter = expected.iter();
-    for i in matrix.iter(2) {
+    for i in matrix.iter(idx(2)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -713,8 +750,8 @@ fn matrix_iter() {
 
     let expected = [22, 75];
     let mut iter = expected.iter();
-    assert_eq!(matrix.count(3), expected.len());
-    for i in matrix.iter(3) {
+    assert_eq!(matrix.count(idx(3)), expected.len());
+    for i in matrix.iter(idx(3)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -722,8 +759,8 @@ fn matrix_iter() {
 
     let expected = [0];
     let mut iter = expected.iter();
-    assert_eq!(matrix.count(4), expected.len());
-    for i in matrix.iter(4) {
+    assert_eq!(matrix.count(idx(4)), expected.len());
+    for i in matrix.iter(idx(4)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -731,38 +768,38 @@ fn matrix_iter() {
 
     let expected = [22, 75];
     let mut iter = expected.iter();
-    assert_eq!(matrix.count(5), expected.len());
-    for i in matrix.iter(5) {
+    assert_eq!(matrix.count(idx(5)), expected.len());
+    for i in matrix.iter(idx(5)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
     assert!(iter.next().is_none());
 
-    assert_eq!(matrix.count(6), 100);
+    assert_eq!(matrix.count(idx(6)), 100);
     let mut count = 0;
-    for (idx, i) in matrix.iter(6).enumerate() {
+    for (idx, i) in matrix.iter(idx(6)).enumerate() {
         assert_eq!(idx, i);
         count += 1;
     }
     assert_eq!(count, 100);
 
-    if let Some(i) = matrix.iter(7).next() {
+    if let Some(i) = matrix.iter(idx(7)).next() {
         panic!("expected no elements in row, but contains element {:?}", i);
     }
 }
 
 #[test]
 fn sparse_matrix_iter() {
-    let mut matrix: SparseBitMatrix<usize, usize> = SparseBitMatrix::new(100);
-    matrix.insert(3, 22);
-    matrix.insert(3, 75);
-    matrix.insert(2, 99);
-    matrix.insert(4, 0);
-    matrix.union_rows(3, 5);
+    let mut matrix: SparseBitMatrix<TestIdx, TestIdx> = SparseBitMatrix::new(100);
+    matrix.insert(idx(3), idx(22));
+    matrix.insert(idx(3), idx(75));
+    matrix.insert(idx(2), idx(99));
+    matrix.insert(idx(4), idx(0));
+    matrix.union_rows(idx(3), idx(5));
 
     let expected = [99];
     let mut iter = expected.iter();
-    for i in matrix.iter(2) {
+    for i in matrix.iter(idx(2)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -770,7 +807,7 @@ fn sparse_matrix_iter() {
 
     let expected = [22, 75];
     let mut iter = expected.iter();
-    for i in matrix.iter(3) {
+    for i in matrix.iter(idx(3)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -778,7 +815,7 @@ fn sparse_matrix_iter() {
 
     let expected = [0];
     let mut iter = expected.iter();
-    for i in matrix.iter(4) {
+    for i in matrix.iter(idx(4)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -786,7 +823,7 @@ fn sparse_matrix_iter() {
 
     let expected = [22, 75];
     let mut iter = expected.iter();
-    for i in matrix.iter(5) {
+    for i in matrix.iter(idx(5)) {
         let j = *iter.next().unwrap();
         assert_eq!(i, j);
     }
@@ -795,119 +832,120 @@ fn sparse_matrix_iter() {
 
 #[test]
 fn sparse_matrix_operations() {
-    let mut matrix: SparseBitMatrix<usize, usize> = SparseBitMatrix::new(100);
-    matrix.insert(3, 22);
-    matrix.insert(3, 75);
-    matrix.insert(2, 99);
-    matrix.insert(4, 0);
+    let mut matrix: SparseBitMatrix<TestIdx, TestIdx> = SparseBitMatrix::new(100);
+    matrix.insert(idx(3), idx(22));
+    matrix.insert(idx(3), idx(75));
+    matrix.insert(idx(2), idx(99));
+    matrix.insert(idx(4), idx(0));
 
-    let mut disjoint: DenseBitSet<usize> = DenseBitSet::new_empty(100);
-    disjoint.insert(33);
+    let mut disjoint: DenseBitSet<TestIdx> = DenseBitSet::new_empty(100);
+    disjoint.insert(idx(33));
 
     let mut superset = DenseBitSet::new_empty(100);
-    superset.insert(22);
-    superset.insert(75);
-    superset.insert(33);
+    superset.insert(idx(22));
+    superset.insert(idx(75));
+    superset.insert(idx(33));
 
     let mut subset = DenseBitSet::new_empty(100);
-    subset.insert(22);
+    subset.insert(idx(22));
 
     // SparseBitMatrix::remove
     {
         let mut matrix = matrix.clone();
-        matrix.remove(3, 22);
-        assert!(!matrix.row(3).unwrap().contains(22));
-        matrix.remove(0, 0);
-        assert!(matrix.row(0).is_none());
+        matrix.remove(idx(3), idx(22));
+        assert!(!matrix.row(idx(3)).unwrap().contains(idx(22)));
+        matrix.remove(idx(0), idx(0));
+        assert!(matrix.row(idx(0)).is_none());
     }
 
     // SparseBitMatrix::clear
     {
         let mut matrix = matrix.clone();
-        matrix.clear(3);
-        assert!(!matrix.row(3).unwrap().contains(75));
-        matrix.clear(0);
-        assert!(matrix.row(0).is_none());
+        matrix.clear(idx(3));
+        assert!(!matrix.row(idx(3)).unwrap().contains(idx(75)));
+        matrix.clear(idx(0));
+        assert!(matrix.row(idx(0)).is_none());
     }
 
     // SparseBitMatrix::intersect_row
     {
         let mut matrix = matrix.clone();
-        assert!(!matrix.intersect_row(3, &superset));
-        assert!(matrix.intersect_row(3, &subset));
-        matrix.intersect_row(0, &disjoint);
-        assert!(matrix.row(0).is_none());
+        assert!(!matrix.intersect_row(idx(3), &superset));
+        assert!(matrix.intersect_row(idx(3), &subset));
+        matrix.intersect_row(idx(0), &disjoint);
+        assert!(matrix.row(idx(0)).is_none());
     }
 
     // SparseBitMatrix::subtract_row
     {
         let mut matrix = matrix.clone();
-        assert!(!matrix.subtract_row(3, &disjoint));
-        assert!(matrix.subtract_row(3, &subset));
-        assert!(matrix.subtract_row(3, &superset));
-        matrix.intersect_row(0, &disjoint);
-        assert!(matrix.row(0).is_none());
+        assert!(!matrix.subtract_row(idx(3), &disjoint));
+        assert!(matrix.subtract_row(idx(3), &subset));
+        assert!(matrix.subtract_row(idx(3), &superset));
+        matrix.intersect_row(idx(0), &disjoint);
+        assert!(matrix.row(idx(0)).is_none());
     }
 
     // SparseBitMatrix::union_row
     {
         let mut matrix = matrix.clone();
-        assert!(!matrix.union_row(3, &subset));
-        assert!(matrix.union_row(3, &disjoint));
-        matrix.union_row(0, &disjoint);
-        assert!(matrix.row(0).is_some());
+        assert!(!matrix.union_row(idx(3), &subset));
+        assert!(matrix.union_row(idx(3), &disjoint));
+        matrix.union_row(idx(0), &disjoint);
+        assert!(matrix.row(idx(0)).is_some());
     }
 }
 
 #[test]
 fn dense_insert_range() {
     #[track_caller]
-    fn check<R>(domain: usize, range: R)
+    fn check<R, I>(domain: usize, range: R, iter: I)
     where
-        R: RangeBounds<usize> + Clone + IntoIterator<Item = usize> + std::fmt::Debug,
+        R: RangeBounds<TestIdx> + Clone + std::fmt::Debug,
+        I: Clone + IntoIterator<Item = usize> + std::fmt::Debug,
     {
-        let mut set = DenseBitSet::new_empty(domain);
+        let mut set = DenseBitSet::<TestIdx>::new_empty(domain);
         set.insert_range(range.clone());
         for i in set.iter() {
             assert!(range.contains(&i));
         }
-        for i in range.clone() {
-            assert!(set.contains(i), "{} in {:?}, inserted {:?}", i, set, range);
+        for i in iter {
+            assert!(set.contains(idx(i)), "{} in {:?}, inserted {:?}", i, set, range);
         }
     }
-    check(300, 10..10);
-    check(300, WORD_BITS..WORD_BITS * 2);
-    check(300, WORD_BITS - 1..WORD_BITS * 2);
-    check(300, WORD_BITS - 1..WORD_BITS);
-    check(300, 10..100);
-    check(300, 10..30);
-    check(300, 0..5);
-    check(300, 0..250);
-    check(300, 200..250);
+    check(300, idx_range(10..10), 10..10);
+    check(300, idx_range(WORD_BITS..WORD_BITS * 2), WORD_BITS..WORD_BITS * 2);
+    check(300, idx_range(WORD_BITS - 1..WORD_BITS * 2), WORD_BITS - 1..WORD_BITS * 2);
+    check(300, idx_range(WORD_BITS - 1..WORD_BITS), WORD_BITS - 1..WORD_BITS);
+    check(300, idx_range(10..100), 10..100);
+    check(300, idx_range(10..30), 10..30);
+    check(300, idx_range(0..5), 0..5);
+    check(300, idx_range(0..250), 0..250);
+    check(300, idx_range(200..250), 200..250);
 
-    check(300, 10..=10);
-    check(300, WORD_BITS..=WORD_BITS * 2);
-    check(300, WORD_BITS - 1..=WORD_BITS * 2);
-    check(300, WORD_BITS - 1..=WORD_BITS);
-    check(300, 10..=100);
-    check(300, 10..=30);
-    check(300, 0..=5);
-    check(300, 0..=250);
-    check(300, 200..=250);
+    check(300, idx_range_inclusive(10..=10), 10..=10);
+    check(300, idx_range_inclusive(WORD_BITS..=WORD_BITS * 2), WORD_BITS..=WORD_BITS * 2);
+    check(300, idx_range_inclusive(WORD_BITS - 1..=WORD_BITS * 2), WORD_BITS - 1..=WORD_BITS * 2);
+    check(300, idx_range_inclusive(WORD_BITS - 1..=WORD_BITS), WORD_BITS - 1..=WORD_BITS);
+    check(300, idx_range_inclusive(10..=100), 10..=100);
+    check(300, idx_range_inclusive(10..=30), 10..=30);
+    check(300, idx_range_inclusive(0..=5), 0..=5);
+    check(300, idx_range_inclusive(0..=250), 0..=250);
+    check(300, idx_range_inclusive(200..=250), 200..=250);
 
     for i in 0..WORD_BITS * 2 {
         for j in i..WORD_BITS * 2 {
-            check(WORD_BITS * 2, i..j);
-            check(WORD_BITS * 2, i..=j);
-            check(300, i..j);
-            check(300, i..=j);
+            check(WORD_BITS * 2, idx_range(i..j), i..j);
+            check(WORD_BITS * 2, idx_range_inclusive(i..=j), i..=j);
+            check(300, idx_range(i..j), i..j);
+            check(300, idx_range_inclusive(i..=j), i..=j);
         }
     }
 }
 
 #[test]
 fn dense_last_set_before() {
-    fn easy(set: &DenseBitSet<usize>, needle: impl RangeBounds<usize>) -> Option<usize> {
+    fn easy(set: &DenseBitSet<TestIdx>, needle: impl RangeBounds<TestIdx>) -> Option<TestIdx> {
         let mut last_leq = None;
         for e in set.iter() {
             if needle.contains(&e) {
@@ -918,7 +956,10 @@ fn dense_last_set_before() {
     }
 
     #[track_caller]
-    fn cmp(set: &DenseBitSet<usize>, needle: impl RangeBounds<usize> + Clone + std::fmt::Debug) {
+    fn cmp(
+        set: &DenseBitSet<TestIdx>,
+        needle: impl RangeBounds<TestIdx> + Clone + std::fmt::Debug,
+    ) {
         assert_eq!(
             set.last_set_in(needle.clone()),
             easy(set, needle.clone()),
@@ -927,28 +968,28 @@ fn dense_last_set_before() {
             set
         );
     }
-    let mut set = DenseBitSet::new_empty(300);
-    cmp(&set, 50..=50);
-    set.insert(WORD_BITS);
-    cmp(&set, WORD_BITS..=WORD_BITS);
-    set.insert(WORD_BITS - 1);
-    cmp(&set, 0..=WORD_BITS - 1);
-    cmp(&set, 0..=5);
-    cmp(&set, 10..100);
-    set.insert(100);
-    cmp(&set, 100..110);
-    cmp(&set, 99..100);
-    cmp(&set, 99..=100);
+    let mut set = DenseBitSet::<TestIdx>::new_empty(300);
+    cmp(&set, idx_range_inclusive(50..=50));
+    set.insert(idx(WORD_BITS));
+    cmp(&set, idx_range_inclusive(WORD_BITS..=WORD_BITS));
+    set.insert(idx(WORD_BITS - 1));
+    cmp(&set, idx_range_inclusive(0..=WORD_BITS - 1));
+    cmp(&set, idx_range_inclusive(0..=5));
+    cmp(&set, idx_range(10..100));
+    set.insert(idx(100));
+    cmp(&set, idx_range(100..110));
+    cmp(&set, idx_range(99..100));
+    cmp(&set, idx_range_inclusive(99..=100));
 
     for i in 0..=WORD_BITS * 2 {
         for j in i..=WORD_BITS * 2 {
             for k in 0..WORD_BITS * 2 {
-                let mut set = DenseBitSet::new_empty(300);
-                cmp(&set, i..j);
-                cmp(&set, i..=j);
-                set.insert(k);
-                cmp(&set, i..j);
-                cmp(&set, i..=j);
+                let mut set = DenseBitSet::<TestIdx>::new_empty(300);
+                cmp(&set, idx_range(i..j));
+                cmp(&set, idx_range_inclusive(i..=j));
+                set.insert(idx(k));
+                cmp(&set, idx_range(i..j));
+                cmp(&set, idx_range_inclusive(i..=j));
             }
         }
     }
@@ -956,56 +997,19 @@ fn dense_last_set_before() {
 
 #[test]
 fn dense_contains_any() {
-    let mut set: DenseBitSet<usize> = DenseBitSet::new_empty(300);
-    assert!(!set.contains_any(0..300));
-    set.insert_range(10..20);
-    set.insert_range(60..70);
-    set.insert_range(150..=250);
+    let mut set: DenseBitSet<TestIdx> = DenseBitSet::new_empty(300);
+    assert!(!set.contains_any(idx_range(0..300)));
+    set.insert_range(idx_range(10..20));
+    set.insert_range(idx_range(60..70));
+    set.insert_range(idx_range_inclusive(150..=250));
 
-    assert!(set.contains_any(0..30));
-    assert!(set.contains_any(5..100));
-    assert!(set.contains_any(250..255));
+    assert!(set.contains_any(idx_range(0..30)));
+    assert!(set.contains_any(idx_range(5..100)));
+    assert!(set.contains_any(idx_range(250..255)));
 
-    assert!(!set.contains_any(20..59));
-    assert!(!set.contains_any(256..290));
+    assert!(!set.contains_any(idx_range(20..59)));
+    assert!(!set.contains_any(idx_range(256..290)));
 
-    set.insert(22);
-    assert!(set.contains_any(20..59));
-}
-
-#[cfg(any())]
-#[bench]
-fn bench_insert(b: &mut test::Bencher) {
-    let mut bs = DenseBitSet::new_filled(99999usize);
-    b.iter(|| {
-        std::hint::black_box(bs.insert(std::hint::black_box(100u32)));
-    });
-}
-
-#[cfg(any())]
-#[bench]
-fn bench_remove(b: &mut test::Bencher) {
-    let mut bs = DenseBitSet::new_filled(99999usize);
-    b.iter(|| {
-        std::hint::black_box(bs.remove(std::hint::black_box(100u32)));
-    });
-}
-
-#[cfg(any())]
-#[bench]
-fn bench_iter(b: &mut test::Bencher) {
-    let bs = DenseBitSet::new_filled(99999usize);
-    b.iter(|| {
-        bs.iter().map(|b: usize| std::hint::black_box(b)).for_each(drop);
-    });
-}
-
-#[cfg(any())]
-#[bench]
-fn bench_intersect(b: &mut test::Bencher) {
-    let mut ba: DenseBitSet<u32> = DenseBitSet::new_filled(99999usize);
-    let bb = DenseBitSet::new_filled(99999usize);
-    b.iter(|| {
-        ba.intersect(std::hint::black_box(&bb));
-    });
+    set.insert(idx(22));
+    assert!(set.contains_any(idx_range(20..59)));
 }

--- a/crates/data-structures/src/index.rs
+++ b/crates/data-structures/src/index.rs
@@ -18,6 +18,18 @@ macro_rules! newtype_index {
             /// The maximum index value.
             $vis const MAX: Self = Self::new(Self::MAX_INDEX);
         }
+
+        impl $crate::bit_set::Idx for $name {
+            #[inline]
+            fn new(index: usize) -> Self {
+                <$name as $crate::index::Idx>::from_usize(index)
+            }
+
+            #[inline]
+            fn index(self) -> usize {
+                <$name as $crate::index::Idx>::index(self)
+            }
+        }
     )*};
 }
 

--- a/crates/data-structures/src/index.rs
+++ b/crates/data-structures/src/index.rs
@@ -18,18 +18,6 @@ macro_rules! newtype_index {
             /// The maximum index value.
             $vis const MAX: Self = Self::new(Self::MAX_INDEX);
         }
-
-        impl $crate::bit_set::Idx for $name {
-            #[inline]
-            fn new(index: usize) -> Self {
-                <$name as $crate::index::Idx>::from_usize(index)
-            }
-
-            #[inline]
-            fn index(self) -> usize {
-                <$name as $crate::index::Idx>::index(self)
-            }
-        }
     )*};
 }
 

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -18,6 +18,8 @@ pub mod map;
 pub mod sync;
 pub mod trustme;
 
+pub mod bit_set;
+
 mod bump_ext;
 pub use bump_ext::BumpExt;
 


### PR DESCRIPTION
This ports the dense and growable indexed bitset pieces from `rustc_index::bit_set` into `solar-data-structures` so compiler analyses can share one typed bitset implementation instead of carrying local `Vec<u64>` copies.

The MIR liveness `LiveSet` now aliases `GrowableBitSet<ValueId>`, and load PRE's key-universe set now wraps `DenseBitSet` with a private index newtype. The new data-structures module includes focused unit coverage for insertion, iteration, growth, and bit relations.
