### PR TITLE
fix(sema): stabilize diagnostic order

### DIFF
--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use solar_ast::{DataLocation, StateMutability, Visibility};
 use solar_data_structures::{
     Never,
-    map::{FxHashMap, FxHashSet},
+    map::{FxHashSet, FxIndexMap},
     parallel,
 };
 use solar_interface::{Span, diagnostics::ErrorGuaranteed, error_code};
@@ -219,7 +219,7 @@ fn check_external_type_clashes(gcx: Gcx<'_>, contract_id: hir::ContractId) {
         return;
     }
 
-    let mut external_declarations: FxHashMap<B256, Vec<ItemId>> = FxHashMap::default();
+    let mut external_declarations: FxIndexMap<B256, Vec<ItemId>> = FxIndexMap::default();
 
     for item_id in gcx.hir.contract_item_ids(contract_id) {
         match gcx.hir.item(item_id) {

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -21,7 +21,7 @@ use crate::{
 use solar_ast::{FunctionKind, StateMutability, Visibility};
 use solar_data_structures::{
     BumpExt,
-    map::{FxHashMap, FxHashSet},
+    map::{FxHashMap, FxHashSet, FxIndexMap},
 };
 use solar_interface::{
     Ident, Span,
@@ -35,7 +35,7 @@ pub(crate) fn check(gcx: Gcx<'_>, contract_id: ContractId) {
     checker.check();
 }
 
-pub(crate) type InheritedFunctions<'gcx> = FxHashMap<OverrideSignature<'gcx>, Vec<OverrideProxy>>;
+pub(crate) type InheritedFunctions<'gcx> = FxIndexMap<OverrideSignature<'gcx>, Vec<OverrideProxy>>;
 
 struct OverrideChecker<'gcx> {
     gcx: Gcx<'gcx>,
@@ -996,7 +996,7 @@ fn compute_inherited_functions<'gcx>(
     contract_id: ContractId,
 ) -> InheritedFunctions<'gcx> {
     let contract = gcx.hir.contract(contract_id);
-    let mut result: InheritedFunctions<'gcx> = FxHashMap::default();
+    let mut result: InheritedFunctions<'gcx> = FxIndexMap::default();
 
     for &base_id in contract.bases.iter() {
         let base = gcx.hir.contract(base_id);

--- a/tests/ui/typeck/external_type_clashes.stderr
+++ b/tests/ui/typeck/external_type_clashes.stderr
@@ -25,18 +25,6 @@ LL │     function f(a) public {}
 error[9914]: function overload clash during conversion to external types for arguments
    ╭▸ ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
    │
-LL │     function c(address) public pure {}
-   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   ╰╴
-help: other declaration is here
-   ╭▸ ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
-   │
-LL │     function c(address payable) public pure {}
-   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-error[9914]: function overload clash during conversion to external types for arguments
-   ╭▸ ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
-   │
 LL │     function f(address) external pure {}
    │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    ╰╴
@@ -45,6 +33,18 @@ help: other declaration is here
    │
 LL │     function f(address payable) external pure {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[9914]: function overload clash during conversion to external types for arguments
+   ╭▸ ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   │
+LL │     function c(address) public pure {}
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ╰╴
+help: other declaration is here
+   ╭▸ ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC
+   │
+LL │     function c(address payable) public pure {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 error[9914]: function overload clash during conversion to external types for arguments
    ╭▸ ROOT/tests/ui/typeck/external_type_clashes.sol:LL:CC


### PR DESCRIPTION
This stabilizes diagnostics whose emission order came from hash-map iteration. Inherited override signatures and external type clash groups now keep first-seen order by using insertion-ordered maps, so unrelated symbol/hash changes do not reshuffle UI output.

The external type clash snapshot now reflects source order for the affected overloads.
