### PR TITLE
feat(lsp): register watched file notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -43,6 +43,10 @@ tracing.workspace = true
 tokio-util = { workspace = true, features = ["compat"] }
 tokio = { workspace = true, features = ["rt", "io-std"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["io-util", "rt", "sync", "time"] }
+tokio-util = { workspace = true, features = ["compat"] }
+
 [features]
 nightly = ["solar-config/nightly"]
 version = ["solar-config/version"]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -17,11 +17,20 @@ use crate::workspace::manifest::ProjectManifest;
 pub(crate) struct Config {
     workspace_roots: Vec<PathBuf>,
     discovered_projects: Vec<ProjectManifest>,
+    watched_file_dynamic_registration: bool,
 }
 
 impl Config {
     pub(crate) fn new(workspace_roots: Vec<PathBuf>) -> Self {
-        Self { workspace_roots, discovered_projects: Default::default() }
+        Self {
+            workspace_roots,
+            discovered_projects: Default::default(),
+            watched_file_dynamic_registration: false,
+        }
+    }
+
+    pub(crate) fn supports_watched_file_dynamic_registration(&self) -> bool {
+        self.watched_file_dynamic_registration
     }
 
     pub(crate) fn rediscover_workspaces(&mut self) {
@@ -58,6 +67,13 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
     // todo: make this absolute guaranteed
     // The latest LSP spec mandates clients report `workspace_folders`, but some might still report
     // `root_uri`.
+    let watched_file_dynamic_registration = params
+        .capabilities
+        .workspace
+        .and_then(|workspace| workspace.did_change_watched_files)
+        .and_then(|capabilities| capabilities.dynamic_registration)
+        .unwrap_or(false);
+
     let workspace_roots = params
         .workspace_folders
         .map(|workspaces| {
@@ -65,6 +81,9 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
         })
         .filter(|workspaces| !workspaces.is_empty())
         .unwrap_or_else(|| vec![root_path.clone()]);
+
+    let mut config = Config::new(workspace_roots);
+    config.watched_file_dynamic_registration = watched_file_dynamic_registration;
 
     (
         ServerCapabilities {
@@ -79,6 +98,43 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             )),
             ..Default::default()
         },
-        Config::new(workspace_roots),
+        config,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use lsp_types::{
+        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, WorkspaceClientCapabilities,
+    };
+
+    use super::*;
+
+    #[test]
+    fn negotiate_capabilities_records_watched_file_dynamic_registration() {
+        let params = InitializeParams {
+            capabilities: ClientCapabilities {
+                workspace: Some(WorkspaceClientCapabilities {
+                    did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                        dynamic_registration: Some(true),
+                        relative_pattern_support: None,
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let (_, config) = negotiate_capabilities(params);
+
+        assert!(config.supports_watched_file_dynamic_registration());
+    }
+
+    #[test]
+    fn negotiate_capabilities_defaults_watched_file_dynamic_registration_to_false() {
+        let (_, config) = negotiate_capabilities(InitializeParams::default());
+
+        assert!(!config.supports_watched_file_dynamic_registration());
+    }
 }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -21,14 +21,6 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub(crate) fn new(workspace_roots: Vec<PathBuf>) -> Self {
-        Self {
-            workspace_roots,
-            discovered_projects: Default::default(),
-            watched_file_dynamic_registration: false,
-        }
-    }
-
     pub(crate) fn supports_watched_file_dynamic_registration(&self) -> bool {
         self.watched_file_dynamic_registration
     }
@@ -80,10 +72,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             workspaces.into_iter().filter_map(|it| it.uri.to_file_path().ok()).collect::<Vec<_>>()
         })
         .filter(|workspaces| !workspaces.is_empty())
-        .unwrap_or_else(|| vec![root_path.clone()]);
-
-    let mut config = Config::new(workspace_roots);
-    config.watched_file_dynamic_registration = watched_file_dynamic_registration;
+        .unwrap_or_else(|| vec![root_path]);
 
     (
         ServerCapabilities {
@@ -98,43 +87,32 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             )),
             ..Default::default()
         },
-        config,
+        Config { workspace_roots, watched_file_dynamic_registration, ..Default::default() },
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use lsp_types::{
-        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, WorkspaceClientCapabilities,
-    };
+    use lsp_types::{DidChangeWatchedFilesClientCapabilities, WorkspaceClientCapabilities};
 
     use super::*;
 
     #[test]
-    fn negotiate_capabilities_records_watched_file_dynamic_registration() {
-        let params = InitializeParams {
-            capabilities: ClientCapabilities {
-                workspace: Some(WorkspaceClientCapabilities {
-                    did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
-                        dynamic_registration: Some(true),
-                        relative_pattern_support: None,
-                    }),
-                    ..Default::default()
-                }),
+    fn negotiate_capabilities_records_watched_file_dynamic_registration_support() {
+        let (_, config) = negotiate_capabilities(InitializeParams::default());
+        assert!(!config.supports_watched_file_dynamic_registration());
+
+        let mut params = InitializeParams::default();
+        params.capabilities.workspace = Some(WorkspaceClientCapabilities {
+            did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                dynamic_registration: Some(true),
                 ..Default::default()
-            },
+            }),
             ..Default::default()
-        };
+        });
 
         let (_, config) = negotiate_capabilities(params);
 
         assert!(config.supports_watched_file_dynamic_registration());
-    }
-
-    #[test]
-    fn negotiate_capabilities_defaults_watched_file_dynamic_registration_to_false() {
-        let (_, config) = negotiate_capabilities(InitializeParams::default());
-
-        assert!(!config.supports_watched_file_dynamic_registration());
     }
 }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -10,8 +10,10 @@ use std::{
 
 use async_lsp::{ClientSocket, LanguageClient, ResponseError};
 use lsp_types::{
-    Diagnostic, InitializeParams, InitializeResult, InitializedParams, LogMessageParams,
-    MessageType, PublishDiagnosticsParams, ServerInfo, Url,
+    Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern,
+    InitializeParams, InitializeResult, InitializedParams, LogMessageParams, MessageType,
+    PublishDiagnosticsParams, Registration, RegistrationParams, ServerInfo, Url, WatchKind,
+    notification::{self, Notification},
 };
 use solar_config::version::SHORT_VERSION;
 use solar_interface::{
@@ -68,6 +70,17 @@ impl GlobalState {
     }
 
     pub(crate) fn on_initialized(&mut self, _: InitializedParams) -> NotifyResult {
+        if self.config.supports_watched_file_dynamic_registration() {
+            let mut client = self.client.clone();
+            tokio::spawn(async move {
+                if let Err(error) =
+                    client.register_capability(watched_file_registration_params()).await
+                {
+                    tracing::warn!(%error, "failed to register watched-file notifications");
+                }
+            });
+        }
+
         let _ = self.client.log_message(LogMessageParams {
             typ: MessageType::INFO,
             message: "solar initialized".into(),
@@ -166,6 +179,24 @@ impl GlobalState {
     }
 }
 
+fn watched_file_registration_params() -> RegistrationParams {
+    let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
+    let options = DidChangeWatchedFilesRegistrationOptions {
+        watchers: vec![
+            FileSystemWatcher { glob_pattern: GlobPattern::String("**/*.sol".into()), kind },
+            FileSystemWatcher { glob_pattern: GlobPattern::String("**/foundry.toml".into()), kind },
+        ],
+    };
+
+    RegistrationParams {
+        registrations: vec![Registration {
+            id: "solar-watched-files".into(),
+            method: notification::DidChangeWatchedFiles::METHOD.into(),
+            register_options: Some(serde_json::to_value(options).unwrap()),
+        }],
+    }
+}
+
 pub(crate) struct GlobalStateSnapshot {
     client: ClientSocket,
     vfs: Arc<RwLock<Vfs>>,
@@ -237,9 +268,39 @@ impl GlobalStateSnapshot {
 #[cfg(test)]
 mod tests {
     use async_lsp::ClientSocket;
-    use lsp_types::{Diagnostic, Position, Range};
+    use lsp_types::{
+        Diagnostic, DidChangeWatchedFilesRegistrationOptions, GlobPattern, Position, Range,
+        RegistrationParams, WatchKind, notification::Notification,
+    };
 
     use super::*;
+
+    #[test]
+    fn watched_file_registration_watches_solidity_and_foundry_manifests() {
+        let params = watched_file_registration_params();
+        let RegistrationParams { registrations } = params;
+        assert_eq!(registrations.len(), 1);
+
+        let registration = registrations.into_iter().next().unwrap();
+        assert_eq!(registration.id, "solar-watched-files");
+        assert_eq!(registration.method, lsp_types::notification::DidChangeWatchedFiles::METHOD);
+
+        let options: DidChangeWatchedFilesRegistrationOptions =
+            serde_json::from_value(registration.register_options.unwrap()).unwrap();
+        let patterns = options
+            .watchers
+            .iter()
+            .map(|watcher| match &watcher.glob_pattern {
+                GlobPattern::String(pattern) => pattern.as_str(),
+                GlobPattern::Relative(_) => panic!("expected string glob pattern"),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(patterns, ["**/*.sol", "**/foundry.toml"]);
+        assert!(options.watchers.iter().all(|watcher| {
+            watcher.kind == Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete)
+        }));
+    }
 
     #[test]
     fn publish_diagnostic_set_retains_unrelated_diagnostics() {

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -13,7 +13,7 @@ use lsp_types::{
     Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern,
     InitializeParams, InitializeResult, InitializedParams, LogMessageParams, MessageType,
     PublishDiagnosticsParams, Registration, RegistrationParams, ServerInfo, Url, WatchKind,
-    notification::{self, Notification},
+    notification::{DidChangeWatchedFiles, Notification},
 };
 use solar_config::version::SHORT_VERSION;
 use solar_interface::{
@@ -191,7 +191,7 @@ fn watched_file_registration_params() -> RegistrationParams {
     RegistrationParams {
         registrations: vec![Registration {
             id: "solar-watched-files".into(),
-            method: notification::DidChangeWatchedFiles::METHOD.into(),
+            method: DidChangeWatchedFiles::METHOD.into(),
             register_options: Some(serde_json::to_value(options).unwrap()),
         }],
     }
@@ -268,38 +268,25 @@ impl GlobalStateSnapshot {
 #[cfg(test)]
 mod tests {
     use async_lsp::ClientSocket;
-    use lsp_types::{
-        Diagnostic, DidChangeWatchedFilesRegistrationOptions, GlobPattern, Position, Range,
-        RegistrationParams, WatchKind, notification::Notification,
-    };
+    use lsp_types::{Diagnostic, Position, Range, WatchKind, notification::Notification};
 
     use super::*;
 
     #[test]
     fn watched_file_registration_watches_solidity_and_foundry_manifests() {
-        let params = watched_file_registration_params();
-        let RegistrationParams { registrations } = params;
-        assert_eq!(registrations.len(), 1);
-
-        let registration = registrations.into_iter().next().unwrap();
+        let [registration] = watched_file_registration_params().registrations.try_into().unwrap();
         assert_eq!(registration.id, "solar-watched-files");
         assert_eq!(registration.method, lsp_types::notification::DidChangeWatchedFiles::METHOD);
 
-        let options: DidChangeWatchedFilesRegistrationOptions =
-            serde_json::from_value(registration.register_options.unwrap()).unwrap();
-        let patterns = options
-            .watchers
-            .iter()
-            .map(|watcher| match &watcher.glob_pattern {
-                GlobPattern::String(pattern) => pattern.as_str(),
-                GlobPattern::Relative(_) => panic!("expected string glob pattern"),
-            })
-            .collect::<Vec<_>>();
-
-        assert_eq!(patterns, ["**/*.sol", "**/foundry.toml"]);
-        assert!(options.watchers.iter().all(|watcher| {
-            watcher.kind == Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete)
-        }));
+        assert_eq!(
+            registration.register_options,
+            Some(serde_json::json!({
+                "watchers": [
+                    { "globPattern": "**/*.sol", "kind": WatchKind::Create | WatchKind::Change | WatchKind::Delete },
+                    { "globPattern": "**/foundry.toml", "kind": WatchKind::Create | WatchKind::Change | WatchKind::Delete },
+                ],
+            }))
+        );
     }
 
     #[test]

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -88,13 +88,12 @@ mod tests {
 
     use async_lsp::{AnyNotification, LanguageServer, LspService, router::Router};
     use lsp_types::{
-        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
-        FileChangeType, FileEvent, InitializeParams, InitializedParams, RegistrationParams,
-        WorkspaceClientCapabilities, notification as notif, notification::Notification, request,
+        DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams, FileChangeType,
+        FileEvent, InitializeParams, InitializedParams, WorkspaceClientCapabilities,
+        notification as notif, notification::Notification, request,
     };
     use tokio::sync::oneshot;
     use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
-    use tower::ServiceBuilder;
 
     use super::*;
 
@@ -122,21 +121,12 @@ mod tests {
     fn initialized_registers_watched_files_when_client_supports_dynamic_registration() {
         tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap().block_on(
             async {
-                struct ClientState {
-                    registration_tx: Option<oneshot::Sender<RegistrationParams>>,
-                }
-
-                let (server_main, _client) = async_lsp::MainLoop::new_server(|client| {
-                    ServiceBuilder::new()
-                        .layer(async_lsp::server::LifecycleLayer::default())
-                        .service(new_router(client))
-                });
+                let (server_main, _client) = async_lsp::MainLoop::new_server(new_router);
                 let (registration_tx, registration_rx) = oneshot::channel();
                 let (client_main, mut server) = async_lsp::MainLoop::new_client(|_| {
-                    let mut router =
-                        Router::new(ClientState { registration_tx: Some(registration_tx) });
+                    let mut router = Router::new(Some(registration_tx));
                     router.request::<request::RegisterCapability, _>(|state, params| {
-                        state.registration_tx.take().unwrap().send(params).unwrap();
+                        state.take().unwrap().send(params).unwrap();
                         async move { Ok(()) }
                     });
                     router.notification::<notif::LogMessage>(|_, _| ControlFlow::Continue(()));
@@ -157,24 +147,15 @@ mod tests {
                         async move { client_main.run_buffered(client_rx, client_tx).await },
                     );
 
-                server
-                    .initialize(InitializeParams {
-                        capabilities: ClientCapabilities {
-                            workspace: Some(WorkspaceClientCapabilities {
-                                did_change_watched_files: Some(
-                                    DidChangeWatchedFilesClientCapabilities {
-                                        dynamic_registration: Some(true),
-                                        relative_pattern_support: None,
-                                    },
-                                ),
-                                ..Default::default()
-                            }),
-                            ..Default::default()
-                        },
+                let mut params = InitializeParams::default();
+                params.capabilities.workspace = Some(WorkspaceClientCapabilities {
+                    did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                        dynamic_registration: Some(true),
                         ..Default::default()
-                    })
-                    .await
-                    .unwrap();
+                    }),
+                    ..Default::default()
+                });
+                server.initialize(params).await.unwrap();
                 server.initialized(InitializedParams {}).unwrap();
 
                 let registrations =
@@ -182,11 +163,8 @@ mod tests {
                         .await
                         .unwrap()
                         .unwrap();
-                assert_eq!(registrations.registrations.len(), 1);
-                assert_eq!(
-                    registrations.registrations[0].method,
-                    notif::DidChangeWatchedFiles::METHOD
-                );
+                let [registration] = registrations.registrations.try_into().unwrap();
+                assert_eq!(registration.method, notif::DidChangeWatchedFiles::METHOD);
 
                 server.shutdown(()).await.unwrap();
                 server.exit(()).unwrap();

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -86,10 +86,15 @@ pub async fn run_server_stdio(_args: LspArgs) -> async_lsp::Result<()> {
 mod tests {
     use std::ops::ControlFlow;
 
-    use async_lsp::{AnyNotification, LspService};
+    use async_lsp::{AnyNotification, LanguageServer, LspService, router::Router};
     use lsp_types::{
-        DidChangeWatchedFilesParams, FileChangeType, FileEvent, notification::Notification,
+        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
+        FileChangeType, FileEvent, InitializeParams, InitializedParams, RegistrationParams,
+        WorkspaceClientCapabilities, notification as notif, notification::Notification, request,
     };
+    use tokio::sync::oneshot;
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+    use tower::ServiceBuilder;
 
     use super::*;
 
@@ -111,5 +116,83 @@ mod tests {
 
             assert!(matches!(router.notify(notification), ControlFlow::Continue(())));
         });
+    }
+
+    #[test]
+    fn initialized_registers_watched_files_when_client_supports_dynamic_registration() {
+        tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap().block_on(
+            async {
+                struct ClientState {
+                    registration_tx: Option<oneshot::Sender<RegistrationParams>>,
+                }
+
+                let (server_main, _client) = async_lsp::MainLoop::new_server(|client| {
+                    ServiceBuilder::new()
+                        .layer(async_lsp::server::LifecycleLayer::default())
+                        .service(new_router(client))
+                });
+                let (registration_tx, registration_rx) = oneshot::channel();
+                let (client_main, mut server) = async_lsp::MainLoop::new_client(|_| {
+                    let mut router =
+                        Router::new(ClientState { registration_tx: Some(registration_tx) });
+                    router.request::<request::RegisterCapability, _>(|state, params| {
+                        state.registration_tx.take().unwrap().send(params).unwrap();
+                        async move { Ok(()) }
+                    });
+                    router.notification::<notif::LogMessage>(|_, _| ControlFlow::Continue(()));
+                    router
+                });
+
+                let (server_stream, client_stream) = tokio::io::duplex(64 << 10);
+                let (server_rx, server_tx) = tokio::io::split(server_stream);
+                let (server_rx, server_tx) = (server_rx.compat(), server_tx.compat_write());
+                let server_main =
+                    tokio::spawn(
+                        async move { server_main.run_buffered(server_rx, server_tx).await },
+                    );
+                let (client_rx, client_tx) = tokio::io::split(client_stream);
+                let (client_rx, client_tx) = (client_rx.compat(), client_tx.compat_write());
+                let client_main =
+                    tokio::spawn(
+                        async move { client_main.run_buffered(client_rx, client_tx).await },
+                    );
+
+                server
+                    .initialize(InitializeParams {
+                        capabilities: ClientCapabilities {
+                            workspace: Some(WorkspaceClientCapabilities {
+                                did_change_watched_files: Some(
+                                    DidChangeWatchedFilesClientCapabilities {
+                                        dynamic_registration: Some(true),
+                                        relative_pattern_support: None,
+                                    },
+                                ),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap();
+                server.initialized(InitializedParams {}).unwrap();
+
+                let registrations =
+                    tokio::time::timeout(std::time::Duration::from_secs(1), registration_rx)
+                        .await
+                        .unwrap()
+                        .unwrap();
+                assert_eq!(registrations.registrations.len(), 1);
+                assert_eq!(
+                    registrations.registrations[0].method,
+                    notif::DidChangeWatchedFiles::METHOD
+                );
+
+                server.shutdown(()).await.unwrap();
+                server.exit(()).unwrap();
+                assert!(server_main.await.unwrap().is_ok());
+                assert!(matches!(client_main.await.unwrap(), Err(async_lsp::Error::Eof)));
+            },
+        );
     }
 }


### PR DESCRIPTION
Towards OSS-403 .

Registers `workspace/didChangeWatchedFiles` dynamically when the client advertises support for watched-file dynamic registration.

This lets the language server ask the client to watch Solidity sources and Foundry manifests:

  - `**/*.sol`
  - `**/foundry.toml`

With these registrations in place, saved Solidity file changes can trigger diagnostics recomputation even when the file is not open in the editor, and `foundry.toml` changes can trigger workspace rediscovery before recomputing diagnostics.

Also adds focused coverage for capability negotiation, watched-file registration parameters, and the initialized LSP flow that sends the dynamic registration request.

cc @DaniPopes 