### PR TITLE
fix: avoid unused ui_test patch warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,3 @@ vergen = { package = "vergen-gitcl", version = "10.0.0-beta.5" }
 # by the `url` crate.
 # See the `idna_adapter` README.md for more details: https://docs.rs/crate/idna_adapter/latest
 idna_adapter = "=1.1.0"
-
-[patch.crates-io]
-ui_test = { git = "https://github.com/DaniPopes/ui_test", branch = "fork" }

--- a/tools/tester/Cargo.toml
+++ b/tools/tester/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 [dependencies]
 regex.workspace = true
 tempfile.workspace = true
-ui_test = "0.30.5"
+ui_test = { git = "https://github.com/DaniPopes/ui_test", branch = "fork", version = "0.30.5" }
 
 [features]
 nightly = []


### PR DESCRIPTION
This moves the ui_test fork from a workspace-wide crates.io patch to the internal test runner's direct dependency. Install-only package graphs no longer see an unused patch, while UI tests still use the same forked ui_test source.

The profile package warnings on un-locked path installs are separate from this patch warning: they come from package-specific profile overrides for the UI test stack when Cargo resolves only the install graph. The documented locked path install resolves cleanly.
