### PR TITLE
fix(parser): clear error literal denominations

### DIFF
--- a/crates/parse/src/parser/lit.rs
+++ b/crates/parse/src/parser/lit.rs
@@ -92,6 +92,9 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         };
         let kind =
             result.unwrap_or_else(|e| LitKind::Err(e.span(lo.to(self.prev_token.span)).emit()));
+        if matches!(kind, LitKind::Err(_)) {
+            subdenomination = None;
+        }
         Ok((lit.symbol, kind, subdenomination))
     }
 

--- a/tests/ui/resolve/denominations.sol
+++ b/tests/ui/resolve/denominations.sol
@@ -2,6 +2,9 @@ contract C {
     uint256 public a = 0x123 ether; //~ ERROR: cannot be used with unit denominations
     uint256 public b = 0x123 days; //~ ERROR: cannot be used with unit denominations
     uint256 public h = 1 years; //~ ERROR: unit denomination is deprecated
+    uint256 public n = 1e+ seconds;
+    //~^ ERROR: expected at least one digit in exponent
+    //~| ERROR: `+` is not allowed in the exponent
 
     // OK
     uint256 public i = 1 seconds;

--- a/tests/ui/resolve/denominations.stderr
+++ b/tests/ui/resolve/denominations.stderr
@@ -1,3 +1,15 @@
+error: expected at least one digit in exponent
+   ╭▸ ROOT/tests/ui/resolve/denominations.sol:LL:CC
+   │
+LL │     uint256 public n = 1e+ seconds;
+   ╰╴                       ━━━
+
+error: `+` is not allowed in the exponent
+   ╭▸ ROOT/tests/ui/resolve/denominations.sol:LL:CC
+   │
+LL │     uint256 public n = 1e+ seconds;
+   ╰╴                       ━━━━━━━━━━━
+
 error: hexadecimal numbers cannot be used with unit denominations
    ╭▸ ROOT/tests/ui/resolve/denominations.sol:LL:CC
    │
@@ -20,5 +32,5 @@ error: using "years" as a unit denomination is deprecated
 LL │     uint256 public h = 1 years;
    ╰╴                       ━━━━━━━
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Malformed numeric literals can carry a parsed denomination even after literal parsing recovers them as error literals. This clears the denomination on error literals so AST validation preserves its invariant and reports the original parse errors instead of panicking.
