### PR TITLE
chore: bump vergen to v10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ thread_local = "1.1"
 tokio = { version = "1.47", default-features = false }
 tokio-util = { version = "0.7", default-features = false }
 unicode-width = "0.2"
-vergen = { package = "vergen-gitcl", version = "10.0.0-beta.5" }
+vergen = { package = "vergen-gitcl", version = "10" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/solar.
 


### PR DESCRIPTION
This removes the stale beta version constraint from the workspace vergen-gitcl dependency and allows the stable v10 line already resolved in Cargo.lock.