### PR TITLE
test(lsp): add shared test fixtures

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -148,12 +148,8 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workspace::WorkspaceKind;
-    use lsp_types::{
-        DidChangeWatchedFilesClientCapabilities, WorkspaceClientCapabilities, WorkspaceFolder,
-    };
-    use std::fs;
-    use tempfile::TempDir;
+    use crate::{test_support::TestProject, workspace::WorkspaceKind};
+    use lsp_types::{DidChangeWatchedFilesClientCapabilities, WorkspaceClientCapabilities};
 
     #[test]
     fn negotiate_capabilities_records_watched_file_dynamic_registration_support() {
@@ -176,32 +172,16 @@ mod tests {
 
     #[test]
     fn rediscover_workspaces_loads_manifests_and_falls_back_to_naked_roots() {
-        let configured = TempDir::new().unwrap();
-        fs::write(
-            configured.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "contracts"
-            "#,
-        )
-        .unwrap();
-        let naked = TempDir::new().unwrap();
+            //- /configured/foundry.toml
+            [profile.default]
+            src = "contracts"
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![
-                WorkspaceFolder {
-                    uri: lsp_types::Url::from_file_path(configured.path()).unwrap(),
-                    name: "configured".into(),
-                },
-                WorkspaceFolder {
-                    uri: lsp_types::Url::from_file_path(naked.path()).unwrap(),
-                    name: "naked".into(),
-                },
-            ]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
+            //- /naked/.keep
+            "#,
+        );
+        let mut config = project.config_with_roots(&["/configured", "/naked"]);
 
         assert_eq!(config.workspaces().len(), 2);
         let foundry = config
@@ -209,9 +189,9 @@ mod tests {
             .iter()
             .find(|workspace| workspace.kind() == WorkspaceKind::Foundry)
             .unwrap();
-        assert_eq!(foundry.source_roots(), &[configured.path().join("contracts")]);
+        assert_eq!(foundry.source_roots(), &[project.path("/configured/contracts")]);
 
-        fs::remove_file(configured.path().join("foundry.toml")).unwrap();
+        project.remove_file("/configured/foundry.toml");
         config.rediscover_workspaces();
 
         assert_eq!(config.workspaces().len(), 2);
@@ -222,43 +202,27 @@ mod tests {
 
     #[test]
     fn rediscover_workspaces_keeps_naked_root_after_manifest_load_error() {
-        let broken = TempDir::new().unwrap();
-        fs::write(broken.path().join("foundry.toml"), "not valid toml =").unwrap();
-        let configured = TempDir::new().unwrap();
-        fs::write(
-            configured.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "contracts"
+            //- /broken/foundry.toml
+            not valid toml =
+
+            //- /configured/foundry.toml
+            [profile.default]
+            src = "contracts"
             "#,
-        )
-        .unwrap();
-
-        let params = InitializeParams {
-            workspace_folders: Some(vec![
-                WorkspaceFolder {
-                    uri: lsp_types::Url::from_file_path(broken.path()).unwrap(),
-                    name: "broken".into(),
-                },
-                WorkspaceFolder {
-                    uri: lsp_types::Url::from_file_path(configured.path()).unwrap(),
-                    name: "configured".into(),
-                },
-            ]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-
-        config.rediscover_workspaces();
+        );
+        let config = project.config_with_roots(&["/broken", "/configured"]);
 
         assert_eq!(config.workspaces().len(), 2);
         assert!(config.workspaces().iter().any(|workspace| {
             workspace.kind() == WorkspaceKind::Naked
-                && workspace.compile_opts().base_path.as_deref() == Some(broken.path())
+                && workspace.compile_opts().base_path.as_deref()
+                    == Some(project.path("/broken").as_path())
         }));
         assert!(config.workspaces().iter().any(|workspace| {
             workspace.kind() == WorkspaceKind::Foundry
-                && workspace.source_roots() == [configured.path().join("contracts")]
+                && workspace.source_roots() == [project.path("/configured/contracts")]
         }));
     }
 }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -371,12 +371,24 @@ fn analyze(batch: AnalysisBatch) -> AnalysisResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::symbols::DeclarationKind;
+    use crate::{symbols::DeclarationKind, test_support::TestProject};
     use async_lsp::ClientSocket;
-    use crop::Rope;
     use lsp_types::{Diagnostic, Position, Range, WatchKind, notification::Notification};
-    use std::fs;
-    use tempfile::TempDir;
+
+    fn snapshot(project: &TestProject) -> GlobalStateSnapshot {
+        snapshot_with_config(project.config(), project.vfs())
+    }
+
+    fn snapshot_with_config(config: Config, vfs: Vfs) -> GlobalStateSnapshot {
+        GlobalStateSnapshot {
+            client: ClientSocket::new_closed(),
+            vfs: Arc::new(RwLock::new(vfs)),
+            config: Arc::new(config),
+            analysis_version: Arc::new(AtomicUsize::new(1)),
+            symbol_tables: Arc::new(Default::default()),
+            published_diagnostic_uris: Arc::new(Default::default()),
+        }
+    }
 
     #[test]
     fn watched_file_registration_watches_solidity_and_foundry_manifests() {
@@ -431,32 +443,18 @@ mod tests {
 
     #[test]
     fn analysis_batches_read_tracked_disk_files() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        fs::create_dir_all(&src).unwrap();
-        fs::write(project.path().join("foundry.toml"), "[profile.default]\nsrc = \"src\"\n")
-            .unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-
-        let path = src.join("Saved.sol");
-        std::fs::write(&path, "contract C { function f() public { number+; } }").unwrap();
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+            //- /src/Saved.sol
+            contract C { function f() public { number+; } }
+            "#,
+        );
+        let path = project.path("/src/Saved.sol");
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(vec![path.clone()]);
         let batch = batches.pop().unwrap();
@@ -469,35 +467,18 @@ mod tests {
 
     #[test]
     fn analysis_batches_ignore_naked_workspace_disk_files() {
-        let project = TempDir::new().unwrap();
-        let disk_path = project.path().join("Disk.sol");
-        let open_path = project.path().join("Open.sol");
-        fs::write(&disk_path, "contract Disk {}").unwrap();
-        fs::write(&open_path, "contract Open {}").unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /Disk.sol
+            contract Disk {}
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-
-        let mut vfs = Vfs::default();
-        vfs.set_file_contents(
-            crate::vfs::VfsPath::from(open_path.clone()),
-            Some(Rope::from("contract Open { function f() public { number+; } }")),
+            //- /Open.sol open
+            contract Open { function f() public { number+; } }
+            "#,
         );
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(RwLock::new(vfs)),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+        let disk_path = project.path("/Disk.sol");
+        let open_path = project.path("/Open.sol");
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(vec![disk_path]);
         let batch = batches.pop().unwrap();
@@ -510,44 +491,22 @@ mod tests {
 
     #[test]
     fn analysis_batches_scan_workspace_source_roots_and_apply_vfs_overlay() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        fs::create_dir_all(&src).unwrap();
-        let source_path = src.join("A.sol");
-        fs::write(&source_path, "contract A {}").unwrap();
-        fs::write(src.join("ignored.txt"), "not solidity").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let mut project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "src"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+
+            //- /src/A.sol
+            contract A {}
+
+            //- /src/ignored.txt
+            not solidity
             "#,
-        )
-        .unwrap();
-
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-
-        let mut vfs = Vfs::default();
-        vfs.set_file_contents(
-            crate::vfs::VfsPath::from(source_path.clone()),
-            Some(Rope::from("contract A { function f() public { number+; } }")),
         );
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(RwLock::new(vfs)),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+        project.open_file("/src/A.sol", "contract A { function f() public { number+; } }");
+        let source_path = project.path("/src/A.sol");
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(Vec::new());
         assert_eq!(batches.len(), 1);
@@ -557,63 +516,37 @@ mod tests {
             batch.files,
             vec![(source_path, "contract A { function f() public { number+; } }".into())]
         );
-        assert_eq!(batch.opts.base_path.as_deref(), Some(project.path()));
+        assert_eq!(batch.opts.base_path.as_deref(), Some(project.root()));
     }
 
     #[test]
     fn analysis_batches_use_cached_workspace_source_files() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        fs::create_dir_all(&src).unwrap();
-        let cached_path = src.join("Cached.sol");
-        let created_after_discovery = src.join("CreatedAfterDiscovery.sol");
-        fs::write(&cached_path, "contract Cached {}").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "src"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+
+            //- /src/Cached.sol
+            contract Cached {}
             "#,
-        )
-        .unwrap();
+        );
+        let cached_path = project.path("/src/Cached.sol");
+        let created_after_discovery = project.path("/src/CreatedAfterDiscovery.sol");
+        let mut config = project.config();
+        project.write_file("/src/CreatedAfterDiscovery.sol", "contract CreatedAfterDiscovery {}");
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-        fs::write(&created_after_discovery, "contract CreatedAfterDiscovery {}").unwrap();
-
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config.clone()),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+        let snapshot = snapshot_with_config(config.clone(), Vfs::default());
 
         let mut batches = snapshot.analysis_batches(Vec::new());
         let batch = batches.pop().unwrap();
         assert_eq!(batch.files, vec![(cached_path, "contract Cached {}".into())]);
 
         config.add_source_file(created_after_discovery.clone());
-        let outside_source_root = project.path().join("test/Outside.sol");
-        fs::create_dir_all(outside_source_root.parent().unwrap()).unwrap();
-        fs::write(&outside_source_root, "contract Outside {}").unwrap();
+        let outside_source_root = project.path("/test/Outside.sol");
+        project.write_file("/test/Outside.sol", "contract Outside {}");
         config.add_source_file(outside_source_root.clone());
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+        let snapshot = snapshot_with_config(config, Vfs::default());
 
         let mut batches = snapshot.analysis_batches(Vec::new());
         let batch = batches.pop().unwrap();
@@ -623,45 +556,21 @@ mod tests {
 
     #[test]
     fn analysis_batches_assign_open_files_to_most_specific_workspace() {
-        let project = TempDir::new().unwrap();
-        let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        let source_path = nested.join("A.sol");
-        fs::write(&source_path, "contract A {}").unwrap();
-
-        let params = InitializeParams {
-            workspace_folders: Some(vec![
-                lsp_types::WorkspaceFolder {
-                    uri: Url::from_file_path(project.path()).unwrap(),
-                    name: "outer".into(),
-                },
-                lsp_types::WorkspaceFolder {
-                    uri: Url::from_file_path(&nested).unwrap(),
-                    name: "inner".into(),
-                },
-            ]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-        let mut vfs = Vfs::default();
-        vfs.set_file_contents(
-            crate::vfs::VfsPath::from(source_path.clone()),
-            Some(Rope::from("contract A {}")),
+        let project = TestProject::from_fixture(
+            r#"
+            //- /nested/A.sol open
+            contract A {}
+            "#,
         );
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(RwLock::new(vfs)),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+        let source_path = project.path("/nested/A.sol");
+        let nested = project.path("/nested");
+        let config = project.config_with_roots(&["/", "/nested"]);
+        let snapshot = snapshot_with_config(config, project.vfs());
 
         let batches = snapshot.analysis_batches(Vec::new());
         let outer_batch = batches
             .iter()
-            .find(|batch| batch.opts.base_path.as_deref() == Some(project.path()))
+            .find(|batch| batch.opts.base_path.as_deref() == Some(project.root()))
             .unwrap();
         let inner_batch = batches
             .iter()
@@ -674,40 +583,21 @@ mod tests {
 
     #[test]
     fn analysis_uses_workspace_remappings_for_import_resolution() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        let lib = project.path().join("lib");
-        fs::create_dir_all(&src).unwrap();
-        fs::create_dir_all(&lib).unwrap();
-        fs::write(src.join("A.sol"), r#"import "@lib/B.sol"; contract A is B {}"#).unwrap();
-        fs::write(lib.join("B.sol"), "contract B {}").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "src"
-                remappings = ["@lib=lib/"]
-            "#,
-        )
-        .unwrap();
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+            remappings = ["@lib=lib/"]
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+            //- /src/A.sol
+            import "@lib/B.sol"; contract A is B {}
+
+            //- /lib/B.sol
+            contract B {}
+            "#,
+        );
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(Vec::new());
         assert_eq!(batches.len(), 1);
@@ -718,37 +608,20 @@ mod tests {
 
     #[test]
     fn analysis_resolves_relative_imports_when_cwd_differs_from_workspace_root() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        fs::create_dir_all(&src).unwrap();
-        fs::write(src.join("A.sol"), r#"import "./B.sol"; contract A is B {}"#).unwrap();
-        fs::write(src.join("B.sol"), "contract B {}").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "src"
-            "#,
-        )
-        .unwrap();
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+            //- /src/A.sol
+            import "./B.sol"; contract A is B {}
+
+            //- /src/B.sol
+            contract B {}
+            "#,
+        );
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(Vec::new());
         assert_eq!(batches.len(), 1);
@@ -759,40 +632,20 @@ mod tests {
 
     #[test]
     fn analysis_uses_foundry_auto_remappings_for_import_resolution() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        let forge_std = project.path().join("lib/forge-std/src");
-        fs::create_dir_all(&src).unwrap();
-        fs::create_dir_all(&forge_std).unwrap();
-        fs::write(src.join("A.sol"), r#"import "forge-std/Test.sol"; contract A is Test {}"#)
-            .unwrap();
-        fs::write(forge_std.join("Test.sol"), "contract Test {}").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "src"
-            "#,
-        )
-        .unwrap();
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+            //- /src/A.sol
+            import "forge-std/Test.sol"; contract A is Test {}
+
+            //- /lib/forge-std/src/Test.sol
+            contract Test {}
+            "#,
+        );
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(Vec::new());
         assert_eq!(batches.len(), 1);
@@ -803,31 +656,17 @@ mod tests {
 
     #[test]
     fn analysis_batches_skip_unreadable_disk_files() {
-        let project = TempDir::new().unwrap();
-        let src = project.path().join("src");
-        fs::create_dir_all(&src).unwrap();
-        fs::write(project.path().join("foundry.toml"), "[profile.default]\nsrc = \"src\"\n")
-            .unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
 
-        let params = InitializeParams {
-            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
-                uri: Url::from_file_path(project.path()).unwrap(),
-                name: "test".into(),
-            }]),
-            ..Default::default()
-        };
-        let (_, mut config) = negotiate_capabilities(params);
-        config.rediscover_workspaces();
-
-        let path = src.join("Missing.sol");
-        let snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(config),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
-        };
+            //- /src/.keep
+            "#,
+        );
+        let path = project.path("/src/Missing.sol");
+        let snapshot = snapshot(&project);
 
         let mut batches = snapshot.analysis_batches(vec![path]);
         let batch = batches.pop().unwrap();
@@ -837,36 +676,35 @@ mod tests {
 
     #[test]
     fn analyze_builds_declaration_symbol_table() {
-        let file = tempfile::Builder::new().suffix("-Symbols.sol").tempfile().unwrap();
-        let path = file.path().to_path_buf();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /Symbols.sol
+            contract C {
+                uint256 public x;
+                struct S { uint256 field; }
+                struct GetterValue {
+                    uint256 visible;
+                    uint256 other;
+                    mapping(uint256 => uint256) hidden;
+                }
+                mapping(uint256 key => uint256 value) public getterMap;
+                mapping(uint256 key => GetterValue value) public getterValues;
+                constructor() {}
+                fallback() external {}
+                receive() external payable {}
+                function f(uint256 y) public returns (uint256 z) {
+                    uint256 local = x + y;
+                    return local;
+                }
+            }
+            enum E { A }
+            "#,
+        );
+        let path = project.path("/Symbols.sol");
         let uri = Url::from_file_path(&path).unwrap();
         let result = analyze(AnalysisBatch {
             opts: CompileOpts::default(),
-            files: vec![(
-                path,
-                r#"
-contract C {
-    uint256 public x;
-    struct S { uint256 field; }
-    struct GetterValue {
-        uint256 visible;
-        uint256 other;
-        mapping(uint256 => uint256) hidden;
-    }
-    mapping(uint256 key => uint256 value) public getterMap;
-    mapping(uint256 key => GetterValue value) public getterValues;
-    constructor() {}
-    fallback() external {}
-    receive() external payable {}
-    function f(uint256 y) public returns (uint256 z) {
-        uint256 local = x + y;
-        return local;
-    }
-}
-enum E { A }
-"#
-                .into(),
-            )],
+            files: vec![(path, project.read_file("/Symbols.sol"))],
             seen_paths: FxHashSet::default(),
         });
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -26,6 +26,9 @@ mod utils;
 mod vfs;
 mod workspace;
 
+#[cfg(test)]
+mod test_support;
+
 pub(crate) type NotifyResult = ControlFlow<async_lsp::Result<()>>;
 
 fn new_router(client: ClientSocket) -> Router<GlobalState> {

--- a/crates/lsp/src/test_support.rs
+++ b/crates/lsp/src/test_support.rs
@@ -6,6 +6,7 @@ use crop::Rope;
 use lsp_types::{InitializeParams, Url, WorkspaceFolder};
 use std::{
     fs,
+    io::Read,
     path::{Path, PathBuf},
 };
 use tempfile::TempDir;
@@ -48,7 +49,9 @@ impl TestProject {
     }
 
     pub(crate) fn read_file(&self, path: &str) -> String {
-        fs::read_to_string(self.path(path)).unwrap()
+        let mut contents = String::new();
+        fs::File::open(self.path(path)).unwrap().read_to_string(&mut contents).unwrap();
+        contents
     }
 
     pub(crate) fn open_file(&mut self, path: &str, contents: &str) {

--- a/crates/lsp/src/test_support.rs
+++ b/crates/lsp/src/test_support.rs
@@ -1,0 +1,192 @@
+use crate::{
+    config::{Config, negotiate_capabilities},
+    vfs::{Vfs, VfsPath},
+};
+use crop::Rope;
+use lsp_types::{InitializeParams, Url, WorkspaceFolder};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+use tempfile::TempDir;
+
+pub(crate) struct TestProject {
+    tmp: TempDir,
+    open_files: Vec<(PathBuf, String)>,
+}
+
+impl TestProject {
+    pub(crate) fn new() -> Self {
+        Self { tmp: TempDir::new().unwrap(), open_files: Vec::new() }
+    }
+
+    pub(crate) fn from_fixture(fixture: &str) -> Self {
+        let mut project = Self::new();
+        for file in parse_fixture(fixture) {
+            project.write_file(&file.path, &file.text);
+            if file.open {
+                project.open_file(&file.path, &file.text);
+            }
+        }
+        project
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        self.tmp.path()
+    }
+
+    pub(crate) fn path(&self, path: &str) -> PathBuf {
+        self.tmp.path().join(path.strip_prefix('/').unwrap_or(path))
+    }
+
+    pub(crate) fn write_file(&self, path: &str, contents: &str) {
+        let path = self.path(path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    pub(crate) fn read_file(&self, path: &str) -> String {
+        fs::read_to_string(self.path(path)).unwrap()
+    }
+
+    pub(crate) fn open_file(&mut self, path: &str, contents: &str) {
+        let path = self.path(path);
+        if let Some((_, existing)) =
+            self.open_files.iter_mut().find(|(candidate, _)| candidate == &path)
+        {
+            existing.clear();
+            existing.push_str(contents);
+        } else {
+            self.open_files.push((path, contents.to_string()));
+        }
+    }
+
+    pub(crate) fn remove_file(&self, path: &str) {
+        fs::remove_file(self.path(path)).unwrap();
+    }
+
+    pub(crate) fn initialize_params(&self) -> InitializeParams {
+        self.initialize_params_with_roots(&["/"])
+    }
+
+    pub(crate) fn initialize_params_with_roots(&self, roots: &[&str]) -> InitializeParams {
+        InitializeParams {
+            workspace_folders: Some(
+                roots
+                    .iter()
+                    .map(|root| {
+                        let path = self.path(root);
+                        WorkspaceFolder {
+                            uri: Url::from_file_path(&path).unwrap(),
+                            name: path
+                                .file_name()
+                                .and_then(|name| name.to_str())
+                                .unwrap_or("root")
+                                .into(),
+                        }
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn config(&self) -> Config {
+        let (_, mut config) = negotiate_capabilities(self.initialize_params());
+        config.rediscover_workspaces();
+        config
+    }
+
+    pub(crate) fn config_with_roots(&self, roots: &[&str]) -> Config {
+        let (_, mut config) = negotiate_capabilities(self.initialize_params_with_roots(roots));
+        config.rediscover_workspaces();
+        config
+    }
+
+    pub(crate) fn vfs(&self) -> Vfs {
+        let mut vfs = Vfs::default();
+        for (path, contents) in &self.open_files {
+            vfs.set_file_contents(VfsPath::from(path.clone()), Some(Rope::from(contents.as_str())));
+        }
+        vfs
+    }
+}
+
+struct FixtureFile {
+    path: String,
+    text: String,
+    open: bool,
+}
+
+fn parse_fixture(fixture: &str) -> Vec<FixtureFile> {
+    let fixture = trim_indent(fixture);
+    let mut files = Vec::new();
+    let mut current: Option<FixtureFile> = None;
+
+    for line in fixture.split_inclusive('\n') {
+        let marker_line = line.trim_end_matches(['\r', '\n']).trim_start();
+        if let Some(meta) = marker_line.strip_prefix("//-") {
+            if let Some(file) = current.take() {
+                files.push(finish_file(file));
+            }
+            current = Some(parse_meta(meta.trim()));
+        } else if let Some(file) = &mut current {
+            file.text.push_str(line);
+        } else if !line.trim().is_empty() {
+            panic!("fixture contents before first file marker: {line:?}");
+        }
+    }
+
+    if let Some(file) = current {
+        files.push(finish_file(file));
+    }
+    files
+}
+
+fn finish_file(mut file: FixtureFile) -> FixtureFile {
+    if file.text.ends_with('\n') {
+        file.text.pop();
+        if file.text.ends_with('\r') {
+            file.text.pop();
+        }
+    }
+    file
+}
+
+fn parse_meta(meta: &str) -> FixtureFile {
+    let mut parts = meta.split_whitespace();
+    let path = parts.next().expect("fixture marker must contain a path").to_string();
+    assert!(path.starts_with('/'), "fixture path must start with `/`: {path}");
+
+    let mut open = false;
+    for part in parts {
+        match part {
+            "open" => open = true,
+            other => panic!("unknown fixture option `{other}`"),
+        }
+    }
+
+    FixtureFile { path, text: String::new(), open }
+}
+
+fn trim_indent(text: &str) -> String {
+    let text = text.trim_matches('\n');
+    let indent = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    let mut trimmed = String::new();
+    for line in text.split_inclusive('\n') {
+        if line.trim().is_empty() {
+            trimmed.push_str(line.trim_start());
+        } else {
+            trimmed.push_str(line.get(indent..).unwrap_or(line));
+        }
+    }
+    trimmed
+}

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -72,29 +72,32 @@ impl ProjectManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
+    use crate::test_support::TestProject;
 
     #[test]
     fn child_discovery_finds_foundry_manifest() {
-        let root = TempDir::new().unwrap();
-        let child = root.path().join("child");
-        fs::create_dir(&child).unwrap();
-        fs::write(child.join("foundry.toml"), "").unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /child/foundry.toml
+            "#,
+        );
 
         assert_eq!(
-            ProjectManifest::discover_all(&[root.path().to_path_buf()]),
-            vec![ProjectManifest::Foundry(child.join("foundry.toml"))],
+            ProjectManifest::discover_all(&[project.root().to_path_buf()]),
+            vec![ProjectManifest::Foundry(project.path("/child/foundry.toml"))],
         );
     }
 
     #[test]
     fn parent_discovery_prefers_nearest_foundry_manifest() {
-        let root = TempDir::new().unwrap();
-        let child = root.path().join("child");
-        fs::create_dir(&child).unwrap();
-        fs::write(root.path().join("foundry.toml"), "").unwrap();
-        fs::write(child.join("foundry.toml"), "").unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+
+            //- /child/foundry.toml
+            "#,
+        );
+        let child = project.path("/child");
 
         assert_eq!(
             ProjectManifest::discover_all(std::slice::from_ref(&child)),

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -246,39 +246,39 @@ fn load_foundry_document(path: &Path) -> Result<FoundryDocument, WorkspaceError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::TestProject;
     use solar_config::EvmVersion;
-    use std::fs;
-    use tempfile::TempDir;
 
     #[test]
     fn foundry_workspace_loads_manifest_compile_config() {
-        let project = TempDir::new().unwrap();
-        fs::create_dir_all(project.path().join("lib/forge-std/src")).unwrap();
-        fs::create_dir_all(project.path().join("vendor/ds-test/src")).unwrap();
-        fs::write(project.path().join("remappings.txt"), "solmate/=lib/solmate/src/\n").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                src = "contracts"
-                libs = ["lib", "vendor"]
-                evm_version = "cancun"
-                remappings = [
-                    "@oz=lib/openzeppelin-contracts/contracts/",
-                    "ds-test=lib/ds-test/src/",
-                ]
-            "#,
-        )
-        .unwrap();
+            //- /lib/forge-std/src/Test.sol
+            contract Test {}
 
-        let workspace = Workspace::load_foundry(project.path().join("foundry.toml")).unwrap();
+            //- /vendor/ds-test/src/Test.sol
+            contract Test {}
+
+            //- /remappings.txt
+            solmate/=lib/solmate/src/
+
+            //- /foundry.toml
+            [profile.default]
+            src = "contracts"
+            libs = ["lib", "vendor"]
+            evm_version = "cancun"
+            remappings = [
+                "@oz=lib/openzeppelin-contracts/contracts/",
+                "ds-test=lib/ds-test/src/",
+            ]
+            "#,
+        );
+
+        let workspace = Workspace::load_foundry(project.path("/foundry.toml")).unwrap();
         let opts = workspace.compile_opts();
 
-        assert_eq!(opts.base_path.as_deref(), Some(project.path()));
-        assert_eq!(
-            opts.include_paths,
-            vec![project.path().join("lib"), project.path().join("vendor")]
-        );
+        assert_eq!(opts.base_path.as_deref(), Some(project.root()));
+        assert_eq!(opts.include_paths, vec![project.path("/lib"), project.path("/vendor")]);
         assert_eq!(opts.evm_version, EvmVersion::Cancun);
         assert_eq!(
             opts.import_remappings.iter().map(ToString::to_string).collect::<Vec<_>>(),
@@ -290,25 +290,27 @@ mod tests {
                 "ds-test=lib/ds-test/src/",
             ]
         );
-        assert_eq!(workspace.source_roots(), &[project.path().join("contracts")]);
+        assert_eq!(workspace.source_roots(), &[project.path("/contracts")]);
     }
 
     #[test]
     fn foundry_workspace_respects_disabled_auto_detect_remappings() {
-        let project = TempDir::new().unwrap();
-        fs::create_dir_all(project.path().join("lib/forge-std/src")).unwrap();
-        fs::write(project.path().join("remappings.txt"), "solmate/=lib/solmate/src/\n").unwrap();
-        fs::write(
-            project.path().join("foundry.toml"),
+        let project = TestProject::from_fixture(
             r#"
-                [profile.default]
-                auto_detect_remappings = false
-                remappings = ["@oz=lib/openzeppelin-contracts/contracts/"]
-            "#,
-        )
-        .unwrap();
+            //- /lib/forge-std/src/Test.sol
+            contract Test {}
 
-        let workspace = Workspace::load_foundry(project.path().join("foundry.toml")).unwrap();
+            //- /remappings.txt
+            solmate/=lib/solmate/src/
+
+            //- /foundry.toml
+            [profile.default]
+            auto_detect_remappings = false
+            remappings = ["@oz=lib/openzeppelin-contracts/contracts/"]
+            "#,
+        );
+
+        let workspace = Workspace::load_foundry(project.path("/foundry.toml")).unwrap();
         let opts = workspace.compile_opts();
 
         assert_eq!(
@@ -319,26 +321,28 @@ mod tests {
 
     #[test]
     fn workspace_path_index_uses_most_specific_base_path() {
-        let project = TempDir::new().unwrap();
-        let nested = project.path().join("nested");
+        let project = TestProject::new();
+        let nested = project.path("/nested");
 
-        let outer = Workspace::naked(project.path().to_path_buf());
-        let inner = Workspace::naked(nested.clone());
+        let outer = Workspace::naked(project.root().to_path_buf());
+        let inner = Workspace::naked(nested);
         let workspaces = vec![outer, inner];
         let index = WorkspacePathIndex::new(&workspaces);
 
-        assert_eq!(index.workspace_idx_for_path(&nested.join("A.sol")), 1);
-        assert_eq!(index.workspace_idx_for_path(&project.path().join("B.sol")), 0);
+        assert_eq!(index.workspace_idx_for_path(&project.path("/nested/A.sol")), 1);
+        assert_eq!(index.workspace_idx_for_path(&project.path("/B.sol")), 0);
     }
 
     #[test]
     fn naked_workspace_does_not_collect_disk_source_files() {
-        let project = TempDir::new().unwrap();
-        let source = project.path().join("src");
-        fs::create_dir(&source).unwrap();
-        fs::write(source.join("A.sol"), "contract A {}").unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/A.sol
+            contract A {}
+            "#,
+        );
 
-        let mut workspace = Workspace::naked(project.path().to_path_buf());
+        let mut workspace = Workspace::naked(project.root().to_path_buf());
         workspace.refresh_source_files();
 
         assert!(workspace.source_files().is_empty());
@@ -346,14 +350,15 @@ mod tests {
 
     #[test]
     fn naked_workspace_does_not_add_created_disk_source_files() {
-        let project = TempDir::new().unwrap();
-        let source = project.path().join("src");
-        fs::create_dir(&source).unwrap();
-        let source_file = source.join("A.sol");
-        fs::write(&source_file, "contract A {}").unwrap();
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/A.sol
+            contract A {}
+            "#,
+        );
 
-        let mut workspace = Workspace::naked(project.path().to_path_buf());
-        workspace.add_source_file(source_file);
+        let mut workspace = Workspace::naked(project.root().to_path_buf());
+        workspace.add_source_file(project.path("/src/A.sol"));
 
         assert!(workspace.source_files().is_empty());
     }


### PR DESCRIPTION
Stacked on #898.

This pulls the repeated LSP temp-project setup into a shared `TestProject` fixture and updates the workspace/global-state tests to use fixture-style file declarations. It keeps the open-file-only behavior covered while making follow-up test changes less noisy.
