### PR TITLE
chore: link zed rust-analyzer project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 /target
-.vscode
-!editors/vscode/.vscode/
-!editors/vscode/.vscode/launch.json
-!editors/vscode/.vscode/tasks.json
 .idea
 /*.sol
 /*.yul

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /target
+/.vscode/*
+!/.vscode/
+!/.vscode/settings.json
 .idea
 /*.sol
 /*.yul

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "rust-analyzer.linkedProjects": [
+    "Cargo.toml",
+    "editors/zed/Cargo.toml"
+  ]
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,12 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "linkedProjects": [
+          "./Cargo.toml",
+          "./editors/zed/Cargo.toml"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds repository-local VS Code and Zed rust-analyzer settings so the main workspace and the Zed extension crate are loaded together. The root VS Code ignore rule now tracks only the shared settings file while keeping other local editor state ignored.