### PR TITLE
test(foundry): use tempdirs for artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 /target
-/.vscode/*
-!/.vscode/
-!/.vscode/settings.json
 .idea
 /*.sol
 /*.yul

--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,3 @@
 /tmp
 .DS_Store
 __pycache__/
-**/cache/
-**/cache-*/
-tests/foundry/**/out-solar/
-tests/foundry/**/out-solc/
-tests/foundry/**/*-test-output-*.json
-crates/codegen/testdata/**/out-solar/
-crates/codegen/testdata/**/out-solc/
-crates/codegen/testdata/**/*-test-output-*.json

--- a/crates/solar/foundry_harness/mod.rs
+++ b/crates/solar/foundry_harness/mod.rs
@@ -109,6 +109,35 @@ impl FoundrySolc {
     }
 }
 
+#[derive(Clone, Copy)]
+enum ForgeCompiler {
+    Solar,
+    Solc,
+}
+
+impl ForgeCompiler {
+    fn cache_prefix(self) -> &'static str {
+        match self {
+            Self::Solar => "solar-foundry-cache-",
+            Self::Solc => "solc-foundry-cache-",
+        }
+    }
+
+    fn out_prefix(self) -> &'static str {
+        match self {
+            Self::Solar => "solar-foundry-out-",
+            Self::Solc => "solc-foundry-out-",
+        }
+    }
+
+    fn command_failure(self) -> &'static str {
+        match self {
+            Self::Solar => "failed to run forge test for Solar",
+            Self::Solc => "failed to run forge test",
+        }
+    }
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -378,20 +407,25 @@ fn write_runtime_report(
 // Forge Execution
 // ============================================================================
 
-/// Runs forge test with Solar as the compiler.
-fn run_forge_test_solar(
-    project_dir: &PathBuf,
+/// Runs forge test for a compiler.
+fn run_forge_test(
+    project_dir: &Path,
     label: &str,
     config: &TestConfig,
+    compiler: ForgeCompiler,
 ) -> (Duration, Vec<TestResult>, HashMap<String, usize>) {
-    let cache_dir = "cache-solar";
-    fs::create_dir_all(project_dir.join(cache_dir))
-        .expect("failed to create Solar cache directory");
-    let out_dir = tempfile::Builder::new()
-        .prefix("solar-foundry-out-")
+    let cache_dir = tempfile::Builder::new()
+        .prefix(compiler.cache_prefix())
         .tempdir()
-        .expect("failed to create Solar output directory");
-    let foundry_solc = foundry_solc();
+        .expect("failed to create Foundry cache directory");
+    let out_dir = tempfile::Builder::new()
+        .prefix(compiler.out_prefix())
+        .tempdir()
+        .expect("failed to create Foundry output directory");
+    let foundry_solc = match compiler {
+        ForgeCompiler::Solar => Some(foundry_solc()),
+        ForgeCompiler::Solc => None,
+    };
 
     let mut cmd = Command::new("forge");
     cmd.current_dir(project_dir)
@@ -403,10 +437,12 @@ fn run_forge_test_solar(
         .arg("--out")
         .arg(out_dir.path())
         .arg("--cache-path")
-        .arg(cache_dir)
+        .arg(cache_dir.path());
+
+    if let Some(foundry_solc) = &foundry_solc {
         // Foundry expects solc-compatible `--version` output when probing `FOUNDRY_SOLC`.
-        .env("SOLC_WRAPPER", "1")
-        .env("FOUNDRY_SOLC", foundry_solc.path());
+        cmd.env("SOLC_WRAPPER", "1").env("FOUNDRY_SOLC", foundry_solc.path());
+    }
 
     // Add forge match filters if specified
     if let Some(ref test_filter) = config.test_filter {
@@ -417,7 +453,8 @@ fn run_forge_test_solar(
     }
 
     let start = Instant::now();
-    let output = cmd.output().expect("failed to run forge test for Solar");
+    let command_failure = compiler.command_failure();
+    let output = cmd.output().unwrap_or_else(|err| panic!("{command_failure}: {err}"));
     let test_time = start.elapsed();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -428,50 +465,6 @@ fn run_forge_test_solar(
             eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
         }
     }
-
-    let tests = parse_test_results(&stdout);
-    let sizes = extract_bytecode_sizes(out_dir.path());
-
-    (test_time, tests, sizes)
-}
-
-/// Runs forge test with solc (baseline).
-fn run_forge_test_solc(
-    project_dir: &PathBuf,
-    config: &TestConfig,
-) -> (Duration, Vec<TestResult>, HashMap<String, usize>) {
-    let cache_dir = "cache-solc";
-    fs::create_dir_all(project_dir.join(cache_dir)).expect("failed to create solc cache directory");
-    let out_dir = tempfile::Builder::new()
-        .prefix("solc-foundry-out-")
-        .tempdir()
-        .expect("failed to create solc output directory");
-
-    let mut cmd = Command::new("forge");
-    cmd.current_dir(project_dir)
-        .arg("test")
-        .arg("--force")
-        .arg("--json")
-        .arg("-vvvvv")
-        .arg("--decode-internal")
-        .arg("--out")
-        .arg(out_dir.path())
-        .arg("--cache-path")
-        .arg(cache_dir);
-
-    // Add forge match filters if specified
-    if let Some(ref test_filter) = config.test_filter {
-        cmd.arg("--match-test").arg(test_filter);
-    }
-    if let Some(ref contract_filter) = config.contract_filter {
-        cmd.arg("--match-contract").arg(contract_filter);
-    }
-
-    let start = Instant::now();
-    let output = cmd.output().expect("failed to run forge test");
-    let test_time = start.elapsed();
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
 
     let tests = parse_test_results(&stdout);
     let sizes = extract_bytecode_sizes(out_dir.path());
@@ -549,8 +542,12 @@ fn run_project_comparison(config: &TestConfig) -> (CompilerRun, CompilerRun) {
     let project_dir = workspace_root().join(&config.path);
 
     // Step 1: Run tests with Solar
-    let (solar_test_time, solar_tests, solar_sizes) =
-        run_forge_test_solar(&project_dir, &format!("{}-solar", config.name), config);
+    let (solar_test_time, solar_tests, solar_sizes) = run_forge_test(
+        &project_dir,
+        &format!("{}-solar", config.name),
+        config,
+        ForgeCompiler::Solar,
+    );
     let solar_tests = filter_tests(solar_tests, config);
     let solar_passed = solar_tests.iter().filter(|t| t.passed).count();
     let solar_failed = solar_tests.iter().filter(|t| !t.passed).count();
@@ -565,7 +562,8 @@ fn run_project_comparison(config: &TestConfig) -> (CompilerRun, CompilerRun) {
     };
 
     // Step 2: Run tests with solc
-    let (solc_test_time, solc_tests, solc_sizes) = run_forge_test_solc(&project_dir, config);
+    let (solc_test_time, solc_tests, solc_sizes) =
+        run_forge_test(&project_dir, &format!("{}-solc", config.name), config, ForgeCompiler::Solc);
     let solc_tests = filter_tests(solc_tests, config);
     let solc_passed = solc_tests.iter().filter(|t| t.passed).count();
     let solc_failed = solc_tests.iter().filter(|t| !t.passed).count();
@@ -705,7 +703,7 @@ fn run_test_with_config(config: &TestConfig) {
 fn run_test_solar_only(config: &TestConfig) {
     let project_dir = workspace_root().join(&config.path);
     let (test_time, tests, bytecode_sizes) =
-        run_forge_test_solar(&project_dir, &config.name, config);
+        run_forge_test(&project_dir, &config.name, config, ForgeCompiler::Solar);
     let tests = filter_tests(tests, config);
 
     let total_passed = tests.iter().filter(|t| t.passed).count();
@@ -801,7 +799,8 @@ fn run_compilation_smoke() {
 
     let config = TestConfig::new("compilation-test", "tests/foundry/arithmetic");
     let project_dir = workspace_root().join(&config.path);
-    let (test_time, tests, sizes) = run_forge_test_solar(&project_dir, "compilation-test", &config);
+    let (test_time, tests, sizes) =
+        run_forge_test(&project_dir, "compilation-test", &config, ForgeCompiler::Solar);
 
     println!("Test time: {:?}", test_time);
     println!("Tests: {:?}", tests.iter().map(|t| &t.name).collect::<Vec<_>>());

--- a/tests/foundry/access-control/.gitignore
+++ b/tests/foundry/access-control/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/arithmetic/.gitignore
+++ b/tests/foundry/arithmetic/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/calls/.gitignore
+++ b/tests/foundry/calls/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/constructor-args/.gitignore
+++ b/tests/foundry/constructor-args/.gitignore
@@ -1,7 +1,0 @@
-out/
-out-solar/
-out-solc/
-cache/
-cache-solar/
-cache-solc/
-*.json

--- a/tests/foundry/control-flow/.gitignore
+++ b/tests/foundry/control-flow/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/equivalence/.gitignore
+++ b/tests/foundry/equivalence/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/erc20-minimal/.gitignore
+++ b/tests/foundry/erc20-minimal/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/erc721-minimal/.gitignore
+++ b/tests/foundry/erc721-minimal/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/events/.gitignore
+++ b/tests/foundry/events/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/inheritance/.gitignore
+++ b/tests/foundry/inheritance/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/libraries/.gitignore
+++ b/tests/foundry/libraries/.gitignore
@@ -1,7 +1,0 @@
-cache-solar/
-cache-solc/
-out-solar/
-out-solc/
-lib/
-cache/
-out/

--- a/tests/foundry/multi-return/.gitignore
+++ b/tests/foundry/multi-return/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/multicall/.gitignore
+++ b/tests/foundry/multicall/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/stack-deep/.gitignore
+++ b/tests/foundry/stack-deep/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/storage/.gitignore
+++ b/tests/foundry/storage/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json

--- a/tests/foundry/stress-arrays/.gitignore
+++ b/tests/foundry/stress-arrays/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/stress-control-flow/.gitignore
+++ b/tests/foundry/stress-control-flow/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/stress-events/.gitignore
+++ b/tests/foundry/stress-events/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/stress-functions/.gitignore
+++ b/tests/foundry/stress-functions/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/stress-inheritance/.gitignore
+++ b/tests/foundry/stress-inheritance/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/stress-mappings/.gitignore
+++ b/tests/foundry/stress-mappings/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/stress-modifiers/.gitignore
+++ b/tests/foundry/stress-modifiers/.gitignore
@@ -1,7 +1,0 @@
-cache/
-cache-solar/
-cache-solc/
-out/
-out-solar/
-out-solc/
-*.json

--- a/tests/foundry/structs/.gitignore
+++ b/tests/foundry/structs/.gitignore
@@ -1,7 +1,0 @@
-cache/
-out/
-cache-solar/
-out-solar/
-cache-solc/
-out-solc/
-*.json

--- a/tests/foundry/vault-minimal/.gitignore
+++ b/tests/foundry/vault-minimal/.gitignore
@@ -1,5 +1,0 @@
-out/
-cache/
-out-*/
-cache-*/
-*-test-output-*.json


### PR DESCRIPTION
Forge integration tests now pass temporary output and cache directories for both Solar and solc runs, so fixture directories no longer need gitignore rules for generated artifacts. The duplicated Solar and solc forge runners are collapsed into one helper that only varies the compiler-specific setup.