### PR TITLE
feat(vscode): add syntax highlighting

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -36,6 +36,27 @@
           ".sol"
         ],
         "configuration": "language-configuration.json"
+      },
+      {
+        "id": "solidity-markdown-injection"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "solidity",
+        "scopeName": "source.solidity",
+        "path": "./syntaxes/solidity.json"
+      },
+      {
+        "language": "solidity-markdown-injection",
+        "scopeName": "markdown.solidity.codeblock",
+        "path": "./syntaxes/solidity-markdown-injection.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.solidity": "solidity"
+        }
       }
     ],
     "configuration": {

--- a/editors/vscode/syntaxes/LICENSE
+++ b/editors/vscode/syntaxes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Nomic Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/editors/vscode/syntaxes/README.md
+++ b/editors/vscode/syntaxes/README.md
@@ -1,0 +1,4 @@
+Solidity syntax grammars vendored from the MIT-licensed
+NomicFoundation/hardhat-vscode extension.
+
+Source: https://github.com/NomicFoundation/hardhat-vscode/tree/03d9428/client/syntaxes

--- a/editors/vscode/syntaxes/solidity-markdown-injection.json
+++ b/editors/vscode/syntaxes/solidity-markdown-injection.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+      {
+          "include": "#solidity-code-block"
+      }
+  ],
+  "repository": {
+      "solidity-code-block": {
+          "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(solidity)(\\s+[^`~]*)?$)",
+          "name": "markup.fenced_code.block.markdown",
+          "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+          "beginCaptures": {
+              "3": {
+                  "name": "punctuation.definition.markdown"
+              },
+              "4": {
+                  "name": "fenced_code.block.language.markdown"
+              },
+              "5": {
+                  "name": "fenced_code.block.language.attributes.markdown"
+              }
+          },
+          "endCaptures": {
+              "3": {
+                  "name": "punctuation.definition.markdown"
+              }
+          },
+          "patterns": [
+              {
+                  "begin": "(^|\\G)(\\s*)(.*)",
+                  "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                  "contentName": "meta.embedded.block.solidity",
+                  "patterns": [
+                      {
+                          "include": "source.solidity"
+                      }
+                  ]
+              }
+          ]
+      }
+  },
+  "scopeName": "markdown.solidity.codeblock"
+}

--- a/editors/vscode/syntaxes/solidity.json
+++ b/editors/vscode/syntaxes/solidity.json
@@ -1,0 +1,1250 @@
+{
+  "fileTypes": ["sol"],
+  "name": "Solidity",
+  "patterns": [
+    {
+      "include": "#natspec"
+    },
+    {
+      "include": "#declaration-userType"
+    },
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#operator"
+    },
+    {
+      "include": "#global"
+    },
+    {
+      "include": "#control"
+    },
+    {
+      "include": "#constant"
+    },
+    {
+      "include": "#primitive"
+    },
+    {
+      "include": "#type-primitive"
+    },
+    {
+      "include": "#type-user"
+    },
+    {
+      "include": "#type-modifier-extended-scope"
+    },
+    {
+      "include": "#declaration"
+    },
+    {
+      "include": "#function-call"
+    },
+    {
+      "include": "#assembly"
+    },
+    {
+      "include": "#punctuation"
+    }
+  ],
+  "repository": {
+    "natspec": {
+      "patterns": [
+        {
+          "begin": "/\\*\\*",
+          "end": "\\*/",
+          "name": "comment.block.documentation",
+          "patterns": [
+            {
+              "include": "#natspec-tags"
+            }
+          ]
+        },
+        {
+          "begin": "///",
+          "end": "$",
+          "name": "comment.block.documentation",
+          "patterns": [
+            {
+              "include": "#natspec-tags"
+            }
+          ]
+        }
+      ]
+    },
+    "natspec-tags": {
+      "patterns": [
+        {
+          "include": "#natspec-tag-title"
+        },
+        {
+          "include": "#natspec-tag-author"
+        },
+        {
+          "include": "#natspec-tag-notice"
+        },
+        {
+          "include": "#natspec-tag-dev"
+        },
+        {
+          "include": "#natspec-tag-inheritdoc"
+        },
+        {
+          "include": "#natspec-tag-param"
+        },
+        {
+          "include": "#natspec-tag-return"
+        },
+        {
+          "include": "#natspec-tag-custom"
+        }
+      ]
+    },
+    "natspec-tag-title": {
+      "match": "(@title)\\b",
+      "name": "storage.type.title.natspec"
+    },
+    "natspec-tag-author": {
+      "match": "(@author)\\b",
+      "name": "storage.type.author.natspec"
+    },
+    "natspec-tag-notice": {
+      "match": "(@notice)\\b",
+      "name": "storage.type.dev.natspec"
+    },
+    "natspec-tag-dev": {
+      "match": "(@dev)\\b",
+      "name": "storage.type.dev.natspec"
+    },
+    "natspec-tag-inheritdoc": {
+      "match": "(@inheritdoc)\\b",
+      "name": "storage.type.dev.natspec"
+    },
+    "natspec-tag-param": {
+      "match": "(@param)(\\s+([A-Za-z_]\\w*))?\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.param.natspec"
+        },
+        "3": {
+          "name": "variable.other.natspec"
+        }
+      }
+    },
+    "natspec-tag-return": {
+      "match": "(@return)(\\s+(_?[a-z]\\w*))?\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.return.natspec"
+        },
+        "3": {
+          "name": "variable.other.natspec"
+        }
+      }
+    },
+    "natspec-tag-custom": {
+      "match": "(@custom:[a-z]+(-[a-z]+)*)\\b",
+      "name": "storage.type.custom.natspec"
+    },
+    "comment": {
+      "patterns": [
+        {
+          "include": "#comment-line"
+        },
+        {
+          "include": "#comment-block"
+        }
+      ]
+    },
+    "comment-line": {
+      "begin": "(?<!tp:)//",
+      "end": "$",
+      "name": "comment.line"
+    },
+    "comment-block": {
+      "begin": "/\\*",
+      "end": "\\*/",
+      "name": "comment.block"
+    },
+    "operator": {
+      "patterns": [
+        {
+          "include": "#operator-logic"
+        },
+        {
+          "include": "#operator-mapping"
+        },
+        {
+          "include": "#operator-arithmetic"
+        },
+        {
+          "include": "#operator-binary"
+        },
+        {
+          "include": "#operator-assignment"
+        }
+      ]
+    },
+    "operator-logic": {
+      "match": "(!|==|!=|<(?!<)|<=|>=|>(?!>)|\\&\\&|\\|\\||\\:(?!=)|\\?)",
+      "name": "keyword.operator.logic"
+    },
+    "operator-mapping": {
+      "match": "(=>)",
+      "name": "keyword.operator.mapping"
+    },
+    "operator-arithmetic": {
+      "match": "(\\+|\\-|\\/|\\%|\\*)",
+      "name": "keyword.operator.arithmetic"
+    },
+    "operator-binary": {
+      "match": "(\\^|\\&|\\||<<|>>)",
+      "name": "keyword.operator.binary"
+    },
+    "operator-assignment": {
+      "match": "(\\:?=)",
+      "name": "keyword.operator.assignment"
+    },
+    "control": {
+      "patterns": [
+        {
+          "include": "#control-flow"
+        },
+        {
+          "include": "#control-using"
+        },
+        {
+          "include": "#control-import"
+        },
+        {
+          "include": "#control-pragma"
+        },
+        {
+          "include": "#control-underscore"
+        },
+        {
+          "include": "#control-unchecked"
+        },
+        {
+          "include": "#control-other"
+        }
+      ]
+    },
+    "control-flow": {
+      "patterns": [
+        {
+          "match": "\\b(if|else|for|while|do|break|continue|try|catch|finally|throw|return)\\b",
+          "name": "keyword.control.flow"
+        },
+        {
+          "begin": "\\b(returns)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.flow.return"
+            }
+          },
+          "end": "(?=\\))",
+          "patterns": [
+            {
+              "include": "#declaration-function-parameters"
+            }
+          ]
+        }
+      ]
+    },
+    "control-using": {
+      "patterns": [
+        {
+          "match": "\\b(using)\\b\\s+\\b([A-Za-z\\d_]+)\\b\\s+\\b(for)\\b\\s+\\b([A-Za-z\\d_]+)",
+          "captures": {
+            "1": {
+              "name": "keyword.control.using"
+            },
+            "2": {
+              "name": "entity.name.type.library"
+            },
+            "3": {
+              "name": "keyword.control.for"
+            },
+            "4": {
+              "name": "entity.name.type"
+            }
+          }
+        },
+        {
+          "match": "\\b(using)\\b",
+          "name": "keyword.control.using"
+        }
+      ]
+    },
+    "control-import": {
+      "patterns": [
+        {
+          "begin": "\\b(import)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.import"
+            }
+          },
+          "end": "(?=\\;)",
+          "patterns": [
+            {
+              "begin": "((?<=\\{))",
+              "end": "((?=\\}))",
+              "patterns": [
+                {
+                  "match": "\\b(\\w+)\\b",
+                  "name": "entity.name.type.interface"
+                }
+              ]
+            },
+            {
+              "match": "\\b(from)\\b",
+              "name": "keyword.control.import.from"
+            },
+            {
+              "include": "#string"
+            },
+            {
+              "include": "#punctuation"
+            }
+          ]
+        },
+        {
+          "match": "\\b(import)\\b",
+          "name": "keyword.control.import"
+        }
+      ]
+    },
+    "control-unchecked": {
+      "match": "\\b(unchecked)\\b",
+      "name": "keyword.control.unchecked"
+    },
+    "control-pragma": {
+      "match": "\\b(pragma)(?:\\s+([A-Za-z_]\\w+)\\s+([^\\s]+))?\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.control.pragma"
+        },
+        "2": {
+          "name": "entity.name.tag.pragma"
+        },
+        "3": {
+          "name": "constant.other.pragma"
+        }
+      }
+    },
+    "control-underscore": {
+      "match": "\\b(_)\\b",
+      "name": "constant.other.underscore"
+    },
+    "control-other": {
+      "match": "\\b(new|delete|emit)\\b",
+      "name": "keyword.control"
+    },
+    "constant": {
+      "patterns": [
+        {
+          "include": "#constant-boolean"
+        },
+        {
+          "include": "#constant-time"
+        },
+        {
+          "include": "#constant-currency"
+        }
+      ]
+    },
+    "constant-boolean": {
+      "match": "\\b(true|false)\\b",
+      "name": "constant.language.boolean"
+    },
+    "constant-time": {
+      "match": "\\b(seconds|minutes|hours|days|weeks|years)\\b",
+      "name": "constant.language.time"
+    },
+    "constant-currency": {
+      "match": "\\b(ether|wei|finney|szabo)\\b",
+      "name": "constant.language.currency"
+    },
+    "number": {
+      "patterns": [
+        {
+          "include": "#number-decimal"
+        },
+        {
+          "include": "#number-hex"
+        },
+        {
+          "include": "#number-scientific"
+        }
+      ]
+    },
+    "number-decimal": {
+      "match": "\\b([0-9_]+(\\.[0-9_]+)?)\\b",
+      "name": "constant.numeric.decimal"
+    },
+    "number-hex": {
+      "match": "\\b(0[xX][a-fA-F0-9]+)\\b",
+      "name": "constant.numeric.hexadecimal"
+    },
+    "number-scientific": {
+      "match": "\\b(?:0\\.(?:0[1-9]|[1-9][0-9_]?)|[1-9][0-9_]*(?:\\.\\d{1,2})?)(?:e[+-]?[0-9_]+)?",
+      "name": "constant.numeric.scientific"
+    },
+    "string": {
+      "patterns": [
+        {
+          "match": "\\\".*?\\\"",
+          "name": "string.quoted.double"
+        },
+        {
+          "match": "\\'.*?\\'",
+          "name": "string.quoted.single"
+        }
+      ]
+    },
+    "primitive": {
+      "patterns": [
+        {
+          "include": "#number-decimal"
+        },
+        {
+          "include": "#number-hex"
+        },
+        {
+          "include": "#number-scientific"
+        },
+        {
+          "include": "#string"
+        }
+      ]
+    },
+    "type-primitive": {
+      "patterns": [
+        {
+          "begin": "\\b(address|string\\d*|bytes\\d*|int\\d*|uint\\d*|bool|hash\\d*)\\b(?:\\[\\])(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "support.type.primitive"
+            }
+          },
+          "end": "(\\))",
+          "patterns": [
+            {
+              "include": "#primitive"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#global"
+            },
+            {
+              "include": "#variable"
+            }
+          ]
+        },
+        {
+          "match": "\\b(address|string\\d*|bytes\\d*|int\\d*|uint\\d*|bool|hash\\d*)\\b",
+          "name": "support.type.primitive"
+        }
+      ]
+    },
+    "type-user": {
+      "patterns": [
+        {
+          "begin": "\\b([A-Z]\\w*)\\b(?:\\[\\])(\\()",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.type"
+            }
+          },
+          "end": "(\\))",
+          "patterns": [
+            {
+              "include": "#primitive"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#global"
+            },
+            {
+              "include": "#variable"
+            }
+          ]
+        },
+        {
+          "match": "\\b([A-Z]\\w*)\\b",
+          "name": "entity.name.type"
+        }
+      ]
+    },
+    "global": {
+      "patterns": [
+        {
+          "include": "#global-variables"
+        },
+        {
+          "include": "#global-functions"
+        }
+      ]
+    },
+    "global-variables": {
+      "patterns": [
+        {
+          "match": "\\b(this)\\b",
+          "name": "variable.language.this"
+        },
+        {
+          "match": "\\b(super)\\b",
+          "name": "variable.language.super"
+        },
+        {
+          "match": "\\b(abi)\\b",
+          "name": "variable.language.builtin.abi"
+        },
+        {
+          "match": "\\b(msg\\.sender|msg|block|tx|now)\\b",
+          "name": "variable.language.transaction"
+        },
+        {
+          "match": "\\b(tx\\.origin|tx\\.gasprice|msg\\.data|msg\\.sig|msg\\.value)\\b",
+          "name": "variable.language.transaction"
+        }
+      ]
+    },
+    "global-functions": {
+      "patterns": [
+        {
+          "match": "\\b(require|assert|revert)\\b",
+          "name": "keyword.control.exceptions"
+        },
+        {
+          "match": "\\b(selfdestruct|suicide)\\b",
+          "name": "keyword.control.contract"
+        },
+        {
+          "match": "\\b(addmod|mulmod|keccak256|sha256|sha3|ripemd160|ecrecover)\\b",
+          "name": "support.function.math"
+        },
+        {
+          "match": "\\b(unicode)\\b",
+          "name": "support.function.string"
+        },
+        {
+          "match": "\\b(blockhash|gasleft)\\b",
+          "name": "variable.language.transaction"
+        },
+        {
+          "match": "\\b(type)\\b",
+          "name": "variable.language.type"
+        }
+      ]
+    },
+    "type-modifier-access": {
+      "match": "\\b(internal|external|private|public)\\b",
+      "name": "storage.type.modifier.access"
+    },
+    "type-modifier-payable": {
+      "match": "\\b(nonpayable|payable)\\b",
+      "name": "storage.type.modifier.payable"
+    },
+    "type-modifier-constant": {
+      "match": "\\b(constant)\\b",
+      "name": "storage.type.modifier.readonly"
+    },
+    "type-modifier-immutable": {
+      "match": "\\b(immutable)\\b",
+      "name": "storage.type.modifier.readonly"
+    },
+    "type-modifier-extended-scope": {
+      "match": "\\b(pure|view|inherited|indexed|storage|memory|virtual|calldata|override|abstract)\\b",
+      "name": "storage.type.modifier.extendedscope"
+    },
+    "variable": {
+      "patterns": [
+        {
+          "match": "\\b(\\_\\w+)\\b",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.function"
+            }
+          }
+        },
+        {
+          "match": "(?:\\.)(\\w+)\\b",
+          "captures": {
+            "1": {
+              "name": "support.variable.property"
+            }
+          }
+        },
+        {
+          "match": "\\b(\\w+)\\b",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.other"
+            }
+          }
+        }
+      ]
+    },
+    "modifier-call": {
+      "patterns": [
+        {
+          "include": "#function-call"
+        },
+        {
+          "match": "\\b(\\w+)\\b",
+          "name": "entity.name.function.modifier"
+        }
+      ]
+    },
+    "declaration": {
+      "patterns": [
+        {
+          "include": "#declaration-contract"
+        },
+        {
+          "include": "#declaration-userType"
+        },
+        {
+          "include": "#declaration-interface"
+        },
+        {
+          "include": "#declaration-library"
+        },
+        {
+          "include": "#declaration-function"
+        },
+        {
+          "include": "#declaration-modifier"
+        },
+        {
+          "include": "#declaration-constructor"
+        },
+        {
+          "include": "#declaration-event"
+        },
+        {
+          "include": "#declaration-storage"
+        },
+        {
+          "include": "#declaration-error"
+        }
+      ]
+    },
+    "declaration-storage-field": {
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#control"
+        },
+        {
+          "include": "#type-primitive"
+        },
+        {
+          "include": "#type-user"
+        },
+        {
+          "include": "#type-modifier-access"
+        },
+        {
+          "include": "#type-modifier-immutable"
+        },
+        {
+          "include": "#type-modifier-extend-scope"
+        },
+        {
+          "include": "#type-modifier-payable"
+        },
+        {
+          "include": "#type-modifier-constant"
+        },
+        {
+          "include": "#primitive"
+        },
+        {
+          "include": "#constant"
+        },
+        {
+          "include": "#operator"
+        },
+        {
+          "include": "#punctuation"
+        }
+      ]
+    },
+    "declaration-storage": {
+      "patterns": [
+        {
+          "include": "#declaration-storage-mapping"
+        },
+        {
+          "include": "#declaration-struct"
+        },
+        {
+          "include": "#declaration-enum"
+        },
+        {
+          "include": "#declaration-storage-field"
+        }
+      ]
+    },
+    "declaration-contract": {
+      "patterns": [
+        {
+          "match": "\\b(contract)\\b\\s+(\\w+)\\b\\s*(?=\\{)",
+          "captures": {
+            "1": {
+              "name": "storage.type.contract"
+            },
+            "2": {
+              "name": "entity.name.type.contract"
+            }
+          }
+        },
+        {
+          "begin": "\\b(contract)\\b\\s+(\\w+)\\b\\s+\\b(is)\\b\\s+",
+          "end": "(?=\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.contract"
+            },
+            "2": {
+              "name": "entity.name.type.contract"
+            },
+            "3": {
+              "name": "storage.modifier.is"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\b(\\w+)\\b",
+              "name": "entity.name.type.contract.extend"
+            }
+          ]
+        }
+      ]
+    },
+    "declaration-userType": {
+      "match": "\\b(type)\\b\\s+(\\w+)\\b\\s+\\b(is)\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.userType"
+        },
+        "2": {
+          "name": "entity.name.type.userType"
+        },
+        "3": {
+          "name": "storage.modifier.is"
+        }
+      }
+    },
+    "declaration-interface": {
+      "patterns": [
+        {
+          "match": "\\b(interface)\\b\\s+(\\w+)\\b\\s*(?=\\{)",
+          "captures": {
+            "1": {
+              "name": "storage.type.interface"
+            },
+            "2": {
+              "name": "entity.name.type.interface"
+            }
+          }
+        },
+        {
+          "begin": "\\b(interface)\\b\\s+(\\w+)\\b\\s+\\b(is)\\b\\s+",
+          "end": "(?=\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.interface"
+            },
+            "2": {
+              "name": "entity.name.type.interface"
+            },
+            "3": {
+              "name": "storage.modifier.is"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\b(\\w+)\\b",
+              "name": "entity.name.type.interface.extend"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        }
+      ]
+    },
+    "declaration-library": {
+      "match": "\\b(library)(\\s+([A-Za-z_]\\w*))?\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.library"
+        },
+        "3": {
+          "name": "entity.name.type.library"
+        }
+      }
+    },
+    "declaration-struct": {
+      "patterns": [
+        {
+          "match": "\\b(struct)(\\s+([A-Za-z_]\\w*))?\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.struct"
+            },
+            "3": {
+              "name": "entity.name.type.struct"
+            }
+          }
+        },
+        {
+          "begin": "\\b(struct)\\b\\s*(\\w+)?\\b\\s*(?=\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.struct"
+            },
+            "2": {
+              "name": "entity.name.type.struct"
+            }
+          },
+          "end": "(?=\\})",
+          "patterns": [
+            {
+              "include": "#type-primitive"
+            },
+            {
+              "include": "#type-user"
+            },
+            {
+              "include": "#variable"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        }
+      ]
+    },
+    "declaration-event": {
+      "patterns": [
+        {
+          "begin": "\\b(event)\\b(?:\\s+(\\w+)\\b)?",
+          "end": "(?=\\))",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.event"
+            },
+            "2": {
+              "name": "entity.name.type.event"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#type-primitive"
+            },
+            {
+              "include": "#type-user"
+            },
+            {
+              "match": "\\b(?:(indexed)\\s)?(\\w+)",
+              "captures": {
+                "1": {
+                  "name": "storage.type.modifier.indexed"
+                },
+                "2": {
+                  "name": "variable.parameter.event"
+                }
+              }
+            },
+            {
+              "include": "#punctuation"
+            }
+          ]
+        },
+        {
+          "match": "\\b(event)(\\s+([A-Za-z_]\\w*))?\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.event"
+            },
+            "3": {
+              "name": "entity.name.type.event"
+            }
+          }
+        }
+      ]
+    },
+    "declaration-constructor": {
+      "patterns": [
+        {
+          "begin": "\\b(constructor)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.constructor"
+            }
+          },
+          "end": "(?=\\{)",
+          "patterns": [
+            {
+              "begin": "\\G\\s*(?=\\()",
+              "end": "(?=\\))",
+              "patterns": [
+                {
+                  "include": "#declaration-function-parameters"
+                }
+              ]
+            },
+            {
+              "begin": "(?<=\\))",
+              "end": "(?=\\{)",
+              "patterns": [
+                {
+                  "include": "#type-modifier-access"
+                },
+                {
+                  "include": "#function-call"
+                },
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            { "include": "#punctuation" }
+          ]
+        },
+        {
+          "match": "\\b(constructor)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.constructor"
+            }
+          }
+        },
+        {
+          "include": "#punctuation"
+        }
+      ]
+    },
+    "declaration-enum": {
+      "patterns": [
+        {
+          "begin": "\\b(enum)\\s+(\\w+)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.enum"
+            },
+            "2": {
+              "name": "entity.name.type.enum"
+            }
+          },
+          "end": "(?=\\})",
+          "patterns": [
+            {
+              "match": "\\b(\\w+)\\b",
+              "name": "variable.other.enummember"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#comment"
+            }
+          ]
+        },
+        {
+          "match": "\\b(enum)(\\s+([A-Za-z_]\\w*))?\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.enum"
+            },
+            "3": {
+              "name": "entity.name.type.enum"
+            }
+          }
+        }
+      ]
+    },
+    "declaration-function-parameters": {
+      "begin": "\\G\\s*(?=\\()",
+      "end": "(?=\\))",
+      "patterns": [
+        {
+          "include": "#type-primitive"
+        },
+        {
+          "include": "#type-user"
+        },
+        {
+          "include": "#type-modifier-extended-scope"
+        },
+        {
+          "match": "\\b([A-Z]\\w*)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.struct"
+            }
+          }
+        },
+        {
+          "include": "#variable"
+        },
+        {
+          "include": "#punctuation"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "declaration-function": {
+      "patterns": [
+        {
+          "begin": "\\b(function)\\s+(\\w+)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.function"
+            },
+            "2": {
+              "name": "entity.name.function"
+            }
+          },
+          "end": "(?=\\{|;)",
+          "patterns": [
+            {
+              "include": "#natspec"
+            },
+            {
+              "include": "#global"
+            },
+            {
+              "include": "#declaration-function-parameters"
+            },
+            {
+              "include": "#type-modifier-access"
+            },
+            {
+              "include": "#type-modifier-payable"
+            },
+            {
+              "include": "#type-modifier-immutable"
+            },
+            {
+              "include": "#type-modifier-extended-scope"
+            },
+            {
+              "include": "#control-flow"
+            },
+            {
+              "include": "#function-call"
+            },
+            {
+              "include": "#modifier-call"
+            },
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#punctuation"
+            }
+          ]
+        },
+        {
+          "match": "\\b(function)\\s+([A-Za-z_]\\w*)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.function"
+            },
+            "2": {
+              "name": "entity.name.function"
+            }
+          }
+        }
+      ]
+    },
+    "declaration-modifier": {
+      "patterns": [
+        {
+          "begin": "\\b(modifier)\\b\\s*(\\w+)",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.function.modifier"
+            },
+            "2": {
+              "name": "entity.name.function.modifier"
+            }
+          },
+          "end": "(?=\\{)",
+          "patterns": [
+            {
+              "include": "#declaration-function-parameters"
+            },
+            {
+              "begin": "(?<=\\))",
+              "end": "(?=\\{)",
+              "patterns": [
+                {
+                  "include": "#declaration-function-parameters"
+                },
+                {
+                  "include": "#type-modifier-access"
+                },
+                {
+                  "include": "#type-modifier-payable"
+                },
+                {
+                  "include": "#type-modifier-immutable"
+                },
+                {
+                  "include": "#type-modifier-extended-scope"
+                },
+                {
+                  "include": "#function-call"
+                },
+                {
+                  "include": "#modifier-call"
+                },
+                {
+                  "include": "#control-flow"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "match": "\\b(modifier)(\\s+([A-Za-z_]\\w*))?\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.modifier"
+            },
+            "3": {
+              "name": "entity.name.function"
+            }
+          }
+        }
+      ]
+    },
+    "declaration-storage-mapping": {
+      "patterns": [
+        {
+          "begin": "\\b(mapping)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "storage.type.mapping"
+            }
+          },
+          "end": "(?=\\))",
+          "patterns": [
+            {
+              "include": "#declaration-storage-mapping"
+            },
+            {
+              "include": "#type-primitive"
+            },
+            {
+              "include": "#type-user"
+            },
+            {
+              "include": "#punctuation"
+            },
+            {
+              "include": "#operator"
+            }
+          ]
+        },
+        {
+          "match": "\\b(mapping)\\b",
+          "name": "storage.type.mapping"
+        }
+      ]
+    },
+    "declaration-error": {
+      "match": "\\b(error)(\\s+([A-Za-z_]\\w*))?\\b",
+      "captures": {
+        "1": {
+          "name": "storage.type.error"
+        },
+        "3": {
+          "name": "entity.name.type.error"
+        }
+      }
+    },
+    "function-call": {
+      "match": "\\b([A-Za-z_]\\w*)\\s*(?=\\()",
+      "captures": {
+        "1": {
+          "name": "entity.name.function"
+        }
+      }
+    },
+    "assembly": {
+      "patterns": [
+        {
+          "match": "\\b(assembly)\\b",
+          "name": "keyword.control.assembly"
+        },
+        {
+          "match": "\\b(let)\\b",
+          "name": "storage.type.assembly"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "match": ";",
+          "name": "punctuation.terminator.statement"
+        },
+        {
+          "match": "\\.",
+          "name": "punctuation.accessor"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator"
+        },
+        {
+          "match": "\\{",
+          "name": "punctuation.brace.curly.begin"
+        },
+        {
+          "match": "\\}",
+          "name": "punctuation.brace.curly.end"
+        },
+        {
+          "match": "\\[",
+          "name": "punctuation.brace.square.begin"
+        },
+        {
+          "match": "\\]",
+          "name": "punctuation.brace.square.end"
+        },
+        {
+          "match": "\\(",
+          "name": "punctuation.parameters.begin"
+        },
+        {
+          "match": "\\)",
+          "name": "punctuation.parameters.end"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.solidity",
+  "uuid": "4a2eb52d-02e5-46fd-848a-0648e20ef769"
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "Node16",
     "target": "ES2020",
     "lib": ["ES2020"],
     "outDir": "out",
     "rootDir": "src",
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node16",
+    "types": ["node", "vscode"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
This adds TextMate grammar contributions to the VS Code extension so Solidity files are highlighted out of the box, and includes a Markdown injection grammar for Solidity fenced code blocks. The grammar assets are vendored from the MIT-licensed Hardhat VS Code extension with the upstream license and source reference included.