### PR TITLE
chore(zed): bump solidity grammar

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -12,4 +12,4 @@ language = "Solidity"
 
 [grammars.solidity]
 repository = "https://github.com/JoranHonig/tree-sitter-solidity"
-commit = "d38dcd0b58b223c43e3f9265914fb3167dc624c6"
+commit = "048fe686cb1fde267243739b8bdbec8fc3a55272"


### PR DESCRIPTION
This bumps the Zed Solidity tree-sitter grammar pin to the latest upstream master revision, JoranHonig/tree-sitter-solidity@048fe686cb1fde267243739b8bdbec8fc3a55272. The update includes upstream grammar changes for newer Solidity/Yul syntax such as global using directives, layout syntax, newer EVM ops, and Yul hex string literals.