### PR TITLE
fix(docs): avoid rustdoc ICE on re-exports

### DIFF
--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Convenience re-exports.
+#[doc(no_inline)]
 pub use bumpalo;
 pub use solar_interface as interface;
 

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -38,6 +38,7 @@ pub use interned::Interned;
 mod thin_slice;
 pub use thin_slice::{RawThinSlice, ThinSlice};
 
+#[doc(no_inline)]
 pub use smallvec;
 
 /// Pluralize a word based on a count.

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -22,6 +22,7 @@ mod parser;
 pub use parser::{Parser, Recovered};
 
 // Convenience re-exports.
+#[doc(no_inline)]
 pub use bumpalo;
 pub use solar_ast::{self as ast, token};
 pub use solar_interface as interface;

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -14,7 +14,9 @@ use solar_interface::{Result, Session, config::CompilerStage};
 use std::ops::ControlFlow;
 
 // Convenience re-exports.
+#[doc(no_inline)]
 pub use ::thread_local;
+#[doc(no_inline)]
 pub use bumpalo;
 pub use solar_ast as ast;
 pub use solar_interface as interface;


### PR DESCRIPTION
Marks third-party convenience re-exports that currently trigger rustdoc to inline external crate docs as `#[doc(no_inline)]`.

`nightly-2026-07-02` ICEs while documenting `solar-compiler` when it walks through the inlined crate docs and reaches `bumpalo::core_alloc` or `smallvec::alloc`. Keeping these external re-exports as links preserves the public API and lets the component crate docs remain inlined.