### PR TITLE
docs: link rustdoc ICE workarounds

### DIFF
--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 // Convenience re-exports.
-#[doc(no_inline)]
+#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use bumpalo;
 pub use solar_interface as interface;
 

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -38,7 +38,7 @@ pub use interned::Interned;
 mod thin_slice;
 pub use thin_slice::{RawThinSlice, ThinSlice};
 
-#[doc(no_inline)]
+#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use smallvec;
 
 /// Pluralize a word based on a count.

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -22,7 +22,7 @@ mod parser;
 pub use parser::{Parser, Recovered};
 
 // Convenience re-exports.
-#[doc(no_inline)]
+#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use bumpalo;
 pub use solar_ast::{self as ast, token};
 pub use solar_interface as interface;

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -14,9 +14,9 @@ use solar_interface::{Result, Session, config::CompilerStage};
 use std::ops::ControlFlow;
 
 // Convenience re-exports.
-#[doc(no_inline)]
+#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use ::thread_local;
-#[doc(no_inline)]
+#[doc(no_inline)] // Work around rustdoc ICE: https://github.com/rust-lang/rust/issues/158686
 pub use bumpalo;
 pub use solar_ast as ast;
 pub use solar_interface as interface;


### PR DESCRIPTION
Adds the upstream rustdoc ICE issue link to the no-inline re-export workarounds so the reason for the attributes is clear in-tree.