### PR TITLE
fix(parser): recover malformed member access

### DIFF
--- a/crates/ast/src/ast/expr.rs
+++ b/crates/ast/src/ast/expr.rs
@@ -2,7 +2,7 @@ use super::{Box, Lit, SubDenomination, Type};
 use crate::BoxSlice;
 use either::Either;
 use solar_data_structures::trustme;
-use solar_interface::{Ident, Span, SpannedOption};
+use solar_interface::{Ident, Span, SpannedOption, diagnostics::ErrorGuaranteed};
 use std::fmt;
 
 /// A list of named arguments: `{a: "1", b: 2}`.
@@ -117,6 +117,9 @@ pub enum ExprKind<'ast> {
 
     /// A unary operation: `!x`, `-x`, `x++`.
     Unary(UnOp, Box<'ast, Expr<'ast>>),
+
+    /// An erroneous expression emitted during parser recovery.
+    Err(ErrorGuaranteed),
 }
 
 /// A binary operation: `a + b`, `a += b`.

--- a/crates/ast/src/visit.rs
+++ b/crates/ast/src/visit.rs
@@ -490,6 +490,7 @@ declare_visitors! {
                 ExprKind::Unary(_op, expr) => {
                     self.visit_expr #_mut(expr)?;
                 }
+                ExprKind::Err(_guar) => {}
             }
             ControlFlow::Continue(())
         }

--- a/crates/parse/src/parser/expr.rs
+++ b/crates/parse/src/parser/expr.rs
@@ -142,8 +142,10 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         loop {
             let kind = if self.eat(TokenKind::Dot) {
                 // expr.member
-                let member = self.parse_ident_any()?;
-                ExprKind::Member(expr, member)
+                match self.parse_ident_any() {
+                    Ok(member) => ExprKind::Member(expr, member),
+                    Err(err) => ExprKind::Err(err.emit()),
+                }
             } else if self.check(TokenKind::OpenDelim(Delimiter::Parenthesis)) {
                 // expr(args)
                 let args = self.parse_call_args()?;

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -3,7 +3,7 @@ use crate::{PResult, Parser, parser::SeqSep};
 use smallvec::SmallVec;
 use solar_ast::{token::*, *};
 use solar_data_structures::CollectAndApply;
-use solar_interface::{Ident, Span, SpannedOption, kw, sym};
+use solar_interface::{Ident, Span, SpannedOption, diagnostics::ErrorGuaranteed, kw, sym};
 
 impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a statement.
@@ -387,7 +387,14 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         if self.check_nr_ident() {
             path.push(IapKind::Member(self.parse_ident()?));
             while self.eat(TokenKind::Dot) {
-                let id = self.ident_or_err(true)?;
+                let id = match self.ident_or_err(true) {
+                    Ok(id) => id,
+                    Err(err) => {
+                        let guar = err.emit();
+                        path.push(IapKind::Err(self.prev_token.span.to(self.token.span), guar));
+                        break;
+                    }
+                };
                 if id.name != kw::Address && id.is_reserved(self.in_yul) {
                     self.expected_ident_found_err().emit();
                 }
@@ -400,7 +407,10 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         } else {
             return self.unexpected();
         }
-        let n_idents = path.len();
+        let n_idents = path
+            .iter()
+            .take_while(|kind| matches!(kind, IapKind::Member(_) | IapKind::MemberTy(..)))
+            .count();
 
         while self.check(TokenKind::OpenDelim(Delimiter::Bracket)) {
             let (span, kind) = self.parse_spanned(Self::parse_expr_index_kind)?;
@@ -427,6 +437,8 @@ enum IapKind<'ast> {
     Member(Ident),
     /// `<ty>`
     MemberTy(Span, ElementaryType),
+    /// An erroneous expression emitted during parser recovery.
+    Err(Span, ErrorGuaranteed),
 }
 
 #[derive(Debug, Default)]
@@ -460,7 +472,11 @@ impl<'ast> IndexAccessedPath<'ast> {
         };
 
         for index in path.skip(self.n_idents - 1) {
-            let IapKind::Index(span, kind) = index else { panic!("parsed too much") };
+            let (span, kind) = match index {
+                IapKind::Index(span, kind) => (span, kind),
+                IapKind::Member(_) | IapKind::MemberTy(..) => panic!("parsed too much"),
+                IapKind::Err(..) => return Some(ty),
+            };
             let size = match kind {
                 IndexKind::Index(expr) => expr,
                 IndexKind::Range(l, r) => {
@@ -487,6 +503,7 @@ impl<'ast> IndexAccessedPath<'ast> {
                 Expr { span, kind: ExprKind::Type(Type { span, kind: TypeKind::Elementary(kind) }) }
             }
             IapKind::Index(..) => panic!("should not happen"),
+            IapKind::Err(span, guar) => Expr { span, kind: ExprKind::Err(guar) },
         });
         for index in path {
             expr = parser.alloc(match index {
@@ -497,6 +514,7 @@ impl<'ast> IndexAccessedPath<'ast> {
                 IapKind::Index(span, kind) => {
                     Expr { span: expr.span.to(span), kind: ExprKind::Index(expr, kind) }
                 }
+                IapKind::Err(span, guar) => Expr { span, kind: ExprKind::Err(guar) },
             });
         }
         Some(expr)

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1780,6 +1780,7 @@ impl<'gcx> ResolveContext<'gcx> {
             ast::ExprKind::TypeCall(ty) => hir::ExprKind::TypeCall(self.lower_type(ty)),
             ast::ExprKind::Type(ty) => hir::ExprKind::Type(self.lower_type(ty)),
             ast::ExprKind::Unary(op, expr) => hir::ExprKind::Unary(*op, self.lower_expr(expr)),
+            ast::ExprKind::Err(guar) => hir::ExprKind::Err(*guar),
         };
         self.hir_builder().expr_owned(self.next_id(), kind, expr.span)
     }

--- a/crates/sema/src/stats/ast.rs
+++ b/crates/sema/src/stats/ast.rs
@@ -84,6 +84,7 @@ impl EnumVariantSize for ast::ExprKind<'_> {
             Self::Tuple(exprs) => variant_payload_size!(self, exprs),
             Self::TypeCall(ty) | Self::Type(ty) => variant_payload_size!(self, ty),
             Self::Unary(op, expr) => variant_payload_size!(self, op, expr),
+            Self::Err(guar) => variant_payload_size!(self, guar),
         }
     }
 }
@@ -459,7 +460,8 @@ impl<'ast> Visit<'ast> for StatCollector {
                 Tuple,
                 TypeCall,
                 Type,
-                Unary
+                Unary,
+                Err
             ]
         );
         self.walk_expr(expr)

--- a/tests/ui/typeck/recovery/calls.sol
+++ b/tests/ui/typeck/recovery/calls.sol
@@ -1,0 +1,24 @@
+//@ compile-flags: -Ztypeck
+
+contract C {
+    function g(uint256 a, uint256 b) public {}
+
+    function namedArgsRecover() public {
+        this.g({a: 1,, b: 2}); //~ ERROR: expected identifier, found `,`
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function abiDecodeEmptyType(bytes memory data) public {
+        uint256 x = abi.decode(data, (, uint256));
+        //~^ ERROR: `abi.decode` type tuple components cannot be empty
+        //~^^ ERROR: mismatched number of components
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function abiDecodeTrailingEmptyType(bytes memory data) public {
+        uint256 x = abi.decode(data, (uint256,));
+        //~^ ERROR: `abi.decode` type tuple components cannot be empty
+        //~^^ ERROR: mismatched number of components
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/recovery/calls.stderr
+++ b/tests/ui/typeck/recovery/calls.stderr
@@ -1,0 +1,60 @@
+error: expected identifier, found `,`
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         this.g({a: 1,, b: 2});
+   │                      ━
+   ╰╴
+help: remove this comma
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         this.g({a: 1,, b: 2});
+   ╰╴                     ━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: `abi.decode` type tuple components cannot be empty
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint256 x = abi.decode(data, (, uint256));
+   ╰╴                                     ━━━━━━━━━━━
+
+error: mismatched number of components
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint256 x = abi.decode(data, (, uint256));
+   │         ━━━━━━━━━━━━┬────────────────────────────━
+   │                     │
+   ╰╴                    expected a tuple with 1 element, found one with 2 elements
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: `abi.decode` type tuple components cannot be empty
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint256 x = abi.decode(data, (uint256,));
+   ╰╴                                     ━━━━━━━━━━
+
+error: mismatched number of components
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint256 x = abi.decode(data, (uint256,));
+   │         ━━━━━━━━━━━━┬───────────────────────────━
+   │                     │
+   ╰╴                    expected a tuple with 1 element, found one with 2 elements
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/calls.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/typeck/recovery/expression_boundaries.sol.todo
+++ b/tests/ui/typeck/recovery/expression_boundaries.sol.todo
@@ -1,0 +1,63 @@
+//@ compile-flags: -Ztypeck
+
+// TODO: These expression-boundary failures should recover by inserting
+// ExprKind::Err at the malformed subexpression and synchronizing at `,`, `;`,
+// `)`, `]`, `}`, or `:` as appropriate.
+
+contract C {
+    uint256[] xs;
+
+    function f(uint256 a, uint256 b) public pure returns (uint256) {
+        return a + b;
+    }
+
+    function missingInitializer() public {
+        uint256 x = ;
+        uint8 y = 300;
+    }
+
+    function missingBinaryRhs() public {
+        uint256 x = 1 + ;
+        uint8 y = 300;
+    }
+
+    function missingParenBinaryRhs() public {
+        uint256 x = (1 + );
+        uint8 y = 300;
+    }
+
+    function missingCallArg() public {
+        uint256 x = f(1, , 2);
+        uint8 y = 300;
+    }
+
+    function missingCallArgAfterBinary() public {
+        uint256 x = f(1 +, 2);
+        uint8 y = 300;
+    }
+
+    function missingArrayElement() public {
+        uint256 x = [1, , 2][0];
+        uint8 y = 300;
+    }
+
+    function missingIndexExpression() public {
+        uint256 x = xs[;
+        uint8 y = 300;
+    }
+
+    function missingIndexBinaryRhs() public {
+        uint256 x = xs[1 + ];
+        uint8 y = 300;
+    }
+
+    function missingTernaryThen() public {
+        uint256 x = true ? : 1;
+        uint8 y = 300;
+    }
+
+    function missingTernaryElse() public {
+        uint256 x = true ? 1 : ;
+        uint8 y = 300;
+    }
+}

--- a/tests/ui/typeck/recovery/malformed_exprs.sol
+++ b/tests/ui/typeck/recovery/malformed_exprs.sol
@@ -1,0 +1,20 @@
+//@ compile-flags: -Ztypeck
+
+contract C {
+    function tupleExpression() public {
+        uint256 x = (1,, true); //~ ERROR: tuple components cannot be empty
+        //~^ ERROR: mismatched number of components
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function omittedIndex(uint256[] memory xs) public {
+        uint256 x = xs[]; //~ ERROR: index expression cannot be omitted
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function memorySlice(uint256[] memory xs) public {
+        uint256 x = xs[:]; //~ ERROR: can only slice dynamic calldata arrays
+        //~^ ERROR: mismatched types
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/recovery/malformed_exprs.stderr
+++ b/tests/ui/typeck/recovery/malformed_exprs.stderr
@@ -1,0 +1,52 @@
+error: tuple components cannot be empty
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint256 x = (1,, true);
+   ╰╴                    ━━━━━━━━━━
+
+error: mismatched number of components
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint256 x = (1,, true);
+   │         ━━━━━━━━━━━━┬─────────━
+   │                     │
+   ╰╴                    expected a tuple with 1 element, found one with 3 elements
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: index expression cannot be omitted
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint256 x = xs[];
+   ╰╴                    ━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: can only slice dynamic calldata arrays
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint256 x = xs[:];
+   ╰╴                    ━━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint256 x = xs[:];
+   ╰╴                    ━━━━━ expected `uint256`, found `uint256[] memory slice`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/malformed_exprs.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/typeck/recovery/member_access.sol
+++ b/tests/ui/typeck/recovery/member_access.sol
@@ -1,0 +1,39 @@
+//@ compile-flags: -Ztypeck
+
+contract C {
+    struct S {
+        uint256 a;
+    }
+
+    function missingStructMember() public {
+        S memory s = S(1);
+        uint256 x = s.else; //~ ERROR: member `else` not found
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function missingStructMemberCall() public {
+        S memory s = S(1);
+        uint256 x = s.else(); //~ ERROR: member `else` not found
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function missingPrimitiveMember() public {
+        uint256 x = (1).foo; //~ ERROR: member `foo` not found
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function missingTupleMember() public {
+        uint256 x = (1, 2).foo; //~ ERROR: member `foo` not found
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function missingMetatypeMember() public {
+        uint256 x = type(C).missing; //~ ERROR: member `missing` not found
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function unresolvedReceiverMember() public {
+        uint256 x = missing.member; //~ ERROR: unresolved symbol `missing`
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/recovery/member_access.stderr
+++ b/tests/ui/typeck/recovery/member_access.stderr
@@ -1,0 +1,74 @@
+error: unresolved symbol `missing`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint256 x = missing.member;
+   ╰╴                    ━━━━━━━
+
+error: member `else` not found on type `struct C.S memory`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint256 x = s.else;
+   ╰╴                      ━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: member `else` not found on type `struct C.S memory`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint256 x = s.else();
+   ╰╴                      ━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: member `foo` not found on type `int_literal[1]`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint256 x = (1).foo;
+   ╰╴                        ━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: member `foo` not found on type `tuple(int_literal[1],int_literal[2])`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint256 x = (1, 2).foo;
+   ╰╴                           ━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: member `missing` not found on type `type(contract C)`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint256 x = type(C).missing;
+   ╰╴                            ━━━━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_access.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: aborting due to 12 previous errors
+

--- a/tests/ui/typeck/recovery/member_parse_recovery.sol
+++ b/tests/ui/typeck/recovery/member_parse_recovery.sol
@@ -1,0 +1,31 @@
+//@ compile-flags: -Ztypeck
+
+contract C {
+    struct S {
+        uint256 a;
+    }
+
+    function missingMemberNameStatement() public {
+        S memory s = S(1);
+        s.; //~ ERROR: expected identifier, found `;`
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function missingMemberNameExpression() public {
+        S memory s = S(1);
+        uint256 x = s.; //~ ERROR: expected identifier, found `;`
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function doubleDotMember() public {
+        S memory s = S(1);
+        uint256 x = s..a; //~ ERROR: expected identifier, found `.`
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+
+    function missingMemberNameBeforeCall() public {
+        S memory s = S(1);
+        s.(); //~ ERROR: expected identifier, found `(`
+        uint8 y = 300; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/recovery/member_parse_recovery.stderr
+++ b/tests/ui/typeck/recovery/member_parse_recovery.stderr
@@ -1,0 +1,50 @@
+error: expected identifier, found `;`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         s.;
+   ╰╴          ━
+
+error: expected identifier, found `;`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         uint256 x = s.;
+   ╰╴                      ━
+
+error: expected identifier, found `.`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         uint256 x = s..a;
+   ╰╴                      ━
+
+error: expected identifier, found `(`
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         s.();
+   ╰╴          ━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/recovery/member_parse_recovery.sol:LL:CC
+   │
+LL │         uint8 y = 300;
+   ╰╴                  ━━━ expected `uint8`, found `int_literal[9]`
+
+error: aborting due to 8 previous errors
+

--- a/tests/ui/typeck/recovery/member_parse_recovery_bare_dot.sol.todo
+++ b/tests/ui/typeck/recovery/member_parse_recovery_bare_dot.sol.todo
@@ -1,0 +1,34 @@
+//@ compile-flags: -Ztypeck
+
+// TODO: These malformed member-access forms should eventually recover into an
+// AST error expression and let typeck continue to later statements. Keep them
+// inactive until they can be promoted with explicit typeck-continuation checks.
+
+contract C {
+    struct S {
+        uint256 a;
+    }
+
+    function missingMemberNameBeforeBrace() public {
+        S memory s = S(1);
+        s.
+    }
+
+    function missingMemberNameBeforeNextStatement() public {
+        S memory s = S(1);
+        s.
+        uint8 y = 300;
+    }
+
+    function missingMemberNameBeforeAssignment() public {
+        S memory s = S(1);
+        s. = 1;
+        uint8 y = 300;
+    }
+
+    function missingMemberNameBeforeIndex() public {
+        S memory s = S(1);
+        s.[0];
+        uint8 y = 300;
+    }
+}

--- a/tests/ui/typeck/recovery/statement_conditions.sol.todo
+++ b/tests/ui/typeck/recovery/statement_conditions.sol.todo
@@ -1,0 +1,36 @@
+//@ compile-flags: -Ztypeck
+
+// TODO: Statement conditions and loop components should recover malformed
+// expressions without losing the following block or statement.
+
+contract C {
+    function missingIfCondition() public {
+        if () {
+            uint8 y = 300;
+        }
+    }
+
+    function badIfCondition() public {
+        if (1 + ) {
+            uint8 y = 300;
+        }
+    }
+
+    function missingWhileCondition() public {
+        while () {
+            uint8 y = 300;
+        }
+    }
+
+    function badForCondition() public {
+        for (; 1 + ; ) {
+            uint8 y = 300;
+        }
+    }
+
+    function badForNextExpression() public {
+        for (; true; 1 + ) {
+            uint8 y = 300;
+        }
+    }
+}

--- a/tests/ui/typeck/recovery/unclosed_delimiters.sol.todo
+++ b/tests/ui/typeck/recovery/unclosed_delimiters.sol.todo
@@ -1,0 +1,40 @@
+//@ compile-flags: -Ztypeck
+
+// TODO: These unclosed delimiter cases currently fail before an AST reaches
+// typeck. Keep them as focused repros for parser recovery work.
+
+contract MissingContractClose {
+    function f() public {
+        uint8 y = 300;
+    }
+
+contract MissingFunctionClose {
+    function f() public {
+        uint8 y = 300;
+}
+
+contract MissingIfParen {
+    function f() public {
+        if (true {
+            uint8 y = 300;
+        }
+    }
+}
+
+contract MissingCallParen {
+    function g(uint256 a, uint256 b) public {}
+
+    function f() public {
+        this.g(1, 2;
+        uint8 y = 300;
+    }
+}
+
+contract MissingIndexBracket {
+    uint256[] xs;
+
+    function f() public {
+        uint256 x = xs[1;
+        uint8 y = 300;
+    }
+}


### PR DESCRIPTION
This adds parser-level error expressions and lowers them through HIR so malformed member access can keep semantic analysis running. It also adds typeck recovery UI coverage for malformed members and other malformed expression shapes, while keeping currently-failing delimiter and expression-boundary repros as inactive .todo fixtures for follow-up parser recovery work.