### PR TITLE
chore: bump inturn to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,14 +1791,14 @@ dependencies = [
 
 [[package]]
 name = "inturn"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58cf1c5e088a860e4b7def7d8fdf8cf222ca33c7a0365619af22e0453b3b79c"
+checksum = "630b41dcc27d131bc9b501515a2cb3dfde2b0de4d8b53bd9c97180fb87696aa2"
 dependencies = [
  "boxcar",
+ "bumpalo",
  "dashmap",
  "hashbrown 0.14.5",
- "stumpalo",
  "thread_local",
 ]
 
@@ -2681,12 +2681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "readme-rustdocifier"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,15 +3521,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "stumpalo"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1628a62e30c1399999472f01517efa4dad9fddb3585cef572520e5dc21c3cf8"
-dependencies = [
- "readme-rustdocifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ oxc_index = { version = "5.0", features = ["nonmax"] }
 indexmap = "2.2"
 itertools = ">=0.10, <=0.14"
 itoa = "1.0"
-inturn = "0.1.0"
+inturn = "0.2.0"
 libc = "0.2"
 memchr = "2.7"
 normalize-path = "0.2.1"

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -439,7 +439,7 @@ impl fmt::Debug for ByteSymbol {
 ///
 /// Initialized in `SessionGlobals` with the `symbols!` macro's initial symbols.
 pub(crate) struct Interner {
-    inner: inturn::BytesInterner<ByteSymbol, solar_data_structures::map::FxBuildHasher>,
+    inner: inturn::sync::BytesInterner<ByteSymbol, solar_data_structures::map::FxBuildHasher>,
 }
 
 impl Interner {
@@ -448,8 +448,10 @@ impl Interner {
     }
 
     pub(crate) fn prefill(init: &[&'static str]) -> Self {
-        let mut inner =
-            inturn::BytesInterner::with_capacity_and_hasher(init.len() * 4, Default::default());
+        let mut inner = inturn::sync::BytesInterner::with_capacity_and_hasher(
+            init.len() * 4,
+            Default::default(),
+        );
         inner.intern_many_mut_static(init.iter().map(|s| s.as_bytes()));
         Self { inner }
     }


### PR DESCRIPTION
Updates the workspace dependency on inturn to 0.2.0 and switches the symbol interner to the new explicit sync module path that matches the previous thread-safe interner API.