### PR TITLE
feat(lsp): add inlay hints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -148,6 +148,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             declaration_provider: Some(DeclarationCapability::Simple(true)),
             definition_provider: Some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
+            inlay_hint_provider: Some(OneOf::Left(true)),
             references_provider: Some(OneOf::Left(true)),
             text_document_sync: Some(TextDocumentSyncCapability::Options(
                 TextDocumentSyncOptions {
@@ -207,6 +208,7 @@ mod tests {
         assert_eq!(capabilities.declaration_provider, Some(DeclarationCapability::Simple(true)));
         assert_eq!(capabilities.definition_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.document_symbol_provider, Some(OneOf::Left(true)));
+        assert_eq!(capabilities.inlay_hint_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.references_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.workspace_symbol_provider, Some(OneOf::Left(true)));
     }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -382,6 +382,7 @@ mod tests {
 
     mod completion;
     mod goto_definition;
+    mod inlay_hint;
     mod references;
     mod support;
 

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -17,9 +17,7 @@ fn returns_parameter_hints_for_positional_calls_and_skips_named_args() {
             }
 
             function caller(address user) public pure returns (uint256) {
-                uint256 positional = target(1, user);
-                uint256 named = target({amount: 2, account: user});
-                return positional + named;
+                return target(1, user) + target({amount: 2, account: user});
             }
         }
         "#,

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -341,6 +341,34 @@ PARAMETER input:
 }
 
 #[test]
+fn displays_multi_return_call_type_hints_as_solidity_tuples() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /MultiReturn.sol
+        contract C {
+            function pair(uint256 amount) internal pure returns (uint256, bool) {
+                return (amount, amount != 0);
+            }
+
+            function caller() public pure returns (uint256, bool) {
+                return pair(1);
+            }
+        }
+        "#,
+        "/MultiReturn.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/MultiReturn.sol",
+        str![[r#"
+PARAMETER amount:
+TYPE : (uint256, bool)
+
+"#]],
+    );
+}
+
+#[test]
 fn uses_function_type_parameter_names_for_function_variable_calls() {
     let fixture = RequestFixture::new_allowing_diagnostics(
         r#"
@@ -361,6 +389,37 @@ fn uses_function_type_parameter_names_for_function_variable_calls() {
 
     fixture.check_inlay_hints(
         "/FunctionType.sol",
+        str![[r#"
+PARAMETER amount:
+PARAMETER account:
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
+fn uses_function_type_parameter_names_for_struct_field_calls() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /FunctionField.sol
+        contract C {
+            struct Holder {
+                function(uint256 amount, address account) internal returns (uint256) callback;
+            }
+
+            Holder holder;
+
+            function caller(address user) public returns (uint256) {
+                return holder.callback(1, user);
+            }
+        }
+        "#,
+        "/FunctionField.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/FunctionField.sol",
         str![[r#"
 PARAMETER amount:
 PARAMETER account:
@@ -393,6 +452,61 @@ fn uses_target_parameter_names_for_abi_encode_call_tuple() {
         str![[r#"
 PARAMETER amount:
 PARAMETER account:
+TYPE : bytes memory
+
+"#]],
+    );
+}
+
+#[test]
+fn uses_target_parameter_names_for_single_abi_encode_call_argument() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /AbiEncodeCallSingle.sol
+        interface I {
+            function target(uint256 amount) external returns (uint256);
+        }
+
+        contract C {
+            function caller() public pure returns (bytes memory) {
+                return abi.encodeCall(I.target, 1);
+            }
+        }
+        "#,
+        "/AbiEncodeCallSingle.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/AbiEncodeCallSingle.sol",
+        str![[r#"
+PARAMETER amount:
+TYPE : bytes memory
+
+"#]],
+    );
+}
+
+#[test]
+fn skips_abi_encode_call_parameter_hints_for_tuple_holes() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /AbiEncodeCallHole.sol
+        interface I {
+            function target(uint256 amount, address account) external returns (uint256);
+        }
+
+        contract C {
+            function caller(address user) public pure returns (bytes memory) {
+                return abi.encodeCall(I.target, (, user));
+            }
+        }
+        "#,
+        "/AbiEncodeCallHole.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/AbiEncodeCallHole.sol",
+        str![[r#"
 TYPE : bytes memory
 
 "#]],

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -458,6 +458,33 @@ TYPE : bytes memory
 }
 
 #[test]
+fn skips_abi_encode_call_parameter_hints_for_tuple_arity_mismatch() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /AbiEncodeCallArityMismatch.sol
+        interface I {
+            function target(uint256 amount, address account) external returns (uint256);
+        }
+
+        contract C {
+            function caller(address user) public pure returns (bytes memory) {
+                return abi.encodeCall(I.target, (1, user, 3));
+            }
+        }
+        "#,
+        "/AbiEncodeCallArityMismatch.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/AbiEncodeCallArityMismatch.sol",
+        str![[r#"
+TYPE : bytes memory
+
+"#]],
+    );
+}
+
+#[test]
 fn uses_target_parameter_names_for_single_abi_encode_call_argument() {
     let fixture = RequestFixture::new(
         r#"

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -106,6 +106,45 @@ TYPE : uint256
 }
 
 #[test]
+fn skips_parameter_hints_for_arguments_with_matching_names() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Names.sol
+        contract C {
+            error Bad(uint256 code, address account);
+
+            function target(uint256 amount, address account) public pure returns (uint256) {
+                return amount;
+            }
+
+            function caller(address account, uint256 amount) public pure returns (uint256) {
+                uint256 bothSame = target(amount, account);
+                uint256 secondSame = target(1, account);
+                return bothSame + secondSame;
+            }
+
+            function fail(address user) public pure {
+                revert Bad(7, account);
+            }
+        }
+        "#,
+        "/Names.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Names.sol",
+        full_range(),
+        str![[r#"
+TYPE : uint256
+PARAMETER amount:
+TYPE : uint256
+PARAMETER code:
+
+"#]],
+    );
+}
+
+#[test]
 fn returns_parameter_hints_for_solidity_callable_forms() {
     let fixture = RequestFixture::new(
         r#"

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -1,0 +1,225 @@
+use super::support::RequestFixture;
+use lsp_types::{Position, Range};
+use snapbox::str;
+
+fn full_range() -> Range {
+    Range { start: Position::new(0, 0), end: Position::new(u32::MAX, u32::MAX) }
+}
+
+#[test]
+fn returns_parameter_hints_for_positional_calls_and_skips_named_args() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Hints.sol
+        contract C {
+            function target(uint256 amount, address account) public pure returns (uint256) {
+                return amount;
+            }
+
+            function caller(address user) public pure returns (uint256) {
+                uint256 positional = target(1, user);
+                uint256 named = target({amount: 2, account: user});
+                return positional + named;
+            }
+        }
+        "#,
+        "/Hints.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Hints.sol",
+        full_range(),
+        str![[r#"
+PARAMETER amount:
+PARAMETER account:
+TYPE : uint256
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
+fn uses_selected_overload_for_parameter_hints() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Overload.sol
+        contract C {
+            function f(uint256 value) public pure returns (uint256) {
+                return value;
+            }
+
+            function f(string memory text) public pure returns (uint256) {
+                return bytes(text).length;
+            }
+
+            function caller() public pure returns (uint256) {
+                return f("abc");
+            }
+        }
+        "#,
+        "/Overload.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Overload.sol",
+        full_range(),
+        str![[r#"
+PARAMETER text:
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
+fn skips_attached_using_receiver_for_parameter_hints() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Using.sol
+        library L {
+            function add(uint256 self, uint256 amount) internal pure returns (uint256) {
+                return self + amount;
+            }
+        }
+
+        using L for uint256;
+
+        contract C {
+            function caller(uint256 value) public pure returns (uint256) {
+                return value.add(3);
+            }
+        }
+        "#,
+        "/Using.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Using.sol",
+        full_range(),
+        str![[r#"
+PARAMETER amount:
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
+fn returns_parameter_hints_for_solidity_callable_forms() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Forms.sol
+        contract BaseList {
+            constructor(uint256 baseValue) {}
+        }
+
+        contract BaseCtor {
+            constructor(uint256 ctorValue) {}
+        }
+
+        contract C is BaseList(1), BaseCtor {
+            struct Pair { uint256 left; uint256 right; }
+            event Seen(uint256 indexed id, address account);
+            error Bad(uint256 code, address account);
+
+            modifier only(uint256 requiredValue) {
+                _;
+            }
+
+            constructor() BaseCtor(2) {}
+
+            function run(address user) public only(3) {
+                Pair memory pair = Pair(4, 5);
+                emit Seen(6, user);
+                revert Bad(7, user);
+            }
+        }
+        "#,
+        "/Forms.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Forms.sol",
+        full_range(),
+        str![[r#"
+PARAMETER baseValue:
+PARAMETER ctorValue:
+PARAMETER requiredValue:
+PARAMETER left:
+PARAMETER right:
+TYPE : struct C.Pair memory
+PARAMETER id:
+PARAMETER account:
+PARAMETER code:
+PARAMETER account:
+
+"#]],
+    );
+}
+
+#[test]
+fn returns_call_type_hints_for_non_unit_calls() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Types.sol
+        contract C {
+            function value() public pure returns (uint256) {
+                return 1;
+            }
+
+            function sideEffect(uint256 input) public pure {
+                input;
+            }
+
+            function caller() public pure {
+                uint256 x = value();
+                sideEffect(x);
+            }
+        }
+        "#,
+        "/Types.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Types.sol",
+        full_range(),
+        str![[r#"
+TYPE : uint256
+PARAMETER input:
+
+"#]],
+    );
+}
+
+#[test]
+fn filters_hints_by_requested_range() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Range.sol
+        contract C {
+            function f(uint256 first, uint256 second) public pure returns (uint256) {
+                return first + second;
+            }
+
+            function caller() public pure returns (uint256) {
+                $1uint256 a = f(1, 2);
+                $2uint256 b = f(3, 4);
+                return a + b;
+            }
+        }
+        "#,
+        "/Range.sol",
+    );
+
+    fixture.check_inlay_hints_between(
+        "$1",
+        "$2",
+        str![[r#"
+PARAMETER first:
+PARAMETER second:
+TYPE : uint256
+
+"#]],
+    );
+}

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -268,7 +268,6 @@ PARAMETER ctorValue:
 PARAMETER requiredValue:
 PARAMETER left:
 PARAMETER right:
-TYPE : struct Pair { uint256 left; uint256 right; }
 PARAMETER id:
 PARAMETER account:
 PARAMETER code:

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -169,6 +169,29 @@ TYPE : uint256
 }
 
 #[test]
+fn skips_inlay_hints_inside_inline_assembly() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Assembly.sol
+        contract C {
+            function run() public pure {
+                assembly {
+                    let y := add(1, 2)
+                }
+            }
+        }
+        "#,
+        "/Assembly.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Assembly.sol",
+        str![[r#"
+"#]],
+    );
+}
+
+#[test]
 fn skips_type_hints_for_explicit_casts() {
     let fixture = RequestFixture::new(
         r#"
@@ -312,6 +335,65 @@ fn returns_call_type_hints_for_non_unit_calls() {
         str![[r#"
 TYPE : uint256
 PARAMETER input:
+
+"#]],
+    );
+}
+
+#[test]
+fn uses_function_type_parameter_names_for_function_variable_calls() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /FunctionType.sol
+        contract C {
+            function target(uint256 amount, address account) internal pure returns (uint256) {
+                return amount;
+            }
+
+            function caller(address user) public pure returns (uint256) {
+                function(uint256 amount, address account) internal pure returns (uint256) f = target;
+                return f(1, user);
+            }
+        }
+        "#,
+        "/FunctionType.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/FunctionType.sol",
+        str![[r#"
+PARAMETER amount:
+PARAMETER account:
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
+fn uses_target_parameter_names_for_abi_encode_call_tuple() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /AbiEncodeCall.sol
+        interface I {
+            function target(uint256 amount, address account) external returns (uint256);
+        }
+
+        contract C {
+            function caller(address user) public pure returns (bytes memory) {
+                return abi.encodeCall(I.target, (1, user));
+            }
+        }
+        "#,
+        "/AbiEncodeCall.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/AbiEncodeCall.sol",
+        str![[r#"
+PARAMETER amount:
+PARAMETER account:
+TYPE : bytes memory
 
 "#]],
     );

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -268,7 +268,7 @@ PARAMETER ctorValue:
 PARAMETER requiredValue:
 PARAMETER left:
 PARAMETER right:
-TYPE : struct C.Pair memory
+TYPE : struct Pair { uint256 left; uint256 right; }
 PARAMETER id:
 PARAMETER account:
 PARAMETER code:

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -143,6 +143,78 @@ PARAMETER code:
 }
 
 #[test]
+fn handles_contextual_builtin_callees() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Builtins.sol
+        type MyUdvt is uint256;
+
+        contract C {
+            uint256[] xs;
+
+            function run(uint256 x, MyUdvt y) public returns (uint256) {
+                xs.push(1);
+                xs.pop();
+
+                MyUdvt wrapped = MyUdvt.wrap(x);
+                uint256 unwrapped = MyUdvt.unwrap(y);
+
+                return MyUdvt.unwrap(wrapped) + unwrapped;
+            }
+        }
+        "#,
+        "/Builtins.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Builtins.sol",
+        full_range(),
+        str![[r#"
+TYPE : MyUdvt
+TYPE : uint256
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
+fn skips_type_hints_for_explicit_casts() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Casts.sol
+        contract Target {}
+
+        enum SomeEnum { A, B }
+
+        contract Repro {
+            function value() public pure returns (uint256) {
+                return 1;
+            }
+
+            function run(address addr) public pure returns (SomeEnum) {
+                Target t = Target(addr);
+                SomeEnum e = SomeEnum(0);
+                uint256 n = uint256(1);
+                uint256 x = value();
+                return e;
+            }
+        }
+        "#,
+        "/Casts.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Casts.sol",
+        full_range(),
+        str![[r#"
+TYPE : uint256
+
+"#]],
+    );
+}
+
+#[test]
 fn returns_parameter_hints_for_solidity_callable_forms() {
     let fixture = RequestFixture::new(
         r#"
@@ -190,6 +262,36 @@ PARAMETER id:
 PARAMETER account:
 PARAMETER code:
 PARAMETER account:
+
+"#]],
+    );
+}
+
+#[test]
+fn returns_parameter_hints_for_new_contract_constructor_calls() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /New.sol
+        contract Target {
+            constructor(uint256 amount, address owner) {}
+        }
+
+        contract C {
+            function run(address user) public {
+                Target deployed = new Target(1, user);
+            }
+        }
+        "#,
+        "/New.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/New.sol",
+        full_range(),
+        str![[r#"
+PARAMETER amount:
+PARAMETER owner:
+TYPE : contract Target
 
 "#]],
     );

--- a/crates/lsp/src/global_state/tests/inlay_hint.rs
+++ b/crates/lsp/src/global_state/tests/inlay_hint.rs
@@ -1,10 +1,5 @@
 use super::support::RequestFixture;
-use lsp_types::{Position, Range};
 use snapbox::str;
-
-fn full_range() -> Range {
-    Range { start: Position::new(0, 0), end: Position::new(u32::MAX, u32::MAX) }
-}
 
 #[test]
 fn returns_parameter_hints_for_positional_calls_and_skips_named_args() {
@@ -26,7 +21,6 @@ fn returns_parameter_hints_for_positional_calls_and_skips_named_args() {
 
     fixture.check_inlay_hints(
         "/Hints.sol",
-        full_range(),
         str![[r#"
 PARAMETER amount:
 PARAMETER account:
@@ -61,7 +55,6 @@ fn uses_selected_overload_for_parameter_hints() {
 
     fixture.check_inlay_hints(
         "/Overload.sol",
-        full_range(),
         str![[r#"
 PARAMETER text:
 TYPE : uint256
@@ -94,7 +87,6 @@ fn skips_attached_using_receiver_for_parameter_hints() {
 
     fixture.check_inlay_hints(
         "/Using.sol",
-        full_range(),
         str![[r#"
 PARAMETER amount:
 TYPE : uint256
@@ -131,7 +123,6 @@ fn skips_parameter_hints_for_arguments_with_matching_names() {
 
     fixture.check_inlay_hints(
         "/Names.sol",
-        full_range(),
         str![[r#"
 TYPE : uint256
 PARAMETER amount:
@@ -168,7 +159,6 @@ fn handles_contextual_builtin_callees() {
 
     fixture.check_inlay_hints(
         "/Builtins.sol",
-        full_range(),
         str![[r#"
 TYPE : MyUdvt
 TYPE : uint256
@@ -206,7 +196,6 @@ fn skips_type_hints_for_explicit_casts() {
 
     fixture.check_inlay_hints(
         "/Casts.sol",
-        full_range(),
         str![[r#"
 TYPE : uint256
 
@@ -250,7 +239,6 @@ fn returns_parameter_hints_for_solidity_callable_forms() {
 
     fixture.check_inlay_hints(
         "/Forms.sol",
-        full_range(),
         str![[r#"
 PARAMETER baseValue:
 PARAMETER ctorValue:
@@ -287,7 +275,6 @@ fn returns_parameter_hints_for_new_contract_constructor_calls() {
 
     fixture.check_inlay_hints(
         "/New.sol",
-        full_range(),
         str![[r#"
 PARAMETER amount:
 PARAMETER owner:
@@ -322,7 +309,6 @@ fn returns_call_type_hints_for_non_unit_calls() {
 
     fixture.check_inlay_hints(
         "/Types.sol",
-        full_range(),
         str![[r#"
 TYPE : uint256
 PARAMETER input:

--- a/crates/lsp/src/global_state/tests/support.rs
+++ b/crates/lsp/src/global_state/tests/support.rs
@@ -3,9 +3,9 @@ use crate::test_support::MarkedProject;
 use async_lsp::ClientSocket;
 use lsp_types::{
     CompletionItem, CompletionParams, CompletionResponse, GotoDefinitionParams,
-    GotoDefinitionResponse, Location, PartialResultParams, Position, ReferenceContext,
-    ReferenceParams, TextDocumentIdentifier, TextDocumentPositionParams, Url,
-    WorkDoneProgressParams,
+    GotoDefinitionResponse, InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Location,
+    PartialResultParams, Position, Range, ReferenceContext, ReferenceParams,
+    TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
 };
 use snapbox::{IntoData, assert_data_eq};
 use solar_config::CompileOpts;
@@ -88,6 +88,33 @@ impl RequestFixture {
         ))
         .unwrap();
         assert_data_eq!(self.locations_output(response), expected);
+    }
+
+    pub(super) fn check_inlay_hints(&self, path: &str, range: Range, expected: impl IntoData) {
+        let mut state = self.state();
+        let uri = Url::from_file_path(self.marked.project().path(path)).unwrap();
+        let response =
+            expect_ready(crate::handlers::inlay_hints(&mut state, inlay_hint_params(uri, range)))
+                .unwrap();
+        assert_data_eq!(inlay_hint_output(&response.unwrap_or_default()), expected);
+    }
+
+    pub(super) fn check_inlay_hints_between(
+        &self,
+        start_marker: &str,
+        end_marker: &str,
+        expected: impl IntoData,
+    ) {
+        let (start_uri, start) = self.marker_location(start_marker);
+        let (end_uri, end) = self.marker_location(end_marker);
+        assert_eq!(start_uri, end_uri);
+        let mut state = self.state();
+        let response = expect_ready(crate::handlers::inlay_hints(
+            &mut state,
+            inlay_hint_params(start_uri, Range { start, end }),
+        ))
+        .unwrap();
+        assert_data_eq!(inlay_hint_output(&response.unwrap_or_default()), expected);
     }
 
     fn state(&self) -> GlobalState {
@@ -174,6 +201,30 @@ fn completion_output(items: &[CompletionItem]) -> String {
     output
 }
 
+fn inlay_hint_output(hints: &[InlayHint]) -> String {
+    let mut output = String::new();
+    for hint in hints {
+        writeln!(output, "{} {}", inlay_hint_kind(hint.kind), inlay_hint_label(&hint.label))
+            .unwrap();
+    }
+    output
+}
+
+fn inlay_hint_kind(kind: Option<InlayHintKind>) -> &'static str {
+    match kind {
+        Some(InlayHintKind::PARAMETER) => "PARAMETER",
+        Some(InlayHintKind::TYPE) => "TYPE",
+        _ => "UNKNOWN",
+    }
+}
+
+fn inlay_hint_label(label: &InlayHintLabel) -> String {
+    match label {
+        InlayHintLabel::String(label) => label.clone(),
+        InlayHintLabel::LabelParts(parts) => parts.iter().map(|part| part.value.as_str()).collect(),
+    }
+}
+
 fn display_path(root: &Path, path: &Path) -> String {
     let path = path.strip_prefix(root).unwrap_or(path);
     format!("/{}", path.display())
@@ -202,6 +253,14 @@ fn reference_params(uri: Url, position: Position, include_declaration: bool) -> 
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),
         context: ReferenceContext { include_declaration },
+    }
+}
+
+fn inlay_hint_params(uri: Url, range: Range) -> InlayHintParams {
+    InlayHintParams {
+        text_document: TextDocumentIdentifier { uri },
+        range,
+        work_done_progress_params: WorkDoneProgressParams::default(),
     }
 }
 

--- a/crates/lsp/src/global_state/tests/support.rs
+++ b/crates/lsp/src/global_state/tests/support.rs
@@ -90,13 +90,9 @@ impl RequestFixture {
         assert_data_eq!(self.locations_output(response), expected);
     }
 
-    pub(super) fn check_inlay_hints(&self, path: &str, range: Range, expected: impl IntoData) {
-        let mut state = self.state();
+    pub(super) fn check_inlay_hints(&self, path: &str, expected: impl IntoData) {
         let uri = Url::from_file_path(self.marked.project().path(path)).unwrap();
-        let response =
-            expect_ready(crate::handlers::inlay_hints(&mut state, inlay_hint_params(uri, range)))
-                .unwrap();
-        assert_data_eq!(inlay_hint_output(&response.unwrap_or_default()), expected);
+        assert_data_eq!(inlay_hint_output(&self.inlay_hints(uri, full_range())), expected);
     }
 
     pub(super) fn check_inlay_hints_between(
@@ -108,13 +104,18 @@ impl RequestFixture {
         let (start_uri, start) = self.marker_location(start_marker);
         let (end_uri, end) = self.marker_location(end_marker);
         assert_eq!(start_uri, end_uri);
+        assert_data_eq!(
+            inlay_hint_output(&self.inlay_hints(start_uri, Range { start, end })),
+            expected
+        );
+    }
+
+    fn inlay_hints(&self, uri: Url, range: Range) -> Vec<InlayHint> {
         let mut state = self.state();
-        let response = expect_ready(crate::handlers::inlay_hints(
-            &mut state,
-            inlay_hint_params(start_uri, Range { start, end }),
-        ))
-        .unwrap();
-        assert_data_eq!(inlay_hint_output(&response.unwrap_or_default()), expected);
+        let response =
+            expect_ready(crate::handlers::inlay_hints(&mut state, inlay_hint_params(uri, range)))
+                .unwrap();
+        response.unwrap_or_default()
     }
 
     fn state(&self) -> GlobalState {
@@ -262,6 +263,10 @@ fn inlay_hint_params(uri: Url, range: Range) -> InlayHintParams {
         range,
         work_done_progress_params: WorkDoneProgressParams::default(),
     }
+}
+
+fn full_range() -> Range {
+    Range { start: Position::new(0, 0), end: Position::new(u32::MAX, u32::MAX) }
 }
 
 fn text_document_position(uri: Url, position: Position) -> TextDocumentPositionParams {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -3,8 +3,8 @@ use async_lsp::ResponseError;
 use crop::Rope;
 use lsp_types::{
     CompletionParams, CompletionResponse, DocumentSymbolParams, DocumentSymbolResponse,
-    GotoDefinitionParams, GotoDefinitionResponse, Position, ReferenceParams, Url,
-    WorkspaceSymbolParams, WorkspaceSymbolResponse,
+    GotoDefinitionParams, GotoDefinitionResponse, InlayHint, InlayHintParams, Position,
+    ReferenceParams, Url, WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
 use std::future::ready;
 
@@ -61,6 +61,14 @@ pub(crate) fn references(
         include_declaration,
     );
     ready(Ok(response))
+}
+
+pub(crate) fn inlay_hints(
+    state: &mut GlobalState,
+    params: InlayHintParams,
+) -> impl Future<Output = Result<Option<Vec<InlayHint>>, ResponseError>> + use<> {
+    let response = state.symbol_tables.read().inlay_hints(&params.text_document.uri, params.range);
+    ready(Ok(Some(response)))
 }
 
 pub(crate) fn completion(

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -6,7 +6,8 @@ use solar_interface::{
 };
 use solar_sema::{
     Gcx,
-    hir::{self, CallArgsKind, ExprKind, ItemId, Visit},
+    builtins::Builtin,
+    hir::{self, CallArgsKind, ExprKind, ItemId, StmtKind, Visit},
     ty::{CallableParamSource, Ty, TyKind},
 };
 use std::ops::ControlFlow;
@@ -137,8 +138,16 @@ impl<'gcx> InlayHintCollector<'gcx> {
         let (CallArgsKind::Unnamed(exprs), Some(param_source)) = (args.kind, param_source) else {
             return;
         };
+        self.push_parameter_hints_for_exprs(exprs, param_source);
+    }
+
+    fn push_parameter_hints_for_exprs(
+        &mut self,
+        exprs: impl IntoIterator<Item = &'gcx hir::Expr<'gcx>>,
+        param_source: CallableParamSource,
+    ) {
         let param_names = self.gcx.callable_param_names(param_source);
-        for (arg, param_name) in exprs.iter().zip(param_names) {
+        for (arg, param_name) in exprs.into_iter().zip(param_names) {
             let Some(param_name) = param_name else {
                 continue;
             };
@@ -154,6 +163,23 @@ impl<'gcx> InlayHintCollector<'gcx> {
                 StoredInlayHint::parameter(location.range.start, format!("{param_name}:")),
             );
         }
+    }
+
+    /// Adds target parameter-name hints for the tuple argument in `abi.encodeCall`.
+    fn push_abi_encode_call_parameter_hints(&mut self, args: &hir::CallArgs<'gcx>) {
+        let CallArgsKind::Unnamed([target, arguments]) = args.kind else {
+            return;
+        };
+        let ExprKind::Tuple(components) = arguments.peel_parens().kind else {
+            return;
+        };
+        let Some(param_source) = self.call_param_source_from_expr(target) else {
+            return;
+        };
+        self.push_parameter_hints_for_exprs(
+            components.iter().filter_map(|component| *component),
+            param_source,
+        );
     }
 
     /// Returns whether an argument expression already makes the parameter name visible.
@@ -207,7 +233,28 @@ impl<'gcx> InlayHintCollector<'gcx> {
             return Some(CallableParamSource::Function { id: ctor, skips_receiver: false });
         }
 
-        callee_ty
+        self.call_param_source_from_expr(callee).or_else(|| {
+            callee_ty
+                .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
+                .and_then(|signature| signature.param_source)
+        })
+    }
+
+    /// Finds the parameter-name source attached to a specific expression.
+    fn call_param_source_from_expr(
+        &self,
+        expr: &'gcx hir::Expr<'gcx>,
+    ) -> Option<CallableParamSource> {
+        let expr = expr.peel_parens();
+        if let ExprKind::Ident([res]) = expr.kind
+            && let Some(variable) = res.as_variable()
+            && matches!(self.gcx.hir.variable(variable).ty.kind, hir::TypeKind::Function(_))
+        {
+            return Some(CallableParamSource::FunctionType(variable));
+        }
+
+        self.gcx
+            .type_of_expr(expr.id)
             .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
             .and_then(|signature| signature.param_source)
     }
@@ -236,10 +283,20 @@ impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         if let ExprKind::Call(callee, ref args, _) = expr.kind {
             let callee_ty = self.gcx.type_of_expr(callee.id);
+            if self.gcx.builtin_callee(callee.id) == Some(Builtin::AbiEncodeCall) {
+                self.push_abi_encode_call_parameter_hints(args);
+            }
             self.push_parameter_hints(args, self.call_param_source(callee, callee_ty));
             self.push_call_type_hint(expr, callee_ty);
         }
         hir::Visit::walk_expr(self, expr)
+    }
+
+    fn visit_stmt(&mut self, stmt: &'gcx hir::Stmt<'gcx>) -> ControlFlow<Self::BreakValue> {
+        if matches!(stmt.kind, StmtKind::AssemblyBlock(_)) {
+            return ControlFlow::Continue(());
+        }
+        hir::Visit::walk_stmt(self, stmt)
     }
 
     fn visit_modifier(

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -174,6 +174,13 @@ impl<'gcx> InlayHintCollector<'gcx> {
     }
 
     fn call_param_source(&self, callee: &'gcx hir::Expr<'gcx>) -> Option<CallableParamSource> {
+        if let ExprKind::New(hir_ty) = &callee.kind
+            && let TyKind::Contract(id) = self.gcx.type_of_hir_ty(hir_ty).kind
+            && let Some(ctor) = self.gcx.hir.contract(id).ctor
+        {
+            return Some(CallableParamSource::Function { id: ctor, skips_receiver: false });
+        }
+
         let signature = if let Some(resolved) = self.gcx.resolved_callee(callee.id) {
             if matches!(resolved.res, Res::Builtin(_)) {
                 self.gcx
@@ -189,10 +196,9 @@ impl<'gcx> InlayHintCollector<'gcx> {
     }
 
     fn is_explicit_cast_call(&self, callee: &'gcx hir::Expr<'gcx>) -> bool {
-        self.gcx.resolved_callee(callee.id).is_none()
-            && self.gcx.type_of_expr(callee.id).is_some_and(
-                |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
-            )
+        self.gcx.type_of_expr(callee.id).is_some_and(
+            |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
+        )
     }
 
     fn modifier_param_source(

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -6,7 +6,7 @@ use solar_interface::{
 };
 use solar_sema::{
     Gcx,
-    hir::{self, CallArgsKind, ExprKind, ItemId, Res, Visit},
+    hir::{self, CallArgsKind, ExprKind, ItemId, Visit},
     ty::{CallableParamSource, TyKind},
 };
 use std::ops::ControlFlow;
@@ -191,11 +191,12 @@ impl<'gcx> InlayHintCollector<'gcx> {
         &self,
         modifier: &'gcx hir::Modifier<'gcx>,
     ) -> Option<CallableParamSource> {
-        let res = match modifier.id {
-            ItemId::Contract(id) => self.gcx.hir.contract(id).ctor.map(ItemId::Function)?,
-            id => id,
+        let id = match modifier.id {
+            ItemId::Contract(id) => self.gcx.hir.contract(id).ctor?,
+            ItemId::Function(id) => id,
+            _ => return None,
         };
-        self.gcx.callable_signature_of_res(Res::Item(res), false)?.param_source
+        Some(CallableParamSource::Function { id, skips_receiver: false })
     }
 }
 

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -147,6 +147,14 @@ impl<'gcx> InlayHintCollector<'gcx> {
         param_source: CallableParamSource,
     ) {
         let param_names = self.gcx.callable_param_names(param_source);
+        self.push_parameter_hints_for_exprs_and_names(exprs, param_names);
+    }
+
+    fn push_parameter_hints_for_exprs_and_names(
+        &mut self,
+        exprs: impl IntoIterator<Item = &'gcx hir::Expr<'gcx>>,
+        param_names: impl IntoIterator<Item = Option<Symbol>>,
+    ) {
         for (arg, param_name) in exprs.into_iter().zip(param_names) {
             let Some(param_name) = param_name else {
                 continue;
@@ -165,21 +173,32 @@ impl<'gcx> InlayHintCollector<'gcx> {
         }
     }
 
-    /// Adds target parameter-name hints for the tuple argument in `abi.encodeCall`.
+    /// Adds target parameter-name hints for the encoded arguments in `abi.encodeCall`.
     fn push_abi_encode_call_parameter_hints(&mut self, args: &hir::CallArgs<'gcx>) {
         let CallArgsKind::Unnamed([target, arguments]) = args.kind else {
-            return;
-        };
-        let ExprKind::Tuple(components) = arguments.peel_parens().kind else {
             return;
         };
         let Some(param_source) = self.call_param_source_from_expr(target) else {
             return;
         };
-        self.push_parameter_hints_for_exprs(
-            components.iter().filter_map(|component| *component),
-            param_source,
-        );
+        let param_names = self.gcx.callable_param_names(param_source);
+        let arguments = arguments.peel_parens();
+
+        match arguments.kind {
+            ExprKind::Tuple(components) => {
+                if components.iter().any(|component| component.is_none()) {
+                    return;
+                }
+                self.push_parameter_hints_for_exprs_and_names(
+                    components.iter().filter_map(|component| *component),
+                    param_names,
+                );
+            }
+            _ if param_names.len() == 1 => {
+                self.push_parameter_hints_for_exprs_and_names([arguments], param_names);
+            }
+            _ => {}
+        }
     }
 
     /// Returns whether an argument expression already makes the parameter name visible.
@@ -216,8 +235,20 @@ impl<'gcx> InlayHintCollector<'gcx> {
         };
         self.index.push(
             location.uri,
-            StoredInlayHint::call_type(location.range.end, format!(": {}", ty.display(self.gcx))),
+            StoredInlayHint::call_type(location.range.end, self.call_type_label(ty)),
         );
+    }
+
+    fn call_type_label(&self, ty: Ty<'gcx>) -> String {
+        if let TyKind::Tuple(tys) = ty.kind {
+            let tys = tys
+                .iter()
+                .map(|ty| ty.display(self.gcx).to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return format!(": ({tys})");
+        }
+        format!(": {}", ty.display(self.gcx))
     }
 
     /// Finds the callable declaration that supplies parameter names for a call expression.
@@ -253,10 +284,32 @@ impl<'gcx> InlayHintCollector<'gcx> {
             return Some(CallableParamSource::FunctionType(variable));
         }
 
+        if let ExprKind::Member(receiver, ident) = expr.kind
+            && let Some(receiver_ty) = self.gcx.type_of_expr(receiver.id)
+            && let Some(field) = self.struct_field(receiver_ty, ident.name)
+            && matches!(self.gcx.hir.variable(field).ty.kind, hir::TypeKind::Function(_))
+        {
+            return Some(CallableParamSource::FunctionType(field));
+        }
+
         self.gcx
             .type_of_expr(expr.id)
             .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
             .and_then(|signature| signature.param_source)
+    }
+
+    fn struct_field(&self, receiver_ty: Ty<'gcx>, name: Symbol) -> Option<hir::VariableId> {
+        let struct_id = match receiver_ty.kind {
+            TyKind::Ref(inner, _) => match inner.kind {
+                TyKind::Struct(id) => id,
+                _ => return None,
+            },
+            TyKind::Struct(id) => id,
+            _ => return None,
+        };
+        self.gcx.hir.strukt(struct_id).fields.iter().copied().find(|&field| {
+            self.gcx.hir.variable(field).name.is_some_and(|field_name| field_name.name == name)
+        })
     }
 
     /// Finds the function or constructor declaration that supplies parameter names for a modifier.

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -186,7 +186,9 @@ impl<'gcx> InlayHintCollector<'gcx> {
 
         match arguments.kind {
             ExprKind::Tuple(components) => {
-                if components.iter().any(|component| component.is_none()) {
+                if components.len() != param_names.len()
+                    || components.iter().any(|component| component.is_none())
+                {
                     return;
                 }
                 self.push_parameter_hints_for_exprs_and_names(

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -1,0 +1,266 @@
+use crate::proto;
+use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, Range, Url};
+use solar_interface::data_structures::{Never, map::FxHashMap};
+use solar_sema::{
+    Gcx,
+    hir::{self, CallArgsKind, ExprKind, ItemId, Res, Visit},
+    ty::{CallableSignature, Ty, TyKind},
+};
+use std::ops::ControlFlow;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct InlayHintIndex {
+    by_file: FxHashMap<Url, Vec<StoredInlayHint>>,
+}
+
+#[derive(Clone, Debug)]
+struct StoredInlayHint {
+    position: Position,
+    label: String,
+    kind: StoredInlayHintKind,
+    padding_left: bool,
+    padding_right: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StoredInlayHintKind {
+    Parameter,
+    CallType,
+}
+
+impl InlayHintIndex {
+    pub(crate) fn build(gcx: Gcx<'_>) -> Self {
+        let mut collector = InlayHintCollector { gcx, index: Self::default() };
+        for source_id in gcx.hir.source_ids() {
+            let _ = collector.visit_nested_source(source_id);
+        }
+        collector.index.sort();
+        collector.index
+    }
+
+    pub(crate) fn extend(&mut self, other: Self) {
+        for (uri, mut hints) in other.by_file {
+            self.by_file.entry(uri).or_default().append(&mut hints);
+        }
+        self.sort();
+    }
+
+    pub(crate) fn hints(&self, uri: &Url, range: Range) -> Vec<InlayHint> {
+        let Some(hints) = self.by_file.get(uri) else {
+            return Vec::new();
+        };
+        let start = hints.partition_point(|hint| hint.position < range.start);
+        hints[start..]
+            .iter()
+            .take_while(|hint| position_before_range_end(hint.position, range))
+            .filter(|hint| range_contains_position(range, hint.position))
+            .map(StoredInlayHint::to_lsp)
+            .collect()
+    }
+
+    fn push(&mut self, uri: Url, hint: StoredInlayHint) {
+        self.by_file.entry(uri).or_default().push(hint);
+    }
+
+    fn sort(&mut self) {
+        for hints in self.by_file.values_mut() {
+            hints.sort_by(|a, b| hint_sort_key(a).cmp(&hint_sort_key(b)));
+        }
+    }
+}
+
+impl StoredInlayHint {
+    fn parameter(position: Position, label: String) -> Self {
+        Self {
+            position,
+            label,
+            kind: StoredInlayHintKind::Parameter,
+            padding_left: false,
+            padding_right: true,
+        }
+    }
+
+    fn call_type(position: Position, label: String) -> Self {
+        Self {
+            position,
+            label,
+            kind: StoredInlayHintKind::CallType,
+            padding_left: true,
+            padding_right: false,
+        }
+    }
+
+    fn to_lsp(&self) -> InlayHint {
+        InlayHint {
+            position: self.position,
+            label: InlayHintLabel::String(self.label.clone()),
+            kind: Some(self.kind.lsp_kind()),
+            text_edits: None,
+            tooltip: None,
+            padding_left: Some(self.padding_left),
+            padding_right: Some(self.padding_right),
+            data: None,
+        }
+    }
+}
+
+impl StoredInlayHintKind {
+    fn lsp_kind(self) -> InlayHintKind {
+        match self {
+            Self::Parameter => InlayHintKind::PARAMETER,
+            Self::CallType => InlayHintKind::TYPE,
+        }
+    }
+
+    fn sort_key(self) -> u8 {
+        match self {
+            Self::Parameter => 0,
+            Self::CallType => 1,
+        }
+    }
+}
+
+struct InlayHintCollector<'gcx> {
+    gcx: Gcx<'gcx>,
+    index: InlayHintIndex,
+}
+
+impl<'gcx> InlayHintCollector<'gcx> {
+    fn push_parameter_hints(
+        &mut self,
+        args: &hir::CallArgs<'gcx>,
+        signature: CallableSignature<'gcx>,
+    ) {
+        let CallArgsKind::Unnamed(exprs) = args.kind else {
+            return;
+        };
+        let Some(param_source) = signature.param_source else {
+            return;
+        };
+        let param_names = self.gcx.callable_param_names(param_source);
+        for ((arg, _param_ty), param_name) in
+            exprs.iter().zip(signature.parameters).zip(param_names)
+        {
+            let Some(param_name) = param_name else {
+                continue;
+            };
+            let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), arg.span)
+            else {
+                continue;
+            };
+            self.index.push(
+                location.uri,
+                StoredInlayHint::parameter(location.range.start, format!("{param_name}:")),
+            );
+        }
+    }
+
+    fn push_call_type_hint(&mut self, expr: &'gcx hir::Expr<'gcx>, callee: &'gcx hir::Expr<'gcx>) {
+        if self.is_explicit_cast_call(callee) {
+            return;
+        }
+        let Some(ty) = self.gcx.type_of_expr(expr.id) else {
+            return;
+        };
+        if !show_call_type_hint(ty) {
+            return;
+        }
+        let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), expr.span) else {
+            return;
+        };
+        self.index.push(
+            location.uri,
+            StoredInlayHint::call_type(location.range.end, format!(": {}", ty.display(self.gcx))),
+        );
+    }
+
+    fn call_signature(&self, callee: &'gcx hir::Expr<'gcx>) -> Option<CallableSignature<'gcx>> {
+        if let Some(callee) = self.gcx.resolved_callee(callee.id) {
+            return self.gcx.callable_signature_of_res(callee.res, callee.attached);
+        }
+        self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty))
+    }
+
+    fn is_explicit_cast_call(&self, callee: &'gcx hir::Expr<'gcx>) -> bool {
+        if self.gcx.resolved_callee(callee.id).is_some() {
+            return false;
+        }
+        let Some(ty) = self.gcx.type_of_expr(callee.id) else {
+            return false;
+        };
+        matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_)))
+    }
+
+    fn modifier_signature(
+        &self,
+        modifier: &'gcx hir::Modifier<'gcx>,
+    ) -> Option<CallableSignature<'gcx>> {
+        let res = match modifier.id {
+            ItemId::Contract(id) => self.gcx.hir.contract(id).ctor.map(ItemId::Function)?,
+            id => id,
+        };
+        self.gcx.callable_signature_of_res(Res::Item(res), false)
+    }
+}
+
+impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'gcx hir::Hir<'gcx> {
+        &self.gcx.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
+        match expr.kind {
+            ExprKind::Call(callee, ref args, opts) => {
+                self.visit_expr(callee)?;
+                if let Some(opts) = opts {
+                    for arg in opts.args {
+                        self.visit_expr(&arg.value)?;
+                    }
+                }
+                if let Some(signature) = self.call_signature(callee) {
+                    self.push_parameter_hints(args, signature);
+                }
+                self.push_call_type_hint(expr, callee);
+                self.visit_call_args(args)?;
+            }
+            _ => {
+                hir::Visit::walk_expr(self, expr)?;
+            }
+        }
+        ControlFlow::Continue(())
+    }
+
+    fn visit_modifier(
+        &mut self,
+        modifier: &'gcx hir::Modifier<'gcx>,
+    ) -> ControlFlow<Self::BreakValue> {
+        if let Some(signature) = self.modifier_signature(modifier) {
+            self.push_parameter_hints(&modifier.args, signature);
+        }
+        self.visit_call_args(&modifier.args)
+    }
+}
+
+fn show_call_type_hint(ty: Ty<'_>) -> bool {
+    !ty.is_unit() && !ty.references_error()
+}
+
+fn hint_sort_key(hint: &StoredInlayHint) -> (u32, u32, u8, &str) {
+    (hint.position.line, hint.position.character, hint.kind.sort_key(), hint.label.as_str())
+}
+
+fn range_contains_position(range: Range, position: Position) -> bool {
+    if range.start == range.end {
+        return position == range.start;
+    }
+    position >= range.start && position < range.end
+}
+
+fn position_before_range_end(position: Position, range: Range) -> bool {
+    if range.start == range.end {
+        return position <= range.end;
+    }
+    position < range.end
+}

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -172,8 +172,14 @@ impl<'gcx> InlayHintCollector<'gcx> {
     }
 
     fn call_param_source(&self, callee: &'gcx hir::Expr<'gcx>) -> Option<CallableParamSource> {
-        let signature = if let Some(callee) = self.gcx.resolved_callee(callee.id) {
-            self.gcx.callable_signature_of_res(callee.res, callee.attached)
+        let signature = if let Some(resolved) = self.gcx.resolved_callee(callee.id) {
+            if matches!(resolved.res, Res::Builtin(_)) {
+                self.gcx
+                    .type_of_expr(callee.id)
+                    .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
+            } else {
+                self.gcx.callable_signature_of_res(resolved.res, resolved.attached)
+            }
         } else {
             self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty))
         };

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -142,11 +142,6 @@ impl<'gcx> InlayHintCollector<'gcx> {
 
     fn argument_name_matches_param(&self, arg: &'gcx hir::Expr<'gcx>, param_name: Symbol) -> bool {
         let arg = arg.peel_parens();
-        if let ExprKind::Ident([Res::Item(item)]) = arg.kind
-            && self.gcx.item_name_opt(*item).is_some_and(|ident| ident.name == param_name)
-        {
-            return true;
-        }
         self.gcx
             .sess
             .source_map()
@@ -181,17 +176,8 @@ impl<'gcx> InlayHintCollector<'gcx> {
             return Some(CallableParamSource::Function { id: ctor, skips_receiver: false });
         }
 
-        let signature = if let Some(resolved) = self.gcx.resolved_callee(callee.id) {
-            if matches!(resolved.res, Res::Builtin(_)) {
-                self.gcx
-                    .type_of_expr(callee.id)
-                    .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
-            } else {
-                self.gcx.callable_signature_of_res(resolved.res, resolved.attached)
-            }
-        } else {
-            self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty))
-        };
+        let signature =
+            self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty));
         signature.and_then(|signature| signature.param_source)
     }
 

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -219,9 +219,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
 
     /// Adds a result-type hint after a call when the call has a useful inferred type.
     fn push_call_type_hint(&mut self, expr: &'gcx hir::Expr<'gcx>, callee_ty: Option<Ty<'gcx>>) {
-        if callee_ty.is_some_and(
-            |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
-        ) {
+        if callee_ty.is_some_and(|ty| matches!(ty.kind, TyKind::Type(_))) {
             return;
         }
         let Some(ty) = self.gcx.type_of_expr(expr.id) else {
@@ -248,41 +246,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
                 .join(", ");
             return format!(": ({tys})");
         }
-        if let Some(label) = self.struct_type_label(ty) {
-            return format!(": {label}");
-        }
         format!(": {}", ty.display(self.gcx))
-    }
-
-    fn struct_type_label(&self, ty: Ty<'gcx>) -> Option<String> {
-        let TyKind::Struct(id) = ty.peel_refs().kind else {
-            return None;
-        };
-        let strukt = self.gcx.hir.strukt(id);
-        let fields = strukt
-            .fields
-            .iter()
-            .map(|&field| self.struct_field_label(field))
-            .collect::<Vec<_>>()
-            .join("; ");
-        Some(format!("struct {} {{ {fields}; }}", strukt.name))
-    }
-
-    fn struct_field_label(&self, field_id: hir::VariableId) -> String {
-        let field = self.gcx.hir.variable(field_id);
-        let ty = self
-            .gcx
-            .sess
-            .source_map()
-            .span_to_snippet(field.ty.span)
-            .map(|snippet| snippet.split_whitespace().collect::<Vec<_>>().join(" "))
-            .unwrap_or_else(|_| {
-                self.gcx.type_of_item(field_id.into()).display(self.gcx).to_string()
-            });
-        match field.name {
-            Some(name) => format!("{ty} {name}"),
-            None => ty,
-        }
     }
 
     /// Finds the callable declaration that supplies parameter names for a call expression.

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -248,7 +248,41 @@ impl<'gcx> InlayHintCollector<'gcx> {
                 .join(", ");
             return format!(": ({tys})");
         }
+        if let Some(label) = self.struct_type_label(ty) {
+            return format!(": {label}");
+        }
         format!(": {}", ty.display(self.gcx))
+    }
+
+    fn struct_type_label(&self, ty: Ty<'gcx>) -> Option<String> {
+        let TyKind::Struct(id) = ty.peel_refs().kind else {
+            return None;
+        };
+        let strukt = self.gcx.hir.strukt(id);
+        let fields = strukt
+            .fields
+            .iter()
+            .map(|&field| self.struct_field_label(field))
+            .collect::<Vec<_>>()
+            .join("; ");
+        Some(format!("struct {} {{ {fields}; }}", strukt.name))
+    }
+
+    fn struct_field_label(&self, field_id: hir::VariableId) -> String {
+        let field = self.gcx.hir.variable(field_id);
+        let ty = self
+            .gcx
+            .sess
+            .source_map()
+            .span_to_snippet(field.ty.span)
+            .map(|snippet| snippet.split_whitespace().collect::<Vec<_>>().join(" "))
+            .unwrap_or_else(|_| {
+                self.gcx.type_of_item(field_id.into()).display(self.gcx).to_string()
+            });
+        match field.name {
+            Some(name) => format!("{ty} {name}"),
+            None => ty,
+        }
     }
 
     /// Finds the callable declaration that supplies parameter names for a call expression.

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -7,7 +7,7 @@ use solar_interface::{
 use solar_sema::{
     Gcx,
     hir::{self, CallArgsKind, ExprKind, ItemId, Visit},
-    ty::{CallableParamSource, TyKind},
+    ty::{CallableParamSource, Ty, TyKind},
 };
 use std::ops::ControlFlow;
 
@@ -142,6 +142,12 @@ impl<'gcx> InlayHintCollector<'gcx> {
 
     fn argument_name_matches_param(&self, arg: &'gcx hir::Expr<'gcx>, param_name: Symbol) -> bool {
         let arg = arg.peel_parens();
+        if let ExprKind::Ident([res]) = arg.kind
+            && let Some(variable) = res.as_variable()
+            && self.gcx.hir.variable(variable).name.is_some_and(|name| name.name == param_name)
+        {
+            return true;
+        }
         self.gcx
             .sess
             .source_map()
@@ -149,8 +155,10 @@ impl<'gcx> InlayHintCollector<'gcx> {
             .is_ok_and(|snippet| snippet == param_name.as_str())
     }
 
-    fn push_call_type_hint(&mut self, expr: &'gcx hir::Expr<'gcx>, callee: &'gcx hir::Expr<'gcx>) {
-        if self.is_explicit_cast_call(callee) {
+    fn push_call_type_hint(&mut self, expr: &'gcx hir::Expr<'gcx>, callee_ty: Option<Ty<'gcx>>) {
+        if callee_ty.is_some_and(
+            |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
+        ) {
             return;
         }
         let Some(ty) = self.gcx.type_of_expr(expr.id) else {
@@ -168,7 +176,11 @@ impl<'gcx> InlayHintCollector<'gcx> {
         );
     }
 
-    fn call_param_source(&self, callee: &'gcx hir::Expr<'gcx>) -> Option<CallableParamSource> {
+    fn call_param_source(
+        &self,
+        callee: &'gcx hir::Expr<'gcx>,
+        callee_ty: Option<Ty<'gcx>>,
+    ) -> Option<CallableParamSource> {
         if let ExprKind::New(hir_ty) = &callee.kind
             && let TyKind::Contract(id) = self.gcx.type_of_hir_ty(hir_ty).kind
             && let Some(ctor) = self.gcx.hir.contract(id).ctor
@@ -176,15 +188,9 @@ impl<'gcx> InlayHintCollector<'gcx> {
             return Some(CallableParamSource::Function { id: ctor, skips_receiver: false });
         }
 
-        let signature =
-            self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty));
-        signature.and_then(|signature| signature.param_source)
-    }
-
-    fn is_explicit_cast_call(&self, callee: &'gcx hir::Expr<'gcx>) -> bool {
-        self.gcx.type_of_expr(callee.id).is_some_and(
-            |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
-        )
+        callee_ty
+            .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
+            .and_then(|signature| signature.param_source)
     }
 
     fn modifier_param_source(
@@ -209,8 +215,9 @@ impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         if let ExprKind::Call(callee, ref args, _) = expr.kind {
-            self.push_parameter_hints(args, self.call_param_source(callee));
-            self.push_call_type_hint(expr, callee);
+            let callee_ty = self.gcx.type_of_expr(callee.id);
+            self.push_parameter_hints(args, self.call_param_source(callee, callee_ty));
+            self.push_call_type_hint(expr, callee_ty);
         }
         hir::Visit::walk_expr(self, expr)
     }

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -19,7 +19,9 @@ pub(crate) struct InlayHintIndex {
 #[derive(Clone, Debug)]
 struct StoredInlayHint {
     position: Position,
-    label: String,
+    // Labels are built once during analysis and only copied into LSP responses,
+    // so store the fixed text without String's unused capacity.
+    label: Box<str>,
     kind: StoredInlayHintKind,
 }
 
@@ -73,19 +75,19 @@ impl InlayHintIndex {
 }
 
 impl StoredInlayHint {
-    fn parameter(position: Position, label: String) -> Self {
-        Self { position, label, kind: StoredInlayHintKind::Parameter }
+    fn parameter(position: Position, label: impl Into<Box<str>>) -> Self {
+        Self { position, label: label.into(), kind: StoredInlayHintKind::Parameter }
     }
 
-    fn call_type(position: Position, label: String) -> Self {
-        Self { position, label, kind: StoredInlayHintKind::CallType }
+    fn call_type(position: Position, label: impl Into<Box<str>>) -> Self {
+        Self { position, label: label.into(), kind: StoredInlayHintKind::CallType }
     }
 
     fn to_lsp(&self) -> InlayHint {
         let (kind, padding_left, padding_right) = self.kind.lsp_fields();
         InlayHint {
             position: self.position,
-            label: InlayHintLabel::String(self.label.clone()),
+            label: InlayHintLabel::String(self.label.to_string()),
             kind: Some(kind),
             text_edits: None,
             tooltip: None,
@@ -230,5 +232,5 @@ impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
 }
 
 fn hint_sort_key(hint: &StoredInlayHint) -> (Position, StoredInlayHintKind, &str) {
-    (hint.position, hint.kind, hint.label.as_str())
+    (hint.position, hint.kind, hint.label.as_ref())
 }

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -1,6 +1,9 @@
 use crate::proto;
 use lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, Range, Url};
-use solar_interface::data_structures::{Never, map::FxHashMap};
+use solar_interface::{
+    Symbol,
+    data_structures::{Never, map::FxHashMap},
+};
 use solar_sema::{
     Gcx,
     hir::{self, CallArgsKind, ExprKind, ItemId, Res, Visit},
@@ -121,6 +124,9 @@ impl<'gcx> InlayHintCollector<'gcx> {
             let Some(param_name) = param_name else {
                 continue;
             };
+            if self.argument_name_matches_param(arg, param_name) {
+                continue;
+            }
             let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), arg.span)
             else {
                 continue;
@@ -130,6 +136,20 @@ impl<'gcx> InlayHintCollector<'gcx> {
                 StoredInlayHint::parameter(location.range.start, format!("{param_name}:")),
             );
         }
+    }
+
+    fn argument_name_matches_param(&self, arg: &'gcx hir::Expr<'gcx>, param_name: Symbol) -> bool {
+        let arg = arg.peel_parens();
+        if let ExprKind::Ident([Res::Item(item)]) = arg.kind
+            && self.gcx.item_name_opt(*item).is_some_and(|ident| ident.name == param_name)
+        {
+            return true;
+        }
+        self.gcx
+            .sess
+            .source_map()
+            .span_to_snippet(arg.span)
+            .is_ok_and(|snippet| snippet == param_name.as_str())
     }
 
     fn push_call_type_hint(&mut self, expr: &'gcx hir::Expr<'gcx>, callee: &'gcx hir::Expr<'gcx>) {

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -4,7 +4,7 @@ use solar_interface::data_structures::{Never, map::FxHashMap};
 use solar_sema::{
     Gcx,
     hir::{self, CallArgsKind, ExprKind, ItemId, Res, Visit},
-    ty::{CallableSignature, Ty, TyKind},
+    ty::{CallableParamSource, TyKind},
 };
 use std::ops::ControlFlow;
 
@@ -18,11 +18,9 @@ struct StoredInlayHint {
     position: Position,
     label: String,
     kind: StoredInlayHintKind,
-    padding_left: bool,
-    padding_right: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum StoredInlayHintKind {
     Parameter,
     CallType,
@@ -39,8 +37,8 @@ impl InlayHintIndex {
     }
 
     pub(crate) fn extend(&mut self, other: Self) {
-        for (uri, mut hints) in other.by_file {
-            self.by_file.entry(uri).or_default().append(&mut hints);
+        for (uri, hints) in other.by_file {
+            self.by_file.entry(uri).or_default().extend(hints);
         }
         self.sort();
     }
@@ -50,10 +48,12 @@ impl InlayHintIndex {
             return Vec::new();
         };
         let start = hints.partition_point(|hint| hint.position < range.start);
+        let include_end = range.start == range.end;
         hints[start..]
             .iter()
-            .take_while(|hint| position_before_range_end(hint.position, range))
-            .filter(|hint| range_contains_position(range, hint.position))
+            .take_while(|hint| {
+                hint.position < range.end || (include_end && hint.position == range.end)
+            })
             .map(StoredInlayHint::to_lsp)
             .collect()
     }
@@ -71,51 +71,33 @@ impl InlayHintIndex {
 
 impl StoredInlayHint {
     fn parameter(position: Position, label: String) -> Self {
-        Self {
-            position,
-            label,
-            kind: StoredInlayHintKind::Parameter,
-            padding_left: false,
-            padding_right: true,
-        }
+        Self { position, label, kind: StoredInlayHintKind::Parameter }
     }
 
     fn call_type(position: Position, label: String) -> Self {
-        Self {
-            position,
-            label,
-            kind: StoredInlayHintKind::CallType,
-            padding_left: true,
-            padding_right: false,
-        }
+        Self { position, label, kind: StoredInlayHintKind::CallType }
     }
 
     fn to_lsp(&self) -> InlayHint {
+        let (kind, padding_left, padding_right) = self.kind.lsp_fields();
         InlayHint {
             position: self.position,
             label: InlayHintLabel::String(self.label.clone()),
-            kind: Some(self.kind.lsp_kind()),
+            kind: Some(kind),
             text_edits: None,
             tooltip: None,
-            padding_left: Some(self.padding_left),
-            padding_right: Some(self.padding_right),
+            padding_left: Some(padding_left),
+            padding_right: Some(padding_right),
             data: None,
         }
     }
 }
 
 impl StoredInlayHintKind {
-    fn lsp_kind(self) -> InlayHintKind {
+    fn lsp_fields(self) -> (InlayHintKind, bool, bool) {
         match self {
-            Self::Parameter => InlayHintKind::PARAMETER,
-            Self::CallType => InlayHintKind::TYPE,
-        }
-    }
-
-    fn sort_key(self) -> u8 {
-        match self {
-            Self::Parameter => 0,
-            Self::CallType => 1,
+            Self::Parameter => (InlayHintKind::PARAMETER, false, true),
+            Self::CallType => (InlayHintKind::TYPE, true, false),
         }
     }
 }
@@ -129,18 +111,13 @@ impl<'gcx> InlayHintCollector<'gcx> {
     fn push_parameter_hints(
         &mut self,
         args: &hir::CallArgs<'gcx>,
-        signature: CallableSignature<'gcx>,
+        param_source: Option<CallableParamSource>,
     ) {
-        let CallArgsKind::Unnamed(exprs) = args.kind else {
-            return;
-        };
-        let Some(param_source) = signature.param_source else {
+        let (CallArgsKind::Unnamed(exprs), Some(param_source)) = (args.kind, param_source) else {
             return;
         };
         let param_names = self.gcx.callable_param_names(param_source);
-        for ((arg, _param_ty), param_name) in
-            exprs.iter().zip(signature.parameters).zip(param_names)
-        {
+        for (arg, param_name) in exprs.iter().zip(param_names) {
             let Some(param_name) = param_name else {
                 continue;
             };
@@ -162,7 +139,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
         let Some(ty) = self.gcx.type_of_expr(expr.id) else {
             return;
         };
-        if !show_call_type_hint(ty) {
+        if ty.is_unit() || ty.references_error() {
             return;
         }
         let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), expr.span) else {
@@ -174,32 +151,31 @@ impl<'gcx> InlayHintCollector<'gcx> {
         );
     }
 
-    fn call_signature(&self, callee: &'gcx hir::Expr<'gcx>) -> Option<CallableSignature<'gcx>> {
-        if let Some(callee) = self.gcx.resolved_callee(callee.id) {
-            return self.gcx.callable_signature_of_res(callee.res, callee.attached);
-        }
-        self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty))
+    fn call_param_source(&self, callee: &'gcx hir::Expr<'gcx>) -> Option<CallableParamSource> {
+        let signature = if let Some(callee) = self.gcx.resolved_callee(callee.id) {
+            self.gcx.callable_signature_of_res(callee.res, callee.attached)
+        } else {
+            self.gcx.type_of_expr(callee.id).and_then(|ty| self.gcx.callable_signature_of_ty(ty))
+        };
+        signature.and_then(|signature| signature.param_source)
     }
 
     fn is_explicit_cast_call(&self, callee: &'gcx hir::Expr<'gcx>) -> bool {
-        if self.gcx.resolved_callee(callee.id).is_some() {
-            return false;
-        }
-        let Some(ty) = self.gcx.type_of_expr(callee.id) else {
-            return false;
-        };
-        matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_)))
+        self.gcx.resolved_callee(callee.id).is_none()
+            && self.gcx.type_of_expr(callee.id).is_some_and(
+                |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
+            )
     }
 
-    fn modifier_signature(
+    fn modifier_param_source(
         &self,
         modifier: &'gcx hir::Modifier<'gcx>,
-    ) -> Option<CallableSignature<'gcx>> {
+    ) -> Option<CallableParamSource> {
         let res = match modifier.id {
             ItemId::Contract(id) => self.gcx.hir.contract(id).ctor.map(ItemId::Function)?,
             id => id,
         };
-        self.gcx.callable_signature_of_res(Res::Item(res), false)
+        self.gcx.callable_signature_of_res(Res::Item(res), false)?.param_source
     }
 }
 
@@ -211,56 +187,22 @@ impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
     }
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
-        match expr.kind {
-            ExprKind::Call(callee, ref args, opts) => {
-                self.visit_expr(callee)?;
-                if let Some(opts) = opts {
-                    for arg in opts.args {
-                        self.visit_expr(&arg.value)?;
-                    }
-                }
-                if let Some(signature) = self.call_signature(callee) {
-                    self.push_parameter_hints(args, signature);
-                }
-                self.push_call_type_hint(expr, callee);
-                self.visit_call_args(args)?;
-            }
-            _ => {
-                hir::Visit::walk_expr(self, expr)?;
-            }
+        if let ExprKind::Call(callee, ref args, _) = expr.kind {
+            self.push_parameter_hints(args, self.call_param_source(callee));
+            self.push_call_type_hint(expr, callee);
         }
-        ControlFlow::Continue(())
+        hir::Visit::walk_expr(self, expr)
     }
 
     fn visit_modifier(
         &mut self,
         modifier: &'gcx hir::Modifier<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
-        if let Some(signature) = self.modifier_signature(modifier) {
-            self.push_parameter_hints(&modifier.args, signature);
-        }
-        self.visit_call_args(&modifier.args)
+        self.push_parameter_hints(&modifier.args, self.modifier_param_source(modifier));
+        hir::Visit::walk_modifier(self, modifier)
     }
 }
 
-fn show_call_type_hint(ty: Ty<'_>) -> bool {
-    !ty.is_unit() && !ty.references_error()
-}
-
-fn hint_sort_key(hint: &StoredInlayHint) -> (u32, u32, u8, &str) {
-    (hint.position.line, hint.position.character, hint.kind.sort_key(), hint.label.as_str())
-}
-
-fn range_contains_position(range: Range, position: Position) -> bool {
-    if range.start == range.end {
-        return position == range.start;
-    }
-    position >= range.start && position < range.end
-}
-
-fn position_before_range_end(position: Position, range: Range) -> bool {
-    if range.start == range.end {
-        return position <= range.end;
-    }
-    position < range.end
+fn hint_sort_key(hint: &StoredInlayHint) -> (Position, StoredInlayHintKind, &str) {
+    (hint.position, hint.kind, hint.label.as_str())
 }

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -32,6 +32,10 @@ enum StoredInlayHintKind {
 }
 
 impl InlayHintIndex {
+    /// Builds the LSP-owned inlay hint index from the compiler HIR.
+    ///
+    /// The compiler's HIR data is scoped to one analysis run. This index copies out the inlay
+    /// hints that LSP requests can query after that run has finished.
     pub(crate) fn build(gcx: Gcx<'_>) -> Self {
         let mut collector = InlayHintCollector { gcx, index: Self::default() };
         for source_id in gcx.hir.source_ids() {
@@ -48,6 +52,10 @@ impl InlayHintIndex {
         self.sort();
     }
 
+    /// Returns the inlay hints requested by the LSP client for a file range.
+    ///
+    /// The LSP inlay hint request includes a range so clients can ask only for the part of a file
+    /// they need. Empty ranges include hints exactly at the requested position.
     pub(crate) fn hints(&self, uri: &Url, range: Range) -> Vec<InlayHint> {
         let Some(hints) = self.by_file.get(uri) else {
             return Vec::new();
@@ -63,10 +71,12 @@ impl InlayHintIndex {
             .collect()
     }
 
+    /// Stores a collected inlay hint under the URI it should be returned for.
     fn push(&mut self, uri: Url, hint: StoredInlayHint) {
         self.by_file.entry(uri).or_default().push(hint);
     }
 
+    /// Orders each file's hints for deterministic LSP responses and range filtering.
     fn sort(&mut self) {
         for hints in self.by_file.values_mut() {
             hints.sort_by(|a, b| hint_sort_key(a).cmp(&hint_sort_key(b)));
@@ -75,14 +85,17 @@ impl InlayHintIndex {
 }
 
 impl StoredInlayHint {
+    /// Creates a parameter-name hint to display before a positional argument.
     fn parameter(position: Position, label: impl Into<Box<str>>) -> Self {
         Self { position, label: label.into(), kind: StoredInlayHintKind::Parameter }
     }
 
+    /// Creates a type hint to display after a call expression.
     fn call_type(position: Position, label: impl Into<Box<str>>) -> Self {
         Self { position, label: label.into(), kind: StoredInlayHintKind::CallType }
     }
 
+    /// Converts the stored hint into the LSP response type.
     fn to_lsp(&self) -> InlayHint {
         let (kind, padding_left, padding_right) = self.kind.lsp_fields();
         InlayHint {
@@ -113,6 +126,9 @@ struct InlayHintCollector<'gcx> {
 }
 
 impl<'gcx> InlayHintCollector<'gcx> {
+    /// Adds parameter-name hints for positional arguments when parameter names are known.
+    ///
+    /// Hints are skipped when the argument already carries the same name as the parameter.
     fn push_parameter_hints(
         &mut self,
         args: &hir::CallArgs<'gcx>,
@@ -140,6 +156,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
         }
     }
 
+    /// Returns whether an argument expression already makes the parameter name visible.
     fn argument_name_matches_param(&self, arg: &'gcx hir::Expr<'gcx>, param_name: Symbol) -> bool {
         let arg = arg.peel_parens();
         if let ExprKind::Ident([res]) = arg.kind
@@ -155,6 +172,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
             .is_ok_and(|snippet| snippet == param_name.as_str())
     }
 
+    /// Adds a result-type hint after a call when the call has a useful inferred type.
     fn push_call_type_hint(&mut self, expr: &'gcx hir::Expr<'gcx>, callee_ty: Option<Ty<'gcx>>) {
         if callee_ty.is_some_and(
             |ty| matches!(ty.kind, TyKind::Type(to) if !matches!(to.kind, TyKind::Struct(_))),
@@ -176,6 +194,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
         );
     }
 
+    /// Finds the callable declaration that supplies parameter names for a call expression.
     fn call_param_source(
         &self,
         callee: &'gcx hir::Expr<'gcx>,
@@ -193,6 +212,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
             .and_then(|signature| signature.param_source)
     }
 
+    /// Finds the function or constructor declaration that supplies parameter names for a modifier.
     fn modifier_param_source(
         &self,
         modifier: &'gcx hir::Modifier<'gcx>,

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -19,6 +19,7 @@ use tower::ServiceBuilder;
 mod config;
 mod global_state;
 mod handlers;
+mod inlay_hints;
 mod proto;
 mod serde;
 mod symbols;
@@ -49,6 +50,7 @@ fn new_router(client: ClientSocket) -> Router<GlobalState> {
         .request::<req::GotoDefinition, _>(handlers::goto_definition)
         .request::<req::GotoDeclaration, _>(handlers::goto_declaration)
         .request::<req::References, _>(handlers::references)
+        .request::<req::InlayHintRequest, _>(handlers::inlay_hints)
         .request::<req::Completion, _>(handlers::completion);
 
     // Workspace management

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1,6 +1,6 @@
 use lsp_types::{
-    CompletionItem, CompletionItemKind, DocumentSymbol, GotoDefinitionResponse, Location, OneOf,
-    Position, Range, SymbolInformation, SymbolKind, Url, WorkspaceSymbol,
+    CompletionItem, CompletionItemKind, DocumentSymbol, GotoDefinitionResponse, InlayHint,
+    Location, OneOf, Position, Range, SymbolInformation, SymbolKind, Url, WorkspaceSymbol,
 };
 use solar_interface::{
     Span,
@@ -17,7 +17,7 @@ use solar_sema::{
 };
 use std::ops::ControlFlow;
 
-use crate::proto;
+use crate::{inlay_hints::InlayHintIndex, proto};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SymbolTables {
@@ -35,6 +35,7 @@ pub(crate) struct SymbolTables {
     references: Vec<SymbolReference>,
     file_references: FxHashMap<Url, Vec<usize>>,
     symbol_references: FxHashMap<SymbolId, Vec<Location>>,
+    inlay_hints: InlayHintIndex,
 }
 
 newtype_index! {
@@ -204,6 +205,7 @@ impl SymbolTables {
         tables.build_receiver_member_completions(gcx);
         tables.build_member_completions(gcx);
         tables.build_references(gcx);
+        tables.inlay_hints = InlayHintIndex::build(gcx);
         tables.rebuild_indexes();
         tables
     }
@@ -231,6 +233,7 @@ impl SymbolTables {
         if self.builtin_member_completions.is_empty() {
             self.builtin_member_completions = std::mem::take(&mut other.builtin_member_completions);
         }
+        self.inlay_hints.extend(other.inlay_hints);
 
         if other.declarations.is_empty() {
             return;
@@ -274,6 +277,10 @@ impl SymbolTables {
         // merging symbol tables from separate analysis batches.
         self.symbols_by_key.clear();
         self.rebuild_indexes();
+    }
+
+    pub(crate) fn inlay_hints(&self, uri: &Url, range: Range) -> Vec<InlayHint> {
+        self.inlay_hints.hints(uri, range)
     }
 
     pub(crate) fn document_symbols(&self, uri: &Url) -> Vec<DocumentSymbol> {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -115,6 +115,41 @@ pub struct MemberCompletion<'gcx> {
     pub resolved: Option<ResolvedMember>,
 }
 
+/// Parameter names available for a callable's visible arguments.
+pub type CallableParamNames = SmallVec<[Option<Symbol>; 8]>;
+
+/// The source declaration used for a callable's parameter names.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CallableParamSource {
+    /// A function-like declaration.
+    Function {
+        /// The function ID.
+        id: hir::FunctionId,
+        /// Whether the leading receiver parameter is not visible at the call site.
+        ///
+        /// Attached member calls strip the receiver from the visible call parameters,
+        /// but named arguments still come from the original function declaration.
+        skips_receiver: bool,
+    },
+    /// A struct constructor.
+    Struct(hir::StructId),
+    /// An event invocation.
+    Event(hir::EventId),
+    /// An error invocation.
+    Error(hir::ErrorId),
+}
+
+/// The visible signature of a callable expression.
+#[derive(Clone, Copy, Debug)]
+pub struct CallableSignature<'gcx> {
+    /// The visible parameter types at the call site.
+    pub parameters: &'gcx [Ty<'gcx>],
+    /// The return types.
+    pub returns: &'gcx [Ty<'gcx>],
+    /// The declaration source for parameter names, if one exists.
+    pub param_source: Option<CallableParamSource>,
+}
+
 impl<'gcx> TypeckResults<'gcx> {
     /// Returns the type inferred for the given expression, if available.
     #[inline]
@@ -827,6 +862,123 @@ impl<'gcx> Gcx<'gcx> {
             hir::Res::Builtin(builtin) => builtin.ty(self),
             hir::Res::Err(guar) => self.mk_ty_err(guar),
         }
+    }
+
+    /// Returns the visible callable signature for the given resolved target.
+    pub fn callable_signature_of_res(
+        self,
+        res: hir::Res,
+        skips_receiver: bool,
+    ) -> Option<CallableSignature<'gcx>> {
+        let mut signature = self.callable_signature_of_ty(self.type_of_res(res))?;
+        if let Some(CallableParamSource::Function { id, .. }) = signature.param_source {
+            signature.param_source = Some(CallableParamSource::Function { id, skips_receiver });
+        }
+        if skips_receiver && let Some((&_receiver, parameters)) = signature.parameters.split_first()
+        {
+            signature.parameters = parameters;
+        }
+        Some(signature)
+    }
+
+    /// Returns the visible callable signature for the given type.
+    pub fn callable_signature_of_ty(self, ty: Ty<'gcx>) -> Option<CallableSignature<'gcx>> {
+        match ty.kind {
+            TyKind::Fn(function_ty) => Some(CallableSignature {
+                parameters: function_ty.parameters,
+                returns: function_ty.returns,
+                param_source: self.callable_param_source_for_fn(function_ty),
+            }),
+            TyKind::Event(parameters, id) => Some(CallableSignature {
+                parameters,
+                returns: Default::default(),
+                param_source: Some(CallableParamSource::Event(id)),
+            }),
+            TyKind::Error(parameters, id) => Some(CallableSignature {
+                parameters,
+                returns: Default::default(),
+                param_source: Some(CallableParamSource::Error(id)),
+            }),
+            TyKind::Type(ty) => self.struct_constructor_signature(ty),
+            TyKind::Err(_) => None,
+            _ => None,
+        }
+    }
+
+    /// Returns the visible callable signature for a member call candidate.
+    pub fn callable_signature_of_member(
+        self,
+        receiver_ty: Ty<'gcx>,
+        member: &members::Member<'gcx>,
+    ) -> Option<CallableSignature<'gcx>> {
+        let TyKind::Fn(function_ty) = member.ty.kind else { return None };
+        let (parameters, skips_receiver) = if member.attached {
+            let (&self_ty, parameters) = function_ty.parameters.split_first()?;
+            if !receiver_ty.convert_implicit_to(self_ty, self) {
+                return None;
+            }
+            (parameters, true)
+        } else {
+            (function_ty.parameters, false)
+        };
+        Some(CallableSignature {
+            parameters,
+            returns: function_ty.returns,
+            param_source: function_ty
+                .function_id
+                .map(|id| CallableParamSource::Function { id, skips_receiver }),
+        })
+    }
+
+    /// Returns the parameter names from a callable parameter source.
+    pub fn callable_param_names(self, source: CallableParamSource) -> CallableParamNames {
+        match source {
+            CallableParamSource::Function { id, skips_receiver } => {
+                let mut names = self.param_names(self.hir.function(id).parameters);
+                if skips_receiver {
+                    debug_assert!(!names.is_empty());
+                    names.remove(0);
+                }
+                names
+            }
+            CallableParamSource::Struct(id) => self.param_names(self.hir.strukt(id).fields),
+            CallableParamSource::Event(id) => self.param_names(self.hir.event(id).parameters),
+            CallableParamSource::Error(id) => self.param_names(self.hir.error(id).parameters),
+        }
+    }
+
+    fn callable_param_source_for_fn(self, function_ty: &TyFn<'gcx>) -> Option<CallableParamSource> {
+        function_ty.function_id.map(|id| {
+            let declared_param_count = self.hir.function(id).parameters.len();
+            let visible_param_count = function_ty.parameters.len();
+            debug_assert!(
+                declared_param_count == visible_param_count
+                    || declared_param_count == visible_param_count + 1
+            );
+            CallableParamSource::Function {
+                id,
+                skips_receiver: declared_param_count == visible_param_count + 1,
+            }
+        })
+    }
+
+    fn struct_constructor_signature(self, ty: Ty<'gcx>) -> Option<CallableSignature<'gcx>> {
+        let TyKind::Struct(id) = ty.kind else { return None };
+        let parameters = self.mk_ty_iter(
+            self.struct_field_types(id)
+                .iter()
+                .map(|&field_ty| field_ty.with_loc_if_ref(self, DataLocation::Memory)),
+        );
+        let returns = self.mk_ty_iter(std::iter::once(ty.with_loc(self, DataLocation::Memory)));
+        Some(CallableSignature {
+            parameters,
+            returns,
+            param_source: Some(CallableParamSource::Struct(id)),
+        })
+    }
+
+    fn param_names(self, params: &[hir::VariableId]) -> CallableParamNames {
+        params.iter().map(|&id| self.hir.variable(id).name.map(|i| i.name)).collect()
     }
 
     /// Returns the type of the given literal.

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -864,22 +864,6 @@ impl<'gcx> Gcx<'gcx> {
         }
     }
 
-    /// Returns the visible callable signature for the given resolved target.
-    pub fn callable_signature_of_res(
-        self,
-        res: hir::Res,
-        skips_receiver: bool,
-    ) -> Option<CallableSignature<'gcx>> {
-        let mut signature = self.callable_signature_of_ty(self.type_of_res(res))?;
-        if let Some(CallableParamSource::Function { id, .. }) = signature.param_source {
-            signature.param_source = Some(CallableParamSource::Function { id, skips_receiver });
-        }
-        if skips_receiver && let Some((_, parameters)) = signature.parameters.split_first() {
-            signature.parameters = parameters;
-        }
-        Some(signature)
-    }
-
     /// Returns the visible callable signature for the given type.
     pub fn callable_signature_of_ty(self, ty: Ty<'gcx>) -> Option<CallableSignature<'gcx>> {
         match ty.kind {

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -874,8 +874,7 @@ impl<'gcx> Gcx<'gcx> {
         if let Some(CallableParamSource::Function { id, .. }) = signature.param_source {
             signature.param_source = Some(CallableParamSource::Function { id, skips_receiver });
         }
-        if skips_receiver && let Some((&_receiver, parameters)) = signature.parameters.split_first()
-        {
+        if skips_receiver && let Some((_, parameters)) = signature.parameters.split_first() {
             signature.parameters = parameters;
         }
         Some(signature)

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -131,6 +131,8 @@ pub enum CallableParamSource {
         /// but named arguments still come from the original function declaration.
         skips_receiver: bool,
     },
+    /// A variable declared with a function type.
+    FunctionType(hir::VariableId),
     /// A struct constructor.
     Struct(hir::StructId),
     /// An event invocation.
@@ -924,6 +926,10 @@ impl<'gcx> Gcx<'gcx> {
                 }
                 names
             }
+            CallableParamSource::FunctionType(id) => match self.hir.variable(id).ty.kind {
+                hir::TypeKind::Function(ty) => self.param_names(ty.parameters),
+                _ => Default::default(),
+            },
             CallableParamSource::Struct(id) => self.param_names(self.hir.strukt(id).fields),
             CallableParamSource::Event(id) => self.param_names(self.hir.event(id).parameters),
             CallableParamSource::Error(id) => self.param_names(self.hir.error(id).parameters),

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -252,6 +252,8 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
 
                 let callee_signature = self.gcx.callable_signature_of_ty(callee_ty);
+                let callee_param_source =
+                    callee_signature.and_then(|signature| signature.param_source);
                 if let TyKind::Type(_) = callee_ty.kind
                     && let Some(signature) = callee_signature
                 {
@@ -280,11 +282,13 @@ impl<'gcx> TypeChecker<'gcx> {
                         }
 
                         let builtin = self.results.builtin_callee(callee.id);
-                        let param_names =
-                            callee_signature.and_then(|signature| signature.param_source);
                         if builtin != Some(Builtin::Require) {
-                            let _ =
-                                self.check_call_args(expr.span, args, f.parameters, param_names);
+                            let _ = self.check_call_args(
+                                expr.span,
+                                args,
+                                f.parameters,
+                                callee_param_source,
+                            );
                         }
                         if let Some(builtin) = builtin {
                             let _ = self.check_builtin_call_args(expr.span, args, builtin);
@@ -292,7 +296,7 @@ impl<'gcx> TypeChecker<'gcx> {
                         self.fn_call_return_type(f.returns)
                     }
                     TyKind::Type(to) => self.check_explicit_cast(expr.span, to, args),
-                    TyKind::Event(param_tys, id) => {
+                    TyKind::Event(param_tys, _) => {
                         if !self.in_emit {
                             self.dcx().emit_err(
                                 expr.span,
@@ -302,15 +306,11 @@ impl<'gcx> TypeChecker<'gcx> {
                         // Clear context so nested calls in args are not considered in emit/revert.
                         self.in_emit = false;
                         self.in_revert = false;
-                        let _ = self.check_call_args(
-                            expr.span,
-                            args,
-                            param_tys,
-                            Some(CallableParamSource::Event(id)),
-                        );
+                        let _ =
+                            self.check_call_args(expr.span, args, param_tys, callee_param_source);
                         self.gcx.types.unit
                     }
-                    TyKind::Error(param_tys, id) => {
+                    TyKind::Error(param_tys, _) => {
                         if !self.in_revert {
                             self.dcx().emit_err(
                                 expr.span,
@@ -320,12 +320,8 @@ impl<'gcx> TypeChecker<'gcx> {
                         // Clear context so nested calls in args are not considered in emit/revert.
                         self.in_emit = false;
                         self.in_revert = false;
-                        let _ = self.check_call_args(
-                            expr.span,
-                            args,
-                            param_tys,
-                            Some(CallableParamSource::Error(id)),
-                        );
+                        let _ =
+                            self.check_call_args(expr.span, args, param_tys, callee_param_source);
                         self.gcx.types.unit
                     }
                     TyKind::Err(_) => callee_ty,
@@ -1147,15 +1143,18 @@ impl<'gcx> TypeChecker<'gcx> {
             }
         };
         let callee_ty = self.type_of_res(selected);
-        let TyKind::Error(param_tys, id) = callee_ty.kind else {
+        let TyKind::Error(param_tys, _) = callee_ty.kind else {
             return self.check_expected(expr, callee_ty, self.gcx.types.string_ref.memory);
         };
+        let param_source = self
+            .gcx
+            .callable_signature_of_ty(callee_ty)
+            .and_then(|signature| signature.param_source);
         self.results.resolved_callees.insert(callee.id, ResolvedCallee::new(selected, false));
         if !self.results.expr_types.contains_key(&callee.id) {
             self.register_ty(callee, callee_ty);
         }
-        let result =
-            self.check_call_args(expr.span, &args, param_tys, Some(CallableParamSource::Error(id)));
+        let result = self.check_call_args(expr.span, &args, param_tys, param_source);
         self.register_ty(expr, self.gcx.types.unit);
         result
     }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -3,8 +3,8 @@ use crate::{
     eval::{ConstValue, ConstantEvaluator, EvalErrorKind},
     hir::{self, Visit},
     ty::{
-        CallableParamSource, CallableSignature, Gcx, ResolvedCallee, Ty, TyConvertError, TyFn,
-        TyFnKind, TyKind, TypeckResults,
+        CallableParamSource, Gcx, ResolvedCallee, Ty, TyConvertError, TyFn, TyFnKind, TyKind,
+        TypeckResults,
     },
 };
 use alloy_primitives::U256;
@@ -251,19 +251,17 @@ impl<'gcx> TypeChecker<'gcx> {
                     callee_ty = self.check_call_options(callee_ty, opts.args, opts.span);
                 }
 
-                // Get the function type for struct constructors, keeping field names.
-                let struct_param_source = if let TyKind::Type(_) = callee_ty.kind
-                    && let Some(signature) = self.gcx.callable_signature_of_ty(callee_ty)
+                let callee_signature = self.gcx.callable_signature_of_ty(callee_ty);
+                if let TyKind::Type(_) = callee_ty.kind
+                    && let Some(signature) = callee_signature
                 {
+                    // Get the function type for struct constructors, keeping field names.
                     callee_ty = self.gcx.mk_builtin_fn(
                         signature.parameters,
                         StateMutability::Pure,
                         signature.returns,
                     );
-                    signature.param_source
-                } else {
-                    None
-                };
+                }
 
                 let ty = match callee_ty.kind {
                     TyKind::Fn(f) => {
@@ -282,8 +280,8 @@ impl<'gcx> TypeChecker<'gcx> {
                         }
 
                         let builtin = self.results.builtin_callee(callee.id);
-                        let param_names = struct_param_source
-                            .or_else(|| self.gcx.callable_signature_of_ty(callee_ty)?.param_source);
+                        let param_names =
+                            callee_signature.and_then(|signature| signature.param_source);
                         if builtin != Some(Builtin::Require) {
                             let _ =
                                 self.check_call_args(expr.span, args, f.parameters, param_names);
@@ -1654,7 +1652,7 @@ impl<'gcx> TypeChecker<'gcx> {
         let mut selected = SmallVec::<[_; 4]>::new();
         for &res in res {
             let ty = self.type_of_res(res);
-            let Some(signature) = self.call_candidate_params(ty) else {
+            let Some(signature) = self.gcx.callable_signature_of_ty(ty) else {
                 continue;
             };
             if self.call_args_match(args, signature.parameters, signature.param_source) {
@@ -1700,10 +1698,6 @@ impl<'gcx> TypeChecker<'gcx> {
         selected
     }
 
-    fn call_candidate_params(&self, ty: Ty<'gcx>) -> Option<CallableSignature<'gcx>> {
-        self.gcx.callable_signature_of_ty(ty)
-    }
-
     fn select_member_call_overload<'a>(
         &mut self,
         receiver_ty: Ty<'gcx>,
@@ -1718,7 +1712,7 @@ impl<'gcx> TypeChecker<'gcx> {
 
         let mut selected = WantOne::Zero;
         for member in members {
-            if let Some(signature) = self.member_call_candidate_params(receiver_ty, member)
+            if let Some(signature) = self.gcx.callable_signature_of_member(receiver_ty, member)
                 && self.call_args_match(args, signature.parameters, signature.param_source)
             {
                 selected.push(member);
@@ -1729,14 +1723,6 @@ impl<'gcx> TypeChecker<'gcx> {
             WantOne::One(member) => Ok(member),
             WantOne::Many => Err(OverloadError::Ambiguous),
         }
-    }
-
-    fn member_call_candidate_params(
-        &self,
-        receiver_ty: Ty<'gcx>,
-        member: &members::Member<'gcx>,
-    ) -> Option<CallableSignature<'gcx>> {
-        self.gcx.callable_signature_of_member(receiver_ty, member)
     }
 
     fn call_args_match(

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -2,7 +2,10 @@ use crate::{
     builtins::{Builtin, members},
     eval::{ConstValue, ConstantEvaluator, EvalErrorKind},
     hir::{self, Visit},
-    ty::{Gcx, ResolvedCallee, Ty, TyConvertError, TyFn, TyFnKind, TyKind, TypeckResults},
+    ty::{
+        CallableParamSource, CallableSignature, Gcx, ResolvedCallee, Ty, TyConvertError, TyFn,
+        TyFnKind, TyKind, TypeckResults,
+    },
 };
 use alloy_primitives::U256;
 use solar_ast::{
@@ -17,24 +20,6 @@ use solar_interface::{
 use std::ops::ControlFlow;
 
 mod yul;
-
-type ParamNames = SmallVec<[Option<Symbol>; 8]>;
-type CallCandidateParams<'gcx> = (&'gcx [Ty<'gcx>], Option<ParamNamesSource>);
-
-#[derive(Clone, Copy)]
-enum ParamNamesSource {
-    Function {
-        id: hir::FunctionId,
-        /// Whether the leading receiver parameter is not visible at the call site.
-        ///
-        /// Attached member calls strip the receiver from the visible call parameters,
-        /// but named arguments still come from the original function declaration.
-        skips_receiver: bool,
-    },
-    Struct(hir::StructId),
-    Event(hir::EventId),
-    Error(hir::ErrorId),
-}
 
 #[derive(Clone, Copy)]
 enum AbiDecodeArg {
@@ -266,12 +251,16 @@ impl<'gcx> TypeChecker<'gcx> {
                     callee_ty = self.check_call_options(callee_ty, opts.args, opts.span);
                 }
 
-                // Get the function type for struct constructors, keeping struct_id for field names.
-                let struct_id = if let TyKind::Type(struct_ty) = callee_ty.kind
-                    && let TyKind::Struct(id) = struct_ty.kind
+                // Get the function type for struct constructors, keeping field names.
+                let struct_param_source = if let TyKind::Type(_) = callee_ty.kind
+                    && let Some(signature) = self.gcx.callable_signature_of_ty(callee_ty)
                 {
-                    callee_ty = struct_constructor(self.gcx, struct_ty, id);
-                    Some(id)
+                    callee_ty = self.gcx.mk_builtin_fn(
+                        signature.parameters,
+                        StateMutability::Pure,
+                        signature.returns,
+                    );
+                    signature.param_source
                 } else {
                     None
                 };
@@ -293,11 +282,8 @@ impl<'gcx> TypeChecker<'gcx> {
                         }
 
                         let builtin = self.results.builtin_callee(callee.id);
-                        let param_names = if let Some(id) = struct_id {
-                            Some(ParamNamesSource::Struct(id))
-                        } else {
-                            self.ty_fn_param_names_source(f)
-                        };
+                        let param_names = struct_param_source
+                            .or_else(|| self.gcx.callable_signature_of_ty(callee_ty)?.param_source);
                         if builtin != Some(Builtin::Require) {
                             let _ =
                                 self.check_call_args(expr.span, args, f.parameters, param_names);
@@ -322,7 +308,7 @@ impl<'gcx> TypeChecker<'gcx> {
                             expr.span,
                             args,
                             param_tys,
-                            Some(ParamNamesSource::Event(id)),
+                            Some(CallableParamSource::Event(id)),
                         );
                         self.gcx.types.unit
                     }
@@ -340,7 +326,7 @@ impl<'gcx> TypeChecker<'gcx> {
                             expr.span,
                             args,
                             param_tys,
-                            Some(ParamNamesSource::Error(id)),
+                            Some(CallableParamSource::Error(id)),
                         );
                         self.gcx.types.unit
                     }
@@ -1001,64 +987,12 @@ impl<'gcx> TypeChecker<'gcx> {
         }
     }
 
-    fn get_param_names(&self, params: &[hir::VariableId]) -> ParamNames {
-        params.iter().map(|&id| self.gcx.hir.variable(id).name.map(|i| i.name)).collect()
-    }
-
-    fn get_call_param_names(&self, function: hir::FunctionId, skips_receiver: bool) -> ParamNames {
-        let mut names = self.get_param_names(self.gcx.hir.function(function).parameters);
-        if skips_receiver {
-            debug_assert!(!names.is_empty());
-            names.remove(0);
-        }
-        names
-    }
-
-    fn ty_fn_param_names_source(&self, function_ty: &TyFn<'gcx>) -> Option<ParamNamesSource> {
-        function_ty.function_id.map(|id| {
-            let declared_param_count = self.gcx.hir.function(id).parameters.len();
-            let visible_param_count = function_ty.parameters.len();
-            debug_assert!(
-                declared_param_count == visible_param_count
-                    || declared_param_count == visible_param_count + 1
-            );
-            ParamNamesSource::Function {
-                id,
-                skips_receiver: declared_param_count == visible_param_count + 1,
-            }
-        })
-    }
-
-    fn get_struct_field_names(
-        &self,
-        id: hir::StructId,
-    ) -> SmallVec<[Option<solar_interface::Symbol>; 8]> {
-        self.gcx
-            .hir
-            .strukt(id)
-            .fields
-            .iter()
-            .map(|&fid| self.gcx.hir.variable(fid).name.map(|i| i.name))
-            .collect()
-    }
-
-    fn get_param_names_from_source(&self, source: ParamNamesSource) -> ParamNames {
-        match source {
-            ParamNamesSource::Function { id, skips_receiver } => {
-                self.get_call_param_names(id, skips_receiver)
-            }
-            ParamNamesSource::Struct(id) => self.get_struct_field_names(id),
-            ParamNamesSource::Event(id) => self.get_param_names(self.gcx.hir.event(id).parameters),
-            ParamNamesSource::Error(id) => self.get_param_names(self.gcx.hir.error(id).parameters),
-        }
-    }
-
     fn check_call_args(
         &mut self,
         call_span: Span,
         args: &hir::CallArgs<'gcx>,
         param_tys: &[Ty<'gcx>],
-        param_names: Option<ParamNamesSource>,
+        param_names: Option<CallableParamSource>,
     ) -> Result<(), ErrorGuaranteed> {
         match args.kind {
             hir::CallArgsKind::Unnamed(exprs) => {
@@ -1223,7 +1157,7 @@ impl<'gcx> TypeChecker<'gcx> {
             self.register_ty(callee, callee_ty);
         }
         let result =
-            self.check_call_args(expr.span, &args, param_tys, Some(ParamNamesSource::Error(id)));
+            self.check_call_args(expr.span, &args, param_tys, Some(CallableParamSource::Error(id)));
         self.register_ty(expr, self.gcx.types.unit);
         result
     }
@@ -1720,10 +1654,10 @@ impl<'gcx> TypeChecker<'gcx> {
         let mut selected = SmallVec::<[_; 4]>::new();
         for &res in res {
             let ty = self.type_of_res(res);
-            let Some((param_tys, param_names)) = self.call_candidate_params(ty) else {
+            let Some(signature) = self.call_candidate_params(ty) else {
                 continue;
             };
-            if self.call_args_match(args, param_tys, param_names) {
+            if self.call_args_match(args, signature.parameters, signature.param_source) {
                 selected.push(res);
             }
         }
@@ -1766,17 +1700,8 @@ impl<'gcx> TypeChecker<'gcx> {
         selected
     }
 
-    fn call_candidate_params(&self, ty: Ty<'gcx>) -> Option<CallCandidateParams<'gcx>> {
-        match ty.kind {
-            TyKind::Fn(function_ty) => {
-                let param_names = self.ty_fn_param_names_source(function_ty);
-                Some((function_ty.parameters, param_names))
-            }
-            TyKind::Event(param_tys, id) => Some((param_tys, Some(ParamNamesSource::Event(id)))),
-            TyKind::Error(param_tys, id) => Some((param_tys, Some(ParamNamesSource::Error(id)))),
-            TyKind::Err(_) => None,
-            _ => None,
-        }
+    fn call_candidate_params(&self, ty: Ty<'gcx>) -> Option<CallableSignature<'gcx>> {
+        self.gcx.callable_signature_of_ty(ty)
     }
 
     fn select_member_call_overload<'a>(
@@ -1793,9 +1718,8 @@ impl<'gcx> TypeChecker<'gcx> {
 
         let mut selected = WantOne::Zero;
         for member in members {
-            if let Some((parameters, param_names)) =
-                self.member_call_candidate_params(receiver_ty, member)
-                && self.call_args_match(args, parameters, param_names)
+            if let Some(signature) = self.member_call_candidate_params(receiver_ty, member)
+                && self.call_args_match(args, signature.parameters, signature.param_source)
             {
                 selected.push(member);
             }
@@ -1811,33 +1735,21 @@ impl<'gcx> TypeChecker<'gcx> {
         &self,
         receiver_ty: Ty<'gcx>,
         member: &members::Member<'gcx>,
-    ) -> Option<CallCandidateParams<'gcx>> {
-        let TyKind::Fn(function_ty) = member.ty.kind else { return None };
-        let (parameters, skips_receiver) = if member.attached {
-            let (&self_ty, parameters) = function_ty.parameters.split_first()?;
-            if !receiver_ty.convert_implicit_to(self_ty, self.gcx) {
-                return None;
-            }
-            (parameters, true)
-        } else {
-            (function_ty.parameters, false)
-        };
-        let param_names =
-            function_ty.function_id.map(|id| ParamNamesSource::Function { id, skips_receiver });
-        Some((parameters, param_names))
+    ) -> Option<CallableSignature<'gcx>> {
+        self.gcx.callable_signature_of_member(receiver_ty, member)
     }
 
     fn call_args_match(
         &mut self,
         args: &hir::CallArgs<'gcx>,
         param_tys: &[Ty<'gcx>],
-        param_names: Option<ParamNamesSource>,
+        param_names: Option<CallableParamSource>,
     ) -> bool {
         match args.kind {
             hir::CallArgsKind::Unnamed(exprs) => self.positional_call_args_match(exprs, param_tys),
             hir::CallArgsKind::Named(named_args) => {
                 let Some(param_names) = param_names else { return false };
-                let names = self.get_param_names_from_source(param_names);
+                let names = self.gcx.callable_param_names(param_names);
                 if named_args.len() != param_tys.len() {
                     return false;
                 }
@@ -2039,7 +1951,7 @@ impl<'gcx> TypeChecker<'gcx> {
         args_span: Span,
         named_args: &'gcx [hir::NamedArg<'gcx>],
         param_tys: &[Ty<'gcx>],
-        param_names: Option<ParamNamesSource>,
+        param_names: Option<CallableParamSource>,
     ) -> Result<(), ErrorGuaranteed> {
         let Some(param_names) = param_names else {
             let guar = self.dcx().emit_err(
@@ -2052,7 +1964,7 @@ impl<'gcx> TypeChecker<'gcx> {
             return Err(guar);
         };
 
-        let param_names = self.get_param_names_from_source(param_names);
+        let param_names = self.gcx.callable_param_names(param_names);
         debug_assert_eq!(param_tys.len(), param_names.len());
         let mut result = Ok(());
 
@@ -3065,16 +2977,5 @@ fn valid_meta_type(ty: Ty<'_>) -> bool {
         TyKind::Elementary(hir::ElementaryType::Int(_) | hir::ElementaryType::UInt(_))
             | TyKind::Contract(_)
             | TyKind::Enum(_)
-    )
-}
-
-fn struct_constructor<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, id: hir::StructId) -> Ty<'gcx> {
-    gcx.mk_builtin_fn(
-        &gcx.struct_field_types(id)
-            .iter()
-            .map(|&ty| ty.with_loc_if_ref(gcx, DataLocation::Memory))
-            .collect::<Vec<_>>(),
-        hir::StateMutability::Pure,
-        &[ty.with_loc(gcx, DataLocation::Memory)],
     )
 }


### PR DESCRIPTION
Towards oss-407.

This adds inlay hints for Solidity calls in the LSP: parameter names for positional arguments and type hints for useful call results.

The hints lean on semantic call resolution, so they follow selected overloads, `using` calls, constructors, events, errors, modifiers, and `abi.encodeCall`. They also avoid noisy cases like named arguments, repeated obvious names, explicit casts, unit results, and malformed `abi.encodeCall` tuples.

cc @DaniPopes 
##### No hints for inline assembly :
<img width="399" height="101" alt="截屏2026-07-07 18 02 39" src="https://github.com/user-attachments/assets/59da5633-ba6a-4bb7-bd1e-221eaa40d1f4" />

##### ABI-encoded calls 
<img width="654" height="390" alt="截屏2026-07-07 15 55 08" src="https://github.com/user-attachments/assets/258e038d-74d3-4b55-ac82-81833a0159b0" />


##### Normal calls
<img width="629" height="567" alt="截屏2026-07-07 15 56 22" src="https://github.com/user-attachments/assets/d158253b-20b2-4a57-aa9d-507d0450fa20" />

#####  Overload 
<img width="631" height="437" alt="截屏2026-07-07 16 06 43" src="https://github.com/user-attachments/assets/ea071177-3d52-4988-ac6c-44063b561cff" />

