### PR TITLE
fix(release): default vergen metadata on error

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,9 @@ uibless = "xtask test ui --bless"
 # Required for `dist` to work with linux arm targets: https://github.com/axodotdev/cargo-dist/issues/74#issuecomment-2053680080
 [env]
 CC_aarch64_unknown_linux_musl = "aarch64-linux-gnu-gcc"
+# Let cargo-release dry-run verification build already-published crates from
+# package tarballs, where Git metadata is unavailable.
+VERGEN_DEFAULT_ON_ERROR = "1"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
`cargo release minor` still dry-runs package verification against the currently published `0.1.8` manifests before the version bump is materialized. That means dependent package checks can compile the already-published `solar-config 0.1.8` tarball outside a Git worktree.

Setting `VERGEN_DEFAULT_ON_ERROR=1` through Cargo config lets those old vergen build scripts emit fallback Git metadata instead of panicking when `.git` is unavailable. Normal workspace builds with Git metadata still emit the real values.
