### PR TITLE
fix(sema): resolve public constant member over its getter

### DIFF
--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1627,7 +1627,19 @@ impl<'gcx> TypeChecker<'gcx> {
         match members {
             [] => Err(MemberAccessError::NotFound),
             [member] => Ok(member),
-            [..] => Err(MemberAccessError::Ambiguous),
+            // Mirror value-position overload resolution: a public state
+            // variable or constant is accompanied by its getter function, and
+            // the unique variable candidate wins for a non-call member access.
+            [..] => {
+                match members
+                    .iter()
+                    .filter(|member| member.res.is_some_and(|res| res.as_variable().is_some()))
+                    .collect::<WantOne<_>>()
+                {
+                    WantOne::One(member) => Ok(member),
+                    WantOne::Zero | WantOne::Many => Err(MemberAccessError::Ambiguous),
+                }
+            }
         }
     }
 

--- a/tests/ui/typeck/library_public_constant_member.sol
+++ b/tests/ui/typeck/library_public_constant_member.sol
@@ -1,0 +1,17 @@
+//@check-pass
+// A `public constant` in a library exposes both the constant and its
+// auto-generated getter as members. Accessing it must resolve to the variable,
+// not report an ambiguity.
+library Errors {
+    string public constant A = "1";
+    uint256 public constant N = 7;
+}
+
+contract C {
+    function s() external pure returns (string memory) {
+        return Errors.A;
+    }
+    function n() external pure returns (uint256) {
+        return Errors.N;
+    }
+}


### PR DESCRIPTION
A `public constant` in a library exposes both the constant and its auto-generated getter as members of the library type, so a member access like `Errors.A` found two candidates and was reported as ambiguous. Mirror value-position overload resolution: when a member access is not a call and exactly one candidate is a variable, resolve to the variable.