### PR TITLE
feat(lsp): add flychecks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3056,6 +3056,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3737,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -5,7 +5,7 @@ use crate::{
     source_map::{LineInfo, SourceFile, SourceMap},
 };
 use anstream::ColorChoice;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use solar_config::HumanEmitterKind;
 use std::{borrow::Cow, io, sync::Arc};
 
@@ -26,7 +26,7 @@ impl Emitter for JsonEmitter {
     fn emit_diagnostic_ref(&mut self, diagnostic: &Diag) {
         if self.rustc_like {
             let diagnostic = self.diagnostic(diagnostic);
-            self.emit(&EmitTyped::Diagnostic(diagnostic))
+            self.emit(&JsonDiagnosticMessage::Diagnostic(diagnostic))
         } else {
             let diagnostic = self.solc_diagnostic(diagnostic);
             self.emit(&diagnostic)
@@ -86,7 +86,7 @@ impl JsonEmitter {
         Emitter::source_map(self).unwrap()
     }
 
-    fn diagnostic(&mut self, diagnostic: &Diag) -> Diagnostic {
+    fn diagnostic(&mut self, diagnostic: &Diag) -> JsonDiagnostic<'static> {
         // Unlike the human emitter, all suggestions are preserved as separate diagnostic children.
         let children = diagnostic
             .children
@@ -95,30 +95,31 @@ impl JsonEmitter {
             .chain(diagnostic.suggestions.iter().map(|sugg| self.suggestion_to_diagnostic(sugg)))
             .collect();
 
-        Diagnostic {
-            message: diagnostic.label().into_owned(),
-            code: diagnostic
-                .id()
-                .map(|code| DiagnosticCode { code: code.to_string(), explanation: None }),
-            level: diagnostic.level.to_str(),
+        JsonDiagnostic {
+            message: Cow::Owned(diagnostic.label().into_owned()),
+            code: diagnostic.id().map(|code| JsonDiagnosticCode {
+                code: Cow::Owned(code.to_string()),
+                explanation: None,
+            }),
+            level: Cow::Borrowed(diagnostic.level.to_str()),
             spans: self.spans(&diagnostic.span),
             children,
-            rendered: Some(self.emit_diagnostic_to_buffer(diagnostic)),
+            rendered: Some(Cow::Owned(self.emit_diagnostic_to_buffer(diagnostic))),
         }
     }
 
-    fn sub_diagnostic(&self, diagnostic: &SubDiagnostic) -> Diagnostic {
-        Diagnostic {
-            message: diagnostic.label().into_owned(),
+    fn sub_diagnostic(&self, diagnostic: &SubDiagnostic) -> JsonDiagnostic<'static> {
+        JsonDiagnostic {
+            message: Cow::Owned(diagnostic.label().into_owned()),
             code: None,
-            level: diagnostic.level.to_str(),
+            level: Cow::Borrowed(diagnostic.level.to_str()),
             spans: self.spans(&diagnostic.span),
             children: vec![],
             rendered: None,
         }
     }
 
-    fn suggestion_to_diagnostic(&self, sugg: &CodeSuggestion) -> Diagnostic {
+    fn suggestion_to_diagnostic(&self, sugg: &CodeSuggestion) -> JsonDiagnostic<'static> {
         // Collect all spans from all substitutions
         let spans = sugg
             .substitutions
@@ -127,27 +128,27 @@ impl JsonEmitter {
             .map(|part| self.span_with_suggestion(part.span, part.snippet.to_string()))
             .collect();
 
-        Diagnostic {
-            message: sugg.msg.as_str().to_string(),
+        JsonDiagnostic {
+            message: Cow::Owned(sugg.msg.as_str().to_string()),
             code: None,
-            level: "help",
+            level: Cow::Borrowed("help"),
             spans,
             children: vec![],
             rendered: None,
         }
     }
 
-    fn spans(&self, msp: &MultiSpan) -> Vec<DiagnosticSpan> {
+    fn spans(&self, msp: &MultiSpan) -> Vec<JsonDiagnosticSpan<'static>> {
         msp.span_labels().iter().map(|label| self.span(label)).collect()
     }
 
-    fn span(&self, label: &SpanLabel) -> DiagnosticSpan {
+    fn span(&self, label: &SpanLabel) -> JsonDiagnosticSpan<'static> {
         let sm = &**self.source_map();
         let span = label.span;
         let start = sm.lookup_char_pos(span.lo());
         let end = sm.lookup_char_pos(span.hi());
-        DiagnosticSpan {
-            file_name: sm.filename_for_diagnostics(&start.file.name).to_string(),
+        JsonDiagnosticSpan {
+            file_name: Cow::Owned(sm.filename_for_diagnostics(&start.file.name).to_string()),
             byte_start: start.file.original_relative_byte_pos(span.lo()).0,
             byte_end: start.file.original_relative_byte_pos(span.hi()).0,
             line_start: start.line,
@@ -156,17 +157,17 @@ impl JsonEmitter {
             column_end: end.col.0 + 1,
             is_primary: label.is_primary,
             text: self.span_lines(span),
-            label: label.label.as_ref().map(|msg| msg.as_str().into()),
+            label: label.label.as_ref().map(|msg| Cow::Owned(msg.as_str().to_string())),
             suggested_replacement: None,
         }
     }
 
-    fn span_with_suggestion(&self, span: Span, replacement: String) -> DiagnosticSpan {
+    fn span_with_suggestion(&self, span: Span, replacement: String) -> JsonDiagnosticSpan<'static> {
         let sm = &**self.source_map();
         let start = sm.lookup_char_pos(span.lo());
         let end = sm.lookup_char_pos(span.hi());
-        DiagnosticSpan {
-            file_name: sm.filename_for_diagnostics(&start.file.name).to_string(),
+        JsonDiagnosticSpan {
+            file_name: Cow::Owned(sm.filename_for_diagnostics(&start.file.name).to_string()),
             byte_start: start.file.original_relative_byte_pos(span.lo()).0,
             byte_end: start.file.original_relative_byte_pos(span.hi()).0,
             line_start: start.line,
@@ -176,19 +177,21 @@ impl JsonEmitter {
             is_primary: true,
             text: self.span_lines(span),
             label: None,
-            suggested_replacement: Some(replacement),
+            suggested_replacement: Some(Cow::Owned(replacement)),
         }
     }
 
-    fn span_lines(&self, span: Span) -> Vec<DiagnosticSpanLine> {
+    fn span_lines(&self, span: Span) -> Vec<JsonDiagnosticSpanLine<'static>> {
         let Ok(f) = self.source_map().span_to_lines(span) else { return Vec::new() };
         let sf = &*f.file;
         f.data.iter().map(|line| self.span_line(sf, line)).collect()
     }
 
-    fn span_line(&self, sf: &SourceFile, line: &LineInfo) -> DiagnosticSpanLine {
-        DiagnosticSpanLine {
-            text: sf.get_line(line.line_index).map_or_else(String::new, |l| l.to_string()),
+    fn span_line(&self, sf: &SourceFile, line: &LineInfo) -> JsonDiagnosticSpanLine<'static> {
+        JsonDiagnosticSpanLine {
+            text: Cow::Owned(
+                sf.get_line(line.line_index).map_or_else(String::new, |l| l.to_string()),
+            ),
             highlight_start: line.start_col.0 + 1,
             highlight_end: line.end_col.0 + 1,
         }
@@ -286,70 +289,98 @@ impl JsonEmitter {
 
 // Rustc-like JSON format.
 
-#[derive(Serialize)]
+/// A rustc-like JSON message emitted by [`JsonEmitter::rustc_like`].
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "$message_type", rename_all = "snake_case")]
-enum EmitTyped {
-    Diagnostic(Diagnostic),
+pub enum JsonDiagnosticMessage<'a> {
+    /// A diagnostic message.
+    Diagnostic(#[serde(borrow)] JsonDiagnostic<'a>),
 }
 
-#[derive(Serialize)]
-struct Diagnostic {
+/// A rustc-like JSON diagnostic emitted by [`JsonEmitter`].
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonDiagnostic<'a> {
     /// The primary error message.
-    message: String,
-    code: Option<DiagnosticCode>,
+    #[serde(borrow)]
+    pub message: Cow<'a, str>,
+    /// The diagnostic code.
+    #[serde(borrow)]
+    pub code: Option<JsonDiagnosticCode<'a>>,
     /// "error", "warning", "note", "help".
-    level: &'static str,
-    spans: Vec<DiagnosticSpan>,
+    #[serde(borrow)]
+    pub level: Cow<'a, str>,
+    /// The diagnostic spans.
+    #[serde(borrow)]
+    pub spans: Vec<JsonDiagnosticSpan<'a>>,
     /// Associated diagnostic messages.
-    children: Vec<Self>,
+    #[serde(borrow)]
+    pub children: Vec<Self>,
     /// The message as the compiler would render it.
-    rendered: Option<String>,
+    #[serde(borrow)]
+    pub rendered: Option<Cow<'a, str>>,
 }
 
-#[derive(Serialize)]
-struct DiagnosticSpan {
-    file_name: String,
-    byte_start: u32,
-    byte_end: u32,
+/// A source span in a rustc-like JSON diagnostic.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonDiagnosticSpan<'a> {
+    /// The diagnostic file name.
+    #[serde(borrow)]
+    pub file_name: Cow<'a, str>,
+    /// The start byte offset.
+    pub byte_start: u32,
+    /// The end byte offset.
+    pub byte_end: u32,
     /// 1-based.
-    line_start: usize,
-    line_end: usize,
+    pub line_start: usize,
+    /// 1-based.
+    pub line_end: usize,
     /// 1-based, character offset.
-    column_start: usize,
-    column_end: usize,
+    pub column_start: usize,
+    /// 1-based, character offset.
+    pub column_end: usize,
     /// Is this a "primary" span -- meaning the point, or one of the points,
     /// where the error occurred?
-    is_primary: bool,
+    pub is_primary: bool,
     /// Source text from the start of line_start to the end of line_end.
-    text: Vec<DiagnosticSpanLine>,
-    /// Label that should be placed at this location (if any)
-    label: Option<String>,
+    #[serde(borrow)]
+    pub text: Vec<JsonDiagnosticSpanLine<'a>>,
+    /// Label that should be placed at this location, if any.
+    #[serde(borrow)]
+    pub label: Option<Cow<'a, str>>,
     /// If we are suggesting a replacement, this will contain text
     /// that should be sliced in atop this span.
-    suggested_replacement: Option<String>,
+    #[serde(borrow)]
+    pub suggested_replacement: Option<Cow<'a, str>>,
 }
 
-#[derive(Serialize)]
-struct DiagnosticSpanLine {
-    text: String,
+/// A source line in a rustc-like JSON diagnostic span.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonDiagnosticSpanLine<'a> {
+    /// The source text.
+    #[serde(borrow)]
+    pub text: Cow<'a, str>,
 
     /// 1-based, character offset in self.text.
-    highlight_start: usize,
+    pub highlight_start: usize,
 
-    highlight_end: usize,
+    /// 1-based, character offset in self.text.
+    pub highlight_end: usize,
 }
 
-#[derive(Serialize)]
-struct DiagnosticCode {
+/// A diagnostic code in a rustc-like JSON diagnostic.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonDiagnosticCode<'a> {
     /// The code itself.
-    code: String,
+    #[serde(borrow)]
+    pub code: Cow<'a, str>,
     /// An explanation for the code.
-    explanation: Option<&'static str>,
+    #[serde(borrow)]
+    pub explanation: Option<Cow<'a, str>>,
 }
 
 // Solc JSON format.
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SolcDiagnostic<'a> {
     #[serde(borrow)]
@@ -376,7 +407,7 @@ impl SolcDiagnostic<'_> {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SourceLocation<'a> {
     #[serde(borrow)]
     pub file: Cow<'a, str>,
@@ -388,7 +419,7 @@ pub struct SourceLocation<'a> {
     pub message: Option<Cow<'a, str>>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,

--- a/crates/interface/src/diagnostics/emitter/mod.rs
+++ b/crates/interface/src/diagnostics/emitter/mod.rs
@@ -8,7 +8,10 @@ pub use human::{HumanBufferEmitter, HumanEmitter};
 #[cfg(feature = "json")]
 mod json;
 #[cfg(feature = "json")]
-pub use json::{JsonEmitter, Severity, SolcDiagnostic, SourceLocation};
+pub use json::{
+    JsonDiagnostic, JsonDiagnosticCode, JsonDiagnosticMessage, JsonDiagnosticSpan,
+    JsonDiagnosticSpanLine, JsonEmitter, Severity, SolcDiagnostic, SourceLocation,
+};
 
 mod mem;
 pub use mem::InMemoryEmitter;

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -25,7 +25,10 @@ pub use emitter::{
     SilentEmitter,
 };
 #[cfg(feature = "json")]
-pub use emitter::{JsonEmitter, Severity, SolcDiagnostic, SourceLocation};
+pub use emitter::{
+    JsonDiagnostic, JsonDiagnosticCode, JsonDiagnosticMessage, JsonDiagnosticSpan,
+    JsonDiagnosticSpanLine, JsonEmitter, Severity, SolcDiagnostic, SourceLocation,
+};
 
 mod message;
 pub use message::{DiagMsg, MultiSpan, SpanLabel};

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -25,7 +25,7 @@ workspace = true
 
 [dependencies]
 solar-config = { workspace = true, features = ["version"] }
-solar-interface.workspace = true
+solar-interface = { workspace = true, features = ["json"] }
 solar-sema.workspace = true
 
 async-lsp = { workspace = true, features = ["omni-trait"] }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -37,7 +37,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 toml_edit = { workspace = true, features = ["serde"] }
 tower.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["process", "rt", "time"] }
 tracing.workspace = true
 
 # This is needed because Windows does not support truly asynchronous pipes.

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -37,7 +37,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 toml_edit = { workspace = true, features = ["serde"] }
 tower.workspace = true
-tokio = { workspace = true, features = ["io-util", "process", "rt", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "process", "rt", "sync", "time"] }
 tracing.workspace = true
 
 # This is needed because Windows does not support truly asynchronous pipes.

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -37,7 +37,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 toml_edit = { workspace = true, features = ["serde"] }
 tower.workspace = true
-tokio = { workspace = true, features = ["process", "rt", "time"] }
+tokio = { workspace = true, features = ["io-util", "process", "rt", "time"] }
 tracing.workspace = true
 
 # This is needed because Windows does not support truly asynchronous pipes.

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,7 +1,11 @@
-use crate::workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest};
+use crate::{
+    flycheck::{FlycheckConfig, FlycheckInitializationOptions},
+    workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest},
+};
 use lsp_types::{
-    CompletionOptions, DeclarationCapability, InitializeParams, OneOf, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    CompletionOptions, DeclarationCapability, InitializeParams, OneOf, SaveOptions,
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions,
 };
 use solar_interface::data_structures::map::FxHashSet;
 use std::{
@@ -19,6 +23,8 @@ use tracing::{info, warn};
 pub(crate) struct Config {
     workspace_roots: Vec<PathBuf>,
     workspaces: Vec<Workspace>,
+    flycheck_options: FlycheckInitializationOptions,
+    flychecks: Vec<FlycheckConfig>,
     watched_file_dynamic_registration: bool,
     hierarchical_document_symbol_support: bool,
 }
@@ -34,6 +40,10 @@ impl Config {
 
     pub(crate) fn workspaces(&self) -> &[Workspace] {
         &self.workspaces
+    }
+
+    pub(crate) fn flychecks_for_path(&self, path: &Path) -> Vec<FlycheckConfig> {
+        self.flychecks.iter().filter(|flycheck| flycheck.applies_to(path)).cloned().collect()
     }
 
     pub(crate) fn rediscover_workspaces(&mut self) {
@@ -70,6 +80,7 @@ impl Config {
         }
         info!(workspaces = ?workspaces.iter().map(Workspace::kind).collect::<Vec<_>>(), "loaded workspaces");
         self.workspaces = workspaces;
+        self.refresh_flychecks();
     }
 
     pub(crate) fn remove_workspace(&mut self, path: &Path) {
@@ -97,6 +108,11 @@ impl Config {
         let idx = WorkspacePathIndex::new(&self.workspaces).workspace_idx_for_path(path);
         self.workspaces[idx].remove_source_file(path);
     }
+
+    fn refresh_flychecks(&mut self) {
+        self.flychecks = self.flycheck_options.configs(&self.workspaces);
+        info!(flychecks = ?self.flychecks.iter().map(|it| it.id.as_str()).collect::<Vec<_>>(), "loaded flychecks");
+    }
 }
 
 fn push_workspace(workspaces: &mut Vec<Workspace>, mut workspace: Workspace) {
@@ -105,6 +121,9 @@ fn push_workspace(workspaces: &mut Vec<Workspace>, mut workspace: Workspace) {
 }
 
 pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabilities, Config) {
+    let flycheck_options =
+        FlycheckInitializationOptions::from_json(params.initialization_options.clone());
+
     // todo: make this absolute guaranteed
     #[allow(deprecated)]
     let root_path = match params.root_uri.and_then(|it| it.to_file_path().ok()) {
@@ -156,7 +175,9 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
                     change: Some(TextDocumentSyncKind::INCREMENTAL),
                     will_save: None,
                     will_save_wait_until: None,
-                    ..Default::default()
+                    save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                        include_text: Some(false),
+                    })),
                 },
             )),
             workspace_symbol_provider: Some(OneOf::Left(true)),
@@ -164,6 +185,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
         },
         Config {
             workspace_roots,
+            flycheck_options,
             watched_file_dynamic_registration,
             hierarchical_document_symbol_support,
             ..Default::default()
@@ -177,7 +199,8 @@ mod tests {
     use crate::{test_support::TestProject, workspace::WorkspaceKind};
     use lsp_types::{
         DidChangeWatchedFilesClientCapabilities, DocumentSymbolClientCapabilities, OneOf,
-        TextDocumentClientCapabilities, WorkspaceClientCapabilities,
+        TextDocumentClientCapabilities, TextDocumentSyncCapability, TextDocumentSyncSaveOptions,
+        WorkspaceClientCapabilities,
     };
 
     #[test]
@@ -211,6 +234,17 @@ mod tests {
         assert_eq!(capabilities.inlay_hint_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.references_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.workspace_symbol_provider, Some(OneOf::Left(true)));
+
+        let TextDocumentSyncCapability::Options(sync_options) =
+            capabilities.text_document_sync.unwrap()
+        else {
+            panic!("expected text document sync options");
+        };
+        let TextDocumentSyncSaveOptions::SaveOptions(save_options) = sync_options.save.unwrap()
+        else {
+            panic!("expected save options");
+        };
+        assert_eq!(save_options.include_text, Some(false));
     }
 
     #[test]
@@ -230,6 +264,39 @@ mod tests {
         let (_, config) = negotiate_capabilities(params);
 
         assert!(config.supports_hierarchical_document_symbols());
+    }
+
+    #[test]
+    fn negotiate_capabilities_records_configured_flychecks() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+
+            //- /src/Test.sol
+            contract Test {}
+            "#,
+        );
+        let mut params = project.initialize_params();
+        params.initialization_options = Some(serde_json::json!({
+            "flychecks": [{
+                "id": "custom",
+                "command": "custom-lint",
+                "args": ["--json"],
+                "output": "solc-json"
+            }]
+        }));
+        let (_, mut config) = negotiate_capabilities(params);
+        config.rediscover_workspaces();
+
+        let flychecks = config.flychecks_for_path(&project.path("/src/Test.sol"));
+
+        assert_eq!(flychecks.len(), 1);
+        assert_eq!(flychecks[0].id.as_str(), "custom");
+        assert_eq!(flychecks[0].command, PathBuf::from("custom-lint"));
+        assert_eq!(flychecks[0].args, ["--json"]);
+        assert_eq!(flychecks[0].cwd, project.root());
     }
 
     #[test]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -111,13 +111,15 @@ impl Config {
     }
 
     fn refresh_flychecks(&mut self) -> Vec<DiagnosticOwner> {
-        let previous_owners =
+        let mut removed_owners =
             self.flychecks.iter().map(FlycheckConfig::owner).collect::<FxHashSet<_>>();
         self.flychecks = self.flycheck_options.configs(&self.workspaces);
-        let current_owners =
-            self.flychecks.iter().map(FlycheckConfig::owner).collect::<FxHashSet<_>>();
-        let mut removed_owners =
-            previous_owners.difference(&current_owners).cloned().collect::<Vec<_>>();
+
+        for owner in self.flychecks.iter().map(FlycheckConfig::owner) {
+            removed_owners.remove(&owner);
+        }
+
+        let mut removed_owners = removed_owners.into_iter().collect::<Vec<_>>();
         removed_owners.sort();
         info!(flychecks = ?self.flychecks.iter().map(|it| it.id.as_str()).collect::<Vec<_>>(), "loaded flychecks");
         removed_owners

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -121,12 +121,15 @@ fn push_workspace(workspaces: &mut Vec<Workspace>, mut workspace: Workspace) {
 }
 
 pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabilities, Config) {
-    let flycheck_options =
-        FlycheckInitializationOptions::from_json(params.initialization_options.clone());
+    let capabilities = params.capabilities;
+    let initialization_options = params.initialization_options;
+    #[allow(deprecated)]
+    let root_uri = params.root_uri;
+    let workspace_folders = params.workspace_folders;
+    let flycheck_options = FlycheckInitializationOptions::from_json(initialization_options);
 
     // todo: make this absolute guaranteed
-    #[allow(deprecated)]
-    let root_path = match params.root_uri.and_then(|it| it.to_file_path().ok()) {
+    let root_path = match root_uri.and_then(|it| it.to_file_path().ok()) {
         Some(it) => it,
         None => {
             // todo: unwrap
@@ -137,8 +140,6 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
     // todo: make this absolute guaranteed
     // The latest LSP spec mandates clients report `workspace_folders`, but some might still report
     // `root_uri`.
-    let capabilities = params.capabilities;
-
     let watched_file_dynamic_registration = capabilities
         .workspace
         .and_then(|workspace| workspace.did_change_watched_files)
@@ -150,8 +151,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
         .and_then(|capabilities| capabilities.hierarchical_document_symbol_support)
         .unwrap_or(false);
 
-    let workspace_roots = params
-        .workspace_folders
+    let workspace_roots = workspace_folders
         .map(|workspaces| {
             workspaces.into_iter().filter_map(|it| it.uri.to_file_path().ok()).collect::<Vec<_>>()
         })
@@ -173,11 +173,10 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
                 TextDocumentSyncOptions {
                     open_close: Some(true),
                     change: Some(TextDocumentSyncKind::INCREMENTAL),
-                    will_save: None,
-                    will_save_wait_until: None,
                     save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
                         include_text: Some(false),
                     })),
+                    ..Default::default()
                 },
             )),
             workspace_symbol_provider: Some(OneOf::Left(true)),

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -121,7 +121,7 @@ impl Config {
 
         let mut removed_owners = removed_owners.into_iter().collect::<Vec<_>>();
         removed_owners.sort();
-        info!(flychecks = ?self.flychecks.iter().map(|it| it.id.as_str()).collect::<Vec<_>>(), "loaded flychecks");
+        info!(flychecks = ?self.flychecks.iter().map(|it| &it.id).collect::<Vec<_>>(), "loaded flychecks");
         removed_owners
     }
 }
@@ -303,7 +303,7 @@ mod tests {
         let flychecks = config.flychecks_for_path(&project.path("/src/Test.sol"));
 
         assert_eq!(flychecks.len(), 1);
-        assert_eq!(flychecks[0].id.as_str(), "custom");
+        assert_eq!(flychecks[0].id, "custom");
         assert_eq!(flychecks[0].command, PathBuf::from("custom-lint"));
         assert_eq!(flychecks[0].args, ["--json"]);
         assert_eq!(flychecks[0].cwd, project.root());

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,4 +1,5 @@
 use crate::{
+    diagnostics::DiagnosticOwner,
     flycheck::{FlycheckConfig, FlycheckInitializationOptions},
     workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest},
 };
@@ -46,7 +47,7 @@ impl Config {
         self.flychecks.iter().filter(|flycheck| flycheck.applies_to(path)).cloned().collect()
     }
 
-    pub(crate) fn rediscover_workspaces(&mut self) {
+    pub(crate) fn rediscover_workspaces(&mut self) -> Vec<DiagnosticOwner> {
         let mut workspaces = Vec::new();
         let mut seen_manifests = FxHashSet::default();
         for root in &self.workspace_roots {
@@ -80,7 +81,7 @@ impl Config {
         }
         info!(workspaces = ?workspaces.iter().map(Workspace::kind).collect::<Vec<_>>(), "loaded workspaces");
         self.workspaces = workspaces;
-        self.refresh_flychecks();
+        self.refresh_flychecks()
     }
 
     pub(crate) fn remove_workspace(&mut self, path: &Path) {
@@ -109,9 +110,17 @@ impl Config {
         self.workspaces[idx].remove_source_file(path);
     }
 
-    fn refresh_flychecks(&mut self) {
+    fn refresh_flychecks(&mut self) -> Vec<DiagnosticOwner> {
+        let previous_owners =
+            self.flychecks.iter().map(FlycheckConfig::owner).collect::<FxHashSet<_>>();
         self.flychecks = self.flycheck_options.configs(&self.workspaces);
+        let current_owners =
+            self.flychecks.iter().map(FlycheckConfig::owner).collect::<FxHashSet<_>>();
+        let mut removed_owners =
+            previous_owners.difference(&current_owners).cloned().collect::<Vec<_>>();
+        removed_owners.sort();
         info!(flychecks = ?self.flychecks.iter().map(|it| it.id.as_str()).collect::<Vec<_>>(), "loaded flychecks");
+        removed_owners
     }
 }
 
@@ -296,6 +305,41 @@ mod tests {
         assert_eq!(flychecks[0].command, PathBuf::from("custom-lint"));
         assert_eq!(flychecks[0].args, ["--json"]);
         assert_eq!(flychecks[0].cwd, project.root());
+    }
+
+    #[test]
+    fn rediscover_workspaces_reports_removed_flycheck_owners() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+
+            //- /src/Test.sol
+            contract Test {}
+            "#,
+        );
+        let mut params = project.initialize_params();
+        params.initialization_options = Some(serde_json::json!({
+            "flychecks": [{
+                "id": "custom",
+                "command": "custom-lint",
+                "output": "solc-json"
+            }]
+        }));
+        let (_, mut config) = negotiate_capabilities(params);
+        assert!(config.rediscover_workspaces().is_empty());
+
+        config.remove_workspace(project.root());
+        let removed_owners = config.rediscover_workspaces();
+
+        assert_eq!(
+            removed_owners,
+            vec![DiagnosticOwner::Flycheck {
+                id: "custom".into(),
+                workspace: project.root().to_path_buf()
+            }]
+        );
     }
 
     #[test]

--- a/crates/lsp/src/diagnostics.rs
+++ b/crates/lsp/src/diagnostics.rs
@@ -1,0 +1,163 @@
+use lsp_types::{Diagnostic, Url};
+use solar_interface::data_structures::map::{FxHashMap, FxHashSet};
+use std::path::PathBuf;
+
+pub(crate) type DiagnosticMap = FxHashMap<Url, Vec<Diagnostic>>;
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) enum DiagnosticOwner {
+    Compiler,
+    Flycheck { id: String, workspace: PathBuf },
+}
+
+#[derive(Default)]
+pub(crate) struct DiagnosticStore {
+    diagnostics: FxHashMap<DiagnosticOwner, DiagnosticMap>,
+    published_uris: FxHashSet<Url>,
+}
+
+impl DiagnosticStore {
+    pub(crate) fn replace(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) {
+        if diagnostics.is_empty() {
+            self.diagnostics.remove(&owner);
+        } else {
+            self.diagnostics.insert(owner, diagnostics);
+        }
+    }
+
+    pub(crate) fn publish_batches(&mut self) -> Vec<(Url, Vec<Diagnostic>)> {
+        let mut merged = DiagnosticMap::default();
+        let mut owners = self.diagnostics.keys().collect::<Vec<_>>();
+        owners.sort();
+
+        for owner in owners {
+            for (uri, diagnostics) in &self.diagnostics[owner] {
+                merged.entry(uri.clone()).or_default().extend(diagnostics.iter().cloned());
+            }
+        }
+
+        let mut uris = merged.keys().cloned().collect::<FxHashSet<_>>();
+        uris.extend(self.published_uris.iter().cloned());
+        let mut uris = uris.into_iter().collect::<Vec<_>>();
+        uris.sort_by(|lhs, rhs| lhs.as_str().cmp(rhs.as_str()));
+
+        let mut next_published_uris = FxHashSet::default();
+        let batches = uris
+            .into_iter()
+            .map(|uri| {
+                let diagnostics = merged.remove(&uri).unwrap_or_default();
+                if !diagnostics.is_empty() {
+                    next_published_uris.insert(uri.clone());
+                }
+                (uri, diagnostics)
+            })
+            .collect();
+
+        self.published_uris = next_published_uris;
+        batches
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::{Position, Range};
+
+    fn diagnostic(message: &str) -> Diagnostic {
+        Diagnostic::new_simple(
+            Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 0, character: 1 },
+            },
+            message.into(),
+        )
+    }
+
+    fn uri(path: &str) -> Url {
+        Url::parse(&format!("file:///workspace/{path}")).unwrap()
+    }
+
+    #[test]
+    fn publish_batches_merges_owners_for_same_uri() {
+        let file = uri("src/Test.sol");
+        let mut store = DiagnosticStore::default();
+
+        store.replace(
+            DiagnosticOwner::Compiler,
+            DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("compiler")])]),
+        );
+        store.replace(
+            DiagnosticOwner::Flycheck {
+                id: "forge-lint".into(),
+                workspace: PathBuf::from("/workspace"),
+            },
+            DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("lint")])]),
+        );
+
+        let batches = store.publish_batches();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].0, file);
+        assert_eq!(
+            batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>(),
+            ["compiler", "lint"]
+        );
+    }
+
+    #[test]
+    fn owner_replacement_does_not_clear_other_owners() {
+        let file = uri("src/Test.sol");
+        let mut store = DiagnosticStore::default();
+
+        store.replace(
+            DiagnosticOwner::Compiler,
+            DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("compiler")])]),
+        );
+        store.replace(
+            DiagnosticOwner::Flycheck {
+                id: "forge-lint".into(),
+                workspace: PathBuf::from("/workspace"),
+            },
+            DiagnosticMap::from_iter([(file, vec![diagnostic("lint")])]),
+        );
+        store.replace(
+            DiagnosticOwner::Flycheck {
+                id: "forge-lint".into(),
+                workspace: PathBuf::from("/workspace"),
+            },
+            DiagnosticMap::default(),
+        );
+
+        let batches = store.publish_batches();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(
+            batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>(),
+            ["compiler"]
+        );
+    }
+
+    #[test]
+    fn publish_batches_clears_stale_uris() {
+        let first = uri("src/First.sol");
+        let second = uri("src/Second.sol");
+        let mut store = DiagnosticStore::default();
+
+        store.replace(
+            DiagnosticOwner::Compiler,
+            DiagnosticMap::from_iter([(first.clone(), vec![diagnostic("first")])]),
+        );
+        let initial = store.publish_batches();
+        assert_eq!(initial, vec![(first.clone(), vec![diagnostic("first")])]);
+
+        store.replace(
+            DiagnosticOwner::Compiler,
+            DiagnosticMap::from_iter([(second.clone(), vec![diagnostic("second")])]),
+        );
+        let batches = store.publish_batches();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0], (first, Vec::new()));
+        assert_eq!(batches[1], (second, vec![diagnostic("second")]));
+    }
+}

--- a/crates/lsp/src/diagnostics.rs
+++ b/crates/lsp/src/diagnostics.rs
@@ -26,6 +26,23 @@ impl DiagnosticStore {
         self.publish_batches(affected_uris)
     }
 
+    pub(crate) fn clear_uris_and_publish_batches(
+        &mut self,
+        uris: impl IntoIterator<Item = Url>,
+    ) -> Vec<(Url, Vec<Diagnostic>)> {
+        let affected_uris = uris.into_iter().collect::<FxHashSet<_>>();
+        if affected_uris.is_empty() {
+            return Vec::new();
+        }
+
+        self.diagnostics.retain(|_, owner_diagnostics| {
+            owner_diagnostics.retain(|uri, _| !affected_uris.contains(uri));
+            !owner_diagnostics.is_empty()
+        });
+
+        self.publish_batches(affected_uris)
+    }
+
     fn replace(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) -> FxHashSet<Url> {
         let mut affected_uris =
             FxHashSet::with_capacity_and_hasher(diagnostics.len(), Default::default());
@@ -203,5 +220,27 @@ mod tests {
             batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>(),
             ["first", "lint"]
         );
+    }
+
+    #[test]
+    fn clearing_uris_removes_diagnostics_from_all_owners() {
+        let file = uri("src/Deleted.sol");
+        let mut store = DiagnosticStore::default();
+
+        store.replace_and_publish_batches(
+            DiagnosticOwner::Compiler,
+            DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("compiler")])]),
+        );
+        store.replace_and_publish_batches(
+            DiagnosticOwner::Flycheck {
+                id: "forge-lint".into(),
+                workspace: PathBuf::from("/workspace"),
+            },
+            DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("lint")])]),
+        );
+
+        let batches = store.clear_uris_and_publish_batches([file.clone()]);
+
+        assert_eq!(batches, vec![(file, Vec::new())]);
     }
 }

--- a/crates/lsp/src/diagnostics.rs
+++ b/crates/lsp/src/diagnostics.rs
@@ -17,44 +17,64 @@ pub(crate) struct DiagnosticStore {
 }
 
 impl DiagnosticStore {
-    pub(crate) fn replace(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) {
-        if diagnostics.is_empty() {
-            self.diagnostics.remove(&owner);
-        } else {
-            self.diagnostics.insert(owner, diagnostics);
-        }
+    pub(crate) fn replace_and_publish_batches(
+        &mut self,
+        owner: DiagnosticOwner,
+        diagnostics: DiagnosticMap,
+    ) -> Vec<(Url, Vec<Diagnostic>)> {
+        let affected_uris = self.replace(owner, diagnostics);
+        self.publish_batches(affected_uris)
     }
 
-    pub(crate) fn publish_batches(&mut self) -> Vec<(Url, Vec<Diagnostic>)> {
-        let mut merged = DiagnosticMap::default();
+    fn replace(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) -> FxHashSet<Url> {
+        let mut affected_uris =
+            FxHashSet::with_capacity_and_hasher(diagnostics.len(), Default::default());
+        affected_uris.extend(diagnostics.keys().cloned());
+
+        let previous = if diagnostics.is_empty() {
+            self.diagnostics.remove(&owner)
+        } else {
+            self.diagnostics.insert(owner, diagnostics)
+        };
+
+        if let Some(previous) = previous {
+            affected_uris.extend(previous.into_keys());
+        }
+
+        affected_uris
+    }
+
+    fn publish_batches(&mut self, affected_uris: FxHashSet<Url>) -> Vec<(Url, Vec<Diagnostic>)> {
         let mut owners = self.diagnostics.keys().collect::<Vec<_>>();
         owners.sort();
 
-        for owner in owners {
-            for (uri, diagnostics) in &self.diagnostics[owner] {
-                merged.entry(uri.clone()).or_default().extend(diagnostics.iter().cloned());
-            }
-        }
-
-        let mut uris = merged.keys().cloned().collect::<FxHashSet<_>>();
-        uris.extend(self.published_uris.iter().cloned());
-        let mut uris = uris.into_iter().collect::<Vec<_>>();
+        let mut uris = affected_uris.into_iter().collect::<Vec<_>>();
         uris.sort_by(|lhs, rhs| lhs.as_str().cmp(rhs.as_str()));
 
-        let mut next_published_uris = FxHashSet::default();
-        let batches = uris
-            .into_iter()
-            .map(|uri| {
-                let diagnostics = merged.remove(&uri).unwrap_or_default();
-                if !diagnostics.is_empty() {
-                    next_published_uris.insert(uri.clone());
-                }
-                (uri, diagnostics)
-            })
-            .collect();
+        uris.into_iter()
+            .filter_map(|uri| {
+                let was_published = self.published_uris.contains(&uri);
+                let mut has_entry = false;
+                let mut diagnostics = Vec::new();
 
-        self.published_uris = next_published_uris;
-        batches
+                for owner in &owners {
+                    if let Some(owner_diagnostics) = self.diagnostics.get(*owner)
+                        && let Some(uri_diagnostics) = owner_diagnostics.get(&uri)
+                    {
+                        has_entry = true;
+                        diagnostics.extend(uri_diagnostics.iter().cloned());
+                    }
+                }
+
+                if diagnostics.is_empty() {
+                    self.published_uris.remove(&uri);
+                } else {
+                    self.published_uris.insert(uri.clone());
+                }
+
+                (has_entry || was_published).then_some((uri, diagnostics))
+            })
+            .collect()
     }
 }
 
@@ -82,19 +102,19 @@ mod tests {
         let file = uri("src/Test.sol");
         let mut store = DiagnosticStore::default();
 
-        store.replace(
+        let batches = store.replace_and_publish_batches(
             DiagnosticOwner::Compiler,
             DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("compiler")])]),
         );
-        store.replace(
+        assert_eq!(batches.len(), 1);
+
+        let batches = store.replace_and_publish_batches(
             DiagnosticOwner::Flycheck {
                 id: "forge-lint".into(),
                 workspace: PathBuf::from("/workspace"),
             },
             DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("lint")])]),
         );
-
-        let batches = store.publish_batches();
 
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].0, file);
@@ -109,26 +129,24 @@ mod tests {
         let file = uri("src/Test.sol");
         let mut store = DiagnosticStore::default();
 
-        store.replace(
+        store.replace_and_publish_batches(
             DiagnosticOwner::Compiler,
             DiagnosticMap::from_iter([(file.clone(), vec![diagnostic("compiler")])]),
         );
-        store.replace(
+        store.replace_and_publish_batches(
             DiagnosticOwner::Flycheck {
                 id: "forge-lint".into(),
                 workspace: PathBuf::from("/workspace"),
             },
             DiagnosticMap::from_iter([(file, vec![diagnostic("lint")])]),
         );
-        store.replace(
+        let batches = store.replace_and_publish_batches(
             DiagnosticOwner::Flycheck {
                 id: "forge-lint".into(),
                 workspace: PathBuf::from("/workspace"),
             },
             DiagnosticMap::default(),
         );
-
-        let batches = store.publish_batches();
 
         assert_eq!(batches.len(), 1);
         assert_eq!(
@@ -143,21 +161,49 @@ mod tests {
         let second = uri("src/Second.sol");
         let mut store = DiagnosticStore::default();
 
-        store.replace(
+        let initial = store.replace_and_publish_batches(
             DiagnosticOwner::Compiler,
             DiagnosticMap::from_iter([(first.clone(), vec![diagnostic("first")])]),
         );
-        let initial = store.publish_batches();
         assert_eq!(initial, vec![(first.clone(), vec![diagnostic("first")])]);
 
-        store.replace(
+        let batches = store.replace_and_publish_batches(
             DiagnosticOwner::Compiler,
             DiagnosticMap::from_iter([(second.clone(), vec![diagnostic("second")])]),
         );
-        let batches = store.publish_batches();
 
         assert_eq!(batches.len(), 2);
         assert_eq!(batches[0], (first, Vec::new()));
         assert_eq!(batches[1], (second, vec![diagnostic("second")]));
+    }
+
+    #[test]
+    fn owner_replacement_only_publishes_affected_uris() {
+        let first = uri("src/First.sol");
+        let second = uri("src/Second.sol");
+        let mut store = DiagnosticStore::default();
+
+        store.replace_and_publish_batches(
+            DiagnosticOwner::Compiler,
+            DiagnosticMap::from_iter([
+                (first.clone(), vec![diagnostic("first")]),
+                (second, vec![diagnostic("second")]),
+            ]),
+        );
+
+        let batches = store.replace_and_publish_batches(
+            DiagnosticOwner::Flycheck {
+                id: "forge-lint".into(),
+                workspace: PathBuf::from("/workspace"),
+            },
+            DiagnosticMap::from_iter([(first.clone(), vec![diagnostic("lint")])]),
+        );
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].0, first);
+        assert_eq!(
+            batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>(),
+            ["first", "lint"]
+        );
     }
 }

--- a/crates/lsp/src/diagnostics.rs
+++ b/crates/lsp/src/diagnostics.rs
@@ -45,8 +45,8 @@ impl DiagnosticStore {
     }
 
     fn publish_batches(&mut self, affected_uris: FxHashSet<Url>) -> Vec<(Url, Vec<Diagnostic>)> {
-        let mut owners = self.diagnostics.keys().collect::<Vec<_>>();
-        owners.sort();
+        let mut owners = self.diagnostics.iter().collect::<Vec<_>>();
+        owners.sort_by_key(|(owner, _)| *owner);
 
         let mut uris = affected_uris.into_iter().collect::<Vec<_>>();
         uris.sort_by(|lhs, rhs| lhs.as_str().cmp(rhs.as_str()));
@@ -57,10 +57,8 @@ impl DiagnosticStore {
                 let mut has_entry = false;
                 let mut diagnostics = Vec::new();
 
-                for owner in &owners {
-                    if let Some(owner_diagnostics) = self.diagnostics.get(*owner)
-                        && let Some(uri_diagnostics) = owner_diagnostics.get(&uri)
-                    {
+                for (_, owner_diagnostics) in &owners {
+                    if let Some(uri_diagnostics) = owner_diagnostics.get(&uri) {
                         has_entry = true;
                         diagnostics.extend(uri_diagnostics.iter().cloned());
                     }

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -1,0 +1,203 @@
+use crate::{
+    diagnostics::DiagnosticOwner,
+    workspace::{Workspace, WorkspaceKind},
+};
+use serde::Deserialize;
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct FlycheckId(String);
+
+impl FlycheckId {
+    fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FlycheckConfig {
+    pub(crate) id: FlycheckId,
+    pub(crate) command: PathBuf,
+    pub(crate) args: Vec<String>,
+    pub(crate) cwd: PathBuf,
+    pub(crate) workspace_root: PathBuf,
+    pub(super) output: FlycheckOutput,
+}
+
+impl FlycheckConfig {
+    pub(crate) fn applies_to(&self, path: &Path) -> bool {
+        path.starts_with(&self.workspace_root)
+    }
+
+    pub(crate) fn owner(&self) -> DiagnosticOwner {
+        DiagnosticOwner::Flycheck {
+            id: self.id.as_str().to_string(),
+            workspace: self.workspace_root.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FlycheckInitializationOptions {
+    forge_path: Option<PathBuf>,
+    flychecks: Option<Vec<FlycheckTemplate>>,
+}
+
+impl FlycheckInitializationOptions {
+    pub(crate) fn from_json(value: Option<serde_json::Value>) -> Self {
+        value.and_then(|value| serde_json::from_value(value).ok()).unwrap_or_default()
+    }
+
+    pub(crate) fn configs(&self, workspaces: &[Workspace]) -> Vec<FlycheckConfig> {
+        let forge_path = self.forge_path();
+        match &self.flychecks {
+            Some(templates) => expand_templates(templates, workspaces),
+            None => default_flychecks(workspaces, forge_path),
+        }
+    }
+
+    pub(crate) fn forge_path(&self) -> PathBuf {
+        self.forge_path.clone().unwrap_or_else(|| PathBuf::from("forge"))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FlycheckTemplate {
+    id: String,
+    command: PathBuf,
+    #[serde(default)]
+    args: Vec<String>,
+    cwd: Option<PathBuf>,
+    #[serde(default)]
+    output: FlycheckOutput,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum FlycheckOutput {
+    #[default]
+    SolcJson,
+    ForgeLintJson,
+}
+
+fn expand_templates(
+    templates: &[FlycheckTemplate],
+    workspaces: &[Workspace],
+) -> Vec<FlycheckConfig> {
+    workspaces
+        .iter()
+        .filter_map(workspace_root)
+        .flat_map(|workspace_root| {
+            templates.iter().map(move |template| {
+                let cwd = template.cwd.as_ref().map_or_else(
+                    || workspace_root.clone(),
+                    |cwd| resolve_workspace_path(&workspace_root, cwd),
+                );
+                FlycheckConfig {
+                    id: FlycheckId::new(template.id.clone()),
+                    command: template.command.clone(),
+                    args: template.args.clone(),
+                    cwd,
+                    workspace_root: workspace_root.clone(),
+                    output: template.output,
+                }
+            })
+        })
+        .collect()
+}
+
+fn default_flychecks(workspaces: &[Workspace], forge_path: PathBuf) -> Vec<FlycheckConfig> {
+    workspaces
+        .iter()
+        .filter(|workspace| workspace.kind() == WorkspaceKind::Foundry)
+        .filter_map(workspace_root)
+        .filter(|root| forge_lint_available(&forge_path, root))
+        .map(|workspace_root| FlycheckConfig {
+            id: FlycheckId::new("forge-lint"),
+            command: forge_path.clone(),
+            args: vec!["lint".into(), "--json".into()],
+            cwd: workspace_root.clone(),
+            workspace_root,
+            output: FlycheckOutput::ForgeLintJson,
+        })
+        .collect()
+}
+
+fn workspace_root(workspace: &Workspace) -> Option<PathBuf> {
+    workspace.compile_opts().base_path.clone()
+}
+
+fn resolve_workspace_path(workspace_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() { path.to_path_buf() } else { workspace_root.join(path) }
+}
+
+fn forge_lint_available(command: &Path, cwd: &Path) -> bool {
+    Command::new(command)
+        .args(["lint", "--help"])
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestProject;
+
+    #[test]
+    fn configured_flychecks_expand_per_workspace() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+            "#,
+        );
+        let options = FlycheckInitializationOptions {
+            forge_path: None,
+            flychecks: Some(vec![FlycheckTemplate {
+                id: "custom".into(),
+                command: "custom-lint".into(),
+                args: vec!["--json".into()],
+                cwd: Some("tools".into()),
+                output: FlycheckOutput::SolcJson,
+            }]),
+        };
+
+        let configs = options.configs(project.config().workspaces());
+
+        assert_eq!(configs.len(), 1);
+        assert_eq!(configs[0].id.as_str(), "custom");
+        assert_eq!(configs[0].command, PathBuf::from("custom-lint"));
+        assert_eq!(configs[0].args, ["--json"]);
+        assert_eq!(configs[0].cwd, project.path("/tools"));
+        assert_eq!(configs[0].workspace_root, project.root());
+    }
+
+    #[test]
+    fn explicit_empty_flychecks_disable_default_detection() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+            "#,
+        );
+        let options =
+            FlycheckInitializationOptions { forge_path: None, flychecks: Some(Vec::new()) };
+
+        assert!(options.configs(project.config().workspaces()).is_empty());
+    }
+}

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -8,22 +8,9 @@ use std::{
     process::{Command, Stdio},
 };
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(crate) struct FlycheckId(String);
-
-impl FlycheckId {
-    fn new(id: impl Into<String>) -> Self {
-        Self(id.into())
-    }
-
-    pub(crate) fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct FlycheckConfig {
-    pub(crate) id: FlycheckId,
+    pub(crate) id: String,
     pub(crate) command: PathBuf,
     pub(crate) args: Vec<String>,
     pub(crate) cwd: PathBuf,
@@ -37,10 +24,7 @@ impl FlycheckConfig {
     }
 
     pub(crate) fn owner(&self) -> DiagnosticOwner {
-        DiagnosticOwner::Flycheck {
-            id: self.id.as_str().to_string(),
-            workspace: self.workspace_root.clone(),
-        }
+        DiagnosticOwner::Flycheck { id: self.id.clone(), workspace: self.workspace_root.clone() }
     }
 }
 
@@ -102,7 +86,7 @@ fn expand_templates(
                     |cwd| resolve_workspace_path(&workspace_root, cwd),
                 );
                 FlycheckConfig {
-                    id: FlycheckId::new(template.id.clone()),
+                    id: template.id.clone(),
                     command: template.command.clone(),
                     args: template.args.clone(),
                     cwd,
@@ -121,7 +105,7 @@ fn default_flychecks(workspaces: &[Workspace], forge_path: PathBuf) -> Vec<Flych
         .filter_map(workspace_root)
         .filter(|root| forge_lint_available(&forge_path, root))
         .map(|workspace_root| FlycheckConfig {
-            id: FlycheckId::new("forge-lint"),
+            id: "forge-lint".into(),
             command: forge_path.clone(),
             args: vec!["lint".into(), "--json".into()],
             cwd: workspace_root.clone(),
@@ -178,7 +162,7 @@ mod tests {
         let configs = options.configs(project.config().workspaces());
 
         assert_eq!(configs.len(), 1);
-        assert_eq!(configs[0].id.as_str(), "custom");
+        assert_eq!(configs[0].id, "custom");
         assert_eq!(configs[0].command, PathBuf::from("custom-lint"));
         assert_eq!(configs[0].args, ["--json"]);
         assert_eq!(configs[0].cwd, project.path("/tools"));

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -57,10 +57,9 @@ impl FlycheckInitializationOptions {
     }
 
     pub(crate) fn configs(&self, workspaces: &[Workspace]) -> Vec<FlycheckConfig> {
-        let forge_path = self.forge_path();
         match &self.flychecks {
             Some(templates) => expand_templates(templates, workspaces),
-            None => default_flychecks(workspaces, forge_path),
+            None => default_flychecks(workspaces, self.forge_path()),
         }
     }
 

--- a/crates/lsp/src/flycheck/mod.rs
+++ b/crates/lsp/src/flycheck/mod.rs
@@ -1,0 +1,6 @@
+mod config;
+mod parser;
+mod runner;
+
+pub(crate) use config::{FlycheckConfig, FlycheckInitializationOptions};
+pub(crate) use runner::run;

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -1,7 +1,15 @@
 use crate::{diagnostics::DiagnosticMap, flycheck::config::FlycheckOutput};
-use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
-use serde_json::Value;
-use solar_interface::{data_structures::map::FxHashMap, source_map::SourceMap};
+use lsp_types::{
+    Diagnostic as LspDiagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url,
+};
+use serde::Deserialize;
+use solar_interface::{
+    data_structures::map::FxHashMap,
+    diagnostics::{
+        JsonDiagnostic, JsonDiagnosticMessage, JsonDiagnosticSpan, Severity, SolcDiagnostic,
+    },
+    source_map::SourceMap,
+};
 use std::path::{Path, PathBuf};
 
 pub(super) fn parse(
@@ -11,10 +19,23 @@ pub(super) fn parse(
 ) -> Result<DiagnosticMap, ParseError> {
     let mut diagnostics = DiagnosticMap::default();
     let mut range_cache = ByteRangeCache::default();
+    let source = source(format);
 
-    let stream = serde_json::Deserializer::from_slice(output).into_iter::<Value>();
-    for value in stream {
-        collect_diagnostics(&value?, cwd, format, &mut diagnostics, &mut range_cache);
+    match format {
+        FlycheckOutput::SolcJson => {
+            let stream =
+                serde_json::Deserializer::from_slice(output).into_iter::<SolcJsonRecord<'_>>();
+            for record in stream {
+                collect_solc_json(record?, cwd, source, &mut diagnostics, &mut range_cache);
+            }
+        }
+        FlycheckOutput::ForgeLintJson => {
+            let stream =
+                serde_json::Deserializer::from_slice(output).into_iter::<JsonEmitterRecord<'_>>();
+            for record in stream {
+                collect_json_emitter(record?, cwd, source, &mut diagnostics, &mut range_cache);
+            }
+        }
     }
 
     Ok(diagnostics)
@@ -26,57 +47,94 @@ pub(crate) enum ParseError {
     Json(#[from] serde_json::Error),
 }
 
-fn collect_diagnostics(
-    value: &Value,
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum SolcJsonRecord<'a> {
+    Diagnostic(#[serde(borrow)] SolcDiagnostic<'a>),
+    Diagnostics(#[serde(borrow)] Vec<SolcDiagnostic<'a>>),
+    Errors(#[serde(borrow)] SolcJsonErrors<'a>),
+}
+
+#[derive(Debug, Deserialize)]
+struct SolcJsonErrors<'a> {
+    #[serde(borrow)]
+    errors: Vec<SolcDiagnostic<'a>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum JsonEmitterRecord<'a> {
+    Rustc(#[serde(borrow)] JsonDiagnosticMessage<'a>),
+    Solc(#[serde(borrow)] SolcDiagnostic<'a>),
+}
+
+fn collect_solc_json(
+    record: SolcJsonRecord<'_>,
     cwd: &Path,
-    format: FlycheckOutput,
+    source: &'static str,
     diagnostics: &mut DiagnosticMap,
     range_cache: &mut ByteRangeCache,
 ) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                collect_diagnostics(value, cwd, format, diagnostics, range_cache);
+    match record {
+        SolcJsonRecord::Diagnostic(diagnostic) => {
+            push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
+        }
+        SolcJsonRecord::Diagnostics(diagnostics_) => {
+            for diagnostic in diagnostics_ {
+                push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
             }
         }
-        Value::Object(object) => {
-            for key in ["diagnostics", "findings", "errors"] {
-                if let Some(value) = object.get(key) {
-                    collect_diagnostics(value, cwd, format, diagnostics, range_cache);
-                    return;
-                }
-            }
-
-            if let Some((uri, diagnostic)) = external_diagnostic(value, cwd, format, range_cache) {
-                diagnostics.entry(uri).or_default().push(diagnostic);
+        SolcJsonRecord::Errors(output) => {
+            for diagnostic in output.errors {
+                push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
             }
         }
-        _ => {}
     }
 }
 
-fn external_diagnostic(
-    value: &Value,
+fn collect_json_emitter(
+    record: JsonEmitterRecord<'_>,
     cwd: &Path,
-    format: FlycheckOutput,
+    source: &'static str,
+    diagnostics: &mut DiagnosticMap,
     range_cache: &mut ByteRangeCache,
-) -> Option<(Url, Diagnostic)> {
-    let location = source_location(value);
-    let path = resolve_path(cwd, location.file?);
+) {
+    match record {
+        JsonEmitterRecord::Rustc(JsonDiagnosticMessage::Diagnostic(diagnostic)) => {
+            push_diagnostic(diagnostics, json_diagnostic(diagnostic, cwd, source, range_cache));
+        }
+        JsonEmitterRecord::Solc(diagnostic) => {
+            push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
+        }
+    }
+}
+
+fn push_diagnostic(diagnostics: &mut DiagnosticMap, diagnostic: Option<(Url, LspDiagnostic)>) {
+    if let Some((uri, diagnostic)) = diagnostic {
+        diagnostics.entry(uri).or_default().push(diagnostic);
+    }
+}
+
+fn solc_diagnostic(
+    diagnostic: SolcDiagnostic<'_>,
+    cwd: &Path,
+    source: &'static str,
+    range_cache: &mut ByteRangeCache,
+) -> Option<(Url, LspDiagnostic)> {
+    let location = diagnostic.source_location?;
+    let path = resolve_path(cwd, location.file.as_ref());
     let uri = Url::from_file_path(&path).ok()?;
-    let range = location.range(&path, range_cache)?;
-    let message = message(value)?;
-    let code = diagnostic_code(value);
+    let range = range_cache.range(&path, location.start as usize, location.end as usize)?;
 
     Some((
         uri,
-        Diagnostic {
+        LspDiagnostic {
             range,
-            severity: Some(severity(value)),
-            code: code.map(NumberOrString::String),
+            severity: Some(solc_severity(diagnostic.severity)),
+            code: diagnostic.error_code.map(|code| NumberOrString::String(code.into_owned())),
             code_description: None,
-            source: Some(source(format).into()),
-            message,
+            source: Some(source.into()),
+            message: diagnostic.message.into_owned(),
             related_information: None,
             tags: None,
             data: None,
@@ -84,40 +142,58 @@ fn external_diagnostic(
     ))
 }
 
-fn source_location(value: &Value) -> ExternalLocation<'_> {
-    value
-        .get("sourceLocation")
-        .or_else(|| value.get("source_location"))
-        .or_else(|| value.get("location"))
-        .or_else(|| value.get("span"))
-        .or_else(|| rustc_primary_span(value))
-        .map_or_else(|| ExternalLocation::from_value(value), ExternalLocation::from_value)
-}
-
-fn message(value: &Value) -> Option<String> {
-    string_field(value, &["message", "msg", "title", "description"]).map(ToOwned::to_owned).or_else(
-        || string_field(value, &["formattedMessage", "formatted_message"]).map(clean_rendered),
-    )
-}
-
-fn diagnostic_code(value: &Value) -> Option<String> {
-    string_field(value, &["errorCode", "error_code", "code", "lint", "id", "name"])
-        .or_else(|| value.get("code").and_then(|code| string_field(code, &["code"])))
-        .map(ToOwned::to_owned)
-}
-
-fn severity(value: &Value) -> DiagnosticSeverity {
-    let Some(severity) = string_field(value, &["severity", "level"]) else {
-        return DiagnosticSeverity::WARNING;
+fn json_diagnostic(
+    diagnostic: JsonDiagnostic<'_>,
+    cwd: &Path,
+    source: &'static str,
+    range_cache: &mut ByteRangeCache,
+) -> Option<(Url, LspDiagnostic)> {
+    let (path, byte_start, byte_end) = {
+        let span = primary_span(&diagnostic)?;
+        (
+            resolve_path(cwd, span.file_name.as_ref()),
+            span.byte_start as usize,
+            span.byte_end as usize,
+        )
     };
 
+    let uri = Url::from_file_path(&path).ok()?;
+    let range = range_cache.range(&path, byte_start, byte_end)?;
+
+    Some((
+        uri,
+        LspDiagnostic {
+            range,
+            severity: Some(json_level_severity(diagnostic.level.as_ref())),
+            code: diagnostic.code.map(|code| NumberOrString::String(code.code.into_owned())),
+            code_description: None,
+            source: Some(source.into()),
+            message: diagnostic.message.into_owned(),
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ))
+}
+
+fn primary_span<'a, 'b>(diagnostic: &'a JsonDiagnostic<'b>) -> Option<&'a JsonDiagnosticSpan<'b>> {
+    diagnostic.spans.iter().find(|span| span.is_primary).or_else(|| diagnostic.spans.first())
+}
+
+fn solc_severity(severity: Severity) -> DiagnosticSeverity {
     match severity {
-        "error" | "fatal" | "high" => DiagnosticSeverity::ERROR,
-        "warning" | "warn" | "medium" | "med" | "low" | "gas" | "code-size" => {
-            DiagnosticSeverity::WARNING
-        }
-        "info" | "information" => DiagnosticSeverity::INFORMATION,
-        "hint" | "help" => DiagnosticSeverity::HINT,
+        Severity::Error => DiagnosticSeverity::ERROR,
+        Severity::Warning => DiagnosticSeverity::WARNING,
+        Severity::Info => DiagnosticSeverity::INFORMATION,
+    }
+}
+
+fn json_level_severity(level: &str) -> DiagnosticSeverity {
+    match level {
+        "error" | "fatal" | "error: internal compiler error" => DiagnosticSeverity::ERROR,
+        "warning" => DiagnosticSeverity::WARNING,
+        "note" | "failure-note" => DiagnosticSeverity::INFORMATION,
+        "help" => DiagnosticSeverity::HINT,
         _ => DiagnosticSeverity::WARNING,
     }
 }
@@ -129,81 +205,9 @@ fn source(format: FlycheckOutput) -> &'static str {
     }
 }
 
-fn string_field<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a str> {
-    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_str))
-}
-
-fn clean_rendered(rendered: &str) -> String {
-    rendered.lines().next().unwrap_or(rendered).to_string()
-}
-
-fn rustc_primary_span(value: &Value) -> Option<&Value> {
-    let spans = value.get("spans")?.as_array()?;
-    spans
-        .iter()
-        .find(|span| bool_field(span, &["is_primary"]).unwrap_or(false))
-        .or_else(|| spans.first())
-}
-
 fn resolve_path(cwd: &Path, path: &str) -> PathBuf {
     let path = Path::new(path);
     if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) }
-}
-
-struct ExternalLocation<'a> {
-    file: Option<&'a str>,
-    start: Option<u64>,
-    end: Option<u64>,
-    line: Option<u64>,
-    column: Option<u64>,
-    end_line: Option<u64>,
-    end_column: Option<u64>,
-}
-
-impl<'a> ExternalLocation<'a> {
-    fn from_value(value: &'a Value) -> Self {
-        Self {
-            file: string_field(value, &["file", "path", "source", "filename"])
-                .or_else(|| {
-                    value
-                        .get("source")
-                        .and_then(|source| string_field(source, &["file", "path", "filename"]))
-                })
-                .or_else(|| string_field(value, &["file_name"])),
-            start: numeric_field(value, &["start", "byteStart", "byte_start"]),
-            end: numeric_field(value, &["end", "byteEnd", "byte_end"]),
-            line: numeric_field(value, &["line", "startLine", "lineStart", "line_start"]),
-            column: numeric_field(
-                value,
-                &["column", "col", "startColumn", "columnStart", "column_start"],
-            ),
-            end_line: numeric_field(value, &["endLine", "lineEnd", "line_end"]),
-            end_column: numeric_field(value, &["endColumn", "columnEnd", "column_end"]),
-        }
-    }
-
-    fn range(&self, path: &Path, range_cache: &mut ByteRangeCache) -> Option<Range> {
-        if let (Some(start), Some(end)) = (self.start, self.end) {
-            return range_cache.range(path, start as usize, end as usize);
-        }
-
-        let line = self.line?;
-        let column = self.column.unwrap_or(1);
-        let end_line = self.end_line.unwrap_or(line);
-        let end_column = self.end_column.unwrap_or(column + 1);
-        Some(Range {
-            start: one_based_position(line, column),
-            end: one_based_position(end_line, end_column),
-        })
-    }
-}
-
-fn numeric_field(value: &Value, keys: &[&str]) -> Option<u64> {
-    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_u64))
-}
-
-fn bool_field(value: &Value, keys: &[&str]) -> Option<bool> {
-    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_bool))
 }
 
 #[derive(Default)]
@@ -258,15 +262,15 @@ impl LineIndex {
     }
 }
 
-fn one_based_position(line: u64, column: u64) -> Position {
-    Position { line: line.saturating_sub(1) as u32, character: column.saturating_sub(1) as u32 }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_support::TestProject;
     use lsp_types::DiagnosticSeverity;
+    use solar_interface::diagnostics::{
+        JsonDiagnosticCode, JsonDiagnosticSpanLine, SourceLocation,
+    };
+    use std::borrow::Cow;
 
     #[test]
     fn parses_solc_like_diagnostics() {
@@ -279,19 +283,17 @@ mod tests {
             "#,
         );
         let file = project.path("/src/Test.sol");
-        let json = serde_json::json!([{
-            "sourceLocation": {
-                "file": file,
-                "start": 20,
-                "end": 24
-            },
-            "severity": "warning",
-            "errorCode": "2018",
-            "message": "function name should use mixedCase"
-        }]);
+        let json = serde_json::to_string(&[solc_diagnostic_fixture(
+            Cow::Owned(file.to_string_lossy().into_owned()),
+            20,
+            24,
+            Severity::Warning,
+            Some("2018"),
+            "function name should use mixedCase",
+        )])
+        .unwrap();
 
-        let diagnostics =
-            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
+        let diagnostics = parse(json.as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
 
         let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
         let diagnostic = &diagnostics[&uri][0];
@@ -302,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_enveloped_forge_lint_findings() {
+    fn parses_standard_json_error_envelope() {
         let project = TestProject::from_fixture(
             r#"
             //- /src/Test.sol
@@ -312,27 +314,24 @@ mod tests {
             "#,
         );
         let json = serde_json::json!({
-            "findings": [{
-                "sourceLocation": {
-                    "file": "src/Test.sol",
-                    "start": 20,
-                    "end": 24
-                },
-                "severity": "med",
-                "lint": "mixed-case-variable",
-                "message": "mutable variables should use mixedCase"
-            }]
+            "errors": [solc_diagnostic_fixture(
+                Cow::Borrowed("src/Test.sol"),
+                20,
+                24,
+                Severity::Warning,
+                Some("2018"),
+                "mutable variables should use mixedCase",
+            )]
         });
 
         let diagnostics =
-            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::ForgeLintJson)
-                .unwrap();
+            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
 
         let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
         let diagnostic = &diagnostics[&uri][0];
-        assert_eq!(diagnostic.source.as_deref(), Some("forge-lint"));
+        assert_eq!(diagnostic.source.as_deref(), Some("flycheck"));
         assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
-        assert_eq!(diagnostic.code, Some(NumberOrString::String("mixed-case-variable".into())));
+        assert_eq!(diagnostic.code, Some(NumberOrString::String("2018".into())));
     }
 
     #[test]
@@ -352,38 +351,20 @@ mod tests {
         let variable_end = variable_start + "bad_name".len();
         let function_start = contents.find("bad_function").unwrap();
         let function_end = function_start + "bad_function".len();
-        let variable = serde_json::json!({
-            "$message_type": "diag",
-            "message": "mutable variables should use mixedCase",
-            "code": { "code": "mixed-case-variable", "explanation": null },
-            "level": "note",
-            "spans": [{
-                "file_name": "src/Test.sol",
-                "byte_start": variable_start,
-                "byte_end": variable_end,
-                "line_start": 2,
-                "line_end": 2,
-                "column_start": 25,
-                "column_end": 33,
-                "is_primary": true
-            }]
-        });
-        let function = serde_json::json!({
-            "$message_type": "diag",
-            "message": "function names should use mixedCase",
-            "code": { "code": "mixed-case-function", "explanation": null },
-            "level": "note",
-            "spans": [{
-                "file_name": "src/Test.sol",
-                "byte_start": function_start,
-                "byte_end": function_end,
-                "line_start": 4,
-                "line_end": 4,
-                "column_start": 26,
-                "column_end": 38,
-                "is_primary": true
-            }]
-        });
+        let variable = serde_json::to_string(&json_diagnostic_fixture(
+            variable_start,
+            variable_end,
+            "mixed-case-variable",
+            "mutable variables should use mixedCase",
+        ))
+        .unwrap();
+        let function = serde_json::to_string(&json_diagnostic_fixture(
+            function_start,
+            function_end,
+            "mixed-case-function",
+            "function names should use mixedCase",
+        ))
+        .unwrap();
         let output = format!("{variable}\n{function}\n");
 
         let diagnostics =
@@ -412,20 +393,77 @@ mod tests {
         let contents = project.read_file("/src/Test.sol");
         let start = contents.find('🚀').unwrap();
         let end = start + "🚀".len();
-        let json = serde_json::json!([{
-            "sourceLocation": {
-                "file": "src/Test.sol",
-                "start": start,
-                "end": end
-            },
-            "message": "rocket"
-        }]);
+        let json = serde_json::to_string(&[solc_diagnostic_fixture(
+            Cow::Borrowed("src/Test.sol"),
+            start,
+            end,
+            Severity::Warning,
+            None,
+            "rocket",
+        )])
+        .unwrap();
 
-        let diagnostics =
-            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
+        let diagnostics = parse(json.as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
 
         let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
         let range = diagnostics[&uri][0].range;
         assert_eq!(range.end.character - range.start.character, 2);
+    }
+
+    fn solc_diagnostic_fixture(
+        file: Cow<'static, str>,
+        start: usize,
+        end: usize,
+        severity: Severity,
+        code: Option<&'static str>,
+        message: &'static str,
+    ) -> SolcDiagnostic<'static> {
+        SolcDiagnostic {
+            source_location: Some(SourceLocation {
+                file,
+                start: start as u32,
+                end: end as u32,
+                message: None,
+            }),
+            secondary_source_locations: Vec::new(),
+            r#type: Cow::Borrowed("Warning"),
+            component: Cow::Borrowed("general"),
+            severity,
+            error_code: code.map(Cow::Borrowed),
+            message: Cow::Borrowed(message),
+            formatted_message: None,
+        }
+    }
+
+    fn json_diagnostic_fixture(
+        start: usize,
+        end: usize,
+        code: &'static str,
+        message: &'static str,
+    ) -> JsonDiagnosticMessage<'static> {
+        JsonDiagnosticMessage::Diagnostic(JsonDiagnostic {
+            message: Cow::Borrowed(message),
+            code: Some(JsonDiagnosticCode { code: Cow::Borrowed(code), explanation: None }),
+            level: Cow::Borrowed("note"),
+            spans: vec![JsonDiagnosticSpan {
+                file_name: Cow::Borrowed("src/Test.sol"),
+                byte_start: start as u32,
+                byte_end: end as u32,
+                line_start: 1,
+                line_end: 1,
+                column_start: 1,
+                column_end: 1,
+                is_primary: true,
+                text: vec![JsonDiagnosticSpanLine {
+                    text: Cow::Borrowed(""),
+                    highlight_start: 1,
+                    highlight_end: 1,
+                }],
+                label: None,
+                suggested_replacement: None,
+            }],
+            children: Vec::new(),
+            rendered: None,
+        })
     }
 }

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -80,13 +80,9 @@ fn collect_solc_json(
         SolcJsonRecord::Diagnostic(diagnostic) => {
             push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
         }
-        SolcJsonRecord::Diagnostics(diagnostics_) => {
+        SolcJsonRecord::Diagnostics(diagnostics_)
+        | SolcJsonRecord::Errors(SolcJsonErrors { errors: diagnostics_ }) => {
             for diagnostic in diagnostics_ {
-                push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
-            }
-        }
-        SolcJsonRecord::Errors(output) => {
-            for diagnostic in output.errors {
                 push_diagnostic(diagnostics, solc_diagnostic(diagnostic, cwd, source, range_cache));
             }
         }

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -1,0 +1,344 @@
+use crate::{diagnostics::DiagnosticMap, flycheck::config::FlycheckOutput};
+use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
+use serde_json::Value;
+use solar_interface::source_map::SourceMap;
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
+
+pub(super) fn parse(
+    output: &[u8],
+    cwd: &Path,
+    format: FlycheckOutput,
+) -> Result<DiagnosticMap, ParseError> {
+    let values = parse_values(output)?;
+    let mut diagnostics = DiagnosticMap::default();
+
+    for value in values {
+        collect_diagnostics(value, cwd, format, &mut diagnostics);
+    }
+
+    Ok(diagnostics)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ParseError {
+    #[error("failed to parse flycheck JSON output: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+fn parse_values(output: &[u8]) -> Result<Vec<Value>, ParseError> {
+    if output.iter().all(u8::is_ascii_whitespace) {
+        return Ok(Vec::new());
+    }
+
+    if let Ok(value) = serde_json::from_slice::<Value>(output) {
+        return Ok(vec![value]);
+    }
+
+    let stream = serde_json::Deserializer::from_slice(output).into_iter::<Value>();
+    stream.collect::<Result<Vec<_>, _>>().map_err(ParseError::Json)
+}
+
+fn collect_diagnostics(
+    value: Value,
+    cwd: &Path,
+    format: FlycheckOutput,
+    diagnostics: &mut DiagnosticMap,
+) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                collect_diagnostics(value, cwd, format, diagnostics);
+            }
+        }
+        Value::Object(mut object) => {
+            for key in ["diagnostics", "findings", "errors"] {
+                if let Some(value) = object.remove(key) {
+                    collect_diagnostics(value, cwd, format, diagnostics);
+                    return;
+                }
+            }
+
+            if let Some((uri, diagnostic)) =
+                external_diagnostic(&Value::Object(object), cwd, format)
+            {
+                diagnostics.entry(uri).or_default().push(diagnostic);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn external_diagnostic(
+    value: &Value,
+    cwd: &Path,
+    format: FlycheckOutput,
+) -> Option<(Url, Diagnostic)> {
+    let location = source_location(value)?;
+    let path = resolve_path(cwd, location.file.as_ref()?);
+    let uri = Url::from_file_path(&path).ok()?;
+    let range = location.range(&path)?;
+    let message = message(value)?;
+    let code = diagnostic_code(value);
+
+    Some((
+        uri,
+        Diagnostic {
+            range,
+            severity: Some(severity(value, format)),
+            code: code.map(NumberOrString::String),
+            code_description: None,
+            source: Some(source(format).into()),
+            message,
+            related_information: None,
+            tags: None,
+            data: None,
+        },
+    ))
+}
+
+fn source_location(value: &Value) -> Option<ExternalLocation<'_>> {
+    value
+        .get("sourceLocation")
+        .or_else(|| value.get("source_location"))
+        .or_else(|| value.get("location"))
+        .or_else(|| value.get("span"))
+        .and_then(ExternalLocation::from_value)
+        .or_else(|| ExternalLocation::from_value(value))
+}
+
+fn message(value: &Value) -> Option<String> {
+    string_field(value, &["message", "msg", "title", "description"]).map(ToOwned::to_owned).or_else(
+        || string_field(value, &["formattedMessage", "formatted_message"]).map(clean_rendered),
+    )
+}
+
+fn diagnostic_code(value: &Value) -> Option<String> {
+    string_field(value, &["errorCode", "error_code", "code", "lint", "id", "name"])
+        .map(ToOwned::to_owned)
+}
+
+fn severity(value: &Value, format: FlycheckOutput) -> DiagnosticSeverity {
+    let Some(severity) = string_field(value, &["severity", "level"]) else {
+        return match format {
+            FlycheckOutput::SolcJson => DiagnosticSeverity::WARNING,
+            FlycheckOutput::ForgeLintJson => DiagnosticSeverity::WARNING,
+        };
+    };
+
+    match severity {
+        "error" | "fatal" | "high" => DiagnosticSeverity::ERROR,
+        "warning" | "warn" | "medium" | "med" | "low" | "gas" | "code-size" => {
+            DiagnosticSeverity::WARNING
+        }
+        "info" | "information" => DiagnosticSeverity::INFORMATION,
+        "hint" | "help" => DiagnosticSeverity::HINT,
+        _ => DiagnosticSeverity::WARNING,
+    }
+}
+
+fn source(format: FlycheckOutput) -> &'static str {
+    match format {
+        FlycheckOutput::SolcJson => "flycheck",
+        FlycheckOutput::ForgeLintJson => "forge-lint",
+    }
+}
+
+fn string_field<'a>(value: &'a Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_str))
+}
+
+fn clean_rendered(rendered: &str) -> String {
+    rendered.lines().next().unwrap_or(rendered).to_string()
+}
+
+fn resolve_path(cwd: &Path, path: &str) -> PathBuf {
+    let path = Path::new(path);
+    if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) }
+}
+
+struct ExternalLocation<'a> {
+    file: Option<Cow<'a, str>>,
+    start: Option<u64>,
+    end: Option<u64>,
+    line: Option<u64>,
+    column: Option<u64>,
+    end_line: Option<u64>,
+    end_column: Option<u64>,
+}
+
+impl<'a> ExternalLocation<'a> {
+    fn from_value(value: &'a Value) -> Option<Self> {
+        Some(Self {
+            file: string_field(value, &["file", "path", "source", "filename"])
+                .map(Cow::Borrowed)
+                .or_else(|| {
+                    value
+                        .get("source")
+                        .and_then(|source| string_field(source, &["file", "path", "filename"]))
+                        .map(Cow::Borrowed)
+                }),
+            start: numeric_field(value, &["start", "byteStart", "byte_start"]),
+            end: numeric_field(value, &["end", "byteEnd", "byte_end"]),
+            line: numeric_field(value, &["line", "startLine", "lineStart", "line_start"]),
+            column: numeric_field(value, &["column", "col", "startColumn", "columnStart"]),
+            end_line: numeric_field(value, &["endLine", "lineEnd", "line_end"]),
+            end_column: numeric_field(value, &["endColumn", "columnEnd", "column_end"]),
+        })
+    }
+
+    fn range(&self, path: &Path) -> Option<Range> {
+        if let (Some(start), Some(end)) = (self.start, self.end) {
+            return byte_range(path, start as usize, end as usize);
+        }
+
+        let line = self.line?;
+        let column = self.column.unwrap_or(1);
+        let end_line = self.end_line.unwrap_or(line);
+        let end_column = self.end_column.unwrap_or(column + 1);
+        Some(Range {
+            start: one_based_position(line, column),
+            end: one_based_position(end_line, end_column),
+        })
+    }
+}
+
+fn numeric_field(value: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_u64))
+}
+
+fn byte_range(path: &Path, start: usize, end: usize) -> Option<Range> {
+    let source_map = SourceMap::empty();
+    let contents = source_map.file_loader().load_file(path).ok()?;
+    Some(Range { start: position_at_byte(&contents, start), end: position_at_byte(&contents, end) })
+}
+
+fn position_at_byte(contents: &str, byte: usize) -> Position {
+    let byte = byte.min(contents.len());
+    let mut line = 0u32;
+    let mut character = 0u32;
+
+    for (idx, char) in contents.char_indices() {
+        if idx >= byte {
+            break;
+        }
+        if char == '\n' {
+            line += 1;
+            character = 0;
+        } else {
+            character += char.len_utf16() as u32;
+        }
+    }
+
+    Position { line, character }
+}
+
+fn one_based_position(line: u64, column: u64) -> Position {
+    Position { line: line.saturating_sub(1) as u32, character: column.saturating_sub(1) as u32 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::TestProject;
+    use lsp_types::DiagnosticSeverity;
+
+    #[test]
+    fn parses_solc_like_diagnostics() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {
+                function bad_name() public {}
+            }
+            "#,
+        );
+        let file = project.path("/src/Test.sol");
+        let json = serde_json::json!([{
+            "sourceLocation": {
+                "file": file,
+                "start": 20,
+                "end": 24
+            },
+            "severity": "warning",
+            "errorCode": "2018",
+            "message": "function name should use mixedCase"
+        }]);
+
+        let diagnostics =
+            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
+
+        let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        let diagnostic = &diagnostics[&uri][0];
+        assert_eq!(diagnostic.source.as_deref(), Some("flycheck"));
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(diagnostic.message, "function name should use mixedCase");
+        assert_eq!(diagnostic.code, Some(NumberOrString::String("2018".into())));
+    }
+
+    #[test]
+    fn parses_enveloped_forge_lint_findings() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {
+                uint256 bad_name;
+            }
+            "#,
+        );
+        let json = serde_json::json!({
+            "findings": [{
+                "sourceLocation": {
+                    "file": "src/Test.sol",
+                    "start": 20,
+                    "end": 24
+                },
+                "severity": "med",
+                "lint": "mixed-case-variable",
+                "message": "mutable variables should use mixedCase"
+            }]
+        });
+
+        let diagnostics =
+            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::ForgeLintJson)
+                .unwrap();
+
+        let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        let diagnostic = &diagnostics[&uri][0];
+        assert_eq!(diagnostic.source.as_deref(), Some("forge-lint"));
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+        assert_eq!(diagnostic.code, Some(NumberOrString::String("mixed-case-variable".into())));
+    }
+
+    #[test]
+    fn byte_offsets_are_converted_to_utf16_positions() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {
+                string value = "🚀";
+            }
+            "#,
+        );
+        let contents = project.read_file("/src/Test.sol");
+        let start = contents.find('🚀').unwrap();
+        let end = start + "🚀".len();
+        let json = serde_json::json!([{
+            "sourceLocation": {
+                "file": "src/Test.sol",
+                "start": start,
+                "end": end
+            },
+            "message": "rocket"
+        }]);
+
+        let diagnostics =
+            parse(json.to_string().as_bytes(), project.root(), FlycheckOutput::SolcJson).unwrap();
+
+        let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        let range = diagnostics[&uri][0].range;
+        assert_eq!(range.end.character - range.start.character, 2);
+    }
+}

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -192,7 +192,7 @@ fn json_level_severity(level: &str) -> DiagnosticSeverity {
     match level {
         "error" | "fatal" | "error: internal compiler error" => DiagnosticSeverity::ERROR,
         "warning" => DiagnosticSeverity::WARNING,
-        "note" | "failure-note" => DiagnosticSeverity::INFORMATION,
+        "note" | "failure-note" | "gas" | "code-size" => DiagnosticSeverity::INFORMATION,
         "help" => DiagnosticSeverity::HINT,
         _ => DiagnosticSeverity::WARNING,
     }
@@ -374,10 +374,49 @@ mod tests {
         let diagnostics = &diagnostics[&uri];
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].source.as_deref(), Some("forge-lint"));
+        assert_eq!(diagnostics[0].severity, Some(DiagnosticSeverity::INFORMATION));
         assert_eq!(diagnostics[0].message, "mutable variables should use mixedCase");
         assert_eq!(diagnostics[0].code, Some(NumberOrString::String("mixed-case-variable".into())));
         assert_eq!(diagnostics[1].message, "function names should use mixedCase");
         assert_eq!(diagnostics[1].code, Some(NumberOrString::String("mixed-case-function".into())));
+    }
+
+    #[test]
+    fn preserves_foundry_information_lint_severities() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {
+                uint256 bad_name;
+            }
+            "#,
+        );
+        let contents = project.read_file("/src/Test.sol");
+        let start = contents.find("bad_name").unwrap();
+        let end = start + "bad_name".len();
+        let levels = ["note", "gas", "code-size"];
+        let output = levels
+            .map(|level| {
+                serde_json::to_string(&json_diagnostic_fixture_with_level(
+                    start,
+                    end,
+                    level,
+                    level,
+                    "foundry lint",
+                ))
+                .unwrap()
+            })
+            .join("\n");
+
+        let diagnostics =
+            parse(output.as_bytes(), project.root(), FlycheckOutput::ForgeLintJson).unwrap();
+
+        let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        let diagnostics = &diagnostics[&uri];
+        assert_eq!(diagnostics.len(), levels.len());
+        for diagnostic in diagnostics {
+            assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::INFORMATION));
+        }
     }
 
     #[test]
@@ -441,10 +480,20 @@ mod tests {
         code: &'static str,
         message: &'static str,
     ) -> JsonDiagnosticMessage<'static> {
+        json_diagnostic_fixture_with_level(start, end, "note", code, message)
+    }
+
+    fn json_diagnostic_fixture_with_level(
+        start: usize,
+        end: usize,
+        level: &'static str,
+        code: &'static str,
+        message: &'static str,
+    ) -> JsonDiagnosticMessage<'static> {
         JsonDiagnosticMessage::Diagnostic(JsonDiagnostic {
             message: Cow::Borrowed(message),
             code: Some(JsonDiagnosticCode { code: Cow::Borrowed(code), explanation: None }),
-            level: Cow::Borrowed("note"),
+            level: Cow::Borrowed(level),
             spans: vec![JsonDiagnosticSpan {
                 file_name: Cow::Borrowed("src/Test.sol"),
                 byte_start: start as u32,

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -2,10 +2,7 @@ use crate::{diagnostics::DiagnosticMap, flycheck::config::FlycheckOutput};
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
 use serde_json::Value;
 use solar_interface::source_map::SourceMap;
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 pub(super) fn parse(
     output: &[u8],
@@ -15,7 +12,7 @@ pub(super) fn parse(
     let values = parse_values(output)?;
     let mut diagnostics = DiagnosticMap::default();
 
-    for value in values {
+    for value in &values {
         collect_diagnostics(value, cwd, format, &mut diagnostics);
     }
 
@@ -29,20 +26,12 @@ pub(crate) enum ParseError {
 }
 
 fn parse_values(output: &[u8]) -> Result<Vec<Value>, ParseError> {
-    if output.iter().all(u8::is_ascii_whitespace) {
-        return Ok(Vec::new());
-    }
-
-    if let Ok(value) = serde_json::from_slice::<Value>(output) {
-        return Ok(vec![value]);
-    }
-
     let stream = serde_json::Deserializer::from_slice(output).into_iter::<Value>();
     stream.collect::<Result<Vec<_>, _>>().map_err(ParseError::Json)
 }
 
 fn collect_diagnostics(
-    value: Value,
+    value: &Value,
     cwd: &Path,
     format: FlycheckOutput,
     diagnostics: &mut DiagnosticMap,
@@ -53,17 +42,15 @@ fn collect_diagnostics(
                 collect_diagnostics(value, cwd, format, diagnostics);
             }
         }
-        Value::Object(mut object) => {
+        Value::Object(object) => {
             for key in ["diagnostics", "findings", "errors"] {
-                if let Some(value) = object.remove(key) {
+                if let Some(value) = object.get(key) {
                     collect_diagnostics(value, cwd, format, diagnostics);
                     return;
                 }
             }
 
-            if let Some((uri, diagnostic)) =
-                external_diagnostic(&Value::Object(object), cwd, format)
-            {
+            if let Some((uri, diagnostic)) = external_diagnostic(value, cwd, format) {
                 diagnostics.entry(uri).or_default().push(diagnostic);
             }
         }
@@ -76,8 +63,8 @@ fn external_diagnostic(
     cwd: &Path,
     format: FlycheckOutput,
 ) -> Option<(Url, Diagnostic)> {
-    let location = source_location(value)?;
-    let path = resolve_path(cwd, location.file.as_ref()?);
+    let location = source_location(value);
+    let path = resolve_path(cwd, location.file?);
     let uri = Url::from_file_path(&path).ok()?;
     let range = location.range(&path)?;
     let message = message(value)?;
@@ -87,7 +74,7 @@ fn external_diagnostic(
         uri,
         Diagnostic {
             range,
-            severity: Some(severity(value, format)),
+            severity: Some(severity(value)),
             code: code.map(NumberOrString::String),
             code_description: None,
             source: Some(source(format).into()),
@@ -99,14 +86,13 @@ fn external_diagnostic(
     ))
 }
 
-fn source_location(value: &Value) -> Option<ExternalLocation<'_>> {
+fn source_location(value: &Value) -> ExternalLocation<'_> {
     value
         .get("sourceLocation")
         .or_else(|| value.get("source_location"))
         .or_else(|| value.get("location"))
         .or_else(|| value.get("span"))
-        .and_then(ExternalLocation::from_value)
-        .or_else(|| ExternalLocation::from_value(value))
+        .map_or_else(|| ExternalLocation::from_value(value), ExternalLocation::from_value)
 }
 
 fn message(value: &Value) -> Option<String> {
@@ -120,12 +106,9 @@ fn diagnostic_code(value: &Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn severity(value: &Value, format: FlycheckOutput) -> DiagnosticSeverity {
+fn severity(value: &Value) -> DiagnosticSeverity {
     let Some(severity) = string_field(value, &["severity", "level"]) else {
-        return match format {
-            FlycheckOutput::SolcJson => DiagnosticSeverity::WARNING,
-            FlycheckOutput::ForgeLintJson => DiagnosticSeverity::WARNING,
-        };
+        return DiagnosticSeverity::WARNING;
     };
 
     match severity {
@@ -160,7 +143,7 @@ fn resolve_path(cwd: &Path, path: &str) -> PathBuf {
 }
 
 struct ExternalLocation<'a> {
-    file: Option<Cow<'a, str>>,
+    file: Option<&'a str>,
     start: Option<u64>,
     end: Option<u64>,
     line: Option<u64>,
@@ -170,23 +153,20 @@ struct ExternalLocation<'a> {
 }
 
 impl<'a> ExternalLocation<'a> {
-    fn from_value(value: &'a Value) -> Option<Self> {
-        Some(Self {
-            file: string_field(value, &["file", "path", "source", "filename"])
-                .map(Cow::Borrowed)
-                .or_else(|| {
-                    value
-                        .get("source")
-                        .and_then(|source| string_field(source, &["file", "path", "filename"]))
-                        .map(Cow::Borrowed)
-                }),
+    fn from_value(value: &'a Value) -> Self {
+        Self {
+            file: string_field(value, &["file", "path", "source", "filename"]).or_else(|| {
+                value
+                    .get("source")
+                    .and_then(|source| string_field(source, &["file", "path", "filename"]))
+            }),
             start: numeric_field(value, &["start", "byteStart", "byte_start"]),
             end: numeric_field(value, &["end", "byteEnd", "byte_end"]),
             line: numeric_field(value, &["line", "startLine", "lineStart", "line_start"]),
             column: numeric_field(value, &["column", "col", "startColumn", "columnStart"]),
             end_line: numeric_field(value, &["endLine", "lineEnd", "line_end"]),
             end_column: numeric_field(value, &["endColumn", "columnEnd", "column_end"]),
-        })
+        }
     }
 
     fn range(&self, path: &Path) -> Option<Range> {

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -92,6 +92,7 @@ fn source_location(value: &Value) -> ExternalLocation<'_> {
         .or_else(|| value.get("source_location"))
         .or_else(|| value.get("location"))
         .or_else(|| value.get("span"))
+        .or_else(|| rustc_primary_span(value))
         .map_or_else(|| ExternalLocation::from_value(value), ExternalLocation::from_value)
 }
 
@@ -103,6 +104,7 @@ fn message(value: &Value) -> Option<String> {
 
 fn diagnostic_code(value: &Value) -> Option<String> {
     string_field(value, &["errorCode", "error_code", "code", "lint", "id", "name"])
+        .or_else(|| value.get("code").and_then(|code| string_field(code, &["code"])))
         .map(ToOwned::to_owned)
 }
 
@@ -137,6 +139,14 @@ fn clean_rendered(rendered: &str) -> String {
     rendered.lines().next().unwrap_or(rendered).to_string()
 }
 
+fn rustc_primary_span(value: &Value) -> Option<&Value> {
+    let spans = value.get("spans")?.as_array()?;
+    spans
+        .iter()
+        .find(|span| bool_field(span, &["is_primary"]).unwrap_or(false))
+        .or_else(|| spans.first())
+}
+
 fn resolve_path(cwd: &Path, path: &str) -> PathBuf {
     let path = Path::new(path);
     if path.is_absolute() { path.to_path_buf() } else { cwd.join(path) }
@@ -155,15 +165,20 @@ struct ExternalLocation<'a> {
 impl<'a> ExternalLocation<'a> {
     fn from_value(value: &'a Value) -> Self {
         Self {
-            file: string_field(value, &["file", "path", "source", "filename"]).or_else(|| {
-                value
-                    .get("source")
-                    .and_then(|source| string_field(source, &["file", "path", "filename"]))
-            }),
+            file: string_field(value, &["file", "path", "source", "filename"])
+                .or_else(|| {
+                    value
+                        .get("source")
+                        .and_then(|source| string_field(source, &["file", "path", "filename"]))
+                })
+                .or_else(|| string_field(value, &["file_name"])),
             start: numeric_field(value, &["start", "byteStart", "byte_start"]),
             end: numeric_field(value, &["end", "byteEnd", "byte_end"]),
             line: numeric_field(value, &["line", "startLine", "lineStart", "line_start"]),
-            column: numeric_field(value, &["column", "col", "startColumn", "columnStart"]),
+            column: numeric_field(
+                value,
+                &["column", "col", "startColumn", "columnStart", "column_start"],
+            ),
             end_line: numeric_field(value, &["endLine", "lineEnd", "line_end"]),
             end_column: numeric_field(value, &["endColumn", "columnEnd", "column_end"]),
         }
@@ -187,6 +202,10 @@ impl<'a> ExternalLocation<'a> {
 
 fn numeric_field(value: &Value, keys: &[&str]) -> Option<u64> {
     keys.iter().find_map(|key| value.get(*key).and_then(Value::as_u64))
+}
+
+fn bool_field(value: &Value, keys: &[&str]) -> Option<bool> {
+    keys.iter().find_map(|key| value.get(*key).and_then(Value::as_bool))
 }
 
 fn byte_range(path: &Path, start: usize, end: usize) -> Option<Range> {
@@ -290,6 +309,70 @@ mod tests {
         assert_eq!(diagnostic.source.as_deref(), Some("forge-lint"));
         assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
         assert_eq!(diagnostic.code, Some(NumberOrString::String("mixed-case-variable".into())));
+    }
+
+    #[test]
+    fn parses_rustc_style_forge_lint_diagnostics() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {
+                uint256 bad_name;
+
+                function bad_function() public {}
+            }
+            "#,
+        );
+        let contents = project.read_file("/src/Test.sol");
+        let variable_start = contents.find("bad_name").unwrap();
+        let variable_end = variable_start + "bad_name".len();
+        let function_start = contents.find("bad_function").unwrap();
+        let function_end = function_start + "bad_function".len();
+        let variable = serde_json::json!({
+            "$message_type": "diag",
+            "message": "mutable variables should use mixedCase",
+            "code": { "code": "mixed-case-variable", "explanation": null },
+            "level": "note",
+            "spans": [{
+                "file_name": "src/Test.sol",
+                "byte_start": variable_start,
+                "byte_end": variable_end,
+                "line_start": 2,
+                "line_end": 2,
+                "column_start": 25,
+                "column_end": 33,
+                "is_primary": true
+            }]
+        });
+        let function = serde_json::json!({
+            "$message_type": "diag",
+            "message": "function names should use mixedCase",
+            "code": { "code": "mixed-case-function", "explanation": null },
+            "level": "note",
+            "spans": [{
+                "file_name": "src/Test.sol",
+                "byte_start": function_start,
+                "byte_end": function_end,
+                "line_start": 4,
+                "line_end": 4,
+                "column_start": 26,
+                "column_end": 38,
+                "is_primary": true
+            }]
+        });
+        let output = format!("{variable}\n{function}\n");
+
+        let diagnostics =
+            parse(output.as_bytes(), project.root(), FlycheckOutput::ForgeLintJson).unwrap();
+
+        let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        let diagnostics = &diagnostics[&uri];
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].source.as_deref(), Some("forge-lint"));
+        assert_eq!(diagnostics[0].message, "mutable variables should use mixedCase");
+        assert_eq!(diagnostics[0].code, Some(NumberOrString::String("mixed-case-variable".into())));
+        assert_eq!(diagnostics[1].message, "function names should use mixedCase");
+        assert_eq!(diagnostics[1].code, Some(NumberOrString::String("mixed-case-function".into())));
     }
 
     #[test]

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -1,4 +1,5 @@
 use crate::{diagnostics::DiagnosticMap, flycheck::config::FlycheckOutput};
+use crop::Rope;
 use lsp_types::{
     Diagnostic as LspDiagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url,
 };
@@ -213,53 +214,28 @@ fn resolve_path(cwd: &Path, path: &str) -> PathBuf {
 #[derive(Default)]
 struct ByteRangeCache {
     source_map: SourceMap,
-    files: FxHashMap<PathBuf, LineIndex>,
+    files: FxHashMap<PathBuf, Rope>,
 }
 
 impl ByteRangeCache {
     fn range(&mut self, path: &Path, start: usize, end: usize) -> Option<Range> {
         if !self.files.contains_key(path) {
             let contents = self.source_map.file_loader().load_file(path).ok()?;
-            self.files.insert(path.to_path_buf(), LineIndex::new(contents));
+            self.files.insert(path.to_path_buf(), Rope::from(contents));
         }
 
         let file = self.files.get(path)?;
-        Some(Range { start: file.position_at_byte(start), end: file.position_at_byte(end) })
+        Some(Range { start: position_at_byte(file, start), end: position_at_byte(file, end) })
     }
 }
 
-struct LineIndex {
-    contents: String,
-    line_starts: Vec<usize>,
-}
+fn position_at_byte(file: &Rope, byte: usize) -> Position {
+    let byte = byte.min(file.byte_len());
+    let line = file.line_of_byte(byte);
+    let line_start = file.byte_of_line(line);
+    let character = file.utf16_code_unit_of_byte(byte) - file.utf16_code_unit_of_byte(line_start);
 
-impl LineIndex {
-    fn new(contents: String) -> Self {
-        let mut line_starts = vec![0];
-        for (idx, byte) in contents.bytes().enumerate() {
-            if byte == b'\n' {
-                line_starts.push(idx + 1);
-            }
-        }
-
-        Self { contents, line_starts }
-    }
-
-    fn position_at_byte(&self, byte: usize) -> Position {
-        let byte = byte.min(self.contents.len());
-        let line = self.line_starts.partition_point(|start| *start <= byte).saturating_sub(1);
-        let line_start = self.line_starts[line];
-        let mut character = 0u32;
-
-        for (idx, char) in self.contents[line_start..].char_indices() {
-            if line_start + idx >= byte {
-                break;
-            }
-            character += char.len_utf16() as u32;
-        }
-
-        Position { line: line as u32, character }
-    }
+    Position { line: line as u32, character: character as u32 }
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -1,7 +1,7 @@
 use crate::{diagnostics::DiagnosticMap, flycheck::config::FlycheckOutput};
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
 use serde_json::Value;
-use solar_interface::source_map::SourceMap;
+use solar_interface::{data_structures::map::FxHashMap, source_map::SourceMap};
 use std::path::{Path, PathBuf};
 
 pub(super) fn parse(
@@ -10,10 +10,11 @@ pub(super) fn parse(
     format: FlycheckOutput,
 ) -> Result<DiagnosticMap, ParseError> {
     let mut diagnostics = DiagnosticMap::default();
+    let mut range_cache = ByteRangeCache::default();
 
     let stream = serde_json::Deserializer::from_slice(output).into_iter::<Value>();
     for value in stream {
-        collect_diagnostics(&value?, cwd, format, &mut diagnostics);
+        collect_diagnostics(&value?, cwd, format, &mut diagnostics, &mut range_cache);
     }
 
     Ok(diagnostics)
@@ -30,22 +31,23 @@ fn collect_diagnostics(
     cwd: &Path,
     format: FlycheckOutput,
     diagnostics: &mut DiagnosticMap,
+    range_cache: &mut ByteRangeCache,
 ) {
     match value {
         Value::Array(values) => {
             for value in values {
-                collect_diagnostics(value, cwd, format, diagnostics);
+                collect_diagnostics(value, cwd, format, diagnostics, range_cache);
             }
         }
         Value::Object(object) => {
             for key in ["diagnostics", "findings", "errors"] {
                 if let Some(value) = object.get(key) {
-                    collect_diagnostics(value, cwd, format, diagnostics);
+                    collect_diagnostics(value, cwd, format, diagnostics, range_cache);
                     return;
                 }
             }
 
-            if let Some((uri, diagnostic)) = external_diagnostic(value, cwd, format) {
+            if let Some((uri, diagnostic)) = external_diagnostic(value, cwd, format, range_cache) {
                 diagnostics.entry(uri).or_default().push(diagnostic);
             }
         }
@@ -57,11 +59,12 @@ fn external_diagnostic(
     value: &Value,
     cwd: &Path,
     format: FlycheckOutput,
+    range_cache: &mut ByteRangeCache,
 ) -> Option<(Url, Diagnostic)> {
     let location = source_location(value);
     let path = resolve_path(cwd, location.file?);
     let uri = Url::from_file_path(&path).ok()?;
-    let range = location.range(&path)?;
+    let range = location.range(&path, range_cache)?;
     let message = message(value)?;
     let code = diagnostic_code(value);
 
@@ -179,9 +182,9 @@ impl<'a> ExternalLocation<'a> {
         }
     }
 
-    fn range(&self, path: &Path) -> Option<Range> {
+    fn range(&self, path: &Path, range_cache: &mut ByteRangeCache) -> Option<Range> {
         if let (Some(start), Some(end)) = (self.start, self.end) {
-            return byte_range(path, start as usize, end as usize);
+            return range_cache.range(path, start as usize, end as usize);
         }
 
         let line = self.line?;
@@ -203,30 +206,56 @@ fn bool_field(value: &Value, keys: &[&str]) -> Option<bool> {
     keys.iter().find_map(|key| value.get(*key).and_then(Value::as_bool))
 }
 
-fn byte_range(path: &Path, start: usize, end: usize) -> Option<Range> {
-    let source_map = SourceMap::empty();
-    let contents = source_map.file_loader().load_file(path).ok()?;
-    Some(Range { start: position_at_byte(&contents, start), end: position_at_byte(&contents, end) })
+#[derive(Default)]
+struct ByteRangeCache {
+    source_map: SourceMap,
+    files: FxHashMap<PathBuf, LineIndex>,
 }
 
-fn position_at_byte(contents: &str, byte: usize) -> Position {
-    let byte = byte.min(contents.len());
-    let mut line = 0u32;
-    let mut character = 0u32;
+impl ByteRangeCache {
+    fn range(&mut self, path: &Path, start: usize, end: usize) -> Option<Range> {
+        if !self.files.contains_key(path) {
+            let contents = self.source_map.file_loader().load_file(path).ok()?;
+            self.files.insert(path.to_path_buf(), LineIndex::new(contents));
+        }
 
-    for (idx, char) in contents.char_indices() {
-        if idx >= byte {
-            break;
+        let file = self.files.get(path)?;
+        Some(Range { start: file.position_at_byte(start), end: file.position_at_byte(end) })
+    }
+}
+
+struct LineIndex {
+    contents: String,
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(contents: String) -> Self {
+        let mut line_starts = vec![0];
+        for (idx, byte) in contents.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
         }
-        if char == '\n' {
-            line += 1;
-            character = 0;
-        } else {
-            character += char.len_utf16() as u32;
-        }
+
+        Self { contents, line_starts }
     }
 
-    Position { line, character }
+    fn position_at_byte(&self, byte: usize) -> Position {
+        let byte = byte.min(self.contents.len());
+        let line = self.line_starts.partition_point(|start| *start <= byte).saturating_sub(1);
+        let line_start = self.line_starts[line];
+        let mut character = 0u32;
+
+        for (idx, char) in self.contents[line_start..].char_indices() {
+            if line_start + idx >= byte {
+                break;
+            }
+            character += char.len_utf16() as u32;
+        }
+
+        Position { line: line as u32, character }
+    }
 }
 
 fn one_based_position(line: u64, column: u64) -> Position {

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -9,11 +9,11 @@ pub(super) fn parse(
     cwd: &Path,
     format: FlycheckOutput,
 ) -> Result<DiagnosticMap, ParseError> {
-    let values = parse_values(output)?;
     let mut diagnostics = DiagnosticMap::default();
 
-    for value in &values {
-        collect_diagnostics(value, cwd, format, &mut diagnostics);
+    let stream = serde_json::Deserializer::from_slice(output).into_iter::<Value>();
+    for value in stream {
+        collect_diagnostics(&value?, cwd, format, &mut diagnostics);
     }
 
     Ok(diagnostics)
@@ -23,11 +23,6 @@ pub(super) fn parse(
 pub(crate) enum ParseError {
     #[error("failed to parse flycheck JSON output: {0}")]
     Json(#[from] serde_json::Error),
-}
-
-fn parse_values(output: &[u8]) -> Result<Vec<Value>, ParseError> {
-    let stream = serde_json::Deserializer::from_slice(output).into_iter::<Value>();
-    stream.collect::<Result<Vec<_>, _>>().map_err(ParseError::Json)
 }
 
 fn collect_diagnostics(

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -9,15 +9,19 @@ use std::{
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt},
-    process::Command,
+    process::{Child, Command},
+    sync::oneshot,
     task::JoinHandle,
     time,
 };
 
 const FLYCHECK_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub(crate) async fn run(config: FlycheckConfig) -> Result<DiagnosticMap, FlycheckError> {
-    let output = command_output(&config, FLYCHECK_TIMEOUT).await?;
+pub(crate) async fn run(
+    config: FlycheckConfig,
+    cancel: oneshot::Receiver<()>,
+) -> Result<DiagnosticMap, FlycheckError> {
+    let output = command_output(&config, FLYCHECK_TIMEOUT, cancel).await?;
     let diagnostics = parser::parse(
         diagnostic_output(&output.stdout, &output.stderr, config.output),
         &config.cwd,
@@ -41,6 +45,7 @@ fn diagnostic_output<'a>(stdout: &'a [u8], stderr: &'a [u8], format: FlycheckOut
 async fn command_output(
     config: &FlycheckConfig,
     timeout: Duration,
+    mut cancel: oneshot::Receiver<()>,
 ) -> Result<Output, FlycheckError> {
     let mut child = Command::new(&config.command)
         .args(&config.args)
@@ -48,22 +53,35 @@ async fn command_output(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .kill_on_drop(true)
         .spawn()?;
 
     let stdout = read_pipe(child.stdout.take().expect("stdout was piped"));
     let stderr = read_pipe(child.stderr.take().expect("stderr was piped"));
-    let status = match time::timeout(timeout, child.wait()).await {
-        Ok(status) => status?,
-        Err(_) => {
-            let kill_result = child.kill().await;
-            abort_pipe(stdout);
-            abort_pipe(stderr);
-            kill_result?;
+    let status = tokio::select! {
+        status = child.wait() => status?,
+        _ = time::sleep(timeout) => {
+            kill_child(&mut child, &stdout, &stderr).await?;
             return Err(FlycheckError::Timeout);
+        }
+        _ = &mut cancel => {
+            kill_child(&mut child, &stdout, &stderr).await?;
+            return Err(FlycheckError::Cancelled);
         }
     };
 
     Ok(Output { status, stdout: collect_pipe(stdout).await?, stderr: collect_pipe(stderr).await? })
+}
+
+async fn kill_child(
+    child: &mut Child,
+    stdout: &JoinHandle<io::Result<Vec<u8>>>,
+    stderr: &JoinHandle<io::Result<Vec<u8>>>,
+) -> io::Result<()> {
+    let result = child.kill().await;
+    abort_pipe(stdout);
+    abort_pipe(stderr);
+    result
 }
 
 fn read_pipe(pipe: impl AsyncRead + Send + Unpin + 'static) -> JoinHandle<io::Result<Vec<u8>>> {
@@ -79,7 +97,7 @@ async fn collect_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u
     pipe.await.map_err(io::Error::other)?
 }
 
-fn abort_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) {
+fn abort_pipe(pipe: &JoinHandle<io::Result<Vec<u8>>>) {
     pipe.abort();
 }
 
@@ -140,7 +158,8 @@ mod tests {
         let [config] =
             config.flychecks_for_path(&project.path("/src/Test.sol")).try_into().unwrap();
 
-        let error = command_output(&config, Duration::from_secs(1)).await.unwrap_err();
+        let (_cancel, cancelled) = oneshot::channel();
+        let error = command_output(&config, Duration::from_secs(1), cancelled).await.unwrap_err();
 
         assert!(matches!(error, FlycheckError::Timeout));
         let pid = project.read_file("/flycheck-pid.txt").parse().unwrap();
@@ -163,6 +182,8 @@ mod tests {
 pub(crate) enum FlycheckError {
     #[error("flycheck command timed out")]
     Timeout,
+    #[error("flycheck command cancelled")]
+    Cancelled,
     #[error("failed to run flycheck command: {0}")]
     Io(#[from] std::io::Error),
     #[error(transparent)]

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -79,8 +79,8 @@ async fn kill_child(
     stderr: &JoinHandle<io::Result<Vec<u8>>>,
 ) -> io::Result<()> {
     let result = child.kill().await;
-    abort_pipe(stdout);
-    abort_pipe(stderr);
+    stdout.abort();
+    stderr.abort();
     result
 }
 
@@ -95,10 +95,6 @@ fn read_pipe(pipe: impl AsyncRead + Send + Unpin + 'static) -> JoinHandle<io::Re
 
 async fn collect_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u8>> {
     pipe.await.map_err(io::Error::other)?
-}
-
-fn abort_pipe(pipe: &JoinHandle<io::Result<Vec<u8>>>) {
-    pipe.abort();
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -2,15 +2,22 @@ use crate::{
     diagnostics::DiagnosticMap,
     flycheck::{FlycheckConfig, config::FlycheckOutput, parser},
 };
-use std::{process::Stdio, time::Duration};
-use tokio::{process::Command, time};
+use std::{
+    io,
+    process::{Output, Stdio},
+    time::Duration,
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt},
+    process::Command,
+    task::JoinHandle,
+    time,
+};
 
 const FLYCHECK_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(crate) async fn run(config: FlycheckConfig) -> Result<DiagnosticMap, FlycheckError> {
-    let output = time::timeout(FLYCHECK_TIMEOUT, command_output(&config))
-        .await
-        .map_err(|_| FlycheckError::Timeout)??;
+    let output = command_output(&config, FLYCHECK_TIMEOUT).await?;
     let diagnostics = parser::parse(
         diagnostic_output(&output.stdout, &output.stderr, config.output),
         &config.cwd,
@@ -31,20 +38,61 @@ fn diagnostic_output<'a>(stdout: &'a [u8], stderr: &'a [u8], format: FlycheckOut
     if format == FlycheckOutput::ForgeLintJson && !stderr.is_empty() { stderr } else { stdout }
 }
 
-async fn command_output(config: &FlycheckConfig) -> Result<std::process::Output, std::io::Error> {
-    Command::new(&config.command)
+async fn command_output(
+    config: &FlycheckConfig,
+    timeout: Duration,
+) -> Result<Output, FlycheckError> {
+    let mut child = Command::new(&config.command)
         .args(&config.args)
         .current_dir(&config.cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
-        .await
+        .spawn()?;
+
+    let stdout = child.stdout.take().map(read_pipe);
+    let stderr = child.stderr.take().map(read_pipe);
+    let status = match time::timeout(timeout, child.wait()).await {
+        Ok(status) => status?,
+        Err(_) => {
+            let kill_result = child.kill().await;
+            abort_pipe(stdout);
+            abort_pipe(stderr);
+            kill_result?;
+            return Err(FlycheckError::Timeout);
+        }
+    };
+
+    Ok(Output { status, stdout: collect_pipe(stdout).await?, stderr: collect_pipe(stderr).await? })
+}
+
+fn read_pipe(pipe: impl AsyncRead + Send + Unpin + 'static) -> JoinHandle<io::Result<Vec<u8>>> {
+    tokio::spawn(async move {
+        let mut pipe = pipe;
+        let mut output = Vec::new();
+        pipe.read_to_end(&mut output).await?;
+        Ok(output)
+    })
+}
+
+async fn collect_pipe(pipe: Option<JoinHandle<io::Result<Vec<u8>>>>) -> io::Result<Vec<u8>> {
+    match pipe {
+        Some(pipe) => pipe.await.map_err(io::Error::other)?,
+        None => Ok(Vec::new()),
+    }
+}
+
+fn abort_pipe(pipe: Option<JoinHandle<io::Result<Vec<u8>>>>) {
+    if let Some(pipe) = pipe {
+        pipe.abort();
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{config::negotiate_capabilities, test_support::TestProject};
+    use std::process::Command as StdCommand;
 
     #[test]
     fn forge_lint_json_diagnostics_are_read_from_stderr() {
@@ -64,6 +112,55 @@ mod tests {
             ),
             br#"{"message":"stdout"}"#
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn timeout_kills_child_process() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+            //- /src/Test.sol
+            contract Test {}
+            "#,
+        );
+        let pid_path = project.path("/flycheck-pid.txt");
+        let mut params = project.initialize_params();
+        params.initialization_options = Some(serde_json::json!({
+            "flychecks": [{
+                "id": "timeout-repro",
+                "command": "/bin/sh",
+                "args": [
+                    "-c",
+                    "printf '%s' \"$$\" > \"$1\"; exec sleep 120",
+                    "sh",
+                    pid_path.display().to_string(),
+                ],
+            }],
+        }));
+        let (_, mut config) = negotiate_capabilities(params);
+        config.rediscover_workspaces();
+        let [config] =
+            config.flychecks_for_path(&project.path("/src/Test.sol")).try_into().unwrap();
+
+        let error = command_output(&config, Duration::from_secs(1)).await.unwrap_err();
+
+        assert!(matches!(error, FlycheckError::Timeout));
+        let pid = project.read_file("/flycheck-pid.txt").parse().unwrap();
+        assert!(!process_exists(pid));
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        StdCommand::new("ps")
+            .args(["-p", &pid.to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
     }
 }
 

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -100,8 +100,9 @@ async fn collect_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use crate::test_support::process_exists;
     use crate::{config::negotiate_capabilities, test_support::TestProject};
-    use std::process::Command as StdCommand;
 
     #[test]
     fn forge_lint_json_diagnostics_are_read_from_stderr() {
@@ -160,17 +161,6 @@ mod tests {
         assert!(matches!(error, FlycheckError::Timeout));
         let pid = project.read_file("/flycheck-pid.txt").parse().unwrap();
         assert!(!process_exists(pid));
-    }
-
-    #[cfg(unix)]
-    fn process_exists(pid: u32) -> bool {
-        StdCommand::new("ps")
-            .args(["-p", &pid.to_string()])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
     }
 }
 

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -50,8 +50,8 @@ async fn command_output(
         .stderr(Stdio::piped())
         .spawn()?;
 
-    let stdout = child.stdout.take().map(read_pipe);
-    let stderr = child.stderr.take().map(read_pipe);
+    let stdout = read_pipe(child.stdout.take().expect("stdout was piped"));
+    let stderr = read_pipe(child.stderr.take().expect("stderr was piped"));
     let status = match time::timeout(timeout, child.wait()).await {
         Ok(status) => status?,
         Err(_) => {
@@ -75,17 +75,12 @@ fn read_pipe(pipe: impl AsyncRead + Send + Unpin + 'static) -> JoinHandle<io::Re
     })
 }
 
-async fn collect_pipe(pipe: Option<JoinHandle<io::Result<Vec<u8>>>>) -> io::Result<Vec<u8>> {
-    match pipe {
-        Some(pipe) => pipe.await.map_err(io::Error::other)?,
-        None => Ok(Vec::new()),
-    }
+async fn collect_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u8>> {
+    pipe.await.map_err(io::Error::other)?
 }
 
-fn abort_pipe(pipe: Option<JoinHandle<io::Result<Vec<u8>>>>) {
-    if let Some(pipe) = pipe {
-        pipe.abort();
-    }
+fn abort_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) {
+    pipe.abort();
 }
 
 #[cfg(test)]

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -1,6 +1,6 @@
 use crate::{
     diagnostics::DiagnosticMap,
-    flycheck::{FlycheckConfig, parser},
+    flycheck::{FlycheckConfig, config::FlycheckOutput, parser},
 };
 use std::{process::Stdio, time::Duration};
 use tokio::{process::Command, time};
@@ -11,7 +11,11 @@ pub(crate) async fn run(config: FlycheckConfig) -> Result<DiagnosticMap, Flychec
     let output = time::timeout(FLYCHECK_TIMEOUT, command_output(&config))
         .await
         .map_err(|_| FlycheckError::Timeout)??;
-    let diagnostics = parser::parse(&output.stdout, &config.cwd, config.output)?;
+    let diagnostics = parser::parse(
+        diagnostic_output(&output.stdout, &output.stderr, config.output),
+        &config.cwd,
+        config.output,
+    )?;
 
     if !output.status.success() && diagnostics.is_empty() {
         return Err(FlycheckError::Failed {
@@ -23,6 +27,10 @@ pub(crate) async fn run(config: FlycheckConfig) -> Result<DiagnosticMap, Flychec
     Ok(diagnostics)
 }
 
+fn diagnostic_output<'a>(stdout: &'a [u8], stderr: &'a [u8], format: FlycheckOutput) -> &'a [u8] {
+    if format == FlycheckOutput::ForgeLintJson && !stderr.is_empty() { stderr } else { stdout }
+}
+
 async fn command_output(config: &FlycheckConfig) -> Result<std::process::Output, std::io::Error> {
     Command::new(&config.command)
         .args(&config.args)
@@ -32,6 +40,31 @@ async fn command_output(config: &FlycheckConfig) -> Result<std::process::Output,
         .stderr(Stdio::piped())
         .output()
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forge_lint_json_diagnostics_are_read_from_stderr() {
+        assert_eq!(
+            diagnostic_output(b"", br#"{"message":"stdout"}"#, FlycheckOutput::ForgeLintJson),
+            br#"{"message":"stdout"}"#
+        );
+    }
+
+    #[test]
+    fn solc_json_diagnostics_are_read_from_stdout() {
+        assert_eq!(
+            diagnostic_output(
+                br#"{"message":"stdout"}"#,
+                br#"{"message":"stderr"}"#,
+                FlycheckOutput::SolcJson
+            ),
+            br#"{"message":"stdout"}"#
+        );
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -1,0 +1,47 @@
+use crate::{
+    diagnostics::DiagnosticMap,
+    flycheck::{FlycheckConfig, parser},
+};
+use std::{process::Stdio, time::Duration};
+use tokio::{process::Command, time};
+
+const FLYCHECK_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(crate) async fn run(config: FlycheckConfig) -> Result<DiagnosticMap, FlycheckError> {
+    let output = time::timeout(FLYCHECK_TIMEOUT, command_output(&config))
+        .await
+        .map_err(|_| FlycheckError::Timeout)??;
+    let diagnostics = parser::parse(&output.stdout, &config.cwd, config.output)?;
+
+    if !output.status.success() && diagnostics.is_empty() {
+        return Err(FlycheckError::Failed {
+            status: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+
+    Ok(diagnostics)
+}
+
+async fn command_output(config: &FlycheckConfig) -> Result<std::process::Output, std::io::Error> {
+    Command::new(&config.command)
+        .args(&config.args)
+        .current_dir(&config.cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FlycheckError {
+    #[error("flycheck command timed out")]
+    Timeout,
+    #[error("failed to run flycheck command: {0}")]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Parse(#[from] parser::ParseError),
+    #[error("flycheck command failed with status {status:?}: {stderr}")]
+    Failed { status: Option<i32>, stderr: String },
+}

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -157,8 +157,7 @@ impl GlobalState {
     }
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
-        let version = self.flycheck_version.fetch_add(1, Ordering::AcqRel) + 1;
-        self.cancel_flychecks();
+        let version = self.begin_flycheck_epoch();
         let flychecks = self.config.flychecks_for_path(&path);
         if flychecks.is_empty() {
             return;
@@ -191,12 +190,17 @@ impl GlobalState {
         &mut self,
         owners: impl IntoIterator<Item = DiagnosticOwner>,
     ) {
-        self.flycheck_version.fetch_add(1, Ordering::AcqRel);
-        self.cancel_flychecks();
+        self.begin_flycheck_epoch();
         let mut snapshot = self.snapshot();
         for owner in owners {
             snapshot.publish_diagnostics(owner, DiagnosticMap::default());
         }
+    }
+
+    fn begin_flycheck_epoch(&mut self) -> usize {
+        let version = self.flycheck_version.fetch_add(1, Ordering::AcqRel) + 1;
+        self.cancel_flychecks();
+        version
     }
 
     fn cancel_flychecks(&mut self) {

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -17,7 +17,10 @@ use lsp_types::{
 use solar_config::{CompileOpts, version::SHORT_VERSION};
 use solar_interface::{
     Session,
-    data_structures::{map::FxHashSet, sync::RwLock},
+    data_structures::{
+        map::{FxHashMap, FxHashSet},
+        sync::RwLock,
+    },
     diagnostics::{DiagCtxt, InMemoryEmitter},
     source_map::{FileName, SourceMap},
 };
@@ -38,8 +41,8 @@ pub(crate) struct GlobalState {
     pub(crate) vfs: Arc<RwLock<Vfs>>,
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
-    flycheck_version: Arc<AtomicUsize>,
-    flycheck_cancels: Vec<oneshot::Sender<()>>,
+    flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
+    flycheck_cancels: FxHashMap<DiagnosticOwner, oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
 }
@@ -50,8 +53,8 @@ impl GlobalState {
             client,
             vfs: Arc::new(Default::default()),
             analysis_version: Arc::new(AtomicUsize::new(0)),
-            flycheck_version: Arc::new(AtomicUsize::new(0)),
-            flycheck_cancels: Vec::new(),
+            flycheck_versions: Arc::new(Default::default()),
+            flycheck_cancels: FxHashMap::default(),
             symbol_tables: Arc::new(Default::default()),
             diagnostics: Arc::new(Default::default()),
             config: Arc::new(Default::default()),
@@ -154,7 +157,6 @@ impl GlobalState {
     }
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
-        let version = self.begin_flycheck_epoch();
         let flychecks = self.config.flychecks_for_path(&path);
         if flychecks.is_empty() {
             return;
@@ -162,24 +164,26 @@ impl GlobalState {
 
         for flycheck in flychecks {
             let owner = flycheck.owner();
+            let version = self.begin_flycheck_epoch(&owner);
             let id = flycheck.id.as_str().to_string();
             let mut snapshot = self.snapshot();
             let (cancel, cancelled) = oneshot::channel();
+            let task_owner = owner.clone();
             tokio::spawn(async move {
                 let result = flycheck::run(flycheck, cancelled).await;
-                if !snapshot.is_current_flycheck(version) {
+                if !snapshot.is_current_flycheck(&task_owner, version) {
                     return;
                 }
 
                 match result {
-                    Ok(diagnostics) => snapshot.publish_diagnostics(owner, diagnostics),
+                    Ok(diagnostics) => snapshot.publish_diagnostics(task_owner, diagnostics),
                     Err(error) => {
                         tracing::warn!(%id, %error, "flycheck failed");
-                        snapshot.publish_diagnostics(owner, DiagnosticMap::default());
+                        snapshot.publish_diagnostics(task_owner, DiagnosticMap::default());
                     }
                 }
             });
-            self.flycheck_cancels.push(cancel);
+            self.flycheck_cancels.insert(owner, cancel);
         }
     }
 
@@ -187,7 +191,11 @@ impl GlobalState {
         &mut self,
         owners: impl IntoIterator<Item = DiagnosticOwner>,
     ) {
-        self.begin_flycheck_epoch();
+        let owners = owners.into_iter().collect::<Vec<_>>();
+        for owner in &owners {
+            self.begin_flycheck_epoch(owner);
+        }
+
         let mut snapshot = self.snapshot();
         for owner in owners {
             snapshot.publish_diagnostics(owner, DiagnosticMap::default());
@@ -198,13 +206,23 @@ impl GlobalState {
         &mut self,
         paths: impl IntoIterator<Item = PathBuf>,
     ) {
+        let paths = paths.into_iter().collect::<Vec<_>>();
         let uris =
-            paths.into_iter().filter_map(|path| Url::from_file_path(path).ok()).collect::<Vec<_>>();
+            paths.iter().filter_map(|path| Url::from_file_path(path).ok()).collect::<Vec<_>>();
         if uris.is_empty() {
             return;
         }
 
-        self.begin_flycheck_epoch();
+        let mut owners = FxHashSet::default();
+        for path in paths {
+            for flycheck in self.config.flychecks_for_path(&path) {
+                owners.insert(flycheck.owner());
+            }
+        }
+        for owner in owners {
+            self.begin_flycheck_epoch(&owner);
+        }
+
         let batches = {
             let mut store = self.diagnostics.write();
             store.clear_uris_and_publish_batches(uris)
@@ -219,14 +237,19 @@ impl GlobalState {
         }
     }
 
-    fn begin_flycheck_epoch(&mut self) -> usize {
-        let version = self.flycheck_version.fetch_add(1, Ordering::AcqRel) + 1;
-        self.cancel_flychecks();
+    fn begin_flycheck_epoch(&mut self, owner: &DiagnosticOwner) -> usize {
+        let version = {
+            let mut versions = self.flycheck_versions.write();
+            let version = versions.get(owner).copied().unwrap_or_default() + 1;
+            versions.insert(owner.clone(), version);
+            version
+        };
+        self.cancel_flycheck(owner);
         version
     }
 
-    fn cancel_flychecks(&mut self) {
-        for cancel in self.flycheck_cancels.drain(..) {
+    fn cancel_flycheck(&mut self, owner: &DiagnosticOwner) {
+        if let Some(cancel) = self.flycheck_cancels.remove(owner) {
             let _ = cancel.send(());
         }
     }
@@ -237,7 +260,7 @@ impl GlobalState {
             vfs: self.vfs.clone(),
             config: self.config.clone(),
             analysis_version: self.analysis_version.clone(),
-            flycheck_version: self.flycheck_version.clone(),
+            flycheck_versions: self.flycheck_versions.clone(),
             symbol_tables: self.symbol_tables.clone(),
             diagnostics: self.diagnostics.clone(),
         }
@@ -280,7 +303,7 @@ pub(crate) struct GlobalStateSnapshot {
     vfs: Arc<RwLock<Vfs>>,
     config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
-    flycheck_version: Arc<AtomicUsize>,
+    flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     symbol_tables: Arc<RwLock<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
 }
@@ -290,8 +313,8 @@ impl GlobalStateSnapshot {
         self.analysis_version.load(Ordering::Acquire) == version
     }
 
-    fn is_current_flycheck(&self, version: usize) -> bool {
-        self.flycheck_version.load(Ordering::Acquire) == version
+    fn is_current_flycheck(&self, owner: &DiagnosticOwner, version: usize) -> bool {
+        self.flycheck_versions.read().get(owner).copied().unwrap_or_default() == version
     }
 
     fn analysis_batches(&self, disk_paths: Vec<PathBuf>) -> Vec<AnalysisBatch> {
@@ -479,10 +502,14 @@ mod tests {
             vfs: Arc::new(RwLock::new(vfs)),
             config: Arc::new(config),
             analysis_version: Arc::new(AtomicUsize::new(1)),
-            flycheck_version: Arc::new(AtomicUsize::new(1)),
+            flycheck_versions: Arc::new(Default::default()),
             symbol_tables: Arc::new(Default::default()),
             diagnostics: Arc::new(Default::default()),
         }
+    }
+
+    fn flycheck_owner(workspace: impl Into<PathBuf>) -> DiagnosticOwner {
+        DiagnosticOwner::Flycheck { id: "slow".into(), workspace: workspace.into() }
     }
 
     #[test]
@@ -503,27 +530,91 @@ mod tests {
     }
 
     #[test]
-    fn saving_without_matching_flychecks_stales_previous_flycheck_results() {
+    fn saving_without_matching_flychecks_keeps_previous_flycheck_results_current() {
         let mut state = GlobalState::new(ClientSocket::new_closed());
         let snapshot = state.snapshot();
+        let owner = flycheck_owner("/workspace");
 
-        assert!(snapshot.is_current_flycheck(0));
+        assert!(snapshot.is_current_flycheck(&owner, 0));
 
         state.run_flychecks_on_save(PathBuf::from("/workspace/Untracked.sol"));
 
-        assert!(!snapshot.is_current_flycheck(0));
+        assert!(snapshot.is_current_flycheck(&owner, 0));
     }
 
     #[test]
-    fn clearing_removed_flychecks_stales_previous_flycheck_results() {
+    fn clearing_removed_flychecks_without_owners_keeps_previous_flycheck_results_current() {
         let mut state = GlobalState::new(ClientSocket::new_closed());
         let snapshot = state.snapshot();
+        let owner = flycheck_owner("/workspace");
 
-        assert!(snapshot.is_current_flycheck(0));
+        assert!(snapshot.is_current_flycheck(&owner, 0));
 
         state.clear_removed_flycheck_diagnostics(Vec::new());
 
-        assert!(!snapshot.is_current_flycheck(0));
+        assert!(snapshot.is_current_flycheck(&owner, 0));
+    }
+
+    #[test]
+    fn clearing_removed_flychecks_stales_removed_owner_results() {
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        let snapshot = state.snapshot();
+        let owner = flycheck_owner("/workspace");
+
+        assert!(snapshot.is_current_flycheck(&owner, 0));
+
+        state.clear_removed_flycheck_diagnostics([owner.clone()]);
+
+        assert!(!snapshot.is_current_flycheck(&owner, 0));
+    }
+
+    #[test]
+    fn clearing_removed_file_diagnostics_stales_matching_flycheck_owner_only() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /first/foundry.toml
+            [profile.default]
+            src = "src"
+            //- /second/foundry.toml
+            [profile.default]
+            src = "src"
+            "#,
+        );
+        let mut params = project.initialize_params_with_roots(&["/first", "/second"]);
+        params.initialization_options = Some(serde_json::json!({
+            "flychecks": [{
+                "id": "slow",
+                "command": "slow",
+            }],
+        }));
+        let (_, mut config) = negotiate_capabilities(params);
+        config.rediscover_workspaces();
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        state.config = Arc::new(config);
+        let snapshot = state.snapshot();
+        let first_owner = flycheck_owner(project.path("/first"));
+        let second_owner = flycheck_owner(project.path("/second"));
+
+        assert!(snapshot.is_current_flycheck(&first_owner, 0));
+        assert!(snapshot.is_current_flycheck(&second_owner, 0));
+
+        state.clear_removed_file_diagnostics([project.path("/first/src/Deleted.sol")]);
+
+        assert!(!snapshot.is_current_flycheck(&first_owner, 0));
+        assert!(snapshot.is_current_flycheck(&second_owner, 0));
+    }
+
+    #[test]
+    fn beginning_flycheck_epoch_keeps_other_owner_cancel_pending() {
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        let first_owner = flycheck_owner("/first");
+        let second_owner = flycheck_owner("/second");
+        let (cancel, mut cancelled) = oneshot::channel();
+        state.flycheck_cancels.insert(first_owner, cancel);
+
+        state.begin_flycheck_epoch(&second_owner);
+
+        assert!(matches!(cancelled.try_recv(), Err(oneshot::error::TryRecvError::Empty)));
     }
 
     #[cfg(unix)]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -343,8 +343,7 @@ impl GlobalStateSnapshot {
     fn publish_diagnostics(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) {
         let batches = {
             let mut store = self.diagnostics.write();
-            store.replace(owner, diagnostics);
-            store.publish_batches()
+            store.replace_and_publish_batches(owner, diagnostics)
         };
 
         for (uri, uri_diagnostics) in batches {

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -182,6 +182,17 @@ impl GlobalState {
         }
     }
 
+    pub(crate) fn clear_removed_flycheck_diagnostics(
+        &mut self,
+        owners: impl IntoIterator<Item = DiagnosticOwner>,
+    ) {
+        self.flycheck_version.fetch_add(1, Ordering::AcqRel);
+        let mut snapshot = self.snapshot();
+        for owner in owners {
+            snapshot.publish_diagnostics(owner, DiagnosticMap::default());
+        }
+    }
+
     fn snapshot(&self) -> GlobalStateSnapshot {
         GlobalStateSnapshot {
             client: self.client.clone(),
@@ -459,6 +470,18 @@ mod tests {
         assert!(snapshot.is_current_flycheck(0));
 
         state.run_flychecks_on_save(PathBuf::from("/workspace/Untracked.sol"));
+
+        assert!(!snapshot.is_current_flycheck(0));
+    }
+
+    #[test]
+    fn clearing_removed_flychecks_stales_previous_flycheck_results() {
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        let snapshot = state.snapshot();
+
+        assert!(snapshot.is_current_flycheck(0));
+
+        state.clear_removed_flycheck_diagnostics(Vec::new());
 
         assert!(!snapshot.is_current_flycheck(0));
     }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -197,6 +197,31 @@ impl GlobalState {
         }
     }
 
+    pub(crate) fn clear_removed_file_diagnostics(
+        &mut self,
+        paths: impl IntoIterator<Item = PathBuf>,
+    ) {
+        let uris =
+            paths.into_iter().filter_map(|path| Url::from_file_path(path).ok()).collect::<Vec<_>>();
+        if uris.is_empty() {
+            return;
+        }
+
+        self.begin_flycheck_epoch();
+        let batches = {
+            let mut store = self.diagnostics.write();
+            store.clear_uris_and_publish_batches(uris)
+        };
+
+        for (uri, uri_diagnostics) in batches {
+            let _ = self.client.publish_diagnostics(PublishDiagnosticsParams::new(
+                uri,
+                uri_diagnostics,
+                None,
+            ));
+        }
+    }
+
     fn begin_flycheck_epoch(&mut self) -> usize {
         let version = self.flycheck_version.fetch_add(1, Ordering::AcqRel) + 1;
         self.cancel_flychecks();

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -34,7 +34,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
     },
 };
-use tokio::task::JoinHandle;
+use tokio::{sync::oneshot, task::JoinHandle};
 
 pub(crate) struct GlobalState {
     client: ClientSocket,
@@ -42,6 +42,7 @@ pub(crate) struct GlobalState {
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
     flycheck_version: Arc<AtomicUsize>,
+    flycheck_cancels: Vec<oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
 }
@@ -53,6 +54,7 @@ impl GlobalState {
             vfs: Arc::new(Default::default()),
             analysis_version: Arc::new(AtomicUsize::new(0)),
             flycheck_version: Arc::new(AtomicUsize::new(0)),
+            flycheck_cancels: Vec::new(),
             symbol_tables: Arc::new(Default::default()),
             diagnostics: Arc::new(Default::default()),
             config: Arc::new(Default::default()),
@@ -156,6 +158,7 @@ impl GlobalState {
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
         let version = self.flycheck_version.fetch_add(1, Ordering::AcqRel) + 1;
+        self.cancel_flychecks();
         let flychecks = self.config.flychecks_for_path(&path);
         if flychecks.is_empty() {
             return;
@@ -165,8 +168,9 @@ impl GlobalState {
             let owner = flycheck.owner();
             let id = flycheck.id.as_str().to_string();
             let mut snapshot = self.snapshot();
+            let (cancel, cancelled) = oneshot::channel();
             tokio::spawn(async move {
-                let result = flycheck::run(flycheck).await;
+                let result = flycheck::run(flycheck, cancelled).await;
                 if !snapshot.is_current_flycheck(version) {
                     return;
                 }
@@ -179,6 +183,7 @@ impl GlobalState {
                     }
                 }
             });
+            self.flycheck_cancels.push(cancel);
         }
     }
 
@@ -187,9 +192,16 @@ impl GlobalState {
         owners: impl IntoIterator<Item = DiagnosticOwner>,
     ) {
         self.flycheck_version.fetch_add(1, Ordering::AcqRel);
+        self.cancel_flychecks();
         let mut snapshot = self.snapshot();
         for owner in owners {
             snapshot.publish_diagnostics(owner, DiagnosticMap::default());
+        }
+    }
+
+    fn cancel_flychecks(&mut self) {
+        for cancel in self.flycheck_cancels.drain(..) {
+            let _ = cancel.send(());
         }
     }
 
@@ -417,10 +429,15 @@ fn analyze(batch: AnalysisBatch) -> AnalysisResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::TestProject;
+    use crate::{config::negotiate_capabilities, test_support::TestProject};
     use async_lsp::ClientSocket;
     use lsp_types::{
         DocumentSymbol, SymbolKind, WatchKind, WorkspaceSymbol, notification::Notification,
+    };
+    use std::{
+        path::Path,
+        process::{Command as StdCommand, Stdio},
+        time::Duration,
     };
 
     mod completion;
@@ -486,6 +503,50 @@ mod tests {
         assert!(!snapshot.is_current_flycheck(0));
     }
 
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn saving_again_cancels_in_flight_flychecks() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+            //- /src/Test.sol
+            contract Test {}
+            "#,
+        );
+        let first_pid_path = project.path("/first-flycheck-pid.txt");
+        let second_pid_path = project.path("/second-flycheck-pid.txt");
+        let mut params = project.initialize_params();
+        params.initialization_options = Some(serde_json::json!({
+            "flychecks": [{
+                "id": "slow",
+                "command": "/bin/sh",
+                "args": [
+                    "-c",
+                    "if [ ! -f \"$1\" ]; then printf '%s' \"$$\" > \"$1\"; exec sleep 120; fi; printf '%s' \"$$\" > \"$2\"; printf '{}\n'",
+                    "sh",
+                    first_pid_path.display().to_string(),
+                    second_pid_path.display().to_string(),
+                ],
+            }],
+        }));
+        let (_, mut config) = negotiate_capabilities(params);
+        config.rediscover_workspaces();
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        state.config = Arc::new(config);
+
+        state.run_flychecks_on_save(project.path("/src/Test.sol"));
+        wait_for_path(&first_pid_path).await;
+        let first_pid = project.read_file("/first-flycheck-pid.txt").parse().unwrap();
+
+        state.run_flychecks_on_save(project.path("/src/Test.sol"));
+        wait_for_path(&second_pid_path).await;
+        wait_for_process_exit(first_pid).await;
+
+        assert!(!process_exists(first_pid));
+    }
+
     #[test]
     fn analysis_batches_read_tracked_disk_files() {
         let project = TestProject::from_fixture(
@@ -508,6 +569,38 @@ mod tests {
             batch.files,
             vec![(path, "contract C { function f() public { number+; } }".into())]
         );
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_path(path: &Path) {
+        for _ in 0..100 {
+            if path.exists() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("timed out waiting for {}", path.display());
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_process_exit(pid: u32) {
+        for _ in 0..100 {
+            if !process_exists(pid) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        StdCommand::new("ps")
+            .args(["-p", &pid.to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -9,18 +9,15 @@ use crate::{
 };
 use async_lsp::{ClientSocket, LanguageClient, ResponseError};
 use lsp_types::{
-    Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern,
-    InitializeParams, InitializeResult, InitializedParams, LogMessageParams, MessageType,
-    PublishDiagnosticsParams, Registration, RegistrationParams, ServerInfo, Url, WatchKind,
+    DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, InitializeParams,
+    InitializeResult, InitializedParams, LogMessageParams, MessageType, PublishDiagnosticsParams,
+    Registration, RegistrationParams, ServerInfo, Url, WatchKind,
     notification::{DidChangeWatchedFiles, Notification},
 };
 use solar_config::{CompileOpts, version::SHORT_VERSION};
 use solar_interface::{
     Session,
-    data_structures::{
-        map::{FxHashMap, FxHashSet},
-        sync::RwLock,
-    },
+    data_structures::{map::FxHashSet, sync::RwLock},
     diagnostics::{DiagCtxt, InMemoryEmitter},
     source_map::{FileName, SourceMap},
 };
@@ -126,7 +123,7 @@ impl GlobalState {
                 return;
             }
 
-            let mut diagnostics = FxHashMap::<Url, Vec<Diagnostic>>::default();
+            let mut diagnostics = DiagnosticMap::default();
             let mut symbol_tables = SymbolTables::default();
 
             for batch in batches {
@@ -256,7 +253,7 @@ impl GlobalState {
 }
 
 struct AnalysisResult {
-    diagnostics: FxHashMap<Url, Vec<Diagnostic>>,
+    diagnostics: DiagnosticMap,
     symbol_tables: SymbolTables,
 }
 
@@ -445,7 +442,7 @@ fn analyze(batch: AnalysisBatch) -> AnalysisResult {
             .read()
             .iter()
             .filter_map(|diag| proto::diagnostic(compiler.sess().source_map(), diag))
-            .fold(FxHashMap::<Url, Vec<Diagnostic>>::default(), |mut diagnostics, (uri, diag)| {
+            .fold(DiagnosticMap::default(), |mut diagnostics, (uri, diag)| {
                 diagnostics.entry(uri).or_default().push(diag);
                 diagnostics
             });
@@ -457,16 +454,14 @@ fn analyze(batch: AnalysisBatch) -> AnalysisResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use crate::test_support::process_exists;
     use crate::{config::negotiate_capabilities, test_support::TestProject};
     use async_lsp::ClientSocket;
     use lsp_types::{
         DocumentSymbol, SymbolKind, WatchKind, WorkspaceSymbol, notification::Notification,
     };
-    use std::{
-        path::Path,
-        process::{Command as StdCommand, Stdio},
-        time::Duration,
-    };
+    use std::{path::Path, time::Duration};
 
     mod completion;
     mod goto_definition;
@@ -618,17 +613,6 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-    }
-
-    #[cfg(unix)]
-    fn process_exists(pid: u32) -> bool {
-        StdCommand::new("ps")
-            .args(["-p", &pid.to_string()])
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .is_ok_and(|status| status.success())
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -1,7 +1,8 @@
 use crate::{
     NotifyResult,
     config::{Config, negotiate_capabilities},
-    proto,
+    diagnostics::{DiagnosticMap, DiagnosticOwner, DiagnosticStore},
+    flycheck, proto,
     symbols::SymbolTables,
     vfs::Vfs,
     workspace::WorkspacePathIndex,
@@ -40,8 +41,9 @@ pub(crate) struct GlobalState {
     pub(crate) vfs: Arc<RwLock<Vfs>>,
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
+    flycheck_version: Arc<AtomicUsize>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
-    published_diagnostic_uris: Arc<RwLock<FxHashSet<Url>>>,
+    diagnostics: Arc<RwLock<DiagnosticStore>>,
 }
 
 impl GlobalState {
@@ -50,8 +52,9 @@ impl GlobalState {
             client,
             vfs: Arc::new(Default::default()),
             analysis_version: Arc::new(AtomicUsize::new(0)),
+            flycheck_version: Arc::new(AtomicUsize::new(0)),
             symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
+            diagnostics: Arc::new(Default::default()),
             config: Arc::new(Default::default()),
         }
     }
@@ -146,9 +149,37 @@ impl GlobalState {
 
             if snapshot.is_current(version) {
                 snapshot.set_symbol_tables(symbol_tables);
-                snapshot.publish_diagnostic_set(diagnostics);
+                snapshot.publish_diagnostics(DiagnosticOwner::Compiler, diagnostics);
             }
         });
+    }
+
+    pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
+        let version = self.flycheck_version.fetch_add(1, Ordering::AcqRel) + 1;
+        let flychecks = self.config.flychecks_for_path(&path);
+        if flychecks.is_empty() {
+            return;
+        }
+
+        for flycheck in flychecks {
+            let owner = flycheck.owner();
+            let id = flycheck.id.as_str().to_string();
+            let mut snapshot = self.snapshot();
+            tokio::spawn(async move {
+                let result = flycheck::run(flycheck).await;
+                if !snapshot.is_current_flycheck(version) {
+                    return;
+                }
+
+                match result {
+                    Ok(diagnostics) => snapshot.publish_diagnostics(owner, diagnostics),
+                    Err(error) => {
+                        tracing::warn!(%id, %error, "flycheck failed");
+                        snapshot.publish_diagnostics(owner, DiagnosticMap::default());
+                    }
+                }
+            });
+        }
     }
 
     fn snapshot(&self) -> GlobalStateSnapshot {
@@ -157,8 +188,9 @@ impl GlobalState {
             vfs: self.vfs.clone(),
             config: self.config.clone(),
             analysis_version: self.analysis_version.clone(),
+            flycheck_version: self.flycheck_version.clone(),
             symbol_tables: self.symbol_tables.clone(),
-            published_diagnostic_uris: self.published_diagnostic_uris.clone(),
+            diagnostics: self.diagnostics.clone(),
         }
     }
 
@@ -199,13 +231,18 @@ pub(crate) struct GlobalStateSnapshot {
     vfs: Arc<RwLock<Vfs>>,
     config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
+    flycheck_version: Arc<AtomicUsize>,
     symbol_tables: Arc<RwLock<SymbolTables>>,
-    published_diagnostic_uris: Arc<RwLock<FxHashSet<Url>>>,
+    diagnostics: Arc<RwLock<DiagnosticStore>>,
 }
 
 impl GlobalStateSnapshot {
     fn is_current(&self, version: usize) -> bool {
         self.analysis_version.load(Ordering::Acquire) == version
+    }
+
+    fn is_current_flycheck(&self, version: usize) -> bool {
+        self.flycheck_version.load(Ordering::Acquire) == version
     }
 
     fn analysis_batches(&self, disk_paths: Vec<PathBuf>) -> Vec<AnalysisBatch> {
@@ -280,18 +317,14 @@ impl GlobalStateSnapshot {
         Cow::Owned(vec![crate::workspace::Workspace::unconfigured()])
     }
 
-    fn publish_diagnostic_set(&mut self, mut diagnostics: FxHashMap<Url, Vec<Diagnostic>>) {
-        let mut uris = diagnostics.keys().cloned().collect::<FxHashSet<_>>();
+    fn publish_diagnostics(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) {
+        let batches = {
+            let mut store = self.diagnostics.write();
+            store.replace(owner, diagnostics);
+            store.publish_batches()
+        };
 
-        let mut published_diagnostic_uris = self.published_diagnostic_uris.write();
-        uris.extend(published_diagnostic_uris.iter().cloned());
-        for uri in uris {
-            let uri_diagnostics = diagnostics.remove(&uri).unwrap_or_default();
-            if !uri_diagnostics.is_empty() {
-                published_diagnostic_uris.insert(uri.clone());
-            } else {
-                published_diagnostic_uris.remove(&uri);
-            }
+        for (uri, uri_diagnostics) in batches {
             let _ = self.client.publish_diagnostics(PublishDiagnosticsParams::new(
                 uri,
                 uri_diagnostics,
@@ -376,8 +409,7 @@ mod tests {
     use crate::test_support::TestProject;
     use async_lsp::ClientSocket;
     use lsp_types::{
-        Diagnostic, DocumentSymbol, Position, Range, SymbolKind, WatchKind, WorkspaceSymbol,
-        notification::Notification,
+        DocumentSymbol, SymbolKind, WatchKind, WorkspaceSymbol, notification::Notification,
     };
 
     mod completion;
@@ -396,8 +428,9 @@ mod tests {
             vfs: Arc::new(RwLock::new(vfs)),
             config: Arc::new(config),
             analysis_version: Arc::new(AtomicUsize::new(1)),
+            flycheck_version: Arc::new(AtomicUsize::new(1)),
             symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: Arc::new(Default::default()),
+            diagnostics: Arc::new(Default::default()),
         }
     }
 
@@ -419,37 +452,15 @@ mod tests {
     }
 
     #[test]
-    fn publish_diagnostic_set_clears_stale_diagnostics() {
-        let clean_uri = Url::parse("file:///workspace/src/Clean.sol").unwrap();
-        let diagnostic_uri = Url::parse("file:///workspace/src/Error.sol").unwrap();
-        let stale_uri = Url::parse("file:///workspace/src/Stale.sol").unwrap();
-        let published_diagnostic_uris =
-            Arc::new(RwLock::new(FxHashSet::from_iter([clean_uri.clone(), stale_uri.clone()])));
-        let mut snapshot = GlobalStateSnapshot {
-            client: ClientSocket::new_closed(),
-            vfs: Arc::new(Default::default()),
-            config: Arc::new(Config::default()),
-            analysis_version: Arc::new(AtomicUsize::new(1)),
-            symbol_tables: Arc::new(Default::default()),
-            published_diagnostic_uris: published_diagnostic_uris.clone(),
-        };
+    fn saving_without_matching_flychecks_stales_previous_flycheck_results() {
+        let mut state = GlobalState::new(ClientSocket::new_closed());
+        let snapshot = state.snapshot();
 
-        let diagnostic = Diagnostic::new_simple(
-            Range {
-                start: Position { line: 0, character: 0 },
-                end: Position { line: 0, character: 1 },
-            },
-            "error".into(),
-        );
-        snapshot.publish_diagnostic_set(FxHashMap::from_iter([(
-            diagnostic_uri.clone(),
-            vec![diagnostic],
-        )]));
+        assert!(snapshot.is_current_flycheck(0));
 
-        let published = published_diagnostic_uris.read();
-        assert!(!published.contains(&clean_uri));
-        assert!(published.contains(&diagnostic_uri));
-        assert!(!published.contains(&stale_uri));
+        state.run_flychecks_on_save(PathBuf::from("/workspace/Untracked.sol"));
+
+        assert!(!snapshot.is_current_flycheck(0));
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 use async_lsp::{ClientSocket, LanguageClient, ResponseError};
 use lsp_types::{
-    DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern, InitializeParams,
-    InitializeResult, InitializedParams, LogMessageParams, MessageType, PublishDiagnosticsParams,
-    Registration, RegistrationParams, ServerInfo, Url, WatchKind,
+    Diagnostic, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher, GlobPattern,
+    InitializeParams, InitializeResult, InitializedParams, LogMessageParams, MessageType,
+    PublishDiagnosticsParams, Registration, RegistrationParams, ServerInfo, Url, WatchKind,
     notification::{DidChangeWatchedFiles, Notification},
 };
 use solar_config::{CompileOpts, version::SHORT_VERSION};
@@ -157,15 +157,10 @@ impl GlobalState {
     }
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
-        let flychecks = self.config.flychecks_for_path(&path);
-        if flychecks.is_empty() {
-            return;
-        }
-
-        for flycheck in flychecks {
+        for flycheck in self.config.flychecks_for_path(&path) {
             let owner = flycheck.owner();
             let version = self.begin_flycheck_epoch(&owner);
-            let id = flycheck.id.as_str().to_string();
+            let id = flycheck.id.clone();
             let mut snapshot = self.snapshot();
             let (cancel, cancelled) = oneshot::channel();
             let task_owner = owner.clone();
@@ -228,13 +223,7 @@ impl GlobalState {
             store.clear_uris_and_publish_batches(uris)
         };
 
-        for (uri, uri_diagnostics) in batches {
-            let _ = self.client.publish_diagnostics(PublishDiagnosticsParams::new(
-                uri,
-                uri_diagnostics,
-                None,
-            ));
-        }
+        publish_diagnostic_batches(&mut self.client, batches);
     }
 
     fn begin_flycheck_epoch(&mut self, owner: &DiagnosticOwner) -> usize {
@@ -295,6 +284,16 @@ fn watched_file_registration_params() -> RegistrationParams {
             method: DidChangeWatchedFiles::METHOD.into(),
             register_options: Some(serde_json::to_value(options).unwrap()),
         }],
+    }
+}
+
+fn publish_diagnostic_batches(
+    client: &mut ClientSocket,
+    batches: impl IntoIterator<Item = (Url, Vec<Diagnostic>)>,
+) {
+    for (uri, uri_diagnostics) in batches {
+        let _ =
+            client.publish_diagnostics(PublishDiagnosticsParams::new(uri, uri_diagnostics, None));
     }
 }
 
@@ -395,13 +394,7 @@ impl GlobalStateSnapshot {
             store.replace_and_publish_batches(owner, diagnostics)
         };
 
-        for (uri, uri_diagnostics) in batches {
-            let _ = self.client.publish_diagnostics(PublishDiagnosticsParams::new(
-                uri,
-                uri_diagnostics,
-                None,
-            ));
-        }
+        publish_diagnostic_batches(&mut self.client, batches);
     }
 }
 

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -89,8 +89,7 @@ pub(crate) fn did_change_configuration(
 ) -> NotifyResult {
     // As stated in https://github.com/microsoft/language-server-protocol/issues/676,
     // this notification's parameters should be ignored and the actual config queried separately.
-    let removed_owners = Arc::make_mut(&mut state.config).rediscover_workspaces();
-    state.clear_removed_flycheck_diagnostics(removed_owners);
+    rediscover_workspaces(state);
     state.recompute();
     ControlFlow::Continue(())
 }
@@ -124,8 +123,7 @@ pub(crate) fn did_change_watched_files(
     }
 
     if should_rediscover {
-        let removed_owners = Arc::make_mut(&mut state.config).rediscover_workspaces();
-        state.clear_removed_flycheck_diagnostics(removed_owners);
+        rediscover_workspaces(state);
     }
     if should_rediscover || !disk_paths.is_empty() {
         state.recompute_with_disk_files(disk_paths);
@@ -150,9 +148,13 @@ pub(crate) fn did_change_workspace_folders(
     let added = params.event.added.into_iter().filter_map(|it| it.uri.to_file_path().ok());
     config.add_workspaces(added);
 
-    let removed_owners = config.rediscover_workspaces();
-    state.clear_removed_flycheck_diagnostics(removed_owners);
+    rediscover_workspaces(state);
     state.recompute();
 
     ControlFlow::Continue(())
+}
+
+fn rediscover_workspaces(state: &mut GlobalState) {
+    let removed_owners = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    state.clear_removed_flycheck_diagnostics(removed_owners);
 }

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -3,7 +3,7 @@ use crop::Rope;
 use lsp_types::{
     DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
     DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    FileChangeType,
+    DidSaveTextDocumentParams, FileChangeType,
 };
 use std::{ops::ControlFlow, sync::Arc};
 use tracing::{error, info};
@@ -67,6 +67,17 @@ pub(crate) fn did_close_text_document(
         let disk_path = path.as_path().map(ToOwned::to_owned);
         state.vfs.write().set_file_contents(path, None);
         state.recompute_with_disk_files(disk_path.into_iter().collect());
+    }
+
+    ControlFlow::Continue(())
+}
+
+pub(crate) fn did_save_text_document(
+    state: &mut GlobalState,
+    params: DidSaveTextDocumentParams,
+) -> NotifyResult {
+    if let Ok(path) = params.text_document.uri.to_file_path() {
+        state.run_flychecks_on_save(path);
     }
 
     ControlFlow::Continue(())

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -89,7 +89,8 @@ pub(crate) fn did_change_configuration(
 ) -> NotifyResult {
     // As stated in https://github.com/microsoft/language-server-protocol/issues/676,
     // this notification's parameters should be ignored and the actual config queried separately.
-    Arc::make_mut(&mut state.config).rediscover_workspaces();
+    let removed_owners = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    state.clear_removed_flycheck_diagnostics(removed_owners);
     state.recompute();
     ControlFlow::Continue(())
 }
@@ -123,7 +124,8 @@ pub(crate) fn did_change_watched_files(
     }
 
     if should_rediscover {
-        Arc::make_mut(&mut state.config).rediscover_workspaces();
+        let removed_owners = Arc::make_mut(&mut state.config).rediscover_workspaces();
+        state.clear_removed_flycheck_diagnostics(removed_owners);
     }
     if should_rediscover || !disk_paths.is_empty() {
         state.recompute_with_disk_files(disk_paths);
@@ -148,7 +150,8 @@ pub(crate) fn did_change_workspace_folders(
     let added = params.event.added.into_iter().filter_map(|it| it.uri.to_file_path().ok());
     config.add_workspaces(added);
 
-    config.rediscover_workspaces();
+    let removed_owners = config.rediscover_workspaces();
+    state.clear_removed_flycheck_diagnostics(removed_owners);
     state.recompute();
 
     ControlFlow::Continue(())

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -100,6 +100,7 @@ pub(crate) fn did_change_watched_files(
 ) -> NotifyResult {
     let mut should_rediscover = false;
     let mut disk_paths = Vec::new();
+    let mut removed_paths = Vec::new();
 
     for event in params.changes {
         let Ok(path) = event.uri.to_file_path() else {
@@ -115,6 +116,7 @@ pub(crate) fn did_change_watched_files(
                     Arc::make_mut(&mut state.config).add_source_file(path.clone());
                 } else if event.typ == FileChangeType::DELETED {
                     Arc::make_mut(&mut state.config).remove_source_file(&path);
+                    removed_paths.push(path.clone());
                 }
                 disk_paths.push(path);
             }
@@ -125,6 +127,7 @@ pub(crate) fn did_change_watched_files(
     if should_rediscover {
         rediscover_workspaces(state);
     }
+    state.clear_removed_file_diagnostics(removed_paths);
     if should_rediscover || !disk_paths.is_empty() {
         state.recompute_with_disk_files(disk_paths);
     }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -17,6 +17,8 @@ use std::ops::ControlFlow;
 use tower::ServiceBuilder;
 
 mod config;
+mod diagnostics;
+mod flycheck;
 mod global_state;
 mod handlers;
 mod inlay_hints;
@@ -63,6 +65,7 @@ fn new_router(client: ClientSocket) -> Router<GlobalState> {
         .notification::<notif::DidOpenTextDocument>(handlers::did_open_text_document)
         .notification::<notif::DidCloseTextDocument>(handlers::did_close_text_document)
         .notification::<notif::DidChangeTextDocument>(handlers::did_change_text_document)
+        .notification::<notif::DidSaveTextDocument>(handlers::did_save_text_document)
         .notification::<notif::DidChangeConfiguration>(handlers::did_change_configuration);
 
     router
@@ -102,9 +105,10 @@ mod tests {
     use super::*;
     use async_lsp::{AnyNotification, LanguageServer, LspService, router::Router};
     use lsp_types::{
-        DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams, FileChangeType,
-        FileEvent, InitializeParams, InitializedParams, WorkspaceClientCapabilities,
-        notification as notif, notification::Notification, request,
+        DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
+        DidSaveTextDocumentParams, FileChangeType, FileEvent, InitializeParams, InitializedParams,
+        TextDocumentIdentifier, WorkspaceClientCapabilities, notification as notif,
+        notification::Notification, request,
     };
     use std::ops::ControlFlow;
     use tokio::sync::oneshot;
@@ -121,6 +125,24 @@ mod tests {
         };
         let notification = serde_json::from_value::<AnyNotification>(serde_json::json!({
             "method": notif::DidChangeWatchedFiles::METHOD,
+            "params": params,
+        }))
+        .unwrap();
+
+        assert!(matches!(router.notify(notification), ControlFlow::Continue(())));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_document_saves() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let params = DidSaveTextDocumentParams {
+            text_document: TextDocumentIdentifier {
+                uri: lsp_types::Url::parse("file:///workspace/src/Test.sol").unwrap(),
+            },
+            text: None,
+        };
+        let notification = serde_json::from_value::<AnyNotification>(serde_json::json!({
+            "method": notif::DidSaveTextDocument::METHOD,
             "params": params,
         }))
         .unwrap();

--- a/crates/lsp/src/test_support.rs
+++ b/crates/lsp/src/test_support.rs
@@ -12,6 +12,17 @@ use std::{
 };
 use tempfile::TempDir;
 
+#[cfg(unix)]
+pub(crate) fn process_exists(pid: u32) -> bool {
+    std::process::Command::new("ps")
+        .args(["-p", &pid.to_string()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
 pub(crate) struct TestProject {
     tmp: TempDir,
     open_files: Vec<(PathBuf, String)>,

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -82,6 +82,52 @@
           "type": "boolean",
           "default": true,
           "description": "Format files on save using forge fmt"
+        },
+        "solarLsp.flychecks": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "description": "Flycheck commands to run on save. Leave unset to auto-detect forge lint when available.",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "command"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Stable diagnostic owner id for this flycheck"
+              },
+              "command": {
+                "type": "string",
+                "description": "Command to execute"
+              },
+              "args": {
+                "type": "array",
+                "default": [],
+                "items": {
+                  "type": "string"
+                },
+                "description": "Command arguments"
+              },
+              "cwd": {
+                "type": "string",
+                "description": "Working directory relative to the workspace root, or an absolute path"
+              },
+              "output": {
+                "type": "string",
+                "default": "solc-json",
+                "enum": [
+                  "solc-json",
+                  "forge-lint-json"
+                ],
+                "description": "JSON diagnostic output format"
+              }
+            }
+          }
         }
       }
     },

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -80,6 +80,7 @@ async function startLanguageServer(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration("solarLsp");
   const solarPath = config.get<string>("serverPath", "solar");
   const forgePath = config.get<string>("forgePath", "forge");
+  const flychecks = config.get("flychecks");
 
   // Check if solar is available first
   let serverCommand: string;
@@ -118,6 +119,10 @@ async function startLanguageServer(context: vscode.ExtensionContext) {
   // Define client options
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "solidity" }],
+    initializationOptions: {
+      forgePath,
+      flychecks,
+    },
     synchronize: {
       fileEvents: vscode.workspace.createFileSystemWatcher("**/*.sol"),
     },


### PR DESCRIPTION
Towards OSS-402

Adds on-save LSP flychecks for external Solidity diagnostics, with default forge lint --json discovery for Foundry workspaces and configurable custom commands from the VS Code extension. Flycheck diagnostics are parsed from solc/forge-style JSON, merged with compiler diagnostics by owner, cancelled when stale, timed out when hung, and republished only for affected files so unrelated diagnostics stay stable.

 Optimization points:

  - Auto-detects forge lint --json for Foundry workspaces.
  - Supports configurable flycheck commands via solarLsp.flychecks.
  - Parses solc JSON, forge lint JSON, and rustc-style diagnostic streams.
  - Converts byte offsets to LSP UTF-16 ranges with cached line indexes.
  - Cancels stale flychecks and kills timed-out child processes.
  - Tracks diagnostics by owner, so compiler and flycheck messages do not overwrite each other.
  - Publishes only affected URIs and clears stale/removed flycheck diagnostics.
  
  
### Original screenshots
<img width="520" height="188" alt="截屏2026-07-08 19 09 56" src="https://github.com/user-attachments/assets/02bd49c3-5ff7-4f78-8441-c287ee827bc2" />

### Modified a bit and save 
<img width="520" height="487" alt="截屏2026-07-08 19 10 47" src="https://github.com/user-attachments/assets/85b00f9a-b701-42ef-8ca4-057af262f46b" />

### multiple-flychecks 
<img width="520" height="516" alt="截屏2026-07-08 19 17 07" src="https://github.com/user-attachments/assets/3b9cf678-d1d9-40ef-a3cb-18500c998911" />

Verified multiple configured flychecks can publish diagnostics for the same file simultaneously without one owner overwriting another. 

<img width="520" height="435" alt="截屏2026-07-08 19 26 57" src="https://github.com/user-attachments/assets/272338df-a560-4082-bf82-0d8bd6f804cf" />

 