### PR TITLE
chore: update solidity to 0.8.36

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLC_VERSION: 0.8.35
+  SOLC_VERSION: 0.8.36
   BENCHMARK_REPOSITORY: walnuthq/solidity-compiler-benchmarks
   BENCHMARK_REF: 759b27b596ca6632717465832859863eccbe41a2
   BENCHMARK_PATH: solidity-compiler-benchmarks

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,7 +46,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SOLC_VERSION: 0.8.35
+  SOLC_VERSION: 0.8.36
   FANDANGO_VERSION: 1.1.1
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           tool: nextest
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -117,7 +117,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: stable
       - name: Install uv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,25 @@ Place these after initial UI metadata directives such as `//@ compile-flags`,
 put the attribution at the top.
 Only add attribution if you're actually porting the semantics of the test 1-1 from Solc, not just "covering the error message". Renames are OK.
 
+### Updating Solc
+
+When updating the tracked Solc version, inspect both the GitHub release notes
+and the source diff before changing code. Use `gh release view vX.Y.Z -R
+argotorg/solidity` for the release notes, and compare tags locally with
+`git -C testdata/solidity diff vOLD..vNEW --stat` plus targeted diffs for
+parser, lexer, analysis, `liblangutil/EVMVersion.*`, and changed tests.
+
+Update `testdata/solidity` to the new tag, bump every local Solc version pin
+such as `SOLC_VERSION` in workflows and the fallback in
+`crates/config/build.rs`, and add any new EVM versions to
+`crates/config/src/lib.rs`. If upstream changes the default EVM version, update
+the default here and bless the affected CLI snapshots.
+
+Always run the complete upstream Solidity test mode with `cargo tq
+solc-solidity` and `cargo tq solc-yul`, without path filters. Update the Solc test ignore
+lists in `tools/tester/src/solc/solidity.rs` and `tools/tester/src/solc/yul.rs`
+only for tests that are still outside this compiler's implemented behavior.
+
 ## Diagnostics Style
 
 Error messages should follow these conventions:

--- a/crates/config/build.rs
+++ b/crates/config/build.rs
@@ -2,7 +2,7 @@
 use std::{env, io::Read, path::Path};
 
 #[cfg(feature = "version")]
-const SOLC_VERSION_FALLBACK: &str = "0.8.35";
+const SOLC_VERSION_FALLBACK: &str = "0.8.36";
 #[cfg(feature = "version")]
 const VERSION_UNKNOWN: &str = "unknown";
 #[cfg(feature = "version")]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -100,9 +100,10 @@ str_enum! {
         Paris,
         Shanghai,
         Cancun,
-        #[default]
         Prague,
+        #[default]
         Osaka,
+        Amsterdam,
     }
 }
 

--- a/tests/ui/cli/help.long.stdout
+++ b/tests/ui/cli/help.long.stdout
@@ -28,8 +28,8 @@ Options:
       --evm-version <EVM_VERSION>
           EVM version
           
-          [default: prague]
-          [possible values: homestead, tangerineWhistle, spuriousDragon, byzantium, constantinople, petersburg, istanbul, berlin, london, paris, shanghai, cancun, prague, osaka]
+          [default: osaka]
+          [possible values: homestead, tangerineWhistle, spuriousDragon, byzantium, constantinople, petersburg, istanbul, berlin, london, paris, shanghai, cancun, prague, osaka, amsterdam]
 
       --stop-after <STOP_AFTER>
           Stop execution after the given compiler stage

--- a/tests/ui/cli/help.short.stdout
+++ b/tests/ui/cli/help.short.stdout
@@ -13,7 +13,7 @@ Arguments:
 
 Options:
   -j, --threads <THREADS>          Number of threads to use. Zero specifies the number of logical cores [default: <DEFAULT>] [aliases: --jobs]
-      --evm-version <EVM_VERSION>  EVM version [default: prague] [possible values: homestead, tangerineWhistle, spuriousDragon, byzantium, constantinople, petersburg, istanbul, berlin, london, paris, shanghai, cancun, prague, osaka]
+      --evm-version <EVM_VERSION>  EVM version [default: osaka] [possible values: homestead, tangerineWhistle, spuriousDragon, byzantium, constantinople, petersburg, istanbul, berlin, london, paris, shanghai, cancun, prague, osaka, amsterdam]
       --stop-after <STOP_AFTER>    Stop execution after the given compiler stage [possible values: parsing, lowering, analysis]
   -O, --optimize <OPTIMIZATION>    MIR optimization objective [default: gas] [possible values: none, gas, size]
       --out-dir <OUT_DIR>          Directory to write output files


### PR DESCRIPTION
This updates the tracked Solidity submodule to 0.8.36 and bumps the matching CI and benchmark solc version pins. The compiler config now recognizes the new Amsterdam EVM version and follows upstream's current default of Osaka, so the CLI help snapshots are updated accordingly.

I also added a short AGENTS.md checklist for future solc updates, covering release-note and source-diff review, full upstream Solidity and Yul test runs, ignore-list maintenance, and EVM-version updates.
