### PR TITLE
fix(sema): allow events and errors named builtins

### DIFF
--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -2318,12 +2318,30 @@ impl Declarations {
         decl: Declaration,
         declarations: &[Declaration],
     ) -> Option<Declaration> {
+        use crate::builtins::Builtin as BuiltinKind;
         use Res::*;
         use hir::ItemId::*;
 
         if declarations.is_empty() {
             return None;
         }
+
+        let filtered;
+        let declarations = if matches!(decl.res, Item(Event(_) | Error(_))) {
+            filtered = declarations
+                .iter()
+                .copied()
+                .filter(|other| {
+                    !matches!(other.res, Res::Builtin(BuiltinKind::This | BuiltinKind::Super))
+                })
+                .collect::<SmallVec<[_; 4]>>();
+            if filtered.is_empty() {
+                return None;
+            }
+            filtered.as_slice()
+        } else {
+            declarations
+        };
 
         // https://github.com/argotorg/solidity/blob/de1a017ccb935d149ed6bcbdb730d89883f8ce02/libsolidity/analysis/DeclarationContainer.cpp#L35
         if matches!(decl.res, Item(Function(_) | Event(_))) {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -2320,6 +2320,21 @@ impl<'gcx> TypeChecker<'gcx> {
             _ => {}
         }
 
+        if let WantOne::One(builtin) = res
+            .iter()
+            .filter(|res| matches!(res, hir::Res::Builtin(Builtin::This | Builtin::Super)))
+            .collect::<WantOne<_>>()
+            && res.iter().all(|res| {
+                matches!(
+                    res,
+                    hir::Res::Builtin(Builtin::This | Builtin::Super)
+                        | hir::Res::Item(hir::ItemId::Event(_) | hir::ItemId::Error(_))
+                )
+            })
+        {
+            return Ok(*builtin);
+        }
+
         match res.iter().filter(|res| res.as_variable().is_some()).collect::<WantOne<_>>() {
             WantOne::Zero => Err(OverloadError::NotFound),
             WantOne::One(var) => Ok(*var),

--- a/tests/ui/typeck/function_calls/event_error/shadow_builtin_identifiers.sol
+++ b/tests/ui/typeck/function_calls/event_error/shadow_builtin_identifiers.sol
@@ -1,0 +1,43 @@
+//@ compile-flags: -Ztypeck
+
+contract EventThis {
+    event this();
+    event this(uint256);
+
+    function f() public returns (address) {
+        emit this();
+        emit this(1);
+        return address(this);
+    }
+}
+
+contract Base {
+    function g() public virtual returns (uint256) {
+        return 1;
+    }
+}
+
+contract EventSuper is Base {
+    event super();
+
+    function f() public returns (uint256) {
+        emit super();
+        return super.g();
+    }
+}
+
+contract ErrorThis {
+    error this();
+
+    function f() public pure {
+        revert this();
+    }
+}
+
+contract ErrorSuper {
+    error super(uint256);
+
+    function f() public pure {
+        revert super(1);
+    }
+}


### PR DESCRIPTION
Fixes #216.

Allows contract-level events and errors named `this` or `super` to coexist with Solar's synthetic builtin declarations.

The change keeps the scope narrow:

- declaration conflict checks ignore synthetic `this` / `super` only when the new declaration is an event or error
- other declarations, such as structs or enums named `this` / `super`, still report conflicts
- value-position resolution still prefers the builtin when the candidates are only `this` / `super` plus event/error declarations, so `address(this)` and `super.g()` continue to resolve as builtins

The regression test covers `event this`, overloaded `event this(uint256)`, `event super`, `error this`, `error super(uint256)`, and the corresponding `emit` / `revert` paths alongside normal builtin usage.

Tested:

- `cargo build -p solar-compiler --bin solar`
- `env TESTER_MODE=ui cargo test -p solar-compiler --test tests -- shadow_builtin_identifiers`
- `cargo fmt --all --check`
- `git diff --check`
