### PR TITLE
feat(cli): color standard JSON diagnostics

### DIFF
--- a/crates/cli/src/standard_json/compile.rs
+++ b/crates/cli/src/standard_json/compile.rs
@@ -59,8 +59,7 @@ pub fn compile_standard_json(
         }
     }
 
-    let mut emitter = JsonEmitter::new(Box::new(io::sink()), Arc::clone(&source_map))
-        .color(opts.color)
+    let mut emitter = JsonEmitter::new(Box::new(io::sink()), Arc::clone(&source_map), opts.color)
         .ui_testing(opts.unstable.ui_testing)
         .human_kind(opts.error_format_human)
         .terminal_width(opts.diagnostic_width);

--- a/crates/cli/src/standard_json/compile.rs
+++ b/crates/cli/src/standard_json/compile.rs
@@ -60,6 +60,7 @@ pub fn compile_standard_json(
     }
 
     let mut emitter = JsonEmitter::new(Box::new(io::sink()), Arc::clone(&source_map))
+        .color(opts.color)
         .ui_testing(opts.unstable.ui_testing)
         .human_kind(opts.error_format_human)
         .terminal_width(opts.diagnostic_width);

--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -185,7 +185,7 @@ impl DiagCtxt {
             ErrorFormat::Json | ErrorFormat::RustcJson => {
                 // `io::Stderr` is not buffered.
                 let writer = Box::new(std::io::BufWriter::new(std::io::stderr()));
-                let json = crate::diagnostics::JsonEmitter::new(writer, source_map)
+                let json = crate::diagnostics::JsonEmitter::new(writer, source_map, opts.color)
                     .pretty(opts.pretty_json_err)
                     .rustc_like(matches!(opts.error_format, ErrorFormat::RustcJson))
                     .ui_testing(opts.unstable.ui_testing)

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -46,6 +46,8 @@ impl JsonEmitter {
         source_map: Arc<SourceMap>,
         color_choice: ColorChoice,
     ) -> Self {
+        let color_choice =
+            if color_choice == ColorChoice::Auto { ColorChoice::Never } else { color_choice };
         Self {
             writer,
             pretty: false,

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -41,20 +41,17 @@ impl Emitter for JsonEmitter {
 
 impl JsonEmitter {
     /// Creates a new `JsonEmitter` that writes to given writer.
-    pub fn new(writer: Box<dyn io::Write + Send>, source_map: Arc<SourceMap>) -> Self {
+    pub fn new(
+        writer: Box<dyn io::Write + Send>,
+        source_map: Arc<SourceMap>,
+        color_choice: ColorChoice,
+    ) -> Self {
         Self {
             writer,
             pretty: false,
             rustc_like: false,
-            human_emitter: HumanBufferEmitter::new(ColorChoice::Never).source_map(Some(source_map)),
+            human_emitter: HumanBufferEmitter::new(color_choice).source_map(Some(source_map)),
         }
-    }
-
-    /// Sets the color choice for rendered messages.
-    pub fn color(mut self, color_choice: ColorChoice) -> Self {
-        let source_map = Arc::clone(self.source_map());
-        self.human_emitter = HumanBufferEmitter::new(color_choice).source_map(Some(source_map));
-        self
     }
 
     /// Sets whether to pretty print the JSON.

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -50,6 +50,13 @@ impl JsonEmitter {
         }
     }
 
+    /// Sets the color choice for rendered messages.
+    pub fn color(mut self, color_choice: ColorChoice) -> Self {
+        let source_map = Arc::clone(self.source_map());
+        self.human_emitter = HumanBufferEmitter::new(color_choice).source_map(Some(source_map));
+        self
+    }
+
     /// Sets whether to pretty print the JSON.
     pub fn pretty(mut self, pretty: bool) -> Self {
         self.pretty = pretty;

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1128,11 +1128,13 @@ note: mutable variables should use mixedCase
     fn test_solc_diagnostic_color() {
         let sm = Arc::new(source_map::SourceMap::empty());
         sm.new_source_file(source_map::FileName::custom("test.sol"), CONTRACT.to_string()).unwrap();
-        let mut emitter = JsonEmitter::new(Box::new(std::io::sink()), sm, ColorChoice::Always);
         let diagnostic = Diag::new(Level::Error, "mismatched types");
 
-        let formatted = emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap();
-        assert!(formatted.contains("\x1b["), "{formatted:?}");
+        for (color, expected) in [(ColorChoice::Always, true), (ColorChoice::Auto, false)] {
+            let mut emitter = JsonEmitter::new(Box::new(std::io::sink()), Arc::clone(&sm), color);
+            let formatted = emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap();
+            assert_eq!(formatted.contains("\x1b["), expected, "{formatted:?}");
+        }
     }
 
     #[test]

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1128,8 +1128,7 @@ note: mutable variables should use mixedCase
     fn test_solc_diagnostic_color() {
         let sm = Arc::new(source_map::SourceMap::empty());
         sm.new_source_file(source_map::FileName::custom("test.sol"), CONTRACT.to_string()).unwrap();
-        let mut emitter =
-            JsonEmitter::new(Box::new(std::io::sink()), sm).color(ColorChoice::Always);
+        let mut emitter = JsonEmitter::new(Box::new(std::io::sink()), sm, ColorChoice::Always);
         let diagnostic = Diag::new(Level::Error, "mismatched types");
 
         let formatted = emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap();
@@ -1516,8 +1515,12 @@ contract Test {
         sm.new_source_file(source_map::FileName::custom("test.sol"), CONTRACT.to_string()).unwrap();
 
         let writer = Arc::new(Mutex::new(Vec::new()));
-        let emitter = JsonEmitter::new(Box::new(SharedWriter(writer.clone())), Arc::clone(&sm))
-            .rustc_like(true);
+        let emitter = JsonEmitter::new(
+            Box::new(SharedWriter(writer.clone())),
+            Arc::clone(&sm),
+            ColorChoice::Never,
+        )
+        .rustc_like(true);
         let dcx = DiagCtxt::new(Box::new(emitter));
         let _ = dcx.emit_diagnostic(diag);
 

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1123,6 +1123,19 @@ note: mutable variables should use mixedCase
         assert_eq!(diag.suggestions[0].style, SuggestionStyle::ShowCode);
     }
 
+    #[cfg(feature = "json")]
+    #[test]
+    fn test_solc_diagnostic_color() {
+        let sm = Arc::new(source_map::SourceMap::empty());
+        sm.new_source_file(source_map::FileName::custom("test.sol"), CONTRACT.to_string()).unwrap();
+        let mut emitter =
+            JsonEmitter::new(Box::new(std::io::sink()), sm).color(ColorChoice::Always);
+        let diagnostic = Diag::new(Level::Error, "mismatched types");
+
+        let formatted = emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap();
+        assert!(formatted.contains("\x1b["), "{formatted:?}");
+    }
+
     #[test]
     fn test_allowed_diagnostic_code_suppresses_warning() {
         let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never)


### PR DESCRIPTION
Forward an explicit color choice to the human renderer used for standard-json `formattedMessage` fields. `--color always` can now embed JSON-escaped ANSI styling, while `auto` is normalized to `never` so machine-readable output does not depend on stderr terminal state or color environment variables.

This allows consumers to preserve Solar's complete styled Unicode diagnostics instead of reparsing them as solc output. It complements foundry-rs/foundry-core#113, which emits already ANSI-styled compiler diagnostics verbatim.
