### PR TITLE
fix(typeck): type Yul bool literals as words

### DIFF
--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -18,7 +18,7 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.dcx().emit_err(lit.span, format!("string literal too long ({len} > 32)")),
                 );
             }
-            LitKind::Address(_) => return self.gcx.types.uint(256),
+            LitKind::Address(_) | LitKind::Bool(_) => return self.gcx.types.uint(256),
             _ => {}
         }
 

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -52,7 +52,12 @@ contract C {
             udvt := add(udvtValue, 1)
             let udvtWordValue := udvtWord
             udvtWord := add(udvtWordValue, 1)
+            let yulTrue := true
+            let yulFalse := false
+            ok := yulTrue
+            ok := false
             ok := iszero(0)
+            pop(yulFalse)
             pop(ok)
             pop(memoryBytes)
 


### PR DESCRIPTION
Inline assembly boolean literals represent EVM stack words, but type checking preserved the Solidity bool type and rejected assignments to Yul locals or Solidity variables viewed as assembly words. This treats boolean literals as uint256 while checking Yul and extends the existing Yul type-check coverage with local and external assignments.

This fixes the failures found when type checking Solady reentrancy guard mocks.