### PR TITLE
refactor(interface): sync rustc diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ cargo run -- -Zhelp                    # Unstable flags help
 
 DO NOT USE `cargo test` DIRECTLY IF YOU CAN AVOID IT.
 
+NEVER RUN TESTS WITH `--all-features`. This enables "tracy" which has heavy overhead per-process, which the UI tests spawn lots of, increasing test times to minutes and 100% CPU for no reason.
+
 ## Architecture
 
 - **solar-parse**: Lexer and parser

--- a/crates/interface/src/diagnostics/builder.rs
+++ b/crates/interface/src/diagnostics/builder.rs
@@ -1,3 +1,7 @@
+//! Diagnostic builder lifecycle and emission guarantees.
+//!
+//! Modified from rustc's [`Diag`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/diagnostic.rs).
+
 use super::{
     Applicability, BugAbort, Diag, DiagCtxt, DiagId, DiagMsg, ErrorGuaranteed, ExplicitBug,
     FatalAbort, Level, MultiSpan, Span, Style, SuggestionStyle,
@@ -6,7 +10,6 @@ use solar_data_structures::Never;
 use std::{
     fmt,
     marker::PhantomData,
-    mem::ManuallyDrop,
     ops::{Deref, DerefMut},
     panic::Location,
 };
@@ -83,21 +86,14 @@ pub struct DiagBuilder<'a, G: EmissionGuarantee> {
     /// return value, especially within the frequently-used `PResult` type.
     /// In theory, return value optimization (RVO) should avoid unnecessary
     /// copying. In practice, it does not (at the time of writing).
-    diagnostic: Box<(Diag, &'a DiagCtxt)>,
+    diagnostic: Option<Box<(Diag, &'a DiagCtxt)>>,
 
     _marker: PhantomData<G>,
 }
 
-impl<G: EmissionGuarantee> Clone for DiagBuilder<'_, G> {
-    #[inline]
-    fn clone(&self) -> Self {
-        Self { diagnostic: self.diagnostic.clone(), _marker: PhantomData }
-    }
-}
-
 impl<G: EmissionGuarantee> fmt::Debug for DiagBuilder<'_, G> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.diagnostic.0.fmt(f)
+        self.diagnostic.as_ref().unwrap().0.fmt(f)
     }
 }
 
@@ -106,31 +102,31 @@ impl<G: EmissionGuarantee> Deref for DiagBuilder<'_, G> {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        &self.diagnostic.0
+        &self.diagnostic.as_ref().unwrap().0
     }
 }
 
 impl<G: EmissionGuarantee> DerefMut for DiagBuilder<'_, G> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.diagnostic.0
+        &mut self.diagnostic.as_mut().unwrap().0
     }
 }
 
 impl<G: EmissionGuarantee> Drop for DiagBuilder<'_, G> {
     #[track_caller]
     fn drop(&mut self) {
-        if std::thread::panicking() {
-            return;
+        if let Some(mut diagnostic) = self.diagnostic.take()
+            && !std::thread::panicking()
+        {
+            let (diag, dcx) = &mut *diagnostic;
+            let _ = dcx.emit_diagnostic(Diag::new(
+                Level::Bug,
+                "the following error was constructed but not emitted",
+            ));
+            let _ = dcx.emit_diagnostic_without_consuming(diag);
+            panic!("error was constructed but not emitted");
         }
-
-        let (diag, dcx) = &mut *self.diagnostic;
-        let _ = dcx.emit_diagnostic(Diag::new(
-            Level::Bug,
-            "the following error was constructed but not emitted",
-        ));
-        let _ = dcx.emit_diagnostic_without_consuming(diag);
-        panic!("error was constructed but not emitted");
     }
 }
 
@@ -139,13 +135,13 @@ impl<'a, G: EmissionGuarantee> DiagBuilder<'a, G> {
     #[inline(never)]
     #[track_caller]
     pub fn new<M: Into<DiagMsg>>(dcx: &'a DiagCtxt, level: Level, msg: M) -> Self {
-        Self { diagnostic: Box::new((Diag::new(level, msg), dcx)), _marker: PhantomData }
+        Self { diagnostic: Some(Box::new((Diag::new(level, msg), dcx))), _marker: PhantomData }
     }
 
     /// Returns the [`DiagCtxt`].
     #[inline]
     pub fn dcx(&self) -> &DiagCtxt {
-        self.diagnostic.1
+        self.diagnostic.as_ref().unwrap().1
     }
 
     /// Emits the diagnostic.
@@ -163,7 +159,7 @@ impl<'a, G: EmissionGuarantee> DiagBuilder<'a, G> {
     }
 
     fn emit_producing_error_guaranteed(&mut self) -> Result<(), ErrorGuaranteed> {
-        let (diag, dcx) = &mut *self.diagnostic;
+        let (diag, dcx) = &mut **self.diagnostic.as_mut().unwrap();
         dcx.emit_diagnostic_without_consuming(diag)
     }
 
@@ -174,10 +170,16 @@ impl<'a, G: EmissionGuarantee> DiagBuilder<'a, G> {
         self.consume_no_panic(|_| {});
     }
 
-    fn consume_no_panic<R>(self, f: impl FnOnce(&mut Self) -> R) -> R {
-        let mut this = ManuallyDrop::new(self);
-        let r = f(&mut *this);
-        unsafe { std::ptr::drop_in_place(&mut this.diagnostic) };
+    /// Cancels this diagnostic and returns its first message, if any.
+    pub fn cancel_into_message(self) -> Option<String> {
+        let message = self.messages.first().map(|(message, _)| message.to_string());
+        self.cancel();
+        message
+    }
+
+    fn consume_no_panic<R>(mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let r = f(&mut self);
+        self.diagnostic = None;
         r
     }
 }
@@ -195,7 +197,7 @@ macro_rules! forward {
             #[doc = concat!("See [`Diag::", stringify!($n), "()`].")]
             #[inline(never)]
             $vis fn $n(mut self, $($name: $ty),*) -> Self {
-                self.diagnostic.0.$n($($name),*);
+                self.diagnostic.as_mut().unwrap().0.$n($($name),*);
                 self
             }
         )*
@@ -207,9 +209,11 @@ impl<G: EmissionGuarantee> DiagBuilder<'_, G> {
     forward! {
         pub fn span(span: impl Into<MultiSpan>);
         pub fn code(code: impl Into<DiagId>);
+        pub fn primary_message(msg: impl Into<DiagMsg>);
 
         pub fn span_label(span: Span, label: impl Into<DiagMsg>);
         pub fn span_labels(spans: impl IntoIterator<Item = Span>, label: impl Into<DiagMsg>);
+        pub fn replace_span_with(after: Span, keep_label: bool);
 
         pub fn warn(msg: impl Into<DiagMsg>);
         pub fn span_warn(span: impl Into<MultiSpan>, msg: impl Into<DiagMsg>);
@@ -217,13 +221,24 @@ impl<G: EmissionGuarantee> DiagBuilder<'_, G> {
         pub fn note(msg: impl Into<DiagMsg>);
         pub fn span_note(span: impl Into<MultiSpan>, msg: impl Into<DiagMsg>);
         pub fn highlighted_note(messages: Vec<(impl Into<DiagMsg>, Style)>);
+        pub fn highlighted_span_note(
+            span: impl Into<MultiSpan>,
+            messages: Vec<(impl Into<DiagMsg>, Style)>
+        );
         pub fn note_once(msg: impl Into<DiagMsg>);
         pub fn span_note_once(span: impl Into<MultiSpan>, msg: impl Into<DiagMsg>);
 
         pub fn help(msg: impl Into<DiagMsg>);
         pub fn help_once(msg: impl Into<DiagMsg>);
         pub fn highlighted_help(messages: Vec<(impl Into<DiagMsg>, Style)>);
+        pub fn highlighted_span_help(
+            span: impl Into<MultiSpan>,
+            messages: Vec<(impl Into<DiagMsg>, Style)>
+        );
         pub fn span_help(span: impl Into<MultiSpan>, msg: impl Into<DiagMsg>);
+
+        pub fn disable_suggestions();
+        pub fn seal_suggestions();
 
         pub fn span_suggestion(
             span: Span,
@@ -238,6 +253,43 @@ impl<G: EmissionGuarantee> DiagBuilder<'_, G> {
             applicability: Applicability,
             style: SuggestionStyle
         );
+        pub fn span_suggestion_verbose(
+            span: Span,
+            msg: impl Into<DiagMsg>,
+            suggestion: impl Into<DiagMsg>,
+            applicability: Applicability,
+        );
+        pub fn span_suggestions(
+            span: Span,
+            msg: impl Into<DiagMsg>,
+            suggestions: impl IntoIterator<Item = DiagMsg>,
+            applicability: Applicability,
+        );
+        pub fn span_suggestions_with_style(
+            span: Span,
+            msg: impl Into<DiagMsg>,
+            suggestions: impl IntoIterator<Item = DiagMsg>,
+            applicability: Applicability,
+            style: SuggestionStyle,
+        );
+        pub fn span_suggestion_short(
+            span: Span,
+            msg: impl Into<DiagMsg>,
+            suggestion: impl Into<DiagMsg>,
+            applicability: Applicability,
+        );
+        pub fn span_suggestion_hidden(
+            span: Span,
+            msg: impl Into<DiagMsg>,
+            suggestion: impl Into<DiagMsg>,
+            applicability: Applicability,
+        );
+        pub fn tool_only_span_suggestion(
+            span: Span,
+            msg: impl Into<DiagMsg>,
+            suggestion: impl Into<DiagMsg>,
+            applicability: Applicability,
+        );
         pub fn multipart_suggestion(
             msg: impl Into<DiagMsg>,
             substitutions: Vec<(Span, DiagMsg)>,
@@ -248,6 +300,16 @@ impl<G: EmissionGuarantee> DiagBuilder<'_, G> {
             substitutions: Vec<(Span, DiagMsg)>,
             applicability: Applicability,
             style: SuggestionStyle
+        );
+        pub fn tool_only_multipart_suggestion(
+            msg: impl Into<DiagMsg>,
+            substitutions: Vec<(Span, DiagMsg)>,
+            applicability: Applicability,
+        );
+        pub fn multipart_suggestions(
+            msg: impl Into<DiagMsg>,
+            suggestions: impl IntoIterator<Item = Vec<(Span, DiagMsg)>>,
+            applicability: Applicability,
         );
     }
 }

--- a/crates/interface/src/diagnostics/context.rs
+++ b/crates/interface/src/diagnostics/context.rs
@@ -1,3 +1,7 @@
+//! Diagnostic collection, deduplication, counting, and emission.
+//!
+//! Modified from rustc's [`DiagCtxt`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/lib.rs).
+
 use super::{
     BugAbort, Diag, DiagBuilder, DiagMsg, DynEmitter, EmissionGuarantee, EmittedDiagnostics,
     ErrorGuaranteed, FatalAbort, HumanBufferEmitter, Level, MultiSpan, SilentEmitter,
@@ -274,6 +278,25 @@ impl DiagCtxt {
         self.with_flags(|f| f.can_emit_warnings = false)
     }
 
+    /// Returns whether warning diagnostics can be emitted.
+    pub fn can_emit_warnings(&self) -> bool {
+        self.inner.lock().flags.can_emit_warnings
+    }
+
+    /// Resets diagnostic counts and the deduplication cache.
+    ///
+    /// This is intended for tools that reuse a diagnostic context for multiple independent runs.
+    pub fn reset_err_count(&self) {
+        let mut inner = self.inner.lock();
+        inner.err_count = 0;
+        inner.deduplicated_err_count = 0;
+        inner.warn_count = 0;
+        inner.deduplicated_warn_count = 0;
+        inner.note_count = 0;
+        inner.deduplicated_note_count = 0;
+        inner.emitted_diagnostics.clear();
+    }
+
     /// Returns `true` if diagnostics are being tracked.
     pub fn track_diagnostics(&self) -> bool {
         self.inner.lock().flags.track_diagnostics
@@ -484,7 +507,7 @@ impl DiagCtxtInner {
             return Ok(());
         }
 
-        if matches!(diagnostic.level, Level::Error | Level::Fatal) && self.treat_err_as_bug() {
+        if matches!(diagnostic.level, Level::Error | Level::Fatal) && self.treat_next_err_as_bug() {
             diagnostic.level = Level::Bug;
         }
 
@@ -499,11 +522,8 @@ impl DiagCtxtInner {
                 !sub_already_emitted
             });
 
-            // if already_emitted {
-            //     diagnostic.note(
-            //         "duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`",
-            //     );
-            // }
+            // Unlike rustc, deduplication is only disabled internally for UI testing, so do not
+            // attach rustc's `-Z deduplicate-diagnostics=no` note.
 
             self.emitter.emit_diagnostic(diagnostic);
             if diagnostic.is_error() {
@@ -579,6 +599,11 @@ impl DiagCtxtInner {
 
     fn treat_err_as_bug(&self) -> bool {
         self.flags.treat_err_as_bug.is_some_and(|c| self.err_count >= c.get())
+    }
+
+    /// Use before incrementing `err_count`.
+    fn treat_next_err_as_bug(&self) -> bool {
+        self.flags.treat_err_as_bug.is_some_and(|c| self.err_count + 1 >= c.get())
     }
 
     fn is_allowed_diagnostic(&self, diagnostic: &Diag) -> bool {

--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -165,18 +165,18 @@ impl HumanEmitter {
 
     /// Sets whether to emit diagnostics in a way that is suitable for UI testing.
     pub fn ui_testing(mut self, yes: bool) -> Self {
-        self.set_ui_testing(yes);
+        self.renderer = self.renderer.anonymized_line_numbers(yes);
         self
     }
 
     /// Sets whether to emit diagnostics in a way that is suitable for UI testing.
     pub fn set_ui_testing(&mut self, yes: bool) {
-        self.renderer = self.renderer.clone().anonymized_line_numbers(yes);
+        self.renderer =
+            std::mem::replace(&mut self.renderer, DEFAULT_RENDERER).anonymized_line_numbers(yes);
     }
 
     /// Sets the human emitter kind (unicode vs short).
     pub fn human_kind(mut self, kind: HumanEmitterKind) -> Self {
-        self.short_message = matches!(kind, HumanEmitterKind::Short);
         match kind {
             HumanEmitterKind::Ascii => {
                 self.renderer = self.renderer.decor_style(DecorStyle::Ascii);
@@ -184,10 +184,12 @@ impl HumanEmitter {
             HumanEmitterKind::Unicode => {
                 self.renderer = self.renderer.decor_style(DecorStyle::Unicode);
             }
-            HumanEmitterKind::Short => {}
+            HumanEmitterKind::Short => {
+                self.short_message = true;
+                self.renderer = self.renderer.short_message(true);
+            }
             _ => unimplemented!("{kind:?}"),
         }
-        self.renderer = self.renderer.short_message(self.short_message);
         self
     }
 

--- a/crates/interface/src/diagnostics/emitter/human.rs
+++ b/crates/interface/src/diagnostics/emitter/human.rs
@@ -1,3 +1,7 @@
+//! Human-readable diagnostics rendered with `annotate-snippets`.
+//!
+//! Modified from rustc's [`AnnotateSnippetEmitter`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs).
+
 use super::{Diag, Emitter};
 use crate::{
     SourceMap, Span,
@@ -9,8 +13,8 @@ use crate::{
     source_map::{FileName, SourceFile},
 };
 use annotate_snippets::{
-    Annotation as ASAnnotation, AnnotationKind, Group, Level as ASLevel, Padding, Patch, Renderer,
-    Snippet, renderer::DecorStyle,
+    Annotation as ASAnnotation, AnnotationKind, Group, Level as ASLevel, Patch, Renderer, Snippet,
+    renderer::DecorStyle,
 };
 use anstream::{AutoStream, ColorChoice};
 use solar_config::HumanEmitterKind;
@@ -46,6 +50,7 @@ pub struct HumanEmitter {
     writer: AutoStream<Box<Writer>>,
     source_map: Option<Arc<SourceMap>>,
     renderer: Renderer,
+    short_message: bool,
 }
 
 // SAFETY: `real_writer` always points to the `Writer` in `writer`.
@@ -112,6 +117,7 @@ impl HumanEmitter {
             writer: AutoStream::new(real_writer, color),
             source_map: None,
             renderer: DEFAULT_RENDERER,
+            short_message: false,
         }
         .human_kind(Default::default())
     }
@@ -159,18 +165,18 @@ impl HumanEmitter {
 
     /// Sets whether to emit diagnostics in a way that is suitable for UI testing.
     pub fn ui_testing(mut self, yes: bool) -> Self {
-        self.renderer = self.renderer.anonymized_line_numbers(yes);
+        self.set_ui_testing(yes);
         self
     }
 
     /// Sets whether to emit diagnostics in a way that is suitable for UI testing.
     pub fn set_ui_testing(&mut self, yes: bool) {
-        self.renderer =
-            std::mem::replace(&mut self.renderer, DEFAULT_RENDERER).anonymized_line_numbers(yes);
+        self.renderer = self.renderer.clone().anonymized_line_numbers(yes);
     }
 
     /// Sets the human emitter kind (unicode vs short).
     pub fn human_kind(mut self, kind: HumanEmitterKind) -> Self {
+        self.short_message = matches!(kind, HumanEmitterKind::Short);
         match kind {
             HumanEmitterKind::Ascii => {
                 self.renderer = self.renderer.decor_style(DecorStyle::Ascii);
@@ -178,11 +184,10 @@ impl HumanEmitter {
             HumanEmitterKind::Unicode => {
                 self.renderer = self.renderer.decor_style(DecorStyle::Unicode);
             }
-            HumanEmitterKind::Short => {
-                self.renderer = self.renderer.short_message(true);
-            }
+            HumanEmitterKind::Short => {}
             _ => unimplemented!("{kind:?}"),
         }
+        self.renderer = self.renderer.short_message(self.short_message);
         self
     }
 
@@ -253,7 +258,12 @@ impl HumanEmitter {
             }));
 
             report.push(group);
-            if let Err(e) = emit_to_destination(renderer.render(&report), level, &mut self.writer) {
+            if let Err(e) = emit_to_destination(
+                renderer.render(&report),
+                level,
+                &mut self.writer,
+                self.short_message,
+            ) {
                 panic!("failed to emit error: {e}");
             }
             return;
@@ -316,17 +326,6 @@ impl HumanEmitter {
             }
         }
 
-        let suggestions_expected = suggestions
-            .iter()
-            .filter(|s| {
-                matches!(
-                    s.style,
-                    SuggestionStyle::HideCodeInline
-                        | SuggestionStyle::ShowCode
-                        | SuggestionStyle::ShowAlways
-                )
-            })
-            .count();
         for suggestion in suggestions.unwrap_tag() {
             match suggestion.style {
                 SuggestionStyle::CompletelyHidden => {
@@ -345,31 +344,43 @@ impl HumanEmitter {
                         .cloned() // clone is required to sort and filter duplicated spans
                         .filter_map(|mut subst| {
                             // Suggestions coming from macros can have malformed spans. This is a
-                            // heavy handed approach to avoid ICEs by
-                            // ignoring the suggestion outright.
+                            // heavy handed approach to avoid ICEs by ignoring the suggestion
+                            // outright.
                             let invalid =
                                 subst.parts.iter().any(|item| sm.is_valid_span(item.span).is_err());
                             if invalid {
                                 debug!("suggestion contains an invalid span: {:?}", subst);
+                                return None;
                             }
 
                             // Assumption: all spans are in the same file, and all spans
                             // are disjoint. Sort in ascending order.
                             subst.parts.sort_by_key(|part| part.span.lo());
-                            // Verify the assumption that all spans are disjoint
-                            assert_eq!(
+                            // Verify the assumption that all spans are disjoint.
+                            debug_assert_eq!(
                                 subst.parts.windows(2).find(|s| s[0].span.overlaps(s[1].span)),
                                 None,
                                 "all spans must be disjoint",
                             );
 
+                            let lo = subst.parts.iter().map(|part| part.span.lo()).min()?;
+                            let lo_file = sm.lookup_source_file(lo);
+                            let hi = subst.parts.iter().map(|part| part.span.hi()).max()?;
+                            let hi_file = sm.lookup_source_file(hi);
+
+                            // The different spans might belong to different files. If so, ignore
+                            // the suggestion.
+                            if lo_file.start_pos != hi_file.start_pos {
+                                return None;
+                            }
+
                             // Account for cases where we are suggesting the same code that's
-                            // already there. This shouldn't happen
-                            // often, but in some cases for multipart
-                            // suggestions it's much easier to handle it here than in the origin.
+                            // already there. This shouldn't happen often, but in some cases for
+                            // multipart suggestions it's much easier to handle it here than in the
+                            // origin.
                             subst.parts.retain(|p| is_different(sm, &p.snippet, p.span));
 
-                            if !invalid { Some(subst) } else { None }
+                            if subst.parts.is_empty() { None } else { Some(subst) }
                         })
                         .collect::<Vec<_>>();
 
@@ -422,7 +433,7 @@ impl HumanEmitter {
 
                                 // Unlike rustc, there is no attribute suggestion in Solidity (yet).
                                 // When similar feature to attribute arrives, refer to rustc's
-                                // implementation https://github.com/rust-lang/rust/blob/4146079cee94242771864147e32fb5d9adbd34f8/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs#L424
+                                // implementation https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs#L405
                                 let fold = true;
 
                                 if let Some((bounding_span, source, line_offset)) =
@@ -472,17 +483,16 @@ impl HumanEmitter {
             }
         }
 
-        // FIXME: This hack should be removed once annotate_snippets is the
-        // default emitter.
-        if suggestions_expected > 0 && report.is_empty() {
-            group = group.element(Padding);
-        }
-
         if !group.is_empty() {
             report.push(group);
         }
 
-        if let Err(e) = emit_to_destination(renderer.render(&report), level, &mut self.writer) {
+        if let Err(e) = emit_to_destination(
+            renderer.render(&report),
+            level,
+            &mut self.writer,
+            self.short_message,
+        ) {
             panic!("failed to emit error: {e}");
         }
     }
@@ -498,8 +508,7 @@ impl HumanEmitter {
     }
 
     // Unlike rustc, there is no translation.
-    // Since the behavior of `translator.translate_messages` does not contains styling,
-    // this function to concatenate messages instead can be used.
+    // Since rustc's message formatting doesn't add styling, concatenating the messages is enough.
     fn no_style_msgs(&self, msgs: &[(DiagMsg, Style)]) -> String {
         msgs.iter().map(|(m, _)| m.as_str()).collect()
     }
@@ -615,14 +624,16 @@ impl HumanBufferEmitter {
 }
 
 fn annotation_level_for_level<'a>(level: Level) -> ASLevel<'a> {
-    match level {
-        Level::Bug | Level::Fatal | Level::Error | Level::FailureNote => ASLevel::ERROR,
+    let name = level.to_str();
+    let annotation_level = match level {
+        Level::Bug | Level::Fatal | Level::Error => ASLevel::ERROR,
         Level::Warning => ASLevel::WARNING,
         Level::Note | Level::OnceNote => ASLevel::NOTE,
         Level::Help | Level::OnceHelp => ASLevel::HELP,
-        Level::Allow => ASLevel::INFO,
-    }
-    .with_name(if level == Level::FailureNote { None } else { Some(level.to_str()) })
+        Level::FailureNote => return ASLevel::NOTE.no_name(),
+        Level::Allow => panic!("should not render a diagnostic with `Allow` level"),
+    };
+    annotation_level.with_name(Some(name))
 }
 
 fn stderr_choice(color_choice: ColorChoice) -> ColorChoice {
@@ -634,13 +645,18 @@ fn stderr_choice(color_choice: ColorChoice) -> ColorChoice {
     }
 }
 
-fn emit_to_destination(rendered: String, lvl: &Level, dst: &mut Writer) -> io::Result<()> {
+fn emit_to_destination(
+    rendered: String,
+    lvl: &Level,
+    dst: &mut Writer,
+    short_message: bool,
+) -> io::Result<()> {
     // Unlike rustc, there is no lock
     // use crate::lock;
     // let _buffer_lock = lock::acquire_global_lock("rustc_errors");
 
     writeln!(dst, "{rendered}")?;
-    if !lvl.is_failure_note() {
+    if !short_message && !lvl.is_failure_note() {
         writeln!(dst)?;
     }
     dst.flush()?;
@@ -714,7 +730,7 @@ fn shrink_file(
     }
 
     let lo = lo_loc.file.line_bounds(lo_loc.line.saturating_sub(1)).start;
-    let hi = lo_loc.file.line_bounds(hi_loc.line.saturating_sub(1)).end;
+    let hi = hi_loc.file.line_bounds(hi_loc.line.saturating_sub(1)).end;
 
     let bounding_span = Span::new(lo, hi);
     let source = sm.span_to_snippet(bounding_span).ok()?;

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -508,7 +508,7 @@ mod tests {
         source_map
             .new_source_file(crate::source_map::FileName::custom("test.sol"), "foo\nbar\n")
             .unwrap();
-        let emitter = JsonEmitter::new(Box::new(io::sink()), source_map);
+        let emitter = JsonEmitter::new(Box::new(io::sink()), source_map, ColorChoice::Never);
 
         let span = emitter.span_with_suggestion(
             Span::new(crate::BytePos(0), crate::BytePos(3)),

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -1,7 +1,14 @@
+//! JSON diagnostics, including rustc-compatible and solc-compatible representations.
+//!
+//! The rustc-compatible representation is modified from rustc's [`JsonEmitter`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/json.rs).
+//! It preserves this codebase's source-map model, which has no macro expansion metadata.
+
 use super::{Emitter, human::HumanBufferEmitter, io_panic};
 use crate::{
     Span,
-    diagnostics::{CodeSuggestion, Diag, Level, MultiSpan, SpanLabel, SubDiagnostic},
+    diagnostics::{
+        Applicability, CodeSuggestion, Diag, Level, MultiSpan, SpanLabel, SubDiagnostic,
+    },
     source_map::{LineInfo, SourceFile, SourceMap},
 };
 use anstream::ColorChoice;
@@ -125,7 +132,9 @@ impl JsonEmitter {
             .substitutions
             .iter()
             .flat_map(|sub| sub.parts.iter())
-            .map(|part| self.span_with_suggestion(part.span, part.snippet.to_string()))
+            .map(|part| {
+                self.span_with_suggestion(part.span, part.snippet.to_string(), sugg.applicability)
+            })
             .collect();
 
         JsonDiagnostic {
@@ -159,11 +168,33 @@ impl JsonEmitter {
             text: self.span_lines(span),
             label: label.label.as_ref().map(|msg| Cow::Owned(msg.as_str().to_string())),
             suggested_replacement: None,
+            suggestion_applicability: None,
+            expansion: None,
         }
     }
 
-    fn span_with_suggestion(&self, span: Span, replacement: String) -> JsonDiagnosticSpan<'static> {
+    fn span_with_suggestion(
+        &self,
+        span: Span,
+        replacement: String,
+        applicability: Applicability,
+    ) -> JsonDiagnosticSpan<'static> {
         let sm = &**self.source_map();
+        let start = sm.lookup_char_pos(span.lo());
+        let span = if start.col.0 == 0
+            && replacement.is_empty()
+            && span.hi() < start.file.end_position()
+            && start.file.contains(span.hi())
+            && start
+                .file
+                .src
+                .get(start.file.relative_position(span.hi()).to_usize()..)
+                .is_some_and(|after| after.starts_with('\n'))
+        {
+            span.with_hi(span.hi() + crate::BytePos(1))
+        } else {
+            span
+        };
         let start = sm.lookup_char_pos(span.lo());
         let end = sm.lookup_char_pos(span.hi());
         JsonDiagnosticSpan {
@@ -178,6 +209,8 @@ impl JsonEmitter {
             text: self.span_lines(span),
             label: None,
             suggested_replacement: Some(Cow::Owned(replacement)),
+            suggestion_applicability: Some(applicability),
+            expansion: None,
         }
     }
 
@@ -306,7 +339,7 @@ pub struct JsonDiagnostic<'a> {
     /// The diagnostic code.
     #[serde(borrow)]
     pub code: Option<JsonDiagnosticCode<'a>>,
-    /// "error", "warning", "note", "help".
+    /// "error: internal compiler error", "error", "warning", "note", or "help".
     #[serde(borrow)]
     pub level: Cow<'a, str>,
     /// The diagnostic spans.
@@ -351,6 +384,25 @@ pub struct JsonDiagnosticSpan<'a> {
     /// that should be sliced in atop this span.
     #[serde(borrow)]
     pub suggested_replacement: Option<Cow<'a, str>>,
+    /// How confidently the suggested replacement can be applied.
+    pub suggestion_applicability: Option<Applicability>,
+    /// Macro expansion that produced this span, if available.
+    #[serde(borrow)]
+    pub expansion: Option<Box<JsonDiagnosticSpanMacroExpansion<'a>>>,
+}
+
+/// A macro expansion represented in a rustc-like JSON diagnostic span.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonDiagnosticSpanMacroExpansion<'a> {
+    /// The span where the macro was invoked.
+    #[serde(borrow)]
+    pub span: JsonDiagnosticSpan<'a>,
+    /// The macro declaration name.
+    #[serde(borrow)]
+    pub macro_decl_name: Cow<'a, str>,
+    /// The span where the macro was defined.
+    #[serde(borrow)]
+    pub def_site_span: JsonDiagnosticSpan<'a>,
 }
 
 /// A source line in a rustc-like JSON diagnostic span.
@@ -443,6 +495,28 @@ fn to_severity(level: Level) -> Severity {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn whole_line_deletion_includes_newline() {
+        let source_map = Arc::new(SourceMap::empty());
+        source_map
+            .new_source_file(crate::source_map::FileName::custom("test.sol"), "foo\nbar\n")
+            .unwrap();
+        let emitter = JsonEmitter::new(Box::new(io::sink()), source_map);
+
+        let span = emitter.span_with_suggestion(
+            Span::new(crate::BytePos(0), crate::BytePos(3)),
+            String::new(),
+            Applicability::MachineApplicable,
+        );
+
+        assert_eq!(span.byte_start, 0);
+        assert_eq!(span.byte_end, 4);
+        assert_eq!(span.line_start, 1);
+        assert_eq!(span.line_end, 2);
+        assert_eq!(span.column_end, 1);
+        assert!(span.expansion.is_none());
+    }
 
     #[test]
     fn solc_diagnostic_serializes_borrowed_strings() {

--- a/crates/interface/src/diagnostics/emitter/mod.rs
+++ b/crates/interface/src/diagnostics/emitter/mod.rs
@@ -1,4 +1,8 @@
-use super::{Diag, Level, MultiSpan, SuggestionStyle};
+//! Diagnostic emitter interfaces and shared rendering helpers.
+//!
+//! Modified from rustc's [`Emitter`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/emitter.rs).
+
+use super::{ConfusionType, Diag, Level, MultiSpan, SuggestionStyle, detect_confusion_type};
 use crate::{SourceMap, diagnostics::Suggestions};
 use std::{any::Any, borrow::Cow, sync::Arc};
 
@@ -10,7 +14,8 @@ mod json;
 #[cfg(feature = "json")]
 pub use json::{
     JsonDiagnostic, JsonDiagnosticCode, JsonDiagnosticMessage, JsonDiagnosticSpan,
-    JsonDiagnosticSpanLine, JsonEmitter, Severity, SolcDiagnostic, SourceLocation,
+    JsonDiagnosticSpanLine, JsonDiagnosticSpanMacroExpansion, JsonEmitter, Severity,
+    SolcDiagnostic, SourceLocation,
 };
 
 mod mem;
@@ -46,11 +51,11 @@ pub trait Emitter: Any {
     ///
     /// There are a lot of conditions to this method, but in short:
     ///
-    /// * If the current `DiagInner` has only one visible `CodeSuggestion`, we format the `help`
+    /// * If the current `Diag` has only one visible `CodeSuggestion`, we format the `help`
     ///   suggestion depending on the content of the substitutions. In that case, we modify the span
     ///   and clear the suggestions.
     ///
-    /// * If the current `DiagInner` has multiple suggestions, we leave `primary_span` and the
+    /// * If the current `Diag` has multiple suggestions, we leave `primary_span` and the
     ///   suggestions untouched.
     fn primary_span_formatted<'a>(
         &self,
@@ -84,7 +89,11 @@ pub trait Emitter: Any {
                 // code inline (`hide_inline`). Therefore, we don't show the substitution.
                 format!("help: {}", sugg.msg.as_str())
             } else {
-                format!("help: {}: `{}`", sugg.msg.as_str(), snippet)
+                let confusion_type = self
+                    .source_map()
+                    .map(|sm| detect_confusion_type(sm, snippet, part.span))
+                    .unwrap_or(ConfusionType::None);
+                format!("help: {}{}: `{}`", sugg.msg.as_str(), confusion_type.label_text(), snippet)
             };
             primary_span.to_mut().push_span_label(part.span, msg);
 

--- a/crates/interface/src/diagnostics/message.rs
+++ b/crates/interface/src/diagnostics/message.rs
@@ -1,4 +1,4 @@
-//! Modified from [`rustc_error_messages`](https://github.com/rust-lang/rust/blob/520e30be83b4ed57b609d33166c988d1512bf4f3/compiler/rustc_error_messages/src/lib.rs).
+//! Modified from [`rustc_error_messages`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_error_messages/src/lib.rs).
 
 use crate::Span;
 use std::{borrow::Cow, ops::Deref};
@@ -89,8 +89,18 @@ impl MultiSpan {
         Self { primary_spans: vec, span_labels: vec![] }
     }
 
+    /// Adds a primary span.
+    pub fn push_primary_span(&mut self, primary_span: Span) {
+        self.primary_spans.push(primary_span);
+    }
+
     pub fn push_span_label(&mut self, span: Span, label: impl Into<DiagMsg>) {
         self.span_labels.push((span, label.into()));
+    }
+
+    /// Adds an already constructed diagnostic message as a span label.
+    pub fn push_span_diag(&mut self, span: Span, diag: DiagMsg) {
+        self.span_labels.push((span, diag));
     }
 
     /// Selects the first primary span (if any).
@@ -132,10 +142,6 @@ impl MultiSpan {
         replacements_occurred
     }
 
-    pub fn pop_span_label(&mut self) -> Option<(Span, DiagMsg)> {
-        self.span_labels.pop()
-    }
-
     /// Returns the strings to highlight. We always ensure that there
     /// is an entry for each of the primary spans -- for each primary
     /// span `P`, if there is at least one label with span `P`, we return
@@ -163,15 +169,17 @@ impl MultiSpan {
         span_labels
     }
 
+    /// Returns the span labels as stored by this `MultiSpan`.
+    pub fn span_labels_raw(&self) -> &[(Span, DiagMsg)] {
+        &self.span_labels
+    }
+
     /// Returns `true` if any of the span labels is displayable.
     pub fn has_span_labels(&self) -> bool {
         self.span_labels.iter().any(|(sp, _)| !sp.is_dummy())
     }
 
-    /// Clone this `MultiSpan` without keeping any of the span labels - sometimes a `MultiSpan` is
-    /// to be re-used in another diagnostic, but includes `span_labels` which have translated
-    /// messages. These translated messages would fail to translate without their diagnostic
-    /// arguments which are unlikely to be cloned alongside the `Span`.
+    /// Clones this `MultiSpan` without keeping any span labels.
     pub fn clone_ignoring_labels(&self) -> Self {
         Self { primary_spans: self.primary_spans.clone(), ..Self::new() }
     }

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1,6 +1,7 @@
 //! Diagnostics implementation.
 //!
-//! Modified from [`rustc_errors`](https://github.com/rust-lang/rust/blob/520e30be83b4ed57b609d33166c988d1512bf4f3/compiler/rustc_errors/src/diagnostic.rs).
+//! Modified from rustc's [`diagnostic.rs`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/diagnostic.rs)
+//! and [`lib.rs`](https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/lib.rs).
 
 use crate::{SourceMap, Span};
 use anstyle::{AnsiColor, Color};
@@ -27,7 +28,8 @@ pub use emitter::{
 #[cfg(feature = "json")]
 pub use emitter::{
     JsonDiagnostic, JsonDiagnosticCode, JsonDiagnosticMessage, JsonDiagnosticSpan,
-    JsonDiagnosticSpanLine, JsonEmitter, Severity, SolcDiagnostic, SourceLocation,
+    JsonDiagnosticSpanLine, JsonDiagnosticSpanMacroExpansion, JsonEmitter, Severity,
+    SolcDiagnostic, SourceLocation,
 };
 
 mod message;
@@ -225,13 +227,14 @@ impl Level {
     #[inline]
     pub fn is_error(self) -> bool {
         match self {
-            Self::Bug | Self::Fatal | Self::Error | Self::FailureNote => true,
+            Self::Bug | Self::Fatal | Self::Error => true,
 
             Self::Warning
             | Self::Note
             | Self::OnceNote
             | Self::Help
             | Self::OnceHelp
+            | Self::FailureNote
             | Self::Allow => false,
         }
     }
@@ -275,7 +278,7 @@ impl Level {
     /// Returns the ANSI color of this level.
     #[inline]
     pub const fn ansi_color(self) -> Option<AnsiColor> {
-        // https://github.com/rust-lang/rust/blob/99472c7049783605444ab888a97059d0cce93a12/compiler/rustc_errors/src/lib.rs#L1768
+        // https://github.com/rust-lang/rust/blob/3b58636b30eb364ac72aeaf03d46347084ed87d1/compiler/rustc_errors/src/lib.rs#L1646
         match self {
             Self::Bug | Self::Fatal | Self::Error => Some(AnsiColor::BrightRed),
             Self::Warning => {
@@ -285,6 +288,12 @@ impl Level {
             Self::Help | Self::OnceHelp => Some(AnsiColor::BrightCyan),
             Self::FailureNote | Self::Allow => None,
         }
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.to_str().fmt(f)
     }
 }
 
@@ -316,7 +325,6 @@ impl Style {
         /// See [rust-lang/rust#36178](https://github.com/rust-lang/rust/pull/36178).
         const BRIGHT_BLUE: Color = Color::Ansi(if cfg!(windows) { BrightCyan } else { BrightBlue });
         const GREEN: Color = Color::Ansi(BrightGreen);
-        const MAGENTA: Color = Color::Ansi(BrightMagenta);
         const RED: Color = Color::Ansi(BrightRed);
         const WHITE: Color = Color::Ansi(BrightWhite);
 
@@ -332,7 +340,7 @@ impl Style {
             Self::UnderlineSecondary | Self::LabelSecondary => s.fg_color(Some(BRIGHT_BLUE)).bold(),
             Self::HeaderMsg | Self::NoStyle => s,
             Self::Level(level2) => s.fg_color(level2.color()).bold(),
-            Self::Highlight => s.fg_color(Some(MAGENTA)).bold(),
+            Self::Highlight => s.fg_color(Some(Color::Ansi(Magenta))).bold(),
         }
     }
 }
@@ -753,6 +761,12 @@ impl Diag {
         self
     }
 
+    /// Sets the primary message of this diagnostic.
+    pub fn primary_message(&mut self, msg: impl Into<DiagMsg>) -> &mut Self {
+        self.messages[0] = (msg.into(), Style::NoStyle);
+        self
+    }
+
     /// Adds a span/label to be included in the resulting snippet.
     ///
     /// This is pushed onto the [`MultiSpan`] that was created when the diagnostic
@@ -776,6 +790,22 @@ impl Diag {
         let label = label.into();
         for span in spans {
             self.span_label(span, label.clone());
+        }
+        self
+    }
+
+    /// Replaces the primary span while preserving secondary labels.
+    pub fn replace_span_with(&mut self, after: Span, keep_label: bool) -> &mut Self {
+        let before = self.span.clone();
+        self.span(after);
+        for span_label in before.span_labels() {
+            if let Some(label) = span_label.label {
+                if span_label.is_primary && keep_label {
+                    self.span.push_span_label(after, label);
+                } else {
+                    self.span.push_span_label(span_label.span, label);
+                }
+            }
         }
         self
     }
@@ -819,6 +849,15 @@ impl Diag {
         self.sub_with_highlights(Level::Note, messages, MultiSpan::new())
     }
 
+    /// Adds a note with a span and customizable highlighted messages.
+    pub fn highlighted_span_note(
+        &mut self,
+        span: impl Into<MultiSpan>,
+        messages: Vec<(impl Into<DiagMsg>, Style)>,
+    ) -> &mut Self {
+        self.sub_with_highlights(Level::Note, messages, span.into())
+    }
+
     /// Prints the span with a note above it.
     /// This is like [`Diag::note()`], but it gets emitted only once.
     pub fn note_once(&mut self, msg: impl Into<DiagMsg>) -> &mut Self {
@@ -849,6 +888,15 @@ impl Diag {
     /// Add a help message attached to this diagnostic with a customizable highlighted message.
     pub fn highlighted_help(&mut self, msgs: Vec<(impl Into<DiagMsg>, Style)>) -> &mut Self {
         self.sub_with_highlights(Level::Help, msgs, MultiSpan::new())
+    }
+
+    /// Adds a help message with a span and customizable highlighted messages.
+    pub fn highlighted_span_help(
+        &mut self,
+        span: impl Into<MultiSpan>,
+        messages: Vec<(impl Into<DiagMsg>, Style)>,
+    ) -> &mut Self {
+        self.sub_with_highlights(Level::Help, messages, span.into())
     }
 
     /// Prints the span with some help above it.
@@ -958,9 +1006,14 @@ impl Diag {
         applicability: Applicability,
         style: SuggestionStyle,
     ) -> &mut Self {
+        let suggestion = suggestion.into();
+        debug_assert!(
+            !(span.lo() == span.hi() && suggestion.is_empty()),
+            "span must not be empty and have no suggestion"
+        );
         self.push_suggestion(CodeSuggestion {
             substitutions: vec![Substitution {
-                parts: vec![SubstitutionPart { snippet: suggestion.into(), span }],
+                parts: vec![SubstitutionPart { snippet: suggestion, span }],
             }],
             msg: msg.into(),
             style,
@@ -969,7 +1022,120 @@ impl Diag {
         self
     }
 
-    /// Show a suggestion that has multiple parts to it.
+    /// Always shows the suggested change as its own subdiagnostic.
+    pub fn span_suggestion_verbose(
+        &mut self,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        suggestion: impl Into<DiagMsg>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.span_suggestion_with_style(
+            span,
+            msg,
+            suggestion,
+            applicability,
+            SuggestionStyle::ShowAlways,
+        )
+    }
+
+    /// Prints a message with multiple alternative suggested edits of the same span.
+    pub fn span_suggestions(
+        &mut self,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        suggestions: impl IntoIterator<Item = DiagMsg>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.span_suggestions_with_style(
+            span,
+            msg,
+            suggestions,
+            applicability,
+            SuggestionStyle::ShowAlways,
+        )
+    }
+
+    /// [`Diag::span_suggestions()`] but with a configurable [`SuggestionStyle`].
+    pub fn span_suggestions_with_style(
+        &mut self,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        suggestions: impl IntoIterator<Item = DiagMsg>,
+        applicability: Applicability,
+        style: SuggestionStyle,
+    ) -> &mut Self {
+        let substitutions = suggestions
+            .into_iter()
+            .map(|snippet| {
+                debug_assert!(
+                    !(span.lo() == span.hi() && snippet.is_empty()),
+                    "span `{span:?}` must not be empty and have no suggestion"
+                );
+                Substitution { parts: vec![SubstitutionPart { span, snippet }] }
+            })
+            .collect();
+        self.push_suggestion(CodeSuggestion {
+            substitutions,
+            msg: msg.into(),
+            style,
+            applicability,
+        });
+        self
+    }
+
+    /// Prints a suggestion inline without displaying its replacement code.
+    pub fn span_suggestion_short(
+        &mut self,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        suggestion: impl Into<DiagMsg>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.span_suggestion_with_style(
+            span,
+            msg,
+            suggestion,
+            applicability,
+            SuggestionStyle::HideCodeInline,
+        )
+    }
+
+    /// Prints a suggestion message without displaying its replacement code.
+    pub fn span_suggestion_hidden(
+        &mut self,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        suggestion: impl Into<DiagMsg>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.span_suggestion_with_style(
+            span,
+            msg,
+            suggestion,
+            applicability,
+            SuggestionStyle::HideCodeAlways,
+        )
+    }
+
+    /// Adds a suggestion for tools without displaying it in human-readable output.
+    pub fn tool_only_span_suggestion(
+        &mut self,
+        span: Span,
+        msg: impl Into<DiagMsg>,
+        suggestion: impl Into<DiagMsg>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.span_suggestion_with_style(
+            span,
+            msg,
+            suggestion,
+            applicability,
+            SuggestionStyle::CompletelyHidden,
+        )
+    }
+
+    /// Shows a multipart suggestion as its own subdiagnostic.
     /// In other words, multiple changes need to be applied as part of this suggestion.
     pub fn multipart_suggestion(
         &mut self,
@@ -981,7 +1147,7 @@ impl Diag {
             msg,
             substitutions,
             applicability,
-            SuggestionStyle::ShowCode,
+            SuggestionStyle::ShowAlways,
         );
         self
     }
@@ -990,19 +1156,92 @@ impl Diag {
     pub fn multipart_suggestion_with_style(
         &mut self,
         msg: impl Into<DiagMsg>,
-        substitutions: Vec<(Span, DiagMsg)>,
+        mut substitutions: Vec<(Span, DiagMsg)>,
         applicability: Applicability,
         style: SuggestionStyle,
     ) -> &mut Self {
+        let mut seen = solar_data_structures::map::FxHashSet::default();
+        substitutions.retain(|(span, msg)| seen.insert((span.lo(), span.hi(), msg.clone())));
+
+        let parts = substitutions
+            .into_iter()
+            .map(|(span, snippet)| SubstitutionPart { span, snippet })
+            .collect::<Vec<_>>();
+
+        assert!(!parts.is_empty());
+        debug_assert_eq!(
+            parts.iter().find(|part| part.span.lo() == part.span.hi() && part.snippet.is_empty()),
+            None,
+            "span must not be empty and have no suggestion",
+        );
+        debug_assert_eq!(
+            parts.windows(2).find(|parts| parts[0].span.overlaps(parts[1].span)),
+            None,
+            "suggestion must not have overlapping parts",
+        );
+
         self.push_suggestion(CodeSuggestion {
-            substitutions: vec![Substitution {
-                parts: substitutions
-                    .into_iter()
-                    .map(|(span, snippet)| SubstitutionPart { span, snippet })
-                    .collect(),
-            }],
+            substitutions: vec![Substitution { parts }],
             msg: msg.into(),
             style,
+            applicability,
+        });
+        self
+    }
+
+    /// Adds a multipart suggestion for tools without displaying it in human-readable output.
+    pub fn tool_only_multipart_suggestion(
+        &mut self,
+        msg: impl Into<DiagMsg>,
+        substitutions: Vec<(Span, DiagMsg)>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        self.multipart_suggestion_with_style(
+            msg,
+            substitutions,
+            applicability,
+            SuggestionStyle::CompletelyHidden,
+        )
+    }
+
+    /// Prints multiple alternative multipart suggestions.
+    pub fn multipart_suggestions(
+        &mut self,
+        msg: impl Into<DiagMsg>,
+        suggestions: impl IntoIterator<Item = Vec<(Span, DiagMsg)>>,
+        applicability: Applicability,
+    ) -> &mut Self {
+        let substitutions = suggestions
+            .into_iter()
+            .map(|suggestion| {
+                let mut parts = suggestion
+                    .into_iter()
+                    .map(|(span, snippet)| SubstitutionPart { span, snippet })
+                    .collect::<Vec<_>>();
+                parts.sort_unstable_by_key(|part| part.span);
+
+                assert!(!parts.is_empty());
+                debug_assert_eq!(
+                    parts
+                        .iter()
+                        .find(|part| part.span.lo() == part.span.hi() && part.snippet.is_empty()),
+                    None,
+                    "span must not be empty and have no suggestion",
+                );
+                debug_assert_eq!(
+                    parts.windows(2).find(|parts| parts[0].span.overlaps(parts[1].span)),
+                    None,
+                    "suggestion must not have overlapping parts",
+                );
+
+                Substitution { parts }
+            })
+            .collect();
+
+        self.push_suggestion(CodeSuggestion {
+            substitutions,
+            msg: msg.into(),
+            style: SuggestionStyle::ShowAlways,
             applicability,
         });
         self
@@ -1052,6 +1291,7 @@ mod tests {
     #[cfg(feature = "json")]
     use snapbox::IntoData as _;
     use snapbox::{assert_data_eq, str};
+    use solar_config::HumanEmitterKind;
 
     #[test]
     fn test_styled_messages() {
@@ -1071,6 +1311,22 @@ mod tests {
         assert_data_eq!(
             &*sub.label_with_style(true),
             str!["plain text [91mremoved[0m middle [92madded[0m"]
+        );
+    }
+
+    #[test]
+    fn test_short_message_has_no_extra_separator() {
+        let mut emitter =
+            HumanBufferEmitter::new(ColorChoice::Never).human_kind(HumanEmitterKind::Short);
+        emitter.inner_mut().set_ui_testing(true);
+        emitter.emit_diagnostic(&mut Diag::new(Level::Error, "boom"));
+
+        assert_data_eq!(
+            emitter.buffer(),
+            str![[r#"
+error: boom
+
+"#]]
         );
     }
 
@@ -1124,6 +1380,31 @@ note: mutable variables should use mixedCase
     }
 
     #[test]
+    fn test_inline_suggestion_marks_confusable_case() {
+        let span = Span::new(BytePos(43), BytePos(47));
+        let mut diag = Diag::new(Level::Warning, "confusable spelling");
+        diag.span(span).span_suggestion(
+            span,
+            "capitalize this",
+            "View",
+            Applicability::MachineApplicable,
+        );
+
+        assert_data_eq!(
+            emit_human_diagnostics(diag),
+            str![[r#"
+warning: confusable spelling
+  ╭▸ <test.sol>:3:27
+  │
+3 │     function foo() public view {
+  ╰╴                          ━━━━ help: capitalize this (notice the capitalization): `View`
+
+
+"#]]
+        );
+    }
+
+    #[test]
     fn test_allowed_diagnostic_code_suppresses_warning() {
         let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never)
             .with_allowed_diagnostic_codes(["1234".to_string()]);
@@ -1146,6 +1427,70 @@ note: mutable variables should use mixedCase
 
         assert!(dcx.has_errors().is_err());
         assert!(dcx.emitted_diagnostics().unwrap().to_string().contains("emitted error"));
+    }
+
+    #[test]
+    fn test_reset_err_count_clears_deduplication_cache() {
+        let (emitter, diagnostics) = InMemoryEmitter::new();
+        let dcx = DiagCtxt::new(Box::new(emitter)).with_flags(|flags| {
+            flags.track_diagnostics = false;
+        });
+
+        for _ in 0..2 {
+            let _ = dcx.err("duplicate").emit();
+        }
+        assert_eq!(dcx.err_count(), 2);
+        assert_eq!(diagnostics.read().len(), 1);
+
+        dcx.reset_err_count();
+        assert_eq!(dcx.err_count(), 0);
+
+        let _ = dcx.err("duplicate").emit();
+        assert_eq!(dcx.err_count(), 1);
+        assert_eq!(diagnostics.read().len(), 2);
+    }
+
+    #[test]
+    fn test_once_subdiagnostic_is_collected_once() {
+        let (emitter, diagnostics) = InMemoryEmitter::new();
+        let dcx = DiagCtxt::new(Box::new(emitter)).with_flags(|flags| {
+            flags.track_diagnostics = false;
+        });
+
+        let _ = dcx.err("first").note_once("shared note").emit();
+        let _ = dcx.err("second").note_once("shared note").emit();
+
+        let diagnostics = diagnostics.read();
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].children.len(), 1);
+        assert!(diagnostics[1].children.is_empty());
+    }
+
+    #[test]
+    fn test_treat_first_error_as_bug() {
+        let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never).with_flags(|flags| {
+            flags.track_diagnostics = false;
+            flags.treat_err_as_bug = std::num::NonZeroUsize::new(1);
+        });
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            dcx.err("boom").emit();
+        }));
+
+        assert!(result.is_err());
+        assert_data_eq!(
+            dcx.emitted_diagnostics().unwrap().to_string(),
+            str![[r#"
+error: internal compiler error: boom
+
+
+"#]]
+        );
+    }
+
+    #[test]
+    fn test_failure_note_is_not_an_error() {
+        assert!(!Level::FailureNote.is_error());
     }
 
     #[test]
@@ -1225,19 +1570,19 @@ help: mutable variables should use mixedCase
 
     #[test]
     fn test_multispan_suggestion() {
-        let (pub_span, pub_sugg) = (Span::new(BytePos(36), BytePos(42)), "external".into());
-        let (view_span, view_sugg) = (Span::new(BytePos(43), BytePos(47)), "pure".into());
+        let (pub_span, pub_sugg) = (Span::new(BytePos(36), BytePos(42)), DiagMsg::from("external"));
+        let (view_span, view_sugg) = (Span::new(BytePos(43), BytePos(47)), DiagMsg::from("pure"));
         let mut diag = Diag::new(Level::Warning, "inefficient visibility and mutability");
         diag.span(vec![pub_span, view_span]).multipart_suggestion(
             "consider changing visibility and mutability",
-            vec![(pub_span, pub_sugg), (view_span, view_sugg)],
+            vec![(pub_span, pub_sugg.clone()), (pub_span, pub_sugg), (view_span, view_sugg)],
             Applicability::MaybeIncorrect,
         );
 
         assert_eq!(diag.suggestions[0].substitutions.len(), 1);
         assert_eq!(diag.suggestions[0].substitutions[0].parts.len(), 2);
         assert_eq!(diag.suggestions[0].applicability, Applicability::MaybeIncorrect);
-        assert_eq!(diag.suggestions[0].style, SuggestionStyle::ShowCode);
+        assert_eq!(diag.suggestions[0].style, SuggestionStyle::ShowAlways);
 
         assert_data_eq!(
             emit_human_diagnostics(diag),
@@ -1299,6 +1644,8 @@ help: consider changing visibility and mutability
           "line_end": 4,
           "line_start": 4,
           "suggested_replacement": "myVar",
+          "suggestion_applicability": "machine-applicable",
+          "expansion": null,
           "text": [
             {
               "highlight_end": 23,
@@ -1326,6 +1673,8 @@ help: consider changing visibility and mutability
       "line_end": 4,
       "line_start": 4,
       "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null,
       "text": [
         {
           "highlight_end": 23,
@@ -1355,7 +1704,7 @@ help: consider changing visibility and mutability
         assert_eq!(diag.suggestions[0].substitutions.len(), 1);
         assert_eq!(diag.suggestions[0].substitutions[0].parts.len(), 2);
         assert_eq!(diag.suggestions[0].applicability, Applicability::MaybeIncorrect);
-        assert_eq!(diag.suggestions[0].style, SuggestionStyle::ShowCode);
+        assert_eq!(diag.suggestions[0].style, SuggestionStyle::ShowAlways);
 
         assert_data_eq!(
             emit_json_diagnostics(diag),
@@ -1381,6 +1730,8 @@ help: consider changing visibility and mutability
           "line_end": 3,
           "line_start": 3,
           "suggested_replacement": "external",
+          "suggestion_applicability": "maybe-incorrect",
+          "expansion": null,
           "text": [
             {
               "highlight_end": 26,
@@ -1400,6 +1751,8 @@ help: consider changing visibility and mutability
           "line_end": 3,
           "line_start": 3,
           "suggested_replacement": "pure",
+          "suggestion_applicability": "maybe-incorrect",
+          "expansion": null,
           "text": [
             {
               "highlight_end": 31,
@@ -1427,6 +1780,8 @@ help: consider changing visibility and mutability
       "line_end": 3,
       "line_start": 3,
       "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null,
       "text": [
         {
           "highlight_end": 26,
@@ -1446,6 +1801,8 @@ help: consider changing visibility and mutability
       "line_end": 3,
       "line_start": 3,
       "suggested_replacement": null,
+      "suggestion_applicability": null,
+      "expansion": null,
       "text": [
         {
           "highlight_end": 31,

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -466,7 +466,6 @@ impl ConfusionType {
 /// to determine whether it should be automatically applied or if the user should be consulted
 /// before applying the suggestion.
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "json", serde(rename_all = "kebab-case"))]
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Applicability {
     /// The suggestion is definitely what the user intended, or maintains the exact meaning of the
@@ -1658,7 +1657,7 @@ help: consider changing visibility and mutability
           "line_end": 4,
           "line_start": 4,
           "suggested_replacement": "myVar",
-          "suggestion_applicability": "machine-applicable",
+          "suggestion_applicability": "MachineApplicable",
           "expansion": null,
           "text": [
             {
@@ -1744,7 +1743,7 @@ help: consider changing visibility and mutability
           "line_end": 3,
           "line_start": 3,
           "suggested_replacement": "external",
-          "suggestion_applicability": "maybe-incorrect",
+          "suggestion_applicability": "MaybeIncorrect",
           "expansion": null,
           "text": [
             {
@@ -1765,7 +1764,7 @@ help: consider changing visibility and mutability
           "line_end": 3,
           "line_start": 3,
           "suggested_replacement": "pure",
-          "suggestion_applicability": "maybe-incorrect",
+          "suggestion_applicability": "MaybeIncorrect",
           "expansion": null,
           "text": [
             {

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -482,6 +482,8 @@ mod tests {
                 }],
                 label: None,
                 suggested_replacement: None,
+                suggestion_applicability: None,
+                expansion: None,
             }],
             children: Vec::new(),
             rendered: None,

--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -106,9 +106,11 @@ fn utf16_column(utf8_pos: CharPos, line: &str) -> u32 {
 #[inline]
 fn severity(level: Level) -> lsp_types::DiagnosticSeverity {
     match level {
-        Level::FailureNote | Level::Fatal | Level::Bug | Level::Error => DiagnosticSeverity::ERROR,
+        Level::Fatal | Level::Bug | Level::Error => DiagnosticSeverity::ERROR,
         Level::Warning => DiagnosticSeverity::WARNING,
         Level::Help | Level::OnceHelp => DiagnosticSeverity::HINT,
-        Level::Note | Level::OnceNote | Level::Allow => DiagnosticSeverity::INFORMATION,
+        Level::Note | Level::OnceNote | Level::FailureNote | Level::Allow => {
+            DiagnosticSeverity::INFORMATION
+        }
     }
 }

--- a/tests/ui/cli/error_format.short.stderr
+++ b/tests/ui/cli/error_format.short.stderr
@@ -1,4 +1,2 @@
 ROOT/tests/ui/cli/error_format.sol:LL:CC: error: expected one of `(`, `.`, `;`, `?`, `[`, or `{`, found `}`: unexpected token
-
 error: aborting due to 1 previous error
-


### PR DESCRIPTION
Re-ports the diagnostic implementation from current rustc across diagnostic collection, builder lifecycle, annotate-snippets rendering, and rustc-compatible JSON. This picks up the current suggestion APIs and validation, correct error-as-bug and failure-note semantics, short-message formatting, JSON applicability and expansion fields, and whole-line deletion spans.

The existing compiler-specific behavior remains intact: annotate-snippets and Unicode output stay the human renderer, source text remains resident, solc JSON remains supported, and rustc-only Fluent translation, macro hygiene and backtraces, error-code URLs, and attribute-suggestion handling remain intentionally omitted.

This also records the repository guardrail against running tests with `--all-features`, which enables the high-overhead `tracy` feature during UI tests.
