### PR TITLE
feat(sema): enable type checking by default

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -296,11 +296,7 @@ fn session() -> Session {
         .with_stderr_emitter_and_color(solar::parse::interface::ColorChoice::Always)
         .opts(solar::config::CompileOpts {
             threads: solar::config::Threads::resolve(1),
-            unstable: solar::config::UnstableOpts {
-                typeck: true,
-                codegen: true,
-                ..Default::default()
-            },
+            unstable: solar::config::UnstableOpts { codegen: true, ..Default::default() },
             ..Default::default()
         })
         .build()

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -353,10 +353,6 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub print_natspec: bool,
 
-    /// Type check the program. WIP.
-    #[cfg_attr(feature = "clap", arg(long))]
-    pub typeck: bool,
-
     /// Print MIR after every MIR optimization pass during codegen.
     #[cfg_attr(feature = "clap", arg(long))]
     pub mir_print_after_each: bool,

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -418,8 +418,7 @@ impl AnalysisBatch {
 
 fn analyze(batch: AnalysisBatch) -> AnalysisResult {
     let (emitter, diag_buffer) = InMemoryEmitter::new();
-    let mut opts = batch.opts;
-    opts.unstable.typeck = true;
+    let opts = batch.opts;
     let sess = Session::builder().opts(opts).dcx(DiagCtxt::new(Box::new(emitter))).build();
 
     let mut compiler = Compiler::new(sess);

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -523,8 +523,7 @@ impl<'gcx> Gcx<'gcx> {
 
     /// Returns the type inferred for the given expression, if available.
     ///
-    /// Expression types are populated by the experimental type checker, which runs when `-Ztypeck`
-    /// or `-Zcodegen` is enabled, or when a codegen output was requested.
+    /// Expression types are populated by the type checker.
     #[inline]
     pub fn type_of_expr(self, id: hir::ExprId) -> Option<Ty<'gcx>> {
         self.typeck_results.get()?.type_of_expr(id)
@@ -989,7 +988,22 @@ impl<'gcx> Gcx<'gcx> {
                 })
             }
             solar_ast::LitKind::Rational(_) => {
-                self.mk_ty_err(self.dcx().emit_err(lit.span, "rational literals are not supported"))
+                let value = lit.symbol.as_str();
+                if value.ends_with('_')
+                    || value.contains("__")
+                    || value.contains("._")
+                    || value.contains("_.")
+                    || value.contains("_e")
+                    || value.contains("_E")
+                    || value.contains("e_")
+                    || value.contains("E_")
+                {
+                    self.mk_ty_misc_err()
+                } else {
+                    self.mk_ty_err(
+                        self.dcx().emit_err(lit.span, "rational literals are not supported"),
+                    )
+                }
             }
             solar_ast::LitKind::Address(_) => self.types.address,
             solar_ast::LitKind::Bool(_) => self.types.bool,

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -640,6 +640,8 @@ impl<'gcx> TypeChecker<'gcx> {
                 let ty = self.gcx.type_of_hir_ty(hir_ty);
                 if valid_meta_type(ty) {
                     self.gcx.mk_ty(TyKind::Meta(ty))
+                } else if ty.references_error() {
+                    ty
                 } else {
                     self.gcx.mk_ty_err(self.dcx().emit_err(hir_ty.span, "invalid type"))
                 }
@@ -736,6 +738,12 @@ impl<'gcx> TypeChecker<'gcx> {
         } else {
             std::slice::from_ref(&rhs_ty)
         };
+
+        if lhs_types.iter().any(|ty| ty.references_error())
+            || rhs_types.iter().any(|ty| ty.references_error())
+        {
+            return;
+        }
 
         if lhs_components.len() != rhs_types.len() {
             self.dcx().emit_err_label(
@@ -2128,6 +2136,9 @@ impl<'gcx> TypeChecker<'gcx> {
                 len.checked_mul(elem_size)
             }
             TyKind::Struct(id) => {
+                if self.gcx.struct_recursiveness(id).is_recursive() {
+                    return None;
+                }
                 let mut size = U256::ZERO;
                 for &field_ty in self.gcx.struct_field_types(id) {
                     let field_size = if field_ty.is_dynamically_sized() {

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -19,32 +19,22 @@ pub(crate) mod override_checker;
 mod udvt;
 
 pub(crate) fn check(gcx: Gcx<'_>) {
-    let mut typeck_results = None;
+    let mut typeck_results = TypeckResults::default();
     parallel!(gcx.sess, gcx.hir.par_contract_ids().for_each(|id| check_contract(gcx, id)), {
-        if gcx.sess.opts.unstable.typeck
-            || gcx.sess.opts.unstable.codegen
-            || gcx.sess.opts.emit.iter().any(|e| e.is_codegen())
-        {
-            typeck_results = Some(
-                gcx.hir
-                    .par_source_ids()
-                    .map(|id| {
-                        check_source(gcx, id);
-                        // TODO: Parallelize more.
-                        checker::check(gcx, id)
-                    })
-                    .reduce(TypeckResults::default, |mut a, b| {
-                        merge_typeck_results(gcx, &mut a, b);
-                        a
-                    }),
-            );
-        } else {
-            gcx.hir.par_source_ids().for_each(|id| check_source(gcx, id));
-        }
+        typeck_results = gcx
+            .hir
+            .par_source_ids()
+            .map(|id| {
+                check_source(gcx, id);
+                // TODO: Parallelize more.
+                checker::check(gcx, id)
+            })
+            .reduce(TypeckResults::default, |mut a, b| {
+                merge_typeck_results(gcx, &mut a, b);
+                a
+            });
     },);
-    if let Some(typeck_results) = typeck_results {
-        gcx.set_typeck_results(typeck_results);
-    }
+    gcx.set_typeck_results(typeck_results);
 }
 
 fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
@@ -579,10 +569,7 @@ impl<'gcx> Visit<'gcx> for BreakContinueChecker<'gcx> {
 mod tests {
     use super::*;
     use crate::{Compiler, hir::ExprKind};
-    use solar_interface::{
-        Session,
-        config::{CompileOpts, UnstableOpts},
-    };
+    use solar_interface::{Session, config::CompileOpts};
     use std::path::PathBuf;
 
     const SOURCE: &str = r#"
@@ -620,14 +607,8 @@ contract D {
         }
     }
 
-    fn binary_expr_types(typeck: bool) -> Vec<Option<String>> {
-        let sess = Session::builder()
-            .opts(CompileOpts {
-                unstable: UnstableOpts { typeck, ..Default::default() },
-                ..Default::default()
-            })
-            .with_test_emitter()
-            .build();
+    fn binary_expr_types() -> Vec<Option<String>> {
+        let sess = Session::builder().opts(CompileOpts::default()).with_test_emitter().build();
         let mut compiler = Compiler::new(sess);
 
         compiler.enter_mut(|c| {
@@ -663,12 +644,7 @@ contract D {
     }
 
     #[test]
-    fn expression_types_are_available_after_typeck() {
-        assert_eq!(binary_expr_types(true), [Some("uint256".to_string()), Some("uint256".into())]);
-    }
-
-    #[test]
-    fn expression_types_are_empty_without_typeck() {
-        assert_eq!(binary_expr_types(false), [None, None]);
+    fn expression_types_are_available_by_default() {
+        assert_eq!(binary_expr_types(), [Some("uint256".to_string()), Some("uint256".into())]);
     }
 }

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -39,9 +39,6 @@ Options:
       -Zprint-natspec
           Print resolved NatSpec docs as diagnostics for UI tests
 
-      -Ztypeck
-          Type check the program. WIP
-
       -Zmir-print-after-each
           Print MIR after every MIR optimization pass during codegen
 

--- a/tests/ui/erc7201/typeck.sol
+++ b/tests/ui/erc7201/typeck.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/globalFunctions/erc7201_builtin_param_string_variable.sol
 // ported-from: test/libsolidity/syntaxTests/globalFunctions/erc7201_builtin_param_wrong_count.sol
 // ported-from: test/libsolidity/syntaxTests/globalFunctions/erc7201_builtin_param_invalid_bytes.sol

--- a/tests/ui/parser/empty_call_args.sol
+++ b/tests/ui/parser/empty_call_args.sol
@@ -3,7 +3,7 @@ function f() {
     f ();
     f ({ });
 
-    revert;
+    revert; //~ ERROR: no matching declarations found
     revert ();
-    revert ({ });
+    revert ({ }); //~ ERROR: no matching declarations found
 }

--- a/tests/ui/parser/empty_call_args.stderr
+++ b/tests/ui/parser/empty_call_args.stderr
@@ -1,0 +1,14 @@
+error: no matching declarations found
+   ╭▸ ROOT/tests/ui/parser/empty_call_args.sol:LL:CC
+   │
+LL │     revert;
+   ╰╴    ━━━━━━
+
+error: no matching declarations found
+   ╭▸ ROOT/tests/ui/parser/empty_call_args.sol:LL:CC
+   │
+LL │     revert ({ });
+   ╰╴    ━━━━━━
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/transient.sol
+++ b/tests/ui/parser/transient.sol
@@ -28,7 +28,7 @@ contract E {
     }
 
     function g2(uint256[] transient transient) external { //~ ERROR: invalid data location
-        transient = 5;
+        transient = 5; //~ ERROR: mismatched types
     }
 
   }

--- a/tests/ui/parser/transient.stderr
+++ b/tests/ui/parser/transient.stderr
@@ -12,5 +12,11 @@ LL │     function g2(uint256[] transient transient) external {
    │
    ╰ note: data location must be `memory` or `calldata` for external function parameter, but got `transient`
 
-error: aborting due to 2 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/parser/transient.sol:LL:CC
+   │
+LL │         transient = 5;
+   ╰╴                    ━ expected `uint256[] memory`, found `int_literal[3]`
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/parser/yul/kws_ok.sol
+++ b/tests/ui/parser/yul/kws_ok.sol
@@ -7,11 +7,13 @@ contract C {
                 b := number()
             }
 
-            number.slot := 69
-            number.slot, number.slot := some_call()
+            number.slot := 69 //~ ERROR: state variables cannot be assigned to in inline assembly
+            number.slot, number.slot := some_call() //~ ERROR: state variables cannot be assigned to in inline assembly
+            //~^ ERROR: state variables cannot be assigned to in inline assembly
 
-            number.number := 69
-            number.number, number.number := some_call()
+            number.number := 69 //~ ERROR: storage variables only support `.slot` and `.offset`
+            number.number, number.number := some_call() //~ ERROR: storage variables only support `.slot` and `.offset`
+            //~^ ERROR: storage variables only support `.slot` and `.offset`
 
             sstore(number.slot, 1)
 

--- a/tests/ui/parser/yul/kws_ok.stderr
+++ b/tests/ui/parser/yul/kws_ok.stderr
@@ -1,0 +1,38 @@
+error: state variables cannot be assigned to in inline assembly
+   ╭▸ ROOT/tests/ui/parser/yul/kws_ok.sol:LL:CC
+   │
+LL │             number.slot := 69
+   ╰╴            ━━━━━━
+
+error: state variables cannot be assigned to in inline assembly
+   ╭▸ ROOT/tests/ui/parser/yul/kws_ok.sol:LL:CC
+   │
+LL │             number.slot, number.slot := some_call()
+   ╰╴            ━━━━━━
+
+error: state variables cannot be assigned to in inline assembly
+   ╭▸ ROOT/tests/ui/parser/yul/kws_ok.sol:LL:CC
+   │
+LL │             number.slot, number.slot := some_call()
+   ╰╴                         ━━━━━━
+
+error: storage variables only support `.slot` and `.offset`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_ok.sol:LL:CC
+   │
+LL │             number.number := 69
+   ╰╴                   ━━━━━━
+
+error: storage variables only support `.slot` and `.offset`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_ok.sol:LL:CC
+   │
+LL │             number.number, number.number := some_call()
+   ╰╴                   ━━━━━━
+
+error: storage variables only support `.slot` and `.offset`
+   ╭▸ ROOT/tests/ui/parser/yul/kws_ok.sol:LL:CC
+   │
+LL │             number.number, number.number := some_call()
+   ╰╴                                  ━━━━━━
+
+error: aborting due to 6 previous errors
+

--- a/tests/ui/resolve/type_paths.sol
+++ b/tests/ui/resolve/type_paths.sol
@@ -18,5 +18,6 @@ contract C {
         
         self.C.Unknown memory h = self.C.Unknown(3);
         //~^ ERROR: unresolved symbol `Unknown`
+        //~| ERROR: member `Unknown` not found on type `type(contract C)`
     }
 }

--- a/tests/ui/resolve/type_paths.stderr
+++ b/tests/ui/resolve/type_paths.stderr
@@ -10,5 +10,11 @@ error: unresolved symbol `Unknown`
 LL │         self.C.Unknown memory h = self.C.Unknown(3);
    ╰╴               ━━━━━━━
 
-error: aborting due to 2 previous errors
+error: member `Unknown` not found on type `type(contract C)`
+   ╭▸ ROOT/tests/ui/resolve/type_paths.sol:LL:CC
+   │
+LL │         self.C.Unknown memory h = self.C.Unknown(3);
+   ╰╴                                         ━━━━━━━
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/standard-json/type-error.jsonc
+++ b/tests/ui/standard-json/type-error.jsonc
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // CHECK: "errors": [
 // CHECK: "message": "mismatched types"
 // CHECK: expected `uint256`, found `bool`

--- a/tests/ui/typeck/address_conversions_explicit.sol
+++ b/tests/ui/typeck/address_conversions_explicit.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 contract C {
     function f(
         address a,

--- a/tests/ui/typeck/base_arguments.sol
+++ b/tests/ui/typeck/base_arguments.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract Base {
     constructor(uint, int) {}
 }

--- a/tests/ui/typeck/base_ctor_abstract.sol
+++ b/tests/ui/typeck/base_ctor_abstract.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // An abstract contract may inherit `is Base` without supplying the base
 // constructor's arguments; a concrete descendant supplies them. This must not
 // be reported as a wrong-argument-count error.

--- a/tests/ui/typeck/bytes_string_explicit_conversions.sol
+++ b/tests/ui/typeck/bytes_string_explicit_conversions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract BytesStringTests {
     // Valid: string literal -> bytes memory.
     function testStringLiteralToBytes() public pure returns (bytes memory) {

--- a/tests/ui/typeck/calldata_slice_conversion.sol
+++ b/tests/ui/typeck/calldata_slice_conversion.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // A calldata `bytes` slice (`data[i:j]`) converts like `bytes`: to fixed-bytes,
 // `bytes`, or `string`. Converting to `bytes`/`string` keeps the calldata
 // location (the result is a view), so it assigns to a calldata variable.

--- a/tests/ui/typeck/contract_address_conversions_explicit.sol
+++ b/tests/ui/typeck/contract_address_conversions_explicit.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract NoReceive {}
 
 contract WithReceive {

--- a/tests/ui/typeck/contract_type_members.sol
+++ b/tests/ui/typeck/contract_type_members.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 library LibraryTypes {
     uint256 constant BASE = 1;
 

--- a/tests/ui/typeck/contract_type_members_public_vars.sol
+++ b/tests/ui/typeck/contract_type_members_public_vars.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract PublicStateVarBase {
     uint256 public baseVar = 42;
 }

--- a/tests/ui/typeck/eval.sol
+++ b/tests/ui/typeck/eval.sol
@@ -26,6 +26,7 @@ contract C {
     function b(uint[x] memory) public {}
     function c(uint[x * 2] memory) public {}
     function d(uint[0 - 1] memory) public {} //~ ERROR: array length cannot be negative
+    //~^ ERROR: mismatched types
     function d2(uint[zeroPublic - 1] memory) public {} //~ ERROR: array length cannot be negative
     function d3(uint[2 ** 4294967295] memory) public {} //~ ERROR: failed to evaluate constant: arithmetic overflow
     function d4(uint[1 << 4294967295] memory) public {} //~ ERROR: failed to evaluate constant: arithmetic overflow
@@ -38,7 +39,9 @@ contract C {
 
     function i(uint[block.timestamp] memory) public {} //~ ERROR: failed to evaluate constant: unsupported expression
     function j(uint["lol"] memory) public {} //~ ERROR: failed to evaluate constant: unsupported literal
+    //~^ ERROR: mismatched types
     function k(uint[--x] memory) public {} //~ ERROR: failed to evaluate constant: unsupported unary operation
+    //~^ ERROR: cannot assign to a constant variable
     function l(uint[stateVar] memory) public {} //~ ERROR: failed to evaluate constant: only constant variables are allowed
     function m(uint[stateVarPublic] memory) public {} //~ ERROR: failed to evaluate constant: only constant variables are allowed
 

--- a/tests/ui/typeck/eval.stderr
+++ b/tests/ui/typeck/eval.stderr
@@ -127,5 +127,23 @@ error: failed to evaluate constant: arithmetic overflow
 LL │     uint[bigLiteral + 1] public tooBig1;
    ╰╴         ━━━━━━━━━━━━━━ evaluation of constant value failed here
 
-error: aborting due to 20 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/eval.sol:LL:CC
+   │
+LL │     function d(uint[0 - 1] memory) public {}
+   ╰╴                    ━━━━━ expected `uint256`, found `int_literal[1]`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/eval.sol:LL:CC
+   │
+LL │     function j(uint["lol"] memory) public {}
+   ╰╴                    ━━━━━ expected `uint256`, found `utf8_string_literal[3]`
+
+error: cannot assign to a constant variable
+   ╭▸ ROOT/tests/ui/typeck/eval.sol:LL:CC
+   │
+LL │     function k(uint[--x] memory) public {}
+   ╰╴                      ━
+
+error: aborting due to 23 previous errors
 

--- a/tests/ui/typeck/explicit_dynamic_bytes_conversion.sol
+++ b/tests/ui/typeck/explicit_dynamic_bytes_conversion.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 contract C {
     function f(bytes memory a0) public pure {
         // Valid conversion

--- a/tests/ui/typeck/explicit_enum_conversion.sol
+++ b/tests/ui/typeck/explicit_enum_conversion.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 contract C {
     enum TrafficLight {
         Red,

--- a/tests/ui/typeck/fixed_bytes_conversions.sol
+++ b/tests/ui/typeck/fixed_bytes_conversions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     // Valid: implicit FixedBytes widening and same-size conversion.
     function validImplicitBytesToBytes(bytes1 b1, bytes4 b4) public pure {

--- a/tests/ui/typeck/function_calls/abi_decode.sol
+++ b/tests/ui/typeck/function_calls/abi_decode.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     struct Unsupported {
         mapping(uint256 => uint256) values;

--- a/tests/ui/typeck/function_calls/abi_encode_call_args.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_call_args.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f1(int256 value) public {
         value;

--- a/tests/ui/typeck/function_calls/abi_encode_call_conversions.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_call_conversions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 interface Target {
     function takesMemoryFunction(function(string memory) external callback) external;
     function takesCalldataFunction(function(string calldata) external callback) external;

--- a/tests/ui/typeck/function_calls/abi_encode_call_function_kinds.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_call_function_kinds.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 library Lib {
     function externalTarget(uint256 value) external {
         value;

--- a/tests/ui/typeck/function_calls/abi_encode_packed.sol
+++ b/tests/ui/typeck/function_calls/abi_encode_packed.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     struct S {
         uint256 value;

--- a/tests/ui/typeck/function_calls/call_checking.sol
+++ b/tests/ui/typeck/function_calls/call_checking.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract CallChecking {
     event E(uint a, bytes32 b);
     event EmptyEvent();

--- a/tests/ui/typeck/function_calls/contract_type_base_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_base_members.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // ported-from: test/libsolidity/semanticTests/functionTypes/selector_1.sol
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/484_function_types_selector_1.sol
 // ported-from: test/libsolidity/syntaxTests/inheritance/override/override_implemented_and_unimplemented_with_implemented_call_via_contract.sol

--- a/tests/ui/typeck/function_calls/contract_type_interface_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_interface_members.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // ported-from: test/libsolidity/smtCheckerTests/function_selector/function_selector_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/assign_function_via_contract_name_to_var.sol
 

--- a/tests/ui/typeck/function_calls/contract_type_state_var_members.sol
+++ b/tests/ui/typeck/function_calls/contract_type_state_var_members.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // ported-from: test/libsolidity/semanticTests/various/state_variable_under_contract_name.sol
 
 contract StateVarScope {

--- a/tests/ui/typeck/function_calls/declaration_function_calls.sol
+++ b/tests/ui/typeck/function_calls/declaration_function_calls.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/types/contractTypeType/members/call_function_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/freeFunctions/free_call_via_contract_type.sol
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/145_external_base_visibility.sol

--- a/tests/ui/typeck/function_calls/enum_value_not_callable.sol
+++ b/tests/ui/typeck/function_calls/enum_value_not_callable.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     enum ActionChoices { GoLeft, GoRight }
     function f() public pure {

--- a/tests/ui/typeck/function_calls/event_error/emit_non_event.sol
+++ b/tests/ui/typeck/function_calls/event_error/emit_non_event.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/emit/emit_non_event.sol
 
 contract EmitNonEvent {

--- a/tests/ui/typeck/function_calls/event_error/error_used_elsewhere.sol
+++ b/tests/ui/typeck/function_calls/event_error/error_used_elsewhere.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/revertStatement/error_used_elsewhere.sol
 
 contract ErrorUsedElsewhere {

--- a/tests/ui/typeck/function_calls/event_error/event_without_emit.sol
+++ b/tests/ui/typeck/function_calls/event_error/event_without_emit.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/events/event_without_emit_deprecated.sol
 // ported-from: test/libsolidity/syntaxTests/events/multiple_event_without_emit.sol
 

--- a/tests/ui/typeck/function_calls/event_error/nested_contexts.sol
+++ b/tests/ui/typeck/function_calls/event_error/nested_contexts.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract EventErrorNestedContexts {
     event MyEvent(uint a, bytes32 b);
     event EmptyEvent();

--- a/tests/ui/typeck/function_calls/event_error/require_custom_error.sol
+++ b/tests/ui/typeck/function_calls/event_error/require_custom_error.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract RequireCustomError {
     error EmptyError();
     error MyError(uint code, string message);

--- a/tests/ui/typeck/function_calls/event_error/revert_event.sol
+++ b/tests/ui/typeck/function_calls/event_error/revert_event.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/revertStatement/revert_event.sol
 
 contract RevertEvent {

--- a/tests/ui/typeck/function_calls/int_not_callable.sol
+++ b/tests/ui/typeck/function_calls/int_not_callable.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f() public {
         ((1(3)), 2); //~ ERROR: expected function

--- a/tests/ui/typeck/function_calls/low_level_call_options.sol
+++ b/tests/ui/typeck/function_calls/low_level_call_options.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/functionCalls/calloptions_on_delegatecall.sol
 // ported-from: test/libsolidity/syntaxTests/functionCalls/calloptions_on_staticcall.sol
 // ported-from: test/libsolidity/smtCheckerTests/external_calls/external_call_with_gas_1.sol

--- a/tests/ui/typeck/function_calls/named_arguments_duplicate_parameter.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_duplicate_parameter.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract test {
     function a(uint a, uint b) public returns (uint r) {
         r = a + b;

--- a/tests/ui/typeck/function_calls/named_arguments_in_any_order.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_in_any_order.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f(uint u, bytes32 s, bool b) internal {}
 

--- a/tests/ui/typeck/function_calls/named_arguments_invalid_name.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_invalid_name.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract test {
     function f(uint a, bool b, bytes32 c, uint d, bool e) public returns (uint r) {
         if (b && !e)

--- a/tests/ui/typeck/function_calls/named_arguments_wrong_count.sol
+++ b/tests/ui/typeck/function_calls/named_arguments_wrong_count.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract test {
     function a(uint a, uint b) public returns (uint r) {
         r = a + b;

--- a/tests/ui/typeck/function_calls/new/abstract_contract.sol
+++ b/tests/ui/typeck/function_calls/new/abstract_contract.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/029_create_abstract_contract.sol
 
 abstract contract A {

--- a/tests/ui/typeck/function_calls/new/dynamic_array_arguments.sol
+++ b/tests/ui/typeck/function_calls/new/dynamic_array_arguments.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/invalidArgs/creating_memory_array.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/new/interface.sol
+++ b/tests/ui/typeck/function_calls/new/interface.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/523_reject_interface_creation.sol
 
 interface I {}

--- a/tests/ui/typeck/function_calls/new/library.sol
+++ b/tests/ui/typeck/function_calls/new/library.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/functionCalls/new_library.sol
 
 library L {}

--- a/tests/ui/typeck/function_calls/new/library_array.sol
+++ b/tests/ui/typeck/function_calls/new/library_array.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/library_array.sol
 
 library L {}

--- a/tests/ui/typeck/function_calls/new/non_array.sol
+++ b/tests/ui/typeck/function_calls/new/non_array.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/265_new_for_non_array.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/new/nonpayable_call_options.sol
+++ b/tests/ui/typeck/function_calls/new/nonpayable_call_options.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/constructor/nonpayable_new.sol
 
 contract NonPayableA1 {

--- a/tests/ui/typeck/function_calls/new/payable_call_options.sol
+++ b/tests/ui/typeck/function_calls/new/payable_call_options.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/constructor/payable_new.sol
 
 contract PayableA1 {}

--- a/tests/ui/typeck/function_calls/new/static_array.sol
+++ b/tests/ui/typeck/function_calls/new/static_array.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/new_no_parentheses.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/overloads.sol
+++ b/tests/ui/typeck/function_calls/overloads.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/freeFunctions/overloads.sol
 
 contract C {

--- a/tests/ui/typeck/function_calls/type_members.sol
+++ b/tests/ui/typeck/function_calls/type_members.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/libraries/library_function_selectors.sol
 // ported-from: test/libsolidity/smtCheckerTests/function_selector/function_selector_via_contract_name.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/external_library_function_to_external_function_type.sol

--- a/tests/ui/typeck/function_calls/variadic.sol
+++ b/tests/ui/typeck/function_calls/variadic.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 interface Target {
     function none() external;
     function single(uint256 value) external;

--- a/tests/ui/typeck/function_ptr_comparisons.sol
+++ b/tests/ui/typeck/function_ptr_comparisons.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/functionTypes/comparison_operators_for_external_functions.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_1.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_internal_eq_2.sol

--- a/tests/ui/typeck/function_ptr_mutability_conversions.sol
+++ b/tests/ui/typeck/function_ptr_mutability_conversions.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/conversion/function_type_nonpayable_payable.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/function_type_nonpayable_pure.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/function_type_nonpayable_view.sol

--- a/tests/ui/typeck/implicit_address.sol
+++ b/tests/ui/typeck/implicit_address.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 function f() {
     address payable e = 0x14aF3198B9Dd911fc828434f8D97df0C0Ff979Ee; //~ ERROR: mismatched types
 

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // Tests for implicit array conversions.
 // Arrays require exactly the same element type - no widening allowed.
 // Fixed arrays must also have the same length.

--- a/tests/ui/typeck/implicit_contract_conversions.sol
+++ b/tests/ui/typeck/implicit_contract_conversions.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 pragma solidity ^0.8.0;
 
 contract Base {}

--- a/tests/ui/typeck/implicit_fixed_bytes.sol
+++ b/tests/ui/typeck/implicit_fixed_bytes.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // Tests for implicit FixedBytes width conversions.
 // See: https://docs.soliditylang.org/en/latest/types.html#implicit-conversions
 // "Smaller bytesN to larger bytesN is allowed (e.g., bytes1 -> bytes32, right-padded with zeros)."

--- a/tests/ui/typeck/implicit_function_ptr.sol
+++ b/tests/ui/typeck/implicit_function_ptr.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // Tests for implicit function pointer conversions.
 // Function pointers require exact parameter/return types.
 // Function kinds must match.

--- a/tests/ui/typeck/implicit_int_literal.sol
+++ b/tests/ui/typeck/implicit_int_literal.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 function f() {
     // === Non-negative literals to uint ===
     // Value must fit in the unsigned range [0, 2^N - 1]

--- a/tests/ui/typeck/implicit_integer_width.sol
+++ b/tests/ui/typeck/implicit_integer_width.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // Tests for implicit integer width conversions.
 // See: https://docs.soliditylang.org/en/latest/types.html#implicit-conversions
 // "Smaller width to larger width is allowed (e.g., uint8 -> uint256, int8 -> int256)."

--- a/tests/ui/typeck/implicit_slice.sol
+++ b/tests/ui/typeck/implicit_slice.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/slice/calldata_dynamic_access.sol
 
 // Tests for array slice implicit conversions.

--- a/tests/ui/typeck/implicit_tuple_conversions.sol
+++ b/tests/ui/typeck/implicit_tuple_conversions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // Tests for implicit tuple conversions.
 // Tuple assignments check element-wise type matching.
 

--- a/tests/ui/typeck/integer_explicit_conversions.sol
+++ b/tests/ui/typeck/integer_explicit_conversions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract IntegerConversions {
     // Int <-> Int (any size - only width changes)
     function validIntToInt(int8 i8, int256 i256) public pure {

--- a/tests/ui/typeck/internal_fn_public_interface.sol
+++ b/tests/ui/typeck/internal_fn_public_interface.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     // Internal function type as public state variable - should error.
     function(uint) internal public myInternalFunc; //~ ERROR: types containing internal function pointers cannot be parameter or return types of public getter functions

--- a/tests/ui/typeck/library_mappings.sol
+++ b/tests/ui/typeck/library_mappings.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/lvalues/library_mapping.sol
 
 contract L {

--- a/tests/ui/typeck/literal_bytes_implicit_conversion.sol
+++ b/tests/ui/typeck/literal_bytes_implicit_conversion.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 contract C {
     function f() public pure {
         // --- Valid: literal to fixed-size bytes (equal size) ---

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // Tests for data location coercion rules.
 // See: https://docs.soliditylang.org/en/latest/types.html#data-location-and-assignment-behaviour
 

--- a/tests/ui/typeck/lvalue/address_balance.sol
+++ b/tests/ui/typeck/lvalue/address_balance.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/015_balance_invalid.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/array_length.sol
+++ b/tests/ui/typeck/lvalue/array_length.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract Test {
     uint256[] dynamicArray;
     uint256[10] fixedArray;

--- a/tests/ui/typeck/lvalue/calldata_array.sol
+++ b/tests/ui/typeck/lvalue/calldata_array.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract Test {
     uint256 state;
     uint256 idx;

--- a/tests/ui/typeck/lvalue/calldata_struct.sol
+++ b/tests/ui/typeck/lvalue/calldata_struct.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 struct S {
     uint256 x;
     uint256 y;

--- a/tests/ui/typeck/lvalue/constant.sol
+++ b/tests/ui/typeck/lvalue/constant.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract Test {
     uint256 constant CONST = 1;
 

--- a/tests/ui/typeck/lvalue/delete_function_type.sol
+++ b/tests/ui/typeck/lvalue/delete_function_type.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/functionTypes/delete_function_type_invalid.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/delete_external_function_type_invalid.sol
 

--- a/tests/ui/typeck/lvalue/expressions.sol
+++ b/tests/ui/typeck/lvalue/expressions.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract Test {
     uint256 a;
     uint256 b;

--- a/tests/ui/typeck/lvalue/fixed_bytes.sol
+++ b/tests/ui/typeck/lvalue/fixed_bytes.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract Test {
     bytes32 fixedBytes;
     bytes1 singleByte;

--- a/tests/ui/typeck/lvalue/function_lvalues.sol
+++ b/tests/ui/typeck/lvalue/function_lvalues.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/lvalues/functions.sol
 
 contract FunctionLvalues {

--- a/tests/ui/typeck/lvalue/immutable.sol
+++ b/tests/ui/typeck/lvalue/immutable.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/immutable/variable_declaration_value.sol
 // ported-from: test/libsolidity/semanticTests/immutable/multiple_initializations.sol
 // ported-from: test/libsolidity/syntaxTests/immutable/ctor_initialization_tuple.sol

--- a/tests/ui/typeck/lvalue/literals.sol
+++ b/tests/ui/typeck/lvalue/literals.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // TODO: `mismatched types` errors on integer literals are a current limitation of solar
 
 contract Test {

--- a/tests/ui/typeck/lvalue/metatype_code.sol
+++ b/tests/ui/typeck/lvalue/metatype_code.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/metaTypes/codeIsNoLValue.sol
 
 contract MetaTypeMemberLvalues {

--- a/tests/ui/typeck/lvalue/push_as_lhs.sol
+++ b/tests/ui/typeck/lvalue/push_as_lhs.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/smtCheckerTests/array_members/push_as_lhs_2d.sol
 // ported-from: test/libsolidity/smtCheckerTests/array_members/push_as_lhs_3d.sol
 

--- a/tests/ui/typeck/lvalue/return_storage_ref.sol
+++ b/tests/ui/typeck/lvalue/return_storage_ref.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/functionCall/mapping_internal_return.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/tuple_assignments.sol
+++ b/tests/ui/typeck/lvalue/tuple_assignments.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/tupleAssignments/assignments_to_tuple_and_non_tuple_expressions_of_tuple_types.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/tuple_push.sol
+++ b/tests/ui/typeck/lvalue/tuple_push.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/array/bytes1_array_push_assign_multi.sol
 
 contract Test {

--- a/tests/ui/typeck/lvalue/valid_calldata.sol
+++ b/tests/ui/typeck/lvalue/valid_calldata.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // Valid operations on calldata (reading is allowed)
 
 struct S {

--- a/tests/ui/typeck/lvalue/valid_memory.sol
+++ b/tests/ui/typeck/lvalue/valid_memory.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/lvalues/valid_lvalues.sol
 // Valid lvalue assignments for memory variables
 

--- a/tests/ui/typeck/lvalue/valid_storage.sol
+++ b/tests/ui/typeck/lvalue/valid_storage.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // Valid lvalue assignments for storage variables
 
 contract Test {

--- a/tests/ui/typeck/mapping_array_value.sol
+++ b/tests/ui/typeck/mapping_array_value.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // A mapping whose value is a fixed-size array: the array size expression must be
 // type-checked exactly once (previously the mapping value was visited twice,
 // causing an "already typechecked" ICE).

--- a/tests/ui/typeck/mapping_assignment.sol
+++ b/tests/ui/typeck/mapping_assignment.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     mapping(uint => uint) a;
     mapping(uint => uint) b;

--- a/tests/ui/typeck/mapping_key_type_check.sol
+++ b/tests/ui/typeck/mapping_key_type_check.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 type U is int;
 enum E {
     A,

--- a/tests/ui/typeck/mapping_structs.sol
+++ b/tests/ui/typeck/mapping_structs.sol
@@ -6,14 +6,14 @@ struct Nested {
     S s;
 }
 
-function free_1(S memory) {}
+function free_1(S memory) {} //~ ERROR: type `struct S memory` is only valid in storage
 function free_2(S storage) {}
-function free_3() returns(S memory) {}
+function free_3() returns(S memory) {} //~ ERROR: type `struct S memory` is only valid in storage
 function free_4() returns(S storage) {}
 
-function free_nested_1(Nested memory) {}
+function free_nested_1(Nested memory) {} //~ ERROR: type `struct Nested memory` is only valid in storage
 function free_nested_2(Nested storage) {}
-function free_nested_3() returns(Nested memory) {}
+function free_nested_3() returns(Nested memory) {} //~ ERROR: type `struct Nested memory` is only valid in storage
 function free_nested_4() returns(Nested storage) {}
 
 contract C {
@@ -25,37 +25,43 @@ contract C {
 
     Nested internal var_nested_1;
     Nested public var_nested_2; //~ ERROR: types containing mappings cannot be parameter or return types of public getter functions
+    //~^ ERROR: type `struct S memory` is only valid in storage
 
     Nested[] internal var_nested_array_1;
     Nested[] public var_nested_array_2; //~ ERROR: types containing mappings cannot be parameter or return types of public getter functions
+    //~^ ERROR: type `struct S memory` is only valid in storage
 
     function func_1(S memory) public {}            //~ ERROR: types containing mappings cannot be parameter or return types of public functions
+    //~^ ERROR: type `struct S memory` is only valid in storage
     function func_2(S storage) public {}           //~ ERROR: types containing mappings cannot be parameter or return types of public functions
     //~^ ERROR: invalid data location
     function func_3() public returns(S memory) {}  //~ ERROR: types containing mappings cannot be parameter or return types of public functions
+    //~^ ERROR: type `struct S memory` is only valid in storage
     function func_4() public returns(S storage) {} //~ ERROR: types containing mappings cannot be parameter or return types of public functions
     //~^ ERROR: invalid data location
 
-    modifier mod_1(S memory) { _; }
+    modifier mod_1(S memory) { _; } //~ ERROR: type `struct S memory` is only valid in storage
     modifier mod_2(S storage) { _; }
 
-    function func_internal_1(S memory) internal {}
+    function func_internal_1(S memory) internal {} //~ ERROR: type `struct S memory` is only valid in storage
     function func_internal_2(S storage) internal {}
-    function func_internal_3() internal returns(S memory) {}
+    function func_internal_3() internal returns(S memory) {} //~ ERROR: type `struct S memory` is only valid in storage
     function func_internal_4() internal returns(S storage) {}
 
     function func_nested_1(Nested memory) public {}            //~ ERROR: types containing mappings cannot be parameter or return types of public functions
+    //~^ ERROR: type `struct Nested memory` is only valid in storage
     function func_nested_2(Nested storage) public {}           //~ ERROR: types containing mappings cannot be parameter or return types of public functions
     //~^ ERROR: invalid data location
     function func_nested_3() public returns(Nested memory) {}  //~ ERROR: types containing mappings cannot be parameter or return types of public functions
+    //~^ ERROR: type `struct Nested memory` is only valid in storage
     function func_nested_4() public returns(Nested storage) {} //~ ERROR: types containing mappings cannot be parameter or return types of public functions
     //~^ ERROR: invalid data location
 
-    modifier mod_nested_1(Nested memory) { _; }
+    modifier mod_nested_1(Nested memory) { _; } //~ ERROR: type `struct Nested memory` is only valid in storage
     modifier mod_nested_2(Nested storage) { _; }
 
-    function func_internal_nested_1(Nested memory) internal {}
+    function func_internal_nested_1(Nested memory) internal {} //~ ERROR: type `struct Nested memory` is only valid in storage
     function func_internal_nested_2(Nested storage) internal {}
-    function func_internal_nested_3() internal returns(Nested memory) {}
+    function func_internal_nested_3() internal returns(Nested memory) {} //~ ERROR: type `struct Nested memory` is only valid in storage
     function func_internal_nested_4() internal returns(Nested storage) {}
 }

--- a/tests/ui/typeck/mapping_structs.stderr
+++ b/tests/ui/typeck/mapping_structs.stderr
@@ -114,5 +114,101 @@ error: types containing mappings cannot be parameter or return types of public f
 LL │     function func_nested_4() public returns(Nested storage) {}
    ╰╴                                            ━━━━━━
 
-error: aborting due to 16 previous errors
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │ function free_1(S memory) {}
+   ╰╴                ━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │ function free_3() returns(S memory) {}
+   ╰╴                          ━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │ function free_nested_1(Nested memory) {}
+   ╰╴                       ━━━━━━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │ function free_nested_3() returns(Nested memory) {}
+   ╰╴                                 ━━━━━━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     Nested public var_nested_2;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     Nested[] public var_nested_array_2;
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_1(S memory) public {}
+   ╰╴                    ━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_3() public returns(S memory) {}
+   ╰╴                                     ━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     modifier mod_1(S memory) { _; }
+   ╰╴                   ━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_internal_1(S memory) internal {}
+   ╰╴                             ━━━━━━━━
+
+error: type `struct S memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_internal_3() internal returns(S memory) {}
+   ╰╴                                                ━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_nested_1(Nested memory) public {}
+   ╰╴                           ━━━━━━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_nested_3() public returns(Nested memory) {}
+   ╰╴                                            ━━━━━━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     modifier mod_nested_1(Nested memory) { _; }
+   ╰╴                          ━━━━━━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_internal_nested_1(Nested memory) internal {}
+   ╰╴                                    ━━━━━━━━━━━━━
+
+error: type `struct Nested memory` is only valid in storage because it contains a (nested) mapping
+   ╭▸ ROOT/tests/ui/typeck/mapping_structs.sol:LL:CC
+   │
+LL │     function func_internal_nested_3() internal returns(Nested memory) {}
+   ╰╴                                                       ━━━━━━━━━━━━━
+
+error: aborting due to 32 previous errors
 

--- a/tests/ui/typeck/new_dynamic_arrays.sol
+++ b/tests/ui/typeck/new_dynamic_arrays.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     struct S {
         uint256 x;

--- a/tests/ui/typeck/pow_associativity.sol
+++ b/tests/ui/typeck/pow_associativity.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 function test() pure {
     uint[2**3**2] memory a;
     uint[512] memory b = a;

--- a/tests/ui/typeck/pow_literal.sol
+++ b/tests/ui/typeck/pow_literal.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // A literal base raised to a non-constant exponent is a runtime value typed
 // `uint256` (matching solc), so `bytes32((2 ** (n + 1)) - 1)` type-checks (a
 // bitmask idiom used by OpenZeppelin's Governor).

--- a/tests/ui/typeck/recovery/calls.sol
+++ b/tests/ui/typeck/recovery/calls.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function g(uint256 a, uint256 b) public {}
 

--- a/tests/ui/typeck/recovery/expression_boundaries.sol.todo
+++ b/tests/ui/typeck/recovery/expression_boundaries.sol.todo
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // TODO: These expression-boundary failures should recover by inserting
 // ExprKind::Err at the malformed subexpression and synchronizing at `,`, `;`,
 // `)`, `]`, `}`, or `:` as appropriate.

--- a/tests/ui/typeck/recovery/malformed_exprs.sol
+++ b/tests/ui/typeck/recovery/malformed_exprs.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function tupleExpression() public {
         uint256 x = (1,, true); //~ ERROR: tuple components cannot be empty

--- a/tests/ui/typeck/recovery/member_access.sol
+++ b/tests/ui/typeck/recovery/member_access.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     struct S {
         uint256 a;

--- a/tests/ui/typeck/recovery/member_parse_recovery.sol
+++ b/tests/ui/typeck/recovery/member_parse_recovery.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     struct S {
         uint256 a;

--- a/tests/ui/typeck/recovery/member_parse_recovery_bare_dot.sol.todo
+++ b/tests/ui/typeck/recovery/member_parse_recovery_bare_dot.sol.todo
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // TODO: These malformed member-access forms should eventually recover into an
 // AST error expression and let typeck continue to later statements. Keep them
 // inactive until they can be promoted with explicit typeck-continuation checks.

--- a/tests/ui/typeck/recovery/statement_conditions.sol.todo
+++ b/tests/ui/typeck/recovery/statement_conditions.sol.todo
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // TODO: Statement conditions and loop components should recover malformed
 // expressions without losing the following block or statement.
 

--- a/tests/ui/typeck/recovery/unclosed_delimiters.sol.todo
+++ b/tests/ui/typeck/recovery/unclosed_delimiters.sol.todo
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // TODO: These unclosed delimiter cases currently fail before an AST reaches
 // typeck. Keep them as focused repros for parser recovery work.
 

--- a/tests/ui/typeck/shift_literal.sol
+++ b/tests/ui/typeck/shift_literal.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // A literal shifted by a non-constant amount is a runtime value, not a
 // compile-time constant; it is typed `uint256` (matching solc), so e.g.
 // `bytes32(1 << role)` type-checks (the role-bitmask idiom).

--- a/tests/ui/typeck/storage_layout_base_slot_bool.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_bool.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/boolean.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/bool_constant.sol
 

--- a/tests/ui/typeck/storage_layout_base_slot_negative.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_negative.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_underflow_value.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/negative_number.sol
 

--- a/tests/ui/typeck/storage_layout_base_slot_overflow.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_overflow.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/intermediate_operation_out_of_range.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_value.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_bitwise_negation_literal.sol

--- a/tests/ui/typeck/storage_layout_base_slot_unsupported.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_unsupported.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_attached_library_function.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/string.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/hex_string.sol

--- a/tests/ui/typeck/storage_layout_base_slot_valid.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_valid.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/simple_layout.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/literal_with_underscore.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/rational_number_without_fractional_part.sol

--- a/tests/ui/typeck/super/calls.sol
+++ b/tests/ui/typeck/super/calls.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // ported-from: test/libsolidity/semanticTests/various/super.sol
 // ported-from: test/libsolidity/semanticTests/various/super_parentheses.sol
 // ported-from: test/libsolidity/semanticTests/inheritance/super_overload.sol

--- a/tests/ui/typeck/super/conversion.sol
+++ b/tests/ui/typeck/super/conversion.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // ported-from: test/libsolidity/syntaxTests/conversion/convert_to_super_empty.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/convert_to_super_nonempty.sol
 // ported-from: test/libsolidity/syntaxTests/conversion/not_allowed_conversion_from_super.sol

--- a/tests/ui/typeck/super/linearized_bases.sol
+++ b/tests/ui/typeck/super/linearized_bases.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract A {
     function fromA() public virtual returns (uint256) {
         return 1;

--- a/tests/ui/typeck/super/member_access.sol
+++ b/tests/ui/typeck/super/member_access.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 // ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/065_super_excludes_current_contract.sol
 // ported-from: test/libsolidity/syntaxTests/inheritance/super_on_external.sol
 // ported-from: test/libsolidity/syntaxTests/super/unimplemented_super_function.sol

--- a/tests/ui/typeck/var_decl_rules.sol
+++ b/tests/ui/typeck/var_decl_rules.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     // Immutable with non-value type (array)
     uint[] immutable IMMUT_ARRAY; //~ ERROR: immutable variables cannot have a non-value type

--- a/tests/ui/typeck/var_loc_file_level.sol
+++ b/tests/ui/typeck/var_loc_file_level.sol
@@ -4,5 +4,7 @@ struct S {
 
 uint memory constant a0 = 0;    //~ ERROR: data locations are not allowed here
 uint[] memory constant b0 = []; //~ ERROR: data locations are not allowed here
+//~^ ERROR: mismatched types
 S memory constant c0 = S(0);    //~ ERROR: data locations are not allowed here
 S[] memory constant d0 = [];    //~ ERROR: data locations are not allowed here
+//~^ ERROR: cannot infer nameable array element type

--- a/tests/ui/typeck/var_loc_file_level.stderr
+++ b/tests/ui/typeck/var_loc_file_level.stderr
@@ -22,5 +22,19 @@ error: data locations are not allowed here
 LL │ S[] memory constant d0 = [];
    ╰╴    ━━━━━━
 
-error: aborting due to 4 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/var_loc_file_level.sol:LL:CC
+   │
+LL │ uint[] memory constant b0 = [];
+   ╰╴                            ━━ expected `uint256[] memory`, found `uint256[0] memory`
+
+error: cannot infer nameable array element type
+   ╭▸ ROOT/tests/ui/typeck/var_loc_file_level.sol:LL:CC
+   │
+LL │ S[] memory constant d0 = [];
+   │                          ━━
+   │
+   ╰ help: add an explicit type conversion for the first element
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/var_loc_state.sol
+++ b/tests/ui/typeck/var_loc_state.sol
@@ -5,6 +5,8 @@ struct S {
 contract C {
     uint memory a1 = 0;    //~ ERROR: data location can only be specified for array, struct or mapping types
     uint[] memory b1 = []; //~ ERROR: invalid data location
+    //~^ ERROR: mismatched types
     S memory c1 = S(0);    //~ ERROR: invalid data location
     S[] memory d1 = [];    //~ ERROR: invalid data location
+    //~^ ERROR: cannot infer nameable array element type
 }

--- a/tests/ui/typeck/var_loc_state.stderr
+++ b/tests/ui/typeck/var_loc_state.stderr
@@ -28,5 +28,19 @@ LL │     S[] memory d1 = [];
    │
    ╰ note: data location must be `none` or `transient` for state variable, but got `memory`
 
-error: aborting due to 4 previous errors
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/var_loc_state.sol:LL:CC
+   │
+LL │     uint[] memory b1 = [];
+   ╰╴                       ━━ expected `uint256[] storage`, found `uint256[0] memory`
+
+error: cannot infer nameable array element type
+   ╭▸ ROOT/tests/ui/typeck/var_loc_state.sol:LL:CC
+   │
+LL │     S[] memory d1 = [];
+   │                     ━━
+   │
+   ╰ help: add an explicit type conversion for the first element
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/yul_type_checking.sol
+++ b/tests/ui/typeck/yul_type_checking.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 type U256 is uint256;
 type Word is bytes32;
 

--- a/tests/ui/using-for/attached_free_functions.sol
+++ b/tests/ui/using-for/attached_free_functions.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/free_functions_individual.sol
 // ported-from: test/libsolidity/semanticTests/using/free_function_multi.sol
 // ported-from: test/libsolidity/semanticTests/using/library_functions_inside_contract.sol

--- a/tests/ui/using-for/attached_function_members.sol
+++ b/tests/ui/using-for/attached_function_members.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_function_attached_but_not_called.sol
 // ported-from: test/libsolidity/syntaxTests/functionTypes/assign_attached_library_function.sol
 // ported-from: test/libsolidity/semanticTests/libraries/internal_library_function_attached_to_internal_function_type.sol

--- a/tests/ui/using-for/global/defined_elsewhere.sol
+++ b/tests/ui/using-for/global/defined_elsewhere.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_for_type_defined_elsewhere.sol
 
 library L {

--- a/tests/ui/using-for/global/directives.sol
+++ b/tests/ui/using-for/global/directives.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_working.sol
 
 import {S, U} from "./auxiliary/global_directives.sol";

--- a/tests/ui/using-for/global/imported_type_global.sol
+++ b/tests/ui/using-for/global/imported_type_global.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_for_type_from_other_file.sol
 
 import {ImportedS, ImportedU} from "./auxiliary/imported_types.sol";

--- a/tests/ui/using-for/global/invalid_global_targets.sol
+++ b/tests/ui/using-for/global/invalid_global_targets.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_for_non_user_defined.sol
 // ported-from: test/libsolidity/syntaxTests/using/global_library_for_builtin.sol
 // ported-from: test/libsolidity/syntaxTests/using/global_library_for_interface.sol

--- a/tests/ui/using-for/global/invalid_operator_targets.sol
+++ b/tests/ui/using-for/global/invalid_operator_targets.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/defining_operator_for_enum.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/defining_operator_for_struct.sol
 

--- a/tests/ui/using-for/global/library.sol
+++ b/tests/ui/using-for/global/library.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/using_global_all_the_types.sol
 
 import {E, S, T} from "./auxiliary/global_library.sol";

--- a/tests/ui/using-for/global/library_invisible.sol
+++ b/tests/ui/using-for/global/library_invisible.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/using_global_invisible.sol
 
 import {C} from "./auxiliary/global_invisible_mid.sol";

--- a/tests/ui/using-for/global_local_clash.sol
+++ b/tests/ui/using-for/global_local_clash.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/global_local_clash.sol
 
 import {S, f1 as f, gen} from "./auxiliary/imported_aliases_and_clashes.sol";

--- a/tests/ui/using-for/imported_functions.sol
+++ b/tests/ui/using-for/imported_functions.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/semanticTests/using/imported_functions.sol
 
 import {inc as aliasedInc} from "./auxiliary/imported_aliases_and_clashes.sol";

--- a/tests/ui/using-for/imports/file_level_using_not_imported.sol
+++ b/tests/ui/using-for/imports/file_level_using_not_imported.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/file_level_inactive_after_import.sol
 
 import "./auxiliary/file_level_using.sol";

--- a/tests/ui/using-for/imports/imported_duplicate_operator.sol
+++ b/tests/ui/using-for/imports/imported_duplicate_operator.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_different_functions_global_and_non_global_different_files.sol
 
 import {Int} from "./auxiliary/transitive_base.sol";

--- a/tests/ui/using-for/imports/imported_global_operator.sol
+++ b/tests/ui/using-for/imports/imported_global_operator.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported.sol
 
 import {Int} from "./auxiliary/imported_using.sol";

--- a/tests/ui/using-for/imports/imported_members.sol
+++ b/tests/ui/using-for/imports/imported_members.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/module_2.sol
 // ported-from: test/libsolidity/syntaxTests/using/library_import_as.sol
 

--- a/tests/ui/using-for/imports/imported_non_global_operator.sol
+++ b/tests/ui/using-for/imports/imported_non_global_operator.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported_non_global.sol
 
 import {ImportedInt} from "./auxiliary/non_global_operator.sol";

--- a/tests/ui/using-for/imports/imported_non_global_operator_definition.sol
+++ b/tests/ui/using-for/imports/imported_non_global_operator_definition.sol
@@ -1,7 +1,5 @@
-//@ compile-flags: -Ztypeck
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
-//@ check-fail
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported_non_global.sol
 
 import {DefinedInt} from "./auxiliary/defined_non_global_operator.sol";

--- a/tests/ui/using-for/imports/module_alias.sol
+++ b/tests/ui/using-for/imports/module_alias.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/module_3.sol
 
 import "./auxiliary/imported_using.sol" as M;

--- a/tests/ui/using-for/imports/transitive_global_operator.sol
+++ b/tests/ui/using-for/imports/transitive_global_operator.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported.sol
 
 import "./auxiliary/transitive_mid.sol";

--- a/tests/ui/using-for/imports/transitive_global_operator_wrong_source.sol
+++ b/tests/ui/using-for/imports/transitive_global_operator_wrong_source.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 //@ error-in-other-file: can only use `global` with types defined in the same source unit at file level
 //@ error-in-other-file: can only use `global` with types defined in the same source unit at file level
 //@ error-in-other-file: can only use `global` with types defined in the same source unit at file level

--- a/tests/ui/using-for/imports/transitive_non_global_operator.sol
+++ b/tests/ui/using-for/imports/transitive_non_global_operator.sol
@@ -1,9 +1,7 @@
-//@ compile-flags: -Ztypeck
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
 //@ error-in-other-file: operators can only be defined in a global
-//@ check-fail
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported_transitively_non_global.sol
 
 import "./auxiliary/non_global_left.sol";

--- a/tests/ui/using-for/invalid/contract_directive.sol
+++ b/tests/ui/using-for/invalid/contract_directive.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_contract_err.sol
 
 contract NotLibrary {

--- a/tests/ui/using-for/invalid/free_no_parameters.sol
+++ b/tests/ui/using-for/invalid/free_no_parameters.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_free_no_parameters_err.sol
 
 function zero() pure returns (uint256) {

--- a/tests/ui/using-for/invalid/implicit_conversion.sol
+++ b/tests/ui/using-for/invalid/implicit_conversion.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/free_functions_implicit_conversion_err.sol
 
 struct S {

--- a/tests/ui/using-for/invalid/library_for_library.sol
+++ b/tests/ui/using-for/invalid/library_for_library.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_library_for_library.sol
 
 library L {}

--- a/tests/ui/using-for/invalid/non_function.sol
+++ b/tests/ui/using-for/invalid/non_function.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_non_function.sol
 
 contract C {

--- a/tests/ui/using-for/invalid/private_library_function.sol
+++ b/tests/ui/using-for/invalid/private_library_function.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/private_library_function_outside_scope.sol
 
 library L {

--- a/tests/ui/using-for/invalid/unbraced_function.sol
+++ b/tests/ui/using-for/invalid/unbraced_function.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/function_name_without_braces_inside_contract_err.sol
 
 function id256(uint256 x) pure returns (uint256) {

--- a/tests/ui/using-for/libraries/self_call.sol
+++ b/tests/ui/using-for/libraries/self_call.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_attached_at_file_level_used_inside_library.sol
 
 library L {

--- a/tests/ui/using-for/libraries/visibility.sol
+++ b/tests/ui/using-for/libraries/visibility.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_at_file_level.sol
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 // ported-from: test/libsolidity/syntaxTests/using/private_library_function_inside_scope.sol

--- a/tests/ui/using-for/locations/calldata_receiver.sol
+++ b/tests/ui/using-for/locations/calldata_receiver.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/bound_calldata_parameter_accepting_calldata.sol
 
 struct S {

--- a/tests/ui/using-for/locations/calldata_rejects_memory.sol
+++ b/tests/ui/using-for/locations/calldata_rejects_memory.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/bound_calldata_parameter_not_accepting_memory.sol
 
 library L {

--- a/tests/ui/using-for/locations/reference_types.sol
+++ b/tests/ui/using-for/locations/reference_types.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/free_reference_type.sol
 
 function memoryHead(uint256[] memory x) pure returns (uint256) {

--- a/tests/ui/using-for/methods.sol
+++ b/tests/ui/using-for/methods.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/using_free_functions.sol
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 // ported-from: test/libsolidity/syntaxTests/using/global_working.sol

--- a/tests/ui/using-for/operators.sol
+++ b/tests/ui/using-for/operators.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/contract_scope_duplicates.sol
+++ b/tests/ui/using-for/operators/contract_scope_duplicates.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_on_file_and_contract_level.sol
 
 type Int is int256;

--- a/tests/ui/using-for/operators/contract_scope_not_inherited.sol
+++ b/tests/ui/using-for/operators/contract_scope_not_inherited.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/using_for_with_operator_at_contract_level_in_base_contract.sol
 
 type Int is int256;

--- a/tests/ui/using-for/operators/duplicate_distinct_functions.sol
+++ b/tests/ui/using-for/operators/duplicate_distinct_functions.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_different_functions_same_directive.sol
 
 type Int is int256;

--- a/tests/ui/using-for/operators/duplicate_same_directive.sol
+++ b/tests/ui/using-for/operators/duplicate_same_directive.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_different_functions_same_directive.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/duplicate_same_function.sol
+++ b/tests/ui/using-for/operators/duplicate_same_function.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_same_function_same_directive.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/multiple_operator_definitions_same_function_separate_directives.sol
 

--- a/tests/ui/using-for/operators/implicit_conversion_failures.sol
+++ b/tests/ui/using-for/operators/implicit_conversion_failures.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_with_implicit_conversion.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/imported_global.sol
+++ b/tests/ui/using-for/operators/imported_global.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_imported.sol
 
 import {Int} from "./auxiliary/operator_imported.sol";

--- a/tests/ui/using-for/operators/invalid_event_implementor.sol
+++ b/tests/ui/using-for/operators/invalid_event_implementor.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_event.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/invalid_implementors.sol
+++ b/tests/ui/using-for/operators/invalid_implementors.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_contract_function_at_file_level.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_library_function_at_file_level.sol
 

--- a/tests/ui/using-for/operators/non_pure_definition.sol
+++ b/tests/ui/using-for/operators/non_pure_definition.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/implementing_operator_with_non_pure_function.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/operator_definition_matrix.sol
+++ b/tests/ui/using-for/operators/operator_definition_matrix.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_no_parameters_binary.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_two_parameters_unary.sol
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_and_returning_types_not_matching_using_for.sol

--- a/tests/ui/using-for/operators/operator_not_method.sol
+++ b/tests/ui/using-for/operators/operator_not_method.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/calling_operator_as_attached_function_via_function_name.sol
 
 type U is uint256;

--- a/tests/ui/using-for/operators/type_mismatch_definitions.sol
+++ b/tests/ui/using-for/operators/type_mismatch_definitions.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/operators/userDefined/operator_taking_and_returning_types_not_matching_using_for.sol
 
 type Int is int256;

--- a/tests/ui/using-for/overloads/ambiguous_library_member.sol
+++ b/tests/ui/using-for/overloads/ambiguous_library_member.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 
 library L {

--- a/tests/ui/using-for/overloads/braced_free_overload_rejected.sol
+++ b/tests/ui/using-for/overloads/braced_free_overload_rejected.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/free_functions_non_unique_err.sol
 // ported-from: test/libsolidity/syntaxTests/using/free_overloads.sol
 

--- a/tests/ui/using-for/overloads/library_member_overloads.sol
+++ b/tests/ui/using-for/overloads/library_member_overloads.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/library_functions_inside_contract.sol
 
 library L {

--- a/tests/ui/using-for/paths/super_qualified_function.sol
+++ b/tests/ui/using-for/paths/super_qualified_function.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/function_from_base_contract_qualified_with_super.sol
 
 contract C {

--- a/tests/ui/using-for/paths/this_qualified_function.sol
+++ b/tests/ui/using-for/paths/this_qualified_function.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/using/external_function_qualified_with_this.sol
 
 contract C {

--- a/tests/ui/yul_lowering/arithmetic.sol
+++ b/tests/ui/yul_lowering/arithmetic.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f(uint256 a, uint256 b) public returns (uint256 x) {
         assembly {

--- a/tests/ui/yul_lowering/break_continue.sol
+++ b/tests/ui/yul_lowering/break_continue.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function ok(uint256 n) public returns (uint256 x) {
         assembly {

--- a/tests/ui/yul_lowering/builtins.sol
+++ b/tests/ui/yul_lowering/builtins.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f() public returns (uint256 x) {
         assembly {

--- a/tests/ui/yul_lowering/control_flow.sol
+++ b/tests/ui/yul_lowering/control_flow.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f(uint256 n) public returns (uint256 x) {
         assembly {

--- a/tests/ui/yul_lowering/dialect_helpers.sol
+++ b/tests/ui/yul_lowering/dialect_helpers.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f() public returns (uint256 x, uint256 y) {
         assembly {

--- a/tests/ui/yul_lowering/for_loop_scope.sol
+++ b/tests/ui/yul_lowering/for_loop_scope.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function init_visible(uint256 n) public returns (uint256 x) {
         assembly {

--- a/tests/ui/yul_lowering/solc_for_statement_2.sol
+++ b/tests/ui/yul_lowering/solc_for_statement_2.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libyul/yulSyntaxTests/for_statement_2.yul
 
 contract C {

--- a/tests/ui/yul_lowering/solc_inline_assembly_instructions_allowed.sol
+++ b/tests/ui/yul_lowering/solc_inline_assembly_instructions_allowed.sol
@@ -1,4 +1,3 @@
-//@ compile-flags: -Ztypeck
 // ported-from: test/libsolidity/syntaxTests/viewPureChecker/inline_assembly_instructions_allowed.sol
 
 contract C {

--- a/tests/ui/yul_lowering/yul_call_non_function.sol
+++ b/tests/ui/yul_lowering/yul_call_non_function.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function helper(uint256 a) internal pure returns (uint256) {
         return a;

--- a/tests/ui/yul_lowering/yul_function_resolution.sol
+++ b/tests/ui/yul_lowering/yul_function_resolution.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f() public returns (uint256 x) {
         assembly {

--- a/tests/ui/yul_lowering/yul_function_scope.sol
+++ b/tests/ui/yul_lowering/yul_function_scope.sol
@@ -1,5 +1,3 @@
-//@ compile-flags: -Ztypeck
-
 contract C {
     function f() public returns (uint256 x, uint256 y) {
         assembly {
@@ -11,7 +9,6 @@ contract C {
 
         assembly {
             x, y := pair(1) //~ ERROR: unresolved symbol
-            //~^ ERROR: mismatched number of components
         }
     }
 

--- a/tests/ui/yul_lowering/yul_function_scope.stderr
+++ b/tests/ui/yul_lowering/yul_function_scope.stderr
@@ -40,11 +40,5 @@ error: unresolved symbol `a`
 LL │                     r := a
    ╰╴                         ━
 
-error: mismatched number of components
-   ╭▸ ROOT/tests/ui/yul_lowering/yul_function_scope.sol:LL:CC
-   │
-LL │             x, y := pair(1)
-   ╰╴            ━━━━    ─────── expected a tuple with 2 elements, found one with 1 element
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Type checking is now part of every compilation instead of being gated by an unstable option. This removes the `-Ztypeck` CLI surface and its test annotations, and lets the LSP and benchmarks rely on the default pipeline.

Enabling the checker globally exposed recovery paths that previously only appeared in opted-in tests. This fixes those cascades, avoids recursive struct expansion during memory-size validation by consulting the existing recursiveness query, and updates the affected diagnostics and fixtures.
