### PR TITLE
feat(parser): recover incomplete input

### DIFF
--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -323,6 +323,10 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub no_resolve_imports: bool,
 
+    /// Recovers incomplete input into a partial AST.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub recover_incomplete_input: bool,
+
     /// Print additional information about the compiler's internal state.
     ///
     /// Valid kinds are `ast` and `hir`.

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -50,7 +50,12 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         }
         if !self.eat(end) {
             let (msg, note) = get_msg_note(self);
-            return Err(self.dcx().err(msg).span(self.token.span).note(note));
+            let err = self.dcx().err(msg).span(self.token.span).note(note);
+            if self.recover_incomplete_input && self.token.kind == TokenKind::Eof {
+                err.emit();
+            } else {
+                return Err(err);
+            }
         }
         Ok(self.alloc_vec(items))
     }

--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -50,12 +50,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         }
         if !self.eat(end) {
             let (msg, note) = get_msg_note(self);
-            let err = self.dcx().err(msg).span(self.token.span).note(note);
-            if self.recover_incomplete_input && self.token.kind == TokenKind::Eof {
-                err.emit();
-            } else {
-                return Err(err);
-            }
+            self.dcx().err(msg).span(self.token.span).note(note).emit();
         }
         Ok(self.alloc_vec(items))
     }

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -58,6 +58,8 @@ pub struct Parser<'sess, 'ast, 'cb> {
     in_yul: bool,
     /// Whether the parser is currently parsing a contract block.
     in_contract: bool,
+    /// Whether incomplete input should be recovered into a partial AST.
+    recover_incomplete_input: bool,
 
     /// Current recursion depth for recursive parsing operations.
     recursion_depth: usize,
@@ -157,6 +159,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
             tokens: tokens.into_iter(),
             in_yul: false,
             in_contract: false,
+            recover_incomplete_input: sess.opts.unstable.recover_incomplete_input,
             recursion_depth: 0,
             import_callback: None,
         };
@@ -409,7 +412,19 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     #[inline]
     #[track_caller]
     fn expect_semi(&mut self) -> PResult<'sess, ()> {
-        self.expect(TokenKind::Semi).map(drop)
+        let recover = self.recover_incomplete_input
+            && matches!(self.token.kind, TokenKind::CloseDelim(Delimiter::Brace) | TokenKind::Eof);
+        if recover && self.last_unexpected_token_span == Some(self.token.span) {
+            return Ok(());
+        }
+        match self.expect(TokenKind::Semi) {
+            Ok(_) => Ok(()),
+            Err(err) if recover => {
+                err.emit();
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Checks if the next token is `tok`, and returns `true` if so.
@@ -666,37 +681,45 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         let mut trailing = false;
         let mut v = SmallVec::<[T; 8]>::new();
 
-        if !allow_empty {
-            v.push(f(self)?);
-            first = false;
-        }
-
-        while !self.check(ket) {
-            if self.token.kind == TokenKind::Eof {
+        loop {
+            let required_first = first && !allow_empty;
+            if !required_first && self.check(ket) {
+                break;
+            }
+            if !required_first && self.token.kind == TokenKind::Eof {
                 recovered = Recovered::Yes;
                 break;
             }
 
-            if let Some(sep_kind) = sep.sep {
-                if first {
-                    // no separator for the first element
-                    first = false;
-                } else {
-                    // check for separator
-                    let recovered_ = self.expect(sep_kind)?;
-                    if recovered_ == Recovered::Yes {
-                        recovered = Recovered::Yes;
-                        break;
-                    }
+            if first {
+                // No separator for the first element.
+                first = false;
+            } else if let Some(sep_kind) = sep.sep {
+                // Check for a separator.
+                let recovered_ = self.expect(sep_kind)?;
+                if recovered_ == Recovered::Yes {
+                    recovered = Recovered::Yes;
+                    break;
+                }
 
-                    if self.check(ket) {
-                        trailing = true;
-                        break;
-                    }
+                if self.check(ket) {
+                    trailing = true;
+                    break;
                 }
             }
 
-            v.push(f(self)?);
+            match f(self) {
+                Ok(value) => v.push(value),
+                Err(err) if self.can_recover_sequence(ket) => {
+                    err.emit();
+                    if self.token.kind == ket {
+                        self.bump();
+                    }
+                    recovered = Recovered::Yes;
+                    break;
+                }
+                Err(err) => return Err(err),
+            }
         }
 
         if let Some(sep_kind) = sep.sep {
@@ -715,6 +738,15 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         }
 
         Ok((self.alloc_smallvec(v), recovered))
+    }
+
+    fn can_recover_sequence(&self, ket: TokenKind) -> bool {
+        self.recover_incomplete_input
+            && (self.token.kind == ket
+                || matches!(
+                    self.token.kind,
+                    TokenKind::Semi | TokenKind::Eof | TokenKind::CloseDelim(_)
+                ))
     }
 
     /// Advance the parser by one token.
@@ -1262,6 +1294,27 @@ import * as B from "b.sol";
                 r#"import "a.sol";"#
             );
         });
+    }
+
+    #[test]
+    fn nonempty_sequence_requires_a_first_element() {
+        for (allow_empty, succeeds) in [(true, true), (false, false)] {
+            let sess = Session::builder()
+                .with_buffer_emitter(Default::default())
+                .single_threaded()
+                .build();
+            sess.enter_sequential(|| {
+                let arena = ast::Arena::new();
+                let mut parser =
+                    Parser::from_source_code(&sess, &arena, "test.sol".to_string().into(), "{}")
+                        .unwrap();
+                let result = parser
+                    .parse_delim_comma_seq(Delimiter::Brace, allow_empty, Parser::parse_ident)
+                    .map_err(|err| err.emit());
+
+                assert_eq!(result.is_ok(), succeeds);
+            });
+        }
     }
 
     #[test]

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -16,6 +16,9 @@ Options:
       -Zno-resolve-imports
           Disables import resolution
 
+      -Zrecover-incomplete-input
+          Recovers incomplete input into a partial AST
+
       -Zdump=<KIND[=PATHS...]>
           Print additional information about the compiler's internal state.
           

--- a/tests/ui/parser/recover_incomplete_input.recover.stderr
+++ b/tests/ui/parser/recover_incomplete_input.recover.stderr
@@ -1,0 +1,32 @@
+error: expected one of `(`, `)`, `+`, `[`, `delete`, `new`, `payable`, `type`, elementary type name, identifier, or literal, found `}`
+   ╭▸ ROOT/tests/ui/parser/recover_incomplete_input.sol:LL:CC
+   │
+LL │         return target(1,
+   │                         ─ expected one of 11 possible tokens
+LL │     }
+   ╰╴    ━ unexpected token
+
+error: expected contract item (function, variable, struct, or modifier definition), found `<eof>`
+   ╭▸ ROOT/tests/ui/parser/recover_incomplete_input.sol:LL:CC
+   │
+LL │     }
+   │     ━
+   │
+   ╰ note: for a full list of valid contract items, see <https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.contractBodyElement>
+
+error: wrong argument count for function call: 1 arguments given but expected 2
+   ╭▸ ROOT/tests/ui/parser/recover_incomplete_input.sol:LL:CC
+   │
+LL │         return target(1,
+   │                ━━━━━━┬──
+   │                      │
+   ╰╴                     expected 2 arguments, found 1
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/parser/recover_incomplete_input.sol:LL:CC
+   │
+LL │         uint8 value = 300;
+   ╰╴                      ━━━ expected `uint8`, found `int_literal[9]`
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/parser/recover_incomplete_input.sol
+++ b/tests/ui/parser/recover_incomplete_input.sol
@@ -1,0 +1,15 @@
+//@ revisions: strict recover
+//@[recover] compile-flags: -Zrecover-incomplete-input
+
+contract C {
+    function target(uint256 amount, address account) internal returns (uint256) {
+        return amount + uint256(uint160(account));
+    }
+
+    function use() internal returns (uint256) {
+        return target(1, //~[recover] ERROR: wrong argument count
+    } //~ ERROR: expected one of
+
+    function later() internal {
+        uint8 value = 300; //~[recover] ERROR: mismatched types
+    } //~[recover] ERROR: expected contract item

--- a/tests/ui/parser/recover_incomplete_input.strict.stderr
+++ b/tests/ui/parser/recover_incomplete_input.strict.stderr
@@ -1,0 +1,10 @@
+error: expected one of `(`, `)`, `+`, `[`, `delete`, `new`, `payable`, `type`, elementary type name, identifier, or literal, found `}`
+   ╭▸ ROOT/tests/ui/parser/recover_incomplete_input.sol:LL:CC
+   │
+LL │         return target(1,
+   │                         ─ expected one of 11 possible tokens
+LL │     }
+   ╰╴    ━ unexpected token
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Should be merged before #941  

This extracts incomplete-input recovery from https://github.com/paradigmxyz/solar/pull/941 into a compiler-facing parser change. The new `-Zrecover-incomplete-input` mode keeps strict parsing as the default while allowing editor-style callers to retain a partial AST after incomplete argument lists, missing semicolons, and EOF-delimited item lists.

A revisioned UI test runs the same source in strict and recovery modes. The recovery revision demonstrates that the incomplete call remains available to semantic analysis and that parsing continues into later items.
