### PR TITLE
fix(sema): match solc storage layouts

### DIFF
--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -12,7 +12,7 @@ use solar_data_structures::{
 };
 use solar_interface::{Ident, Span, Symbol, diagnostics::ErrorGuaranteed, source_map::SourceFile};
 use std::{cell::Cell, fmt, ops::ControlFlow, sync::Arc};
-use strum::{EnumCount, EnumIs};
+use strum::EnumIs;
 
 pub use ast::{
     BinOp, BinOpKind, ContractKind, DataLocation, ElementaryType, FunctionKind, Lit, NatSpecItem,
@@ -85,18 +85,18 @@ pub struct Hir<'hir> {
     pub(crate) contracts: IndexVec<ContractId, Contract<'hir>>,
     /// All functions.
     pub(crate) functions: IndexVec<FunctionId, Function<'hir>>,
+    /// All constants and variables.
+    pub(crate) variables: IndexVec<VariableId, Variable<'hir>>,
     /// All structs.
     pub(crate) structs: IndexVec<StructId, Struct<'hir>>,
     /// All enums.
     pub(crate) enums: IndexVec<EnumId, Enum<'hir>>,
     /// All user-defined value types.
     pub(crate) udvts: IndexVec<UdvtId, Udvt<'hir>>,
-    /// All events.
-    pub(crate) events: IndexVec<EventId, Event<'hir>>,
     /// All custom errors.
     pub(crate) errors: IndexVec<ErrorId, Error<'hir>>,
-    /// All constants and variables.
-    pub(crate) variables: IndexVec<VariableId, Variable<'hir>>,
+    /// All events.
+    pub(crate) events: IndexVec<EventId, Event<'hir>>,
 }
 
 macro_rules! indexvec_methods {
@@ -181,12 +181,12 @@ impl<'hir> Hir<'hir> {
             docs,
             contracts: IndexVec::new(),
             functions: IndexVec::new(),
+            variables: IndexVec::new(),
             structs: IndexVec::new(),
             enums: IndexVec::new(),
             udvts: IndexVec::new(),
-            events: IndexVec::new(),
             errors: IndexVec::new(),
-            variables: IndexVec::new(),
+            events: IndexVec::new(),
         }
     }
 
@@ -195,12 +195,12 @@ impl<'hir> Hir<'hir> {
         doc => docs, DocId => Doc<'hir>;
         contract => contracts, ContractId => Contract<'hir>;
         function => functions, FunctionId => Function<'hir>;
+        variable => variables, VariableId => Variable<'hir>;
         strukt => structs, StructId => Struct<'hir>;
         enumm => enums, EnumId => Enum<'hir>;
         udvt => udvts, UdvtId => Udvt<'hir>;
-        event => events, EventId => Event<'hir>;
         error => errors, ErrorId => Error<'hir>;
-        variable => variables, VariableId => Variable<'hir>;
+        event => events, EventId => Event<'hir>;
     }
 
     /// Returns the item associated with the given ID.
@@ -220,18 +220,35 @@ impl<'hir> Hir<'hir> {
 
     /// Returns an ID that is unique across all HIR item kinds.
     pub fn global_item_id(&self, id: impl Into<ItemId>) -> usize {
-        let id = id.into();
-        let counts: [usize; ItemKind::COUNT] = [
-            self.contracts.len(),
-            self.functions.len(),
-            self.variables.len(),
-            self.structs.len(),
-            self.enums.len(),
-            self.udvts.len(),
-            self.errors.len(),
-            self.events.len(),
-        ];
-        counts[..id.kind() as usize].iter().sum::<usize>() + id.index()
+        self.global_item_id_(id.into())
+    }
+
+    fn global_item_id_(&self, id: ItemId) -> usize {
+        let mut base = 0;
+        'out: {
+            macro_rules! sum_base {
+                ($($kind:ident : $kinds:ident,)*) => {
+                    $(
+                        if id.kind() > ItemKind::$kind {
+                            base += self.$kinds.len();
+                        } else {
+                            break 'out;
+                        }
+                    )*
+                };
+            }
+            sum_base!(
+                Contract : contracts,
+                Function : functions,
+                Variable : variables,
+                Struct : structs,
+                Enum : enums,
+                Udvt : udvts,
+                Error : errors,
+                Event : events,
+            );
+        }
+        base + id.raw_index()
     }
 
     /// Returns an iterator over all item IDs.
@@ -703,8 +720,7 @@ impl<'hir> Item<'_, 'hir> {
 }
 
 /// HIR item kinds in global ID order.
-#[derive(Clone, Copy, EnumCount)]
-#[repr(usize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum ItemKind {
     Contract,
     Function,
@@ -745,6 +761,7 @@ impl fmt::Debug for ItemId {
 }
 
 impl ItemId {
+    #[inline]
     fn kind(self) -> ItemKind {
         match self {
             Self::Contract(_) => ItemKind::Contract,
@@ -758,7 +775,8 @@ impl ItemId {
         }
     }
 
-    fn index(self) -> usize {
+    #[inline]
+    fn raw_index(self) -> usize {
         match self {
             Self::Contract(id) => id.index(),
             Self::Function(id) => id.index(),

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -218,6 +218,52 @@ impl<'hir> Hir<'hir> {
         }
     }
 
+    /// Returns an ID that is unique across all HIR item kinds.
+    pub fn global_item_id(&self, id: impl Into<ItemId>) -> usize {
+        match id.into() {
+            ItemId::Contract(id) => id.index(),
+            ItemId::Function(id) => self.contracts.len() + id.index(),
+            ItemId::Variable(id) => self.contracts.len() + self.functions.len() + id.index(),
+            ItemId::Struct(id) => {
+                self.contracts.len() + self.functions.len() + self.variables.len() + id.index()
+            }
+            ItemId::Enum(id) => {
+                self.contracts.len()
+                    + self.functions.len()
+                    + self.variables.len()
+                    + self.structs.len()
+                    + id.index()
+            }
+            ItemId::Udvt(id) => {
+                self.contracts.len()
+                    + self.functions.len()
+                    + self.variables.len()
+                    + self.structs.len()
+                    + self.enums.len()
+                    + id.index()
+            }
+            ItemId::Error(id) => {
+                self.contracts.len()
+                    + self.functions.len()
+                    + self.variables.len()
+                    + self.structs.len()
+                    + self.enums.len()
+                    + self.udvts.len()
+                    + id.index()
+            }
+            ItemId::Event(id) => {
+                self.contracts.len()
+                    + self.functions.len()
+                    + self.variables.len()
+                    + self.structs.len()
+                    + self.enums.len()
+                    + self.udvts.len()
+                    + self.errors.len()
+                    + id.index()
+            }
+        }
+    }
+
     /// Returns an iterator over all item IDs.
     pub fn item_ids(&self) -> impl Iterator<Item = ItemId> + Clone {
         self.item_ids_vec().into_iter()

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -12,7 +12,7 @@ use solar_data_structures::{
 };
 use solar_interface::{Ident, Span, Symbol, diagnostics::ErrorGuaranteed, source_map::SourceFile};
 use std::{cell::Cell, fmt, ops::ControlFlow, sync::Arc};
-use strum::EnumIs;
+use strum::{EnumCount, EnumIs};
 
 pub use ast::{
     BinOp, BinOpKind, ContractKind, DataLocation, ElementaryType, FunctionKind, Lit, NatSpecItem,
@@ -220,48 +220,18 @@ impl<'hir> Hir<'hir> {
 
     /// Returns an ID that is unique across all HIR item kinds.
     pub fn global_item_id(&self, id: impl Into<ItemId>) -> usize {
-        match id.into() {
-            ItemId::Contract(id) => id.index(),
-            ItemId::Function(id) => self.contracts.len() + id.index(),
-            ItemId::Variable(id) => self.contracts.len() + self.functions.len() + id.index(),
-            ItemId::Struct(id) => {
-                self.contracts.len() + self.functions.len() + self.variables.len() + id.index()
-            }
-            ItemId::Enum(id) => {
-                self.contracts.len()
-                    + self.functions.len()
-                    + self.variables.len()
-                    + self.structs.len()
-                    + id.index()
-            }
-            ItemId::Udvt(id) => {
-                self.contracts.len()
-                    + self.functions.len()
-                    + self.variables.len()
-                    + self.structs.len()
-                    + self.enums.len()
-                    + id.index()
-            }
-            ItemId::Error(id) => {
-                self.contracts.len()
-                    + self.functions.len()
-                    + self.variables.len()
-                    + self.structs.len()
-                    + self.enums.len()
-                    + self.udvts.len()
-                    + id.index()
-            }
-            ItemId::Event(id) => {
-                self.contracts.len()
-                    + self.functions.len()
-                    + self.variables.len()
-                    + self.structs.len()
-                    + self.enums.len()
-                    + self.udvts.len()
-                    + self.errors.len()
-                    + id.index()
-            }
-        }
+        let id = id.into();
+        let counts: [usize; ItemKind::COUNT] = [
+            self.contracts.len(),
+            self.functions.len(),
+            self.variables.len(),
+            self.structs.len(),
+            self.enums.len(),
+            self.udvts.len(),
+            self.errors.len(),
+            self.events.len(),
+        ];
+        counts[..id.kind() as usize].iter().sum::<usize>() + id.index()
     }
 
     /// Returns an iterator over all item IDs.
@@ -732,6 +702,20 @@ impl<'hir> Item<'_, 'hir> {
     }
 }
 
+/// HIR item kinds in global ID order.
+#[derive(Clone, Copy, EnumCount)]
+#[repr(usize)]
+enum ItemKind {
+    Contract,
+    Function,
+    Variable,
+    Struct,
+    Enum,
+    Udvt,
+    Error,
+    Event,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, From, EnumIs)]
 pub enum ItemId {
     Contract(ContractId),
@@ -761,6 +745,32 @@ impl fmt::Debug for ItemId {
 }
 
 impl ItemId {
+    fn kind(self) -> ItemKind {
+        match self {
+            Self::Contract(_) => ItemKind::Contract,
+            Self::Function(_) => ItemKind::Function,
+            Self::Variable(_) => ItemKind::Variable,
+            Self::Struct(_) => ItemKind::Struct,
+            Self::Enum(_) => ItemKind::Enum,
+            Self::Udvt(_) => ItemKind::Udvt,
+            Self::Error(_) => ItemKind::Error,
+            Self::Event(_) => ItemKind::Event,
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Contract(id) => id.index(),
+            Self::Function(id) => id.index(),
+            Self::Variable(id) => id.index(),
+            Self::Struct(id) => id.index(),
+            Self::Enum(id) => id.index(),
+            Self::Udvt(id) => id.index(),
+            Self::Error(id) => id.index(),
+            Self::Event(id) => id.index(),
+        }
+    }
+
     /// Returns the description of the item.
     pub fn description(&self) -> &'static str {
         match self {

--- a/crates/sema/src/output/storage_layout.rs
+++ b/crates/sema/src/output/storage_layout.rs
@@ -16,8 +16,8 @@ use solar_data_structures::map::FxIndexMap;
 #[serde(rename_all = "camelCase")]
 pub struct StorageLayoutOutput {
     pub storage: Vec<StorageLayoutEntry>,
-    #[serde(skip_serializing_if = "FxIndexMap::is_empty")]
-    pub types: FxIndexMap<String, StorageLayoutType>,
+    /// `solc` emits `null` rather than an empty object when no storage types are present.
+    pub types: Option<FxIndexMap<String, StorageLayoutType>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -133,7 +133,8 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
             }
         }
 
-        StorageLayoutOutput { storage, types: self.types }
+        let types = (!self.types.is_empty()).then_some(self.types);
+        StorageLayoutOutput { storage, types }
     }
 
     fn layout_members(&mut self, fields: &[hir::VariableId]) -> (Vec<StorageLayoutEntry>, U256) {
@@ -156,7 +157,7 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
         ty: String,
     ) -> StorageLayoutEntry {
         StorageLayoutEntry {
-            ast_id: variable_id.index() as u64,
+            ast_id: self.gcx.hir.global_item_id(variable_id) as u64,
             contract: self.contract_name.clone(),
             label: self.gcx.hir.variable(variable_id).name.unwrap().to_string(),
             offset,
@@ -272,11 +273,21 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
                     false,
                 )
             ),
-            TyKind::Contract(id) => format!("t_contract({}){}", self.gcx.item_name(id), id.index()),
-            TyKind::Struct(id) => format!("t_struct({}){}", self.gcx.item_name(id), id.index()),
-            TyKind::Enum(id) => format!("t_enum({}){}", self.gcx.item_name(id), id.index()),
+            TyKind::Contract(id) => {
+                format!("t_contract({}){}", self.gcx.item_name(id), self.gcx.hir.global_item_id(id))
+            }
+            TyKind::Struct(id) => {
+                format!("t_struct({}){}", self.gcx.item_name(id), self.gcx.hir.global_item_id(id))
+            }
+            TyKind::Enum(id) => {
+                format!("t_enum({}){}", self.gcx.item_name(id), self.gcx.hir.global_item_id(id))
+            }
             TyKind::Udvt(_, id) => {
-                format!("t_userDefinedValueType({}){}", self.gcx.item_name(id), id.index())
+                format!(
+                    "t_userDefinedValueType({}){}",
+                    self.gcx.item_name(id),
+                    self.gcx.hir.global_item_id(id)
+                )
             }
             TyKind::Fn(function) => {
                 let kind = if function.is_external() { "external" } else { "internal" };

--- a/crates/sema/src/output/storage_layout.rs
+++ b/crates/sema/src/output/storage_layout.rs
@@ -16,6 +16,7 @@ use solar_data_structures::map::FxIndexMap;
 #[serde(rename_all = "camelCase")]
 pub struct StorageLayoutOutput {
     pub storage: Vec<StorageLayoutEntry>,
+    #[serde(skip_serializing_if = "FxIndexMap::is_empty")]
     pub types: FxIndexMap<String, StorageLayoutType>,
 }
 
@@ -192,6 +193,7 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
         }
         self.types.insert(key.clone(), StorageLayoutType::default());
 
+        let location = ty.loc();
         let ty = ty.peel_refs();
         let mut info = StorageLayoutType {
             encoding: StorageEncoding::Inplace,
@@ -207,14 +209,16 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
             TyKind::Mapping(key_ty, value_ty) => {
                 info.encoding = StorageEncoding::Mapping;
                 info.key = Some(self.generate_type(key_ty));
-                info.value = Some(self.generate_type(value_ty));
+                info.value = Some(
+                    self.generate_type(value_ty.with_loc_if_ref(self.gcx, DataLocation::Storage)),
+                );
             }
             TyKind::Array(base, _) => {
-                info.base = Some(self.generate_type(base));
+                info.base = Some(self.generate_type(base.with_loc_if_ref_opt(self.gcx, location)));
             }
             TyKind::DynArray(base) => {
                 info.encoding = StorageEncoding::DynamicArray;
-                info.base = Some(self.generate_type(base));
+                info.base = Some(self.generate_type(base.with_loc_if_ref_opt(self.gcx, location)));
             }
             TyKind::Elementary(ElementaryType::Bytes | ElementaryType::String) => {
                 info.encoding = StorageEncoding::Bytes;
@@ -231,24 +235,42 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
     }
 
     fn storage_type_key(&self, ty: Ty<'gcx>) -> String {
+        self.storage_type_key_with(ty, None, false)
+    }
+
+    fn storage_type_key_with(
+        &self,
+        ty: Ty<'gcx>,
+        location: Option<DataLocation>,
+        pointer: bool,
+    ) -> String {
         match ty.kind {
             TyKind::Ref(inner, location) => {
-                let key = self.storage_type_key(inner);
+                let key = self.storage_type_key_with(inner, Some(location), pointer);
                 if matches!(inner.peel_refs().kind, TyKind::Mapping(..)) {
                     key
                 } else {
-                    format!("{key}_{location}")
+                    let pointer = if pointer { "_ptr" } else { "" };
+                    format!("{key}_{location}{pointer}")
                 }
             }
             TyKind::Elementary(ty) => format!("t_{}", ty.to_string().replace(' ', "_")),
             TyKind::Array(base, length) => {
-                format!("t_array({}){length}", self.storage_type_key(base))
+                let base = base.with_loc_if_ref_opt(self.gcx, location);
+                format!("t_array({}){length}", self.storage_type_key_with(base, None, pointer))
             }
-            TyKind::DynArray(base) => format!("t_array({})dyn", self.storage_type_key(base)),
+            TyKind::DynArray(base) => {
+                let base = base.with_loc_if_ref_opt(self.gcx, location);
+                format!("t_array({})dyn", self.storage_type_key_with(base, None, pointer))
+            }
             TyKind::Mapping(key, value) => format!(
                 "t_mapping({},{})",
-                self.storage_type_key(key),
-                self.storage_type_key(value)
+                self.storage_type_key_with(key, None, false),
+                self.storage_type_key_with(
+                    value.with_loc_if_ref(self.gcx, DataLocation::Storage),
+                    None,
+                    false,
+                )
             ),
             TyKind::Contract(id) => format!("t_contract({}){}", self.gcx.item_name(id), id.index()),
             TyKind::Struct(id) => format!("t_struct({}){}", self.gcx.item_name(id), id.index()),
@@ -261,13 +283,13 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
                 let params = function
                     .parameters
                     .iter()
-                    .map(|ty| self.storage_type_key(*ty))
+                    .map(|ty| self.function_type_key(*ty))
                     .collect::<Vec<_>>()
                     .join(",");
                 let returns = function
                     .returns
                     .iter()
-                    .map(|ty| self.storage_type_key(*ty))
+                    .map(|ty| self.function_type_key(*ty))
                     .collect::<Vec<_>>()
                     .join(",");
                 format!(
@@ -277,6 +299,10 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
             }
             _ => unreachable!("invalid storage type: {ty:?}"),
         }
+    }
+
+    fn function_type_key(&self, ty: Ty<'gcx>) -> String {
+        self.storage_type_key_with(ty, None, true)
     }
 
     fn storage_type_label(&self, ty: Ty<'gcx>) -> String {
@@ -292,20 +318,22 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
             ),
             TyKind::Contract(id) => format!("contract {}", self.gcx.item_name(id)),
             TyKind::Struct(id) => format!("struct {}", self.gcx.item_canonical_name(id)),
-            TyKind::Enum(id) => format!("enum {}", self.gcx.item_name(id)),
-            TyKind::Udvt(_, id) => self.gcx.item_name(id).to_string(),
+            TyKind::Enum(id) => format!("enum {}", self.gcx.item_canonical_name(id)),
+            TyKind::Udvt(_, id) => self.gcx.item_canonical_name(id).to_string(),
             TyKind::Fn(function) => {
                 let params = function
                     .parameters
                     .iter()
                     .map(|ty| self.storage_type_label(*ty))
                     .collect::<Vec<_>>()
-                    .join(", ");
-                let kind = if function.is_external() { "external" } else { "internal" };
-                let mut label = format!("function ({params}) {kind}");
+                    .join(",");
+                let mut label = format!("function ({params})");
                 if function.state_mutability != hir::StateMutability::NonPayable {
                     label.push(' ');
                     label.push_str(&function.state_mutability.to_string());
+                }
+                if function.is_external() {
+                    label.push_str(" external");
                 }
                 if !function.returns.is_empty() {
                     let returns = function
@@ -313,7 +341,7 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
                         .iter()
                         .map(|ty| self.storage_type_label(*ty))
                         .collect::<Vec<_>>()
-                        .join(", ");
+                        .join(",");
                     label.push_str(&format!(" returns ({returns})"));
                 }
                 label
@@ -336,7 +364,15 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
                 | ElementaryType::FixedBytes(size) => U256::from(size.bytes()),
             },
             TyKind::Array(base, length) => {
-                slots_for(self.storage_bytes(base) * length) * U256::from(32)
+                let base_bytes = self.storage_bytes(base);
+                let slots = if self.is_packable(base) {
+                    let items_per_slot = U256::from(32) / base_bytes;
+                    length / items_per_slot
+                        + U256::from(u8::from(length % items_per_slot != U256::ZERO))
+                } else {
+                    slots_for(base_bytes) * length
+                };
+                slots.max(U256::from(1)) * U256::from(32)
             }
             TyKind::DynArray(_) | TyKind::Mapping(..) => U256::from(32),
             TyKind::Struct(struct_id) => {
@@ -399,5 +435,5 @@ impl StorageCursor {
 }
 
 fn slots_for(bytes: U256) -> U256 {
-    (bytes + U256::from(31)) / U256::from(32)
+    bytes / U256::from(32) + U256::from(u8::from(bytes % U256::from(32) != U256::ZERO))
 }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -87,7 +87,22 @@ impl<'gcx> TypeChecker<'gcx> {
         let mut evaluator = ConstantEvaluator::new(self.gcx);
         match evaluator.try_eval_value(slot) {
             Ok(ConstValue::Integer(value)) => {
-                if value.as_u256().is_none() {
+                if let Some(base_slot) = value.as_u256() {
+                    let Some(contract_id) = self.contract else {
+                        unreachable!("storage layout specifier outside a contract")
+                    };
+                    if let Ok(Some(size)) = super::storage_size_upper_bound(
+                        self.gcx,
+                        contract_id,
+                        DataLocation::Storage,
+                    ) && base_slot.checked_add(size).is_none()
+                    {
+                        self.dcx().emit_err(
+                            slot.span,
+                            "contract extends past the end of storage when this base slot value is specified",
+                        );
+                    }
+                } else {
                     self.dcx().emit_err(slot.span, "base slot of storage layout evaluates to a value outside the range of type `uint256`");
                 }
             }

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -413,19 +413,44 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 /// Reference: <https://github.com/argotorg/solidity/blob/03e2739809769ae0c8d236a883aadc900da60536/libsolidity/analysis/ContractLevelChecker.cpp#L556C1-L570C2>
 fn check_storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let span = gcx.hir.contract(contract_id).name.span;
-    let total_size = match storage_size_upper_bound(gcx, contract_id) {
-        Ok(Some(total_size)) => total_size,
-        Ok(None) => {
-            gcx.dcx().emit_err(span, "contract requires too much storage");
-            return;
+    let mut storage_size = None;
+    let mut transient_storage_size = None;
+    for location in [DataLocation::Storage, DataLocation::Transient] {
+        let total_size = match storage_size_upper_bound(gcx, contract_id, location) {
+            Ok(Some(total_size)) => total_size,
+            Ok(None) => {
+                let message = if location == DataLocation::Storage {
+                    "contract requires too much storage"
+                } else {
+                    "contract requires too much transient storage"
+                };
+                gcx.dcx().emit_err(span, message);
+                continue;
+            }
+            Err(_) => continue,
+        };
+        match location {
+            DataLocation::Storage => storage_size = Some(total_size),
+            DataLocation::Transient => transient_storage_size = Some(total_size),
+            DataLocation::Memory | DataLocation::Calldata => unreachable!(),
         }
-        Err(_) => return,
-    };
+    }
 
-    if gcx.sess.opts.unstable.print_max_storage_sizes {
+    if gcx.sess.opts.unstable.print_max_storage_sizes
+        && let (Some(storage_size), Some(transient_storage_size)) =
+            (storage_size, transient_storage_size)
+    {
         let full_contract_name = gcx.contract_fully_qualified_name(contract_id);
         gcx.dcx()
-            .note(format!("{full_contract_name} requires a maximum of {total_size} storage slots"))
+            .note(format!(
+                "{full_contract_name} requires a maximum of {storage_size} storage slots"
+            ))
+            .span(span)
+            .emit();
+        gcx.dcx()
+            .note(format!(
+                "{full_contract_name} requires a maximum of {transient_storage_size} transient storage slots"
+            ))
             .span(span)
             .emit();
     }
@@ -434,12 +459,15 @@ fn check_storage_size_upper_bound(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 fn storage_size_upper_bound(
     gcx: Gcx<'_>,
     contract_id: hir::ContractId,
+    location: DataLocation,
 ) -> Result<Option<U256>, ErrorGuaranteed> {
     let mut total_size = U256::ZERO;
     for item_id in gcx.hir.contract_item_ids(contract_id) {
-        // Skip constant and immutable variables
+        // Skip constant and immutable variables and variables from the other storage space.
         if let hir::Item::Variable(var) = gcx.hir.item(item_id)
             && !(var.is_constant() || var.is_immutable())
+            && (var.data_location == Some(DataLocation::Transient))
+                == (location == DataLocation::Transient)
         {
             let ty = gcx.type_of_item(item_id);
             let Some(size) = ty_storage_size_upper_bound(ty, gcx)? else { return Ok(None) };

--- a/tests/ui/standard-json/natspec-storage-layout.jsonc
+++ b/tests/ui/standard-json/natspec-storage-layout.jsonc
@@ -9,7 +9,7 @@
 // CHECK: "return": "count value"
 // CHECK: "storageLayout": {
 // CHECK: "slot": "10"
-// CHECK: "t_struct(Pair)0_storage"
+// CHECK: "t_struct(Pair){{[0-9]+}}_storage"
 // CHECK: "offset": 16
 // CHECK: "t_mapping(t_uint256,t_address)"
 // CHECK: "transientStorageLayout": {

--- a/tests/ui/standard-json/natspec-storage-layout.stdout
+++ b/tests/ui/standard-json/natspec-storage-layout.stdout
@@ -50,7 +50,7 @@
         "storageLayout": {
           "storage": [
             {
-              "astId": 0,
+              "astId": 5,
               "contract": "A.sol:A",
               "label": "base",
               "offset": 0,
@@ -58,7 +58,7 @@
               "type": "t_uint8"
             },
             {
-              "astId": 1,
+              "astId": 6,
               "contract": "A.sol:A",
               "label": "count",
               "offset": 0,
@@ -66,15 +66,15 @@
               "type": "t_uint256"
             },
             {
-              "astId": 2,
+              "astId": 7,
               "contract": "A.sol:A",
               "label": "pair",
               "offset": 0,
               "slot": "12",
-              "type": "t_struct(Pair)0_storage"
+              "type": "t_struct(Pair)19_storage"
             },
             {
-              "astId": 3,
+              "astId": 8,
               "contract": "A.sol:A",
               "label": "owners",
               "offset": 0,
@@ -93,13 +93,13 @@
               "label": "uint256",
               "numberOfBytes": "32"
             },
-            "t_struct(Pair)0_storage": {
+            "t_struct(Pair)19_storage": {
               "encoding": "inplace",
               "label": "struct A.Pair",
               "numberOfBytes": "32",
               "members": [
                 {
-                  "astId": 7,
+                  "astId": 12,
                   "contract": "A.sol:A",
                   "label": "left",
                   "offset": 0,
@@ -107,7 +107,7 @@
                   "type": "t_uint128"
                 },
                 {
-                  "astId": 8,
+                  "astId": 13,
                   "contract": "A.sol:A",
                   "label": "right",
                   "offset": 16,
@@ -138,7 +138,7 @@
         "transientStorageLayout": {
           "storage": [
             {
-              "astId": 4,
+              "astId": 9,
               "contract": "A.sol:A",
               "label": "low",
               "offset": 0,
@@ -146,7 +146,7 @@
               "type": "t_uint128"
             },
             {
-              "astId": 5,
+              "astId": 10,
               "contract": "A.sol:A",
               "label": "high",
               "offset": 16,
@@ -154,7 +154,7 @@
               "type": "t_uint128"
             },
             {
-              "astId": 6,
+              "astId": 11,
               "contract": "A.sol:A",
               "label": "holder",
               "offset": 0,

--- a/tests/ui/standard-json/storage-layout-inheritance.jsonc
+++ b/tests/ui/standard-json/storage-layout-inheritance.jsonc
@@ -17,10 +17,10 @@
 // CHECK: "offset": 24
 // CHECK: "Empty": {
 // CHECK: "storage": []
-// CHECK-NOT: "types":
+// CHECK: "types": null
 // CHECK: "transientStorageLayout": {
 // CHECK: "storage": []
-// CHECK-NOT: "types":
+// CHECK: "types": null
 {
   "language": "Solidity",
   "sources": {

--- a/tests/ui/standard-json/storage-layout-inheritance.jsonc
+++ b/tests/ui/standard-json/storage-layout-inheritance.jsonc
@@ -1,0 +1,45 @@
+// CHECK: "Inheritance": {
+// CHECK: "label": "baseValue"
+// CHECK: "offset": 0
+// CHECK: "slot": "42"
+// CHECK: "label": "rightValue"
+// CHECK: "offset": 16
+// CHECK: "slot": "42"
+// CHECK: "label": "derivedValue"
+// CHECK: "offset": 24
+// CHECK: "slot": "42"
+// CHECK: "transientStorageLayout": {
+// CHECK: "label": "baseTransient"
+// CHECK: "offset": 0
+// CHECK: "label": "rightTransient"
+// CHECK: "offset": 8
+// CHECK: "label": "derivedTransient"
+// CHECK: "offset": 24
+// CHECK: "Empty": {
+// CHECK: "storage": []
+// CHECK-NOT: "types":
+// CHECK: "transientStorageLayout": {
+// CHECK: "storage": []
+// CHECK-NOT: "types":
+{
+  "language": "Solidity",
+  "sources": {
+    "inheritance.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.36;\ncontract Base { uint128 baseValue; uint64 transient baseTransient; }\ncontract Right { uint64 rightValue; uint128 transient rightTransient; }\ncontract Inheritance is Base, Right layout at 42 {\n    uint constant IGNORED_CONSTANT = 1;\n    uint immutable ignoredImmutable;\n    uint64 derivedValue;\n    uint64 transient derivedTransient;\n    constructor() { ignoredImmutable = 1; }\n}\ncontract Empty {}"
+    }
+  },
+  "settings": {
+    "outputSelection": {
+      "inheritance.sol": {
+        "Inheritance": [
+          "storageLayout",
+          "transientStorageLayout"
+        ],
+        "Empty": [
+          "storageLayout",
+          "transientStorageLayout"
+        ]
+      }
+    }
+  }
+}

--- a/tests/ui/standard-json/storage-layout-inheritance.stdout
+++ b/tests/ui/standard-json/storage-layout-inheritance.stdout
@@ -10,7 +10,7 @@
         "storageLayout": {
           "storage": [
             {
-              "astId": 0,
+              "astId": 5,
               "contract": "inheritance.sol:Inheritance",
               "label": "baseValue",
               "offset": 0,
@@ -18,7 +18,7 @@
               "type": "t_uint128"
             },
             {
-              "astId": 2,
+              "astId": 7,
               "contract": "inheritance.sol:Inheritance",
               "label": "rightValue",
               "offset": 16,
@@ -26,7 +26,7 @@
               "type": "t_uint64"
             },
             {
-              "astId": 6,
+              "astId": 11,
               "contract": "inheritance.sol:Inheritance",
               "label": "derivedValue",
               "offset": 24,
@@ -50,7 +50,7 @@
         "transientStorageLayout": {
           "storage": [
             {
-              "astId": 1,
+              "astId": 6,
               "contract": "inheritance.sol:Inheritance",
               "label": "baseTransient",
               "offset": 0,
@@ -58,7 +58,7 @@
               "type": "t_uint64"
             },
             {
-              "astId": 3,
+              "astId": 8,
               "contract": "inheritance.sol:Inheritance",
               "label": "rightTransient",
               "offset": 8,
@@ -66,7 +66,7 @@
               "type": "t_uint128"
             },
             {
-              "astId": 7,
+              "astId": 12,
               "contract": "inheritance.sol:Inheritance",
               "label": "derivedTransient",
               "offset": 24,
@@ -90,10 +90,12 @@
       },
       "Empty": {
         "storageLayout": {
-          "storage": []
+          "storage": [],
+          "types": null
         },
         "transientStorageLayout": {
-          "storage": []
+          "storage": [],
+          "types": null
         }
       }
     }

--- a/tests/ui/standard-json/storage-layout-inheritance.stdout
+++ b/tests/ui/standard-json/storage-layout-inheritance.stdout
@@ -1,0 +1,101 @@
+{
+  "sources": {
+    "inheritance.sol": {
+      "id": 0
+    }
+  },
+  "contracts": {
+    "inheritance.sol": {
+      "Inheritance": {
+        "storageLayout": {
+          "storage": [
+            {
+              "astId": 0,
+              "contract": "inheritance.sol:Inheritance",
+              "label": "baseValue",
+              "offset": 0,
+              "slot": "42",
+              "type": "t_uint128"
+            },
+            {
+              "astId": 2,
+              "contract": "inheritance.sol:Inheritance",
+              "label": "rightValue",
+              "offset": 16,
+              "slot": "42",
+              "type": "t_uint64"
+            },
+            {
+              "astId": 6,
+              "contract": "inheritance.sol:Inheritance",
+              "label": "derivedValue",
+              "offset": 24,
+              "slot": "42",
+              "type": "t_uint64"
+            }
+          ],
+          "types": {
+            "t_uint128": {
+              "encoding": "inplace",
+              "label": "uint128",
+              "numberOfBytes": "16"
+            },
+            "t_uint64": {
+              "encoding": "inplace",
+              "label": "uint64",
+              "numberOfBytes": "8"
+            }
+          }
+        },
+        "transientStorageLayout": {
+          "storage": [
+            {
+              "astId": 1,
+              "contract": "inheritance.sol:Inheritance",
+              "label": "baseTransient",
+              "offset": 0,
+              "slot": "0",
+              "type": "t_uint64"
+            },
+            {
+              "astId": 3,
+              "contract": "inheritance.sol:Inheritance",
+              "label": "rightTransient",
+              "offset": 8,
+              "slot": "0",
+              "type": "t_uint128"
+            },
+            {
+              "astId": 7,
+              "contract": "inheritance.sol:Inheritance",
+              "label": "derivedTransient",
+              "offset": 24,
+              "slot": "0",
+              "type": "t_uint64"
+            }
+          ],
+          "types": {
+            "t_uint64": {
+              "encoding": "inplace",
+              "label": "uint64",
+              "numberOfBytes": "8"
+            },
+            "t_uint128": {
+              "encoding": "inplace",
+              "label": "uint128",
+              "numberOfBytes": "16"
+            }
+          }
+        }
+      },
+      "Empty": {
+        "storageLayout": {
+          "storage": []
+        },
+        "transientStorageLayout": {
+          "storage": []
+        }
+      }
+    }
+  }
+}

--- a/tests/ui/standard-json/storage-layout-types.jsonc
+++ b/tests/ui/standard-json/storage-layout-types.jsonc
@@ -1,0 +1,33 @@
+// CHECK: "label": "unevenArray"
+// CHECK: "slot": "4"
+// CHECK: "type": "t_array(t_bytes17)3_storage"
+// CHECK: "label": "oddWidthArray"
+// CHECK: "slot": "7"
+// CHECK: "numberOfBytes": "96"
+// CHECK: "label": "struct LayoutTypes.Packed"
+// CHECK: "label": "tail"
+// CHECK: "slot": "4"
+// CHECK: "t_mapping(t_address,t_struct(Packed){{[0-9]+}}_storage)"
+// CHECK: "t_mapping(t_address,t_array(t_uint8)dyn_storage)"
+// CHECK: "label": "enum LayoutTypes.Choice"
+// CHECK: "label": "LayoutTypes.Small"
+// CHECK: "t_function_external_view(t_array(t_array(t_uint8)dyn_calldata_ptr)2_calldata_ptr,t_array(t_bytes_memory_ptr)dyn_memory_ptr)returns(t_array(t_string_memory_ptr)dyn_memory_ptr)"
+// CHECK: "label": "function (uint8[][2],bytes[]) view external returns (string[])"
+// CHECK: "label": "function (uint256) pure returns (bool)"
+{
+  "language": "Solidity",
+  "sources": {
+    "types.sol": {
+      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.36;\ncontract LayoutTypes {\n    enum Choice { A, B }\n    type Small is uint24;\n    struct Packed { uint8 head; bytes17[3] values; uint8 tail; }\n    bytes raw;\n    string text;\n    uint8[][2] nestedDynamic;\n    bytes17[3] unevenArray;\n    uint24[21] oddWidthArray;\n    Packed packed;\n    mapping(address => Packed) records;\n    mapping(address => uint8[]) dynamicRecords;\n    Choice choice;\n    Small small;\n    function(uint8[][2] calldata, bytes[] memory) external view returns (string[] memory) externalFn;\n    function(uint256) internal pure returns (bool) internalFn;\n    address payable recipient;\n}"
+    }
+  },
+  "settings": {
+    "outputSelection": {
+      "types.sol": {
+        "LayoutTypes": [
+          "storageLayout"
+        ]
+      }
+    }
+  }
+}

--- a/tests/ui/standard-json/storage-layout-types.stdout
+++ b/tests/ui/standard-json/storage-layout-types.stdout
@@ -10,7 +10,7 @@
         "storageLayout": {
           "storage": [
             {
-              "astId": 0,
+              "astId": 1,
               "contract": "types.sol:LayoutTypes",
               "label": "raw",
               "offset": 0,
@@ -18,7 +18,7 @@
               "type": "t_bytes_storage"
             },
             {
-              "astId": 1,
+              "astId": 2,
               "contract": "types.sol:LayoutTypes",
               "label": "text",
               "offset": 0,
@@ -26,7 +26,7 @@
               "type": "t_string_storage"
             },
             {
-              "astId": 2,
+              "astId": 3,
               "contract": "types.sol:LayoutTypes",
               "label": "nestedDynamic",
               "offset": 0,
@@ -34,7 +34,7 @@
               "type": "t_array(t_array(t_uint8)dyn_storage)2_storage"
             },
             {
-              "astId": 3,
+              "astId": 4,
               "contract": "types.sol:LayoutTypes",
               "label": "unevenArray",
               "offset": 0,
@@ -42,7 +42,7 @@
               "type": "t_array(t_bytes17)3_storage"
             },
             {
-              "astId": 4,
+              "astId": 5,
               "contract": "types.sol:LayoutTypes",
               "label": "oddWidthArray",
               "offset": 0,
@@ -50,23 +50,23 @@
               "type": "t_array(t_uint24)21_storage"
             },
             {
-              "astId": 5,
+              "astId": 6,
               "contract": "types.sol:LayoutTypes",
               "label": "packed",
               "offset": 0,
               "slot": "10",
-              "type": "t_struct(Packed)0_storage"
+              "type": "t_struct(Packed)22_storage"
             },
             {
-              "astId": 6,
+              "astId": 7,
               "contract": "types.sol:LayoutTypes",
               "label": "records",
               "offset": 0,
               "slot": "15",
-              "type": "t_mapping(t_address,t_struct(Packed)0_storage)"
+              "type": "t_mapping(t_address,t_struct(Packed)22_storage)"
             },
             {
-              "astId": 7,
+              "astId": 8,
               "contract": "types.sol:LayoutTypes",
               "label": "dynamicRecords",
               "offset": 0,
@@ -74,23 +74,23 @@
               "type": "t_mapping(t_address,t_array(t_uint8)dyn_storage)"
             },
             {
-              "astId": 8,
+              "astId": 9,
               "contract": "types.sol:LayoutTypes",
               "label": "choice",
               "offset": 0,
               "slot": "17",
-              "type": "t_enum(Choice)0"
+              "type": "t_enum(Choice)23"
             },
             {
-              "astId": 9,
+              "astId": 10,
               "contract": "types.sol:LayoutTypes",
               "label": "small",
               "offset": 1,
               "slot": "17",
-              "type": "t_userDefinedValueType(Small)0"
+              "type": "t_userDefinedValueType(Small)24"
             },
             {
-              "astId": 10,
+              "astId": 11,
               "contract": "types.sol:LayoutTypes",
               "label": "externalFn",
               "offset": 4,
@@ -98,7 +98,7 @@
               "type": "t_function_external_view(t_array(t_array(t_uint8)dyn_calldata_ptr)2_calldata_ptr,t_array(t_bytes_memory_ptr)dyn_memory_ptr)returns(t_array(t_string_memory_ptr)dyn_memory_ptr)"
             },
             {
-              "astId": 11,
+              "astId": 12,
               "contract": "types.sol:LayoutTypes",
               "label": "internalFn",
               "offset": 0,
@@ -106,7 +106,7 @@
               "type": "t_function_internal_pure(t_uint256)returns(t_bool)"
             },
             {
-              "astId": 12,
+              "astId": 13,
               "contract": "types.sol:LayoutTypes",
               "label": "recipient",
               "offset": 8,
@@ -164,13 +164,13 @@
               "label": "uint24",
               "numberOfBytes": "3"
             },
-            "t_struct(Packed)0_storage": {
+            "t_struct(Packed)22_storage": {
               "encoding": "inplace",
               "label": "struct LayoutTypes.Packed",
               "numberOfBytes": "160",
               "members": [
                 {
-                  "astId": 13,
+                  "astId": 14,
                   "contract": "types.sol:LayoutTypes",
                   "label": "head",
                   "offset": 0,
@@ -178,7 +178,7 @@
                   "type": "t_uint8"
                 },
                 {
-                  "astId": 14,
+                  "astId": 15,
                   "contract": "types.sol:LayoutTypes",
                   "label": "values",
                   "offset": 0,
@@ -186,7 +186,7 @@
                   "type": "t_array(t_bytes17)3_storage"
                 },
                 {
-                  "astId": 15,
+                  "astId": 16,
                   "contract": "types.sol:LayoutTypes",
                   "label": "tail",
                   "offset": 0,
@@ -195,12 +195,12 @@
                 }
               ]
             },
-            "t_mapping(t_address,t_struct(Packed)0_storage)": {
+            "t_mapping(t_address,t_struct(Packed)22_storage)": {
               "encoding": "mapping",
               "label": "mapping(address => struct LayoutTypes.Packed)",
               "numberOfBytes": "32",
               "key": "t_address",
-              "value": "t_struct(Packed)0_storage"
+              "value": "t_struct(Packed)22_storage"
             },
             "t_address": {
               "encoding": "inplace",
@@ -214,12 +214,12 @@
               "key": "t_address",
               "value": "t_array(t_uint8)dyn_storage"
             },
-            "t_enum(Choice)0": {
+            "t_enum(Choice)23": {
               "encoding": "inplace",
               "label": "enum LayoutTypes.Choice",
               "numberOfBytes": "1"
             },
-            "t_userDefinedValueType(Small)0": {
+            "t_userDefinedValueType(Small)24": {
               "encoding": "inplace",
               "label": "LayoutTypes.Small",
               "numberOfBytes": "3"

--- a/tests/ui/standard-json/storage-layout-types.stdout
+++ b/tests/ui/standard-json/storage-layout-types.stdout
@@ -1,0 +1,247 @@
+{
+  "sources": {
+    "types.sol": {
+      "id": 0
+    }
+  },
+  "contracts": {
+    "types.sol": {
+      "LayoutTypes": {
+        "storageLayout": {
+          "storage": [
+            {
+              "astId": 0,
+              "contract": "types.sol:LayoutTypes",
+              "label": "raw",
+              "offset": 0,
+              "slot": "0",
+              "type": "t_bytes_storage"
+            },
+            {
+              "astId": 1,
+              "contract": "types.sol:LayoutTypes",
+              "label": "text",
+              "offset": 0,
+              "slot": "1",
+              "type": "t_string_storage"
+            },
+            {
+              "astId": 2,
+              "contract": "types.sol:LayoutTypes",
+              "label": "nestedDynamic",
+              "offset": 0,
+              "slot": "2",
+              "type": "t_array(t_array(t_uint8)dyn_storage)2_storage"
+            },
+            {
+              "astId": 3,
+              "contract": "types.sol:LayoutTypes",
+              "label": "unevenArray",
+              "offset": 0,
+              "slot": "4",
+              "type": "t_array(t_bytes17)3_storage"
+            },
+            {
+              "astId": 4,
+              "contract": "types.sol:LayoutTypes",
+              "label": "oddWidthArray",
+              "offset": 0,
+              "slot": "7",
+              "type": "t_array(t_uint24)21_storage"
+            },
+            {
+              "astId": 5,
+              "contract": "types.sol:LayoutTypes",
+              "label": "packed",
+              "offset": 0,
+              "slot": "10",
+              "type": "t_struct(Packed)0_storage"
+            },
+            {
+              "astId": 6,
+              "contract": "types.sol:LayoutTypes",
+              "label": "records",
+              "offset": 0,
+              "slot": "15",
+              "type": "t_mapping(t_address,t_struct(Packed)0_storage)"
+            },
+            {
+              "astId": 7,
+              "contract": "types.sol:LayoutTypes",
+              "label": "dynamicRecords",
+              "offset": 0,
+              "slot": "16",
+              "type": "t_mapping(t_address,t_array(t_uint8)dyn_storage)"
+            },
+            {
+              "astId": 8,
+              "contract": "types.sol:LayoutTypes",
+              "label": "choice",
+              "offset": 0,
+              "slot": "17",
+              "type": "t_enum(Choice)0"
+            },
+            {
+              "astId": 9,
+              "contract": "types.sol:LayoutTypes",
+              "label": "small",
+              "offset": 1,
+              "slot": "17",
+              "type": "t_userDefinedValueType(Small)0"
+            },
+            {
+              "astId": 10,
+              "contract": "types.sol:LayoutTypes",
+              "label": "externalFn",
+              "offset": 4,
+              "slot": "17",
+              "type": "t_function_external_view(t_array(t_array(t_uint8)dyn_calldata_ptr)2_calldata_ptr,t_array(t_bytes_memory_ptr)dyn_memory_ptr)returns(t_array(t_string_memory_ptr)dyn_memory_ptr)"
+            },
+            {
+              "astId": 11,
+              "contract": "types.sol:LayoutTypes",
+              "label": "internalFn",
+              "offset": 0,
+              "slot": "18",
+              "type": "t_function_internal_pure(t_uint256)returns(t_bool)"
+            },
+            {
+              "astId": 12,
+              "contract": "types.sol:LayoutTypes",
+              "label": "recipient",
+              "offset": 8,
+              "slot": "18",
+              "type": "t_address_payable"
+            }
+          ],
+          "types": {
+            "t_bytes_storage": {
+              "encoding": "bytes",
+              "label": "bytes",
+              "numberOfBytes": "32"
+            },
+            "t_string_storage": {
+              "encoding": "bytes",
+              "label": "string",
+              "numberOfBytes": "32"
+            },
+            "t_array(t_array(t_uint8)dyn_storage)2_storage": {
+              "encoding": "inplace",
+              "label": "uint8[][2]",
+              "numberOfBytes": "64",
+              "base": "t_array(t_uint8)dyn_storage"
+            },
+            "t_array(t_uint8)dyn_storage": {
+              "encoding": "dynamic_array",
+              "label": "uint8[]",
+              "numberOfBytes": "32",
+              "base": "t_uint8"
+            },
+            "t_uint8": {
+              "encoding": "inplace",
+              "label": "uint8",
+              "numberOfBytes": "1"
+            },
+            "t_array(t_bytes17)3_storage": {
+              "encoding": "inplace",
+              "label": "bytes17[3]",
+              "numberOfBytes": "96",
+              "base": "t_bytes17"
+            },
+            "t_bytes17": {
+              "encoding": "inplace",
+              "label": "bytes17",
+              "numberOfBytes": "17"
+            },
+            "t_array(t_uint24)21_storage": {
+              "encoding": "inplace",
+              "label": "uint24[21]",
+              "numberOfBytes": "96",
+              "base": "t_uint24"
+            },
+            "t_uint24": {
+              "encoding": "inplace",
+              "label": "uint24",
+              "numberOfBytes": "3"
+            },
+            "t_struct(Packed)0_storage": {
+              "encoding": "inplace",
+              "label": "struct LayoutTypes.Packed",
+              "numberOfBytes": "160",
+              "members": [
+                {
+                  "astId": 13,
+                  "contract": "types.sol:LayoutTypes",
+                  "label": "head",
+                  "offset": 0,
+                  "slot": "0",
+                  "type": "t_uint8"
+                },
+                {
+                  "astId": 14,
+                  "contract": "types.sol:LayoutTypes",
+                  "label": "values",
+                  "offset": 0,
+                  "slot": "1",
+                  "type": "t_array(t_bytes17)3_storage"
+                },
+                {
+                  "astId": 15,
+                  "contract": "types.sol:LayoutTypes",
+                  "label": "tail",
+                  "offset": 0,
+                  "slot": "4",
+                  "type": "t_uint8"
+                }
+              ]
+            },
+            "t_mapping(t_address,t_struct(Packed)0_storage)": {
+              "encoding": "mapping",
+              "label": "mapping(address => struct LayoutTypes.Packed)",
+              "numberOfBytes": "32",
+              "key": "t_address",
+              "value": "t_struct(Packed)0_storage"
+            },
+            "t_address": {
+              "encoding": "inplace",
+              "label": "address",
+              "numberOfBytes": "20"
+            },
+            "t_mapping(t_address,t_array(t_uint8)dyn_storage)": {
+              "encoding": "mapping",
+              "label": "mapping(address => uint8[])",
+              "numberOfBytes": "32",
+              "key": "t_address",
+              "value": "t_array(t_uint8)dyn_storage"
+            },
+            "t_enum(Choice)0": {
+              "encoding": "inplace",
+              "label": "enum LayoutTypes.Choice",
+              "numberOfBytes": "1"
+            },
+            "t_userDefinedValueType(Small)0": {
+              "encoding": "inplace",
+              "label": "LayoutTypes.Small",
+              "numberOfBytes": "3"
+            },
+            "t_function_external_view(t_array(t_array(t_uint8)dyn_calldata_ptr)2_calldata_ptr,t_array(t_bytes_memory_ptr)dyn_memory_ptr)returns(t_array(t_string_memory_ptr)dyn_memory_ptr)": {
+              "encoding": "inplace",
+              "label": "function (uint8[][2],bytes[]) view external returns (string[])",
+              "numberOfBytes": "24"
+            },
+            "t_function_internal_pure(t_uint256)returns(t_bool)": {
+              "encoding": "inplace",
+              "label": "function (uint256) pure returns (bool)",
+              "numberOfBytes": "8"
+            },
+            "t_address_payable": {
+              "encoding": "inplace",
+              "label": "address payable",
+              "numberOfBytes": "20"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/ui/typeck/contract_storage_illegal_size.stderr
+++ b/tests/ui/typeck/contract_storage_illegal_size.stderr
@@ -4,11 +4,17 @@ note: ROOT/tests/ui/typeck/contract_storage_illegal_size.sol:AlmostIllegal requi
 LL │ contract AlmostIllegal {
    ╰╴         ━━━━━━━━━━━━━
 
+note: ROOT/tests/ui/typeck/contract_storage_illegal_size.sol:AlmostIllegal requires a maximum of 0 transient storage slots
+   ╭▸ ROOT/tests/ui/typeck/contract_storage_illegal_size.sol:LL:CC
+   │
+LL │ contract AlmostIllegal {
+   ╰╴         ━━━━━━━━━━━━━
+
 error: contract requires too much storage
    ╭▸ ROOT/tests/ui/typeck/contract_storage_illegal_size.sol:LL:CC
    │
 LL │ contract Illegal {
    ╰╴         ━━━━━━━
 
-error: aborting due to 1 previous error; 1 note emitted
+error: aborting due to 1 previous error; 2 notes emitted
 

--- a/tests/ui/typeck/contract_storage_size_check.sol
+++ b/tests/ui/typeck/contract_storage_size_check.sol
@@ -5,9 +5,12 @@ struct Person {
     uint age;
 }
 
-contract B {
+contract B { //~ NOTE: :B requires a maximum of 2 storage slots
+    //~^ NOTE: :B requires a maximum of 2 transient storage slots
     uint c;
     bool x;
+    uint transient tc;
+    bool transient tx;
 }
 
 contract A { //~ NOTE: :A requires a maximum of 77 storage slots

--- a/tests/ui/typeck/contract_storage_size_check.stderr
+++ b/tests/ui/typeck/contract_storage_size_check.stderr
@@ -4,7 +4,19 @@ note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:B requires a maximum 
 LL │ contract B {
    ╰╴         ━
 
+note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:B requires a maximum of 2 transient storage slots
+   ╭▸ ROOT/tests/ui/typeck/contract_storage_size_check.sol:LL:CC
+   │
+LL │ contract B {
+   ╰╴         ━
+
 note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:A requires a maximum of 77 storage slots
+   ╭▸ ROOT/tests/ui/typeck/contract_storage_size_check.sol:LL:CC
+   │
+LL │ contract A {
+   ╰╴         ━
+
+note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:A requires a maximum of 0 transient storage slots
    ╭▸ ROOT/tests/ui/typeck/contract_storage_size_check.sol:LL:CC
    │
 LL │ contract A {
@@ -16,7 +28,19 @@ note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:M requires a maximum 
 LL │ contract M {
    ╰╴         ━
 
+note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:M requires a maximum of 0 transient storage slots
+   ╭▸ ROOT/tests/ui/typeck/contract_storage_size_check.sol:LL:CC
+   │
+LL │ contract M {
+   ╰╴         ━
+
 note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:Random requires a maximum of 38 storage slots
+   ╭▸ ROOT/tests/ui/typeck/contract_storage_size_check.sol:LL:CC
+   │
+LL │ contract Random {
+   ╰╴         ━━━━━━
+
+note: ROOT/tests/ui/typeck/contract_storage_size_check.sol:Random requires a maximum of 0 transient storage slots
    ╭▸ ROOT/tests/ui/typeck/contract_storage_size_check.sol:LL:CC
    │
 LL │ contract Random {

--- a/tests/ui/typeck/storage_layout_base_slot_overflow.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_overflow.sol
@@ -1,8 +1,14 @@
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/intermediate_operation_out_of_range.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_value.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_bitwise_negation_literal.sol
+// ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/contract_extends_past_storage_end.sol
 
 contract IntermediateOperationOutOfRange layout at (2**256 + 1) * 2 - 2**256 - 3 {} //~ ERROR: failed to evaluate constant: arithmetic overflow
 contract OverflowAdd layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {} //~ ERROR: failed to evaluate constant: arithmetic overflow
 contract OverflowPow layout at 2**256 {} //~ ERROR: failed to evaluate constant: arithmetic overflow
 contract BitwiseNegationLiteral layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {} //~ ERROR: failed to evaluate constant: arithmetic overflow
+
+contract ExtendsPastEnd layout at 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff {
+    //~^ ERROR: contract extends past the end of storage when this base slot value is specified
+    uint x;
+}

--- a/tests/ui/typeck/storage_layout_base_slot_overflow.stderr
+++ b/tests/ui/typeck/storage_layout_base_slot_overflow.stderr
@@ -24,5 +24,11 @@ error: failed to evaluate constant: arithmetic overflow
 LL │ …l layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
    ╰╴             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ evaluation of constant value failed here
 
-error: aborting due to 4 previous errors
+error: contract extends past the end of storage when this base slot value is specified
+   ╭▸ ROOT/tests/ui/typeck/storage_layout_base_slot_overflow.sol:LL:CC
+   │
+LL │ contract ExtendsPastEnd layout at 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff {
+   ╰╴                                  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Storage layout generation differed from solc for fixed arrays whose element width does not divide a slot, nested reference type identifiers, mapping value locations, and several user-defined and function type labels. These mismatches could shift following variables or produce incompatible Standard JSON type metadata.

This aligns the layout and type-description algorithms with the tracked solc implementation, validates custom base slots against the end of storage, reports storage and transient-storage upper bounds independently, and adds Standard JSON fixtures covering the corrected cases. Compiler-assigned AST and declaration IDs remain implementation-specific, while the resulting layouts are otherwise semantically identical.