### PR TITLE
feat(bench): adopt common schema

### DIFF
--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import platform
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -315,12 +317,149 @@ def append_github_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
+def metric(value: int | float, unit: str, statistic: str) -> dict[str, Any]:
+    return {"value": value, "unit": unit, "statistic": statistic}
+
+
+def load_timing(path: Path | None, label: str) -> dict[str, Any] | None:
+    if path is None or not path.exists():
+        warning(f"{label} benchmark timing not found: {path}")
+        return None
+    with path.open() as f:
+        timing = json.load(f)
+    if not isinstance(timing, dict):
+        warning(f"{label} benchmark timing has unexpected shape: expected object")
+        return None
+    return timing
+
+
+def common_benchmark(
+    name: str, results: list[dict[str, Any]], timing: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    if not results or timing is None:
+        return None
+
+    wall_time = timing.get("wall_time_seconds")
+    if not isinstance(wall_time, (int, float)):
+        warning(f"{name} benchmark timing is missing wall time")
+        return None
+
+    successful = []
+    failed = 0
+    for result in results:
+        compiler = compiler_data(result, "solar")
+        if compiler.get("status") == "ok":
+            successful.append(compiler)
+        else:
+            failed += 1
+
+    benchmark = {
+        "name": f"codegen_runtime_suite/{name}",
+        "wall_time": metric(wall_time, "second", "total"),
+        "counters": {
+            "tests": metric(len(results), "count", "total"),
+            "successful_compilations": metric(len(successful), "count", "total"),
+            "failed_compilations": metric(failed, "count", "total"),
+        },
+    }
+
+    def complete_values(key: str) -> list[int] | None:
+        values = [compiler.get(key) for compiler in successful]
+        if failed or not values or any(type(value) is not int for value in values):
+            return None
+        return values
+
+    gas = {}
+    total_gas_values = complete_values("total_gas")
+    deploy_gas_values = complete_values("deploy_gas")
+    if total_gas_values is not None:
+        gas["runtime"] = metric(sum(total_gas_values), "gas", "total")
+    if deploy_gas_values is not None:
+        gas["deployment"] = metric(sum(deploy_gas_values), "gas", "total")
+    if gas:
+        benchmark["gas"] = gas
+
+    compiler_metrics = {}
+    creation_sizes = complete_values("bytecode_size")
+    runtime_sizes = complete_values("runtime_size")
+    if creation_sizes is not None:
+        compiler_metrics["creation_bytecode_size"] = metric(
+            sum(creation_sizes), "byte", "total"
+        )
+    if runtime_sizes is not None:
+        compiler_metrics["runtime_bytecode_size"] = metric(
+            sum(runtime_sizes), "byte", "total"
+        )
+    if compiler_metrics:
+        benchmark["compiler"] = compiler_metrics
+    return benchmark
+
+
+def git_commit() -> str:
+    commit = os.environ.get("GITHUB_SHA")
+    if commit:
+        return commit
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+    ).strip()
+
+
+def runner_metadata() -> dict[str, Any]:
+    runner = {
+        "os": platform.system().lower(),
+        "arch": platform.machine(),
+        "logical_cpus": os.cpu_count() or 1,
+    }
+    image = os.environ.get("ImageOS")
+    if image:
+        runner["image"] = image
+    return runner
+
+
+def write_common_result(
+    output: Path,
+    micro_results: list[dict[str, Any]],
+    repo_results: list[dict[str, Any]],
+    micro_timing: dict[str, Any] | None,
+    repo_timing: dict[str, Any] | None,
+) -> None:
+    benchmarks = [
+        benchmark
+        for benchmark in (
+            common_benchmark("micro", micro_results, micro_timing),
+            common_benchmark("repo", repo_results, repo_timing),
+        )
+        if benchmark is not None
+    ]
+    if not benchmarks:
+        warning("common benchmark result has no measurements; not writing output")
+        return
+
+    result = {
+        "schema_version": 1,
+        "repo": os.environ.get("GITHUB_REPOSITORY", "paradigmxyz/solar"),
+        "commit": git_commit(),
+        "runner": runner_metadata(),
+        "benchmarks": benchmarks,
+    }
+    pr = os.environ.get("BENCHMARK_PR_NUMBER")
+    if pr:
+        result["pr"] = int(pr)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w") as f:
+        json.dump(result, f, indent=2)
+        f.write("\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--micro", type=Path)
     parser.add_argument("--repo", type=Path)
     parser.add_argument("--baseline-micro", type=Path)
     parser.add_argument("--baseline-repo", type=Path)
+    parser.add_argument("--micro-timing", type=Path)
+    parser.add_argument("--repo-timing", type=Path)
+    parser.add_argument("--common-output", type=Path)
     args = parser.parse_args()
 
     micro_results = load_results(args.micro, "micro")
@@ -350,6 +489,14 @@ def main() -> int:
         micro_results, baseline_micro
     ) or has_baseline_changes(repo_results, baseline_repo)
     append_github_output("should_comment", "true" if should_comment else "false")
+    if args.common_output is not None:
+        write_common_result(
+            args.common_output,
+            micro_results,
+            repo_results,
+            load_timing(args.micro_timing, "micro"),
+            load_timing(args.repo_timing, "repository"),
+        )
     return 0
 
 

--- a/.github/scripts/test_check_codegen_benchmark.py
+++ b/.github/scripts/test_check_codegen_benchmark.py
@@ -1,0 +1,179 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from jsonschema import Draft202012Validator
+
+sys.path.insert(0, str(Path(__file__).parent))
+import check_codegen_benchmark as benchmark
+
+
+SCHEMA = json.loads(
+    (Path(__file__).resolve().parents[2] / "benches/schema/benchmark-result-v1.schema.json").read_text()
+)
+DEFAULT_TIMING = object()
+
+
+def result(**compiler):
+    return {"test_id": "test", "compilers": {"solar": compiler}}
+
+
+class CommonBenchmarkResultTests(unittest.TestCase):
+    def write_result(self, micro, repo=None, micro_timing=DEFAULT_TIMING, repo_timing=None):
+        if repo is None:
+            repo = []
+        if micro_timing is DEFAULT_TIMING:
+            micro_timing = {"wall_time_seconds": 1.25}
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+            os.environ,
+            {
+                "GITHUB_REPOSITORY": "paradigmxyz/solar",
+                "GITHUB_SHA": "0123456789abcdef0123456789abcdef01234567",
+                "BENCHMARK_PR_NUMBER": "123",
+            },
+        ), patch.object(
+            benchmark,
+            "runner_metadata",
+            return_value={"os": "linux", "arch": "x86_64", "logical_cpus": 4},
+        ):
+            output = Path(directory) / "common.json"
+            benchmark.write_common_result(
+                output,
+                micro,
+                repo,
+                micro_timing,
+                repo_timing,
+            )
+            document = json.loads(output.read_text())
+        Draft202012Validator(SCHEMA).validate(document)
+        return document
+
+    def test_writes_complete_schema_valid_result(self):
+        micro = [
+            result(
+                status="ok",
+                total_gas=10,
+                deploy_gas=20,
+                bytecode_size=30,
+                runtime_size=40,
+            ),
+            result(
+                status="ok",
+                total_gas=1,
+                deploy_gas=2,
+                bytecode_size=3,
+                runtime_size=4,
+            ),
+        ]
+        document = self.write_result(micro)
+        self.assertEqual(
+            document,
+            {
+                "schema_version": 1,
+                "repo": "paradigmxyz/solar",
+                "commit": "0123456789abcdef0123456789abcdef01234567",
+                "pr": 123,
+                "runner": {"os": "linux", "arch": "x86_64", "logical_cpus": 4},
+                "benchmarks": [
+                    {
+                        "name": "codegen_runtime_suite/micro",
+                        "wall_time": {
+                            "value": 1.25,
+                            "unit": "second",
+                            "statistic": "total",
+                        },
+                        "counters": {
+                            "tests": {"value": 2, "unit": "count", "statistic": "total"},
+                            "successful_compilations": {
+                                "value": 2,
+                                "unit": "count",
+                                "statistic": "total",
+                            },
+                            "failed_compilations": {
+                                "value": 0,
+                                "unit": "count",
+                                "statistic": "total",
+                            },
+                        },
+                        "gas": {
+                            "runtime": {"value": 11, "unit": "gas", "statistic": "total"},
+                            "deployment": {
+                                "value": 22,
+                                "unit": "gas",
+                                "statistic": "total",
+                            },
+                        },
+                        "compiler": {
+                            "creation_bytecode_size": {
+                                "value": 33,
+                                "unit": "byte",
+                                "statistic": "total",
+                            },
+                            "runtime_bytecode_size": {
+                                "value": 44,
+                                "unit": "byte",
+                                "statistic": "total",
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+
+    def test_omits_aggregates_after_compilation_failure(self):
+        compilation_failure = [
+            result(
+                status="ok",
+                total_gas=10,
+                deploy_gas=20,
+                bytecode_size=30,
+                runtime_size=40,
+            ),
+            result(status="failed"),
+        ]
+        document = self.write_result(compilation_failure)
+        benchmark_result = document["benchmarks"][0]
+        self.assertNotIn("gas", benchmark_result)
+        self.assertNotIn("compiler", benchmark_result)
+        self.assertEqual(benchmark_result["counters"]["failed_compilations"]["value"], 1)
+
+    def test_omits_each_incomplete_metric(self):
+        complete = {
+            "status": "ok",
+            "total_gas": 10,
+            "deploy_gas": 20,
+            "bytecode_size": 30,
+            "runtime_size": 40,
+        }
+        cases = [
+            ("total_gas", "gas", "runtime"),
+            ("deploy_gas", "gas", "deployment"),
+            ("bytecode_size", "compiler", "creation_bytecode_size"),
+            ("runtime_size", "compiler", "runtime_bytecode_size"),
+        ]
+        for missing, group, metric_name in cases:
+            with self.subTest(missing=missing):
+                incomplete = complete | {missing: None}
+                document = self.write_result([result(**complete), result(**incomplete)])
+                self.assertNotIn(metric_name, document["benchmarks"][0][group])
+
+    def test_omits_suite_without_timing(self):
+        results = [result(status="ok", bytecode_size=1, runtime_size=1)]
+        document = self.write_result(
+            results,
+            results,
+            micro_timing=None,
+            repo_timing={"wall_time_seconds": 2.0},
+        )
+        self.assertEqual(
+            [entry["name"] for entry in document["benchmarks"]],
+            ["codegen_runtime_suite/repo"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Checkout Solar
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Test common benchmark result adapter
+        run: |
+          python3 -m venv "$RUNNER_TEMP/schema-test"
+          "$RUNNER_TEMP/schema-test/bin/pip" install jsonschema==4.25.1
+          "$RUNNER_TEMP/schema-test/bin/python" -m unittest discover \
+            -s .github/scripts -p 'test_check_codegen_benchmark.py'
+
       - name: Checkout benchmark corpus
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -98,7 +105,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/target/codegen-bench"
-          if ! python3 ./solar_bench.py --verbose \
+          timing="$GITHUB_WORKSPACE/target/codegen-bench/micro-timing.json"
+          if /usr/bin/time -q -f '{"wall_time_seconds": %e}' -o "$timing.tmp" \
+            python3 ./solar_bench.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
             --solar "$GITHUB_WORKSPACE/target/debug/solar" \
             --suite micro \
@@ -107,6 +116,9 @@ jobs:
             --start-anvil \
             --allow-failures \
             --output "$GITHUB_WORKSPACE/target/codegen-bench/micro.json"; then
+            mv "$timing.tmp" "$timing"
+          else
+            rm -f "$timing.tmp"
             echo "::warning::Micro codegen benchmark failed to complete"
           fi
 
@@ -116,7 +128,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/target/codegen-bench"
-          if ! python3 ./solar_bench.py --verbose \
+          timing="$GITHUB_WORKSPACE/target/codegen-bench/repo-timing.json"
+          if /usr/bin/time -q -f '{"wall_time_seconds": %e}' -o "$timing.tmp" \
+            python3 ./solar_bench.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
             --solar "$GITHUB_WORKSPACE/target/debug/solar" \
             --suite repo \
@@ -125,18 +139,26 @@ jobs:
             --start-anvil \
             --allow-failures \
             --output "$GITHUB_WORKSPACE/target/codegen-bench/repo.json"; then
+            mv "$timing.tmp" "$timing"
+          else
+            rm -f "$timing.tmp"
             echo "::warning::Repository codegen benchmark failed to complete"
           fi
 
       - name: Generate runtime benchmark report
         id: runtime-report
         if: always()
+        env:
+          BENCHMARK_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           mkdir -p target/codegen-bench
           args=(
             --micro target/codegen-bench/micro.json
             --repo target/codegen-bench/repo.json
+            --micro-timing target/codegen-bench/micro-timing.json
+            --repo-timing target/codegen-bench/repo-timing.json
+            --common-output target/codegen-bench/common.json
           )
           if [[ -f target/codegen-bench/baseline/micro.json ]]; then
             args+=(--baseline-micro target/codegen-bench/baseline/micro.json)

--- a/benches/README.md
+++ b/benches/README.md
@@ -23,6 +23,9 @@ invoking other commands such as `cargo test`.
 ## Results
 
 You can view the Solar-only results on [codspeed.io](https://codspeed.io/paradigmxyz/solar).
+The codegen runtime workflow also publishes `common.json` using the vendored common benchmark
+result schema in [`schema/`](schema/). Its wall time is the total for the comparison suite, including
+the harness, both compilers, and runtime checks.
 
 The following results were achieved on:
 - Target: `x86_64-unknown-linux-gnu`

--- a/benches/schema/benchmark-result-v1.schema.json
+++ b/benches/schema/benchmark-result-v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/foundry-rs/foundry/benches/schema/benchmark-result-v1.schema.json",
+  "title": "Benchmark result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "repo", "commit", "runner", "benchmarks"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "repo": { "$ref": "#/$defs/nonEmptyString" },
+    "commit": { "$ref": "#/$defs/nonEmptyString" },
+    "pr": { "type": "integer", "minimum": 1 },
+    "runner": { "$ref": "#/$defs/runner" },
+    "benchmarks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/benchmark" }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch"],
+      "properties": {
+        "os": { "$ref": "#/$defs/nonEmptyString" },
+        "arch": { "$ref": "#/$defs/nonEmptyString" },
+        "image": { "$ref": "#/$defs/nonEmptyString" },
+        "cpu": { "$ref": "#/$defs/nonEmptyString" },
+        "logical_cpus": { "type": "integer", "minimum": 1 },
+        "total_memory_bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "wall_time"],
+      "properties": {
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "wall_time": { "$ref": "#/$defs/metric" },
+        "memory": { "$ref": "#/$defs/metric" },
+        "counters": { "$ref": "#/$defs/metricMap" },
+        "gas": { "$ref": "#/$defs/metricMap" },
+        "solver": { "$ref": "#/$defs/metricMap" },
+        "compiler": { "$ref": "#/$defs/metricMap" }
+      }
+    },
+    "metricMap": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "pattern": "^[a-z][a-z0-9_]*$" },
+      "additionalProperties": { "$ref": "#/$defs/metric" }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit", "statistic"],
+      "properties": {
+        "value": { "type": "number" },
+        "unit": { "$ref": "#/$defs/nonEmptyString" },
+        "statistic": { "enum": ["mean", "median", "min", "max", "total", "point"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adopts the common benchmark result schema from [Foundry #15743](https://github.com/foundry-rs/foundry/pull/15743) and emits it from codegen runtime benchmarks while preserving existing outputs. 

Closes OSS-475