### PR TITLE
feat(sema): add literal eval query

### DIFF
--- a/crates/codegen/src/utils/evm_word.rs
+++ b/crates/codegen/src/utils/evm_word.rs
@@ -1,6 +1,6 @@
 //! EVM word-level constant operations used by MIR folding passes.
 //!
-//! These helpers intentionally do not reuse `sema::eval::ConstantEvaluator`:
+//! These helpers intentionally do not reuse `Gcx::eval_const`:
 //! sema evaluates Solidity source constants and reports semantic errors, while
 //! MIR folding must match 256-bit EVM wrapping and zero-divisor semantics.
 

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -24,31 +24,67 @@ pub fn erc7201_slot(namespace_id: &[u8]) -> B256 {
 
 /// Evaluates the given array size expression, emitting an error diagnostic if it fails.
 pub fn eval_array_len(gcx: Gcx<'_>, size: &hir::Expr<'_>) -> Result<U256, ErrorGuaranteed> {
-    match ConstantEvaluator::new(gcx).eval(size) {
-        Ok(int) => {
-            let Some(int) = int.as_u256() else {
-                let msg = "array length cannot be negative";
-                return Err(gcx.dcx().emit_err(size.span, msg));
-            };
-            if int.is_zero() {
-                let msg = "array length must be greater than zero";
-                Err(gcx.dcx().emit_err(size.span, msg))
-            } else {
-                Ok(int)
-            }
-        }
-        Err(guar) => Err(guar),
+    let int = gcx.eval_const(size)?;
+    let Some(int) = int.as_u256() else {
+        let msg = "array length cannot be negative";
+        return Err(gcx.dcx().emit_err(size.span, msg));
+    };
+    if int.is_zero() {
+        let msg = "array length must be greater than zero";
+        Err(gcx.dcx().emit_err(size.span, msg))
+    } else {
+        Ok(int)
     }
 }
 
 impl<'gcx> Gcx<'gcx> {
-    /// Attempts to evaluate a literal expression without emitting diagnostics.
-    ///
-    /// Returns `None` for non-literal expressions and unsupported literals.
-    pub fn eval_const(self, expr: &hir::Expr<'_>) -> Option<ConstValue> {
-        let hir::ExprKind::Lit(lit) = expr.peel_parens().kind else { return None };
-        try_eval_lit(lit).ok()
+    /// Evaluates the given expression as an integer constant, emitting an error diagnostic if it
+    /// fails.
+    pub fn eval_const(self, expr: &hir::Expr<'_>) -> Result<&'gcx IntScalar, ErrorGuaranteed> {
+        self.try_eval_const(expr).map_err(|err| self.emit_const_eval_error(expr, err))
     }
+
+    /// Evaluates the given expression as an integer constant without emitting diagnostics.
+    pub fn try_eval_const(self, expr: &hir::Expr<'_>) -> Result<&'gcx IntScalar, EvalError> {
+        match self.try_eval_const_value(expr)? {
+            ConstValue::Integer(value) => Ok(value),
+            ConstValue::Bool(_) => Err(EE::UnsupportedExpr.into()),
+            ConstValue::String(_) => Err(EE::UnsupportedLiteral.into()),
+        }
+    }
+
+    /// Evaluates the given expression to a typed constant value, emitting an error diagnostic if
+    /// it fails.
+    pub fn eval_const_value(
+        self,
+        expr: &hir::Expr<'_>,
+    ) -> Result<&'gcx ConstValue, ErrorGuaranteed> {
+        self.try_eval_const_value(expr).map_err(|err| self.emit_const_eval_error(expr, err))
+    }
+
+    /// Evaluates the given expression to a typed constant value without emitting diagnostics.
+    pub fn try_eval_const_value(self, expr: &hir::Expr<'_>) -> Result<&'gcx ConstValue, EvalError> {
+        match self.eval_const_value_result(expr) {
+            Ok(value) => Ok(value),
+            Err(err) => Err(err.clone()),
+        }
+    }
+
+    /// Emits a diagnostic for the given constant evaluation error.
+    pub fn emit_const_eval_error(self, expr: &hir::Expr<'_>, err: EvalError) -> ErrorGuaranteed {
+        match err.kind {
+            EE::AlreadyEmitted(guar) => guar,
+            _ => {
+                let msg = format!("failed to evaluate constant: {}", err.kind.msg());
+                let label = "evaluation of constant value failed here";
+                self.dcx().emit_err_label(expr.span, msg, err.span, label)
+            }
+        }
+    }
+}
+
+pub(crate) fn eval_const(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> EvalResult {
+    ConstantEvaluator::new(gcx).try_eval_value(expr)
 }
 
 /// Evaluates Solidity constant expressions.
@@ -56,38 +92,19 @@ impl<'gcx> Gcx<'gcx> {
 /// This supports the source-level constants needed by semantic analysis and
 /// codegen's HIR lowering pre-folds. It does not evaluate runtime-dependent
 /// expressions such as function calls or memory allocation.
-pub struct ConstantEvaluator<'gcx> {
-    pub gcx: Gcx<'gcx>,
+struct ConstantEvaluator<'gcx> {
+    gcx: Gcx<'gcx>,
     depth: usize,
 }
 
-type EvalResult = Result<ConstValue, EvalError>;
+pub(crate) type EvalResult = Result<ConstValue, EvalError>;
 
 impl<'gcx> ConstantEvaluator<'gcx> {
-    /// Creates a new constant evaluator.
-    pub fn new(gcx: Gcx<'gcx>) -> Self {
+    fn new(gcx: Gcx<'gcx>) -> Self {
         Self { gcx, depth: 0 }
     }
 
-    /// Evaluates the given expression, emitting an error diagnostic if it fails.
-    pub fn eval(&mut self, expr: &hir::Expr<'_>) -> Result<IntScalar, ErrorGuaranteed> {
-        self.try_eval(expr).map_err(|err| self.emit_eval_error(expr, err))
-    }
-
-    /// Evaluates the given expression, returning an error if it fails.
-    pub fn try_eval(&mut self, expr: &hir::Expr<'_>) -> Result<IntScalar, EvalError> {
-        self.try_eval_value(expr).and_then(ConstValue::into_integer)
-    }
-
-    /// Evaluates the given expression to a typed constant value, emitting an
-    /// error diagnostic if it fails.
-    pub fn eval_value(&mut self, expr: &hir::Expr<'_>) -> Result<ConstValue, ErrorGuaranteed> {
-        self.try_eval_value(expr).map_err(|err| self.emit_eval_error(expr, err))
-    }
-
-    /// Evaluates the given expression to a typed constant value, returning an
-    /// error if it fails.
-    pub fn try_eval_value(&mut self, expr: &hir::Expr<'_>) -> EvalResult {
+    fn try_eval_value(&mut self, expr: &hir::Expr<'_>) -> EvalResult {
         self.depth += 1;
         if self.depth > RECURSION_LIMIT {
             return Err(EE::RecursionLimitReached.spanned(expr.span));
@@ -100,18 +117,6 @@ impl<'gcx> ConstantEvaluator<'gcx> {
         }
         self.depth = self.depth.checked_sub(1).unwrap();
         res
-    }
-
-    /// Emits a diagnostic for the given evaluation error.
-    pub fn emit_eval_error(&self, expr: &hir::Expr<'_>, err: EvalError) -> ErrorGuaranteed {
-        match err.kind {
-            EE::AlreadyEmitted(guar) => guar,
-            _ => {
-                let msg = format!("failed to evaluate constant: {}", err.kind.msg());
-                let label = "evaluation of constant value failed here";
-                self.gcx.dcx().emit_err_label(expr.span, msg, err.span, label)
-            }
-        }
     }
 
     fn eval_expr(&mut self, expr: &hir::Expr<'_>) -> EvalResult {
@@ -140,7 +145,7 @@ impl<'gcx> ConstantEvaluator<'gcx> {
             }
             // hir::ExprKind::Index(_, _) => unimplemented!(),
             // hir::ExprKind::Slice(_, _, _) => unimplemented!(),
-            hir::ExprKind::Lit(lit) => try_eval_lit(lit),
+            hir::ExprKind::Lit(lit) => self.eval_lit(lit),
             // hir::ExprKind::Member(_, _) => unimplemented!(),
             // hir::ExprKind::New(_) => unimplemented!(),
             // hir::ExprKind::Payable(_) => unimplemented!(),
@@ -180,20 +185,20 @@ impl<'gcx> ConstantEvaluator<'gcx> {
         }
         Err(EE::UnsupportedExpr.into())
     }
-}
 
-fn try_eval_lit(lit: &hir::Lit<'_>) -> EvalResult {
-    match lit.kind {
-        LitKind::Str(StrKind::Str | StrKind::Unicode, s, _) => Ok(ConstValue::String(s)),
-        LitKind::Str(StrKind::Hex, _, _) => Err(EE::UnsupportedLiteral.into()),
-        LitKind::Number(n) => Ok(ConstValue::Integer(IntScalar::new(n))),
-        // LitKind::Rational(ratio) => todo!(),
-        LitKind::Address(address) => {
-            Ok(ConstValue::Integer(IntScalar::from_be_bytes(address.as_slice())))
+    fn eval_lit(&mut self, lit: &hir::Lit<'_>) -> EvalResult {
+        match lit.kind {
+            LitKind::Str(StrKind::Str | StrKind::Unicode, s, _) => Ok(ConstValue::String(s)),
+            LitKind::Str(StrKind::Hex, _, _) => Err(EE::UnsupportedLiteral.into()),
+            LitKind::Number(n) => Ok(ConstValue::Integer(IntScalar::new(n))),
+            // LitKind::Rational(ratio) => todo!(),
+            LitKind::Address(address) => {
+                Ok(ConstValue::Integer(IntScalar::from_be_bytes(address.as_slice())))
+            }
+            LitKind::Bool(bool) => Ok(ConstValue::Bool(bool)),
+            LitKind::Err(guar) => Err(EE::AlreadyEmitted(guar).into()),
+            _ => Err(EE::UnsupportedLiteral.into()),
         }
-        LitKind::Bool(bool) => Ok(ConstValue::Bool(bool)),
-        LitKind::Err(guar) => Err(EE::AlreadyEmitted(guar).into()),
-        _ => Err(EE::UnsupportedLiteral.into()),
     }
 }
 
@@ -477,7 +482,7 @@ impl IntScalar {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum EvalErrorKind {
     RecursionLimitReached,
     ArithmeticOverflow,
@@ -496,7 +501,7 @@ impl EvalErrorKind {
         EvalError { kind: self, span }
     }
 
-    fn msg(&self) -> &'static str {
+    pub(crate) fn msg(&self) -> &'static str {
         match self {
             Self::RecursionLimitReached => "recursion limit reached",
             Self::ArithmeticOverflow => "arithmetic overflow",
@@ -511,7 +516,7 @@ impl EvalErrorKind {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct EvalError {
     pub span: Span,
     pub kind: EvalErrorKind,
@@ -534,10 +539,8 @@ impl std::error::Error for EvalError {}
 #[cfg(test)]
 mod tests {
     use super::{ConstValue, IntScalar, erc7201_slot};
-    use crate::{Compiler, hir, ty::Gcx};
-    use alloy_primitives::{U256, address, b256};
-    use solar_interface::{ColorChoice, Session};
-    use std::path::PathBuf;
+    use crate::hir;
+    use alloy_primitives::{U256, b256};
 
     #[test]
     fn const_value_integer_accessors() {
@@ -565,52 +568,6 @@ mod tests {
     }
 
     #[test]
-    fn gcx_eval_const_evaluates_literals_only() {
-        let compiler = lower_source(
-            r#"
-contract Test {
-    uint256 number = 42;
-    bool boolean = true;
-    string text = "hello";
-    string unicodeText = unicode"hello";
-    address account = 0x52908400098527886E0F7030069857D2E4169EE7;
-    uint256 parenthesized = (7);
-
-    uint256 binary = 1 + 2;
-    int256 unary = -1;
-    uint256 constant named = 9;
-    uint256 identifier = named;
-    bytes hexString = hex"1234";
-}
-"#,
-        );
-
-        compiler.enter_sequential(|compiler| {
-            let gcx = compiler.gcx();
-
-            assert_integer(gcx.eval_const(initializer(gcx, "number")), U256::from(42));
-            assert!(matches!(
-                gcx.eval_const(initializer(gcx, "boolean")),
-                Some(ConstValue::Bool(true))
-            ));
-            assert_string(gcx.eval_const(initializer(gcx, "text")), b"hello");
-            assert_string(gcx.eval_const(initializer(gcx, "unicodeText")), b"hello");
-            assert_integer(
-                gcx.eval_const(initializer(gcx, "account")),
-                U256::from_be_slice(
-                    address!("52908400098527886E0F7030069857D2E4169EE7").as_slice(),
-                ),
-            );
-            assert_integer(gcx.eval_const(initializer(gcx, "parenthesized")), U256::from(7));
-
-            for name in ["binary", "unary", "identifier", "hexString"] {
-                assert!(gcx.eval_const(initializer(gcx, name)).is_none(), "{name}");
-            }
-        });
-        assert!(compiler.sess().dcx.has_errors().is_ok());
-    }
-
-    #[test]
     fn erc7201_slot_matches_eip_example() {
         assert_eq!(
             erc7201_slot(b"example.main"),
@@ -624,48 +581,5 @@ contract Test {
             erc7201_slot(b"85"),
             b256!("06d0d983459328e82eacb1bf2d6fadfa38a6896e9d4cbfe0e1aa41c6281bab00")
         );
-    }
-
-    fn assert_integer(value: Option<ConstValue>, expected: U256) {
-        let Some(ConstValue::Integer(value)) = value else {
-            panic!("expected integer literal, got {value:?}")
-        };
-        assert_eq!(value.as_u256(), Some(expected));
-    }
-
-    fn assert_string(value: Option<ConstValue>, expected: &[u8]) {
-        let Some(ConstValue::String(value)) = value else {
-            panic!("expected string literal, got {value:?}")
-        };
-        assert_eq!(value.as_byte_str(), expected);
-    }
-
-    fn initializer<'gcx>(gcx: Gcx<'gcx>, name: &str) -> &'gcx hir::Expr<'gcx> {
-        gcx.hir
-            .variables()
-            .find(|variable| variable.name.is_some_and(|variable| variable.as_str() == name))
-            .and_then(|variable| variable.initializer)
-            .unwrap_or_else(|| panic!("initializer for `{name}` not found"))
-    }
-
-    fn lower_source(src: &str) -> Compiler {
-        let sess =
-            Session::builder().with_buffer_emitter(ColorChoice::Never).single_threaded().build();
-        let mut compiler = Compiler::new(sess);
-
-        let _ = compiler.enter_mut(|compiler| -> solar_interface::Result<_> {
-            let mut parsing_context = compiler.parse();
-            let file = compiler
-                .sess()
-                .source_map()
-                .new_source_file(PathBuf::from("test.sol"), src.to_string())
-                .unwrap();
-            parsing_context.add_file(file);
-            parsing_context.parse();
-            let _ = compiler.lower_asts()?;
-            Ok(())
-        });
-
-        compiler
     }
 }

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -41,6 +41,16 @@ pub fn eval_array_len(gcx: Gcx<'_>, size: &hir::Expr<'_>) -> Result<U256, ErrorG
     }
 }
 
+impl<'gcx> Gcx<'gcx> {
+    /// Attempts to evaluate a literal expression without emitting diagnostics.
+    ///
+    /// Returns `None` for non-literal expressions and unsupported literals.
+    pub fn eval_const(self, expr: &hir::Expr<'_>) -> Option<ConstValue> {
+        let hir::ExprKind::Lit(lit) = expr.peel_parens().kind else { return None };
+        try_eval_lit(lit).ok()
+    }
+}
+
 /// Evaluates Solidity constant expressions.
 ///
 /// This supports the source-level constants needed by semantic analysis and
@@ -130,7 +140,7 @@ impl<'gcx> ConstantEvaluator<'gcx> {
             }
             // hir::ExprKind::Index(_, _) => unimplemented!(),
             // hir::ExprKind::Slice(_, _, _) => unimplemented!(),
-            hir::ExprKind::Lit(lit) => self.eval_lit(lit),
+            hir::ExprKind::Lit(lit) => try_eval_lit(lit),
             // hir::ExprKind::Member(_, _) => unimplemented!(),
             // hir::ExprKind::New(_) => unimplemented!(),
             // hir::ExprKind::Payable(_) => unimplemented!(),
@@ -170,20 +180,20 @@ impl<'gcx> ConstantEvaluator<'gcx> {
         }
         Err(EE::UnsupportedExpr.into())
     }
+}
 
-    fn eval_lit(&mut self, lit: &hir::Lit<'_>) -> EvalResult {
-        match lit.kind {
-            LitKind::Str(StrKind::Str | StrKind::Unicode, s, _) => Ok(ConstValue::String(s)),
-            LitKind::Str(StrKind::Hex, _, _) => Err(EE::UnsupportedLiteral.into()),
-            LitKind::Number(n) => Ok(ConstValue::Integer(IntScalar::new(n))),
-            // LitKind::Rational(ratio) => todo!(),
-            LitKind::Address(address) => {
-                Ok(ConstValue::Integer(IntScalar::from_be_bytes(address.as_slice())))
-            }
-            LitKind::Bool(bool) => Ok(ConstValue::Bool(bool)),
-            LitKind::Err(guar) => Err(EE::AlreadyEmitted(guar).into()),
-            _ => Err(EE::UnsupportedLiteral.into()),
+fn try_eval_lit(lit: &hir::Lit<'_>) -> EvalResult {
+    match lit.kind {
+        LitKind::Str(StrKind::Str | StrKind::Unicode, s, _) => Ok(ConstValue::String(s)),
+        LitKind::Str(StrKind::Hex, _, _) => Err(EE::UnsupportedLiteral.into()),
+        LitKind::Number(n) => Ok(ConstValue::Integer(IntScalar::new(n))),
+        // LitKind::Rational(ratio) => todo!(),
+        LitKind::Address(address) => {
+            Ok(ConstValue::Integer(IntScalar::from_be_bytes(address.as_slice())))
         }
+        LitKind::Bool(bool) => Ok(ConstValue::Bool(bool)),
+        LitKind::Err(guar) => Err(EE::AlreadyEmitted(guar).into()),
+        _ => Err(EE::UnsupportedLiteral.into()),
     }
 }
 
@@ -524,8 +534,10 @@ impl std::error::Error for EvalError {}
 #[cfg(test)]
 mod tests {
     use super::{ConstValue, IntScalar, erc7201_slot};
-    use crate::hir;
-    use alloy_primitives::{U256, b256};
+    use crate::{Compiler, hir, ty::Gcx};
+    use alloy_primitives::{U256, address, b256};
+    use solar_interface::{ColorChoice, Session};
+    use std::path::PathBuf;
 
     #[test]
     fn const_value_integer_accessors() {
@@ -553,6 +565,52 @@ mod tests {
     }
 
     #[test]
+    fn gcx_eval_const_evaluates_literals_only() {
+        let compiler = lower_source(
+            r#"
+contract Test {
+    uint256 number = 42;
+    bool boolean = true;
+    string text = "hello";
+    string unicodeText = unicode"hello";
+    address account = 0x52908400098527886E0F7030069857D2E4169EE7;
+    uint256 parenthesized = (7);
+
+    uint256 binary = 1 + 2;
+    int256 unary = -1;
+    uint256 constant named = 9;
+    uint256 identifier = named;
+    bytes hexString = hex"1234";
+}
+"#,
+        );
+
+        compiler.enter_sequential(|compiler| {
+            let gcx = compiler.gcx();
+
+            assert_integer(gcx.eval_const(initializer(gcx, "number")), U256::from(42));
+            assert!(matches!(
+                gcx.eval_const(initializer(gcx, "boolean")),
+                Some(ConstValue::Bool(true))
+            ));
+            assert_string(gcx.eval_const(initializer(gcx, "text")), b"hello");
+            assert_string(gcx.eval_const(initializer(gcx, "unicodeText")), b"hello");
+            assert_integer(
+                gcx.eval_const(initializer(gcx, "account")),
+                U256::from_be_slice(
+                    address!("52908400098527886E0F7030069857D2E4169EE7").as_slice(),
+                ),
+            );
+            assert_integer(gcx.eval_const(initializer(gcx, "parenthesized")), U256::from(7));
+
+            for name in ["binary", "unary", "identifier", "hexString"] {
+                assert!(gcx.eval_const(initializer(gcx, name)).is_none(), "{name}");
+            }
+        });
+        assert!(compiler.sess().dcx.has_errors().is_ok());
+    }
+
+    #[test]
     fn erc7201_slot_matches_eip_example() {
         assert_eq!(
             erc7201_slot(b"example.main"),
@@ -566,5 +624,48 @@ mod tests {
             erc7201_slot(b"85"),
             b256!("06d0d983459328e82eacb1bf2d6fadfa38a6896e9d4cbfe0e1aa41c6281bab00")
         );
+    }
+
+    fn assert_integer(value: Option<ConstValue>, expected: U256) {
+        let Some(ConstValue::Integer(value)) = value else {
+            panic!("expected integer literal, got {value:?}")
+        };
+        assert_eq!(value.as_u256(), Some(expected));
+    }
+
+    fn assert_string(value: Option<ConstValue>, expected: &[u8]) {
+        let Some(ConstValue::String(value)) = value else {
+            panic!("expected string literal, got {value:?}")
+        };
+        assert_eq!(value.as_byte_str(), expected);
+    }
+
+    fn initializer<'gcx>(gcx: Gcx<'gcx>, name: &str) -> &'gcx hir::Expr<'gcx> {
+        gcx.hir
+            .variables()
+            .find(|variable| variable.name.is_some_and(|variable| variable.as_str() == name))
+            .and_then(|variable| variable.initializer)
+            .unwrap_or_else(|| panic!("initializer for `{name}` not found"))
+    }
+
+    fn lower_source(src: &str) -> Compiler {
+        let sess =
+            Session::builder().with_buffer_emitter(ColorChoice::Never).single_threaded().build();
+        let mut compiler = Compiler::new(sess);
+
+        let _ = compiler.enter_mut(|compiler| -> solar_interface::Result<_> {
+            let mut parsing_context = compiler.parse();
+            let file = compiler
+                .sess()
+                .source_map()
+                .new_source_file(PathBuf::from("test.sol"), src.to_string())
+                .unwrap();
+            parsing_context.add_file(file);
+            parsing_context.parse();
+            let _ = compiler.lower_asts()?;
+            Ok(())
+        });
+
+        compiler
     }
 }

--- a/crates/sema/src/output/storage_layout.rs
+++ b/crates/sema/src/output/storage_layout.rs
@@ -1,5 +1,4 @@
 use crate::{
-    eval::ConstantEvaluator,
     hir,
     ty::{Gcx, Ty, TyKind},
 };
@@ -94,8 +93,8 @@ impl<'gcx> StorageLayoutBuilder<'gcx> {
         let contract = self.gcx.hir.contract(self.contract_id);
         let base_slot = match self.location {
             DataLocation::Storage => contract.layout.map_or(U256::ZERO, |layout| {
-                ConstantEvaluator::new(self.gcx)
-                    .eval(layout)
+                self.gcx
+                    .eval_const(layout)
                     .ok()
                     .and_then(|value| value.as_u256())
                     .unwrap_or_default()

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1291,12 +1291,30 @@ fn fn_state_mutability(kind: TyFnKind, state_mutability: StateMutability) -> Sta
     }
 }
 
+macro_rules! cached_key_type {
+    ($key_type:ty) => {
+        $key_type
+    };
+    ($key_type:ty, $cache_key_type:ty) => {
+        $cache_key_type
+    };
+}
+
+macro_rules! cached_key_expr {
+    ($key:expr) => {
+        $key
+    };
+    ($key:expr, $cache_key:expr) => {
+        $cache_key
+    };
+}
+
 macro_rules! cached {
-    ($($(#[$attr:meta])* $vis:vis fn $name:ident($gcx:ident: _, $key:ident : $key_type:ty) -> $value:ty $imp:block)*) => {
+    ($($(#[$attr:meta])* $vis:vis fn $name:ident($gcx:ident: _, $key:ident : $key_type:ty) $(cached_by($cache_key_type:ty, $cache_key:expr))? -> $value:ty $imp:block)*) => {
         #[derive(Default)]
         struct Cache<'gcx> {
             $(
-                $name: FxOnceMap<$key_type, $value>,
+                $name: FxOnceMap<cached_key_type!($key_type $(, $cache_key_type)?), $value>,
             )*
         }
 
@@ -1304,11 +1322,12 @@ macro_rules! cached {
             $(
                 $(#[$attr])*
                 $vis fn $name(self, $key: $key_type) -> $value {
+                    let cache_key = cached_key_expr!($key $(, $cache_key)?);
                     #[cfg(false)]
-                    let _guard = log_cache_query(stringify!($name), &$key);
+                    let _guard = log_cache_query(stringify!($name), &cache_key);
                     #[cfg(false)]
                     let mut hit = true;
-                    let r = cache_insert(&self.cache.$name, $key, |&$key| {
+                    let r = cache_insert(&self.cache.$name, cache_key, |_| {
                         #[cfg(false)]
                         {
                             hit = false;
@@ -1604,7 +1623,14 @@ fn internal_function_members_in_context(
     let (id, current_contract) = key;
     gcx.bump().alloc_vec(members::internal_function_members_in_context(gcx, id, current_contract))
 }
+
+pub(crate) fn eval_const_value_result(gcx: _, expr: &hir::Expr<'_>)
+    cached_by(hir::ExprId, expr.id) -> &'gcx crate::eval::EvalResult
+{
+    gcx.alloc(crate::eval::eval_const(gcx, expr))
 }
+
+} // cached!
 
 fn var_type<'gcx>(gcx: Gcx<'gcx>, var: &'gcx hir::Variable<'gcx>, ty: Ty<'gcx>) -> Ty<'gcx> {
     use hir::DataLocation::*;

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtins::{Builtin, members},
-    eval::{ConstValue, ConstantEvaluator, EvalErrorKind},
+    eval::{ConstValue, EvalErrorKind},
     hir::{self, Visit},
     ty::{
         CallableParamSource, Gcx, ResolvedCallee, Ty, TyConvertError, TyFn, TyFnKind, TyKind,
@@ -84,8 +84,7 @@ impl<'gcx> TypeChecker<'gcx> {
     }
 
     fn check_storage_layout_base_slot(&mut self, slot: &'gcx hir::Expr<'gcx>) {
-        let mut evaluator = ConstantEvaluator::new(self.gcx);
-        match evaluator.try_eval_value(slot) {
+        match self.gcx.try_eval_const_value(slot) {
             Ok(ConstValue::Integer(value)) => {
                 if let Some(base_slot) = value.as_u256() {
                     let Some(contract_id) = self.contract else {
@@ -112,10 +111,10 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             Ok(ConstValue::String(_)) => {
                 let err = EvalErrorKind::UnsupportedLiteral.spanned(slot.span);
-                evaluator.emit_eval_error(slot, err);
+                self.gcx.emit_const_eval_error(slot, err);
             }
             Err(err) => {
-                evaluator.emit_eval_error(slot, err);
+                self.gcx.emit_const_eval_error(slot, err);
             }
         }
     }
@@ -806,8 +805,7 @@ impl<'gcx> TypeChecker<'gcx> {
     /// Returns the resulting IntLiteral type if successful, or None if evaluation fails.
     /// This is used to preserve literal type through literal expressions.
     fn try_eval_int_literal_expr(&self, expr: &'gcx hir::Expr<'gcx>) -> Option<Ty<'gcx>> {
-        let mut evaluator = ConstantEvaluator::new(self.gcx);
-        let result = evaluator.try_eval(expr).ok()?;
+        let result = self.gcx.try_eval_const(expr).ok()?;
         let compatible_fixed_bytes = result.is_zero().then_some(TypeSize::ZERO);
         self.gcx.mk_ty_int_literal_with_fixed_bytes(
             result.is_negative(),


### PR DESCRIPTION
Adds a Clippy-style, non-diagnostic `Gcx::eval_const` query for consumers that need to inspect an HIR expression's value. The initial surface intentionally accepts only literal expressions, including parenthesized literals, and returns `None` for operators, identifiers, and unsupported literal kinds, keeping lint behavior conservative.

The query reuses `ConstValue` and factors literal conversion out of `ConstantEvaluator`, so compiler evaluation and external queries share one representation without duplicating evaluator logic. This gives downstream lint implementations a small pattern-match API while leaving room to expand folding centrally later.