### PR TITLE
feat(sema): add call argument query

### DIFF
--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -178,7 +178,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
         let CallArgsKind::Unnamed([target, arguments]) = args.kind else {
             return;
         };
-        let Some(param_source) = self.call_param_source_from_expr(target) else {
+        let Some(param_source) = self.gcx.call_param_source(target) else {
             return;
         };
         let param_names = self.gcx.callable_param_names(param_source);
@@ -251,67 +251,6 @@ impl<'gcx> InlayHintCollector<'gcx> {
         format!(": {}", ty.display(self.gcx))
     }
 
-    /// Finds the callable declaration that supplies parameter names for a call expression.
-    fn call_param_source(
-        &self,
-        callee: &'gcx hir::Expr<'gcx>,
-        callee_ty: Option<Ty<'gcx>>,
-    ) -> Option<CallableParamSource> {
-        if let ExprKind::New(hir_ty) = &callee.kind
-            && let TyKind::Contract(id) = self.gcx.type_of_hir_ty(hir_ty).kind
-            && let Some(ctor) = self.gcx.hir.contract(id).ctor
-        {
-            return Some(CallableParamSource::Function { id: ctor, skips_receiver: false });
-        }
-
-        self.call_param_source_from_expr(callee).or_else(|| {
-            callee_ty
-                .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
-                .and_then(|signature| signature.param_source)
-        })
-    }
-
-    /// Finds the parameter-name source attached to a specific expression.
-    fn call_param_source_from_expr(
-        &self,
-        expr: &'gcx hir::Expr<'gcx>,
-    ) -> Option<CallableParamSource> {
-        let expr = expr.peel_parens();
-        if let ExprKind::Ident([res]) = expr.kind
-            && let Some(variable) = res.as_variable()
-            && matches!(self.gcx.hir.variable(variable).ty.kind, hir::TypeKind::Function(_))
-        {
-            return Some(CallableParamSource::FunctionType(variable));
-        }
-
-        if let ExprKind::Member(receiver, ident) = expr.kind
-            && let Some(receiver_ty) = self.gcx.type_of_expr(receiver.id)
-            && let Some(field) = self.struct_field(receiver_ty, ident.name)
-            && matches!(self.gcx.hir.variable(field).ty.kind, hir::TypeKind::Function(_))
-        {
-            return Some(CallableParamSource::FunctionType(field));
-        }
-
-        self.gcx
-            .type_of_expr(expr.id)
-            .and_then(|ty| self.gcx.callable_signature_of_ty(ty))
-            .and_then(|signature| signature.param_source)
-    }
-
-    fn struct_field(&self, receiver_ty: Ty<'gcx>, name: Symbol) -> Option<hir::VariableId> {
-        let struct_id = match receiver_ty.kind {
-            TyKind::Ref(inner, _) => match inner.kind {
-                TyKind::Struct(id) => id,
-                _ => return None,
-            },
-            TyKind::Struct(id) => id,
-            _ => return None,
-        };
-        self.gcx.hir.strukt(struct_id).fields.iter().copied().find(|&field| {
-            self.gcx.hir.variable(field).name.is_some_and(|field_name| field_name.name == name)
-        })
-    }
-
     /// Finds the function or constructor declaration that supplies parameter names for a modifier.
     fn modifier_param_source(
         &self,
@@ -339,7 +278,7 @@ impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
             if self.gcx.builtin_callee(callee.id) == Some(Builtin::AbiEncodeCall) {
                 self.push_abi_encode_call_parameter_hints(args);
             }
-            self.push_parameter_hints(args, self.call_param_source(callee, callee_ty));
+            self.push_parameter_hints(args, self.gcx.call_param_source(callee));
             self.push_call_type_hint(expr, callee_ty);
         }
         hir::Visit::walk_expr(self, expr)

--- a/crates/lsp/src/signature_help.rs
+++ b/crates/lsp/src/signature_help.rs
@@ -651,7 +651,7 @@ fn signature_declaration_parts<'gcx>(
             );
             doc_id = Some(variable.doc);
         }
-        None => {
+        Some(CallableParamSource::Builtin(_)) | None => {
             let fallback_name = fallback_name.or_else(|| match res {
                 Some(Res::Builtin(builtin)) => Some(builtin.name().to_string()),
                 _ => None,

--- a/crates/lsp/src/tests/inlay_hint.rs
+++ b/crates/lsp/src/tests/inlay_hint.rs
@@ -429,6 +429,54 @@ TYPE : uint256
 }
 
 #[test]
+fn prefers_selected_attached_function_over_colliding_struct_field() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Collision.sol
+        struct Holder {
+            function(bool fieldFlag, address fieldAccount) internal pure callback;
+        }
+
+        library L {
+            function callback(
+                Holder memory self,
+                uint256 attachedFirst,
+                address attachedAccount
+            ) internal pure {
+                self;
+                attachedFirst;
+                attachedAccount;
+            }
+        }
+
+        contract C {
+            using L for Holder;
+
+            function fieldTarget(bool fieldFlag, address fieldAccount) internal pure {
+                fieldFlag;
+                fieldAccount;
+            }
+
+            function caller(address user) public pure {
+                Holder memory holder = Holder({callback: fieldTarget});
+                holder.callback(1, user);
+            }
+        }
+        "#,
+        "/Collision.sol",
+    );
+
+    fixture.check_inlay_hints(
+        "/Collision.sol",
+        str![[r#"
+PARAMETER attachedFirst:
+PARAMETER attachedAccount:
+
+"#]],
+    );
+}
+
+#[test]
 fn uses_target_parameter_names_for_abi_encode_call_tuple() {
     let fixture = RequestFixture::new(
         r#"

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1706,6 +1706,13 @@ pub struct NamedArg<'hir> {
     pub value: Expr<'hir>,
 }
 
+impl NamedArg<'_> {
+    /// Returns the declaration-order parameter index for this named argument.
+    pub(crate) fn parameter_index(&self, parameter_names: &[Option<Symbol>]) -> Option<usize> {
+        parameter_names.iter().position(|&name| name == Some(self.name.name))
+    }
+}
+
 /// Function call options: `foo{ gas: 100_000 }`.
 #[derive(Clone, Copy, Debug)]
 pub struct CallOptions<'hir> {
@@ -1761,6 +1768,25 @@ impl<'hir> CallArgs<'hir> {
         &self,
     ) -> impl ExactSizeIterator<Item = &Expr<'hir>> + DoubleEndedIterator + Clone {
         self.kind.exprs()
+    }
+
+    /// Returns the source argument bound to the parameter at `index`.
+    ///
+    /// `parameter_names` is only required for named arguments and must be in declaration order.
+    pub(crate) fn argument_for_parameter(
+        &self,
+        index: usize,
+        parameter_names: Option<&[Option<Symbol>]>,
+    ) -> Option<&'hir Expr<'hir>> {
+        match self.kind {
+            CallArgsKind::Unnamed(exprs) => exprs.get(index),
+            CallArgsKind::Named(args) => {
+                let parameter_names = parameter_names?;
+                args.iter()
+                    .find(|arg| arg.parameter_index(parameter_names) == Some(index))
+                    .map(|arg| &arg.value)
+            }
+        }
     }
 }
 

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -20,6 +20,7 @@ use solar_interface::{
     config::CompilerStage,
     diagnostics::{DiagCtxt, ErrorGuaranteed},
     source_map::{FileName, SourceFile},
+    sym,
 };
 use std::{
     fmt,
@@ -141,6 +142,8 @@ pub enum CallableParamSource {
     Event(hir::EventId),
     /// An error invocation.
     Error(hir::ErrorId),
+    /// A builtin with named parameters.
+    Builtin(Builtin),
 }
 
 /// The visible signature of a callable expression.
@@ -528,6 +531,94 @@ impl<'gcx> Gcx<'gcx> {
     #[inline]
     pub fn type_of_expr(self, id: hir::ExprId) -> Option<Ty<'gcx>> {
         self.typeck_results.get()?.type_of_expr(id)
+    }
+
+    /// Returns the source argument at the given visible parameter index.
+    ///
+    /// Named arguments are reordered into the selected callable's declaration order. For an
+    /// attached `using for` call, the implicit receiver is not part of this indexing. Positional
+    /// variadic calls are indexed by their source arguments, and explicit type conversions expose
+    /// their single argument at index zero.
+    ///
+    /// Returns `None` if type checking did not identify a callable target. This query maps source
+    /// arguments but does not revalidate their types.
+    pub fn call_arg(
+        self,
+        call: &hir::Expr<'gcx>,
+        parameter_index: usize,
+    ) -> Option<&'gcx hir::Expr<'gcx>> {
+        let hir::ExprKind::Call(callee, args, _) = call.peel_parens().kind else { return None };
+        let callee_ty = self.type_of_expr(callee.id)?;
+        let signature = self.callable_signature_of_ty(callee_ty);
+
+        let parameter_names = match args.kind {
+            hir::CallArgsKind::Unnamed(_) => {
+                let valid_index = signature.is_some_and(|signature| {
+                    parameter_index < signature.parameters.len()
+                        || signature
+                            .parameters
+                            .last()
+                            .is_some_and(|ty| matches!(ty.kind, TyKind::Variadic))
+                }) || matches!(callee_ty.kind, TyKind::Type(_))
+                    && parameter_index == 0;
+                if !valid_index {
+                    return None;
+                }
+                None
+            }
+            hir::CallArgsKind::Named(_) => {
+                let signature = signature?;
+                if parameter_index >= signature.parameters.len() {
+                    return None;
+                }
+                let source = self.call_param_source(callee).or(signature.param_source)?;
+                Some(self.callable_param_names(source))
+            }
+        };
+        args.argument_for_parameter(parameter_index, parameter_names.as_deref())
+    }
+
+    /// Returns the parameter-name source for a type-checked call callee.
+    ///
+    /// The selected callable type takes precedence. Syntax and builtin semantics only recover
+    /// parameter names when the selected signature does not carry a declaration source.
+    pub fn call_param_source(self, callee: &hir::Expr<'gcx>) -> Option<CallableParamSource> {
+        let callee = callee.peel_parens();
+        if let Some(source) = self
+            .type_of_expr(callee.id)
+            .and_then(|ty| self.callable_signature_of_ty(ty))
+            .and_then(|signature| signature.param_source)
+        {
+            return Some(source);
+        }
+
+        if let hir::ExprKind::Ident([res]) = callee.kind
+            && let Some(id) = res.as_variable()
+            && matches!(self.hir.variable(id).ty.kind, hir::TypeKind::Function(_))
+        {
+            return Some(CallableParamSource::FunctionType(id));
+        }
+        if let hir::ExprKind::Member(receiver, name) = callee.kind
+            && let Some(receiver_ty) = self.type_of_expr(receiver.id)
+            && let Some(ResolvedMember::StructField { struct_id, field_index }) =
+                self.resolve_member_target(receiver_ty, name.name, None)
+            && let Some(&id) = self.hir.strukt(struct_id).fields.get(field_index)
+            && matches!(self.hir.variable(id).ty.kind, hir::TypeKind::Function(_))
+        {
+            return Some(CallableParamSource::FunctionType(id));
+        }
+        if let hir::ExprKind::New(hir_ty) = &callee.kind
+            && let TyKind::Contract(id) = self.type_of_hir_ty(hir_ty).kind
+            && let Some(id) = self.hir.contract(id).ctor
+        {
+            return Some(CallableParamSource::Function { id, skips_receiver: false });
+        }
+        if let Some(builtin) = self.builtin_callee(callee.id)
+            && matches!(builtin, Builtin::AbiDecode)
+        {
+            return Some(CallableParamSource::Builtin(builtin));
+        }
+        None
     }
 
     /// Returns the overload/member target selected for a call callee expression, if available.
@@ -934,6 +1025,10 @@ impl<'gcx> Gcx<'gcx> {
             CallableParamSource::Struct(id) => self.param_names(self.hir.strukt(id).fields),
             CallableParamSource::Event(id) => self.param_names(self.hir.event(id).parameters),
             CallableParamSource::Error(id) => self.param_names(self.hir.error(id).parameters),
+            CallableParamSource::Builtin(Builtin::AbiDecode) => {
+                [Some(sym::data), Some(sym::types)].into_iter().collect()
+            }
+            CallableParamSource::Builtin(_) => Default::default(),
         }
     }
 
@@ -1786,4 +1881,249 @@ fn log_cache_query(name: &str, key: &dyn fmt::Debug) -> tracing::span::EnteredSp
 #[cfg(false)]
 fn log_cache_query_result(result: &dyn fmt::Debug, hit: bool) {
     trace!(?result, hit);
+}
+
+#[cfg(test)]
+mod call_arg_tests {
+    use super::*;
+    use crate::{Compiler, hir::Visit};
+    use solar_data_structures::Never;
+    use solar_interface::{Session, config::CompileOpts};
+    use std::{collections::BTreeMap, ops::ControlFlow, path::PathBuf};
+
+    struct CallCollector<'hir> {
+        hir: &'hir hir::Hir<'hir>,
+        calls: Vec<&'hir hir::Expr<'hir>>,
+    }
+
+    impl<'hir> Visit<'hir> for CallCollector<'hir> {
+        type BreakValue = Never;
+
+        fn hir(&self) -> &'hir hir::Hir<'hir> {
+            self.hir
+        }
+
+        fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+            if matches!(expr.kind, hir::ExprKind::Call(..)) {
+                self.calls.push(expr);
+            }
+            self.walk_expr(expr)
+        }
+    }
+
+    fn call_arguments(source: &str, expect_errors: bool) -> BTreeMap<String, Vec<Option<String>>> {
+        let sess = Session::builder().opts(CompileOpts::default()).with_test_emitter().build();
+        let mut compiler = Compiler::new(sess);
+
+        compiler.enter_mut(|c| {
+            let mut pcx = c.parse();
+            let file =
+                c.sess().source_map().new_source_file(PathBuf::from("test.sol"), source).unwrap();
+            pcx.add_file(file);
+            pcx.parse();
+
+            assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
+            assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
+        });
+        assert_eq!(compiler.sess().dcx.has_errors().is_err(), expect_errors);
+
+        compiler.enter(|c| {
+            let gcx = c.gcx();
+            let mut visitor = CallCollector { hir: &gcx.hir, calls: Vec::new() };
+            for source in gcx.hir.source_ids() {
+                let _ = visitor.visit_nested_source(source);
+            }
+            visitor
+                .calls
+                .into_iter()
+                .map(|call| {
+                    let source_map = gcx.sess.source_map();
+                    let call_source = source_map.span_to_snippet(call.span).unwrap();
+                    let arguments = (0..3)
+                        .map(|index| {
+                            gcx.call_arg(call, index)
+                                .map(|arg| source_map.span_to_snippet(arg.span).unwrap())
+                        })
+                        .collect();
+                    (call_source, arguments)
+                })
+                .collect()
+        })
+    }
+
+    #[test]
+    fn call_arg_uses_visible_parameter_order() {
+        let calls = call_arguments(
+            r#"
+struct CollisionHolder {
+    function(bool fieldFlag, address fieldAccount) internal pure callback;
+}
+
+library L {
+    function attached(uint256 self, uint256 first, uint256 second)
+        internal
+        pure
+        returns (uint256)
+    {
+        return self + first + second;
+    }
+
+    function callback(
+        CollisionHolder memory self,
+        uint256 attachedFirst,
+        address attachedAccount
+    ) internal pure {
+        self;
+        attachedFirst;
+        attachedAccount;
+    }
+}
+
+contract D {
+    constructor(uint256 first, uint256 second) {
+        first;
+        second;
+    }
+}
+
+contract C {
+    using L for uint256;
+    using L for CollisionHolder;
+
+    struct Pair { uint256 first; uint256 second; }
+    event E(uint256 first, uint256 second);
+    error Err(uint256 first, uint256 second);
+
+    function target(uint256 first, uint256 second) internal pure {}
+    function fieldTarget(bool fieldFlag, address fieldAccount) internal pure {
+        fieldFlag;
+        fieldAccount;
+    }
+    function overloaded(uint256 first, uint256 second) internal pure {}
+    function overloaded(address recipient, uint256 amount) internal pure {}
+
+    function calls(uint256 receiver) external {
+        target(11, 22);
+        target({second: 22, first: 11});
+        receiver.attached({second: 22, first: 11});
+        Pair memory pair = Pair({second: 22, first: 11});
+        D created = new D(11, 22);
+        emit E({second: 22, first: 11});
+        overloaded({amount: 22, recipient: address(11)});
+        abi.encode(11, 22, 33);
+        CollisionHolder memory collision =
+            CollisionHolder({callback: fieldTarget});
+        collision.callback({attachedAccount: address(44), attachedFirst: 33});
+        pair;
+        created;
+        collision;
+    }
+
+    function fail() external pure {
+        revert Err({second: 22, first: 11});
+    }
+
+    function decode(bytes memory raw) external pure returns (uint256) {
+        return abi.decode({types: (uint256), data: raw});
+    }
+}
+"#,
+            false,
+        );
+
+        assert_eq!(calls["target(11, 22)"], [Some("11".into()), Some("22".into()), None]);
+        assert_eq!(
+            calls["target({second: 22, first: 11})"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(
+            calls["receiver.attached({second: 22, first: 11})"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(
+            calls["Pair({second: 22, first: 11})"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(calls["new D(11, 22)"], [Some("11".into()), Some("22".into()), None]);
+        assert_eq!(
+            calls["emit E({second: 22, first: 11});"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(
+            calls["revert Err({second: 22, first: 11});"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(
+            calls["overloaded({amount: 22, recipient: address(11)})"],
+            [Some("address(11)".into()), Some("22".into()), None]
+        );
+        assert_eq!(calls["address(11)"], [Some("11".into()), None, None]);
+        assert_eq!(
+            calls["abi.encode(11, 22, 33)"],
+            [Some("11".into()), Some("22".into()), Some("33".into())]
+        );
+        assert_eq!(
+            calls["abi.decode({types: (uint256), data: raw})"],
+            [Some("raw".into()), Some("(uint256)".into()), None]
+        );
+        assert_eq!(
+            calls["collision.callback({attachedAccount: address(44), attachedFirst: 33})"],
+            [Some("33".into()), Some("address(44)".into()), None]
+        );
+    }
+
+    #[test]
+    fn call_arg_handles_error_recovery() {
+        let calls = call_arguments(
+            r#"
+contract C {
+    struct Holder {
+        function(uint256 first, uint256 second) internal pure callback;
+    }
+
+    function ambiguous(uint256 value) internal pure {}
+    function ambiguous(int256 value) internal pure {}
+    function target(uint256 first, uint256 second) internal pure {}
+
+    function calls() external pure {
+        ambiguous({value: 1});
+        ambiguous(1);
+        abi.encode({value: 1});
+        uint256 notCallable = 1;
+        notCallable(1);
+        new D({second: 22, first: 11});
+        function(uint256 first, uint256 second) internal pure callback = target;
+        callback({second: 22, first: 11});
+        Holder memory holder = Holder({callback: target});
+        holder.callback({second: 44, first: 33});
+    }
+}
+
+contract D {
+    constructor(uint256 first, uint256 second) {
+        first;
+        second;
+    }
+}
+"#,
+            true,
+        );
+
+        assert_eq!(calls["ambiguous({value: 1})"], [None, None, None]);
+        assert_eq!(calls["ambiguous(1)"], [None, None, None]);
+        assert_eq!(calls["abi.encode({value: 1})"], [None, None, None]);
+        assert_eq!(calls["notCallable(1)"], [None, None, None]);
+        assert_eq!(
+            calls["new D({second: 22, first: 11})"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(
+            calls["callback({second: 22, first: 11})"],
+            [Some("11".into()), Some("22".into()), None]
+        );
+        assert_eq!(
+            calls["holder.callback({second: 44, first: 33})"],
+            [Some("33".into()), Some("44".into()), None]
+        );
+    }
 }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -27,6 +27,23 @@ enum AbiDecodeArg {
     Types,
 }
 
+impl AbiDecodeArg {
+    fn from_parameter_index(index: usize) -> Option<Self> {
+        match index {
+            0 => Some(Self::Data),
+            1 => Some(Self::Types),
+            _ => None,
+        }
+    }
+
+    fn parameter_index(self) -> usize {
+        match self {
+            Self::Data => 0,
+            Self::Types => 1,
+        }
+    }
+}
+
 pub(super) fn check<'gcx>(gcx: Gcx<'gcx>, source: hir::SourceId) -> TypeckResults<'gcx> {
     let mut checker = TypeChecker::new(gcx, source);
     let _ = checker.visit_nested_source(source);
@@ -1371,6 +1388,8 @@ impl<'gcx> TypeChecker<'gcx> {
         let mut result = Ok(());
         result = result.and(self.check_exact_arg_count(call_span, args_span, named_args.len(), 2));
 
+        let param_names =
+            self.gcx.callable_param_names(CallableParamSource::Builtin(Builtin::AbiDecode));
         let mut seen_names: SmallVec<[solar_interface::Symbol; 2]> = SmallVec::new();
         for arg in named_args {
             let arg_name = arg.name.name;
@@ -1383,7 +1402,9 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             seen_names.push(arg_name);
 
-            if let Some(kind) = abi_decode_arg_kind(arg_name) {
+            if let Some(kind) =
+                arg.parameter_index(&param_names).and_then(AbiDecodeArg::from_parameter_index)
+            {
                 result = result.and(self.check_abi_decode_arg(kind, &arg.value));
             } else {
                 result = result.and(Err(self.dcx().emit_err(
@@ -1454,7 +1475,11 @@ impl<'gcx> TypeChecker<'gcx> {
                 types_expr
             }
             hir::CallArgsKind::Named(named_args) => {
-                let Some(arg) = named_args.iter().find(|arg| arg.name.name == sym::types) else {
+                let param_names =
+                    self.gcx.callable_param_names(CallableParamSource::Builtin(Builtin::AbiDecode));
+                let Some(arg) = named_args.iter().find(|arg| {
+                    arg.parameter_index(&param_names) == Some(AbiDecodeArg::Types.parameter_index())
+                }) else {
                     unreachable!(
                         "`abi.decode` named arguments should be checked before deriving return type"
                     );
@@ -1773,8 +1798,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 }
                 let mut seen = DenseBitSet::new_empty(param_tys.len());
                 for arg in named_args {
-                    let Some(index) = names.iter().position(|&name| name == Some(arg.name.name))
-                    else {
+                    let Some(index) = arg.parameter_index(&names) else {
                         return false;
                     };
                     if !seen.insert(index) {
@@ -2017,7 +2041,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             seen_names.push(arg_name);
 
-            let param_idx = param_names.iter().position(|n| n.is_some_and(|name| name == arg_name));
+            let param_idx = arg.parameter_index(&param_names);
 
             match param_idx {
                 Some(idx) => {
@@ -2731,16 +2755,6 @@ fn valid_bytes_concat_arg(ty: Ty<'_>) -> bool {
             TyKind::Slice(array)
                 if matches!(array.peel_refs().kind, TyKind::Elementary(ElementaryType::Bytes))
         )
-}
-
-fn abi_decode_arg_kind(name: Symbol) -> Option<AbiDecodeArg> {
-    if name == sym::data {
-        Some(AbiDecodeArg::Data)
-    } else if name == sym::types {
-        Some(AbiDecodeArg::Types)
-    } else {
-        None
-    }
 }
 
 fn abi_encode_call_function_kind_message(kind: TyFnKind) -> &'static str {


### PR DESCRIPTION
Adds `Gcx::call_arg`, a semantic query that returns the source argument bound to a visible parameter index. It handles positional and reordered named arguments, selected overloads, attached `using for` receivers, constructors, events, errors, variadic builtins, explicit conversions, function-typed variables, and function-typed struct fields.

Parameter-source discovery is centralized in sema and shared with the LSP, replacing its parallel constructor and function-field lookup. Special `abi.decode` parameter names now use the same binding path in type checking, lint queries, and inlay hints, while unresolved or genuinely ambiguous calls remain conservative.
