### PR TITLE
feat(bench): add on-demand benchmark runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,17 +7,48 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+    inputs:
+      benchmark:
+        description: Benchmark family to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - codegen-runtime
+          - codspeed
+          - gungraun
+      comparison_ref:
+        description: Git ref to use as the Gungraun baseline
+        required: true
+        default: main
+        type: string
+      solc_version:
+        description: solc release used by the codegen runtime benchmark
+        required: true
+        default: 0.8.36
+        type: string
+      benchmark_ref:
+        description: solidity-compiler-benchmarks Git ref
+        required: true
+        default: 759b27b596ca6632717465832859863eccbe41a2
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
-  SOLC_VERSION: 0.8.36
+  SOLC_VERSION: ${{ inputs.solc_version || '0.8.36' }}
   BENCHMARK_REPOSITORY: walnuthq/solidity-compiler-benchmarks
-  BENCHMARK_REF: 759b27b596ca6632717465832859863eccbe41a2
+  DEFAULT_BENCHMARK_REF: 759b27b596ca6632717465832859863eccbe41a2
+  BENCHMARK_REF: ${{ inputs.benchmark_ref || '759b27b596ca6632717465832859863eccbe41a2' }}
   BENCHMARK_PATH: solidity-compiler-benchmarks
 
 jobs:
   codegen-runtime:
     name: codegen runtime benchmark
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.benchmark == 'all' ||
+      inputs.benchmark == 'codegen-runtime'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -72,6 +103,7 @@ jobs:
 
       - name: Download baseline (main branch)
         id: baseline
+        if: inputs.benchmark_ref == '' || inputs.benchmark_ref == env.DEFAULT_BENCHMARK_REF
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -82,6 +114,7 @@ jobs:
             gh run list \
               --workflow bench.yml \
               --branch main \
+              --event push \
               --status success \
               --limit 1 \
               --json databaseId \
@@ -211,7 +244,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Save baseline (main only)
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codegen-runtime-baseline
@@ -222,6 +255,10 @@ jobs:
           if-no-files-found: ignore
 
   codspeed:
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.benchmark == 'all' ||
+      inputs.benchmark == 'codspeed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -251,11 +288,16 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   gungraun:
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.benchmark == 'all' ||
+      inputs.benchmark == 'gungraun'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       BASELINE: base
+      COMPARISON_REF: ${{ inputs.comparison_ref || github.base_ref || 'main' }}
       IAI_CALLGRIND_RUNNER: iai-callgrind-runner
       GUNGRAUN_RUNNER: gungraun-runner
     steps:
@@ -276,11 +318,15 @@ jobs:
       - name: Checkout base
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.base_ref || 'main' }}
+          ref: ${{ env.COMPARISON_REF }}
           fetch-depth: 2
       - name: Checkout HEAD^
-        if: ${{ !github.base_ref }}
+        if: github.event_name == 'push'
         run: git checkout HEAD^
+      - name: Checkout base submodules
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --recursive --checkout
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
@@ -298,18 +344,22 @@ jobs:
       - name: Save baseline
         run: |
           bench_target=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name == "solar-bench").targets[] | select(any(.kind[]; . == "bench") and (.name == "gungraun" or .name == "iai")).name' | head -n1)
-          cargo bench -p solar-bench --bench "$bench_target" --features ci -- --save-baseline=$BASELINE
+          cargo bench -p solar-bench --bench "$bench_target" --features ci -- --save-baseline="$BASELINE"
           if [ "$bench_target" = "iai" ] && [ -d target/iai ] && [ ! -e target/gungraun ]; then
             mv target/iai target/gungraun
           fi
-      - name: Checkout PR
+      - name: Checkout candidate
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           clean: false
+      - name: Checkout candidate submodules
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --recursive --checkout
       - name: Install benchmark runner
         run: |
           version=$(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "gungraun").version')
           cargo binstall gungraun-runner --version "$version" --no-confirm --no-symlinks --force
           which gungraun-runner
-      - name: Compare PR benchmarks
-        run: cargo bench -p solar-bench --bench gungraun --features ci -- --baseline=$BASELINE
+      - name: Compare candidate benchmarks
+        run: cargo bench -p solar-bench --bench gungraun --features ci -- --baseline="$BASELINE"

--- a/benches/README.md
+++ b/benches/README.md
@@ -27,6 +27,17 @@ The codegen runtime workflow also publishes `common.json` using the vendored com
 result schema in [`schema/`](schema/). Its wall time is the total for the comparison suite, including
 the harness, both compilers, and runtime checks.
 
+The [benchmark workflow](../.github/workflows/bench.yml) runs automatically for pull requests and
+updates to `main`. It can also be dispatched for all families or one selected family. Dispatch inputs
+can select another Solar Git ref as the Gungraun baseline and override the pinned solc release or
+codegen benchmark corpus revision. For example:
+
+```bash
+gh workflow run bench.yml --ref my-branch \
+  -f benchmark=gungraun \
+  -f comparison_ref=main
+```
+
 The following results were achieved on:
 - Target: `x86_64-unknown-linux-gnu`
 - CPU: AMD Ryzen 9 5950X

--- a/benches/README.md
+++ b/benches/README.md
@@ -28,9 +28,13 @@ result schema in [`schema/`](schema/). Its wall time is the total for the compar
 the harness, both compilers, and runtime checks.
 
 The [benchmark workflow](../.github/workflows/bench.yml) runs automatically for pull requests and
-updates to `main`. It can also be dispatched for all families or one selected family. Dispatch inputs
-can select another Solar Git ref as the Gungraun baseline and override the pinned solc release or
-codegen benchmark corpus revision. For example:
+updates to `main`. It can also be dispatched for all benchmark families or one selected family:
+codegen runtime comparisons, CodSpeed instrumentation, or Gungraun instruction counts. Dispatch
+inputs can select another Solar Git ref as the Gungraun baseline and override the pinned solc release
+or codegen benchmark corpus revision.
+
+For example, this command benchmarks the `my-branch` candidate with Gungraun, compares it against
+`main`, and skips the codegen runtime and CodSpeed jobs:
 
 ```bash
 gh workflow run bench.yml --ref my-branch \


### PR DESCRIPTION
Adds configurable on-demand benchmark runs for Solar while preserving the existing pull request and `main` branch behavior. Manual runs can select a benchmark family, compare Gungraun results against another Solar ref, and override the pinned `solc` version or benchmark corpus revision.

Closes OSS-474