### PR TITLE
feat(codegen): emit final EVM IR

### DIFF
--- a/crates/cli/src/commands/compile.rs
+++ b/crates/cli/src/commands/compile.rs
@@ -1,4 +1,4 @@
-use solar_config::{CompileOpts, CompilerOutput};
+use solar_config::CompileOpts;
 use solar_interface::{Result, Session};
 use solar_sema::{CompilerRef, ParsingContext};
 use std::{ops::ControlFlow, process::ExitCode};
@@ -84,16 +84,14 @@ pub(crate) fn run_pipeline(
         return Ok(ControlFlow::Break(()));
     };
 
-    // Code generation (MIR and bytecode) is experimental and not part of the
+    // Code generation (MIR, EVM IR, and bytecode) is experimental and not part of the
     // stable, solc-compatible pipeline yet, so it is gated behind `-Zcodegen`.
-    let needs_codegen = sess.opts.emit.iter().any(|e| {
-        matches!(e, CompilerOutput::Mir | CompilerOutput::Bin | CompilerOutput::BinRuntime)
-    });
+    let needs_codegen = sess.opts.emit.iter().any(|e| e.is_codegen());
     if needs_codegen && !sess.opts.unstable.codegen {
         return Err(sess
             .dcx
             .err("code generation is experimental")
-            .help("pass `-Zcodegen` to emit MIR or bytecode")
+            .help("pass `-Zcodegen` to emit MIR, EVM IR, or bytecode")
             .emit());
     }
 

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -80,28 +80,15 @@ fn process_evmir(args: &EvmOptArgs) -> Result<(), String> {
         .load_file(Path::new(&args.input))
         .map_err(|e| format!("failed to read {}: {e}", args.input))?;
     let text = source.src.as_str();
-    let mut result: Result<(), String> = Ok(());
     sess.enter(|| {
         let input_name = Ident::with_dummy_span(Symbol::intern(&args.input)).to_string();
         for (name, section) in evm_ir_sections(text, &input_name) {
-            let mut module = match parse_evm_ir_module(section) {
-                Ok(module) => module,
-                Err(err) => {
-                    result = Err(format!("{err}"));
-                    return;
-                }
-            };
-            if let Err(err) = verify_evm_ir_module(&module) {
-                result = Err(format!("{err}"));
-                return;
-            }
-            if let Err(err) = run_pipeline(&mut module, name, args) {
-                result = Err(err);
-                return;
-            }
+            let mut module = parse_evm_ir_module(section).map_err(|err| format!("{err}"))?;
+            verify_evm_ir_module(&module).map_err(|err| format!("{err}"))?;
+            run_pipeline(&mut module, name, args)?;
         }
-    });
-    result
+        Ok(())
+    })
 }
 
 fn evm_ir_sections<'a>(input: &'a str, input_name: &'a str) -> Vec<(&'a str, &'a str)> {

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -82,21 +82,55 @@ fn process_evmir(args: &EvmOptArgs) -> Result<(), String> {
     let text = source.src.as_str();
     let mut result: Result<(), String> = Ok(());
     sess.enter(|| {
-        let mut module = match parse_evm_ir_module(text) {
-            Ok(m) => m,
-            Err(e) => {
-                result = Err(format!("{e}"));
+        let input_name = Ident::with_dummy_span(Symbol::intern(&args.input)).to_string();
+        for (name, section) in evm_ir_sections(text, &input_name) {
+            let mut module = match parse_evm_ir_module(section) {
+                Ok(module) => module,
+                Err(err) => {
+                    result = Err(format!("{err}"));
+                    return;
+                }
+            };
+            if let Err(err) = verify_evm_ir_module(&module) {
+                result = Err(format!("{err}"));
                 return;
             }
-        };
-        if let Err(e) = verify_evm_ir_module(&module) {
-            result = Err(format!("{e}"));
-            return;
+            if let Err(err) = run_pipeline(&mut module, name, args) {
+                result = Err(err);
+                return;
+            }
         }
-        let name = Ident::with_dummy_span(Symbol::intern(&args.input)).to_string();
-        result = run_pipeline(&mut module, &name, args);
     });
     result
+}
+
+fn evm_ir_sections<'a>(input: &'a str, input_name: &'a str) -> Vec<(&'a str, &'a str)> {
+    let mut sections = Vec::new();
+    let mut name = input_name;
+    let mut offset = 0;
+    let mut section_start = 0;
+    for line in input.split_inclusive('\n') {
+        let end = offset + line.len();
+        if let Some(next_name) =
+            line.trim().strip_prefix("// === ").and_then(|line| line.strip_suffix(" ==="))
+        {
+            let section = &input[section_start..offset];
+            if section.lines().any(|line| line.trim_start().starts_with("bb")) {
+                sections.push((name, section));
+            }
+            name = next_name;
+            section_start = end;
+        }
+        offset = end;
+    }
+    let section = &input[section_start..];
+    if section.lines().any(|line| line.trim_start().starts_with("bb")) {
+        sections.push((name, section));
+    }
+    if sections.is_empty() {
+        sections.push((input_name, input));
+    }
+    sections
 }
 
 pub(crate) fn run(args: EvmOptArgs) -> ExitCode {
@@ -111,6 +145,26 @@ pub(crate) fn run(args: EvmOptArgs) -> ExitCode {
         Err(e) => {
             eprintln!("error: {e}");
             ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emitted_evm_ir_sections_parse_and_verify() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("tests/ui/codegen/emit_abi_bin.evmir.stdout");
+        #[allow(clippy::disallowed_methods)]
+        let input = std::fs::read_to_string(path).unwrap();
+        let sections = evm_ir_sections(&input, "emit_abi_bin");
+        assert_eq!(sections.len(), 4);
+        for (_, section) in sections {
+            let module = parse_evm_ir_module(section).unwrap();
+            verify_evm_ir_module(&module).unwrap();
         }
     }
 }

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -82,42 +82,10 @@ fn process_evmir(args: &EvmOptArgs) -> Result<(), String> {
     let text = source.src.as_str();
     sess.enter(|| {
         let input_name = Ident::with_dummy_span(Symbol::intern(&args.input)).to_string();
-        for (name, section) in evm_ir_sections(text, &input_name) {
-            let mut module = parse_evm_ir_module(section).map_err(|err| format!("{err}"))?;
-            verify_evm_ir_module(&module).map_err(|err| format!("{err}"))?;
-            run_pipeline(&mut module, name, args)?;
-        }
-        Ok(())
+        let mut module = parse_evm_ir_module(text).map_err(|err| format!("{err}"))?;
+        verify_evm_ir_module(&module).map_err(|err| format!("{err}"))?;
+        run_pipeline(&mut module, &input_name, args)
     })
-}
-
-fn evm_ir_sections<'a>(input: &'a str, input_name: &'a str) -> Vec<(&'a str, &'a str)> {
-    let mut sections = Vec::new();
-    let mut name = input_name;
-    let mut offset = 0;
-    let mut section_start = 0;
-    for line in input.split_inclusive('\n') {
-        let end = offset + line.len();
-        if let Some(next_name) =
-            line.trim().strip_prefix("// === ").and_then(|line| line.strip_suffix(" ==="))
-        {
-            let section = &input[section_start..offset];
-            if section.lines().any(|line| line.trim_start().starts_with("bb")) {
-                sections.push((name, section));
-            }
-            name = next_name;
-            section_start = end;
-        }
-        offset = end;
-    }
-    let section = &input[section_start..];
-    if section.lines().any(|line| line.trim_start().starts_with("bb")) {
-        sections.push((name, section));
-    }
-    if sections.is_empty() {
-        sections.push((input_name, input));
-    }
-    sections
 }
 
 pub(crate) fn run(args: EvmOptArgs) -> ExitCode {
@@ -132,26 +100,6 @@ pub(crate) fn run(args: EvmOptArgs) -> ExitCode {
         Err(e) => {
             eprintln!("error: {e}");
             ExitCode::FAILURE
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn emitted_evm_ir_sections_parse_and_verify() {
-        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join("tests/ui/codegen/emit_abi_bin.evmir.stdout");
-        #[allow(clippy::disallowed_methods)]
-        let input = std::fs::read_to_string(path).unwrap();
-        let sections = evm_ir_sections(&input, "emit_abi_bin");
-        assert_eq!(sections.len(), 4);
-        for (_, section) in sections {
-            let module = parse_evm_ir_module(section).unwrap();
-            verify_evm_ir_module(&module).unwrap();
         }
     }
 }

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -35,53 +35,27 @@ struct CombinedJsonContract<'a> {
 
 pub(crate) fn emit_requested(compiler: &mut CompilerRef<'_>) -> Result {
     let gcx = compiler.gcx();
-    emit_sema_json(gcx)?;
+    emit_combined_json(gcx)?;
     emit_mir(gcx)?;
-    emit_evm_ir(gcx)?;
-    emit_codegen_json(gcx)
+    emit_evm_ir(gcx)
 }
 
-fn emit_sema_json(gcx: Gcx<'_>) -> Result {
-    let sess = gcx.sess;
-    let emit_abi = sess.opts.emit.contains(&CompilerOutput::Abi);
-    let emit_hashes = sess.opts.emit.contains(&CompilerOutput::Hashes);
-
-    if !emit_abi && !emit_hashes {
-        return Ok(());
-    }
-
-    let mut output = CombinedJson {
-        contracts: BTreeMap::default(),
-        version: solar_config::version::SEMVER_VERSION,
-    };
-
-    for id in gcx.hir.contract_ids() {
-        let name = contract_output_name(gcx, id);
-        let contract_output = output.contracts.entry(name).or_default();
-
-        if emit_abi {
-            contract_output.abi = Some(gcx.contract_abi(id));
-        }
-        if emit_hashes {
-            contract_output.hashes = Some(contract_hashes(gcx, id));
-        }
-    }
-
-    write_output_json(gcx, &output, false)
-}
-
-fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
+fn emit_combined_json(gcx: Gcx<'_>) -> Result {
     let sess = gcx.sess;
     let emit_abi = sess.opts.emit.contains(&CompilerOutput::Abi);
     let emit_hashes = sess.opts.emit.contains(&CompilerOutput::Hashes);
     let emit_bin = sess.opts.emit.contains(&CompilerOutput::Bin);
     let emit_bin_runtime = sess.opts.emit.contains(&CompilerOutput::BinRuntime);
 
-    if !emit_bin && !emit_bin_runtime {
+    if !emit_abi && !emit_hashes && !emit_bin && !emit_bin_runtime {
         return Ok(());
     }
 
-    let bytecodes = generate_contract_bytecodes(gcx, false)?;
+    let bytecodes = if emit_bin || emit_bin_runtime {
+        Some(generate_contract_bytecodes(gcx, false)?)
+    } else {
+        None
+    };
 
     let mut output = CombinedJson {
         contracts: BTreeMap::default(),
@@ -99,7 +73,7 @@ fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
             contract_output.hashes = Some(contract_hashes(gcx, id));
         }
 
-        if let Some(bytecode) = bytecodes.get(&id) {
+        if let Some(bytecode) = bytecodes.as_ref().and_then(|bytecodes| bytecodes.get(&id)) {
             if emit_bin {
                 contract_output.bin = Some(bytecode.deployment.clone());
             }
@@ -109,7 +83,7 @@ fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
         }
     }
 
-    write_output_json(gcx, &output, true)
+    write_output_json(gcx, &output, emit_bin || emit_bin_runtime)
 }
 
 fn write_output_json<T: serde::Serialize>(

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -42,10 +42,17 @@ pub(crate) fn emit_requested(compiler: &mut CompilerRef<'_>) -> Result {
 
 fn emit_combined_json(gcx: Gcx<'_>) -> Result {
     let sess = gcx.sess;
-    let emit_abi = sess.opts.emit.contains(&CompilerOutput::Abi);
-    let emit_hashes = sess.opts.emit.contains(&CompilerOutput::Hashes);
-    let emit_bin = sess.opts.emit.contains(&CompilerOutput::Bin);
-    let emit_bin_runtime = sess.opts.emit.contains(&CompilerOutput::BinRuntime);
+    let (mut emit_abi, mut emit_hashes, mut emit_bin, mut emit_bin_runtime) =
+        (false, false, false, false);
+    for output in &sess.opts.emit {
+        match output {
+            CompilerOutput::Abi => emit_abi = true,
+            CompilerOutput::Hashes => emit_hashes = true,
+            CompilerOutput::Bin => emit_bin = true,
+            CompilerOutput::BinRuntime => emit_bin_runtime = true,
+            _ => {}
+        }
+    }
 
     if !emit_abi && !emit_hashes && !emit_bin && !emit_bin_runtime {
         return Ok(());

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -1,4 +1,4 @@
-use solar_codegen::{Backend, EvmCodegen, lower};
+use solar_codegen::{Backend, EvmCodegen, EvmCodegenConfig, EvmIrModule, lower};
 use solar_config::CompilerOutput;
 use solar_data_structures::map::{FxHashMap, FxHashSet};
 use solar_interface::Result;
@@ -49,6 +49,7 @@ pub(crate) fn emit_requested(compiler: &mut CompilerRef<'_>) -> Result {
     let gcx = compiler.gcx();
     emit_sema_json(gcx)?;
     emit_mir(gcx)?;
+    emit_evm_ir(gcx)?;
     emit_codegen_json(gcx)
 }
 
@@ -92,8 +93,7 @@ fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
         return Ok(());
     }
 
-    let bytecodes =
-        if emit_bin || emit_bin_runtime { Some(generate_contract_bytecodes(gcx)?) } else { None };
+    let bytecodes = generate_contract_bytecodes(gcx, false)?;
 
     let mut output = CodegenCombinedJson {
         contracts: BTreeMap::default(),
@@ -111,9 +111,7 @@ fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
             contract_output.hashes = Some(contract_hashes(gcx, id));
         }
 
-        if let Some(bytecodes) = &bytecodes
-            && let Some(bytecode) = bytecodes.get(&id)
-        {
+        if let Some(bytecode) = bytecodes.get(&id) {
             if emit_bin {
                 contract_output.bin = Some(bytecode.deployment.clone());
             }
@@ -180,13 +178,60 @@ fn emit_mir(gcx: Gcx<'_>) -> Result {
     Ok(())
 }
 
+fn emit_evm_ir(gcx: Gcx<'_>) -> Result {
+    let sess = gcx.sess;
+    let emit_deployment = sess.opts.emit.contains(&CompilerOutput::EvmIr);
+    let emit_runtime = sess.opts.emit.contains(&CompilerOutput::EvmIrRuntime);
+    if !emit_deployment && !emit_runtime {
+        return Ok(());
+    }
+
+    let bytecodes = generate_contract_bytecodes(gcx, true)?;
+    let out_path = sess.opts.out_dir.as_deref().map(|dir| dir.join("combined.evmir"));
+    let mut writer = out_writer(out_path.as_deref())
+        .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+    if sess.opts.out_dir.is_none()
+        && sess
+            .opts
+            .emit
+            .iter()
+            .any(|output| matches!(output, CompilerOutput::Abi | CompilerOutput::Hashes))
+    {
+        writeln!(writer)
+            .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+    }
+    for id in gcx.hir.contract_ids() {
+        let Some(bytecode) = bytecodes.get(&id) else { continue };
+        let name = gcx.contract_fully_qualified_name(id);
+        if emit_deployment {
+            writeln!(writer, "// === {name} (creation) ===")
+                .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+            write!(writer, "{}", bytecode.deployment_evm_ir.as_deref().unwrap_or_default())
+                .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+        }
+        if emit_runtime {
+            writeln!(writer, "// === {name} (runtime) ===")
+                .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+            write!(writer, "{}", bytecode.runtime_evm_ir.as_deref().unwrap_or_default())
+                .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+        }
+    }
+    writer.flush().map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
+    Ok(())
+}
+
 #[derive(Clone)]
 struct GeneratedBytecodes {
     deployment: String,
     runtime: String,
+    deployment_evm_ir: Option<String>,
+    runtime_evm_ir: Option<String>,
 }
 
-fn generate_contract_bytecodes(gcx: Gcx<'_>) -> Result<FxHashMap<ContractId, GeneratedBytecodes>> {
+fn generate_contract_bytecodes(
+    gcx: Gcx<'_>,
+    capture_evm_ir: bool,
+) -> Result<FxHashMap<ContractId, GeneratedBytecodes>> {
     let mut all_bytecodes = FxHashMap::default();
     let mut visiting = FxHashSet::default();
     for id in gcx.hir.contract_ids() {
@@ -205,18 +250,36 @@ fn generate_contract_bytecodes(gcx: Gcx<'_>) -> Result<FxHashMap<ContractId, Gen
 
         let mut module = lower::lower_contract_with_bytecodes(gcx, id, &all_bytecodes);
         gcx.dcx().has_errors()?;
-        let mut codegen = EvmCodegen::new(gcx);
+        let mut codegen =
+            EvmCodegen::new(EvmCodegenConfig { capture_evm_ir, ..EvmCodegenConfig::from(gcx) });
         let artifact = codegen.lower_module(&mut module);
         bytecodes.insert(
             id,
             GeneratedBytecodes {
                 deployment: alloy_primitives::hex::encode(artifact.deployment),
                 runtime: alloy_primitives::hex::encode(artifact.runtime),
+                deployment_evm_ir: capture_evm_ir
+                    .then(|| format_deployment_evm_ir(&artifact.deployment_evm_ir)),
+                runtime_evm_ir: artifact.runtime_evm_ir.map(|ir| ir.to_text().to_string()),
             },
         );
     }
 
     Ok(bytecodes)
+}
+
+pub(crate) fn format_deployment_evm_ir(modules: &[EvmIrModule]) -> String {
+    use std::fmt::Write;
+
+    let mut output = String::new();
+    for (index, module) in modules.iter().enumerate() {
+        if index != 0 {
+            output.push('\n');
+        }
+        writeln!(output, "// === {} ===", module.name).unwrap();
+        write!(output, "{}", module.to_text()).unwrap();
+    }
+    output
 }
 
 fn ensure_contract_bytecode(

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -1,3 +1,4 @@
+use alloy_json_abi::AbiItem;
 use alloy_primitives::Bytes;
 use solar_codegen::{Backend, EvmCodegen, EvmCodegenConfig, EvmIrModule, lower};
 use solar_config::CompilerOutput;
@@ -13,32 +14,17 @@ use std::{
 type Hashes = BTreeMap<String, String>;
 
 #[derive(Default, serde::Serialize)]
-struct SemaCombinedJson<Abi> {
+struct CombinedJson<'a> {
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    contracts: BTreeMap<String, SemaCombinedJsonContract<Abi>>,
-    version: &'static str,
-}
-
-#[derive(Default, serde::Serialize)]
-struct SemaCombinedJsonContract<Abi> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    abi: Option<Abi>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    hashes: Option<Hashes>,
-}
-
-#[derive(Default, serde::Serialize)]
-struct CodegenCombinedJson {
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    contracts: BTreeMap<String, CodegenCombinedJsonContract>,
+    contracts: BTreeMap<String, CombinedJsonContract<'a>>,
     version: &'static str,
 }
 
 #[derive(Default, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
-struct CodegenCombinedJsonContract {
+struct CombinedJsonContract<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    abi: Option<serde_json::Value>,
+    abi: Option<Vec<AbiItem<'a>>>,
     #[serde(serialize_with = "serialize_hex_bytes", skip_serializing_if = "Option::is_none")]
     bin: Option<Bytes>,
     #[serde(serialize_with = "serialize_hex_bytes", skip_serializing_if = "Option::is_none")]
@@ -64,7 +50,7 @@ fn emit_sema_json(gcx: Gcx<'_>) -> Result {
         return Ok(());
     }
 
-    let mut output = SemaCombinedJson {
+    let mut output = CombinedJson {
         contracts: BTreeMap::default(),
         version: solar_config::version::SEMVER_VERSION,
     };
@@ -97,7 +83,7 @@ fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
 
     let bytecodes = generate_contract_bytecodes(gcx, false)?;
 
-    let mut output = CodegenCombinedJson {
+    let mut output = CombinedJson {
         contracts: BTreeMap::default(),
         version: solar_config::version::SEMVER_VERSION,
     };
@@ -107,7 +93,7 @@ fn emit_codegen_json(gcx: Gcx<'_>) -> Result {
         let contract_output = output.contracts.entry(name).or_default();
 
         if emit_abi {
-            contract_output.abi = Some(serde_json::to_value(gcx.contract_abi(id)).unwrap());
+            contract_output.abi = Some(gcx.contract_abi(id));
         }
         if emit_hashes {
             contract_output.hashes = Some(contract_hashes(gcx, id));

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Bytes;
 use solar_codegen::{Backend, EvmCodegen, EvmCodegenConfig, EvmIrModule, lower};
 use solar_config::CompilerOutput;
 use solar_data_structures::map::{FxHashMap, FxHashSet};
@@ -37,10 +38,14 @@ struct CodegenCombinedJson {
 struct CodegenCombinedJsonContract {
     #[serde(skip_serializing_if = "Option::is_none")]
     abi: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    bin: Option<String>,
-    #[serde(rename = "bin-runtime", skip_serializing_if = "Option::is_none")]
-    bin_runtime: Option<String>,
+    #[serde(serialize_with = "serialize_hex_bytes", skip_serializing_if = "Option::is_none")]
+    bin: Option<Bytes>,
+    #[serde(
+        rename = "bin-runtime",
+        serialize_with = "serialize_hex_bytes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    bin_runtime: Option<Bytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hashes: Option<Hashes>,
 }
@@ -220,10 +225,9 @@ fn emit_evm_ir(gcx: Gcx<'_>) -> Result {
     Ok(())
 }
 
-#[derive(Clone)]
 struct GeneratedBytecodes {
-    deployment: String,
-    runtime: String,
+    deployment: Bytes,
+    runtime: Bytes,
     deployment_evm_ir: Option<String>,
     runtime_evm_ir: Option<String>,
 }
@@ -256,8 +260,8 @@ fn generate_contract_bytecodes(
         bytecodes.insert(
             id,
             GeneratedBytecodes {
-                deployment: alloy_primitives::hex::encode(artifact.deployment),
-                runtime: alloy_primitives::hex::encode(artifact.runtime),
+                deployment: artifact.deployment.into(),
+                runtime: artifact.runtime.into(),
                 deployment_evm_ir: capture_evm_ir
                     .then(|| format_deployment_evm_ir(&artifact.deployment_evm_ir)),
                 runtime_evm_ir: artifact.runtime_evm_ir.map(|ir| ir.to_text().to_string()),
@@ -266,6 +270,14 @@ fn generate_contract_bytecodes(
     }
 
     Ok(bytecodes)
+}
+
+fn serialize_hex_bytes<S>(bytes: &Option<Bytes>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let Some(bytes) = bytes else { return serializer.serialize_none() };
+    serializer.serialize_str(&alloy_primitives::hex::encode(bytes))
 }
 
 pub(crate) fn format_deployment_evm_ir(modules: &[EvmIrModule]) -> String {

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -35,16 +35,13 @@ struct CodegenCombinedJson {
 }
 
 #[derive(Default, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 struct CodegenCombinedJsonContract {
     #[serde(skip_serializing_if = "Option::is_none")]
     abi: Option<serde_json::Value>,
     #[serde(serialize_with = "serialize_hex_bytes", skip_serializing_if = "Option::is_none")]
     bin: Option<Bytes>,
-    #[serde(
-        rename = "bin-runtime",
-        serialize_with = "serialize_hex_bytes",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(serialize_with = "serialize_hex_bytes", skip_serializing_if = "Option::is_none")]
     bin_runtime: Option<Bytes>,
     #[serde(skip_serializing_if = "Option::is_none")]
     hashes: Option<Hashes>,

--- a/crates/codegen/src/backend/evm/assembler.rs
+++ b/crates/codegen/src/backend/evm/assembler.rs
@@ -1437,186 +1437,224 @@ enum CompactPush {
 
 /// Common EVM op.
 pub mod op {
-    pub const STOP: u8 = 0x00;
-    pub const ADD: u8 = 0x01;
-    pub const MUL: u8 = 0x02;
-    pub const SUB: u8 = 0x03;
-    pub const DIV: u8 = 0x04;
-    pub const SDIV: u8 = 0x05;
-    pub const MOD: u8 = 0x06;
-    pub const SMOD: u8 = 0x07;
-    pub const ADDMOD: u8 = 0x08;
-    pub const MULMOD: u8 = 0x09;
-    pub const EXP: u8 = 0x0a;
-    pub const SIGNEXTEND: u8 = 0x0b;
+    macro_rules! opcode_mnemonic {
+        (r#return) => {
+            "return"
+        };
+        ($mnemonic:ident) => {
+            stringify!($mnemonic)
+        };
+    }
 
-    pub const LT: u8 = 0x10;
-    pub const GT: u8 = 0x11;
-    pub const SLT: u8 = 0x12;
-    pub const SGT: u8 = 0x13;
-    pub const EQ: u8 = 0x14;
-    pub const ISZERO: u8 = 0x15;
-    pub const AND: u8 = 0x16;
-    pub const OR: u8 = 0x17;
-    pub const XOR: u8 = 0x18;
-    pub const NOT: u8 = 0x19;
-    pub const BYTE: u8 = 0x1a;
-    pub const SHL: u8 = 0x1b;
-    pub const SHR: u8 = 0x1c;
-    pub const SAR: u8 = 0x1d;
-    pub const CLZ: u8 = 0x1e;
+    macro_rules! opcodes {
+        ($($opcode:literal => $constant:ident => $mnemonic:ident;)*) => {
+            $(
+                #[doc = concat!("Opcode byte for `", stringify!($constant), "`.")]
+                pub const $constant: u8 = $opcode;
+            )*
 
-    pub const KECCAK256: u8 = 0x20;
+            /// Maps each opcode byte to its canonical mnemonic.
+            static OPCODE_MNEMONICS: [Option<&str>; 256] = {
+                let mut map = [None; 256];
+                let mut prev = 0;
+                $(
+                    let opcode: u8 = $opcode;
+                    assert!(opcode == 0 || opcode > prev, "opcodes must be sorted in ascending order");
+                    prev = opcode;
+                    map[opcode as usize] = Some(opcode_mnemonic!($mnemonic));
+                )*
+                let _ = prev;
+                map
+            };
 
-    pub const ADDRESS: u8 = 0x30;
-    pub const BALANCE: u8 = 0x31;
-    pub const ORIGIN: u8 = 0x32;
-    pub const CALLER: u8 = 0x33;
-    pub const CALLVALUE: u8 = 0x34;
-    pub const CALLDATALOAD: u8 = 0x35;
-    pub const CALLDATASIZE: u8 = 0x36;
-    pub const CALLDATACOPY: u8 = 0x37;
-    pub const CODESIZE: u8 = 0x38;
-    pub const CODECOPY: u8 = 0x39;
-    pub const GASPRICE: u8 = 0x3a;
-    pub const EXTCODESIZE: u8 = 0x3b;
-    pub const EXTCODECOPY: u8 = 0x3c;
-    pub const RETURNDATASIZE: u8 = 0x3d;
-    pub const RETURNDATACOPY: u8 = 0x3e;
-    pub const EXTCODEHASH: u8 = 0x3f;
+            /// Returns the canonical mnemonic for an opcode.
+            #[must_use]
+            pub const fn mnemonic(opcode: u8) -> Option<&'static str> {
+                OPCODE_MNEMONICS[opcode as usize]
+            }
 
-    pub const BLOCKHASH: u8 = 0x40;
-    pub const COINBASE: u8 = 0x41;
-    pub const TIMESTAMP: u8 = 0x42;
-    pub const NUMBER: u8 = 0x43;
-    pub const PREVRANDAO: u8 = 0x44;
-    pub const GASLIMIT: u8 = 0x45;
-    pub const CHAINID: u8 = 0x46;
-    pub const SELFBALANCE: u8 = 0x47;
-    pub const BASEFEE: u8 = 0x48;
-    pub const BLOBHASH: u8 = 0x49;
-    pub const BLOBBASEFEE: u8 = 0x4a;
+            /// Returns the opcode for a canonical mnemonic.
+            #[must_use]
+            pub fn from_mnemonic(mnemonic: &str) -> Option<u8> {
+                match mnemonic {
+                    $(opcode_mnemonic!($mnemonic) => Some($opcode),)*
+                    _ => None,
+                }
+            }
+        };
+    }
 
-    pub const POP: u8 = 0x50;
-    pub const MLOAD: u8 = 0x51;
-    pub const MSTORE: u8 = 0x52;
-    pub const MSTORE8: u8 = 0x53;
-    pub const SLOAD: u8 = 0x54;
-    pub const SSTORE: u8 = 0x55;
-    pub const JUMP: u8 = 0x56;
-    pub const JUMPI: u8 = 0x57;
-    pub const PC: u8 = 0x58;
-    pub const MSIZE: u8 = 0x59;
-    pub const GAS: u8 = 0x5a;
-    pub const JUMPDEST: u8 = 0x5b;
-    pub const TLOAD: u8 = 0x5c;
-    pub const TSTORE: u8 = 0x5d;
-    pub const MCOPY: u8 = 0x5e;
-    pub const PUSH0: u8 = 0x5f;
-    pub const PUSH1: u8 = 0x60;
-    pub const PUSH2: u8 = 0x61;
-    pub const PUSH3: u8 = 0x62;
-    pub const PUSH4: u8 = 0x63;
-    pub const PUSH5: u8 = 0x64;
-    pub const PUSH6: u8 = 0x65;
-    pub const PUSH7: u8 = 0x66;
-    pub const PUSH8: u8 = 0x67;
-    pub const PUSH9: u8 = 0x68;
-    pub const PUSH10: u8 = 0x69;
-    pub const PUSH11: u8 = 0x6a;
-    pub const PUSH12: u8 = 0x6b;
-    pub const PUSH13: u8 = 0x6c;
-    pub const PUSH14: u8 = 0x6d;
-    pub const PUSH15: u8 = 0x6e;
-    pub const PUSH16: u8 = 0x6f;
-    pub const PUSH17: u8 = 0x70;
-    pub const PUSH18: u8 = 0x71;
-    pub const PUSH19: u8 = 0x72;
-    pub const PUSH20: u8 = 0x73;
-    pub const PUSH21: u8 = 0x74;
-    pub const PUSH22: u8 = 0x75;
-    pub const PUSH23: u8 = 0x76;
-    pub const PUSH24: u8 = 0x77;
-    pub const PUSH25: u8 = 0x78;
-    pub const PUSH26: u8 = 0x79;
-    pub const PUSH27: u8 = 0x7a;
-    pub const PUSH28: u8 = 0x7b;
-    pub const PUSH29: u8 = 0x7c;
-    pub const PUSH30: u8 = 0x7d;
-    pub const PUSH31: u8 = 0x7e;
-    pub const PUSH32: u8 = 0x7f;
-
-    pub const DUP1: u8 = 0x80;
-    pub const DUP2: u8 = 0x81;
-    pub const DUP3: u8 = 0x82;
-    pub const DUP4: u8 = 0x83;
-    pub const DUP5: u8 = 0x84;
-    pub const DUP6: u8 = 0x85;
-    pub const DUP7: u8 = 0x86;
-    pub const DUP8: u8 = 0x87;
-    pub const DUP9: u8 = 0x88;
-    pub const DUP10: u8 = 0x89;
-    pub const DUP11: u8 = 0x8a;
-    pub const DUP12: u8 = 0x8b;
-    pub const DUP13: u8 = 0x8c;
-    pub const DUP14: u8 = 0x8d;
-    pub const DUP15: u8 = 0x8e;
-    pub const DUP16: u8 = 0x8f;
-
-    pub const SWAP1: u8 = 0x90;
-    pub const SWAP2: u8 = 0x91;
-    pub const SWAP3: u8 = 0x92;
-    pub const SWAP4: u8 = 0x93;
-    pub const SWAP5: u8 = 0x94;
-    pub const SWAP6: u8 = 0x95;
-    pub const SWAP7: u8 = 0x96;
-    pub const SWAP8: u8 = 0x97;
-    pub const SWAP9: u8 = 0x98;
-    pub const SWAP10: u8 = 0x99;
-    pub const SWAP11: u8 = 0x9a;
-    pub const SWAP12: u8 = 0x9b;
-    pub const SWAP13: u8 = 0x9c;
-    pub const SWAP14: u8 = 0x9d;
-    pub const SWAP15: u8 = 0x9e;
-    pub const SWAP16: u8 = 0x9f;
-
-    pub const LOG0: u8 = 0xa0;
-    pub const LOG1: u8 = 0xa1;
-    pub const LOG2: u8 = 0xa2;
-    pub const LOG3: u8 = 0xa3;
-    pub const LOG4: u8 = 0xa4;
-
-    pub const DATALOAD: u8 = 0xd0;
-    pub const DATALOADN: u8 = 0xd1;
-    pub const DATASIZE: u8 = 0xd2;
-    pub const DATACOPY: u8 = 0xd3;
-
-    pub const RJUMP: u8 = 0xe0;
-    pub const RJUMPI: u8 = 0xe1;
-    pub const RJUMPV: u8 = 0xe2;
-    pub const CALLF: u8 = 0xe3;
-    pub const RETF: u8 = 0xe4;
-    pub const JUMPF: u8 = 0xe5;
-    pub const DUPN: u8 = 0xe6;
-    pub const SWAPN: u8 = 0xe7;
-    pub const EXCHANGE: u8 = 0xe8;
-    pub const EOFCREATE: u8 = 0xec;
-    pub const RETURNCONTRACT: u8 = 0xee;
-
-    pub const CREATE: u8 = 0xf0;
-    pub const CALL: u8 = 0xf1;
-    pub const CALLCODE: u8 = 0xf2;
-    pub const RETURN: u8 = 0xf3;
-    pub const DELEGATECALL: u8 = 0xf4;
-    pub const CREATE2: u8 = 0xf5;
-    pub const RETURNDATALOAD: u8 = 0xf7;
-    pub const EXTCALL: u8 = 0xf8;
-    pub const EXTDELEGATECALL: u8 = 0xf9;
-    pub const STATICCALL: u8 = 0xfa;
-    pub const EXTSTATICCALL: u8 = 0xfb;
-    pub const REVERT: u8 = 0xfd;
-    pub const INVALID: u8 = 0xfe;
-    pub const SELFDESTRUCT: u8 = 0xff;
+    opcodes! {
+        0x00 => STOP => stop;
+        0x01 => ADD => add;
+        0x02 => MUL => mul;
+        0x03 => SUB => sub;
+        0x04 => DIV => div;
+        0x05 => SDIV => sdiv;
+        0x06 => MOD => mod;
+        0x07 => SMOD => smod;
+        0x08 => ADDMOD => addmod;
+        0x09 => MULMOD => mulmod;
+        0x0a => EXP => exp;
+        0x0b => SIGNEXTEND => signextend;
+        0x10 => LT => lt;
+        0x11 => GT => gt;
+        0x12 => SLT => slt;
+        0x13 => SGT => sgt;
+        0x14 => EQ => eq;
+        0x15 => ISZERO => iszero;
+        0x16 => AND => and;
+        0x17 => OR => or;
+        0x18 => XOR => xor;
+        0x19 => NOT => not;
+        0x1a => BYTE => byte;
+        0x1b => SHL => shl;
+        0x1c => SHR => shr;
+        0x1d => SAR => sar;
+        0x1e => CLZ => clz;
+        0x20 => KECCAK256 => keccak256;
+        0x30 => ADDRESS => address;
+        0x31 => BALANCE => balance;
+        0x32 => ORIGIN => origin;
+        0x33 => CALLER => caller;
+        0x34 => CALLVALUE => callvalue;
+        0x35 => CALLDATALOAD => calldataload;
+        0x36 => CALLDATASIZE => calldatasize;
+        0x37 => CALLDATACOPY => calldatacopy;
+        0x38 => CODESIZE => codesize;
+        0x39 => CODECOPY => codecopy;
+        0x3a => GASPRICE => gasprice;
+        0x3b => EXTCODESIZE => extcodesize;
+        0x3c => EXTCODECOPY => extcodecopy;
+        0x3d => RETURNDATASIZE => returndatasize;
+        0x3e => RETURNDATACOPY => returndatacopy;
+        0x3f => EXTCODEHASH => extcodehash;
+        0x40 => BLOCKHASH => blockhash;
+        0x41 => COINBASE => coinbase;
+        0x42 => TIMESTAMP => timestamp;
+        0x43 => NUMBER => number;
+        0x44 => PREVRANDAO => prevrandao;
+        0x45 => GASLIMIT => gaslimit;
+        0x46 => CHAINID => chainid;
+        0x47 => SELFBALANCE => selfbalance;
+        0x48 => BASEFEE => basefee;
+        0x49 => BLOBHASH => blobhash;
+        0x4a => BLOBBASEFEE => blobbasefee;
+        0x50 => POP => pop;
+        0x51 => MLOAD => mload;
+        0x52 => MSTORE => mstore;
+        0x53 => MSTORE8 => mstore8;
+        0x54 => SLOAD => sload;
+        0x55 => SSTORE => sstore;
+        0x56 => JUMP => jump;
+        0x57 => JUMPI => jumpi;
+        0x58 => PC => pc;
+        0x59 => MSIZE => msize;
+        0x5a => GAS => gas;
+        0x5b => JUMPDEST => jumpdest;
+        0x5c => TLOAD => tload;
+        0x5d => TSTORE => tstore;
+        0x5e => MCOPY => mcopy;
+        0x5f => PUSH0 => push0;
+        0x60 => PUSH1 => push1;
+        0x61 => PUSH2 => push2;
+        0x62 => PUSH3 => push3;
+        0x63 => PUSH4 => push4;
+        0x64 => PUSH5 => push5;
+        0x65 => PUSH6 => push6;
+        0x66 => PUSH7 => push7;
+        0x67 => PUSH8 => push8;
+        0x68 => PUSH9 => push9;
+        0x69 => PUSH10 => push10;
+        0x6a => PUSH11 => push11;
+        0x6b => PUSH12 => push12;
+        0x6c => PUSH13 => push13;
+        0x6d => PUSH14 => push14;
+        0x6e => PUSH15 => push15;
+        0x6f => PUSH16 => push16;
+        0x70 => PUSH17 => push17;
+        0x71 => PUSH18 => push18;
+        0x72 => PUSH19 => push19;
+        0x73 => PUSH20 => push20;
+        0x74 => PUSH21 => push21;
+        0x75 => PUSH22 => push22;
+        0x76 => PUSH23 => push23;
+        0x77 => PUSH24 => push24;
+        0x78 => PUSH25 => push25;
+        0x79 => PUSH26 => push26;
+        0x7a => PUSH27 => push27;
+        0x7b => PUSH28 => push28;
+        0x7c => PUSH29 => push29;
+        0x7d => PUSH30 => push30;
+        0x7e => PUSH31 => push31;
+        0x7f => PUSH32 => push32;
+        0x80 => DUP1 => dup1;
+        0x81 => DUP2 => dup2;
+        0x82 => DUP3 => dup3;
+        0x83 => DUP4 => dup4;
+        0x84 => DUP5 => dup5;
+        0x85 => DUP6 => dup6;
+        0x86 => DUP7 => dup7;
+        0x87 => DUP8 => dup8;
+        0x88 => DUP9 => dup9;
+        0x89 => DUP10 => dup10;
+        0x8a => DUP11 => dup11;
+        0x8b => DUP12 => dup12;
+        0x8c => DUP13 => dup13;
+        0x8d => DUP14 => dup14;
+        0x8e => DUP15 => dup15;
+        0x8f => DUP16 => dup16;
+        0x90 => SWAP1 => swap1;
+        0x91 => SWAP2 => swap2;
+        0x92 => SWAP3 => swap3;
+        0x93 => SWAP4 => swap4;
+        0x94 => SWAP5 => swap5;
+        0x95 => SWAP6 => swap6;
+        0x96 => SWAP7 => swap7;
+        0x97 => SWAP8 => swap8;
+        0x98 => SWAP9 => swap9;
+        0x99 => SWAP10 => swap10;
+        0x9a => SWAP11 => swap11;
+        0x9b => SWAP12 => swap12;
+        0x9c => SWAP13 => swap13;
+        0x9d => SWAP14 => swap14;
+        0x9e => SWAP15 => swap15;
+        0x9f => SWAP16 => swap16;
+        0xa0 => LOG0 => log0;
+        0xa1 => LOG1 => log1;
+        0xa2 => LOG2 => log2;
+        0xa3 => LOG3 => log3;
+        0xa4 => LOG4 => log4;
+        0xd0 => DATALOAD => dataload;
+        0xd1 => DATALOADN => dataloadn;
+        0xd2 => DATASIZE => datasize;
+        0xd3 => DATACOPY => datacopy;
+        0xe0 => RJUMP => rjump;
+        0xe1 => RJUMPI => rjumpi;
+        0xe2 => RJUMPV => rjumpv;
+        0xe3 => CALLF => callf;
+        0xe4 => RETF => retf;
+        0xe5 => JUMPF => jumpf;
+        0xe6 => DUPN => dupn;
+        0xe7 => SWAPN => swapn;
+        0xe8 => EXCHANGE => exchange;
+        0xec => EOFCREATE => eofcreate;
+        0xee => RETURNCONTRACT => returncontract;
+        0xf0 => CREATE => create;
+        0xf1 => CALL => call;
+        0xf2 => CALLCODE => callcode;
+        0xf3 => RETURN => r#return;
+        0xf4 => DELEGATECALL => delegatecall;
+        0xf5 => CREATE2 => create2;
+        0xf7 => RETURNDATALOAD => returndataload;
+        0xf8 => EXTCALL => extcall;
+        0xf9 => EXTDELEGATECALL => extdelegatecall;
+        0xfa => STATICCALL => staticcall;
+        0xfb => EXTSTATICCALL => extstaticcall;
+        0xfd => REVERT => revert;
+        0xfe => INVALID => invalid;
+        0xff => SELFDESTRUCT => selfdestruct;
+    }
 
     /// Returns the PUSH opcode for the given width (1-32).
     #[must_use]
@@ -1656,6 +1694,15 @@ mod tests {
             optimization: OptimizationMode::Size,
             ..AssemblerConfig::default()
         })
+    }
+
+    #[test]
+    fn opcode_mnemonics_round_trip() {
+        for opcode in 0..=u8::MAX {
+            if let Some(mnemonic) = op::mnemonic(opcode) {
+                assert_eq!(op::from_mnemonic(mnemonic), Some(opcode));
+            }
+        }
     }
 
     #[test]

--- a/crates/codegen/src/backend/evm/assembler.rs
+++ b/crates/codegen/src/backend/evm/assembler.rs
@@ -1446,8 +1446,17 @@ pub mod op {
         };
     }
 
+    macro_rules! opcode_stack_io {
+        (_,_) => {
+            None
+        };
+        ($inputs:literal, $outputs:literal) => {
+            Some(($inputs, $outputs))
+        };
+    }
+
     macro_rules! opcodes {
-        ($($opcode:literal => $constant:ident => $mnemonic:ident;)*) => {
+        ($($opcode:literal => $constant:ident => $mnemonic:ident => stack_io($inputs:tt, $outputs:tt);)*) => {
             $(
                 #[doc = concat!("Opcode byte for `", stringify!($constant), "`.")]
                 pub const $constant: u8 = $opcode;
@@ -1481,179 +1490,188 @@ pub mod op {
                     _ => None,
                 }
             }
+
+            /// Returns the number of stack items consumed and produced by an opcode.
+            #[must_use]
+            pub const fn stack_io(opcode: u8) -> Option<(u16, u16)> {
+                match opcode {
+                    $($opcode => opcode_stack_io!($inputs, $outputs),)*
+                    _ => None,
+                }
+            }
         };
     }
 
     opcodes! {
-        0x00 => STOP => stop;
-        0x01 => ADD => add;
-        0x02 => MUL => mul;
-        0x03 => SUB => sub;
-        0x04 => DIV => div;
-        0x05 => SDIV => sdiv;
-        0x06 => MOD => mod;
-        0x07 => SMOD => smod;
-        0x08 => ADDMOD => addmod;
-        0x09 => MULMOD => mulmod;
-        0x0a => EXP => exp;
-        0x0b => SIGNEXTEND => signextend;
-        0x10 => LT => lt;
-        0x11 => GT => gt;
-        0x12 => SLT => slt;
-        0x13 => SGT => sgt;
-        0x14 => EQ => eq;
-        0x15 => ISZERO => iszero;
-        0x16 => AND => and;
-        0x17 => OR => or;
-        0x18 => XOR => xor;
-        0x19 => NOT => not;
-        0x1a => BYTE => byte;
-        0x1b => SHL => shl;
-        0x1c => SHR => shr;
-        0x1d => SAR => sar;
-        0x1e => CLZ => clz;
-        0x20 => KECCAK256 => keccak256;
-        0x30 => ADDRESS => address;
-        0x31 => BALANCE => balance;
-        0x32 => ORIGIN => origin;
-        0x33 => CALLER => caller;
-        0x34 => CALLVALUE => callvalue;
-        0x35 => CALLDATALOAD => calldataload;
-        0x36 => CALLDATASIZE => calldatasize;
-        0x37 => CALLDATACOPY => calldatacopy;
-        0x38 => CODESIZE => codesize;
-        0x39 => CODECOPY => codecopy;
-        0x3a => GASPRICE => gasprice;
-        0x3b => EXTCODESIZE => extcodesize;
-        0x3c => EXTCODECOPY => extcodecopy;
-        0x3d => RETURNDATASIZE => returndatasize;
-        0x3e => RETURNDATACOPY => returndatacopy;
-        0x3f => EXTCODEHASH => extcodehash;
-        0x40 => BLOCKHASH => blockhash;
-        0x41 => COINBASE => coinbase;
-        0x42 => TIMESTAMP => timestamp;
-        0x43 => NUMBER => number;
-        0x44 => PREVRANDAO => prevrandao;
-        0x45 => GASLIMIT => gaslimit;
-        0x46 => CHAINID => chainid;
-        0x47 => SELFBALANCE => selfbalance;
-        0x48 => BASEFEE => basefee;
-        0x49 => BLOBHASH => blobhash;
-        0x4a => BLOBBASEFEE => blobbasefee;
-        0x50 => POP => pop;
-        0x51 => MLOAD => mload;
-        0x52 => MSTORE => mstore;
-        0x53 => MSTORE8 => mstore8;
-        0x54 => SLOAD => sload;
-        0x55 => SSTORE => sstore;
-        0x56 => JUMP => jump;
-        0x57 => JUMPI => jumpi;
-        0x58 => PC => pc;
-        0x59 => MSIZE => msize;
-        0x5a => GAS => gas;
-        0x5b => JUMPDEST => jumpdest;
-        0x5c => TLOAD => tload;
-        0x5d => TSTORE => tstore;
-        0x5e => MCOPY => mcopy;
-        0x5f => PUSH0 => push0;
-        0x60 => PUSH1 => push1;
-        0x61 => PUSH2 => push2;
-        0x62 => PUSH3 => push3;
-        0x63 => PUSH4 => push4;
-        0x64 => PUSH5 => push5;
-        0x65 => PUSH6 => push6;
-        0x66 => PUSH7 => push7;
-        0x67 => PUSH8 => push8;
-        0x68 => PUSH9 => push9;
-        0x69 => PUSH10 => push10;
-        0x6a => PUSH11 => push11;
-        0x6b => PUSH12 => push12;
-        0x6c => PUSH13 => push13;
-        0x6d => PUSH14 => push14;
-        0x6e => PUSH15 => push15;
-        0x6f => PUSH16 => push16;
-        0x70 => PUSH17 => push17;
-        0x71 => PUSH18 => push18;
-        0x72 => PUSH19 => push19;
-        0x73 => PUSH20 => push20;
-        0x74 => PUSH21 => push21;
-        0x75 => PUSH22 => push22;
-        0x76 => PUSH23 => push23;
-        0x77 => PUSH24 => push24;
-        0x78 => PUSH25 => push25;
-        0x79 => PUSH26 => push26;
-        0x7a => PUSH27 => push27;
-        0x7b => PUSH28 => push28;
-        0x7c => PUSH29 => push29;
-        0x7d => PUSH30 => push30;
-        0x7e => PUSH31 => push31;
-        0x7f => PUSH32 => push32;
-        0x80 => DUP1 => dup1;
-        0x81 => DUP2 => dup2;
-        0x82 => DUP3 => dup3;
-        0x83 => DUP4 => dup4;
-        0x84 => DUP5 => dup5;
-        0x85 => DUP6 => dup6;
-        0x86 => DUP7 => dup7;
-        0x87 => DUP8 => dup8;
-        0x88 => DUP9 => dup9;
-        0x89 => DUP10 => dup10;
-        0x8a => DUP11 => dup11;
-        0x8b => DUP12 => dup12;
-        0x8c => DUP13 => dup13;
-        0x8d => DUP14 => dup14;
-        0x8e => DUP15 => dup15;
-        0x8f => DUP16 => dup16;
-        0x90 => SWAP1 => swap1;
-        0x91 => SWAP2 => swap2;
-        0x92 => SWAP3 => swap3;
-        0x93 => SWAP4 => swap4;
-        0x94 => SWAP5 => swap5;
-        0x95 => SWAP6 => swap6;
-        0x96 => SWAP7 => swap7;
-        0x97 => SWAP8 => swap8;
-        0x98 => SWAP9 => swap9;
-        0x99 => SWAP10 => swap10;
-        0x9a => SWAP11 => swap11;
-        0x9b => SWAP12 => swap12;
-        0x9c => SWAP13 => swap13;
-        0x9d => SWAP14 => swap14;
-        0x9e => SWAP15 => swap15;
-        0x9f => SWAP16 => swap16;
-        0xa0 => LOG0 => log0;
-        0xa1 => LOG1 => log1;
-        0xa2 => LOG2 => log2;
-        0xa3 => LOG3 => log3;
-        0xa4 => LOG4 => log4;
-        0xd0 => DATALOAD => dataload;
-        0xd1 => DATALOADN => dataloadn;
-        0xd2 => DATASIZE => datasize;
-        0xd3 => DATACOPY => datacopy;
-        0xe0 => RJUMP => rjump;
-        0xe1 => RJUMPI => rjumpi;
-        0xe2 => RJUMPV => rjumpv;
-        0xe3 => CALLF => callf;
-        0xe4 => RETF => retf;
-        0xe5 => JUMPF => jumpf;
-        0xe6 => DUPN => dupn;
-        0xe7 => SWAPN => swapn;
-        0xe8 => EXCHANGE => exchange;
-        0xec => EOFCREATE => eofcreate;
-        0xee => RETURNCONTRACT => returncontract;
-        0xf0 => CREATE => create;
-        0xf1 => CALL => call;
-        0xf2 => CALLCODE => callcode;
-        0xf3 => RETURN => r#return;
-        0xf4 => DELEGATECALL => delegatecall;
-        0xf5 => CREATE2 => create2;
-        0xf7 => RETURNDATALOAD => returndataload;
-        0xf8 => EXTCALL => extcall;
-        0xf9 => EXTDELEGATECALL => extdelegatecall;
-        0xfa => STATICCALL => staticcall;
-        0xfb => EXTSTATICCALL => extstaticcall;
-        0xfd => REVERT => revert;
-        0xfe => INVALID => invalid;
-        0xff => SELFDESTRUCT => selfdestruct;
+        0x00 => STOP => stop => stack_io(0, 0);
+        0x01 => ADD => add => stack_io(2, 1);
+        0x02 => MUL => mul => stack_io(2, 1);
+        0x03 => SUB => sub => stack_io(2, 1);
+        0x04 => DIV => div => stack_io(2, 1);
+        0x05 => SDIV => sdiv => stack_io(2, 1);
+        0x06 => MOD => mod => stack_io(2, 1);
+        0x07 => SMOD => smod => stack_io(2, 1);
+        0x08 => ADDMOD => addmod => stack_io(3, 1);
+        0x09 => MULMOD => mulmod => stack_io(3, 1);
+        0x0a => EXP => exp => stack_io(2, 1);
+        0x0b => SIGNEXTEND => signextend => stack_io(2, 1);
+        0x10 => LT => lt => stack_io(2, 1);
+        0x11 => GT => gt => stack_io(2, 1);
+        0x12 => SLT => slt => stack_io(2, 1);
+        0x13 => SGT => sgt => stack_io(2, 1);
+        0x14 => EQ => eq => stack_io(2, 1);
+        0x15 => ISZERO => iszero => stack_io(1, 1);
+        0x16 => AND => and => stack_io(2, 1);
+        0x17 => OR => or => stack_io(2, 1);
+        0x18 => XOR => xor => stack_io(2, 1);
+        0x19 => NOT => not => stack_io(1, 1);
+        0x1a => BYTE => byte => stack_io(2, 1);
+        0x1b => SHL => shl => stack_io(2, 1);
+        0x1c => SHR => shr => stack_io(2, 1);
+        0x1d => SAR => sar => stack_io(2, 1);
+        0x1e => CLZ => clz => stack_io(1, 1);
+        0x20 => KECCAK256 => keccak256 => stack_io(2, 1);
+        0x30 => ADDRESS => address => stack_io(0, 1);
+        0x31 => BALANCE => balance => stack_io(1, 1);
+        0x32 => ORIGIN => origin => stack_io(0, 1);
+        0x33 => CALLER => caller => stack_io(0, 1);
+        0x34 => CALLVALUE => callvalue => stack_io(0, 1);
+        0x35 => CALLDATALOAD => calldataload => stack_io(1, 1);
+        0x36 => CALLDATASIZE => calldatasize => stack_io(0, 1);
+        0x37 => CALLDATACOPY => calldatacopy => stack_io(3, 0);
+        0x38 => CODESIZE => codesize => stack_io(0, 1);
+        0x39 => CODECOPY => codecopy => stack_io(3, 0);
+        0x3a => GASPRICE => gasprice => stack_io(0, 1);
+        0x3b => EXTCODESIZE => extcodesize => stack_io(1, 1);
+        0x3c => EXTCODECOPY => extcodecopy => stack_io(4, 0);
+        0x3d => RETURNDATASIZE => returndatasize => stack_io(0, 1);
+        0x3e => RETURNDATACOPY => returndatacopy => stack_io(3, 0);
+        0x3f => EXTCODEHASH => extcodehash => stack_io(1, 1);
+        0x40 => BLOCKHASH => blockhash => stack_io(1, 1);
+        0x41 => COINBASE => coinbase => stack_io(0, 1);
+        0x42 => TIMESTAMP => timestamp => stack_io(0, 1);
+        0x43 => NUMBER => number => stack_io(0, 1);
+        0x44 => PREVRANDAO => prevrandao => stack_io(0, 1);
+        0x45 => GASLIMIT => gaslimit => stack_io(0, 1);
+        0x46 => CHAINID => chainid => stack_io(0, 1);
+        0x47 => SELFBALANCE => selfbalance => stack_io(0, 1);
+        0x48 => BASEFEE => basefee => stack_io(0, 1);
+        0x49 => BLOBHASH => blobhash => stack_io(1, 1);
+        0x4a => BLOBBASEFEE => blobbasefee => stack_io(0, 1);
+        0x50 => POP => pop => stack_io(1, 0);
+        0x51 => MLOAD => mload => stack_io(1, 1);
+        0x52 => MSTORE => mstore => stack_io(2, 0);
+        0x53 => MSTORE8 => mstore8 => stack_io(2, 0);
+        0x54 => SLOAD => sload => stack_io(1, 1);
+        0x55 => SSTORE => sstore => stack_io(2, 0);
+        0x56 => JUMP => jump => stack_io(1, 0);
+        0x57 => JUMPI => jumpi => stack_io(2, 0);
+        0x58 => PC => pc => stack_io(0, 1);
+        0x59 => MSIZE => msize => stack_io(0, 1);
+        0x5a => GAS => gas => stack_io(0, 1);
+        0x5b => JUMPDEST => jumpdest => stack_io(0, 0);
+        0x5c => TLOAD => tload => stack_io(1, 1);
+        0x5d => TSTORE => tstore => stack_io(2, 0);
+        0x5e => MCOPY => mcopy => stack_io(3, 0);
+        0x5f => PUSH0 => push0 => stack_io(0, 1);
+        0x60 => PUSH1 => push1 => stack_io(0, 1);
+        0x61 => PUSH2 => push2 => stack_io(0, 1);
+        0x62 => PUSH3 => push3 => stack_io(0, 1);
+        0x63 => PUSH4 => push4 => stack_io(0, 1);
+        0x64 => PUSH5 => push5 => stack_io(0, 1);
+        0x65 => PUSH6 => push6 => stack_io(0, 1);
+        0x66 => PUSH7 => push7 => stack_io(0, 1);
+        0x67 => PUSH8 => push8 => stack_io(0, 1);
+        0x68 => PUSH9 => push9 => stack_io(0, 1);
+        0x69 => PUSH10 => push10 => stack_io(0, 1);
+        0x6a => PUSH11 => push11 => stack_io(0, 1);
+        0x6b => PUSH12 => push12 => stack_io(0, 1);
+        0x6c => PUSH13 => push13 => stack_io(0, 1);
+        0x6d => PUSH14 => push14 => stack_io(0, 1);
+        0x6e => PUSH15 => push15 => stack_io(0, 1);
+        0x6f => PUSH16 => push16 => stack_io(0, 1);
+        0x70 => PUSH17 => push17 => stack_io(0, 1);
+        0x71 => PUSH18 => push18 => stack_io(0, 1);
+        0x72 => PUSH19 => push19 => stack_io(0, 1);
+        0x73 => PUSH20 => push20 => stack_io(0, 1);
+        0x74 => PUSH21 => push21 => stack_io(0, 1);
+        0x75 => PUSH22 => push22 => stack_io(0, 1);
+        0x76 => PUSH23 => push23 => stack_io(0, 1);
+        0x77 => PUSH24 => push24 => stack_io(0, 1);
+        0x78 => PUSH25 => push25 => stack_io(0, 1);
+        0x79 => PUSH26 => push26 => stack_io(0, 1);
+        0x7a => PUSH27 => push27 => stack_io(0, 1);
+        0x7b => PUSH28 => push28 => stack_io(0, 1);
+        0x7c => PUSH29 => push29 => stack_io(0, 1);
+        0x7d => PUSH30 => push30 => stack_io(0, 1);
+        0x7e => PUSH31 => push31 => stack_io(0, 1);
+        0x7f => PUSH32 => push32 => stack_io(0, 1);
+        0x80 => DUP1 => dup1 => stack_io(1, 2);
+        0x81 => DUP2 => dup2 => stack_io(2, 3);
+        0x82 => DUP3 => dup3 => stack_io(3, 4);
+        0x83 => DUP4 => dup4 => stack_io(4, 5);
+        0x84 => DUP5 => dup5 => stack_io(5, 6);
+        0x85 => DUP6 => dup6 => stack_io(6, 7);
+        0x86 => DUP7 => dup7 => stack_io(7, 8);
+        0x87 => DUP8 => dup8 => stack_io(8, 9);
+        0x88 => DUP9 => dup9 => stack_io(9, 10);
+        0x89 => DUP10 => dup10 => stack_io(10, 11);
+        0x8a => DUP11 => dup11 => stack_io(11, 12);
+        0x8b => DUP12 => dup12 => stack_io(12, 13);
+        0x8c => DUP13 => dup13 => stack_io(13, 14);
+        0x8d => DUP14 => dup14 => stack_io(14, 15);
+        0x8e => DUP15 => dup15 => stack_io(15, 16);
+        0x8f => DUP16 => dup16 => stack_io(16, 17);
+        0x90 => SWAP1 => swap1 => stack_io(2, 2);
+        0x91 => SWAP2 => swap2 => stack_io(3, 3);
+        0x92 => SWAP3 => swap3 => stack_io(4, 4);
+        0x93 => SWAP4 => swap4 => stack_io(5, 5);
+        0x94 => SWAP5 => swap5 => stack_io(6, 6);
+        0x95 => SWAP6 => swap6 => stack_io(7, 7);
+        0x96 => SWAP7 => swap7 => stack_io(8, 8);
+        0x97 => SWAP8 => swap8 => stack_io(9, 9);
+        0x98 => SWAP9 => swap9 => stack_io(10, 10);
+        0x99 => SWAP10 => swap10 => stack_io(11, 11);
+        0x9a => SWAP11 => swap11 => stack_io(12, 12);
+        0x9b => SWAP12 => swap12 => stack_io(13, 13);
+        0x9c => SWAP13 => swap13 => stack_io(14, 14);
+        0x9d => SWAP14 => swap14 => stack_io(15, 15);
+        0x9e => SWAP15 => swap15 => stack_io(16, 16);
+        0x9f => SWAP16 => swap16 => stack_io(17, 17);
+        0xa0 => LOG0 => log0 => stack_io(2, 0);
+        0xa1 => LOG1 => log1 => stack_io(3, 0);
+        0xa2 => LOG2 => log2 => stack_io(4, 0);
+        0xa3 => LOG3 => log3 => stack_io(5, 0);
+        0xa4 => LOG4 => log4 => stack_io(6, 0);
+        0xd0 => DATALOAD => dataload => stack_io(1, 1);
+        0xd1 => DATALOADN => dataloadn => stack_io(0, 1);
+        0xd2 => DATASIZE => datasize => stack_io(0, 1);
+        0xd3 => DATACOPY => datacopy => stack_io(3, 0);
+        0xe0 => RJUMP => rjump => stack_io(0, 0);
+        0xe1 => RJUMPI => rjumpi => stack_io(1, 0);
+        0xe2 => RJUMPV => rjumpv => stack_io(1, 0);
+        0xe3 => CALLF => callf => stack_io(_, _);
+        0xe4 => RETF => retf => stack_io(_, _);
+        0xe5 => JUMPF => jumpf => stack_io(_, _);
+        0xe6 => DUPN => dupn => stack_io(0, 1);
+        0xe7 => SWAPN => swapn => stack_io(0, 0);
+        0xe8 => EXCHANGE => exchange => stack_io(0, 0);
+        0xec => EOFCREATE => eofcreate => stack_io(4, 1);
+        0xee => RETURNCONTRACT => returncontract => stack_io(2, 0);
+        0xf0 => CREATE => create => stack_io(3, 1);
+        0xf1 => CALL => call => stack_io(7, 1);
+        0xf2 => CALLCODE => callcode => stack_io(7, 1);
+        0xf3 => RETURN => r#return => stack_io(2, 0);
+        0xf4 => DELEGATECALL => delegatecall => stack_io(6, 1);
+        0xf5 => CREATE2 => create2 => stack_io(4, 1);
+        0xf7 => RETURNDATALOAD => returndataload => stack_io(1, 1);
+        0xf8 => EXTCALL => extcall => stack_io(4, 1);
+        0xf9 => EXTDELEGATECALL => extdelegatecall => stack_io(3, 1);
+        0xfa => STATICCALL => staticcall => stack_io(6, 1);
+        0xfb => EXTSTATICCALL => extstaticcall => stack_io(3, 1);
+        0xfd => REVERT => revert => stack_io(2, 0);
+        0xfe => INVALID => invalid => stack_io(0, 0);
+        0xff => SELFDESTRUCT => selfdestruct => stack_io(1, 0);
     }
 
     /// Returns the PUSH opcode for the given width (1-32).
@@ -1703,6 +1721,10 @@ mod tests {
                 assert_eq!(op::from_mnemonic(mnemonic), Some(opcode));
             }
         }
+        assert_eq!(op::stack_io(op::ADD), Some((2, 1)));
+        assert_eq!(op::stack_io(op::MSTORE), Some((2, 0)));
+        assert_eq!(op::stack_io(op::CALLVALUE), Some((0, 1)));
+        assert_eq!(op::stack_io(op::CALLF), None);
     }
 
     #[test]

--- a/crates/codegen/src/backend/evm/assembler.rs
+++ b/crates/codegen/src/backend/evm/assembler.rs
@@ -5,7 +5,7 @@
 //! - Two-pass assembly for resolving jump targets
 //! - Variable-width PUSH sizing based on offset magnitudes
 
-use crate::mir::IMMUTABLE_WORD_SIZE;
+use crate::{backend::evm::EvmIrModule, mir::IMMUTABLE_WORD_SIZE};
 use alloy_primitives::U256;
 use smallvec::SmallVec;
 use solar_config::{EvmVersion, OptimizationMode};
@@ -62,6 +62,8 @@ pub struct AssembledCode {
     pub label_offsets: FxHashMap<Label, usize>,
     /// All immutable placeholders, in emission order.
     pub immutable_refs: Vec<ImmutableRef>,
+    /// Final EVM IR captured immediately before byte emission.
+    pub evm_ir: Option<EvmIrModule>,
 }
 
 /// Configuration for EVM bytecode assembly.
@@ -81,6 +83,8 @@ pub struct AssemblerConfig {
     /// Kept separate from `evm_ir_stack_schedule` so the experimental scheduler
     /// flag remains bytecode-neutral.
     pub evm_ir_layout_passes: bool,
+    /// Capture the final EVM IR without running additional passes.
+    pub capture_evm_ir: bool,
 }
 
 /// Two-pass assembler for EVM bytecode.
@@ -796,6 +800,8 @@ impl Assembler {
         }
         self.hoist_hot_terminal_spans(&mut program.instructions);
 
+        let evm_ir = self.config.capture_evm_ir.then(|| program.to_evm_ir_module(self)).flatten();
+
         // Label-free constructor and deployment snippets need neither offset
         // discovery nor push-width relaxation.
         if !program
@@ -803,7 +809,9 @@ impl Assembler {
             .iter()
             .any(|inst| matches!(inst.kind(), AsmInstKind::Label(_) | AsmInstKind::PushLabel(_)))
         {
-            let result = self.emit_bytecode(&program, FxHashMap::default(), &FxHashMap::default());
+            let mut result =
+                self.emit_bytecode(&program, FxHashMap::default(), &FxHashMap::default());
+            result.evm_ir = evm_ir;
             self.clear();
             return result;
         }
@@ -832,7 +840,8 @@ impl Assembler {
 
             if !changed {
                 // Stable - emit final bytecode
-                let result = self.emit_bytecode(&program, label_offsets, &push_widths);
+                let mut result = self.emit_bytecode(&program, label_offsets, &push_widths);
+                result.evm_ir = evm_ir;
                 self.clear();
                 return result;
             }
@@ -844,7 +853,8 @@ impl Assembler {
 
         // Fallback - just emit with current widths
         let (label_offsets, _) = self.compute_offsets(&program, &push_widths);
-        let result = self.emit_bytecode(&program, label_offsets, &push_widths);
+        let mut result = self.emit_bytecode(&program, label_offsets, &push_widths);
+        result.evm_ir = evm_ir;
         self.clear();
         result
     }
@@ -1406,6 +1416,7 @@ impl BytecodeAssembler {
             bytecode: self.bytecode,
             label_offsets,
             immutable_refs: self.immutable_refs,
+            evm_ir: None,
         }
     }
 }

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -286,9 +286,7 @@ impl StructuredAsmProgram {
                 if let Some(stack_op) = stack_op_from_opcode(opcode) {
                     EvmIrInstruction::stack_op(stack_op)
                 } else {
-                    let mut inst = EvmIrInstruction::new(opcode_mnemonic(opcode), Vec::new());
-                    inst.metadata.stack = Some(EvmIrStackEffect::new(0, 0));
-                    inst
+                    EvmIrInstruction::new(opcode_mnemonic(opcode), Vec::new())
                 }
             }
             AsmInstKind::PushInline(value) => {

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -461,10 +461,15 @@ fn push_instruction(operand: EvmIrOperand) -> EvmIrInstruction {
 }
 
 fn opcode_mnemonic(opcode: u8) -> String {
-    format!("{OP_PREFIX}{opcode:02x}")
+    crate::backend::evm::ir::opcode_mnemonic(opcode)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{OP_PREFIX}{opcode:02x}"))
 }
 
 fn parse_opcode_mnemonic(mnemonic: &str) -> Option<u8> {
+    if let Some(opcode) = crate::backend::evm::ir::opcode_by_mnemonic(mnemonic) {
+        return Some(opcode);
+    }
     let value = mnemonic.strip_prefix(OP_PREFIX)?;
     u8::from_str_radix(value, 16).ok()
 }
@@ -529,4 +534,25 @@ struct StructuredAsmBlock {
 #[derive(Clone, Debug, Default)]
 pub(in crate::backend::evm) struct EvmAsmProgram {
     pub(in crate::backend::evm) instructions: Vec<AsmInst>,
+}
+
+impl EvmAsmProgram {
+    /// Converts the final linear program back to EVM IR without running passes.
+    pub(in crate::backend::evm) fn to_evm_ir_module<C>(
+        &self,
+        context: &mut C,
+    ) -> Option<EvmIrModule>
+    where
+        C: StructuredAsmContext,
+    {
+        let mut structured = StructuredAsmProgram::default();
+        for &inst in &self.instructions {
+            if let AsmInstKind::Label(label) = inst.kind() {
+                structured.define_label(label);
+            } else {
+                structured.push(inst);
+            }
+        }
+        structured.to_evm_ir_module(context).map(|(module, _)| module)
+    }
 }

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -461,13 +461,11 @@ fn push_instruction(operand: EvmIrOperand) -> EvmIrInstruction {
 }
 
 fn opcode_mnemonic(opcode: u8) -> String {
-    crate::backend::evm::ir::opcode_mnemonic(opcode)
-        .map(str::to_string)
-        .unwrap_or_else(|| format!("{OP_PREFIX}{opcode:02x}"))
+    op::mnemonic(opcode).map(str::to_string).unwrap_or_else(|| format!("{OP_PREFIX}{opcode:02x}"))
 }
 
 fn parse_opcode_mnemonic(mnemonic: &str) -> Option<u8> {
-    if let Some(opcode) = crate::backend::evm::ir::opcode_by_mnemonic(mnemonic) {
+    if let Some(opcode) = op::from_mnemonic(mnemonic) {
         return Some(opcode);
     }
     let value = mnemonic.strip_prefix(OP_PREFIX)?;

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -423,6 +423,7 @@ impl StructuredAsmProgram {
                 program.push(AsmInst::op(op::JUMP));
             }
             EvmIrTerminatorKind::RawOpcode(opcode) => program.push(AsmInst::op(*opcode)),
+            EvmIrTerminatorKind::FallthroughNext => {}
             EvmIrTerminatorKind::Stop => program.push(AsmInst::op(op::STOP)),
             EvmIrTerminatorKind::Invalid => program.push(AsmInst::op(op::INVALID)),
             EvmIrTerminatorKind::Return { .. }

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -7,6 +7,7 @@
 //! - Two-pass assembly for label resolution
 
 use super::{
+    EvmIrModule, EvmIrTerminatorKind,
     assembler::{Assembler, AssemblerConfig, DeferredConst, ImmutableRef, Label, op},
     stack::{
         MAX_STACK_ACCESS, ScheduledOp, SpillSlot, StackModel, StackOp, StackScheduler, TargetSlot,
@@ -41,6 +42,12 @@ const GLOBAL_STACK_MIN_BLOCKS: usize = 8;
 const GLOBAL_STACK_MIN_ARG_USES: usize = 6;
 const GLOBAL_STACK_DENSE_AMORTIZATION_BLOCKS: usize = 16;
 
+#[derive(Default)]
+struct GeneratedCode {
+    bytecode: Vec<u8>,
+    evm_ir: Option<EvmIrModule>,
+}
+
 /// Configuration for the EVM backend.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct EvmCodegenConfig {
@@ -61,6 +68,8 @@ pub struct EvmCodegenConfig {
     pub evm_ir_stack_schedule: bool,
     /// Run EVM IR layout/code-size passes in the assembler bridge.
     pub evm_ir_layout_passes: bool,
+    /// Capture final EVM IR immediately before assembly.
+    pub capture_evm_ir: bool,
 }
 
 impl EvmCodegenConfig {
@@ -76,6 +85,7 @@ impl EvmCodegenConfig {
             // compilation path so produced bytecode is unchanged.
             evm_ir_stack_schedule: false,
             evm_ir_layout_passes: false,
+            capture_evm_ir: false,
         }
     }
 
@@ -85,6 +95,7 @@ impl EvmCodegenConfig {
             optimization: self.optimization,
             evm_ir_stack_schedule: self.evm_ir_stack_schedule,
             evm_ir_layout_passes: self.evm_ir_layout_passes,
+            capture_evm_ir: self.capture_evm_ir,
         }
     }
 }
@@ -745,7 +756,7 @@ impl EvmCodegen {
         self.run_optimization_passes(module);
         // Immutable reads are `PUSH32` zero placeholders here; only a
         // constructor run patches them with actual values.
-        self.generate_runtime_code(module)
+        self.generate_runtime_code(module).bytecode
     }
 
     /// Generates deployment bytecode for a module.
@@ -754,13 +765,21 @@ impl EvmCodegen {
     ///
     /// This runs optimization passes (including DCE) on the module before codegen unless disabled.
     pub fn generate_deployment_bytecode(&mut self, module: &mut Module) -> (Vec<u8>, Vec<u8>) {
+        let artifact = self.generate_deployment_artifact(module);
+        (artifact.deployment, artifact.runtime)
+    }
+
+    fn generate_deployment_artifact(&mut self, module: &mut Module) -> EvmArtifact {
         if module.is_interface {
-            return (Vec::new(), Vec::new());
+            return EvmArtifact::default();
         }
         self.run_optimization_passes(module);
         // First generate the runtime code
-        let runtime_code = self.generate_runtime_code(module);
-        let runtime_len = runtime_code.len();
+        let mut runtime_code = self.generate_runtime_code(module);
+        if let Some(evm_ir) = &mut runtime_code.evm_ir {
+            evm_ir.name = "runtime".to_string();
+        }
+        let runtime_len = runtime_code.bytecode.len();
         let immutable_refs = std::mem::take(&mut self.runtime_immutable_refs);
 
         // The constructor copies the runtime code to memory and patches the
@@ -787,7 +806,7 @@ impl EvmCodegen {
                 copy_base,
                 &immutable_refs,
             );
-            let next_deploy_code_len = constructor_code.len() + postlude.len();
+            let next_deploy_code_len = constructor_code.bytecode.len() + postlude.bytecode.len();
             let next_arg_offset = next_deploy_code_len + runtime_len;
             if next_deploy_code_len == deploy_code_len && next_arg_offset == constructor_arg_offset
             {
@@ -808,26 +827,48 @@ impl EvmCodegen {
         // [immutable patches]   ; patch staged words into the PUSH32 placeholders
         // PUSH<n> copy_base     ; memory offset
         // RETURN                ; return the runtime code
-        let postlude = self.build_deployment_postlude(
+        let mut postlude = self.build_deployment_postlude(
             deploy_code_len,
             runtime_len,
             copy_base,
             &immutable_refs,
         );
+        if let Some(evm_ir) = &mut constructor_code.evm_ir {
+            evm_ir.name = "constructor".to_string();
+        }
+        if let Some(evm_ir) = &mut postlude.evm_ir {
+            evm_ir.name = "deployment".to_string();
+        }
 
         // Build the deployment bytecode
         let mut deploy_bytecode = Vec::new();
 
         // Add constructor code first
-        deploy_bytecode.extend_from_slice(&constructor_code);
-        deploy_bytecode.extend_from_slice(&postlude);
+        deploy_bytecode.extend_from_slice(&constructor_code.bytecode);
+        deploy_bytecode.extend_from_slice(&postlude.bytecode);
 
         // Append runtime code
-        deploy_bytecode.extend_from_slice(&runtime_code);
+        deploy_bytecode.extend_from_slice(&runtime_code.bytecode);
+
+        let mut deployment_evm_ir = Vec::new();
+        if let Some(evm_ir) = constructor_code.evm_ir {
+            deployment_evm_ir.push(evm_ir);
+        }
+        if let Some(evm_ir) = postlude.evm_ir {
+            deployment_evm_ir.push(evm_ir);
+        }
+        if let Some(evm_ir) = runtime_code.evm_ir.clone() {
+            deployment_evm_ir.push(evm_ir);
+        }
 
         // The returned runtime artifact keeps the zero placeholders, like
         // solc's `deployedBytecode` for contracts with immutables.
-        (deploy_bytecode, runtime_code)
+        EvmArtifact {
+            deployment: deploy_bytecode,
+            runtime: runtime_code.bytecode,
+            deployment_evm_ir,
+            runtime_evm_ir: runtime_code.evm_ir,
+        }
     }
 
     fn build_deployment_postlude(
@@ -836,7 +877,7 @@ impl EvmCodegen {
         runtime_len: usize,
         copy_base: u64,
         immutable_refs: &[ImmutableRef],
-    ) -> Vec<u8> {
+    ) -> GeneratedCode {
         self.asm.clear();
 
         // Copy runtime code from creation code to memory at `copy_base`.
@@ -858,7 +899,8 @@ impl EvmCodegen {
         // Return the patched runtime code; the DUP'd length is still on the stack.
         self.asm.emit_push(U256::from(copy_base));
         self.asm.emit_op(op::RETURN);
-        self.asm.assemble().bytecode
+        let result = self.asm.assemble();
+        GeneratedCode { bytecode: result.bytecode, evm_ir: result.evm_ir }
     }
 
     /// Generates constructor code that runs during deployment.
@@ -870,7 +912,7 @@ impl EvmCodegen {
         &mut self,
         module: &Module,
         constructor_arg_offset: Option<usize>,
-    ) -> Vec<u8> {
+    ) -> GeneratedCode {
         // Find constructor function if it exists
         let constructor =
             module.functions.iter_enumerated().find(|(_, f)| f.attributes.is_constructor);
@@ -975,16 +1017,26 @@ impl EvmCodegen {
             self.in_constructor = false;
             self.constructor_param_count = 0;
 
-            let mut bytecode = self.asm.assemble().bytecode;
+            let result = self.asm.assemble();
+            let mut bytecode = result.bytecode;
+            let mut evm_ir = result.evm_ir;
 
             // Remove trailing STOP (0x00) if present - we want to fall through to CODECOPY/RETURN
             if bytecode.last() == Some(&op::STOP) {
                 bytecode.pop();
+                if let Some(last_block) = evm_ir.as_mut().and_then(|ir| ir.blocks.last_mut())
+                    && matches!(
+                        last_block.terminator.as_ref().map(|term| &term.kind),
+                        Some(EvmIrTerminatorKind::RawOpcode(op::STOP))
+                    )
+                {
+                    last_block.terminator = None;
+                }
             }
 
-            bytecode
+            GeneratedCode { bytecode, evm_ir }
         } else {
-            Vec::new()
+            GeneratedCode::default()
         }
     }
 
@@ -1018,7 +1070,7 @@ impl EvmCodegen {
     }
 
     /// Generates runtime bytecode for a module.
-    fn generate_runtime_code(&mut self, module: &Module) -> Vec<u8> {
+    fn generate_runtime_code(&mut self, module: &Module) -> GeneratedCode {
         self.asm.clear();
         self.block_labels.clear();
         self.function_labels.clear();
@@ -1055,7 +1107,7 @@ impl EvmCodegen {
         let result = self.asm.assemble();
         self.asm.set_structural_outlining(false);
         self.runtime_immutable_refs = result.immutable_refs;
-        result.bytecode
+        GeneratedCode { bytecode: result.bytecode, evm_ir: result.evm_ir }
     }
 
     /// Generates the runtime from a `dispatch`-phase module: the MIR `entry`
@@ -4905,13 +4957,17 @@ impl Default for EvmCodegen {
     }
 }
 
-/// The artifact produced by the EVM backend: deployment and runtime bytecode.
+/// The artifact produced by the EVM backend.
 #[derive(Clone, Debug, Default)]
 pub struct EvmArtifact {
     /// Deployment (init) bytecode that, when run, returns the runtime code.
     pub deployment: Vec<u8>,
     /// Runtime bytecode, i.e. the code stored on-chain.
     pub runtime: Vec<u8>,
+    /// Final creation-code EVM IR segments in bytecode order.
+    pub deployment_evm_ir: Vec<EvmIrModule>,
+    /// Final runtime EVM IR immediately before byte emission.
+    pub runtime_evm_ir: Option<EvmIrModule>,
 }
 
 impl crate::backend::Backend for EvmCodegen {
@@ -4922,8 +4978,7 @@ impl crate::backend::Backend for EvmCodegen {
     }
 
     fn lower_module(&mut self, module: &mut Module) -> EvmArtifact {
-        let (deployment, runtime) = self.generate_deployment_bytecode(module);
-        EvmArtifact { deployment, runtime }
+        self.generate_deployment_artifact(module)
     }
 }
 

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -1024,13 +1024,13 @@ impl EvmCodegen {
             // Remove trailing STOP (0x00) if present - we want to fall through to CODECOPY/RETURN
             if bytecode.last() == Some(&op::STOP) {
                 bytecode.pop();
-                if let Some(last_block) = evm_ir.as_mut().and_then(|ir| ir.blocks.last_mut())
-                    && matches!(
-                        last_block.terminator.as_ref().map(|term| &term.kind),
-                        Some(EvmIrTerminatorKind::RawOpcode(op::STOP))
-                    )
+                if let Some(terminator) = evm_ir
+                    .as_mut()
+                    .and_then(|ir| ir.blocks.last_mut())
+                    .and_then(|block| block.terminator.as_mut())
+                    && matches!(&terminator.kind, EvmIrTerminatorKind::RawOpcode(op::STOP))
                 {
-                    last_block.terminator = None;
+                    terminator.kind = EvmIrTerminatorKind::FallthroughNext;
                 }
             }
 

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -416,10 +416,8 @@ pub(super) fn default_instruction_stack_effect(inst: &EvmIrInstruction) -> EvmIr
             EvmIrStackEffect::new(0, 1)
         }
         EvmIrInstructionKind::Operation(mnemonic) => {
-            if let Some(opcode) = super::assembler::op::from_mnemonic(mnemonic)
-                && let Some((inputs, outputs)) = super::assembler::op::stack_io(opcode)
-            {
-                EvmIrStackEffect::new(inputs, outputs)
+            if let Some(effect) = opcode_stack_effect(mnemonic) {
+                effect
             } else {
                 EvmIrStackEffect::new(
                     inst.operands.len().try_into().unwrap_or(u16::MAX),
@@ -428,6 +426,12 @@ pub(super) fn default_instruction_stack_effect(inst: &EvmIrInstruction) -> EvmIr
             }
         }
     }
+}
+
+fn opcode_stack_effect(mnemonic: &str) -> Option<EvmIrStackEffect> {
+    let opcode = super::assembler::op::from_mnemonic(mnemonic)?;
+    let (inputs, outputs) = super::assembler::op::stack_io(opcode)?;
+    Some(EvmIrStackEffect::new(inputs, outputs))
 }
 
 fn default_terminator_stack_effect(kind: &EvmIrTerminatorKind) -> EvmIrStackEffect {

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -415,10 +415,18 @@ pub(super) fn default_instruction_stack_effect(inst: &EvmIrInstruction) -> EvmIr
         EvmIrInstructionKind::Operation(_) if is_encoded_push_instruction(inst) => {
             EvmIrStackEffect::new(0, 1)
         }
-        EvmIrInstructionKind::Operation(_) => EvmIrStackEffect::new(
-            inst.operands.len().try_into().unwrap_or(u16::MAX),
-            u16::from(inst.result.is_some()),
-        ),
+        EvmIrInstructionKind::Operation(mnemonic) => {
+            if let Some(opcode) = super::assembler::op::from_mnemonic(mnemonic)
+                && let Some((inputs, outputs)) = super::assembler::op::stack_io(opcode)
+            {
+                EvmIrStackEffect::new(inputs, outputs)
+            } else {
+                EvmIrStackEffect::new(
+                    inst.operands.len().try_into().unwrap_or(u16::MAX),
+                    u16::from(inst.result.is_some()),
+                )
+            }
+        }
     }
 }
 
@@ -434,8 +442,10 @@ fn default_terminator_stack_effect(kind: &EvmIrTerminatorKind) -> EvmIrStackEffe
         | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Stop
-        | EvmIrTerminatorKind::Invalid
-        | EvmIrTerminatorKind::RawOpcode(_) => EvmIrStackEffect::new(0, 0),
+        | EvmIrTerminatorKind::Invalid => EvmIrStackEffect::new(0, 0),
+        EvmIrTerminatorKind::RawOpcode(opcode) => super::assembler::op::stack_io(*opcode)
+            .map(|(inputs, outputs)| EvmIrStackEffect::new(inputs, outputs))
+            .unwrap_or_else(|| EvmIrStackEffect::new(0, 0)),
     }
 }
 

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -301,6 +301,8 @@ impl EvmIrTerminator {
 pub enum EvmIrTerminatorKind {
     /// Physical fallthrough into the next laid-out block.
     Fallthrough(EvmIrBlockId),
+    /// Physical fallthrough into the next separately captured program segment.
+    FallthroughNext,
     /// Unconditional jump.
     Jump(EvmIrBlockId),
     /// Conditional branch.
@@ -429,6 +431,7 @@ fn default_terminator_stack_effect(kind: &EvmIrTerminatorKind) -> EvmIrStackEffe
         }
         EvmIrTerminatorKind::SelfDestruct { .. } => EvmIrStackEffect::new(1, 0),
         EvmIrTerminatorKind::Fallthrough(_)
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -361,6 +361,55 @@ pub enum EvmIrOperand {
     Symbol(String),
 }
 
+macro_rules! evm_opcodes {
+    ($($opcode:literal => $mnemonic:literal),+ $(,)?) => {
+        pub(crate) fn opcode_mnemonic(opcode: u8) -> Option<&'static str> {
+            match opcode {
+                $($opcode => Some($mnemonic),)+
+                _ => None,
+            }
+        }
+
+        pub(crate) fn opcode_by_mnemonic(mnemonic: &str) -> Option<u8> {
+            match mnemonic {
+                $($mnemonic => Some($opcode),)+
+                _ => None,
+            }
+        }
+    };
+}
+
+evm_opcodes! {
+    0x00 => "stop", 0x01 => "add", 0x02 => "mul", 0x03 => "sub", 0x04 => "div",
+    0x05 => "sdiv", 0x06 => "mod", 0x07 => "smod", 0x08 => "addmod", 0x09 => "mulmod",
+    0x0a => "exp", 0x0b => "signextend",
+    0x10 => "lt", 0x11 => "gt", 0x12 => "slt", 0x13 => "sgt", 0x14 => "eq",
+    0x15 => "iszero", 0x16 => "and", 0x17 => "or", 0x18 => "xor", 0x19 => "not",
+    0x1a => "byte", 0x1b => "shl", 0x1c => "shr", 0x1d => "sar", 0x1e => "clz",
+    0x20 => "keccak256",
+    0x30 => "address", 0x31 => "balance", 0x32 => "origin", 0x33 => "caller",
+    0x34 => "callvalue", 0x35 => "calldataload", 0x36 => "calldatasize",
+    0x37 => "calldatacopy", 0x38 => "codesize", 0x39 => "codecopy", 0x3a => "gasprice",
+    0x3b => "extcodesize", 0x3c => "extcodecopy", 0x3d => "returndatasize",
+    0x3e => "returndatacopy", 0x3f => "extcodehash",
+    0x40 => "blockhash", 0x41 => "coinbase", 0x42 => "timestamp", 0x43 => "number",
+    0x44 => "prevrandao", 0x45 => "gaslimit", 0x46 => "chainid", 0x47 => "selfbalance",
+    0x48 => "basefee", 0x49 => "blobhash", 0x4a => "blobbasefee",
+    0x50 => "pop", 0x51 => "mload", 0x52 => "mstore", 0x53 => "mstore8",
+    0x54 => "sload", 0x55 => "sstore", 0x56 => "jump", 0x57 => "jumpi", 0x58 => "pc",
+    0x59 => "msize", 0x5a => "gas", 0x5b => "jumpdest", 0x5c => "tload",
+    0x5d => "tstore", 0x5e => "mcopy", 0x5f => "push0",
+    0xa0 => "log0", 0xa1 => "log1", 0xa2 => "log2", 0xa3 => "log3", 0xa4 => "log4",
+    0xd0 => "dataload", 0xd1 => "dataloadn", 0xd2 => "datasize", 0xd3 => "datacopy",
+    0xe0 => "rjump", 0xe1 => "rjumpi", 0xe2 => "rjumpv", 0xe3 => "callf",
+    0xe4 => "retf", 0xe5 => "jumpf", 0xe6 => "dupn", 0xe7 => "swapn",
+    0xe8 => "exchange", 0xec => "eofcreate", 0xee => "returncontract",
+    0xf0 => "create", 0xf1 => "call", 0xf2 => "callcode", 0xf3 => "return",
+    0xf4 => "delegatecall", 0xf5 => "create2", 0xf7 => "returndataload",
+    0xf8 => "extcall", 0xf9 => "extdelegatecall", 0xfa => "staticcall",
+    0xfb => "extstaticcall", 0xfd => "revert", 0xfe => "invalid", 0xff => "selfdestruct",
+}
+
 /// Generic metadata carried by instructions and terminators.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EvmIrMetadata {

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -361,55 +361,6 @@ pub enum EvmIrOperand {
     Symbol(String),
 }
 
-macro_rules! evm_opcodes {
-    ($($opcode:literal => $mnemonic:literal),+ $(,)?) => {
-        pub(crate) fn opcode_mnemonic(opcode: u8) -> Option<&'static str> {
-            match opcode {
-                $($opcode => Some($mnemonic),)+
-                _ => None,
-            }
-        }
-
-        pub(crate) fn opcode_by_mnemonic(mnemonic: &str) -> Option<u8> {
-            match mnemonic {
-                $($mnemonic => Some($opcode),)+
-                _ => None,
-            }
-        }
-    };
-}
-
-evm_opcodes! {
-    0x00 => "stop", 0x01 => "add", 0x02 => "mul", 0x03 => "sub", 0x04 => "div",
-    0x05 => "sdiv", 0x06 => "mod", 0x07 => "smod", 0x08 => "addmod", 0x09 => "mulmod",
-    0x0a => "exp", 0x0b => "signextend",
-    0x10 => "lt", 0x11 => "gt", 0x12 => "slt", 0x13 => "sgt", 0x14 => "eq",
-    0x15 => "iszero", 0x16 => "and", 0x17 => "or", 0x18 => "xor", 0x19 => "not",
-    0x1a => "byte", 0x1b => "shl", 0x1c => "shr", 0x1d => "sar", 0x1e => "clz",
-    0x20 => "keccak256",
-    0x30 => "address", 0x31 => "balance", 0x32 => "origin", 0x33 => "caller",
-    0x34 => "callvalue", 0x35 => "calldataload", 0x36 => "calldatasize",
-    0x37 => "calldatacopy", 0x38 => "codesize", 0x39 => "codecopy", 0x3a => "gasprice",
-    0x3b => "extcodesize", 0x3c => "extcodecopy", 0x3d => "returndatasize",
-    0x3e => "returndatacopy", 0x3f => "extcodehash",
-    0x40 => "blockhash", 0x41 => "coinbase", 0x42 => "timestamp", 0x43 => "number",
-    0x44 => "prevrandao", 0x45 => "gaslimit", 0x46 => "chainid", 0x47 => "selfbalance",
-    0x48 => "basefee", 0x49 => "blobhash", 0x4a => "blobbasefee",
-    0x50 => "pop", 0x51 => "mload", 0x52 => "mstore", 0x53 => "mstore8",
-    0x54 => "sload", 0x55 => "sstore", 0x56 => "jump", 0x57 => "jumpi", 0x58 => "pc",
-    0x59 => "msize", 0x5a => "gas", 0x5b => "jumpdest", 0x5c => "tload",
-    0x5d => "tstore", 0x5e => "mcopy", 0x5f => "push0",
-    0xa0 => "log0", 0xa1 => "log1", 0xa2 => "log2", 0xa3 => "log3", 0xa4 => "log4",
-    0xd0 => "dataload", 0xd1 => "dataloadn", 0xd2 => "datasize", 0xd3 => "datacopy",
-    0xe0 => "rjump", 0xe1 => "rjumpi", 0xe2 => "rjumpv", 0xe3 => "callf",
-    0xe4 => "retf", 0xe5 => "jumpf", 0xe6 => "dupn", 0xe7 => "swapn",
-    0xe8 => "exchange", 0xec => "eofcreate", 0xee => "returncontract",
-    0xf0 => "create", 0xf1 => "call", 0xf2 => "callcode", 0xf3 => "return",
-    0xf4 => "delegatecall", 0xf5 => "create2", 0xf7 => "returndataload",
-    0xf8 => "extcall", 0xf9 => "extdelegatecall", 0xfa => "staticcall",
-    0xfb => "extstaticcall", 0xfd => "revert", 0xfe => "invalid", 0xff => "selfdestruct",
-}
-
 /// Generic metadata carried by instructions and terminators.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EvmIrMetadata {

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -64,11 +64,15 @@ fn display_instruction<'a>(
                 inst.operands.iter().map(|operand| display_operand(module, operand)).format(", ")
             )?;
         }
-        write!(
-            f,
-            "{}",
-            display_metadata(&inst.metadata, Some(default_instruction_stack_effect(inst)))
-        )
+        let default_stack = match &inst.kind {
+            EvmIrInstructionKind::Operation(_)
+                if inst.operands.is_empty() && inst.result.is_none() =>
+            {
+                None
+            }
+            _ => Some(default_instruction_stack_effect(inst)),
+        };
+        write!(f, "{}", display_metadata(&inst.metadata, default_stack))
     })
 }
 
@@ -81,6 +85,7 @@ fn display_terminator<'a>(
             EvmIrTerminatorKind::Fallthrough(target) => {
                 write!(f, "fallthrough {}", display_block_id(module, *target))?;
             }
+            EvmIrTerminatorKind::FallthroughNext => write!(f, "fallthrough_next")?,
             EvmIrTerminatorKind::Jump(target) => {
                 write!(f, "jump {}", display_block_id(module, *target))?;
             }

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -64,15 +64,11 @@ fn display_instruction<'a>(
                 inst.operands.iter().map(|operand| display_operand(module, operand)).format(", ")
             )?;
         }
-        let default_stack = match &inst.kind {
-            EvmIrInstructionKind::Operation(_)
-                if inst.operands.is_empty() && inst.result.is_none() =>
-            {
-                None
-            }
-            _ => Some(default_instruction_stack_effect(inst)),
-        };
-        write!(f, "{}", display_metadata(&inst.metadata, default_stack))
+        write!(
+            f,
+            "{}",
+            display_metadata(&inst.metadata, Some(default_instruction_stack_effect(inst)))
+        )
     })
 }
 

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -136,7 +136,7 @@ fn display_terminator<'a>(
                 write!(f, "selfdestruct {}", display_operand(module, recipient))?;
             }
             EvmIrTerminatorKind::RawOpcode(opcode) => {
-                if let Some(mnemonic) = opcode_mnemonic(*opcode) {
+                if let Some(mnemonic) = super::super::assembler::op::mnemonic(*opcode) {
                     write!(f, "terminal {mnemonic}")?;
                 } else {
                     write!(f, "terminal 0x{opcode:02x}")?;

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -136,7 +136,11 @@ fn display_terminator<'a>(
                 write!(f, "selfdestruct {}", display_operand(module, recipient))?;
             }
             EvmIrTerminatorKind::RawOpcode(opcode) => {
-                write!(f, "terminal 0x{opcode:02x}")?;
+                if let Some(mnemonic) = opcode_mnemonic(*opcode) {
+                    write!(f, "terminal {mnemonic}")?;
+                } else {
+                    write!(f, "terminal 0x{opcode:02x}")?;
+                }
             }
         }
         write!(

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -552,6 +552,7 @@ impl<'a> Parser<'a> {
     ) -> Result<Option<EvmIrTerminatorKind>, EvmIrParseError> {
         let kind = match mnemonic {
             "fallthrough" => EvmIrTerminatorKind::Fallthrough(self.parse_block_ref(block_labels)?),
+            "fallthrough_next" => EvmIrTerminatorKind::FallthroughNext,
             "jump" => EvmIrTerminatorKind::Jump(self.parse_block_ref(block_labels)?),
             "br" => {
                 let condition =

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -611,9 +611,19 @@ impl<'a> Parser<'a> {
                 EvmIrTerminatorKind::SelfDestruct { recipient }
             }
             "terminal" => {
-                let opcode = self.parse_uint_literal()?;
-                let Ok(opcode) = u8::try_from(opcode) else {
-                    return Err(self.error("raw terminal opcode must fit in one byte"));
+                self.skip_inline();
+                let opcode = if self.peek_char().is_some_and(|c| c.is_ascii_digit()) {
+                    let opcode = self.parse_uint_literal()?;
+                    let Ok(opcode) = u8::try_from(opcode) else {
+                        return Err(self.error("raw terminal opcode must fit in one byte"));
+                    };
+                    opcode
+                } else {
+                    let mnemonic = self.parse_ident()?;
+                    let Some(opcode) = opcode_by_mnemonic(mnemonic) else {
+                        return Err(self.error(format!("unknown terminal opcode `{mnemonic}`")));
+                    };
+                    opcode
                 };
                 EvmIrTerminatorKind::RawOpcode(opcode)
             }

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -620,7 +620,7 @@ impl<'a> Parser<'a> {
                     opcode
                 } else {
                     let mnemonic = self.parse_ident()?;
-                    let Some(opcode) = opcode_by_mnemonic(mnemonic) else {
+                    let Some(opcode) = super::super::assembler::op::from_mnemonic(mnemonic) else {
                         return Err(self.error(format!("unknown terminal opcode `{mnemonic}`")));
                     };
                     opcode

--- a/crates/codegen/src/backend/evm/ir/passes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes.rs
@@ -164,6 +164,7 @@ fn estimated_terminator_size(kind: &EvmIrTerminatorKind) -> usize {
         | EvmIrTerminatorKind::Invalid
         | EvmIrTerminatorKind::RawOpcode(_) => 1,
         EvmIrTerminatorKind::Fallthrough(_)
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Branch { .. }
         | EvmIrTerminatorKind::Switch { .. } => 0,
@@ -234,6 +235,7 @@ fn terminal_terminator_key(
 ) -> TerminalTerminatorKey {
     match kind {
         EvmIrTerminatorKind::Fallthrough(target) => TerminalTerminatorKey::Fallthrough(*target),
+        EvmIrTerminatorKind::FallthroughNext => TerminalTerminatorKey::FallthroughNext,
         EvmIrTerminatorKind::Jump(target) => TerminalTerminatorKey::Jump(*target),
         EvmIrTerminatorKind::Branch { condition, then_block, else_block } => {
             TerminalTerminatorKey::Branch {
@@ -283,6 +285,7 @@ struct TerminalInstructionKey {
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum TerminalTerminatorKey {
     Fallthrough(EvmIrBlockId),
+    FallthroughNext,
     Jump(EvmIrBlockId),
     Branch {
         condition: TerminalOperandKey,
@@ -377,6 +380,7 @@ fn visit_terminator_targets_mut(
         }
         EvmIrTerminatorKind::Return { .. }
         | EvmIrTerminatorKind::Revert { .. }
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid
         | EvmIrTerminatorKind::SelfDestruct { .. }

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -237,12 +237,6 @@ impl ModelStack {
 /// words the predecessor leaves, in order. The predecessor may leave additional
 /// words below them — a successor only names the prefix it consumes. The entry
 /// block must start from an empty stack.
-///
-/// Limitation: a *scheduled* operation has its operands cleared and does not
-/// record a stack effect, so its input arity is no longer recoverable from the
-/// instruction alone; such ops fall back to [`default_instruction_stack_effect`]
-/// (inputs = 0). This does not affect the cross-block check, which compares a
-/// successor's declared value identities against the predecessor's exit words.
 fn verify_stack_consistency(module: &EvmIrModule) -> Result<(), EvmIrVerifyError> {
     if let Some(entry) = module.entry_block
         && !module.blocks[entry].entry_stack.is_empty()
@@ -594,15 +588,6 @@ fn verify_instruction_shape(
             ));
         }
     } else {
-        if operandless_operation_needs_stack_metadata(inst) {
-            return Err(EvmIrVerifyError::in_block(
-                block_id,
-                format!(
-                    "operand-cleared instruction `{}` must declare an explicit stack effect",
-                    inst.mnemonic()
-                ),
-            ));
-        }
         for operand in &inst.operands {
             if !matches!(operand, EvmIrOperand::Value(_)) {
                 return Err(EvmIrVerifyError::in_block(
@@ -613,43 +598,6 @@ fn verify_instruction_shape(
         }
     }
     Ok(())
-}
-
-fn operandless_operation_needs_stack_metadata(inst: &EvmIrInstruction) -> bool {
-    inst.operands.is_empty()
-        && inst.metadata.stack.is_none()
-        && matches!(
-            &inst.kind,
-            EvmIrInstructionKind::Operation(mnemonic)
-                if !(inst.result.is_some() && is_zero_input_operation(mnemonic))
-        )
-}
-
-fn is_zero_input_operation(mnemonic: &str) -> bool {
-    matches!(
-        mnemonic,
-        "address"
-            | "origin"
-            | "caller"
-            | "callvalue"
-            | "calldatasize"
-            | "codesize"
-            | "gasprice"
-            | "coinbase"
-            | "timestamp"
-            | "number"
-            | "prevrandao"
-            | "difficulty"
-            | "gaslimit"
-            | "chainid"
-            | "selfbalance"
-            | "basefee"
-            | "blobbasefee"
-            | "returndatasize"
-            | "msize"
-            | "gas"
-            | "pc"
-    )
 }
 
 fn verify_terminator_shape(

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -588,6 +588,22 @@ fn verify_instruction_shape(
             ));
         }
     } else {
+        if inst.operands.is_empty()
+            && inst.metadata.stack.is_none()
+            && matches!(
+                &inst.kind,
+                EvmIrInstructionKind::Operation(mnemonic)
+                    if opcode_stack_effect(mnemonic).is_none()
+            )
+        {
+            return Err(EvmIrVerifyError::in_block(
+                block_id,
+                format!(
+                    "operand-cleared instruction `{}` must declare an explicit stack effect",
+                    inst.mnemonic()
+                ),
+            ));
+        }
         for operand in &inst.operands {
             if !matches!(operand, EvmIrOperand::Value(_)) {
                 return Err(EvmIrVerifyError::in_block(

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -510,6 +510,7 @@ fn consume_stack_value(
 fn terminator_name(kind: &EvmIrTerminatorKind) -> &'static str {
     match kind {
         EvmIrTerminatorKind::Fallthrough(_) => "fallthrough",
+        EvmIrTerminatorKind::FallthroughNext => "fallthrough_next",
         EvmIrTerminatorKind::Jump(_) => "jump",
         EvmIrTerminatorKind::Branch { .. } => "br",
         EvmIrTerminatorKind::Switch { .. } => "switch",
@@ -679,6 +680,7 @@ fn verify_terminator_shape(
             verify_stack_value_operand(block_id, recipient, "selfdestruct recipient")?
         }
         EvmIrTerminatorKind::Fallthrough(_)
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid
@@ -766,6 +768,7 @@ fn visit_terminator_operands<E>(
 ) -> Result<(), E> {
     match kind {
         EvmIrTerminatorKind::Fallthrough(_)
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid
@@ -807,6 +810,7 @@ fn visit_terminator_targets<E>(
         }
         EvmIrTerminatorKind::Return { .. }
         | EvmIrTerminatorKind::Revert { .. }
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid
         | EvmIrTerminatorKind::SelfDestruct { .. }

--- a/crates/codegen/src/backend/evm/ir_stack_schedule.rs
+++ b/crates/codegen/src/backend/evm/ir_stack_schedule.rs
@@ -882,6 +882,7 @@ fn block_successors(block: &EvmIrBlock) -> Vec<EvmIrBlockId> {
         }
         EvmIrTerminatorKind::Return { .. }
         | EvmIrTerminatorKind::Revert { .. }
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid
         | EvmIrTerminatorKind::SelfDestruct { .. }
@@ -948,6 +949,7 @@ fn terminator_arrange_operands(kind: &EvmIrTerminatorKind) -> Vec<EvmIrValueId> 
         }
         EvmIrTerminatorKind::SelfDestruct { recipient } => push(recipient),
         EvmIrTerminatorKind::Fallthrough(_)
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid
@@ -976,6 +978,7 @@ fn visit_terminator_value_operands(
         }
         EvmIrTerminatorKind::SelfDestruct { recipient } => visit(recipient),
         EvmIrTerminatorKind::Fallthrough(_)
+        | EvmIrTerminatorKind::FallthroughNext
         | EvmIrTerminatorKind::Jump(_)
         | EvmIrTerminatorKind::Stop
         | EvmIrTerminatorKind::Invalid

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -184,16 +184,20 @@ str_enum! {
         BinRuntime,
         /// Function signature hashes.
         Hashes,
-        /// Textual MIR (mid-level IR) for inspection and FileCheck-style tests.
+        /// Textual Mid-Level IR.
         Mir,
+        /// Creation EVM IR.
+        EvmIr,
+        /// Runtime EVM IR.
+        EvmIrRuntime,
     }
 }
 
 impl CompilerOutput {
     /// Returns `true` for outputs produced by the codegen backend (which lowers
-    /// to MIR), i.e. `bin`, `bin-runtime`, and `mir`.
+    /// to MIR), i.e. bytecode, EVM IR, and MIR outputs.
     pub fn is_codegen(self) -> bool {
-        matches!(self, Self::Bin | Self::BinRuntime | Self::Mir)
+        matches!(self, Self::Bin | Self::BinRuntime | Self::EvmIr | Self::EvmIrRuntime | Self::Mir)
     }
 }
 

--- a/tests/ui/cli/help.long.stdout
+++ b/tests/ui/cli/help.long.stdout
@@ -53,7 +53,7 @@ Options:
       --emit <EMIT>
           Comma separated list of types of output for the compiler to emit
           
-          [possible values: abi, bin, bin-runtime, evm-ir, evm-ir-runtime, hashes, mir]
+          [possible values: abi, bin, bin-runtime, hashes, mir, evm-ir, evm-ir-runtime]
 
       --standard-json
           Switch to Standard JSON input/output mode

--- a/tests/ui/cli/help.long.stdout
+++ b/tests/ui/cli/help.long.stdout
@@ -53,7 +53,7 @@ Options:
       --emit <EMIT>
           Comma separated list of types of output for the compiler to emit
           
-          [possible values: abi, bin, bin-runtime, hashes, mir]
+          [possible values: abi, bin, bin-runtime, evm-ir, evm-ir-runtime, hashes, mir]
 
       --standard-json
           Switch to Standard JSON input/output mode

--- a/tests/ui/cli/help.short.stdout
+++ b/tests/ui/cli/help.short.stdout
@@ -18,7 +18,7 @@ Options:
   -O, --optimize <OPTIMIZATION>    MIR optimization objective [default: gas] [possible values: none, gas, size]
       --libraries <NAME=ADDRESS>   Library addresses for linking, as `LibraryName=0xADDRESS`
       --out-dir <OUT_DIR>          Directory to write output files
-      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, hashes, mir]
+      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, evm-ir, evm-ir-runtime, hashes, mir]
       --standard-json              Switch to Standard JSON input/output mode
   -Z <FLAG>                        Unstable flags. WARNING: these are completely unstable, and may change at any time
   -h, --help                       Print help (see more with '--help')

--- a/tests/ui/cli/help.short.stdout
+++ b/tests/ui/cli/help.short.stdout
@@ -18,7 +18,7 @@ Options:
   -O, --optimize <OPTIMIZATION>    MIR optimization objective [default: gas] [possible values: none, gas, size]
       --libraries <NAME=ADDRESS>   Library addresses for linking, as `LibraryName=0xADDRESS`
       --out-dir <OUT_DIR>          Directory to write output files
-      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, evm-ir, evm-ir-runtime, hashes, mir]
+      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, hashes, mir, evm-ir, evm-ir-runtime]
       --standard-json              Switch to Standard JSON input/output mode
   -Z <FLAG>                        Unstable flags. WARNING: these are completely unstable, and may change at any time
   -h, --help                       Print help (see more with '--help')

--- a/tests/ui/codegen/abi_encode_packed_calldata_slice.sol
+++ b/tests/ui/codegen/abi_encode_packed_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // `abi.encodePacked(...)` may include a slice of a `bytes`/`string` calldata
 // value, `data[start:end]` (open bounds default to `0`/`data.length`). The

--- a/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
+++ b/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
@@ -2,392 +2,392 @@
 bb0 (entry):
   push 384
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xd07523
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x2a5dea89
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 96
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 68
-  calldataload
-  sub
+  calldataload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 320
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 192
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup3
-  mload
+  mload !meta(stack=0->0)
   swap3
   pop
   dup3
   dup3
   dup3
-  mcopy
+  mcopy !meta(stack=0->0)
   swap1
   pop
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   fallthrough bb3
 bb3:
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 4
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   push 36
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup3
-  sub
+  sub !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  add
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup3
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 320
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 256
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 0x7000000000000000000000000000000000000000000000000000000000000000
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup4
-  mload
+  mload !meta(stack=0->0)
   swap4
   pop
   dup4
   dup4
   dup3
-  mcopy
+  mcopy !meta(stack=0->0)
   swap2
   pop
   dup3
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   swap2
   pop
   push 1
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   swap1
-  add
+  add !meta(stack=0->0)
   dup2
   swap1
-  sub
+  sub !meta(stack=0->0)
   swap1
   jump bb3
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 65
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
+++ b/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
@@ -1,1 +1,393 @@
-{"contracts":{"ROOT/tests/ui/codegen/abi_encode_packed_calldata_slice.sol:AbiEncodePackedCalldataSlice":{"bin-runtime":"61018060405234602b573615602b575f3560e01c8062d0752314602f5780632a5dea891461011457602b565b5f80fd5b366004900360609012602b575f608052602460043501602435604435038060a05260243582018060e05291508160e052601f81018061012052818060a052901091505061020757601f19610120511680610140521561014051602082828203029050018060c05290508060c052602081018061010052818060c0529010905061020757604051610100518061010052810160405260a0518060a052815260208101602060c0510381015f81525060a0518060a05260e0518060e0528237604051825192508282825e9050818101915080610160529003610160515b2060805260206080f35b366004900360409012602b575f6080526004600435013560246004350160243582038060a05291508160a05260243590018060c052601f82018061012052828060a052901091505061020757601f1961012051168061014052156101405160208282820302905001806101005290508061010052602081018060e052818061010052901090506102075760405160e0518060e052810160405260a0518060a0528152602081016020610100510381015f81525060a0518060a05260c0518060c0528237604051607060f81b815260018101835193508383825e91508282019150915060018152602090018190039061010a565b634e487b7160e01b5f52604160045260245ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/abi_encode_packed_calldata_slice.sol:AbiEncodePackedCalldataSlice (runtime) ===
+bb0 (entry):
+  push 384
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xd07523
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0x2a5dea89
+  eq
+  push bb4
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 96
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 36
+  push 4
+  calldataload
+  add
+  push 36
+  calldataload
+  push 68
+  calldataload
+  sub
+  dup1
+  push 160
+  mstore
+  push 36
+  calldataload
+  dup3
+  add
+  dup1
+  push 224
+  mstore
+  swap2
+  pop
+  dup2
+  push 224
+  mstore
+  push 31
+  dup2
+  add
+  dup1
+  push 288
+  mstore
+  dup2
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  swap2
+  pop
+  pop
+  push bb5
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 288
+  mload
+  and
+  dup1
+  push 320
+  mstore
+  iszero
+  push 320
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 192
+  mstore
+  swap1
+  pop
+  dup1
+  push 192
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb5
+  jumpi
+  push 64
+  mload
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 192
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup3
+  calldatacopy
+  push 64
+  mload
+  dup3
+  mload
+  swap3
+  pop
+  dup3
+  dup3
+  dup3
+  mcopy
+  swap1
+  pop
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup1
+  push 352
+  mstore
+  swap1
+  sub
+  push 352
+  mload
+  fallthrough bb3
+bb3:
+  keccak256
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 4
+  push 4
+  calldataload
+  add
+  calldataload
+  push 36
+  push 4
+  calldataload
+  add
+  push 36
+  calldataload
+  dup3
+  sub
+  dup1
+  push 160
+  mstore
+  swap2
+  pop
+  dup2
+  push 160
+  mstore
+  push 36
+  calldataload
+  swap1
+  add
+  dup1
+  push 192
+  mstore
+  push 31
+  dup3
+  add
+  dup1
+  push 288
+  mstore
+  dup3
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  swap2
+  pop
+  pop
+  push bb5
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 288
+  mload
+  and
+  dup1
+  push 320
+  mstore
+  iszero
+  push 320
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 256
+  mstore
+  swap1
+  pop
+  dup1
+  push 256
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 256
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb5
+  jumpi
+  push 64
+  mload
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 256
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup3
+  calldatacopy
+  push 64
+  mload
+  push 0x7000000000000000000000000000000000000000000000000000000000000000
+  dup2
+  mstore
+  push 1
+  dup2
+  add
+  dup4
+  mload
+  swap4
+  pop
+  dup4
+  dup4
+  dup3
+  mcopy
+  swap2
+  pop
+  dup3
+  dup3
+  add
+  swap2
+  pop
+  swap2
+  pop
+  push 1
+  dup2
+  mstore
+  push 32
+  swap1
+  add
+  dup2
+  swap1
+  sub
+  swap1
+  jump bb3
+bb5:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 65
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
+++ b/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
@@ -2,392 +2,392 @@
 bb0 (entry):
   push 384
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xd07523
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x2a5dea89
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 96
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 68
-  calldataload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  calldataload
+  sub
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup2
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 320
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 192
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup3
-  mload !meta(stack=0->0)
+  mload
   swap3
   pop
   dup3
   dup3
   dup3
-  mcopy !meta(stack=0->0)
+  mcopy
   swap1
   pop
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 352
-  mload !meta(stack=0->0)
+  mload
   fallthrough bb3
 bb3:
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   push 36
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup3
-  sub !meta(stack=0->0)
+  sub
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup2
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  add !meta(stack=0->0)
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup3
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 320
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 256
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 0x7000000000000000000000000000000000000000000000000000000000000000
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup4
-  mload !meta(stack=0->0)
+  mload
   swap4
   pop
   dup4
   dup4
   dup3
-  mcopy !meta(stack=0->0)
+  mcopy
   swap2
   pop
   dup3
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   swap2
   pop
   push 1
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   swap1
-  add !meta(stack=0->0)
+  add
   dup2
   swap1
-  sub !meta(stack=0->0)
+  sub
   swap1
   jump bb3
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 65
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/abi_packed_calldata_bytes.sol
+++ b/tests/ui/codegen/abi_packed_calldata_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // `abi.encodePacked(...)` may include a `bytes`/`string` calldata argument,
 // which is packed as its raw data (no length prefix, no padding). The calldata

--- a/tests/ui/codegen/abi_packed_calldata_bytes.stdout
+++ b/tests/ui/codegen/abi_packed_calldata_bytes.stdout
@@ -2,359 +2,359 @@
 bb0 (entry):
   push 352
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x21bd63cb
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xf1245422
-  eq
+  eq !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb3
   jump bb8
 bb3:
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 288
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 224
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup3
-  mload
+  mload !meta(stack=0->0)
   swap3
   pop
   dup3
   dup3
   dup3
-  mcopy
+  mcopy !meta(stack=0->0)
   swap1
   pop
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   fallthrough bb4
 bb4:
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb5:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb6
   jump bb8
 bb6:
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 288
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 192
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 0x7072650000000000000000000000000000000000000000000000000000000000
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 3
   dup2
-  add
+  add !meta(stack=0->0)
   dup4
-  mload
+  mload !meta(stack=0->0)
   swap4
   pop
   dup4
   dup4
   dup3
-  mcopy
+  mcopy !meta(stack=0->0)
   swap2
   pop
   dup3
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   swap2
   pop
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 96
-  shl
+  shl !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 20
   swap1
-  add
+  add !meta(stack=0->0)
   dup2
   swap1
-  sub
+  sub !meta(stack=0->0)
   swap1
   jump bb4
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 65
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb8:
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 4
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   swap1

--- a/tests/ui/codegen/abi_packed_calldata_bytes.stdout
+++ b/tests/ui/codegen/abi_packed_calldata_bytes.stdout
@@ -2,359 +2,359 @@
 bb0 (entry):
   push 352
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x21bd63cb
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xf1245422
-  eq !meta(stack=0->0)
+  eq
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb3
   jump bb8
 bb3:
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 224
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup3
-  mload !meta(stack=0->0)
+  mload
   swap3
   pop
   dup3
   dup3
   dup3
-  mcopy !meta(stack=0->0)
+  mcopy
   swap1
   pop
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 320
-  mload !meta(stack=0->0)
+  mload
   fallthrough bb4
 bb4:
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb5:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb6
   jump bb8
 bb6:
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 192
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 0x7072650000000000000000000000000000000000000000000000000000000000
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 3
   dup2
-  add !meta(stack=0->0)
+  add
   dup4
-  mload !meta(stack=0->0)
+  mload
   swap4
   pop
   dup4
   dup4
   dup3
-  mcopy !meta(stack=0->0)
+  mcopy
   swap2
   pop
   dup3
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   swap2
   pop
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 96
-  shl !meta(stack=0->0)
+  shl
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 20
   swap1
-  add !meta(stack=0->0)
+  add
   dup2
   swap1
-  sub !meta(stack=0->0)
+  sub
   swap1
   jump bb4
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 65
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb8:
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   swap1

--- a/tests/ui/codegen/abi_packed_calldata_bytes.stdout
+++ b/tests/ui/codegen/abi_packed_calldata_bytes.stdout
@@ -1,1 +1,361 @@
-{"contracts":{"ROOT/tests/ui/codegen/abi_packed_calldata_bytes.sol:P":{"bin-runtime":"61016060405234602b573615602b575f3560e01c806321bd63cb14602f578063f12454221460ed57602b565b5f80fd5b366004900360409012602b5760426101d0565b6101bc57601f19610100511680610120521561012051602082828203029050018060e05290508060e052602081018060c052818060e052901090506101bc5760405160c0518060c052810160405260a0518060a052815260208101602060e0510381015f81525060246004350160a0518060a05281833750604051825192508282825e90508181019150602435825260208201915080610140529003610140515b2060805260206080f35b366004900360409012602b576024355f1960601c811603602b5761010f6101d0565b6101bc57601f19610100511680610120521561012051602082828203029050018060c05290508060c052602081018060e052818060c052901090506101bc5760405160e0518060e052810160405260a0518060a052815260208101602060c0510381015f81525060246004350160a0518060a052818337506040516270726560e81b815260038101835193508383825e91508282019150915060243560601b8152601490018190039060e3565b634e487b7160e01b5f52604160045260245ffd5b5f608052600460043501358060a052601f81018061010052818060a052901090509056"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/abi_packed_calldata_bytes.sol:P (runtime) ===
+bb0 (entry):
+  push 352
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x21bd63cb
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0xf1245422
+  eq
+  push bb5
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push bb3
+  jump bb8
+bb3:
+  push bb7
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 256
+  mload
+  and
+  dup1
+  push 288
+  mstore
+  iszero
+  push 288
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 224
+  mstore
+  swap1
+  pop
+  dup1
+  push 224
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 192
+  mstore
+  dup2
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb7
+  jumpi
+  push 64
+  mload
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 224
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 4
+  calldataload
+  add
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  push 64
+  mload
+  dup3
+  mload
+  swap3
+  pop
+  dup3
+  dup3
+  dup3
+  mcopy
+  swap1
+  pop
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  push 36
+  calldataload
+  dup3
+  mstore
+  push 32
+  dup3
+  add
+  swap2
+  pop
+  dup1
+  push 320
+  mstore
+  swap1
+  sub
+  push 320
+  mload
+  fallthrough bb4
+bb4:
+  keccak256
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb5:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push bb6
+  jump bb8
+bb6:
+  push bb7
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 256
+  mload
+  and
+  dup1
+  push 288
+  mstore
+  iszero
+  push 288
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 192
+  mstore
+  swap1
+  pop
+  dup1
+  push 192
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb7
+  jumpi
+  push 64
+  mload
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 192
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 4
+  calldataload
+  add
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  push 64
+  mload
+  push 0x7072650000000000000000000000000000000000000000000000000000000000
+  dup2
+  mstore
+  push 3
+  dup2
+  add
+  dup4
+  mload
+  swap4
+  pop
+  dup4
+  dup4
+  dup3
+  mcopy
+  swap2
+  pop
+  dup3
+  dup3
+  add
+  swap2
+  pop
+  swap2
+  pop
+  push 36
+  calldataload
+  push 96
+  shl
+  dup2
+  mstore
+  push 20
+  swap1
+  add
+  dup2
+  swap1
+  sub
+  swap1
+  jump bb4
+bb7:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 65
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb8:
+  push 0
+  push 128
+  mstore
+  push 4
+  push 4
+  calldataload
+  add
+  calldataload
+  dup1
+  push 160
+  mstore
+  push 31
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  swap1
+  terminal jump

--- a/tests/ui/codegen/assembler_block_dedup.sol
+++ b/tests/ui/codegen/assembler_block_dedup.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin-runtime --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime --pretty-json
 contract AssemblerBlockDedup {
     function a() public pure returns (uint256) {
         return 1;

--- a/tests/ui/codegen/assembler_block_dedup.stdout
+++ b/tests/ui/codegen/assembler_block_dedup.stdout
@@ -2,38 +2,38 @@
 bb0 (entry):
   push 192
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xdbe671f
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x4df7e3d0
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x5ce8bda8
-  eq
+  eq !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xfeb97429
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -44,64 +44,64 @@ bb2:
   fallthrough bb3
 bb3:
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  iszero
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 160
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   fallthrough bb5
 bb5:
   push 2
   jump bb3
 bb6:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  iszero
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 160
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb5

--- a/tests/ui/codegen/assembler_block_dedup.stdout
+++ b/tests/ui/codegen/assembler_block_dedup.stdout
@@ -1,8 +1,107 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/assembler_block_dedup.sol:AssemblerBlockDedup": {
-      "bin-runtime": "60c060405234603e573615603e575f3560e01c80630dbe671f1460425780634df7e3d01460425780635ce8bda8146077578063feb9742914604e57603e565b5f80fd5b60015b60805260206080f35b366004900360209012603e576004358060a052151560a05103603e57600435603e575b60026045565b366004900360209012603e576004358060a052151560a05103603e57600435603e57607156"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/assembler_block_dedup.sol:AssemblerBlockDedup (runtime) ===
+bb0 (entry):
+  push 192
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xdbe671f
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0x4df7e3d0
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0x5ce8bda8
+  eq
+  push bb6
+  jumpi
+  dup1
+  push 0xfeb97429
+  eq
+  push bb4
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 1
+  fallthrough bb3
+bb3:
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  dup1
+  push 160
+  mstore
+  iszero
+  iszero
+  push 160
+  mload
+  sub
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push bb1
+  jumpi
+  fallthrough bb5
+bb5:
+  push 2
+  jump bb3
+bb6:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  dup1
+  push 160
+  mstore
+  iszero
+  iszero
+  push 160
+  mload
+  sub
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push bb1
+  jumpi
+  jump bb5

--- a/tests/ui/codegen/assembler_block_dedup.stdout
+++ b/tests/ui/codegen/assembler_block_dedup.stdout
@@ -2,38 +2,38 @@
 bb0 (entry):
   push 192
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xdbe671f
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x4df7e3d0
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x5ce8bda8
-  eq !meta(stack=0->0)
+  eq
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xfeb97429
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -44,64 +44,64 @@ bb2:
   fallthrough bb3
 bb3:
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
+  iszero
   push 160
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   fallthrough bb5
 bb5:
   push 2
   jump bb3
 bb6:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
+  iszero
   push 160
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb5

--- a/tests/ui/codegen/calldata_array_to_memory.sol
+++ b/tests/ui/codegen/calldata_array_to_memory.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // A calldata dynamic array converted to memory (declaration initializer,
 // assignment, or a struct-literal field) must materialize as a

--- a/tests/ui/codegen/calldata_array_to_memory.stdout
+++ b/tests/ui/codegen/calldata_array_to_memory.stdout
@@ -2,38 +2,38 @@
 bb0 (entry):
   push 672
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x2be02e45
-  eq
+  eq !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x3ce9e381
-  eq
+  eq !meta(stack=0->0)
   push bb10
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x7da1365e
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x874b8e9d
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -41,205 +41,205 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload
+  sload !meta(stack=0->0)
   fallthrough bb3
 bb3:
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 4
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 251
-  shr
+  shr !meta(stack=0->0)
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup2
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup4
   dup1
   push 352
-  mstore
-  calldatacopy
+  mstore !meta(stack=0->0)
+  calldatacopy !meta(stack=0->0)
   pop
   swap2
   pop
   push 0
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   pop
   pop
   push 0
   jump bb5
 bb5:
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   jump bb3
 bb6:
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 448
-  mload
-  lt
-  iszero
+  mload !meta(stack=0->0)
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
-  add
-  mload
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 512
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   push 1
   dup2
   dup1
   push 480
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -247,370 +247,370 @@ bb6:
   pop
   pop
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   jump bb5
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 50
   fallthrough bb8
 bb8:
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb9:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 4
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 251
-  shr
+  shr !meta(stack=0->0)
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup2
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 36
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   pop
   swap1
   pop
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   jump bb3
 bb10:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 96
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 96
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 36
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 251
-  shr
+  shr !meta(stack=0->0)
   swap1
   pop
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup2
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 36
   push 36
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   pop
   swap1
   pop
   push 32
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 4
   push 68
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 544
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 640
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 640
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 512
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 68
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   pop
   push 64
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
-  mload
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 10
   dup2
   dup1
   push 608
-  mstore
-  mul
+  mstore !meta(stack=0->0)
+  mul !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 10
   dup2
-  div
+  div !meta(stack=0->0)
   dup3
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -620,98 +620,98 @@ bb10:
   swap2
   pop
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
-  mload
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 100
   dup2
   dup1
   push 576
-  mstore
-  mul
+  mstore !meta(stack=0->0)
+  mul !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 100
   dup2
-  div
+  div !meta(stack=0->0)
   dup3
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap2
   pop
   dup2
   swap2
   pop
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   jump bb3
 bb11:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 65
   jump bb8
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   jump bb8

--- a/tests/ui/codegen/calldata_array_to_memory.stdout
+++ b/tests/ui/codegen/calldata_array_to_memory.stdout
@@ -2,38 +2,38 @@
 bb0 (entry):
   push 672
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x2be02e45
-  eq !meta(stack=0->0)
+  eq
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x3ce9e381
-  eq !meta(stack=0->0)
+  eq
   push bb10
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x7da1365e
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x874b8e9d
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -41,205 +41,205 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload !meta(stack=0->0)
+  sload
   fallthrough bb3
 bb3:
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 251
-  shr !meta(stack=0->0)
+  shr
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup2
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup4
   dup2
   dup4
   dup1
   push 352
-  mstore !meta(stack=0->0)
-  calldatacopy !meta(stack=0->0)
+  mstore
+  calldatacopy
   pop
   swap2
   pop
   push 0
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   pop
   pop
   push 0
   jump bb5
 bb5:
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   jump bb3
 bb6:
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 448
-  mload !meta(stack=0->0)
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mload
+  lt
+  iszero
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  add
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 512
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup2
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   push 1
   dup2
   dup1
   push 480
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -247,370 +247,370 @@ bb6:
   pop
   pop
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   jump bb5
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 50
   fallthrough bb8
 bb8:
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb9:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 251
-  shr !meta(stack=0->0)
+  shr
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup2
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 36
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup4
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   pop
   swap1
   pop
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   jump bb3
 bb10:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 96
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 96
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 251
-  shr !meta(stack=0->0)
+  shr
   swap1
   pop
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup2
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 36
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup4
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   pop
   swap1
   pop
   push 32
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 4
   push 68
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 544
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 640
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 640
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 512
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 68
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   pop
   push 64
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
+  mload
   push 10
   dup2
   dup1
   push 608
-  mstore !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  mstore
+  mul
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 10
   dup2
-  div !meta(stack=0->0)
+  div
   dup3
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap2
   pop
   dup2
@@ -620,98 +620,98 @@ bb10:
   swap2
   pop
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
+  mload
   push 100
   dup2
   dup1
   push 576
-  mstore !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  mstore
+  mul
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 100
   dup2
-  div !meta(stack=0->0)
+  div
   dup3
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap2
   pop
   dup2
   swap2
   pop
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   jump bb3
 bb11:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 65
   jump bb8
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   jump bb8

--- a/tests/ui/codegen/calldata_array_to_memory.stdout
+++ b/tests/ui/codegen/calldata_array_to_memory.stdout
@@ -1,1 +1,717 @@
-{"contracts":{"ROOT/tests/ui/codegen/calldata_array_to_memory.sol:C":{"bin-runtime":"6102a06040523460415736156041575f3560e01c80632be02e451461019c5780633ce9e3811461020c5780637da1365e146045578063874b8e9d146051576041565b5f80fd5b5f545b60805260206080f35b3660049003602090126041575f608052600460043501358060e05260fb1c6103f95760e0518060e05260051b602081016040518061010052818101915081604052905060e0518060e05281526020810180610160526024600435018381838061016052375091505f60a0525f60c05250505f60c7565b61010051806101005251901060ed5760a051806101a0525f556101a051806101a0526048565b60c051806101c05260051b8061018052610100518061010052516101c051101561018657806101805261016051015160a051818061022052818061020052018061014052915081610140528061020052901061040a5761014051806101405260a05260c051600181806101e05201806101205281806101e052811091508191505061040a5761012051806101205260c0526101205160c7565b634e487b7160e01b5f525060325b60045260245ffd5b3660049003602090126041575f6080525f60a052600460043501358060c05260fb1c6103f95760c0518060c05260051b60208101604051818101915081604052905060c0518060c05281526020810160246004350183818337505090508060e05260a05260e0518060e052516048565b3660049003606090126041575f6080526040518060e052606081016040526004358152600460243501358060a05260fb1c90506103f95760a0518060a05260051b60208101604051818101915081604052905060a0518060a0528152602081016024602435018381833750509050602060e05101806101c0528181529050600460443501358060c052601f81018061022052818060c05290109150506103f957601f196102205116806102805215610280516020828282030290500180610200529050806102005260208101806101a052818061020052901090506103f9576040516101a051806101a052810160405260c0518060c0528152602081016020610200510381015f81525060246044350160c0518060c0528183375050604060e051018061014052818152905060e0518060e0525180610120526101c051806101c0525151600a81806102605202806101e052600a810482806102605290149150819150509150501561040a576101e051806101e05261012051018061010052610120518061012052901061040a57610140518061014052515160648180610240520280610180526064810482806102405290149150819150501561040a5761018051806101805261010051018061016052610100518061010052901061040a576101605180610160526048565b634e487b7160e01b5f526041610194565b634e487b7160e01b5f52601161019456"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/calldata_array_to_memory.sol:C (runtime) ===
+bb0 (entry):
+  push 672
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x2be02e45
+  eq
+  push bb9
+  jumpi
+  dup1
+  push 0x3ce9e381
+  eq
+  push bb10
+  jumpi
+  dup1
+  push 0x7da1365e
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0x874b8e9d
+  eq
+  push bb4
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  sload
+  fallthrough bb3
+bb3:
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 4
+  push 4
+  calldataload
+  add
+  calldataload
+  dup1
+  push 224
+  mstore
+  push 251
+  shr
+  push bb11
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  push 5
+  shl
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 352
+  mstore
+  push 36
+  push 4
+  calldataload
+  add
+  dup4
+  dup2
+  dup4
+  dup1
+  push 352
+  mstore
+  calldatacopy
+  pop
+  swap2
+  pop
+  push 0
+  push 160
+  mstore
+  push 0
+  push 192
+  mstore
+  pop
+  pop
+  push 0
+  jump bb5
+bb5:
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  mload
+  swap1
+  lt
+  push bb6
+  jumpi
+  push 160
+  mload
+  dup1
+  push 416
+  mstore
+  push 0
+  sstore
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  jump bb3
+bb6:
+  push 192
+  mload
+  dup1
+  push 448
+  mstore
+  push 5
+  shl
+  dup1
+  push 384
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  mload
+  push 448
+  mload
+  lt
+  iszero
+  push bb7
+  jumpi
+  dup1
+  push 384
+  mstore
+  push 352
+  mload
+  add
+  mload
+  push 160
+  mload
+  dup2
+  dup1
+  push 544
+  mstore
+  dup2
+  dup1
+  push 512
+  mstore
+  add
+  dup1
+  push 320
+  mstore
+  swap2
+  pop
+  dup2
+  push 320
+  mstore
+  dup1
+  push 512
+  mstore
+  swap1
+  lt
+  push bb12
+  jumpi
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  push 160
+  mstore
+  push 192
+  mload
+  push 1
+  dup2
+  dup1
+  push 480
+  mstore
+  add
+  dup1
+  push 288
+  mstore
+  dup2
+  dup1
+  push 480
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb12
+  jumpi
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  push 192
+  mstore
+  push 288
+  mload
+  jump bb5
+bb7:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  pop
+  push 50
+  fallthrough bb8
+bb8:
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb9:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 0
+  push 160
+  mstore
+  push 4
+  push 4
+  calldataload
+  add
+  calldataload
+  dup1
+  push 192
+  mstore
+  push 251
+  shr
+  push bb11
+  jumpi
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  push 5
+  shl
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 36
+  push 4
+  calldataload
+  add
+  dup4
+  dup2
+  dup4
+  calldatacopy
+  pop
+  pop
+  swap1
+  pop
+  dup1
+  push 224
+  mstore
+  push 160
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  jump bb3
+bb10:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 96
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 64
+  mload
+  dup1
+  push 224
+  mstore
+  push 96
+  dup2
+  add
+  push 64
+  mstore
+  push 4
+  calldataload
+  dup2
+  mstore
+  push 4
+  push 36
+  calldataload
+  add
+  calldataload
+  dup1
+  push 160
+  mstore
+  push 251
+  shr
+  swap1
+  pop
+  push bb11
+  jumpi
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  push 5
+  shl
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 36
+  push 36
+  calldataload
+  add
+  dup4
+  dup2
+  dup4
+  calldatacopy
+  pop
+  pop
+  swap1
+  pop
+  push 32
+  push 224
+  mload
+  add
+  dup1
+  push 448
+  mstore
+  dup2
+  dup2
+  mstore
+  swap1
+  pop
+  push 4
+  push 68
+  calldataload
+  add
+  calldataload
+  dup1
+  push 192
+  mstore
+  push 31
+  dup2
+  add
+  dup1
+  push 544
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  swap2
+  pop
+  pop
+  push bb11
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 544
+  mload
+  and
+  dup1
+  push 640
+  mstore
+  iszero
+  push 640
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 512
+  mstore
+  swap1
+  pop
+  dup1
+  push 512
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 416
+  mstore
+  dup2
+  dup1
+  push 512
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb11
+  jumpi
+  push 64
+  mload
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 512
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 68
+  calldataload
+  add
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  pop
+  push 64
+  push 224
+  mload
+  add
+  dup1
+  push 320
+  mstore
+  dup2
+  dup2
+  mstore
+  swap1
+  pop
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  dup1
+  push 288
+  mstore
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  mload
+  mload
+  push 10
+  dup2
+  dup1
+  push 608
+  mstore
+  mul
+  dup1
+  push 480
+  mstore
+  push 10
+  dup2
+  div
+  dup3
+  dup1
+  push 608
+  mstore
+  swap1
+  eq
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  swap2
+  pop
+  pop
+  iszero
+  push bb12
+  jumpi
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  push 288
+  mload
+  add
+  dup1
+  push 256
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  push bb12
+  jumpi
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  mload
+  mload
+  push 100
+  dup2
+  dup1
+  push 576
+  mstore
+  mul
+  dup1
+  push 384
+  mstore
+  push 100
+  dup2
+  div
+  dup3
+  dup1
+  push 576
+  mstore
+  swap1
+  eq
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  iszero
+  push bb12
+  jumpi
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  push 256
+  mload
+  add
+  dup1
+  push 352
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  swap1
+  lt
+  push bb12
+  jumpi
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  jump bb3
+bb11:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 65
+  jump bb8
+bb12:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  jump bb8

--- a/tests/ui/codegen/cold_call_hot_fallthrough.sol
+++ b/tests/ui/codegen/cold_call_hot_fallthrough.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zno-mir-dispatch -O size --emit=bin-runtime --pretty-json
+//@compile-flags: -Zcodegen -Zno-mir-dispatch -O size --emit=evm-ir-runtime --pretty-json
 
 // Calls to the non-returning helper make their blocks cold. The backend should
 // lay out each successful continuation as the branch fallthrough.

--- a/tests/ui/codegen/cold_call_hot_fallthrough.stdout
+++ b/tests/ui/codegen/cold_call_hot_fallthrough.stdout
@@ -1,8 +1,153 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/cold_call_hot_fallthrough.sol:ColdCallHotFallthrough": {
-      "bin-runtime": "6101c06040523460315736156031575f3560e01c8063161e40291460355780634b692dff146063575f5ffd5bfe5b5f80fd5b5f5ffd5b366004900360209012602d575f608052600435156059575b60043560805260206080f35b5b604d6004356080565b366004900360209012602d575f608052606460043510605a57604d565b6101205261012051609b57602b6004637a65726f60e01b60de565b6001610120510360b457602b6003626f6e6560e81b60de565b6002610120510360cd57602b60036274776f60e81b60de565b602b6005646f7468657260d81b60de565b6101a052610180526308c379a060e01b5f526020600452610180516024526101a05160445260645ffd"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/cold_call_hot_fallthrough.sol:ColdCallHotFallthrough (runtime) ===
+bb0 (entry):
+  push 448
+  push 64
+  mstore
+  callvalue
+  push bb3
+  jumpi
+  calldatasize
+  iszero
+  push bb3
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x161e4029
+  eq
+  push bb4
+  jumpi
+  dup1
+  push 0x4b692dff
+  eq
+  push bb8
+  jumpi
+  push 0
+  push 0
+  terminal revert
+bb1:
+  terminal invalid
+bb2:
+  push 0
+  dup1
+  terminal revert
+bb3:
+  push 0
+  push 0
+  terminal revert
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb2
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 4
+  calldataload
+  iszero
+  push bb6
+  jumpi
+  fallthrough bb5
+bb5:
+  push 4
+  calldataload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb6:
+  fallthrough bb7
+bb7:
+  push bb5
+  push 4
+  calldataload
+  jump bb9
+bb8:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb2
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 100
+  push 4
+  calldataload
+  lt
+  push bb7
+  jumpi
+  jump bb5
+bb9:
+  push 288
+  mstore
+  push 288
+  mload
+  push bb10
+  jumpi
+  push bb1
+  push 4
+  push 0x7a65726f00000000000000000000000000000000000000000000000000000000
+  jump bb13
+bb10:
+  push 1
+  push 288
+  mload
+  sub
+  push bb11
+  jumpi
+  push bb1
+  push 3
+  push 0x6f6e650000000000000000000000000000000000000000000000000000000000
+  jump bb13
+bb11:
+  push 2
+  push 288
+  mload
+  sub
+  push bb12
+  jumpi
+  push bb1
+  push 3
+  push 0x74776f0000000000000000000000000000000000000000000000000000000000
+  jump bb13
+bb12:
+  push bb1
+  push 5
+  push 0x6f74686572000000000000000000000000000000000000000000000000000000
+  jump bb13
+bb13:
+  push 416
+  mstore
+  push 384
+  mstore
+  push 0x8c379a000000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 32
+  push 4
+  mstore
+  push 384
+  mload
+  push 36
+  mstore
+  push 416
+  mload
+  push 68
+  mstore
+  push 100
+  push 0
+  terminal revert

--- a/tests/ui/codegen/cold_call_hot_fallthrough.stdout
+++ b/tests/ui/codegen/cold_call_hot_fallthrough.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 448
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb3
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x161e4029
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x4b692dff
-  eq
+  eq !meta(stack=0->0)
   push bb8
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 0
   terminal revert
@@ -38,29 +38,29 @@ bb3:
   push 0
   terminal revert
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
-  iszero
+  calldataload !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   fallthrough bb5
 bb5:
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
@@ -69,35 +69,35 @@ bb6:
 bb7:
   push bb5
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   jump bb9
 bb8:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 100
   push 4
-  calldataload
-  lt
+  calldataload !meta(stack=0->0)
+  lt !meta(stack=0->0)
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb5
 bb9:
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push bb10
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb1
   push 4
   push 0x7a65726f00000000000000000000000000000000000000000000000000000000
@@ -105,10 +105,10 @@ bb9:
 bb10:
   push 1
   push 288
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb1
   push 3
   push 0x6f6e650000000000000000000000000000000000000000000000000000000000
@@ -116,10 +116,10 @@ bb10:
 bb11:
   push 2
   push 288
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb1
   push 3
   push 0x74776f0000000000000000000000000000000000000000000000000000000000
@@ -131,23 +131,23 @@ bb12:
   jump bb13
 bb13:
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 0x8c379a000000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   push 36
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   push 68
-  mstore
+  mstore !meta(stack=0->0)
   push 100
   push 0
   terminal revert

--- a/tests/ui/codegen/cold_call_hot_fallthrough.stdout
+++ b/tests/ui/codegen/cold_call_hot_fallthrough.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 448
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb3
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x161e4029
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x4b692dff
-  eq !meta(stack=0->0)
+  eq
   push bb8
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 0
   terminal revert
@@ -38,29 +38,29 @@ bb3:
   push 0
   terminal revert
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  calldataload
+  iszero
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   fallthrough bb5
 bb5:
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
@@ -69,35 +69,35 @@ bb6:
 bb7:
   push bb5
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   jump bb9
 bb8:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 100
   push 4
-  calldataload !meta(stack=0->0)
-  lt !meta(stack=0->0)
+  calldataload
+  lt
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb5
 bb9:
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   push bb10
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb1
   push 4
   push 0x7a65726f00000000000000000000000000000000000000000000000000000000
@@ -105,10 +105,10 @@ bb9:
 bb10:
   push 1
   push 288
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb1
   push 3
   push 0x6f6e650000000000000000000000000000000000000000000000000000000000
@@ -116,10 +116,10 @@ bb10:
 bb11:
   push 2
   push 288
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb1
   push 3
   push 0x74776f0000000000000000000000000000000000000000000000000000000000
@@ -131,23 +131,23 @@ bb12:
   jump bb13
 bb13:
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 0x8c379a000000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
+  mload
   push 36
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
+  mload
   push 68
-  mstore !meta(stack=0->0)
+  mstore
   push 100
   push 0
   terminal revert

--- a/tests/ui/codegen/constructor_internal_call_bin.sol
+++ b/tests/ui/codegen/constructor_internal_call_bin.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
 
 contract ConstructorInternalCallBin {
     uint256 public value;

--- a/tests/ui/codegen/constructor_internal_call_bin.stdout
+++ b/tests/ui/codegen/constructor_internal_call_bin.stdout
@@ -3,241 +3,242 @@
 bb0 (entry):
   push 0x4000
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 400
-  codesize
-  sub
+  codesize !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push 400
   push 128
-  codecopy
+  codecopy !meta(stack=0->0)
   jump bb6
 bb1:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   fallthrough bb2
 bb2:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   terminal jump
 bb3:
   push 11
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
-  mul
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mul !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 11
   dup2
-  div
+  div !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
-  sub
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb4
   jump bb1
 bb4:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 160
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 160
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 160
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   jump bb2
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb6:
   push 7
   push 128
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb7
   jump bb1
 bb7:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 0x1000
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup1
   push 0x1000
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
+  fallthrough_next
 
 // === deployment ===
 bb0 (entry):
@@ -245,7 +246,7 @@ bb0 (entry):
   dup1
   push 353
   push 0
-  codecopy
+  codecopy !meta(stack=0->0)
   push 0
   terminal return
 
@@ -253,23 +254,23 @@ bb0 (entry):
 bb0 (entry):
   push 160
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x3fa4f245
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -277,9 +278,9 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return

--- a/tests/ui/codegen/constructor_internal_call_bin.stdout
+++ b/tests/ui/codegen/constructor_internal_call_bin.stdout
@@ -3,241 +3,241 @@
 bb0 (entry):
   push 0x4000
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 400
-  codesize !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  codesize
+  sub
   push 400
   push 128
-  codecopy !meta(stack=0->0)
+  codecopy
   jump bb6
 bb1:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   fallthrough bb2
 bb2:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   terminal jump
 bb3:
   push 11
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  add
+  mload
+  mul
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 11
   dup2
-  div !meta(stack=0->0)
+  div
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  add
+  mload
+  sub
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb4
   jump bb1
 bb4:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 160
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 160
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 160
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   jump bb2
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb6:
   push 7
   push 128
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb7
   jump bb1
 bb7:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 0x1000
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup1
   push 0x1000
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   fallthrough_next
 
 // === deployment ===
@@ -246,7 +246,7 @@ bb0 (entry):
   dup1
   push 353
   push 0
-  codecopy !meta(stack=0->0)
+  codecopy
   push 0
   terminal return
 
@@ -254,23 +254,23 @@ bb0 (entry):
 bb0 (entry):
   push 160
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x3fa4f245
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -278,9 +278,9 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return

--- a/tests/ui/codegen/constructor_internal_call_bin.stdout
+++ b/tests/ui/codegen/constructor_internal_call_bin.stdout
@@ -1,8 +1,285 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/constructor_internal_call_bin.sol:ConstructorInternalCallBin": {
-      "bin": "6140006040526101903803610190608039610109565b60a0516080015f81525060a0516040015160355760015b60a05160600152565b600b60a05160400151028060a05160c001528060a05160c00152600b810460a05160400151901490501560f557600160a051604001510360405160a05181602001528181604001528060a0526101000160405250608f6015565b60a051606001518060a05160e0015260a05160405260a0516020015160a0528060a05160e001528060a05160e0015260a05160c00151018060a05160a001528060a05160a0015260a05160c001518060a05160c00152901060f55760a05160a00151602c565b634e487b7160e01b5f52601160045260245ffd5b60076080511660405160a05181602001528181604001528060a05261010001604052506101336015565b60a05160600151806110005260a05160405260a0516020015160a05280611000525f55602f806101615f395ff360a06040523460205736156020575f3560e01c80633fa4f245146024576020565b5f80fd5b5f5460805260206080f3"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/constructor_internal_call_bin.sol:ConstructorInternalCallBin (creation) ===
+// === constructor ===
+bb0 (entry):
+  push 0x4000
+  push 64
+  mstore
+  push 400
+  codesize
+  sub
+  push 400
+  push 128
+  codecopy
+  jump bb6
+bb1:
+  push 160
+  mload
+  push 128
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 160
+  mload
+  push 64
+  add
+  mload
+  push bb3
+  jumpi
+  push 1
+  fallthrough bb2
+bb2:
+  push 160
+  mload
+  push 96
+  add
+  mstore
+  terminal jump
+bb3:
+  push 11
+  push 160
+  mload
+  push 64
+  add
+  mload
+  mul
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  push 11
+  dup2
+  div
+  push 160
+  mload
+  push 64
+  add
+  mload
+  swap1
+  eq
+  swap1
+  pop
+  iszero
+  push bb5
+  jumpi
+  push 1
+  push 160
+  mload
+  push 64
+  add
+  mload
+  sub
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  dup2
+  dup2
+  push 64
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 256
+  add
+  push 64
+  mstore
+  pop
+  push bb4
+  jump bb1
+bb4:
+  push 160
+  mload
+  push 96
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  push 160
+  mload
+  push 64
+  mstore
+  push 160
+  mload
+  push 32
+  add
+  mload
+  push 160
+  mstore
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  push 160
+  mload
+  push 192
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 160
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 160
+  add
+  mstore
+  push 160
+  mload
+  push 192
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  swap1
+  lt
+  push bb5
+  jumpi
+  push 160
+  mload
+  push 160
+  add
+  mload
+  jump bb2
+bb5:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb6:
+  push 7
+  push 128
+  mload
+  and
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  dup2
+  dup2
+  push 64
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 256
+  add
+  push 64
+  mstore
+  pop
+  push bb7
+  jump bb1
+bb7:
+  push 160
+  mload
+  push 96
+  add
+  mload
+  dup1
+  push 0x1000
+  mstore
+  push 160
+  mload
+  push 64
+  mstore
+  push 160
+  mload
+  push 32
+  add
+  mload
+  push 160
+  mstore
+  dup1
+  push 0x1000
+  mstore
+  push 0
+  sstore
+
+// === deployment ===
+bb0 (entry):
+  push 47
+  dup1
+  push 353
+  push 0
+  codecopy
+  push 0
+  terminal return
+
+// === runtime ===
+bb0 (entry):
+  push 160
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x3fa4f245
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  sload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return

--- a/tests/ui/codegen/emit_abi_bin.bin.stdout
+++ b/tests/ui/codegen/emit_abi_bin.bin.stdout
@@ -1,0 +1,35 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/codegen/emit_abi_bin.sol:C": {
+      "abi": [
+        {
+          "type": "constructor",
+          "inputs": [
+            {
+              "name": "value",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "x",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        }
+      ],
+      "bin": "614000604052604c3803604c6080396080515f55602f80601d5f395ff360a06040523460205736156020575f3560e01c80630c55699c146024576020565b5f80fd5b5f5460805260206080f3",
+      "bin-runtime": "60a06040523460205736156020575f3560e01c80630c55699c146024576020565b5f80fd5b5f5460805260206080f3"
+    }
+  },
+  "version": "VERSION"
+}

--- a/tests/ui/codegen/emit_abi_bin.evmir.stdout
+++ b/tests/ui/codegen/emit_abi_bin.evmir.stdout
@@ -36,17 +36,18 @@
 bb0 (entry):
   push 0x4000
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 76
-  codesize
-  sub
+  codesize !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push 76
   push 128
-  codecopy
+  codecopy !meta(stack=0->0)
   push 128
-  mload
+  mload !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
+  fallthrough_next
 
 // === deployment ===
 bb0 (entry):
@@ -54,7 +55,7 @@ bb0 (entry):
   dup1
   push 29
   push 0
-  codecopy
+  codecopy !meta(stack=0->0)
   push 0
   terminal return
 
@@ -62,23 +63,23 @@ bb0 (entry):
 bb0 (entry):
   push 160
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xc55699c
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -86,9 +87,9 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
@@ -96,23 +97,23 @@ bb2:
 bb0 (entry):
   push 160
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xc55699c
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -120,9 +121,9 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return

--- a/tests/ui/codegen/emit_abi_bin.evmir.stdout
+++ b/tests/ui/codegen/emit_abi_bin.evmir.stdout
@@ -36,17 +36,17 @@
 bb0 (entry):
   push 0x4000
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 76
-  codesize !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  codesize
+  sub
   push 76
   push 128
-  codecopy !meta(stack=0->0)
+  codecopy
   push 128
-  mload !meta(stack=0->0)
+  mload
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   fallthrough_next
 
 // === deployment ===
@@ -55,7 +55,7 @@ bb0 (entry):
   dup1
   push 29
   push 0
-  codecopy !meta(stack=0->0)
+  codecopy
   push 0
   terminal return
 
@@ -63,23 +63,23 @@ bb0 (entry):
 bb0 (entry):
   push 160
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xc55699c
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -87,9 +87,9 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
@@ -97,23 +97,23 @@ bb2:
 bb0 (entry):
   push 160
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xc55699c
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -121,9 +121,9 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return

--- a/tests/ui/codegen/emit_abi_bin.sol
+++ b/tests/ui/codegen/emit_abi_bin.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=abi,bin,bin-runtime --pretty-json
+//@compile-flags: -Zcodegen --emit=abi,evm-ir,evm-ir-runtime --pretty-json
 
 contract C {
     uint public x;

--- a/tests/ui/codegen/emit_abi_bin.sol
+++ b/tests/ui/codegen/emit_abi_bin.sol
@@ -1,5 +1,7 @@
+//@ revisions: evmir bin
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=abi,evm-ir,evm-ir-runtime --pretty-json
+//@[evmir] compile-flags: -Zcodegen --emit=abi,evm-ir,evm-ir-runtime --pretty-json
+//@[bin] compile-flags: -Zcodegen --emit=abi,bin,bin-runtime --pretty-json
 
 contract C {
     uint public x;

--- a/tests/ui/codegen/emit_abi_bin.stdout
+++ b/tests/ui/codegen/emit_abi_bin.stdout
@@ -30,38 +30,99 @@
     }
   },
   "version": "VERSION"
-}{
-  "contracts": {
-    "ROOT/tests/ui/codegen/emit_abi_bin.sol:C": {
-      "abi": [
-        {
-          "inputs": [
-            {
-              "internalType": "uint256",
-              "name": "value",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "nonpayable",
-          "type": "constructor"
-        },
-        {
-          "inputs": [],
-          "name": "x",
-          "outputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        }
-      ],
-      "bin": "614000604052604c3803604c6080396080515f55602f80601d5f395ff360a06040523460205736156020575f3560e01c80630c55699c146024576020565b5f80fd5b5f5460805260206080f3",
-      "bin-runtime": "60a06040523460205736156020575f3560e01c80630c55699c146024576020565b5f80fd5b5f5460805260206080f3"
-    }
-  },
-  "version": "VERSION"
 }
+// === ROOT/tests/ui/codegen/emit_abi_bin.sol:C (creation) ===
+// === constructor ===
+bb0 (entry):
+  push 0x4000
+  push 64
+  mstore
+  push 76
+  codesize
+  sub
+  push 76
+  push 128
+  codecopy
+  push 128
+  mload
+  push 0
+  sstore
+
+// === deployment ===
+bb0 (entry):
+  push 47
+  dup1
+  push 29
+  push 0
+  codecopy
+  push 0
+  terminal return
+
+// === runtime ===
+bb0 (entry):
+  push 160
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xc55699c
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  sload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+// === ROOT/tests/ui/codegen/emit_abi_bin.sol:C (runtime) ===
+bb0 (entry):
+  push 160
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xc55699c
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  sload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return

--- a/tests/ui/codegen/enum_conversion_qualified.sol
+++ b/tests/ui/codegen/enum_conversion_qualified.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // An explicit enum conversion written through its container, `Container.Enum(x)`
 // (the callee is a member access resolving to an enum), is the identity on the

--- a/tests/ui/codegen/enum_conversion_qualified.stdout
+++ b/tests/ui/codegen/enum_conversion_qualified.stdout
@@ -3,43 +3,43 @@
 bb0 (entry):
   push 160
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xbc477c04
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
-  iszero
+  calldataload !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return

--- a/tests/ui/codegen/enum_conversion_qualified.stdout
+++ b/tests/ui/codegen/enum_conversion_qualified.stdout
@@ -1,1 +1,45 @@
-{"contracts":{"ROOT/tests/ui/codegen/enum_conversion_qualified.sol:DataTypes":{"bin-runtime":""},"ROOT/tests/ui/codegen/enum_conversion_qualified.sol:E":{"bin-runtime":"60a06040523460205736156020575f3560e01c8063bc477c04146024576020565b5f80fd5b3660049003602090126020576004351560805260206080f3"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/enum_conversion_qualified.sol:DataTypes (runtime) ===
+// === ROOT/tests/ui/codegen/enum_conversion_qualified.sol:E (runtime) ===
+bb0 (entry):
+  push 160
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xbc477c04
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  iszero
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return

--- a/tests/ui/codegen/enum_conversion_qualified.stdout
+++ b/tests/ui/codegen/enum_conversion_qualified.stdout
@@ -3,43 +3,43 @@
 bb0 (entry):
   push 160
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xbc477c04
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  calldataload
+  iszero
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return

--- a/tests/ui/codegen/evm-ir/stack_cross_block_prefix.stdout
+++ b/tests/ui/codegen/evm-ir/stack_cross_block_prefix.stdout
@@ -4,5 +4,5 @@ bb0 (entry):
   %top = push 2
   jump bb1
 bb1 (in %top):
-  %r = iszero !meta(stack=1->1)
+  %r = iszero
   stop

--- a/tests/ui/codegen/evm-ir/stack_entry_signature.stdout
+++ b/tests/ui/codegen/evm-ir/stack_entry_signature.stdout
@@ -4,5 +4,5 @@ bb0 (entry):
   jump bb1
 bb1 (in %a):
   dup1
-  %b = add !meta(stack=2->1)
+  %b = add
   stop

--- a/tests/ui/codegen/evm-ir/stack_infer_entry.stdout
+++ b/tests/ui/codegen/evm-ir/stack_infer_entry.stdout
@@ -4,5 +4,5 @@ bb0 (entry):
   jump bb1
 bb1 (in %a):
   dup1
-  %b = add !meta(stack=2->1)
+  %b = add
   stop

--- a/tests/ui/codegen/evm-ir/stack_multi_use.stdout
+++ b/tests/ui/codegen/evm-ir/stack_multi_use.stdout
@@ -3,7 +3,7 @@ bb0 (entry):
   %a = push 1
   dup1
   dup1
-  %b = add !meta(stack=2->1)
+  %b = add
   swap1
-  %c = mul !meta(stack=2->1)
+  %c = mul
   stop

--- a/tests/ui/codegen/evm-ir/stack_schedule.stdout
+++ b/tests/ui/codegen/evm-ir/stack_schedule.stdout
@@ -3,8 +3,8 @@ bb0 (entry):
   %a = push 1
   %b = push 2
   swap1
-  %c = sub !meta(stack=2->1)
+  %c = sub
   %zero = push 0
   swap1
-  %d = eq !meta(stack=2->1)
+  %d = eq
   stop

--- a/tests/ui/codegen/evm-ir/stack_schedule_operand_cleared_noop.stdout
+++ b/tests/ui/codegen/evm-ir/stack_schedule_operand_cleared_noop.stdout
@@ -3,9 +3,9 @@ bb0 (entry):
   push 1
   push 2
   swap1
-  sub !meta(stack=2->1)
+  sub
   push 0
   swap1
-  eq !meta(stack=2->1)
+  eq
   pop
   stop

--- a/tests/ui/codegen/evm-ir/stack_spill_reload.stdout
+++ b/tests/ui/codegen/evm-ir/stack_spill_reload.stdout
@@ -19,13 +19,13 @@ bb0 (entry):
   %v16 = push 16
   swap15
   push 0x1000
-  mstore !meta(stack=2->0)
+  mstore
   swap15
   swap1
   swap14
   swap1
-  %r = add !meta(stack=2->1)
+  %r = add
   push 0x1000
-  mload !meta(stack=1->1)
-  %s = mul !meta(stack=2->1)
+  mload
+  %s = mul
   stop

--- a/tests/ui/codegen/evm-ir/stack_terminator_branch.stdout
+++ b/tests/ui/codegen/evm-ir/stack_terminator_branch.stdout
@@ -3,7 +3,7 @@ bb0 (entry):
   %a = push 1
   %b = push 0
   swap1
-  %cond = eq !meta(stack=2->1)
+  %cond = eq
   %junk = push 7
   swap1
   br %cond, bb1, bb2

--- a/tests/ui/codegen/evm-ir/stack_terminator_multi_use.stdout
+++ b/tests/ui/codegen/evm-ir/stack_terminator_multi_use.stdout
@@ -3,6 +3,6 @@ bb0 (entry):
   %off = push 64
   dup1
   dup1
-  %size = add !meta(stack=2->1)
+  %size = add
   swap1
   return %off, %size

--- a/tests/ui/codegen/evm-ir/stack_terminator_switch.stdout
+++ b/tests/ui/codegen/evm-ir/stack_terminator_switch.stdout
@@ -2,7 +2,7 @@
 bb0 (entry):
   %x = push 3
   dup1
-  %sel = add !meta(stack=2->1)
+  %sel = add
   %junk = push 9
   swap1
   switch %sel, default bb1, [1 => bb2]

--- a/tests/ui/codegen/evm-ir/stack_verify_missing_effect.evmir
+++ b/tests/ui/codegen/evm-ir/stack_verify_missing_effect.evmir
@@ -1,6 +1,6 @@
 //@ failure-status: 1
-// Once operands are cleared, non-push operations must carry an explicit stack
-// effect. Otherwise the verifier cannot model their runtime pops.
+// Once operands are cleared, unregistered operations must carry an explicit
+// stack effect. Otherwise the verifier cannot model their runtime pops.
 bb0 (entry):
-  %r = add
+  %r = mystery
   stop

--- a/tests/ui/codegen/evm-ir/stack_verify_missing_effect.stderr
+++ b/tests/ui/codegen/evm-ir/stack_verify_missing_effect.stderr
@@ -1,1 +1,1 @@
-error: EVM IR verification failed: block 0: `add` consumes 2 stack words but only 0 are available
+error: EVM IR verification failed: block 0: operand-cleared instruction `mystery` must declare an explicit stack effect

--- a/tests/ui/codegen/evm-ir/stack_verify_missing_effect.stderr
+++ b/tests/ui/codegen/evm-ir/stack_verify_missing_effect.stderr
@@ -1,1 +1,1 @@
-error: EVM IR verification failed: block 0: operand-cleared instruction `add` must declare an explicit stack effect
+error: EVM IR verification failed: block 0: `add` consumes 2 stack words but only 0 are available

--- a/tests/ui/codegen/global_stack_calldata_alias.sol
+++ b/tests/ui/codegen/global_stack_calldata_alias.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 contract Test {
     function select(address account, uint256 value) external pure returns (uint256) {

--- a/tests/ui/codegen/global_stack_calldata_alias.stdout
+++ b/tests/ui/codegen/global_stack_calldata_alias.stdout
@@ -2,71 +2,71 @@
 bb0 (entry):
   push 320
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xc21f7bbb
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
+  and
   dup2
-  sub !meta(stack=0->0)
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   dup2
-  eq !meta(stack=0->0)
+  eq
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb6
 bb3:
   push 1
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -74,53 +74,53 @@ bb3:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
   fallthrough bb4
 bb4:
-  mstore !meta(stack=0->0)
+  mstore
   fallthrough bb5
 bb5:
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb6:
   push 2
   dup2
-  eq !meta(stack=0->0)
+  eq
   push bb8
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb9
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb8:
   push 2
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -128,32 +128,32 @@ bb8:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
   jump bb4
 bb9:
   push 3
   dup2
-  sub !meta(stack=0->0)
+  sub
   push bb10
-  jumpi !meta(stack=0->0)
+  jumpi
   push 3
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -161,32 +161,32 @@ bb9:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
   jump bb4
 bb10:
   push 4
   dup2
-  sub !meta(stack=0->0)
+  sub
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -194,27 +194,27 @@ bb10:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
   jump bb4
 bb11:
   push 5
   swap1
-  sub !meta(stack=0->0)
+  sub
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 5
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -222,9 +222,9 @@ bb11:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
   jump bb4

--- a/tests/ui/codegen/global_stack_calldata_alias.stdout
+++ b/tests/ui/codegen/global_stack_calldata_alias.stdout
@@ -1,1 +1,230 @@
-{"contracts":{"ROOT/tests/ui/codegen/global_stack_calldata_alias.sol:Test":{"bin-runtime":"6101406040523460215736156021575f3560e01c8063c21f7bbb146025576021565b5f80fd5b366004900360409012602435906021576004355f1960601c8116810360215760018114604f57607f565b60018201806101205290508061012052818110915081915050608a5761012051806101205b525b60805260206080f35b60028114609e5760c2565b634e487b7160e01b5f52601160045260245ffd5b600282018060e05290508060e052818110915081915050608a5760e0518060e06074565b6003810360ed57600382018060a05290508060a052818110915081915050608a5760a0518060a06074565b6004810361011d5760048201806101005290508061010052818110915081915050608a5761010051806101006074565b60059003607657600581018060c052818110915081915050608a5760c0518060c0607456"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/global_stack_calldata_alias.sol:Test (runtime) ===
+bb0 (entry):
+  push 320
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xc21f7bbb
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push 36
+  calldataload
+  swap1
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  dup2
+  sub
+  push bb1
+  jumpi
+  push 1
+  dup2
+  eq
+  push bb3
+  jumpi
+  jump bb6
+bb3:
+  push 1
+  dup3
+  add
+  dup1
+  push 288
+  mstore
+  swap1
+  pop
+  dup1
+  push 288
+  mstore
+  dup2
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 288
+  mload
+  dup1
+  push 288
+  fallthrough bb4
+bb4:
+  mstore
+  fallthrough bb5
+bb5:
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb6:
+  push 2
+  dup2
+  eq
+  push bb8
+  jumpi
+  jump bb9
+bb7:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb8:
+  push 2
+  dup3
+  add
+  dup1
+  push 224
+  mstore
+  swap1
+  pop
+  dup1
+  push 224
+  mstore
+  dup2
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  jump bb4
+bb9:
+  push 3
+  dup2
+  sub
+  push bb10
+  jumpi
+  push 3
+  dup3
+  add
+  dup1
+  push 160
+  mstore
+  swap1
+  pop
+  dup1
+  push 160
+  mstore
+  dup2
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 160
+  mload
+  dup1
+  push 160
+  jump bb4
+bb10:
+  push 4
+  dup2
+  sub
+  push bb11
+  jumpi
+  push 4
+  dup3
+  add
+  dup1
+  push 256
+  mstore
+  swap1
+  pop
+  dup1
+  push 256
+  mstore
+  dup2
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 256
+  mload
+  dup1
+  push 256
+  jump bb4
+bb11:
+  push 5
+  swap1
+  sub
+  push bb5
+  jumpi
+  push 5
+  dup2
+  add
+  dup1
+  push 192
+  mstore
+  dup2
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 192
+  mload
+  dup1
+  push 192
+  jump bb4

--- a/tests/ui/codegen/global_stack_calldata_alias.stdout
+++ b/tests/ui/codegen/global_stack_calldata_alias.stdout
@@ -2,71 +2,71 @@
 bb0 (entry):
   push 320
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xc21f7bbb
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
+  and !meta(stack=0->0)
   dup2
-  sub
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   dup2
-  eq
+  eq !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb6
 bb3:
   push 1
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -74,53 +74,53 @@ bb3:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
   fallthrough bb4
 bb4:
-  mstore
+  mstore !meta(stack=0->0)
   fallthrough bb5
 bb5:
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb6:
   push 2
   dup2
-  eq
+  eq !meta(stack=0->0)
   push bb8
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb9
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb8:
   push 2
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -128,32 +128,32 @@ bb8:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
   jump bb4
 bb9:
   push 3
   dup2
-  sub
+  sub !meta(stack=0->0)
   push bb10
-  jumpi
+  jumpi !meta(stack=0->0)
   push 3
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -161,32 +161,32 @@ bb9:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
   jump bb4
 bb10:
   push 4
   dup2
-  sub
+  sub !meta(stack=0->0)
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -194,27 +194,27 @@ bb10:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
   jump bb4
 bb11:
   push 5
   swap1
-  sub
+  sub !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 5
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -222,9 +222,9 @@ bb11:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
   jump bb4

--- a/tests/ui/codegen/internal_call_frame_dealloc.sol
+++ b/tests/ui/codegen/internal_call_frame_dealloc.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin-runtime --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime --pretty-json
 
 contract InternalCallFrameDealloc {
     function f(uint256 x) public pure returns (uint256) {

--- a/tests/ui/codegen/internal_call_frame_dealloc.stdout
+++ b/tests/ui/codegen/internal_call_frame_dealloc.stdout
@@ -2,23 +2,23 @@
 bb0 (entry):
   push 352
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xb3de648b
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -26,269 +26,269 @@ bb1:
   terminal revert
 bb2:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   terminal jump
 bb3:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   terminal jump
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push bb5
   jump bb3
 bb5:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push bb6
   jump bb2
 bb6:
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push bb7
   jump bb3
 bb7:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push bb8
   jump bb2
 bb8:
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb9:
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
-  sub
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb10
   jump bb3
 bb10:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push bb11
   jump bb2
 bb11:
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 160
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 160
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   pop
   terminal jump
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/internal_call_frame_dealloc.stdout
+++ b/tests/ui/codegen/internal_call_frame_dealloc.stdout
@@ -1,8 +1,294 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/internal_call_frame_dealloc.sol:InternalCallFrameDealloc": {
-      "bin-runtime": "6101606040523460215736156021575f3560e01c8063b3de648b146056576021565b5f80fd5b60a05160405260a0516020015160a052565b60a0516080015f81525060a05160400151610117575f60a05160600152565b3660049003602090126021575f60805260405160a051816020015260043581604001528060a05260e00160405260896037565b60a051606001518060e052609a6025565b8060e05260016004350180610140526004359010905061019a5760405160a05181602001526101405181604001528060a05260e00160405260d86037565b60a05160600151806101205260ea6025565b806101205260e05101806101005260e0518060e052901061019a5761010051806101005260805260206080f35b600160a051604001510360405160a05181602001528181604001528060a05260e001604052506101446037565b60a051606001518060a05160c0015261015a6025565b8060a05160c001528060a05160c0015260a05160400151018060a05160a001528060a05160a0015260a05160400151811061019a578060a0516060015250565b634e487b7160e01b5f52601160045260245ffd"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/internal_call_frame_dealloc.sol:InternalCallFrameDealloc (runtime) ===
+bb0 (entry):
+  push 352
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xb3de648b
+  eq
+  push bb4
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 160
+  mload
+  push 64
+  mstore
+  push 160
+  mload
+  push 32
+  add
+  mload
+  push 160
+  mstore
+  terminal jump
+bb3:
+  push 160
+  mload
+  push 128
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 160
+  mload
+  push 64
+  add
+  mload
+  push bb9
+  jumpi
+  push 0
+  push 160
+  mload
+  push 96
+  add
+  mstore
+  terminal jump
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  push 4
+  calldataload
+  dup2
+  push 64
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 224
+  add
+  push 64
+  mstore
+  push bb5
+  jump bb3
+bb5:
+  push 160
+  mload
+  push 96
+  add
+  mload
+  dup1
+  push 224
+  mstore
+  push bb6
+  jump bb2
+bb6:
+  dup1
+  push 224
+  mstore
+  push 1
+  push 4
+  calldataload
+  add
+  dup1
+  push 320
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  swap1
+  pop
+  push bb12
+  jumpi
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  push 320
+  mload
+  dup2
+  push 64
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 224
+  add
+  push 64
+  mstore
+  push bb7
+  jump bb3
+bb7:
+  push 160
+  mload
+  push 96
+  add
+  mload
+  dup1
+  push 288
+  mstore
+  push bb8
+  jump bb2
+bb8:
+  dup1
+  push 288
+  mstore
+  push 224
+  mload
+  add
+  dup1
+  push 256
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  push bb12
+  jumpi
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb9:
+  push 1
+  push 160
+  mload
+  push 64
+  add
+  mload
+  sub
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  dup2
+  dup2
+  push 64
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 224
+  add
+  push 64
+  mstore
+  pop
+  push bb10
+  jump bb3
+bb10:
+  push 160
+  mload
+  push 96
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  push bb11
+  jump bb2
+bb11:
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  push 160
+  mload
+  push 64
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 160
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 160
+  add
+  mstore
+  push 160
+  mload
+  push 64
+  add
+  mload
+  dup2
+  lt
+  push bb12
+  jumpi
+  dup1
+  push 160
+  mload
+  push 96
+  add
+  mstore
+  pop
+  terminal jump
+bb12:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/internal_call_frame_dealloc.stdout
+++ b/tests/ui/codegen/internal_call_frame_dealloc.stdout
@@ -2,23 +2,23 @@
 bb0 (entry):
   push 352
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xb3de648b
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -26,269 +26,269 @@ bb1:
   terminal revert
 bb2:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   terminal jump
 bb3:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   terminal jump
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push bb5
   jump bb3
 bb5:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push bb6
   jump bb2
 bb6:
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push bb7
   jump bb3
 bb7:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push bb8
   jump bb2
 bb8:
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb9:
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  add
+  mload
+  sub
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb10
   jump bb3
 bb10:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push bb11
   jump bb2
 bb11:
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 160
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 160
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup2
-  lt !meta(stack=0->0)
+  lt
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   pop
   terminal jump
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/library_mapping_storage_param.sol
+++ b/tests/ui/codegen/library_mapping_storage_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // A `library` function may take a `mapping`/`storage` reference parameter and
 // bind a storage-reference local from it:

--- a/tests/ui/codegen/library_mapping_storage_param.stdout
+++ b/tests/ui/codegen/library_mapping_storage_param.stdout
@@ -2,15 +2,15 @@
 bb0 (entry):
   push 0
   push 64
-  mstore
-  calldatasize
-  iszero
+  mstore !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   push 0
   push 0
   terminal revert
@@ -22,82 +22,82 @@ bb1:
 bb0 (entry):
   push 704
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xd2514e84
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   dup1
   push 320
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 1
   push 320
-  mload
-  add
-  sload
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  sload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 288
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -105,24 +105,24 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/library_mapping_storage_param.stdout
+++ b/tests/ui/codegen/library_mapping_storage_param.stdout
@@ -2,15 +2,15 @@
 bb0 (entry):
   push 0
   push 64
-  mstore !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   push 0
   push 0
   terminal revert
@@ -22,82 +22,82 @@ bb1:
 bb0 (entry):
   push 704
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xd2514e84
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 1
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mload
+  add
+  sload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -105,24 +105,24 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/library_mapping_storage_param.stdout
+++ b/tests/ui/codegen/library_mapping_storage_param.stdout
@@ -1,1 +1,128 @@
-{"contracts":{"ROOT/tests/ui/codegen/library_mapping_storage_param.sol:C":{"bin-runtime":"6102c06040523460215736156021575f3560e01c8063d2514e84146025576021565b5f80fd5b3660049003602090126021576004355f1960601c8116036021576004355f525f60205260405f20806101405254600161014051015480610160528180610120520180610100528180610120528110915081915050608e5761010051806101005260805260206080f35b634e487b7160e01b5f52601160045260245ffd"},"ROOT/tests/ui/codegen/library_mapping_storage_param.sol:L":{"bin-runtime":"5f60405236156011575f3560e01c5f5ffd5b5f5ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/library_mapping_storage_param.sol:L (runtime) ===
+bb0 (entry):
+  push 0
+  push 64
+  mstore
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  push 0
+  push 0
+  terminal revert
+bb1:
+  push 0
+  push 0
+  terminal revert
+// === ROOT/tests/ui/codegen/library_mapping_storage_param.sol:C (runtime) ===
+bb0 (entry):
+  push 704
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xd2514e84
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  dup1
+  push 320
+  mstore
+  sload
+  push 1
+  push 320
+  mload
+  add
+  sload
+  dup1
+  push 352
+  mstore
+  dup2
+  dup1
+  push 288
+  mstore
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 288
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/library_wrapper_storage_param.sol
+++ b/tests/ui/codegen/library_wrapper_storage_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // The external wrapper of a public library function must decode a
 // storage-reference parameter as its slot (one calldata word), not

--- a/tests/ui/codegen/library_wrapper_storage_param.stdout
+++ b/tests/ui/codegen/library_wrapper_storage_param.stdout
@@ -3,62 +3,62 @@
 bb0 (entry):
   push 416
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xdef537e0
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 128
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 2
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   dup1
   push 320
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -66,41 +66,41 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 4
-  calldataload
-  sload
+  calldataload !meta(stack=0->0)
+  sload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 288
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -108,47 +108,47 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 4
-  calldataload
-  add
-  sload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  sload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/library_wrapper_storage_param.stdout
+++ b/tests/ui/codegen/library_wrapper_storage_param.stdout
@@ -3,62 +3,62 @@
 bb0 (entry):
   push 416
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xdef537e0
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 128
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 2
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -66,41 +66,41 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 4
-  calldataload !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  calldataload
+  sload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -108,47 +108,47 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  calldataload
+  add
+  sload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/library_wrapper_storage_param.stdout
+++ b/tests/ui/codegen/library_wrapper_storage_param.stdout
@@ -1,1 +1,154 @@
-{"contracts":{"ROOT/tests/ui/codegen/library_wrapper_storage_param.sol:DataTypes":{"bin-runtime":""},"ROOT/tests/ui/codegen/library_wrapper_storage_param.sol:L":{"bin-runtime":"6101a06040523460215736156021575f3560e01c8063def537e0146025576021565b5f80fd5b3660049003608090126021576002600435018060a05254602435818061014052018060e052818061014052811091508191505060c65760e0518060e05260a0515560a0518060a05254600435548061018052818061012052018060c052818061012052811091508191505060c65760016004350154806101605260c05101806101005260c0518060c052901060c65761010051806101005260805260206080f35b634e487b7160e01b5f52601160045260245ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/library_wrapper_storage_param.sol:DataTypes (runtime) ===
+// === ROOT/tests/ui/codegen/library_wrapper_storage_param.sol:L (runtime) ===
+bb0 (entry):
+  push 416
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xdef537e0
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 128
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 2
+  push 4
+  calldataload
+  add
+  dup1
+  push 160
+  mstore
+  sload
+  push 36
+  calldataload
+  dup2
+  dup1
+  push 320
+  mstore
+  add
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 320
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  push 160
+  mload
+  sstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  sload
+  push 4
+  calldataload
+  sload
+  dup1
+  push 384
+  mstore
+  dup2
+  dup1
+  push 288
+  mstore
+  add
+  dup1
+  push 192
+  mstore
+  dup2
+  dup1
+  push 288
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 1
+  push 4
+  calldataload
+  add
+  sload
+  dup1
+  push 352
+  mstore
+  push 192
+  mload
+  add
+  dup1
+  push 256
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/linked_library_call.sol
+++ b/tests/ui/codegen/linked_library_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries Lib=0x1111111111111111111111111111111111111111 --emit=bin-runtime
+//@compile-flags: -Zcodegen --libraries Lib=0x1111111111111111111111111111111111111111 --emit=evm-ir-runtime
 
 // With `--libraries Lib=0xADDR`, a call to a `public` library function is
 // lowered as an ABI-encoded DELEGATECALL to the linked address (storage

--- a/tests/ui/codegen/linked_library_call.stdout
+++ b/tests/ui/codegen/linked_library_call.stdout
@@ -1,1 +1,229 @@
-{"contracts":{"ROOT/tests/ui/codegen/linked_library_call.sol:C":{"bin-runtime":"60e06040523460205736156020575f3560e01c80633dd41ca6146024576020565b5f80fd5b3660049003604090126020576004355f1960601c8116036020575f6080526040518060a05260205263ed2f0bb860e01b60a05152600460a051015f815250602460a05101600435815250604460a051016024358152505a60205f606460a0517311111111111111111111111111111111111111115af490501560ab575f5160805260206080f35b3d8060c0525f803e60c0515ffd"},"ROOT/tests/ui/codegen/linked_library_call.sol:Lib":{"bin-runtime":"6101006040523460215736156021575f3560e01c8063ed2f0bb8146025576021565b5f80fd5b3660049003606090126021576024355f1960601c8116036021576024355f5260043560205260405f208060a05254604435818060e052018060c052818060e0528110915081915050608c5760c0518060c05260a0515560a0518060a0525460805260206080f35b634e487b7160e01b5f52601160045260245ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/linked_library_call.sol:Lib (runtime) ===
+bb0 (entry):
+  push 256
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xed2f0bb8
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 96
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 0
+  mstore
+  push 4
+  calldataload
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  dup1
+  push 160
+  mstore
+  sload
+  push 68
+  calldataload
+  dup2
+  dup1
+  push 224
+  mstore
+  add
+  dup1
+  push 192
+  mstore
+  dup2
+  dup1
+  push 224
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  push 160
+  mload
+  sstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  sload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+// === ROOT/tests/ui/codegen/linked_library_call.sol:C (runtime) ===
+bb0 (entry):
+  push 224
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x3dd41ca6
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 64
+  mload
+  dup1
+  push 160
+  mstore
+  push 32
+  mstore
+  push 0xed2f0bb800000000000000000000000000000000000000000000000000000000
+  push 160
+  mload
+  mstore
+  push 4
+  push 160
+  mload
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 160
+  mload
+  add
+  push 4
+  calldataload
+  dup2
+  mstore
+  pop
+  push 68
+  push 160
+  mload
+  add
+  push 36
+  calldataload
+  dup2
+  mstore
+  pop
+  gas
+  push 32
+  push 0
+  push 100
+  push 160
+  mload
+  push 0x1111111111111111111111111111111111111111
+  gas
+  delegatecall
+  swap1
+  pop
+  iszero
+  push bb3
+  jumpi
+  push 0
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  returndatasize
+  dup1
+  push 192
+  mstore
+  push 0
+  dup1
+  returndatacopy
+  push 192
+  mload
+  push 0
+  terminal revert

--- a/tests/ui/codegen/linked_library_call.stdout
+++ b/tests/ui/codegen/linked_library_call.stdout
@@ -2,77 +2,77 @@
 bb0 (entry):
   push 256
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xed2f0bb8
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 96
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 68
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   dup1
   push 224
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -80,33 +80,33 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
@@ -114,116 +114,116 @@ bb3:
 bb0 (entry):
   push 224
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x3dd41ca6
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 0xed2f0bb800000000000000000000000000000000000000000000000000000000
   push 160
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 4
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 68
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
-  gas
+  gas !meta(stack=0->0)
   push 32
   push 0
   push 100
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 0x1111111111111111111111111111111111111111
-  gas
-  delegatecall
+  gas !meta(stack=0->0)
+  delegatecall !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  mload
+  mload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
-  returndatasize
+  returndatasize !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   dup1
-  returndatacopy
+  returndatacopy !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   push 0
   terminal revert

--- a/tests/ui/codegen/linked_library_call.stdout
+++ b/tests/ui/codegen/linked_library_call.stdout
@@ -2,77 +2,77 @@
 bb0 (entry):
   push 256
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xed2f0bb8
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 96
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 68
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -80,33 +80,33 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
@@ -114,116 +114,116 @@ bb3:
 bb0 (entry):
   push 224
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x3dd41ca6
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 0xed2f0bb800000000000000000000000000000000000000000000000000000000
   push 160
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 4
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 68
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
-  gas !meta(stack=0->0)
+  gas
   push 32
   push 0
   push 100
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 0x1111111111111111111111111111111111111111
-  gas !meta(stack=0->0)
-  delegatecall !meta(stack=0->0)
+  gas
+  delegatecall
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  mload !meta(stack=0->0)
+  mload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
-  returndatasize !meta(stack=0->0)
+  returndatasize
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   dup1
-  returndatacopy !meta(stack=0->0)
+  returndatacopy
   push 192
-  mload !meta(stack=0->0)
+  mload
   push 0
   terminal revert

--- a/tests/ui/codegen/linked_library_chain.sol
+++ b/tests/ui/codegen/linked_library_chain.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries Inner=0x1000000000000000000000000000000000000001,Outer=0x1000000000000000000000000000000000000002 --emit=bin-runtime
+//@compile-flags: -Zcodegen --libraries Inner=0x1000000000000000000000000000000000000001,Outer=0x1000000000000000000000000000000000000002 --emit=evm-ir-runtime
 
 // A linked library may itself call another linked library, forwarding a
 // storage-reference parameter: the storage struct travels as its slot through

--- a/tests/ui/codegen/linked_library_chain.stdout
+++ b/tests/ui/codegen/linked_library_chain.stdout
@@ -3,57 +3,57 @@
 bb0 (entry):
   push 224
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xfaf4836c
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
-  sload
+  calldataload !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -61,30 +61,30 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
-  sstore
+  calldataload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 4
-  calldataload
-  sload
+  calldataload !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
@@ -92,45 +92,45 @@ bb3:
 bb0 (entry):
   push 224
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x5e0b1cef
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb3
 bb3:
   push 32
@@ -138,164 +138,164 @@ bb3:
   terminal return
 bb4:
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 0xfaf4836c00000000000000000000000000000000000000000000000000000000
   push 160
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 4
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
-  gas
+  gas !meta(stack=0->0)
   push 32
   push 0
   push 68
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 0x1000000000000000000000000000000000000001
-  gas
-  delegatecall
+  gas !meta(stack=0->0)
+  delegatecall !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  mload
+  mload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb5:
-  returndatasize
+  returndatasize !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   dup1
-  returndatacopy
+  returndatacopy !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   push 0
   terminal revert
 // === ROOT/tests/ui/codegen/linked_library_chain.sol:C (runtime) ===
 bb0 (entry):
   push 224
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xb20e7344
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 0x5e0b1cef00000000000000000000000000000000000000000000000000000000
   push 160
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 4
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
-  gas
+  gas !meta(stack=0->0)
   push 32
   push 0
   push 68
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 0x1000000000000000000000000000000000000002
-  gas
-  delegatecall
+  gas !meta(stack=0->0)
+  delegatecall !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  mload
+  mload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
-  returndatasize
+  returndatasize !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   dup1
-  returndatacopy
+  returndatacopy !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   push 0
   terminal revert

--- a/tests/ui/codegen/linked_library_chain.stdout
+++ b/tests/ui/codegen/linked_library_chain.stdout
@@ -3,57 +3,57 @@
 bb0 (entry):
   push 224
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xfaf4836c
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  calldataload
+  sload
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -61,30 +61,30 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  calldataload
+  sstore
   push 4
-  calldataload !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  calldataload
+  sload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
@@ -92,45 +92,45 @@ bb3:
 bb0 (entry):
   push 224
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x5e0b1cef
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb3
 bb3:
   push 32
@@ -138,164 +138,164 @@ bb3:
   terminal return
 bb4:
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 0xfaf4836c00000000000000000000000000000000000000000000000000000000
   push 160
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 4
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
-  gas !meta(stack=0->0)
+  gas
   push 32
   push 0
   push 68
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 0x1000000000000000000000000000000000000001
-  gas !meta(stack=0->0)
-  delegatecall !meta(stack=0->0)
+  gas
+  delegatecall
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  mload !meta(stack=0->0)
+  mload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb5:
-  returndatasize !meta(stack=0->0)
+  returndatasize
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   dup1
-  returndatacopy !meta(stack=0->0)
+  returndatacopy
   push 192
-  mload !meta(stack=0->0)
+  mload
   push 0
   terminal revert
 // === ROOT/tests/ui/codegen/linked_library_chain.sol:C (runtime) ===
 bb0 (entry):
   push 224
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xb20e7344
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 0x5e0b1cef00000000000000000000000000000000000000000000000000000000
   push 160
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 4
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
-  gas !meta(stack=0->0)
+  gas
   push 32
   push 0
   push 68
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 0x1000000000000000000000000000000000000002
-  gas !meta(stack=0->0)
-  delegatecall !meta(stack=0->0)
+  gas
+  delegatecall
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  mload !meta(stack=0->0)
+  mload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
-  returndatasize !meta(stack=0->0)
+  returndatasize
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   dup1
-  returndatacopy !meta(stack=0->0)
+  returndatacopy
   push 192
-  mload !meta(stack=0->0)
+  mload
   push 0
   terminal revert

--- a/tests/ui/codegen/linked_library_chain.stdout
+++ b/tests/ui/codegen/linked_library_chain.stdout
@@ -1,1 +1,301 @@
-{"contracts":{"ROOT/tests/ui/codegen/linked_library_chain.sol:C":{"bin-runtime":"60e06040523460205736156020575f3560e01c8063b20e7344146024576020565b5f80fd5b3660049003602090126020575f6080526040518060a052602052635e0b1cef60e01b60a05152600460a051015f815250602460a051016004358152505a60205f604460a0517310000000000000000000000000000000000000025af49050156091575f5160805260206080f35b3d8060c0525f803e60c0515ffd"},"ROOT/tests/ui/codegen/linked_library_chain.sol:DataTypes":{"bin-runtime":""},"ROOT/tests/ui/codegen/linked_library_chain.sol:Inner":{"bin-runtime":"60e06040523460205736156020575f3560e01c8063faf4836c146024576020565b5f80fd5b36600490036040901260205760043554602435818060c052018060a052818060c052811091508191505060695760a0518060a052600435556004355460805260206080f35b634e487b7160e01b5f52601160045260245ffd"},"ROOT/tests/ui/codegen/linked_library_chain.sol:Outer":{"bin-runtime":"60e06040523460205736156020575f3560e01c80635e0b1cef146024576020565b5f80fd5b3660049003604090126020575f608052602435604457603e565b60206080f35b6040518060a05260205263faf4836c60e01b60a05152600460a05101600435815250602460a051016024358152505a60205f604460a0517310000000000000000000000000000000000000015af490501560a3575f5160805260206080f35b3d8060c0525f803e60c0515ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/linked_library_chain.sol:DataTypes (runtime) ===
+// === ROOT/tests/ui/codegen/linked_library_chain.sol:Inner (runtime) ===
+bb0 (entry):
+  push 224
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xfaf4836c
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  sload
+  push 36
+  calldataload
+  dup2
+  dup1
+  push 192
+  mstore
+  add
+  dup1
+  push 160
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  push 4
+  calldataload
+  sstore
+  push 4
+  calldataload
+  sload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+// === ROOT/tests/ui/codegen/linked_library_chain.sol:Outer (runtime) ===
+bb0 (entry):
+  push 224
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x5e0b1cef
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 36
+  calldataload
+  push bb4
+  jumpi
+  jump bb3
+bb3:
+  push 32
+  push 128
+  terminal return
+bb4:
+  push 64
+  mload
+  dup1
+  push 160
+  mstore
+  push 32
+  mstore
+  push 0xfaf4836c00000000000000000000000000000000000000000000000000000000
+  push 160
+  mload
+  mstore
+  push 4
+  push 160
+  mload
+  add
+  push 4
+  calldataload
+  dup2
+  mstore
+  pop
+  push 36
+  push 160
+  mload
+  add
+  push 36
+  calldataload
+  dup2
+  mstore
+  pop
+  gas
+  push 32
+  push 0
+  push 68
+  push 160
+  mload
+  push 0x1000000000000000000000000000000000000001
+  gas
+  delegatecall
+  swap1
+  pop
+  iszero
+  push bb5
+  jumpi
+  push 0
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb5:
+  returndatasize
+  dup1
+  push 192
+  mstore
+  push 0
+  dup1
+  returndatacopy
+  push 192
+  mload
+  push 0
+  terminal revert
+// === ROOT/tests/ui/codegen/linked_library_chain.sol:C (runtime) ===
+bb0 (entry):
+  push 224
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xb20e7344
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 64
+  mload
+  dup1
+  push 160
+  mstore
+  push 32
+  mstore
+  push 0x5e0b1cef00000000000000000000000000000000000000000000000000000000
+  push 160
+  mload
+  mstore
+  push 4
+  push 160
+  mload
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 160
+  mload
+  add
+  push 4
+  calldataload
+  dup2
+  mstore
+  pop
+  gas
+  push 32
+  push 0
+  push 68
+  push 160
+  mload
+  push 0x1000000000000000000000000000000000000002
+  gas
+  delegatecall
+  swap1
+  pop
+  iszero
+  push bb3
+  jumpi
+  push 0
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  returndatasize
+  dup1
+  push 192
+  mstore
+  push 0
+  dup1
+  returndatacopy
+  push 192
+  mload
+  push 0
+  terminal revert

--- a/tests/ui/codegen/linked_library_dynamic_fields.sol
+++ b/tests/ui/codegen/linked_library_dynamic_fields.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries L=0x1000000000000000000000000000000000000001 --emit=bin-runtime
+//@compile-flags: -Zcodegen --libraries L=0x1000000000000000000000000000000000000001 --emit=evm-ir-runtime
 
 // A linked library call whose struct parameter carries dynamic fields:
 // the head word of each dynamic field holds an args-relative offset and the

--- a/tests/ui/codegen/linked_library_dynamic_fields.stdout
+++ b/tests/ui/codegen/linked_library_dynamic_fields.stdout
@@ -1,1 +1,997 @@
-{"contracts":{"ROOT/tests/ui/codegen/linked_library_dynamic_fields.sol:C":{"bin-runtime":"61022060405234602b573615602b575f3560e01c80632220ae27146061578063776f384314602f57602b565b5f80fd5b366004900360209012602b576004355f1960601c811603602b576004355f525f60205260405f20545b60805260206080f35b366004900360809012602b576064355f1960601c811603602b575f608052600460243501358060a05260fb1c6102a95760a0518060a05260051b602081016040518060e052818101915081604052905060a0518060a0528152602081018061010052602460243501838183806101005237509150600460443501358060c052601f8101806101a052818060c052901091505090506102a957601f196101a05116806101e052156101e05160208282820302905001806101605290508061016052602081018061014052818061016052901090506102a957604051610140518061014052810160405260c0518060c0528152602081016020610160510381015f81525060246044350160c0518060c0528183375060405160808101806101805260405260043581526020810160e0518060e05281525060408101838152506060810160643581525061018051806101805260205263fa06cb9660e01b6101805152608481015f815260a48201600435815250610104820160643581525060c4820160a081525060e0518060e05251806101c05260051b61012483016101c051806101c052815250610144830181610100518061010052825e5060c0900160e48301925080610120528252905082519250601f8301601f199016610120518061012052820191508382529250602090018282825e5050602090016101205101600490015a60205160205f6101205160405151601f01601f1916602001016004016020517310000000000000000000000000000000000000015af49150509050156102bd575f516058565b634e487b7160e01b5f52604160045260245ffd5b3d80610200525f803e610200515ffd"},"ROOT/tests/ui/codegen/linked_library_dynamic_fields.sol:L":{"bin-runtime":"6103806040523460215736156021575f3560e01c8063fa06cb96146025576021565b5f80fd5b366004900360409012602157604051806101605260808101602435825260046044350135806102805260051b602081018201604052610280518061028052825260a0830160246044350182818337505050602082018061012052818152905060046064350135601f8101601f1990166040516020820181016040528281529150602082016024606435018281833750505060408301806101e05281815290506084355f1960601c81161491505090501560215760606101605101806101c05260843581525f6080526101605180610160525160a0525f60c052505f610105565b610120518061012052515190106101b2576101e051806101e05251516103e88180610300520280610220526103e881048280610300529014915081915050156102d25760a05161022051806102205281806102c05201806101005281806102c05281109150819150506102d25761010051806101005260a0526101c051806101c052515f5260043560205260405f2061010051806101005281555061010051806101005260805260206080f35b61012051806101205251806102405260c051806103205260051b8061026052818061024052516103205110156102bb5760208201915080610260520151806101805260c051600181806102e052018060e05281806102e052811091508191505090506102d25760e0518060e0526101805102806101a05260e0518060e0521560e0518060e05282046101805180610180529014179050156102d25760a0516101a051806101a05281806103405201806102005281806103405281109150819150506102d25761020051806102005260a05260c051600181806102a05201806101405281806102a05281109150819150506102d25761014051806101405260c05261014051610105565b634e487b7160e01b5f52505060325b60045260245ffd5b634e487b7160e01b5f5260116102ca56"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/linked_library_dynamic_fields.sol:L (runtime) ===
+bb0 (entry):
+  push 896
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xfa06cb96
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 64
+  mload
+  dup1
+  push 352
+  mstore
+  push 128
+  dup2
+  add
+  push 36
+  calldataload
+  dup3
+  mstore
+  push 4
+  push 68
+  calldataload
+  add
+  calldataload
+  dup1
+  push 640
+  mstore
+  push 5
+  shl
+  push 32
+  dup2
+  add
+  dup3
+  add
+  push 64
+  mstore
+  push 640
+  mload
+  dup1
+  push 640
+  mstore
+  dup3
+  mstore
+  push 160
+  dup4
+  add
+  push 36
+  push 68
+  calldataload
+  add
+  dup3
+  dup2
+  dup4
+  calldatacopy
+  pop
+  pop
+  pop
+  push 32
+  dup3
+  add
+  dup1
+  push 288
+  mstore
+  dup2
+  dup2
+  mstore
+  swap1
+  pop
+  push 4
+  push 100
+  calldataload
+  add
+  calldataload
+  push 31
+  dup2
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  push 64
+  mload
+  push 32
+  dup3
+  add
+  dup2
+  add
+  push 64
+  mstore
+  dup3
+  dup2
+  mstore
+  swap2
+  pop
+  push 32
+  dup3
+  add
+  push 36
+  push 100
+  calldataload
+  add
+  dup3
+  dup2
+  dup4
+  calldatacopy
+  pop
+  pop
+  pop
+  push 64
+  dup4
+  add
+  dup1
+  push 480
+  mstore
+  dup2
+  dup2
+  mstore
+  swap1
+  pop
+  push 132
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  eq
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  iszero
+  push bb1
+  jumpi
+  push 96
+  push 352
+  mload
+  add
+  dup1
+  push 448
+  mstore
+  push 132
+  calldataload
+  dup2
+  mstore
+  push 0
+  push 128
+  mstore
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  mload
+  push 160
+  mstore
+  push 0
+  push 192
+  mstore
+  pop
+  push 0
+  jump bb3
+bb3:
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  mload
+  mload
+  swap1
+  lt
+  push bb4
+  jumpi
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  mload
+  mload
+  push 0x3e8
+  dup2
+  dup1
+  push 768
+  mstore
+  mul
+  dup1
+  push 544
+  mstore
+  push 0x3e8
+  dup2
+  div
+  dup3
+  dup1
+  push 768
+  mstore
+  swap1
+  eq
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  iszero
+  push bb7
+  jumpi
+  push 160
+  mload
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  dup2
+  dup1
+  push 704
+  mstore
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 704
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 160
+  mstore
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  mload
+  push 0
+  mstore
+  push 4
+  calldataload
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  sstore
+  pop
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  mload
+  dup1
+  push 576
+  mstore
+  push 192
+  mload
+  dup1
+  push 800
+  mstore
+  push 5
+  shl
+  dup1
+  push 608
+  mstore
+  dup2
+  dup1
+  push 576
+  mstore
+  mload
+  push 800
+  mload
+  lt
+  iszero
+  push bb5
+  jumpi
+  push 32
+  dup3
+  add
+  swap2
+  pop
+  dup1
+  push 608
+  mstore
+  add
+  mload
+  dup1
+  push 384
+  mstore
+  push 192
+  mload
+  push 1
+  dup2
+  dup1
+  push 736
+  mstore
+  add
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 736
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb7
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  push 384
+  mload
+  mul
+  dup1
+  push 416
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  iszero
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup3
+  div
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  swap1
+  eq
+  or
+  swap1
+  pop
+  iszero
+  push bb7
+  jumpi
+  push 160
+  mload
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  dup2
+  dup1
+  push 832
+  mstore
+  add
+  dup1
+  push 512
+  mstore
+  dup2
+  dup1
+  push 832
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  push 160
+  mstore
+  push 192
+  mload
+  push 1
+  dup2
+  dup1
+  push 672
+  mstore
+  add
+  dup1
+  push 320
+  mstore
+  dup2
+  dup1
+  push 672
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb7
+  jumpi
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  push 192
+  mstore
+  push 320
+  mload
+  jump bb3
+bb5:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  pop
+  pop
+  push 50
+  fallthrough bb6
+bb6:
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb7:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  jump bb6
+// === ROOT/tests/ui/codegen/linked_library_dynamic_fields.sol:C (runtime) ===
+bb0 (entry):
+  push 544
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x2220ae27
+  eq
+  push bb4
+  jumpi
+  dup1
+  push 0x776f3843
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  sload
+  fallthrough bb3
+bb3:
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 128
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 100
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 4
+  push 36
+  calldataload
+  add
+  calldataload
+  dup1
+  push 160
+  mstore
+  push 251
+  shr
+  push bb5
+  jumpi
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  push 5
+  shl
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  push 36
+  push 36
+  calldataload
+  add
+  dup4
+  dup2
+  dup4
+  dup1
+  push 256
+  mstore
+  calldatacopy
+  pop
+  swap2
+  pop
+  push 4
+  push 68
+  calldataload
+  add
+  calldataload
+  dup1
+  push 192
+  mstore
+  push 31
+  dup2
+  add
+  dup1
+  push 416
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb5
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 416
+  mload
+  and
+  dup1
+  push 480
+  mstore
+  iszero
+  push 480
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 352
+  mstore
+  swap1
+  pop
+  dup1
+  push 352
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 320
+  mstore
+  dup2
+  dup1
+  push 352
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb5
+  jumpi
+  push 64
+  mload
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 352
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 68
+  calldataload
+  add
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  push 64
+  mload
+  push 128
+  dup2
+  add
+  dup1
+  push 384
+  mstore
+  push 64
+  mstore
+  push 4
+  calldataload
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  mstore
+  pop
+  push 64
+  dup2
+  add
+  dup4
+  dup2
+  mstore
+  pop
+  push 96
+  dup2
+  add
+  push 100
+  calldataload
+  dup2
+  mstore
+  pop
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  push 32
+  mstore
+  push 0xfa06cb9600000000000000000000000000000000000000000000000000000000
+  push 384
+  mload
+  mstore
+  push 132
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  push 164
+  dup3
+  add
+  push 4
+  calldataload
+  dup2
+  mstore
+  pop
+  push 260
+  dup3
+  add
+  push 100
+  calldataload
+  dup2
+  mstore
+  pop
+  push 196
+  dup3
+  add
+  push 160
+  dup2
+  mstore
+  pop
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  dup1
+  push 448
+  mstore
+  push 5
+  shl
+  push 292
+  dup4
+  add
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  dup2
+  mstore
+  pop
+  push 324
+  dup4
+  add
+  dup2
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup3
+  mcopy
+  pop
+  push 192
+  swap1
+  add
+  push 228
+  dup4
+  add
+  swap3
+  pop
+  dup1
+  push 288
+  mstore
+  dup3
+  mstore
+  swap1
+  pop
+  dup3
+  mload
+  swap3
+  pop
+  push 31
+  dup4
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  dup3
+  add
+  swap2
+  pop
+  dup4
+  dup3
+  mstore
+  swap3
+  pop
+  push 32
+  swap1
+  add
+  dup3
+  dup3
+  dup3
+  mcopy
+  pop
+  pop
+  push 32
+  swap1
+  add
+  push 288
+  mload
+  add
+  push 4
+  swap1
+  add
+  gas
+  push 32
+  mload
+  push 32
+  push 0
+  push 288
+  mload
+  push 64
+  mload
+  mload
+  push 31
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  and
+  push 32
+  add
+  add
+  push 4
+  add
+  push 32
+  mload
+  push 0x1000000000000000000000000000000000000001
+  gas
+  delegatecall
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  iszero
+  push bb6
+  jumpi
+  push 0
+  mload
+  jump bb3
+bb5:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 65
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb6:
+  returndatasize
+  dup1
+  push 512
+  mstore
+  push 0
+  dup1
+  returndatacopy
+  push 512
+  mload
+  push 0
+  terminal revert

--- a/tests/ui/codegen/linked_library_dynamic_fields.stdout
+++ b/tests/ui/codegen/linked_library_dynamic_fields.stdout
@@ -2,258 +2,258 @@
 bb0 (entry):
   push 896
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xfa06cb96
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 128
   dup2
-  add
+  add !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 68
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup3
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 640
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   push 160
   dup4
-  add
+  add !meta(stack=0->0)
   push 36
   push 68
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup3
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   pop
   pop
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 4
   push 100
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   dup3
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   push 36
   push 100
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup3
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   pop
   pop
   push 64
   dup4
-  add
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 132
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  eq
+  and !meta(stack=0->0)
+  eq !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 96
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 132
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 0
   jump bb3
 bb3:
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
-  mload
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
-  mload
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 0x3e8
   dup2
   dup1
   push 768
-  mstore
-  mul
+  mstore !meta(stack=0->0)
+  mul !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 0x3e8
   dup2
-  div
+  div !meta(stack=0->0)
   dup3
   dup1
   push 768
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap2
   pop
   dup2
   swap2
   pop
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 704
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -261,108 +261,108 @@ bb3:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  sstore
+  sstore !meta(stack=0->0)
   pop
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 800
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 576
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 800
-  mload
-  lt
-  iszero
+  mload !meta(stack=0->0)
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup1
   push 608
-  mstore
-  add
-  mload
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   push 1
   dup2
   dup1
   push 736
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -372,65 +372,65 @@ bb4:
   swap1
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
-  mul
+  mload !meta(stack=0->0)
+  mul !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  div
+  div !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
-  or
+  eq !meta(stack=0->0)
+  or !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 832
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 832
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -438,31 +438,31 @@ bb4:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   push 1
   dup2
   dup1
   push 672
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -470,528 +470,528 @@ bb4:
   pop
   pop
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   jump bb3
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   pop
   pop
   push 50
   fallthrough bb6
 bb6:
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   jump bb6
 // === ROOT/tests/ui/codegen/linked_library_dynamic_fields.sol:C (runtime) ===
 bb0 (entry):
   push 544
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x2220ae27
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x776f3843
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
-  sload
+  keccak256 !meta(stack=0->0)
+  sload !meta(stack=0->0)
   fallthrough bb3
 bb3:
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 128
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 100
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 36
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 251
-  shr
+  shr !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup2
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 36
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup4
   dup1
   push 256
-  mstore
-  calldatacopy
+  mstore !meta(stack=0->0)
+  calldatacopy !meta(stack=0->0)
   pop
   swap2
   pop
   push 4
   push 68
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 416
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 480
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 352
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 68
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 128
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 64
   dup2
-  add
+  add !meta(stack=0->0)
   dup4
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 96
   dup2
-  add
+  add !meta(stack=0->0)
   push 100
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 0xfa06cb9600000000000000000000000000000000000000000000000000000000
   push 384
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 132
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 164
   dup3
-  add
+  add !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 260
   dup3
-  add
+  add !meta(stack=0->0)
   push 100
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 196
   dup3
-  add
+  add !meta(stack=0->0)
   push 160
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 292
   dup4
-  add
+  add !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 324
   dup4
-  add
+  add !meta(stack=0->0)
   dup2
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  mcopy
+  mcopy !meta(stack=0->0)
   pop
   push 192
   swap1
-  add
+  add !meta(stack=0->0)
   push 228
   dup4
-  add
+  add !meta(stack=0->0)
   swap3
   pop
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup3
-  mload
+  mload !meta(stack=0->0)
   swap3
   pop
   push 31
   dup4
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup4
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   swap3
   pop
   push 32
   swap1
-  add
+  add !meta(stack=0->0)
   dup3
   dup3
   dup3
-  mcopy
+  mcopy !meta(stack=0->0)
   pop
   pop
   push 32
   swap1
-  add
+  add !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 4
   swap1
-  add
-  gas
+  add !meta(stack=0->0)
+  gas !meta(stack=0->0)
   push 32
-  mload
+  mload !meta(stack=0->0)
   push 32
   push 0
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 64
-  mload
-  mload
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 31
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-  and
+  and !meta(stack=0->0)
   push 32
-  add
-  add
+  add !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 4
-  add
+  add !meta(stack=0->0)
   push 32
-  mload
+  mload !meta(stack=0->0)
   push 0x1000000000000000000000000000000000000001
-  gas
-  delegatecall
+  gas !meta(stack=0->0)
+  delegatecall !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  mload
+  mload !meta(stack=0->0)
   jump bb3
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 65
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb6:
-  returndatasize
+  returndatasize !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   dup1
-  returndatacopy
+  returndatacopy !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   push 0
   terminal revert

--- a/tests/ui/codegen/linked_library_dynamic_fields.stdout
+++ b/tests/ui/codegen/linked_library_dynamic_fields.stdout
@@ -2,258 +2,258 @@
 bb0 (entry):
   push 896
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xfa06cb96
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 128
   dup2
-  add !meta(stack=0->0)
+  add
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 68
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup3
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 640
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   push 160
   dup4
-  add !meta(stack=0->0)
+  add
   push 36
   push 68
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup3
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   pop
   pop
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 4
   push 100
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   dup3
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   push 36
   push 100
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup3
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   pop
   pop
   push 64
   dup4
-  add !meta(stack=0->0)
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 132
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  eq !meta(stack=0->0)
+  and
+  eq
   swap2
   pop
   pop
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 96
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 132
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 0
   jump bb3
 bb3:
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
+  mload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
+  mload
   push 0x3e8
   dup2
   dup1
   push 768
-  mstore !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  mstore
+  mul
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 0x3e8
   dup2
-  div !meta(stack=0->0)
+  div
   dup3
   dup1
   push 768
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap2
   pop
   dup2
   swap2
   pop
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 704
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -261,108 +261,108 @@ bb3:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  sstore !meta(stack=0->0)
+  sstore
   pop
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 800
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 576
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 800
-  mload !meta(stack=0->0)
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mload
+  lt
+  iszero
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup1
   push 608
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  add
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   push 1
   dup2
   dup1
   push 736
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -372,65 +372,65 @@ bb4:
   swap1
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  mload
+  mul
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  div !meta(stack=0->0)
+  div
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
-  or !meta(stack=0->0)
+  eq
+  or
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 832
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 832
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -438,31 +438,31 @@ bb4:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   push 1
   dup2
   dup1
   push 672
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -470,528 +470,528 @@ bb4:
   pop
   pop
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   jump bb3
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   pop
   pop
   push 50
   fallthrough bb6
 bb6:
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   jump bb6
 // === ROOT/tests/ui/codegen/linked_library_dynamic_fields.sol:C (runtime) ===
 bb0 (entry):
   push 544
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x2220ae27
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x776f3843
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  keccak256
+  sload
   fallthrough bb3
 bb3:
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 128
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 100
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 251
-  shr !meta(stack=0->0)
+  shr
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup2
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup4
   dup2
   dup4
   dup1
   push 256
-  mstore !meta(stack=0->0)
-  calldatacopy !meta(stack=0->0)
+  mstore
+  calldatacopy
   pop
   swap2
   pop
   push 4
   push 68
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   swap1
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 416
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 480
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 480
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 352
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 68
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 128
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 64
   dup2
-  add !meta(stack=0->0)
+  add
   dup4
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 96
   dup2
-  add !meta(stack=0->0)
+  add
   push 100
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 0xfa06cb9600000000000000000000000000000000000000000000000000000000
   push 384
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 132
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 164
   dup3
-  add !meta(stack=0->0)
+  add
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 260
   dup3
-  add !meta(stack=0->0)
+  add
   push 100
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 196
   dup3
-  add !meta(stack=0->0)
+  add
   push 160
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 292
   dup4
-  add !meta(stack=0->0)
+  add
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 324
   dup4
-  add !meta(stack=0->0)
+  add
   dup2
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  mcopy !meta(stack=0->0)
+  mcopy
   pop
   push 192
   swap1
-  add !meta(stack=0->0)
+  add
   push 228
   dup4
-  add !meta(stack=0->0)
+  add
   swap3
   pop
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup3
-  mload !meta(stack=0->0)
+  mload
   swap3
   pop
   push 31
   dup4
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup4
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   swap3
   pop
   push 32
   swap1
-  add !meta(stack=0->0)
+  add
   dup3
   dup3
   dup3
-  mcopy !meta(stack=0->0)
+  mcopy
   pop
   pop
   push 32
   swap1
-  add !meta(stack=0->0)
+  add
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 4
   swap1
-  add !meta(stack=0->0)
-  gas !meta(stack=0->0)
+  add
+  gas
   push 32
-  mload !meta(stack=0->0)
+  mload
   push 32
   push 0
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 64
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  mload
   push 31
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-  and !meta(stack=0->0)
+  and
   push 32
-  add !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  add
   push 4
-  add !meta(stack=0->0)
+  add
   push 32
-  mload !meta(stack=0->0)
+  mload
   push 0x1000000000000000000000000000000000000001
-  gas !meta(stack=0->0)
-  delegatecall !meta(stack=0->0)
+  gas
+  delegatecall
   swap2
   pop
   pop
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  mload !meta(stack=0->0)
+  mload
   jump bb3
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 65
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb6:
-  returndatasize !meta(stack=0->0)
+  returndatasize
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   dup1
-  returndatacopy !meta(stack=0->0)
+  returndatacopy
   push 512
-  mload !meta(stack=0->0)
+  mload
   push 0
   terminal revert

--- a/tests/ui/codegen/log_topic_reuse.sol
+++ b/tests/ui/codegen/log_topic_reuse.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // A value used as a `LOG` topic and then used again *later in the same block*
 // (here `value` is both the event topic and the stored word) must survive the

--- a/tests/ui/codegen/log_topic_reuse.stdout
+++ b/tests/ui/codegen/log_topic_reuse.stdout
@@ -1,1 +1,75 @@
-{"contracts":{"ROOT/tests/ui/codegen/log_topic_reuse.sol:LogTopicReuse":{"bin-runtime":"60a060405234602a573615602a575f3560e01c806347799da814602e578063b3de648b14603957602a565b5f80fd5b5f5460805260206080f35b366004900360209012602a576004355f52600160205260405f2054806080527f48257dc961b6f792c2b78a080dacfed693b660960a702de21cee364e20270e2f5f5fa2608051806080525f5500"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/log_topic_reuse.sol:LogTopicReuse (runtime) ===
+bb0 (entry):
+  push 160
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x47799da8
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0xb3de648b
+  eq
+  push bb3
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  sload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0
+  mstore
+  push 1
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  sload
+  dup1
+  push 128
+  mstore
+  push 0x48257dc961b6f792c2b78a080dacfed693b660960a702de21cee364e20270e2f
+  push 0
+  push 0
+  log2
+  push 128
+  mload
+  dup1
+  push 128
+  mstore
+  push 0
+  sstore
+  terminal stop

--- a/tests/ui/codegen/log_topic_reuse.stdout
+++ b/tests/ui/codegen/log_topic_reuse.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 160
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x47799da8
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xb3de648b
-  eq !meta(stack=0->0)
+  eq
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -31,45 +31,45 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  keccak256
+  sload
   dup1
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0x48257dc961b6f792c2b78a080dacfed693b660960a702de21cee364e20270e2f
   push 0
   push 0
-  log2 !meta(stack=0->0)
+  log2
   push 128
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   terminal stop

--- a/tests/ui/codegen/log_topic_reuse.stdout
+++ b/tests/ui/codegen/log_topic_reuse.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 160
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x47799da8
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xb3de648b
-  eq
+  eq !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -31,45 +31,45 @@ bb1:
   terminal revert
 bb2:
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
-  sload
+  keccak256 !meta(stack=0->0)
+  sload !meta(stack=0->0)
   dup1
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0x48257dc961b6f792c2b78a080dacfed693b660960a702de21cee364e20270e2f
   push 0
   push 0
-  log2
+  log2 !meta(stack=0->0)
   push 128
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   terminal stop

--- a/tests/ui/codegen/low_level_call_calldata_bytes.sol
+++ b/tests/ui/codegen/low_level_call_calldata_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // A low-level call may take a `bytes calldata` value as its call data, e.g. a
 // proxy fallback `impl.delegatecall(data)` with `bytes calldata data` (aave-v3

--- a/tests/ui/codegen/low_level_call_calldata_bytes.stdout
+++ b/tests/ui/codegen/low_level_call_calldata_bytes.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 352
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x6a57f6c7
-  eq
+  eq !meta(stack=0->0)
   push bb8
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x6b995abd
-  eq
+  eq !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -31,101 +31,101 @@ bb1:
   terminal revert
 bb2:
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   terminal jump
 bb3:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb4
   jump bb14
 bb4:
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb5
   jump bb13
 bb5:
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb6
   jump bb2
 bb6:
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 224
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 36
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   dup2
-  mload
+  mload !meta(stack=0->0)
   swap2
   pop
-  gas
+  gas !meta(stack=0->0)
   push 0
   push 0
   push 64
-  mload
-  mload
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
+  add !meta(stack=0->0)
   push 0
   push 4
-  calldataload
-  gas
-  call
+  calldataload !meta(stack=0->0)
+  gas !meta(stack=0->0)
+  call !meta(stack=0->0)
   fallthrough bb7
 bb7:
   swap2
@@ -134,136 +134,136 @@ bb7:
   swap1
   pop
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb8:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb9
   jump bb14
 bb9:
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb10
   jump bb13
 bb10:
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb11
   jump bb2
 bb11:
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 224
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 36
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   dup2
-  mload
+  mload !meta(stack=0->0)
   swap2
   pop
-  gas
+  gas !meta(stack=0->0)
   push 0
   push 0
   push 64
-  mload
-  mload
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
+  add !meta(stack=0->0)
   push 4
-  calldataload
-  gas
-  delegatecall
+  calldataload !meta(stack=0->0)
+  gas !meta(stack=0->0)
+  delegatecall !meta(stack=0->0)
   jump bb7
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 65
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb13:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 320
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   swap1
@@ -271,27 +271,27 @@ bb13:
 bb14:
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 36
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   swap1

--- a/tests/ui/codegen/low_level_call_calldata_bytes.stdout
+++ b/tests/ui/codegen/low_level_call_calldata_bytes.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 352
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x6a57f6c7
-  eq !meta(stack=0->0)
+  eq
   push bb8
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x6b995abd
-  eq !meta(stack=0->0)
+  eq
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -31,101 +31,101 @@ bb1:
   terminal revert
 bb2:
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   terminal jump
 bb3:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb4
   jump bb14
 bb4:
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb5
   jump bb13
 bb5:
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb6
   jump bb2
 bb6:
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 224
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   dup2
-  mload !meta(stack=0->0)
+  mload
   swap2
   pop
-  gas !meta(stack=0->0)
+  gas
   push 0
   push 0
   push 64
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  mload
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
+  add
   push 0
   push 4
-  calldataload !meta(stack=0->0)
-  gas !meta(stack=0->0)
-  call !meta(stack=0->0)
+  calldataload
+  gas
+  call
   fallthrough bb7
 bb7:
   swap2
@@ -134,136 +134,136 @@ bb7:
   swap1
   pop
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb8:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb9
   jump bb14
 bb9:
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb10
   jump bb13
 bb10:
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb11
   jump bb2
 bb11:
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 224
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   dup2
-  mload !meta(stack=0->0)
+  mload
   swap2
   pop
-  gas !meta(stack=0->0)
+  gas
   push 0
   push 0
   push 64
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  mload
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
+  add
   push 4
-  calldataload !meta(stack=0->0)
-  gas !meta(stack=0->0)
-  delegatecall !meta(stack=0->0)
+  calldataload
+  gas
+  delegatecall
   jump bb7
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 65
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb13:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 320
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   swap1
@@ -271,27 +271,27 @@ bb13:
 bb14:
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   swap1

--- a/tests/ui/codegen/low_level_call_calldata_bytes.stdout
+++ b/tests/ui/codegen/low_level_call_calldata_bytes.stdout
@@ -1,1 +1,298 @@
-{"contracts":{"ROOT/tests/ui/codegen/low_level_call_calldata_bytes.sol:C":{"bin-runtime":"61016060405234602b573615602b575f3560e01c80636a57f6c71460c95780636b995abd14604c57602b565b5f80fd5b604051610100518061010052810160405260c0518060c052815290565b366004900360409012602b576004355f1960601c811603602b57606d61018a565b61013b57607861014f565b61013b576082602f565b60208101602060e0510381015f81525060246024350160c0518060c05281833750815191505a5f5f604051516040516020015f6004355af15b915050905060805260206080f35b366004900360409012602b576004355f1960601c811603602b5760ea61018a565b61013b5760f561014f565b61013b57610100602f565b60208101602060e0510381015f81525060246024350160c0518060c05281833750815191505a5f5f604051516040516020016004355af460bb565b634e487b7160e01b5f52604160045260245ffd5b601f19610120511680610140521561014051602082828203029050018060e05290508060e052602081018061010052818060e0529010905090565b5f608052600460243501358060c052601f81018061012052818060c052901090509056"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/low_level_call_calldata_bytes.sol:C (runtime) ===
+bb0 (entry):
+  push 352
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x6a57f6c7
+  eq
+  push bb8
+  jumpi
+  dup1
+  push 0x6b995abd
+  eq
+  push bb3
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 64
+  mload
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  mstore
+  swap1
+  terminal jump
+bb3:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push bb4
+  jump bb14
+bb4:
+  push bb12
+  jumpi
+  push bb5
+  jump bb13
+bb5:
+  push bb12
+  jumpi
+  push bb6
+  jump bb2
+bb6:
+  push 32
+  dup2
+  add
+  push 32
+  push 224
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 36
+  calldataload
+  add
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  dup2
+  mload
+  swap2
+  pop
+  gas
+  push 0
+  push 0
+  push 64
+  mload
+  mload
+  push 64
+  mload
+  push 32
+  add
+  push 0
+  push 4
+  calldataload
+  gas
+  call
+  fallthrough bb7
+bb7:
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb8:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push bb9
+  jump bb14
+bb9:
+  push bb12
+  jumpi
+  push bb10
+  jump bb13
+bb10:
+  push bb12
+  jumpi
+  push bb11
+  jump bb2
+bb11:
+  push 32
+  dup2
+  add
+  push 32
+  push 224
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 36
+  calldataload
+  add
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  dup2
+  mload
+  swap2
+  pop
+  gas
+  push 0
+  push 0
+  push 64
+  mload
+  mload
+  push 64
+  mload
+  push 32
+  add
+  push 4
+  calldataload
+  gas
+  delegatecall
+  jump bb7
+bb12:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 65
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb13:
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 288
+  mload
+  and
+  dup1
+  push 320
+  mstore
+  iszero
+  push 320
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 224
+  mstore
+  swap1
+  pop
+  dup1
+  push 224
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  swap1
+  terminal jump
+bb14:
+  push 0
+  push 128
+  mstore
+  push 4
+  push 36
+  calldataload
+  add
+  calldataload
+  dup1
+  push 192
+  mstore
+  push 31
+  dup2
+  add
+  dup1
+  push 288
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  swap1
+  terminal jump

--- a/tests/ui/codegen/member_call_unresolved.sol
+++ b/tests/ui/codegen/member_call_unresolved.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin
+//@compile-flags: -Zcodegen --emit=evm-ir
 //@check-fail
 // A member call on a receiver whose type is an unresolved import must produce
 // diagnostics, not an ICE in codegen (the typeck-invariant panic).

--- a/tests/ui/codegen/public_library_call.sol
+++ b/tests/ui/codegen/public_library_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // A `public`/`external` library function called from another contract is
 // compiled by solc into the library's own runtime and reached via delegatecall

--- a/tests/ui/codegen/public_library_call.stdout
+++ b/tests/ui/codegen/public_library_call.stdout
@@ -2,77 +2,77 @@
 bb0 (entry):
   push 352
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xed2f0bb8
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 96
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 68
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   dup1
   push 256
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -80,38 +80,38 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
-  sload
-  caller
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 255
-  and
+  and !meta(stack=0->0)
   dup2
   dup1
   push 288
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -119,24 +119,24 @@ bb2:
   pop
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
@@ -144,105 +144,105 @@ bb3:
 bb0 (entry):
   push 672
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x3dd41ca6
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push bb3
   jump bb4
 bb3:
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
   push 352
-  mload
+  mload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   dup1
   push 608
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup2
   dup1
   push 576
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -250,38 +250,38 @@ bb4:
   pop
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 608
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 608
-  mstore
-  sload
-  caller
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 255
-  and
+  and !meta(stack=0->0)
   dup2
   dup1
   push 480
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -289,19 +289,19 @@ bb4:
   pop
   pop
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   terminal jump
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/public_library_call.stdout
+++ b/tests/ui/codegen/public_library_call.stdout
@@ -1,1 +1,307 @@
-{"contracts":{"ROOT/tests/ui/codegen/public_library_call.sol:C":{"bin-runtime":"6102a06040523460215736156021575f3560e01c80633dd41ca6146025576021565b5f80fd5b3660049003604090126021576004355f1960601c8116036021575f6080525f610140526004356101605260243561018052605c606d565b6101a0518060e05260805260206080f35b610160515f526101405160205260405f2080610260525461018051818061024052018061020052818061024052811091508191505060e8576102005180610200526102605155610260518061026052543360ff1681806101e05201806102205281806101e052811091508191505060e857610220516101a052565b634e487b7160e01b5f52601160045260245ffd"},"ROOT/tests/ui/codegen/public_library_call.sol:Lib":{"bin-runtime":"6101606040523460215736156021575f3560e01c8063ed2f0bb8146025576021565b5f80fd5b3660049003606090126021576024355f1960601c8116036021576024355f5260043560205260405f208060a05254604435818061010052018060c052818061010052811091508191505060b55760c0518060c05260a0515560a0518060a052543360ff16818061012052018060e052818061012052811091508191505060b55760e0518060e05260805260206080f35b634e487b7160e01b5f52601160045260245ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/public_library_call.sol:Lib (runtime) ===
+bb0 (entry):
+  push 352
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xed2f0bb8
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 96
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 0
+  mstore
+  push 4
+  calldataload
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  dup1
+  push 160
+  mstore
+  sload
+  push 68
+  calldataload
+  dup2
+  dup1
+  push 256
+  mstore
+  add
+  dup1
+  push 192
+  mstore
+  dup2
+  dup1
+  push 256
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  push 160
+  mload
+  sstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  sload
+  caller
+  push 255
+  and
+  dup2
+  dup1
+  push 288
+  mstore
+  add
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 288
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb3
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+// === ROOT/tests/ui/codegen/public_library_call.sol:C (runtime) ===
+bb0 (entry):
+  push 672
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x3dd41ca6
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 0
+  push 320
+  mstore
+  push 4
+  calldataload
+  push 352
+  mstore
+  push 36
+  calldataload
+  push 384
+  mstore
+  push bb3
+  jump bb4
+bb3:
+  push 416
+  mload
+  dup1
+  push 224
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  push 352
+  mload
+  push 0
+  mstore
+  push 320
+  mload
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  dup1
+  push 608
+  mstore
+  sload
+  push 384
+  mload
+  dup2
+  dup1
+  push 576
+  mstore
+  add
+  dup1
+  push 512
+  mstore
+  dup2
+  dup1
+  push 576
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb5
+  jumpi
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  push 608
+  mload
+  sstore
+  push 608
+  mload
+  dup1
+  push 608
+  mstore
+  sload
+  caller
+  push 255
+  and
+  dup2
+  dup1
+  push 480
+  mstore
+  add
+  dup1
+  push 544
+  mstore
+  dup2
+  dup1
+  push 480
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb5
+  jumpi
+  push 544
+  mload
+  push 416
+  mstore
+  terminal jump
+bb5:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/public_library_call.stdout
+++ b/tests/ui/codegen/public_library_call.stdout
@@ -2,77 +2,77 @@
 bb0 (entry):
   push 352
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xed2f0bb8
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 96
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 68
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   dup1
   push 256
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -80,38 +80,38 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  mstore
+  sload
+  caller
   push 255
-  and !meta(stack=0->0)
+  and
   dup2
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -119,24 +119,24 @@ bb2:
   pop
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
@@ -144,105 +144,105 @@ bb3:
 bb0 (entry):
   push 672
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x3dd41ca6
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push bb3
   jump bb4
 bb3:
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
   push 352
-  mload !meta(stack=0->0)
+  mload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   dup1
   push 608
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup2
   dup1
   push 576
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -250,38 +250,38 @@ bb4:
   pop
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   push 608
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 608
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  mstore
+  sload
+  caller
   push 255
-  and !meta(stack=0->0)
+  and
   dup2
   dup1
   push 480
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -289,19 +289,19 @@ bb4:
   pop
   pop
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 544
-  mload !meta(stack=0->0)
+  mload
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   terminal jump
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/revert_error_helper.sol
+++ b/tests/ui/codegen/revert_error_helper.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // Constant short revert messages share one synthesized `__revert_error`
 // helper per module: each `require`/`revert` site passes the length and the

--- a/tests/ui/codegen/revert_error_helper.stdout
+++ b/tests/ui/codegen/revert_error_helper.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 320
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x561cce0a
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xa871da91
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -32,111 +32,111 @@ bb1:
 bb2:
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0x3339000000000000000000000000000000000000000000000000000000000000
   fallthrough bb3
 bb3:
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   jump bb5
 bb4:
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0x746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121
   jump bb3
 bb5:
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  mload
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   dup2
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   push 64
   dup4
-  add
+  add !meta(stack=0->0)
   push 32
   dup3
-  sub
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 32
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup4
-  mcopy
+  mcopy !meta(stack=0->0)
   pop
   pop
   swap1
   pop
   push 64
   swap1
-  add
+  add !meta(stack=0->0)
   dup2
   terminal return
 // === ROOT/tests/ui/codegen/revert_error_helper.sol:R (runtime) ===
 bb0 (entry):
   push 352
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xc4186a6
-  eq
+  eq !meta(stack=0->0)
   push bb14
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x17a0525e
-  eq
+  eq !meta(stack=0->0)
   push bb17
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x9927bee4
-  eq
+  eq !meta(stack=0->0)
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x9af992c0
-  eq
+  eq !meta(stack=0->0)
   push bb8
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x9ee36b07
-  eq
+  eq !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -145,192 +145,192 @@ bb1:
 bb2:
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 5
   push 4
-  calldataload
-  gt
-  iszero
+  calldataload !meta(stack=0->0)
+  gt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   swap1
   terminal jump
 bb3:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb4
   jump bb2
 bb4:
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   fallthrough bb5
 bb5:
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb6:
   push 2
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 0x3339000000000000000000000000000000000000000000000000000000000000
   fallthrough bb7
 bb7:
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   jump bb20
 bb8:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb9
   jump bb2
 bb9:
   push bb10
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb5
 bb10:
   push 11
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 0x6c69746572616c206d7367000000000000000000000000000000000000000000
   jump bb7
 bb11:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb12
   jump bb2
 bb12:
   push bb13
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb5
 bb13:
   push 15
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 0x6c6f63616c2d636f6e73742d6d73670000000000000000000000000000000000
   jump bb7
 bb14:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb15
   jump bb2
 bb15:
   push bb16
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb5
 bb16:
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 96
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 33
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 0x746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 0x2100000000000000000000000000000000000000000000000000000000000000
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 0x8c379a000000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 33
   push 36
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 100
-  mstore
+  mstore !meta(stack=0->0)
   push 33
   dup2
   push 68
-  mcopy
+  mcopy !meta(stack=0->0)
   pop
   push 132
   push 0
   terminal revert
 bb17:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb18
   jump bb2
 bb18:
   push bb19
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb5
 bb19:
   push 11
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 0x7265766572742d70617468000000000000000000000000000000000000000000
   jump bb7
 bb20:
   push 0x8c379a000000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 36
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   push 68
-  mstore
+  mstore !meta(stack=0->0)
   push 100
   push 0
   terminal revert

--- a/tests/ui/codegen/revert_error_helper.stdout
+++ b/tests/ui/codegen/revert_error_helper.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 320
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x561cce0a
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xa871da91
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -32,111 +32,111 @@ bb1:
 bb2:
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0x3339000000000000000000000000000000000000000000000000000000000000
   fallthrough bb3
 bb3:
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   jump bb5
 bb4:
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0x746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121
   jump bb3
 bb5:
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  mload
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   dup2
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   push 64
   dup4
-  add !meta(stack=0->0)
+  add
   push 32
   dup3
-  sub !meta(stack=0->0)
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 32
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup4
   dup2
   dup4
-  mcopy !meta(stack=0->0)
+  mcopy
   pop
   pop
   swap1
   pop
   push 64
   swap1
-  add !meta(stack=0->0)
+  add
   dup2
   terminal return
 // === ROOT/tests/ui/codegen/revert_error_helper.sol:R (runtime) ===
 bb0 (entry):
   push 352
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xc4186a6
-  eq !meta(stack=0->0)
+  eq
   push bb14
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x17a0525e
-  eq !meta(stack=0->0)
+  eq
   push bb17
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x9927bee4
-  eq !meta(stack=0->0)
+  eq
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x9af992c0
-  eq !meta(stack=0->0)
+  eq
   push bb8
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x9ee36b07
-  eq !meta(stack=0->0)
+  eq
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -145,192 +145,192 @@ bb1:
 bb2:
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 5
   push 4
-  calldataload !meta(stack=0->0)
-  gt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  calldataload
+  gt
+  iszero
   swap1
   terminal jump
 bb3:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb4
   jump bb2
 bb4:
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   fallthrough bb5
 bb5:
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb6:
   push 2
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 0x3339000000000000000000000000000000000000000000000000000000000000
   fallthrough bb7
 bb7:
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   jump bb20
 bb8:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb9
   jump bb2
 bb9:
   push bb10
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb5
 bb10:
   push 11
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 0x6c69746572616c206d7367000000000000000000000000000000000000000000
   jump bb7
 bb11:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb12
   jump bb2
 bb12:
   push bb13
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb5
 bb13:
   push 15
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 0x6c6f63616c2d636f6e73742d6d73670000000000000000000000000000000000
   jump bb7
 bb14:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb15
   jump bb2
 bb15:
   push bb16
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb5
 bb16:
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 96
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 33
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 0x746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 0x2100000000000000000000000000000000000000000000000000000000000000
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 0x8c379a000000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 33
   push 36
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 100
-  mstore !meta(stack=0->0)
+  mstore
   push 33
   dup2
   push 68
-  mcopy !meta(stack=0->0)
+  mcopy
   pop
   push 132
   push 0
   terminal revert
 bb17:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb18
   jump bb2
 bb18:
   push bb19
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb5
 bb19:
   push 11
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 0x7265766572742d70617468000000000000000000000000000000000000000000
   jump bb7
 bb20:
   push 0x8c379a000000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 36
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   push 68
-  mstore !meta(stack=0->0)
+  mstore
   push 100
   push 0
   terminal revert

--- a/tests/ui/codegen/revert_error_helper.stdout
+++ b/tests/ui/codegen/revert_error_helper.stdout
@@ -1,1 +1,336 @@
-{"contracts":{"ROOT/tests/ui/codegen/revert_error_helper.sol:Errors":{"bin-runtime":"61014060405234602b573615602b575f3560e01c8063561cce0a146042578063a871da9114602f57602b565b5f80fd5b5f60805261333960f01b5b61012052606b565b5f6080527f746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121603a565b6040516020815261012051516020820181815250601f8101601f199016604083016020820381015f815250602061012051018381835e505090506040900181f3"},"ROOT/tests/ui/codegen/revert_error_helper.sol:R":{"bin-runtime":"61016060405234604a573615604a575f3560e01c80630c4186a61460fc57806317a0525e1461017f5780639927bee41460c65780639af992c01460945780639ee36b0714605c57604a565b5f80fd5b5f6080526005600435111590565b366004900360209012604a57606e604e565b607e575b60043560805260206080f35b60026101205261333960f01b5b610140526101b3565b366004900360209012604a5760a6604e565b60ad576072565b600b610120526a6c69746572616c206d736760a81b608b565b366004900360209012604a5760d8604e565b60df576072565b600f610120526e6c6f63616c2d636f6e73742d6d736760881b608b565b366004900360209012604a5761010f604e565b610117576072565b6040516060810160405260218152602081017f746869732d69732d612d33332d627974652d6c6f6e672d6d65737361676521218152604082019150602160f81b825290506308c379a060e01b5f52602060045260216024525f60645260218160445e5060845ffd5b366004900360209012604a57610192604e565b61019a576072565b600b610120526a7265766572742d7061746860a81b608b565b6308c379a060e01b5f526020600452610120516024526101405160445260645ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/revert_error_helper.sol:Errors (runtime) ===
+bb0 (entry):
+  push 320
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x561cce0a
+  eq
+  push bb4
+  jumpi
+  dup1
+  push 0xa871da91
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  push 128
+  mstore
+  push 0x3339000000000000000000000000000000000000000000000000000000000000
+  fallthrough bb3
+bb3:
+  push 288
+  mstore
+  jump bb5
+bb4:
+  push 0
+  push 128
+  mstore
+  push 0x746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121
+  jump bb3
+bb5:
+  push 64
+  mload
+  push 32
+  dup2
+  mstore
+  push 288
+  mload
+  mload
+  push 32
+  dup3
+  add
+  dup2
+  dup2
+  mstore
+  pop
+  push 31
+  dup2
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  push 64
+  dup4
+  add
+  push 32
+  dup3
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 32
+  push 288
+  mload
+  add
+  dup4
+  dup2
+  dup4
+  mcopy
+  pop
+  pop
+  swap1
+  pop
+  push 64
+  swap1
+  add
+  dup2
+  terminal return
+// === ROOT/tests/ui/codegen/revert_error_helper.sol:R (runtime) ===
+bb0 (entry):
+  push 352
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xc4186a6
+  eq
+  push bb14
+  jumpi
+  dup1
+  push 0x17a0525e
+  eq
+  push bb17
+  jumpi
+  dup1
+  push 0x9927bee4
+  eq
+  push bb11
+  jumpi
+  dup1
+  push 0x9af992c0
+  eq
+  push bb8
+  jumpi
+  dup1
+  push 0x9ee36b07
+  eq
+  push bb3
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0
+  push 128
+  mstore
+  push 5
+  push 4
+  calldataload
+  gt
+  iszero
+  swap1
+  terminal jump
+bb3:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push bb4
+  jump bb2
+bb4:
+  push bb6
+  jumpi
+  fallthrough bb5
+bb5:
+  push 4
+  calldataload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb6:
+  push 2
+  push 288
+  mstore
+  push 0x3339000000000000000000000000000000000000000000000000000000000000
+  fallthrough bb7
+bb7:
+  push 320
+  mstore
+  jump bb20
+bb8:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push bb9
+  jump bb2
+bb9:
+  push bb10
+  jumpi
+  jump bb5
+bb10:
+  push 11
+  push 288
+  mstore
+  push 0x6c69746572616c206d7367000000000000000000000000000000000000000000
+  jump bb7
+bb11:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push bb12
+  jump bb2
+bb12:
+  push bb13
+  jumpi
+  jump bb5
+bb13:
+  push 15
+  push 288
+  mstore
+  push 0x6c6f63616c2d636f6e73742d6d73670000000000000000000000000000000000
+  jump bb7
+bb14:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push bb15
+  jump bb2
+bb15:
+  push bb16
+  jumpi
+  jump bb5
+bb16:
+  push 64
+  mload
+  push 96
+  dup2
+  add
+  push 64
+  mstore
+  push 33
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 0x746869732d69732d612d33332d627974652d6c6f6e672d6d6573736167652121
+  dup2
+  mstore
+  push 64
+  dup3
+  add
+  swap2
+  pop
+  push 0x2100000000000000000000000000000000000000000000000000000000000000
+  dup3
+  mstore
+  swap1
+  pop
+  push 0x8c379a000000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 32
+  push 4
+  mstore
+  push 33
+  push 36
+  mstore
+  push 0
+  push 100
+  mstore
+  push 33
+  dup2
+  push 68
+  mcopy
+  pop
+  push 132
+  push 0
+  terminal revert
+bb17:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push bb18
+  jump bb2
+bb18:
+  push bb19
+  jumpi
+  jump bb5
+bb19:
+  push 11
+  push 288
+  mstore
+  push 0x7265766572742d70617468000000000000000000000000000000000000000000
+  jump bb7
+bb20:
+  push 0x8c379a000000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 32
+  push 4
+  mstore
+  push 288
+  mload
+  push 36
+  mstore
+  push 320
+  mload
+  push 68
+  mstore
+  push 100
+  push 0
+  terminal revert

--- a/tests/ui/codegen/stack-too-deep/call_args.sol
+++ b/tests/ui/codegen/stack-too-deep/call_args.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;
 

--- a/tests/ui/codegen/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/stack-too-deep/call_args.stdout
@@ -1,8 +1,691 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/stack-too-deep/call_args.sol:StackTooDeepCall": {
-      "bin": "61044680600a5f395ff36105606040523460215736156021575f3560e01c80632b096926146025576021565b5f80fd5b36600490036020901260215760016004350180610460526004359010610432576002600435018061034052600435901061043257600360043501806104a0526004359010610432576004600435018061038052600435901061043257600560043501806104e052600435901061043257600660043501806103c052600435901061043257600760043501806105205260043590106104325760086004350180610400526004359010610432576009600435018061054052600435901061043257600a600435018061042052600435901061043257600b600435018061030052600435901061043257600c600435018061044052600435901061043257600d600435018061032052600435901061043257600e600435018061048052600435901061043257600f600435018061036052600435901061043257601060043501806104c052600435901061043257601160043501806103a0526004359010610432576012600435018061050052600435901061043257601360043501806103e05260043590106104325761046051806104605260043501806102a0526004359010610432576103405180610340526102a051018060e0526102a051806102a0529010610432576104a051806104a05260e05101806101605260e0518060e0529010610432576103805180610380526101605101806101e0526101605180610160529010610432576104e051806104e0526101e0510180610260526101e051806101e0529010610432576103c051806103c05261026051018060a05261026051806102605290106104325761052051806105205260a05101806101205260a0518060a0529010610432576104005180610400526101205101806101a0526101205180610120529010610432576105405180610540526101a0510180610220526101a051806101a0529010610432576104205180610420526102205101806102c0526102205180610220529010610432576103005180610300526102c0510180610100526102c051806102c05290106104325761044051806104405261010051018061018052610100518061010052901061043257610320518061032052610180510180610200526101805180610180529010610432576104805180610480526102005101806102805261020051806102005290106104325761036051806103605261028051018060c0526102805180610280529010610432576104c051806104c05260c05101806101405260c0518060c0529010610432576103a051806103a0526101405101806101c0526101405180610140529010610432576105005180610500526101c0510180610240526101c051806101c0529010610432576103e051806103e0526102405101806102e0526102405180610240529010610432576102e051806102e05260805260206080f35b634e487b7160e01b5f52601160045260245ffd"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/stack-too-deep/call_args.sol:StackTooDeepCall (creation) ===
+// === deployment ===
+bb0 (entry):
+  push 0x446
+  dup1
+  push 10
+  push 0
+  codecopy
+  push 0
+  terminal return
+
+// === runtime ===
+bb0 (entry):
+  push 0x560
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x2b096926
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 1
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x460
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 2
+  push 4
+  calldataload
+  add
+  dup1
+  push 832
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 3
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x4a0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 4
+  push 4
+  calldataload
+  add
+  dup1
+  push 896
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 5
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x4e0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 6
+  push 4
+  calldataload
+  add
+  dup1
+  push 960
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 7
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x520
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 8
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x400
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 9
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x540
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 10
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x420
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 11
+  push 4
+  calldataload
+  add
+  dup1
+  push 768
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 12
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x440
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 13
+  push 4
+  calldataload
+  add
+  dup1
+  push 800
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 14
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x480
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 15
+  push 4
+  calldataload
+  add
+  dup1
+  push 864
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 16
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x4c0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 17
+  push 4
+  calldataload
+  add
+  dup1
+  push 928
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 18
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x500
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 19
+  push 4
+  calldataload
+  add
+  dup1
+  push 992
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x460
+  mload
+  dup1
+  push 0x460
+  mstore
+  push 4
+  calldataload
+  add
+  dup1
+  push 672
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 832
+  mload
+  dup1
+  push 832
+  mstore
+  push 672
+  mload
+  add
+  dup1
+  push 224
+  mstore
+  push 672
+  mload
+  dup1
+  push 672
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x4a0
+  mload
+  dup1
+  push 0x4a0
+  mstore
+  push 224
+  mload
+  add
+  dup1
+  push 352
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 896
+  mload
+  dup1
+  push 896
+  mstore
+  push 352
+  mload
+  add
+  dup1
+  push 480
+  mstore
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x4e0
+  mload
+  dup1
+  push 0x4e0
+  mstore
+  push 480
+  mload
+  add
+  dup1
+  push 608
+  mstore
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 960
+  mload
+  dup1
+  push 960
+  mstore
+  push 608
+  mload
+  add
+  dup1
+  push 160
+  mstore
+  push 608
+  mload
+  dup1
+  push 608
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x520
+  mload
+  dup1
+  push 0x520
+  mstore
+  push 160
+  mload
+  add
+  dup1
+  push 288
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x400
+  mload
+  dup1
+  push 0x400
+  mstore
+  push 288
+  mload
+  add
+  dup1
+  push 416
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x540
+  mload
+  dup1
+  push 0x540
+  mstore
+  push 416
+  mload
+  add
+  dup1
+  push 544
+  mstore
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x420
+  mload
+  dup1
+  push 0x420
+  mstore
+  push 544
+  mload
+  add
+  dup1
+  push 704
+  mstore
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 768
+  mload
+  dup1
+  push 768
+  mstore
+  push 704
+  mload
+  add
+  dup1
+  push 256
+  mstore
+  push 704
+  mload
+  dup1
+  push 704
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x440
+  mload
+  dup1
+  push 0x440
+  mstore
+  push 256
+  mload
+  add
+  dup1
+  push 384
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 800
+  mload
+  dup1
+  push 800
+  mstore
+  push 384
+  mload
+  add
+  dup1
+  push 512
+  mstore
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x480
+  mload
+  dup1
+  push 0x480
+  mstore
+  push 512
+  mload
+  add
+  dup1
+  push 640
+  mstore
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 864
+  mload
+  dup1
+  push 864
+  mstore
+  push 640
+  mload
+  add
+  dup1
+  push 192
+  mstore
+  push 640
+  mload
+  dup1
+  push 640
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x4c0
+  mload
+  dup1
+  push 0x4c0
+  mstore
+  push 192
+  mload
+  add
+  dup1
+  push 320
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 928
+  mload
+  dup1
+  push 928
+  mstore
+  push 320
+  mload
+  add
+  dup1
+  push 448
+  mstore
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x500
+  mload
+  dup1
+  push 0x500
+  mstore
+  push 448
+  mload
+  add
+  dup1
+  push 576
+  mstore
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 992
+  mload
+  dup1
+  push 992
+  mstore
+  push 576
+  mload
+  add
+  dup1
+  push 736
+  mstore
+  push 576
+  mload
+  dup1
+  push 576
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 736
+  mload
+  dup1
+  push 736
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/stack-too-deep/call_args.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 10
   push 0
-  codecopy !meta(stack=0->0)
+  codecopy
   push 0
   terminal return
 
@@ -13,679 +13,679 @@ bb0 (entry):
 bb0 (entry):
   push 0x560
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x2b096926
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 2
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 832
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 3
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 896
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 5
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x4e0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 6
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 960
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 7
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x520
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 8
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x400
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 9
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x540
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 10
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 11
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 768
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 12
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 13
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 800
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 14
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x480
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 15
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 864
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 16
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x4c0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 17
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 18
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 19
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 992
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x460
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 832
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 832
-  mstore !meta(stack=0->0)
+  mstore
   push 672
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 672
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4a0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 896
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 896
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4e0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4e0
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 960
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 960
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x520
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x520
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x400
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x400
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x540
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x540
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x420
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 768
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 768
-  mstore !meta(stack=0->0)
+  mstore
   push 704
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 704
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 800
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 800
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x480
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 864
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 864
-  mstore !meta(stack=0->0)
+  mstore
   push 640
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 640
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4c0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4c0
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 928
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x500
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 992
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 992
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 736
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/stack-too-deep/call_args.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 10
   push 0
-  codecopy
+  codecopy !meta(stack=0->0)
   push 0
   terminal return
 
@@ -13,679 +13,679 @@ bb0 (entry):
 bb0 (entry):
   push 0x560
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x2b096926
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 2
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 832
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 3
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 896
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 5
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4e0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 6
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 960
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 7
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x520
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 8
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x400
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 9
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x540
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 10
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 11
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 768
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 12
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 13
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 800
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 14
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x480
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 15
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 864
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 16
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4c0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 17
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 18
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 19
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 992
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x460
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 832
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 832
-  mstore
+  mstore !meta(stack=0->0)
   push 672
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 672
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4a0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 896
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 896
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4e0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4e0
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 960
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 960
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x520
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x520
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x400
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x400
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x540
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x540
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x420
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 768
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 768
-  mstore
+  mstore !meta(stack=0->0)
   push 704
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 704
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 800
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 800
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x480
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 864
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 864
-  mstore
+  mstore !meta(stack=0->0)
   push 640
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 640
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4c0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4c0
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 928
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x500
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 992
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 992
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 736
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack-too-deep/locals.sol
+++ b/tests/ui/codegen/stack-too-deep/locals.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;
 

--- a/tests/ui/codegen/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/stack-too-deep/locals.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 10
   push 0
-  codecopy !meta(stack=0->0)
+  codecopy
   push 0
   terminal return
 
@@ -13,745 +13,745 @@ bb0 (entry):
 bb0 (entry):
   push 0x5e0
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x188b85b4
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x4c0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 2
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 864
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 3
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 960
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 5
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x540
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 6
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x400
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 7
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x580
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 8
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 9
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x5c0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 10
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x480
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 11
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 800
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 12
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 13
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 832
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 14
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x4e0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 15
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 16
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x520
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 17
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 992
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 18
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x560
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 19
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 20
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x5a0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 21
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4c0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4c0
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 864
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 864
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x500
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   push 736
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 736
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 960
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 960
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x540
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x540
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x400
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x400
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x580
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x580
-  mstore !meta(stack=0->0)
+  mstore
   push 672
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 672
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x5c0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x5c0
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x480
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 800
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 800
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 768
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4a0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   push 768
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 768
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 768
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 832
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 832
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4e0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4e0
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 928
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x520
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x520
-  mstore !meta(stack=0->0)
+  mstore
   push 704
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 704
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 992
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 992
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x560
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x560
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x420
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x5a0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x5a0
-  mstore !meta(stack=0->0)
+  mstore
   push 640
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 640
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x460
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 896
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 896
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 896
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/stack-too-deep/locals.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 10
   push 0
-  codecopy
+  codecopy !meta(stack=0->0)
   push 0
   terminal return
 
@@ -13,745 +13,745 @@ bb0 (entry):
 bb0 (entry):
   push 0x5e0
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x188b85b4
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4c0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 2
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 864
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 3
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 960
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 5
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x540
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 6
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x400
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 7
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x580
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 8
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 9
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x5c0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 10
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x480
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 11
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 800
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 12
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 13
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 832
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 14
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4e0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 15
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 16
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x520
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 17
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 992
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 18
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x560
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 19
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 20
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x5a0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 21
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4c0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4c0
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 864
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 864
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x500
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   push 736
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 736
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 960
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 960
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x540
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x540
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x400
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x400
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x580
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x580
-  mstore
+  mstore !meta(stack=0->0)
   push 672
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 672
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x5c0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x5c0
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x480
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 800
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 800
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 768
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4a0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   push 768
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 768
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 768
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 832
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 832
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4e0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4e0
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 928
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x520
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x520
-  mstore
+  mstore !meta(stack=0->0)
   push 704
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 704
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 992
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 992
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x560
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x560
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x420
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x5a0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x5a0
-  mstore
+  mstore !meta(stack=0->0)
   push 640
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 640
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x460
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 896
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 896
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 896
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/stack-too-deep/locals.stdout
@@ -1,8 +1,757 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/stack-too-deep/locals.sol:StackTooDeepLocals": {
-      "bin": "6104b280600a5f395ff36105e06040523460215736156021575f3560e01c8063188b85b4146025576021565b5f80fd5b366004900360209012602157600160043501806104c052600435901061049e576002600435018061036052600435901061049e576003600435018061050052600435901061049e57600460043501806103c052600435901061049e576005600435018061054052600435901061049e576006600435018061040052600435901061049e576007600435018061058052600435901061049e576008600435018061044052600435901061049e57600960043501806105c052600435901061049e57600a600435018061048052600435901061049e57600b600435018061032052600435901061049e57600c60043501806104a052600435901061049e57600d600435018061034052600435901061049e57600e60043501806104e052600435901061049e57600f60043501806103a052600435901061049e576010600435018061052052600435901061049e57601160043501806103e052600435901061049e576012600435018061056052600435901061049e576013600435018061042052600435901061049e57601460043501806105a052600435901061049e576015600435018061046052600435901061049e576104c051806104c052600435018061024052600435901061049e576103605180610360526102405101806102e052610240518061024052901061049e576105005180610500526102e0510180610100526102e051806102e052901061049e576103c051806103c05261010051018061018052610100518061010052901061049e5761054051806105405261018051018061020052610180518061018052901061049e576104005180610400526102005101806102a052610200518061020052901061049e576105805180610580526102a051018060c0526102a051806102a052901061049e5761044051806104405260c05101806101405260c0518060c052901061049e576105c051806105c0526101405101806101c052610140518061014052901061049e576104805180610480526101c0510180610260526101c051806101c052901061049e5761032051806103205261026051018061030052610260518061026052901061049e576104a051806104a05261030051018061012052610300518061030052901061049e576103405180610340526101205101806101a052610120518061012052901061049e576104e051806104e0526101a0510180610220526101a051806101a052901061049e576103a051806103a0526102205101806102c052610220518061022052901061049e576105205180610520526102c051018060e0526102c051806102c052901061049e576103e051806103e05260e05101806101605260e0518060e052901061049e576105605180610560526101605101806101e052610160518061016052901061049e576104205180610420526101e0510180610280526101e051806101e052901061049e576105a051806105a05261028051018060a052610280518061028052901061049e5761046051806104605260a05101806103805260a0518060a052901061049e5761038051806103805260805260206080f35b634e487b7160e01b5f52601160045260245ffd"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/stack-too-deep/locals.sol:StackTooDeepLocals (creation) ===
+// === deployment ===
+bb0 (entry):
+  push 0x4b2
+  dup1
+  push 10
+  push 0
+  codecopy
+  push 0
+  terminal return
+
+// === runtime ===
+bb0 (entry):
+  push 0x5e0
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x188b85b4
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 1
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x4c0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 2
+  push 4
+  calldataload
+  add
+  dup1
+  push 864
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 3
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x500
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 4
+  push 4
+  calldataload
+  add
+  dup1
+  push 960
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 5
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x540
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 6
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x400
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 7
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x580
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 8
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x440
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 9
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x5c0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 10
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x480
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 11
+  push 4
+  calldataload
+  add
+  dup1
+  push 800
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 12
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x4a0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 13
+  push 4
+  calldataload
+  add
+  dup1
+  push 832
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 14
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x4e0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 15
+  push 4
+  calldataload
+  add
+  dup1
+  push 928
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 16
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x520
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 17
+  push 4
+  calldataload
+  add
+  dup1
+  push 992
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 18
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x560
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 19
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x420
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 20
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x5a0
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 21
+  push 4
+  calldataload
+  add
+  dup1
+  push 0x460
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x4c0
+  mload
+  dup1
+  push 0x4c0
+  mstore
+  push 4
+  calldataload
+  add
+  dup1
+  push 576
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 864
+  mload
+  dup1
+  push 864
+  mstore
+  push 576
+  mload
+  add
+  dup1
+  push 736
+  mstore
+  push 576
+  mload
+  dup1
+  push 576
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x500
+  mload
+  dup1
+  push 0x500
+  mstore
+  push 736
+  mload
+  add
+  dup1
+  push 256
+  mstore
+  push 736
+  mload
+  dup1
+  push 736
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 960
+  mload
+  dup1
+  push 960
+  mstore
+  push 256
+  mload
+  add
+  dup1
+  push 384
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x540
+  mload
+  dup1
+  push 0x540
+  mstore
+  push 384
+  mload
+  add
+  dup1
+  push 512
+  mstore
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x400
+  mload
+  dup1
+  push 0x400
+  mstore
+  push 512
+  mload
+  add
+  dup1
+  push 672
+  mstore
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x580
+  mload
+  dup1
+  push 0x580
+  mstore
+  push 672
+  mload
+  add
+  dup1
+  push 192
+  mstore
+  push 672
+  mload
+  dup1
+  push 672
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x440
+  mload
+  dup1
+  push 0x440
+  mstore
+  push 192
+  mload
+  add
+  dup1
+  push 320
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x5c0
+  mload
+  dup1
+  push 0x5c0
+  mstore
+  push 320
+  mload
+  add
+  dup1
+  push 448
+  mstore
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x480
+  mload
+  dup1
+  push 0x480
+  mstore
+  push 448
+  mload
+  add
+  dup1
+  push 608
+  mstore
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 800
+  mload
+  dup1
+  push 800
+  mstore
+  push 608
+  mload
+  add
+  dup1
+  push 768
+  mstore
+  push 608
+  mload
+  dup1
+  push 608
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x4a0
+  mload
+  dup1
+  push 0x4a0
+  mstore
+  push 768
+  mload
+  add
+  dup1
+  push 288
+  mstore
+  push 768
+  mload
+  dup1
+  push 768
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 832
+  mload
+  dup1
+  push 832
+  mstore
+  push 288
+  mload
+  add
+  dup1
+  push 416
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x4e0
+  mload
+  dup1
+  push 0x4e0
+  mstore
+  push 416
+  mload
+  add
+  dup1
+  push 544
+  mstore
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 928
+  mload
+  dup1
+  push 928
+  mstore
+  push 544
+  mload
+  add
+  dup1
+  push 704
+  mstore
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x520
+  mload
+  dup1
+  push 0x520
+  mstore
+  push 704
+  mload
+  add
+  dup1
+  push 224
+  mstore
+  push 704
+  mload
+  dup1
+  push 704
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 992
+  mload
+  dup1
+  push 992
+  mstore
+  push 224
+  mload
+  add
+  dup1
+  push 352
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x560
+  mload
+  dup1
+  push 0x560
+  mstore
+  push 352
+  mload
+  add
+  dup1
+  push 480
+  mstore
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x420
+  mload
+  dup1
+  push 0x420
+  mstore
+  push 480
+  mload
+  add
+  dup1
+  push 640
+  mstore
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x5a0
+  mload
+  dup1
+  push 0x5a0
+  mstore
+  push 640
+  mload
+  add
+  dup1
+  push 160
+  mstore
+  push 640
+  mload
+  dup1
+  push 640
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 0x460
+  mload
+  dup1
+  push 0x460
+  mstore
+  push 160
+  mload
+  add
+  dup1
+  push 896
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 896
+  mload
+  dup1
+  push 896
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/stack-too-deep/params.sol
+++ b/tests/ui/codegen/stack-too-deep/params.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;
 

--- a/tests/ui/codegen/stack-too-deep/params.stdout
+++ b/tests/ui/codegen/stack-too-deep/params.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 10
   push 0
-  codecopy
+  codecopy !meta(stack=0->0)
   push 0
   terminal return
 
@@ -13,375 +13,375 @@ bb0 (entry):
 bb0 (entry):
   push 768
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x8c4ee692
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 640
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 68
-  calldataload
+  calldataload !meta(stack=0->0)
   push 544
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 100
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 132
-  calldataload
+  calldataload !meta(stack=0->0)
   push 480
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 164
-  calldataload
+  calldataload !meta(stack=0->0)
   push 160
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 196
-  calldataload
+  calldataload !meta(stack=0->0)
   push 416
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 228
-  calldataload
+  calldataload !meta(stack=0->0)
   push 672
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 672
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 260
-  calldataload
+  calldataload !meta(stack=0->0)
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 292
-  calldataload
+  calldataload !meta(stack=0->0)
   push 608
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 324
-  calldataload
+  calldataload !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 356
-  calldataload
+  calldataload !meta(stack=0->0)
   push 576
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 388
-  calldataload
+  calldataload !meta(stack=0->0)
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 420
-  calldataload
+  calldataload !meta(stack=0->0)
   push 512
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 452
-  calldataload
+  calldataload !meta(stack=0->0)
   push 192
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 192
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 484
-  calldataload
+  calldataload !meta(stack=0->0)
   push 448
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 516
-  calldataload
+  calldataload !meta(stack=0->0)
   push 704
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 704
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 548
-  calldataload
+  calldataload !meta(stack=0->0)
   push 384
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 580
-  calldataload
+  calldataload !meta(stack=0->0)
   push 640
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 640
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 612
-  calldataload
+  calldataload !meta(stack=0->0)
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 736
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack-too-deep/params.stdout
+++ b/tests/ui/codegen/stack-too-deep/params.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 10
   push 0
-  codecopy !meta(stack=0->0)
+  codecopy
   push 0
   terminal return
 
@@ -13,375 +13,375 @@ bb0 (entry):
 bb0 (entry):
   push 768
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x8c4ee692
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 640
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 68
-  calldataload !meta(stack=0->0)
+  calldataload
   push 544
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 100
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 132
-  calldataload !meta(stack=0->0)
+  calldataload
   push 480
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 164
-  calldataload !meta(stack=0->0)
+  calldataload
   push 160
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 196
-  calldataload !meta(stack=0->0)
+  calldataload
   push 416
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 228
-  calldataload !meta(stack=0->0)
+  calldataload
   push 672
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 672
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 260
-  calldataload !meta(stack=0->0)
+  calldataload
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 292
-  calldataload !meta(stack=0->0)
+  calldataload
   push 608
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 324
-  calldataload !meta(stack=0->0)
+  calldataload
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 356
-  calldataload !meta(stack=0->0)
+  calldataload
   push 576
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 388
-  calldataload !meta(stack=0->0)
+  calldataload
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 420
-  calldataload !meta(stack=0->0)
+  calldataload
   push 512
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 452
-  calldataload !meta(stack=0->0)
+  calldataload
   push 192
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 192
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 484
-  calldataload !meta(stack=0->0)
+  calldataload
   push 448
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 516
-  calldataload !meta(stack=0->0)
+  calldataload
   push 704
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 704
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 548
-  calldataload !meta(stack=0->0)
+  calldataload
   push 384
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 580
-  calldataload !meta(stack=0->0)
+  calldataload
   push 640
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 640
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 612
-  calldataload !meta(stack=0->0)
+  calldataload
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 736
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack-too-deep/params.stdout
+++ b/tests/ui/codegen/stack-too-deep/params.stdout
@@ -1,8 +1,387 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/stack-too-deep/params.sol:StackTooDeepParams": {
-      "bin": "61026580600a5f395ff36103006040523460215736156021575f3560e01c80638c4ee692146025576021565b5f80fd5b3660049003610280901260215760243560043501806102205260043590106102515760443561022051018060e05261022051806102205290106102515760643560e05101806101e05260e0518060e0529010610251576084356101e051018060a0526101e051806101e05290106102515760a43560a05101806101a05260a0518060a05290106102515760c4356101a05101806102a0526101a051806101a05290106102515760e4356102a0510180610160526102a051806102a052901061025157610104356101605101806102605261016051806101605290106102515761012435610260510180610120526102605180610260529010610251576101443561012051018061024052610120518061012052901061025157610164356102405101806101005261024051806102405290106102515761018435610100510180610200526101005180610100529010610251576101a43561020051018060c0526102005180610200529010610251576101c43560c05101806101c05260c0518060c0529010610251576101e4356101c05101806102c0526101c051806101c052901061025157610204356102c0510180610180526102c051806102c05290106102515761022435610180510180610280526101805180610180529010610251576102443561028051018061014052610280518061028052901061025157610264356101405101806102e0526101405180610140529010610251576102e051806102e05260805260206080f35b634e487b7160e01b5f52601160045260245ffd"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/stack-too-deep/params.sol:StackTooDeepParams (creation) ===
+// === deployment ===
+bb0 (entry):
+  push 613
+  dup1
+  push 10
+  push 0
+  codecopy
+  push 0
+  terminal return
+
+// === runtime ===
+bb0 (entry):
+  push 768
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x8c4ee692
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 640
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 4
+  calldataload
+  add
+  dup1
+  push 544
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 68
+  calldataload
+  push 544
+  mload
+  add
+  dup1
+  push 224
+  mstore
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 100
+  calldataload
+  push 224
+  mload
+  add
+  dup1
+  push 480
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 132
+  calldataload
+  push 480
+  mload
+  add
+  dup1
+  push 160
+  mstore
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 164
+  calldataload
+  push 160
+  mload
+  add
+  dup1
+  push 416
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 196
+  calldataload
+  push 416
+  mload
+  add
+  dup1
+  push 672
+  mstore
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 228
+  calldataload
+  push 672
+  mload
+  add
+  dup1
+  push 352
+  mstore
+  push 672
+  mload
+  dup1
+  push 672
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 260
+  calldataload
+  push 352
+  mload
+  add
+  dup1
+  push 608
+  mstore
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 292
+  calldataload
+  push 608
+  mload
+  add
+  dup1
+  push 288
+  mstore
+  push 608
+  mload
+  dup1
+  push 608
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 324
+  calldataload
+  push 288
+  mload
+  add
+  dup1
+  push 576
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 356
+  calldataload
+  push 576
+  mload
+  add
+  dup1
+  push 256
+  mstore
+  push 576
+  mload
+  dup1
+  push 576
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 388
+  calldataload
+  push 256
+  mload
+  add
+  dup1
+  push 512
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 420
+  calldataload
+  push 512
+  mload
+  add
+  dup1
+  push 192
+  mstore
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 452
+  calldataload
+  push 192
+  mload
+  add
+  dup1
+  push 448
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 484
+  calldataload
+  push 448
+  mload
+  add
+  dup1
+  push 704
+  mstore
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 516
+  calldataload
+  push 704
+  mload
+  add
+  dup1
+  push 384
+  mstore
+  push 704
+  mload
+  dup1
+  push 704
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 548
+  calldataload
+  push 384
+  mload
+  add
+  dup1
+  push 640
+  mstore
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 580
+  calldataload
+  push 640
+  mload
+  add
+  dup1
+  push 320
+  mstore
+  push 640
+  mload
+  dup1
+  push 640
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 612
+  calldataload
+  push 320
+  mload
+  add
+  dup1
+  push 736
+  mstore
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  push bb3
+  jumpi
+  push 736
+  mload
+  dup1
+  push 736
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/stack_phi_loop.sol
+++ b/tests/ui/codegen/stack_phi_loop.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin-runtime --pretty-json
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime --pretty-json
 
 contract StackPhiLoop {
     function loopCarried(uint256 n, bool flag) public pure returns (uint256) {

--- a/tests/ui/codegen/stack_phi_loop.stdout
+++ b/tests/ui/codegen/stack_phi_loop.stdout
@@ -2,33 +2,33 @@
 bb0 (entry):
   push 576
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x50d1f082
-  eq !meta(stack=0->0)
+  eq
   push bb17
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x71b76bb2
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xfb08deb2
-  eq !meta(stack=0->0)
+  eq
   push bb12
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -37,13 +37,13 @@ bb1:
 bb2:
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  lt !meta(stack=0->0)
+  lt
   push bb16
-  jumpi !meta(stack=0->0)
+  jumpi
   dup2
   dup1
   push 352
@@ -51,60 +51,60 @@ bb2:
 bb3:
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  lt !meta(stack=0->0)
+  lt
   push bb19
-  jumpi !meta(stack=0->0)
+  jumpi
   dup2
   dup1
   push 448
   jump bb9
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup1
   push 416
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
+  iszero
   push 416
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb6
 bb5:
   push 7
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   jump bb7
 bb6:
   push 11
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   fallthrough bb7
 bb7:
   push 0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 0
   push 0
@@ -113,21 +113,21 @@ bb7:
 bb8:
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  lt !meta(stack=0->0)
+  lt
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   dup2
   dup1
   push 288
   fallthrough bb9
 bb9:
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   pop
   pop
   push 32
@@ -136,238 +136,238 @@ bb9:
 bb10:
   push 1
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 320
-  mload !meta(stack=0->0)
+  mload
   push 3
-  mul !meta(stack=0->0)
+  mul
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
+  add
   swap1
   jump bb8
 bb11:
   push 3
   dup2
-  mul !meta(stack=0->0)
+  mul
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 3
   dup2
-  div !meta(stack=0->0)
+  div
   dup3
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap2
   pop
   pop
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb10
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb23
 bb12:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   jump bb13
 bb13:
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 448
-  mload !meta(stack=0->0)
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mload
+  lt
+  iszero
   push bb14
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 448
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   push 384
-  mload !meta(stack=0->0)
+  mload
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb13
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb23
 bb14:
   push 0
   push 256
-  mload !meta(stack=0->0)
+  mload
   swap1
   jump bb2
 bb15:
   push 1
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 352
-  mload !meta(stack=0->0)
+  mload
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 1
-  shl !meta(stack=0->0)
+  shl
   push 3
-  add !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  add
   swap1
   jump bb2
 bb16:
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 3
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb15
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb23
 bb17:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 0
   swap1
@@ -375,10 +375,10 @@ bb17:
 bb18:
   push 1
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 288
-  mload !meta(stack=0->0)
+  mload
   swap1
   jump bb3
 bb19:
@@ -388,108 +388,108 @@ bb19:
 bb20:
   dup2
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   dup3
-  lt !meta(stack=0->0)
+  lt
   dup4
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   pop
   swap1
   pop
   push bb22
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb18
 bb21:
   push 1
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 256
-  mload !meta(stack=0->0)
+  mload
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 256
-  mload !meta(stack=0->0)
+  mload
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 1
-  add !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  add
   swap2
   swap1
   jump bb20
 bb22:
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb21
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb23
 bb23:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/stack_phi_loop.stdout
+++ b/tests/ui/codegen/stack_phi_loop.stdout
@@ -1,8 +1,495 @@
-{
-  "contracts": {
-    "ROOT/tests/ui/codegen/stack_phi_loop.sol:StackPhiLoop": {
-      "bin-runtime": "6102406040523460375736156037575f3560e01c806350d1f0821461023657806371b76bb2146069578063fb08deb21461014a576037565b5f80fd5b806101205260243581106101d157818061016060bd565b806101005260043581106102595781806101c060bd565b366004900360409012603757602435806101a05215156101a051036037576024356091576099565b60075f52609e565b600b5f525b5f518061010052505f5f905b8061014052600435811060e65781806101205b52608052505060206080f35b6001610140510161012051610140516003026101005101019060aa565b600381028060e0526003810482806101405290149150509050156103015761010051806101005260e05101806101605260e0518060e0529010610301576101605180610160526101205101806101805261012051806101205290101560c957610301565b3660049003604090126037575f6101c0525f61010052610165565b6004356101c05110156101ac5760016101c0510180610180526101005101806101e0526101005180610100528110610180516101c052816101005290501561016557610301565b5f6101005190603b565b60016101205101610160516101205160011b6003010190603b565b806101205260011b806101405260011c61012051806101205290149050156103015760036101405101806101a0526101405180610140529010610301576101a051806101a052610160510180610200526101605180610160529010156101b657610301565b3660049003604090126037575f5f906052565b6001610100510161012051906052565b5f905b816101605260243582108361012052915050905061029c57610249565b60016101605101610100516101205161010051610160510160010101919061025c565b610160518061016052610100510180610140526101005180610100529010610301576001610140510180610180526101405180610140529010610301576101805180610180526101205101806101a05261012051806101205290101561027957610301565b634e487b7160e01b5f52601160045260245ffd"
-    }
-  },
-  "version": "VERSION"
-}
+// === ROOT/tests/ui/codegen/stack_phi_loop.sol:StackPhiLoop (runtime) ===
+bb0 (entry):
+  push 576
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x50d1f082
+  eq
+  push bb17
+  jumpi
+  dup1
+  push 0x71b76bb2
+  eq
+  push bb4
+  jumpi
+  dup1
+  push 0xfb08deb2
+  eq
+  push bb12
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  dup1
+  push 288
+  mstore
+  push 36
+  calldataload
+  dup2
+  lt
+  push bb16
+  jumpi
+  dup2
+  dup1
+  push 352
+  jump bb9
+bb3:
+  dup1
+  push 256
+  mstore
+  push 4
+  calldataload
+  dup2
+  lt
+  push bb19
+  jumpi
+  dup2
+  dup1
+  push 448
+  jump bb9
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  dup1
+  push 416
+  mstore
+  iszero
+  iszero
+  push 416
+  mload
+  sub
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push bb5
+  jumpi
+  jump bb6
+bb5:
+  push 7
+  push 0
+  mstore
+  jump bb7
+bb6:
+  push 11
+  push 0
+  mstore
+  fallthrough bb7
+bb7:
+  push 0
+  mload
+  dup1
+  push 256
+  mstore
+  pop
+  push 0
+  push 0
+  swap1
+  fallthrough bb8
+bb8:
+  dup1
+  push 320
+  mstore
+  push 4
+  calldataload
+  dup2
+  lt
+  push bb11
+  jumpi
+  dup2
+  dup1
+  push 288
+  fallthrough bb9
+bb9:
+  mstore
+  push 128
+  mstore
+  pop
+  pop
+  push 32
+  push 128
+  terminal return
+bb10:
+  push 1
+  push 320
+  mload
+  add
+  push 288
+  mload
+  push 320
+  mload
+  push 3
+  mul
+  push 256
+  mload
+  add
+  add
+  swap1
+  jump bb8
+bb11:
+  push 3
+  dup2
+  mul
+  dup1
+  push 224
+  mstore
+  push 3
+  dup2
+  div
+  dup3
+  dup1
+  push 320
+  mstore
+  swap1
+  eq
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  iszero
+  push bb23
+  jumpi
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 224
+  mload
+  add
+  dup1
+  push 352
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  push bb23
+  jumpi
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  push 288
+  mload
+  add
+  dup1
+  push 384
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  iszero
+  push bb10
+  jumpi
+  jump bb23
+bb12:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 448
+  mstore
+  push 0
+  push 256
+  mstore
+  jump bb13
+bb13:
+  push 4
+  calldataload
+  push 448
+  mload
+  lt
+  iszero
+  push bb14
+  jumpi
+  push 1
+  push 448
+  mload
+  add
+  dup1
+  push 384
+  mstore
+  push 256
+  mload
+  add
+  dup1
+  push 480
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  lt
+  push 384
+  mload
+  push 448
+  mstore
+  dup2
+  push 256
+  mstore
+  swap1
+  pop
+  iszero
+  push bb13
+  jumpi
+  jump bb23
+bb14:
+  push 0
+  push 256
+  mload
+  swap1
+  jump bb2
+bb15:
+  push 1
+  push 288
+  mload
+  add
+  push 352
+  mload
+  push 288
+  mload
+  push 1
+  shl
+  push 3
+  add
+  add
+  swap1
+  jump bb2
+bb16:
+  dup1
+  push 288
+  mstore
+  push 1
+  shl
+  dup1
+  push 320
+  mstore
+  push 1
+  shr
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  eq
+  swap1
+  pop
+  iszero
+  push bb23
+  jumpi
+  push 3
+  push 320
+  mload
+  add
+  dup1
+  push 416
+  mstore
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  push bb23
+  jumpi
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  push 352
+  mload
+  add
+  dup1
+  push 512
+  mstore
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  swap1
+  lt
+  iszero
+  push bb15
+  jumpi
+  jump bb23
+bb17:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 0
+  swap1
+  jump bb3
+bb18:
+  push 1
+  push 256
+  mload
+  add
+  push 288
+  mload
+  swap1
+  jump bb3
+bb19:
+  push 0
+  swap1
+  fallthrough bb20
+bb20:
+  dup2
+  push 352
+  mstore
+  push 36
+  calldataload
+  dup3
+  lt
+  dup4
+  push 288
+  mstore
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb22
+  jumpi
+  jump bb18
+bb21:
+  push 1
+  push 352
+  mload
+  add
+  push 256
+  mload
+  push 288
+  mload
+  push 256
+  mload
+  push 352
+  mload
+  add
+  push 1
+  add
+  add
+  swap2
+  swap1
+  jump bb20
+bb22:
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  push 256
+  mload
+  add
+  dup1
+  push 320
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  swap1
+  lt
+  push bb23
+  jumpi
+  push 1
+  push 320
+  mload
+  add
+  dup1
+  push 384
+  mstore
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  push bb23
+  jumpi
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  push 288
+  mload
+  add
+  dup1
+  push 416
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  iszero
+  push bb21
+  jumpi
+  jump bb23
+bb23:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/stack_phi_loop.stdout
+++ b/tests/ui/codegen/stack_phi_loop.stdout
@@ -2,33 +2,33 @@
 bb0 (entry):
   push 576
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x50d1f082
-  eq
+  eq !meta(stack=0->0)
   push bb17
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x71b76bb2
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xfb08deb2
-  eq
+  eq !meta(stack=0->0)
   push bb12
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -37,13 +37,13 @@ bb1:
 bb2:
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push bb16
-  jumpi
+  jumpi !meta(stack=0->0)
   dup2
   dup1
   push 352
@@ -51,60 +51,60 @@ bb2:
 bb3:
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push bb19
-  jumpi
+  jumpi !meta(stack=0->0)
   dup2
   dup1
   push 448
   jump bb9
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup1
   push 416
-  mstore
-  iszero
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 416
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb6
 bb5:
   push 7
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   jump bb7
 bb6:
   push 11
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   fallthrough bb7
 bb7:
   push 0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 0
   push 0
@@ -113,21 +113,21 @@ bb7:
 bb8:
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   dup2
   dup1
   push 288
   fallthrough bb9
 bb9:
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   pop
   pop
   push 32
@@ -136,238 +136,238 @@ bb9:
 bb10:
   push 1
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   push 3
-  mul
+  mul !meta(stack=0->0)
   push 256
-  mload
-  add
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  add !meta(stack=0->0)
   swap1
   jump bb8
 bb11:
   push 3
   dup2
-  mul
+  mul !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 3
   dup2
-  div
+  div !meta(stack=0->0)
   dup3
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb10
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb23
 bb12:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   jump bb13
 bb13:
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 448
-  mload
-  lt
-  iszero
+  mload !meta(stack=0->0)
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb14
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 448
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb13
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb23
 bb14:
   push 0
   push 256
-  mload
+  mload !meta(stack=0->0)
   swap1
   jump bb2
 bb15:
   push 1
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   push 3
-  add
-  add
+  add !meta(stack=0->0)
+  add !meta(stack=0->0)
   swap1
   jump bb2
 bb16:
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 3
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb15
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb23
 bb17:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 0
   swap1
@@ -375,10 +375,10 @@ bb17:
 bb18:
   push 1
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   swap1
   jump bb3
 bb19:
@@ -388,108 +388,108 @@ bb19:
 bb20:
   dup2
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   dup3
-  lt
+  lt !meta(stack=0->0)
   dup4
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
   push bb22
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb18
 bb21:
   push 1
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 1
-  add
-  add
+  add !meta(stack=0->0)
+  add !meta(stack=0->0)
   swap2
   swap1
   jump bb20
 bb22:
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb21
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb23
 bb23:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/static_frames.sol
+++ b/tests/ui/codegen/static_frames.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // Static frame overlays: non-recursive internal functions get
 // compile-time-fixed frame addresses (absolute pushes, no frame-pointer or

--- a/tests/ui/codegen/static_frames.stdout
+++ b/tests/ui/codegen/static_frames.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 0x680
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x313ae541
-  eq
+  eq !meta(stack=0->0)
   push bb10
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x86b714e2
-  eq
+  eq !meta(stack=0->0)
   push bb8
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -37,308 +37,308 @@ bb3:
   jump bb5
 bb4:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   terminal jump
 bb5:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 160
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
   terminal jump
 bb6:
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 320
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
   terminal jump
 bb7:
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
-  sub
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 320
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 320
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
   terminal jump
 bb8:
   push 0
-  sload
+  sload !meta(stack=0->0)
   fallthrough bb9
 bb9:
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb10:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 3
   push 4
-  calldataload
-  mul
+  calldataload !meta(stack=0->0)
+  mul !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 3
   dup2
-  div
+  div !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   push bb11
   jump bb16
 bb11:
   push 736
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  eq
+  eq !meta(stack=0->0)
   swap1
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 7
   push 4
-  calldataload
-  mod
+  calldataload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb12
   jump bb2
 bb12:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push bb13
   jump bb4
 bb13:
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 5
   push 4
-  calldataload
-  mod
+  calldataload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   pop
   pop
   push bb14
   jump bb3
 bb14:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push bb15
   jump bb4
 bb15:
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 576
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -348,106 +348,106 @@ bb15:
   swap1
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   jump bb9
 bb16:
   push 704
-  mload
+  mload !meta(stack=0->0)
   push 672
-  mload
-  xor
+  mload !meta(stack=0->0)
+  xor !meta(stack=0->0)
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 1
   dup2
   dup1
   push 960
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 960
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -457,33 +457,33 @@ bb16:
   swap1
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x480
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 3
   push 0x4a0
-  mload
-  div
+  mload !meta(stack=0->0)
+  div !meta(stack=0->0)
   push 1
   dup2
   dup1
   push 0x500
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -491,45 +491,45 @@ bb16:
   pop
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 5
   push 0x4a0
-  mload
-  mod
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   push 2
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 992
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 992
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -537,249 +537,249 @@ bb16:
   pop
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x420
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  sub
+  sub !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x460
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   push 0x4a0
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x400
-  mstore
+  mstore !meta(stack=0->0)
   push 0x4a0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 928
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 928
-  mstore
+  mstore !meta(stack=0->0)
   push 0x400
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 0x4e0
-  mstore
+  mstore !meta(stack=0->0)
   push 0x400
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x400
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4e0
-  mload
+  mload !meta(stack=0->0)
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   terminal jump
 bb17:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  sub
+  sub !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  xor
+  xor !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 0x3e8
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
   pop
   push bb20
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb18
 bb18:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
   fallthrough bb19
 bb19:
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   terminal jump
 bb20:
   push bb21
@@ -787,53 +787,53 @@ bb20:
 bb21:
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 352
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 352
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb22
   jump bb6
 bb22:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 352
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup2
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push bb23
   jump bb2
 bb23:
@@ -842,567 +842,567 @@ bb23:
 bb24:
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  sub
+  sub !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 544
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  xor
+  xor !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 0x3e8
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 512
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   fallthrough bb25
 bb25:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
   jump bb19
 bb26:
   push bb28
-  jumpi
+  jumpi !meta(stack=0->0)
   push 3
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mstore
-  add
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 480
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 97
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   push 7
   swap1
-  add
+  add !meta(stack=0->0)
   fallthrough bb27
 bb27:
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   pop
   terminal jump
 bb28:
   push 3
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   push 0
-  sload
+  sload !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 512
-  add
-  mstore
-  add
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 512
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 0
-  sstore
+  sstore !meta(stack=0->0)
   push 97
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push bb29
   jump bb7
 bb29:
   push 3
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb30
   jump bb6
 bb30:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 384
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup2
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 320
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push bb31
   jump bb33
 bb31:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 352
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push bb32
   jump bb4
 bb32:
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 352
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 352
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 448
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 416
   jump bb19
 bb33:
   push bb34
   jump bb5
 bb34:
-  iszero
+  iszero !meta(stack=0->0)
   push bb37
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  add
-  mload
-  sub
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 5
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  add
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup2
   push 32
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 192
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup2
   push 64
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 256
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup2
   push 96
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push bb35
   jump bb3
 bb35:
@@ -1411,28 +1411,28 @@ bb35:
 bb36:
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 224
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -1440,55 +1440,55 @@ bb36:
   pop
   pop
   push bb38
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb25
 bb37:
   push 13
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 96
-  add
-  mload
-  mod
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
+  mod !meta(stack=0->0)
   jump bb27
 bb38:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb39:
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 128
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup1
   push 160
-  mload
+  mload !meta(stack=0->0)
   push 288
-  add
-  mstore
+  add !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   swap1
   terminal jump

--- a/tests/ui/codegen/static_frames.stdout
+++ b/tests/ui/codegen/static_frames.stdout
@@ -1,1 +1,1494 @@
-{"contracts":{"ROOT/tests/ui/codegen/static_frames.sol:SF":{"bin-runtime":"61068060405234602b573615602b575f3560e01c8063313ae5411460a957806386b714e214609d57602b565b5f80fd5b6103aa604f565b610620604f565b60a05160405260a0516020015160a052565b60a05160a0015f81525060a0516040015190565b60405160a051816020015260a0516101400151816040015290565b600160a05160400151038060a05161014001528060a051610140015290565b5f545b60805260206080f35b366004900360209012602b575f6080526003600435028060e05260038104600435901490501561088d576001600435018061010052600435901061088d57610100516102a0526004356102c05260fd610287565b6102e051806102205261010051806101005260011b806101205260011c610100518061010052901490501561088d576102205180610220526101205101806101e052610120518061012052901061088d5760076004350660405160a051816020015281816040015260043581606001528060a0526102400160405250610180602f565b60a051608001518061018052610193603d565b806101805260056004350660405160a051816020015281816040015260043581606001528060a0526102200160405250506101cb6036565b60a05160800151806101c0526101de603d565b806101c0525f5460e0518060e05281806102405201806101a0528180610240528110915081915050905061088d576101a051806101a0525f556101e051806101e05260e05101806101605260e0518060e052901061088d5761018051806101805261016051018061014052610160518061016052901061088d576101c051806101c05261014051018061020052610140518061014052901061088d5761020051806102005260a0565b6102c0516102a05118806104a0525f54600181806103c05201806104805281806103c0528110915081915050905061088d576104805180610480525f5560036104a051046001818061050052018061044052818061050052811091508191505061088d5760056104a0510660028101806103a0529050806103a0526020525f5461044051806104405281806103e05201806104205281806103e052811091508191505061088d576104205180610420525f5561044051806104405260011b806104605260011c610440518061044052900361088d576104605180610460526104a0510180610400526104a051806104a052901061088d576103a051806103a0526104005101806104e052610400518061040052901061088d576104e0516102e052565b60a05160600151018060a0516101e001528060a0516101e0015260a05160600151901061088d5760a0516101e001518060a0516101e0015260011b8060a05161010001528060a05161010001528060a051610100015260011c60a0516101e001518060a0516101e00152900361088d57600160a0516101000151018060a05161018001528060a051610180015260a05161010001518060a0516101000152901061088d575f5460a05161018001518060a051610180015290185f556103e860a0516101800151068060a05160c001528060a05160c0015260a0516040015190506104a457610493565b60a05160c05b015160a05160800152565b6104ab607e565b600160a05160600151018060a05161016001528060a051610160015260a051606001519010905061088d576104dd6063565b60a051610160015181606001528060a052610240016040526104fc602f565b6105046108a1565b8060a051610120015260a05160c00151018060a0516101a001528060a0516101a0015260a05160c001518060a05160c00152901061088d5760a05161012001518060a051610120015260011b8060a05161022001528060a05161022001528060a051610220015260011c60a05161012001518060a0516101200152900361088d57600160a0516102200151018060a0516101c001528060a0516101c0015260a05161022001518060a0516102200152901061088d575f5460a0516101c001518060a0516101c0015290185f556103e860a0516101c00151068060a051610200015260a0516101a00151018060a05160e001528060a05160e0015260a0516101a001518060a0516101a00152901061088d575b60a05160e0610499565b61069157600360a05160600151065f54818060a0516101000152818060a0516101e00152018060a05160c0015291508160a05160c001528060a0516101e00152901061088d5760a05160c001518060a05160c001525f55606160a0516060015106600790015b8060a0516080015250565b600360a05160600151065f54818060a0516101200152818060a0516102000152018060a05160e0015291508160a05160e001528060a0516102000152901061088d5760a05160e001518060a05160e001525f55606160a05160600151068060a0516101c001528060a0516101c00152610707607e565b600360a05160600151018060a05161018001528060a051610180015260a05160600151901091505061088d5761073a6063565b60a051610180015181606001528060a0526101400160405261075a6107c0565b60a051608001518060a0516101600152610771603d565b8060a05161016001528060a051610160015260a0516101c00151018060a0516101a001528060a0516101a0015260a0516101c001518060a0516101c00152901061088d5760a0516101a0610499565b6107c7604f565b1561087e57600160a05160400151038060a05160c001528060a05160c00152600560a05160600151018060a05161010001528060a051610100015260a051606001519010905061088d5760405160a051816020015260a05160c00151816040015260a051610100015181606001528060a052610220016040526108476036565b61084f6108a1565b600181018060a05160e001528060a05160e00152818060a0516101200152811091508191505061088d57610616565b600d60a0516060015106610686565b634e487b7160e01b5f52601160045260245ffd5b60a051608001518060a051610120015260a05160405260a0516020015160a0528060a05161012001529056"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/static_frames.sol:SF (runtime) ===
+bb0 (entry):
+  push 0x680
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x313ae541
+  eq
+  push bb10
+  jumpi
+  dup1
+  push 0x86b714e2
+  eq
+  push bb8
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push bb17
+  jump bb5
+bb3:
+  push bb26
+  jump bb5
+bb4:
+  push 160
+  mload
+  push 64
+  mstore
+  push 160
+  mload
+  push 32
+  add
+  mload
+  push 160
+  mstore
+  terminal jump
+bb5:
+  push 160
+  mload
+  push 160
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 160
+  mload
+  push 64
+  add
+  mload
+  swap1
+  terminal jump
+bb6:
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  push 160
+  mload
+  push 320
+  add
+  mload
+  dup2
+  push 64
+  add
+  mstore
+  swap1
+  terminal jump
+bb7:
+  push 1
+  push 160
+  mload
+  push 64
+  add
+  mload
+  sub
+  dup1
+  push 160
+  mload
+  push 320
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 320
+  add
+  mstore
+  swap1
+  terminal jump
+bb8:
+  push 0
+  sload
+  fallthrough bb9
+bb9:
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb10:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 3
+  push 4
+  calldataload
+  mul
+  dup1
+  push 224
+  mstore
+  push 3
+  dup2
+  div
+  push 4
+  calldataload
+  swap1
+  eq
+  swap1
+  pop
+  iszero
+  push bb38
+  jumpi
+  push 1
+  push 4
+  calldataload
+  add
+  dup1
+  push 256
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 256
+  mload
+  push 672
+  mstore
+  push 4
+  calldataload
+  push 704
+  mstore
+  push bb11
+  jump bb16
+bb11:
+  push 736
+  mload
+  dup1
+  push 544
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 1
+  shl
+  dup1
+  push 288
+  mstore
+  push 1
+  shr
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  swap1
+  eq
+  swap1
+  pop
+  iszero
+  push bb38
+  jumpi
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  push 288
+  mload
+  add
+  dup1
+  push 480
+  mstore
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 7
+  push 4
+  calldataload
+  mod
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  dup2
+  dup2
+  push 64
+  add
+  mstore
+  push 4
+  calldataload
+  dup2
+  push 96
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 576
+  add
+  push 64
+  mstore
+  pop
+  push bb12
+  jump bb2
+bb12:
+  push 160
+  mload
+  push 128
+  add
+  mload
+  dup1
+  push 384
+  mstore
+  push bb13
+  jump bb4
+bb13:
+  dup1
+  push 384
+  mstore
+  push 5
+  push 4
+  calldataload
+  mod
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  dup2
+  dup2
+  push 64
+  add
+  mstore
+  push 4
+  calldataload
+  dup2
+  push 96
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 544
+  add
+  push 64
+  mstore
+  pop
+  pop
+  push bb14
+  jump bb3
+bb14:
+  push 160
+  mload
+  push 128
+  add
+  mload
+  dup1
+  push 448
+  mstore
+  push bb15
+  jump bb4
+bb15:
+  dup1
+  push 448
+  mstore
+  push 0
+  sload
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 576
+  mstore
+  add
+  dup1
+  push 416
+  mstore
+  dup2
+  dup1
+  push 576
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb38
+  jumpi
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  push 0
+  sstore
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  push 224
+  mload
+  add
+  dup1
+  push 352
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  push 352
+  mload
+  add
+  dup1
+  push 320
+  mstore
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  push 320
+  mload
+  add
+  dup1
+  push 512
+  mstore
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  jump bb9
+bb16:
+  push 704
+  mload
+  push 672
+  mload
+  xor
+  dup1
+  push 0x4a0
+  mstore
+  push 0
+  sload
+  push 1
+  dup2
+  dup1
+  push 960
+  mstore
+  add
+  dup1
+  push 0x480
+  mstore
+  dup2
+  dup1
+  push 960
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb38
+  jumpi
+  push 0x480
+  mload
+  dup1
+  push 0x480
+  mstore
+  push 0
+  sstore
+  push 3
+  push 0x4a0
+  mload
+  div
+  push 1
+  dup2
+  dup1
+  push 0x500
+  mstore
+  add
+  dup1
+  push 0x440
+  mstore
+  dup2
+  dup1
+  push 0x500
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb38
+  jumpi
+  push 5
+  push 0x4a0
+  mload
+  mod
+  push 2
+  dup2
+  add
+  dup1
+  push 928
+  mstore
+  swap1
+  pop
+  dup1
+  push 928
+  mstore
+  push 32
+  mstore
+  push 0
+  sload
+  push 0x440
+  mload
+  dup1
+  push 0x440
+  mstore
+  dup2
+  dup1
+  push 992
+  mstore
+  add
+  dup1
+  push 0x420
+  mstore
+  dup2
+  dup1
+  push 992
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb38
+  jumpi
+  push 0x420
+  mload
+  dup1
+  push 0x420
+  mstore
+  push 0
+  sstore
+  push 0x440
+  mload
+  dup1
+  push 0x440
+  mstore
+  push 1
+  shl
+  dup1
+  push 0x460
+  mstore
+  push 1
+  shr
+  push 0x440
+  mload
+  dup1
+  push 0x440
+  mstore
+  swap1
+  sub
+  push bb38
+  jumpi
+  push 0x460
+  mload
+  dup1
+  push 0x460
+  mstore
+  push 0x4a0
+  mload
+  add
+  dup1
+  push 0x400
+  mstore
+  push 0x4a0
+  mload
+  dup1
+  push 0x4a0
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 928
+  mload
+  dup1
+  push 928
+  mstore
+  push 0x400
+  mload
+  add
+  dup1
+  push 0x4e0
+  mstore
+  push 0x400
+  mload
+  dup1
+  push 0x400
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 0x4e0
+  mload
+  push 736
+  mstore
+  terminal jump
+bb17:
+  push 160
+  mload
+  push 96
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 480
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 480
+  add
+  mstore
+  push 160
+  mload
+  push 96
+  add
+  mload
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 160
+  mload
+  push 480
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 480
+  add
+  mstore
+  push 1
+  shl
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  push 1
+  shr
+  push 160
+  mload
+  push 480
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 480
+  add
+  mstore
+  swap1
+  sub
+  push bb38
+  jumpi
+  push 1
+  push 160
+  mload
+  push 256
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 384
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 384
+  add
+  mstore
+  push 160
+  mload
+  push 256
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 0
+  sload
+  push 160
+  mload
+  push 384
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 384
+  add
+  mstore
+  swap1
+  xor
+  push 0
+  sstore
+  push 0x3e8
+  push 160
+  mload
+  push 384
+  add
+  mload
+  mod
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  push 160
+  mload
+  push 64
+  add
+  mload
+  swap1
+  pop
+  push bb20
+  jumpi
+  jump bb18
+bb18:
+  push 160
+  mload
+  push 192
+  fallthrough bb19
+bb19:
+  add
+  mload
+  push 160
+  mload
+  push 128
+  add
+  mstore
+  terminal jump
+bb20:
+  push bb21
+  jump bb7
+bb21:
+  push 1
+  push 160
+  mload
+  push 96
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 352
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 352
+  add
+  mstore
+  push 160
+  mload
+  push 96
+  add
+  mload
+  swap1
+  lt
+  swap1
+  pop
+  push bb38
+  jumpi
+  push bb22
+  jump bb6
+bb22:
+  push 160
+  mload
+  push 352
+  add
+  mload
+  dup2
+  push 96
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 576
+  add
+  push 64
+  mstore
+  push bb23
+  jump bb2
+bb23:
+  push bb24
+  jump bb39
+bb24:
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  push 160
+  mload
+  push 192
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 416
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 416
+  add
+  mstore
+  push 160
+  mload
+  push 192
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 160
+  mload
+  push 288
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  push 1
+  shl
+  dup1
+  push 160
+  mload
+  push 544
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 544
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 544
+  add
+  mstore
+  push 1
+  shr
+  push 160
+  mload
+  push 288
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  swap1
+  sub
+  push bb38
+  jumpi
+  push 1
+  push 160
+  mload
+  push 544
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 448
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 448
+  add
+  mstore
+  push 160
+  mload
+  push 544
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 544
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 0
+  sload
+  push 160
+  mload
+  push 448
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 448
+  add
+  mstore
+  swap1
+  xor
+  push 0
+  sstore
+  push 0x3e8
+  push 160
+  mload
+  push 448
+  add
+  mload
+  mod
+  dup1
+  push 160
+  mload
+  push 512
+  add
+  mstore
+  push 160
+  mload
+  push 416
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  push 160
+  mload
+  push 416
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 416
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  fallthrough bb25
+bb25:
+  push 160
+  mload
+  push 224
+  jump bb19
+bb26:
+  push bb28
+  jumpi
+  push 3
+  push 160
+  mload
+  push 96
+  add
+  mload
+  mod
+  push 0
+  sload
+  dup2
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  dup2
+  dup1
+  push 160
+  mload
+  push 480
+  add
+  mstore
+  add
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  swap2
+  pop
+  dup2
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 480
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 160
+  mload
+  push 192
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  push 0
+  sstore
+  push 97
+  push 160
+  mload
+  push 96
+  add
+  mload
+  mod
+  push 7
+  swap1
+  add
+  fallthrough bb27
+bb27:
+  dup1
+  push 160
+  mload
+  push 128
+  add
+  mstore
+  pop
+  terminal jump
+bb28:
+  push 3
+  push 160
+  mload
+  push 96
+  add
+  mload
+  mod
+  push 0
+  sload
+  dup2
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  dup2
+  dup1
+  push 160
+  mload
+  push 512
+  add
+  mstore
+  add
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  swap2
+  pop
+  dup2
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 512
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 160
+  mload
+  push 224
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  push 0
+  sstore
+  push 97
+  push 160
+  mload
+  push 96
+  add
+  mload
+  mod
+  dup1
+  push 160
+  mload
+  push 448
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 448
+  add
+  mstore
+  push bb29
+  jump bb7
+bb29:
+  push 3
+  push 160
+  mload
+  push 96
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 384
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 384
+  add
+  mstore
+  push 160
+  mload
+  push 96
+  add
+  mload
+  swap1
+  lt
+  swap2
+  pop
+  pop
+  push bb38
+  jumpi
+  push bb30
+  jump bb6
+bb30:
+  push 160
+  mload
+  push 384
+  add
+  mload
+  dup2
+  push 96
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 320
+  add
+  push 64
+  mstore
+  push bb31
+  jump bb33
+bb31:
+  push 160
+  mload
+  push 128
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 352
+  add
+  mstore
+  push bb32
+  jump bb4
+bb32:
+  dup1
+  push 160
+  mload
+  push 352
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 352
+  add
+  mstore
+  push 160
+  mload
+  push 448
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 416
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 416
+  add
+  mstore
+  push 160
+  mload
+  push 448
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 448
+  add
+  mstore
+  swap1
+  lt
+  push bb38
+  jumpi
+  push 160
+  mload
+  push 416
+  jump bb19
+bb33:
+  push bb34
+  jump bb5
+bb34:
+  iszero
+  push bb37
+  jumpi
+  push 1
+  push 160
+  mload
+  push 64
+  add
+  mload
+  sub
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 192
+  add
+  mstore
+  push 5
+  push 160
+  mload
+  push 96
+  add
+  mload
+  add
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 256
+  add
+  mstore
+  push 160
+  mload
+  push 96
+  add
+  mload
+  swap1
+  lt
+  swap1
+  pop
+  push bb38
+  jumpi
+  push 64
+  mload
+  push 160
+  mload
+  dup2
+  push 32
+  add
+  mstore
+  push 160
+  mload
+  push 192
+  add
+  mload
+  dup2
+  push 64
+  add
+  mstore
+  push 160
+  mload
+  push 256
+  add
+  mload
+  dup2
+  push 96
+  add
+  mstore
+  dup1
+  push 160
+  mstore
+  push 544
+  add
+  push 64
+  mstore
+  push bb35
+  jump bb3
+bb35:
+  push bb36
+  jump bb39
+bb36:
+  push 1
+  dup2
+  add
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  dup1
+  push 160
+  mload
+  push 224
+  add
+  mstore
+  dup2
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb38
+  jumpi
+  jump bb25
+bb37:
+  push 13
+  push 160
+  mload
+  push 96
+  add
+  mload
+  mod
+  jump bb27
+bb38:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb39:
+  push 160
+  mload
+  push 128
+  add
+  mload
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  push 160
+  mload
+  push 64
+  mstore
+  push 160
+  mload
+  push 32
+  add
+  mload
+  push 160
+  mstore
+  dup1
+  push 160
+  mload
+  push 288
+  add
+  mstore
+  swap1
+  terminal jump

--- a/tests/ui/codegen/static_frames.stdout
+++ b/tests/ui/codegen/static_frames.stdout
@@ -2,28 +2,28 @@
 bb0 (entry):
   push 0x680
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x313ae541
-  eq !meta(stack=0->0)
+  eq
   push bb10
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x86b714e2
-  eq !meta(stack=0->0)
+  eq
   push bb8
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -37,308 +37,308 @@ bb3:
   jump bb5
 bb4:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   terminal jump
 bb5:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 160
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
   terminal jump
 bb6:
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 320
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
   terminal jump
 bb7:
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  add
+  mload
+  sub
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 320
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 320
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
   terminal jump
 bb8:
   push 0
-  sload !meta(stack=0->0)
+  sload
   fallthrough bb9
 bb9:
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb10:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 3
   push 4
-  calldataload !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  calldataload
+  mul
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 3
   dup2
-  div !meta(stack=0->0)
+  div
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 256
-  mload !meta(stack=0->0)
+  mload
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   push bb11
   jump bb16
 bb11:
   push 736
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  eq !meta(stack=0->0)
+  eq
   swap1
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 7
   push 4
-  calldataload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  calldataload
+  mod
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb12
   jump bb2
 bb12:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push bb13
   jump bb4
 bb13:
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 5
   push 4
-  calldataload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  calldataload
+  mod
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   pop
   pop
   push bb14
   jump bb3
 bb14:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push bb15
   jump bb4
 bb15:
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 576
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -348,106 +348,106 @@ bb15:
   swap1
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   jump bb9
 bb16:
   push 704
-  mload !meta(stack=0->0)
+  mload
   push 672
-  mload !meta(stack=0->0)
-  xor !meta(stack=0->0)
+  mload
+  xor
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 1
   dup2
   dup1
   push 960
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 0x480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 960
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -457,33 +457,33 @@ bb16:
   swap1
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x480
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 3
   push 0x4a0
-  mload !meta(stack=0->0)
-  div !meta(stack=0->0)
+  mload
+  div
   push 1
   dup2
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -491,45 +491,45 @@ bb16:
   pop
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 5
   push 0x4a0
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  mload
+  mod
   push 2
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 992
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 992
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -537,249 +537,249 @@ bb16:
   pop
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x420
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  sub !meta(stack=0->0)
+  sub
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x460
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   push 0x4a0
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 0x400
-  mstore !meta(stack=0->0)
+  mstore
   push 0x4a0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 928
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 928
-  mstore !meta(stack=0->0)
+  mstore
   push 0x400
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 0x4e0
-  mstore !meta(stack=0->0)
+  mstore
   push 0x400
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x400
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4e0
-  mload !meta(stack=0->0)
+  mload
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   terminal jump
 bb17:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  sub !meta(stack=0->0)
+  sub
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  xor !meta(stack=0->0)
+  xor
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 0x3e8
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
   pop
   push bb20
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb18
 bb18:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
   fallthrough bb19
 bb19:
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   terminal jump
 bb20:
   push bb21
@@ -787,53 +787,53 @@ bb20:
 bb21:
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 352
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 352
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb22
   jump bb6
 bb22:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 352
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup2
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push bb23
   jump bb2
 bb23:
@@ -842,567 +842,567 @@ bb23:
 bb24:
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  sub !meta(stack=0->0)
+  sub
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 544
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  sload !meta(stack=0->0)
+  sload
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  xor !meta(stack=0->0)
+  xor
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 0x3e8
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 512
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   fallthrough bb25
 bb25:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
   jump bb19
 bb26:
   push bb28
-  jumpi !meta(stack=0->0)
+  jumpi
   push 3
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   push 0
-  sload !meta(stack=0->0)
+  sload
   dup2
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mstore
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap2
   pop
   dup2
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 480
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 97
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   push 7
   swap1
-  add !meta(stack=0->0)
+  add
   fallthrough bb27
 bb27:
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   pop
   terminal jump
 bb28:
   push 3
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   push 0
-  sload !meta(stack=0->0)
+  sload
   dup2
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 512
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mstore
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap2
   pop
   dup2
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 512
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 0
-  sstore !meta(stack=0->0)
+  sstore
   push 97
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push bb29
   jump bb7
 bb29:
   push 3
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb30
   jump bb6
 bb30:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 384
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup2
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 320
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push bb31
   jump bb33
 bb31:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 352
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push bb32
   jump bb4
 bb32:
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 352
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 352
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 448
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 416
   jump bb19
 bb33:
   push bb34
   jump bb5
 bb34:
-  iszero !meta(stack=0->0)
+  iszero
   push bb37
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  add
+  mload
+  sub
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 5
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  mload
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup2
   push 32
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 192
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup2
   push 64
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 256
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup2
   push 96
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push bb35
   jump bb3
 bb35:
@@ -1411,28 +1411,28 @@ bb35:
 bb36:
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 224
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -1440,55 +1440,55 @@ bb36:
   pop
   pop
   push bb38
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb25
 bb37:
   push 13
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 96
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
-  mod !meta(stack=0->0)
+  add
+  mload
+  mod
   jump bb27
 bb38:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb39:
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 128
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup1
   push 160
-  mload !meta(stack=0->0)
+  mload
   push 288
-  add !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  add
+  mstore
   swap1
   terminal jump

--- a/tests/ui/codegen/storage_bytes_member.sol
+++ b/tests/ui/codegen/storage_bytes_member.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // A `bytes` struct field reached through a storage reference bound from a
 // mapping element (`state.part` below) uses Solidity's packed short/long

--- a/tests/ui/codegen/storage_bytes_member.stdout
+++ b/tests/ui/codegen/storage_bytes_member.stdout
@@ -2,48 +2,48 @@
 bb0 (entry):
   push 0x620
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x4407bb95
-  eq
+  eq !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x53b8a6c6
-  eq
+  eq !meta(stack=0->0)
   push bb17
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x56d88e27
-  eq
+  eq !meta(stack=0->0)
   push bb25
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x72bd964d
-  eq
+  eq !meta(stack=0->0)
   push bb34
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xbee6975a
-  eq
+  eq !meta(stack=0->0)
   push bb30
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xe0886f90
-  eq
+  eq !meta(stack=0->0)
   push bb28
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
@@ -51,90 +51,90 @@ bb1:
   terminal revert
 bb2:
   push 0x5c0
-  mload
+  mload !meta(stack=0->0)
   push 0x440
-  mstore
+  mstore !meta(stack=0->0)
   terminal jump
 bb3:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 255
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 255
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
-  caller
+  jumpi !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 0
   jump bb4
 bb4:
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   fallthrough bb5
 bb5:
   terminal stop
 bb6:
   push 128
-  mload
+  mload !meta(stack=0->0)
   push 1
   dup2
   dup1
   push 672
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   dup2
@@ -142,230 +142,230 @@ bb6:
   pop
   pop
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 416
-  mload
+  mload !meta(stack=0->0)
   jump bb4
 bb7:
   push 256
-  mload
+  mload !meta(stack=0->0)
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   push bb8
   jump bb36
 bb8:
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 576
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   dup1
   push 800
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 800
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap1
   pop
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   dup2
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup3
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 352
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup3
-  sub
+  sub !meta(stack=0->0)
   swap2
   pop
   dup2
   dup2
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 0
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   push 32
   push 576
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
   dup1
   push 352
-  mstore
-  mcopy
+  mstore !meta(stack=0->0)
+  mcopy !meta(stack=0->0)
   pop
   push 128
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 832
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
   push bb11
-  jumpi
+  jumpi !meta(stack=0->0)
   push 255
   push 608
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 248
-  shl
+  shl !meta(stack=0->0)
   push 0xff00000000000000000000000000000000000000000000000000000000000000
   swap1
-  and
+  and !meta(stack=0->0)
   push 248
-  shr
+  shr !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 352
-  mload
-  add
-  mstore8
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  mstore8 !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 1
   dup2
-  and
+  and !meta(stack=0->0)
   push 1
   swap1
-  eq
+  eq !meta(stack=0->0)
   push 255
   dup3
-  and
+  and !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   dup3
   push 1
-  shr
+  shr !meta(stack=0->0)
   swap3
   pop
   dup3
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 31
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   dup3
-  and
+  and !meta(stack=0->0)
   swap2
   pop
   dup2
   push 5
-  shr
+  shr !meta(stack=0->0)
   swap2
   pop
   push 0
@@ -373,72 +373,72 @@ bb8:
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   pop
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup3
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   push 5
-  shr
+  shr !meta(stack=0->0)
   push 31
   dup4
-  gt
+  gt !meta(stack=0->0)
   push 0
   dup3
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  keccak256
+  keccak256 !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   dup3
   swap2
   pop
@@ -450,363 +450,363 @@ bb8:
   pop
   pop
   push bb13
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb12
 bb9:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   pop
   pop
   push 65
   fallthrough bb10
 bb10:
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb11:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   jump bb10
 bb12:
   push 352
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 3
-  shl
+  shl !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   swap1
-  shr
-  not
-  and
+  shr !meta(stack=0->0)
+  not !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
-  or
+  shl !meta(stack=0->0)
+  or !meta(stack=0->0)
   push 256
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   jump bb15
 bb13:
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   push 1
   swap1
-  or
+  or !meta(stack=0->0)
   push 256
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 0
   push 224
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 0
   fallthrough bb14
 bb14:
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb15
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 448
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 352
-  mload
-  add
-  mload
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  sstore
+  sstore !meta(stack=0->0)
   push 1
   push 448
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 736
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 736
-  mload
+  mload !meta(stack=0->0)
   jump bb14
 bb15:
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 320
-  mload
+  mload !meta(stack=0->0)
   fallthrough bb16
 bb16:
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 768
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 0
   dup2
-  sstore
+  sstore !meta(stack=0->0)
   pop
   push 1
   push 768
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 704
-  mload
+  mload !meta(stack=0->0)
   jump bb16
 bb17:
-  caller
+  caller !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb18
   jump bb36
 bb18:
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 352
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 448
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb19
-  jumpi
+  jumpi !meta(stack=0->0)
   push 1
   push 448
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push 30
   push 448
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   dup1
   push 640
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 640
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap1
   pop
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup2
   dup2
   dup1
   push 512
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   swap2
   pop
   dup2
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup3
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 320
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup4
-  sub
+  sub !meta(stack=0->0)
   swap3
   pop
   dup3
   dup2
-  add
+  add !meta(stack=0->0)
   swap3
   pop
   push 0
   dup4
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   push 32
   push 352
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup5
   dup1
   push 320
-  mstore
-  mcopy
+  mstore !meta(stack=0->0)
+  mcopy !meta(stack=0->0)
   pop
   swap2
   pop
   dup2
   dup1
   push 512
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 1
   dup2
-  and
+  and !meta(stack=0->0)
   push 1
   swap1
-  eq
+  eq !meta(stack=0->0)
   push 255
   dup3
-  and
+  and !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   dup3
   push 1
-  shr
+  shr !meta(stack=0->0)
   swap3
   pop
   dup3
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 31
   dup3
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   dup3
-  and
+  and !meta(stack=0->0)
   swap2
   pop
   dup2
   push 5
-  shr
+  shr !meta(stack=0->0)
   swap2
   pop
   push 0
@@ -814,62 +814,62 @@ bb18:
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   pop
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup4
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   push 5
-  shr
+  shr !meta(stack=0->0)
   push 31
   dup5
-  gt
+  gt !meta(stack=0->0)
   push 0
   dup3
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup2
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
-  keccak256
+  keccak256 !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   swap2
   pop
@@ -881,335 +881,335 @@ bb18:
   pop
   pop
   push bb21
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb20
 bb19:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 49
   jump bb10
 bb20:
   push 320
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 320
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 3
-  shl
+  shl !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   swap1
-  shr
-  not
-  and
+  shr !meta(stack=0->0)
+  not !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
-  or
+  shl !meta(stack=0->0)
+  or !meta(stack=0->0)
   push 224
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   jump bb23
 bb21:
   push 256
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shl
+  shl !meta(stack=0->0)
   push 1
   swap1
-  or
+  or !meta(stack=0->0)
   push 224
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   fallthrough bb22
 bb22:
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb23
-  jumpi
+  jumpi !meta(stack=0->0)
   push 128
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 384
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 384
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shl
+  shl !meta(stack=0->0)
   push 320
-  mload
-  add
-  mload
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   swap1
-  sstore
+  sstore !meta(stack=0->0)
   push 1
   push 384
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
+  mload !meta(stack=0->0)
   jump bb22
 bb23:
   push 288
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 288
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   fallthrough bb24
 bb24:
   push 416
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 416
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
-  iszero
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb5
-  jumpi
+  jumpi !meta(stack=0->0)
   push 128
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 0
   dup2
-  sstore
+  sstore !meta(stack=0->0)
   pop
   push 1
   push 544
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 608
-  mload
+  mload !meta(stack=0->0)
   jump bb24
 bb25:
   push 0
   push 128
-  mstore
-  caller
+  mstore !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 1
   swap1
-  add
+  add !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb26
   jump bb36
 bb26:
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   fallthrough bb27
 bb27:
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb28:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
-  caller
+  mstore !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 1
   swap1
-  add
+  add !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb29
   jump bb36
 bb29:
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
-  mload
+  mstore !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 4
-  calldataload
-  lt
-  iszero
+  calldataload !meta(stack=0->0)
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb40
-  jumpi
+  jumpi !meta(stack=0->0)
   push 32
   push 224
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  add
-  mload
+  add !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 0xff00000000000000000000000000000000000000000000000000000000000000
   swap1
-  and
+  and !meta(stack=0->0)
   jump bb27
 bb30:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xff00000000000000000000000000000000000000000000000000000000000000
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
-  caller
+  jumpi !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 128
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   dup2
-  and
+  and !meta(stack=0->0)
   push 1
   swap1
-  eq
+  eq !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   push 255
   dup3
-  and
+  and !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   dup3
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   dup2
   dup2
   dup5
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   pop
   push 4
-  calldataload
-  lt
-  iszero
+  calldataload !meta(stack=0->0)
+  lt !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb40
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 248
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   swap2
   pop
@@ -1217,154 +1217,154 @@ bb30:
   swap1
   pop
   push bb32
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb31
 bb31:
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 31
-  sub
+  sub !meta(stack=0->0)
   push 3
-  shl
+  shl !meta(stack=0->0)
   push 255
   dup2
-  shl
-  not
+  shl !meta(stack=0->0)
+  not !meta(stack=0->0)
   push 192
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  shl
+  shl !meta(stack=0->0)
   swap2
   pop
-  or
+  or !meta(stack=0->0)
   push 128
-  mload
-  sstore
+  mload !meta(stack=0->0)
+  sstore !meta(stack=0->0)
   jump bb33
 bb32:
   push 128
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 5
-  shr
-  add
+  shr !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 31
   push 4
-  calldataload
-  and
+  calldataload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup2
-  sload
+  sload !meta(stack=0->0)
   dup2
   push 31
-  sub
+  sub !meta(stack=0->0)
   swap2
   pop
   dup2
   push 3
-  shl
+  shl !meta(stack=0->0)
   swap2
   pop
   push 255
   dup3
-  shl
-  not
-  and
+  shl !meta(stack=0->0)
+  not !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  shl
+  shl !meta(stack=0->0)
   swap2
   pop
-  or
+  or !meta(stack=0->0)
   swap1
-  sstore
+  sstore !meta(stack=0->0)
   fallthrough bb33
 bb33:
   terminal stop
 bb34:
   push 0
   push 128
-  mstore
-  caller
+  mstore !meta(stack=0->0)
+  caller !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 0
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 0
-  keccak256
+  keccak256 !meta(stack=0->0)
   push 1
   swap1
-  add
+  add !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push bb35
   jump bb36
 bb35:
   push 0x440
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup1
   push 0x420
-  mstore
+  mstore !meta(stack=0->0)
   jump bb39
 bb36:
   push 0x420
-  mload
-  sload
+  mload !meta(stack=0->0)
+  sload !meta(stack=0->0)
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   push 1
   dup2
-  and
+  and !meta(stack=0->0)
   push 1
   swap1
-  eq
+  eq !meta(stack=0->0)
   push 255
   dup3
-  and
+  and !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   dup3
   dup1
   push 0x500
-  mstore
+  mstore !meta(stack=0->0)
   push 1
-  shr
+  shr !meta(stack=0->0)
   dup2
   dup2
   dup5
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap2
   pop
   pop
@@ -1372,66 +1372,66 @@ bb36:
   dup2
   dup1
   push 0x4a0
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   dup1
   push 0x4c0
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 0x4c0
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   swap1
   pop
   push 32
   swap1
-  add
+  add !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x540
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 0x5c0
-  mstore
+  mstore !meta(stack=0->0)
   dup3
   dup2
-  add
+  add !meta(stack=0->0)
   swap3
   pop
   dup3
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   dup3
   dup1
   push 0x4a0
-  mstore
+  mstore !meta(stack=0->0)
   dup3
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   push 64
   dup3
-  add
+  add !meta(stack=0->0)
   dup1
   push 0x5a0
-  mstore
+  mstore !meta(stack=0->0)
   dup4
   swap2
   pop
@@ -1442,132 +1442,132 @@ bb36:
   swap1
   pop
   push bb37
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
   push 0x500
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   push 0x5a0
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   jump bb2
 bb37:
   push 0x420
-  mload
+  mload !meta(stack=0->0)
   push 0x540
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 32
   push 0x540
-  mload
-  keccak256
+  mload !meta(stack=0->0)
+  keccak256 !meta(stack=0->0)
   push 0x4c0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4c0
-  mstore
+  mstore !meta(stack=0->0)
   push 5
-  shr
+  shr !meta(stack=0->0)
   push 0x5a0
-  mload
+  mload !meta(stack=0->0)
   swap2
   swap1
   jump bb38
 bb38:
   dup1
   push 0x5e0
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   push 0x4e0
-  mstore
+  mstore !meta(stack=0->0)
   dup3
   push 0x460
-  mstore
+  mstore !meta(stack=0->0)
   swap2
   pop
   pop
-  iszero
+  iszero !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0x4e0
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 0x4e0
-  mstore
-  sload
+  mstore !meta(stack=0->0)
+  sload !meta(stack=0->0)
   push 0x460
-  mload
-  mstore
+  mload !meta(stack=0->0)
+  mstore !meta(stack=0->0)
   push 1
   push 0x4e0
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 32
   push 0x460
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 1
   push 0x5e0
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   swap1
   swap2
   swap1
   jump bb38
 bb39:
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 0x420
-  mload
-  mload
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 32
   dup3
-  add
+  add !meta(stack=0->0)
   dup2
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and
+  and !meta(stack=0->0)
   push 64
   dup4
-  add
+  add !meta(stack=0->0)
   push 32
   dup3
-  sub
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 32
   push 0x420
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup4
   dup2
   dup4
-  mcopy
+  mcopy !meta(stack=0->0)
   pop
   pop
   swap1
   pop
   push 64
   swap1
-  add
+  add !meta(stack=0->0)
   dup2
   terminal return
 bb40:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 50
   jump bb10

--- a/tests/ui/codegen/storage_bytes_member.stdout
+++ b/tests/ui/codegen/storage_bytes_member.stdout
@@ -2,48 +2,48 @@
 bb0 (entry):
   push 0x620
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x4407bb95
-  eq !meta(stack=0->0)
+  eq
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x53b8a6c6
-  eq !meta(stack=0->0)
+  eq
   push bb17
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x56d88e27
-  eq !meta(stack=0->0)
+  eq
   push bb25
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x72bd964d
-  eq !meta(stack=0->0)
+  eq
   push bb34
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xbee6975a
-  eq !meta(stack=0->0)
+  eq
   push bb30
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xe0886f90
-  eq !meta(stack=0->0)
+  eq
   push bb28
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
@@ -51,90 +51,90 @@ bb1:
   terminal revert
 bb2:
   push 0x5c0
-  mload !meta(stack=0->0)
+  mload
   push 0x440
-  mstore !meta(stack=0->0)
+  mstore
   terminal jump
 bb3:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 255
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 255
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  jumpi
+  caller
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 0
   jump bb4
 bb4:
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   fallthrough bb5
 bb5:
   terminal stop
 bb6:
   push 128
-  mload !meta(stack=0->0)
+  mload
   push 1
   dup2
   dup1
   push 672
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   dup2
@@ -142,230 +142,230 @@ bb6:
   pop
   pop
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 416
-  mload !meta(stack=0->0)
+  mload
   jump bb4
 bb7:
   push 256
-  mload !meta(stack=0->0)
+  mload
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   push bb8
   jump bb36
 bb8:
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 576
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  lt !meta(stack=0->0)
+  lt
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   dup1
   push 800
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 800
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap1
   pop
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   dup2
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup3
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 352
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup3
-  sub !meta(stack=0->0)
+  sub
   swap2
   pop
   dup2
   dup2
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 0
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   push 32
   push 576
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup4
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
   dup1
   push 352
-  mstore !meta(stack=0->0)
-  mcopy !meta(stack=0->0)
+  mstore
+  mcopy
   pop
   push 128
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 832
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   swap1
   pop
   push bb11
-  jumpi !meta(stack=0->0)
+  jumpi
   push 255
   push 608
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   push 248
-  shl !meta(stack=0->0)
+  shl
   push 0xff00000000000000000000000000000000000000000000000000000000000000
   swap1
-  and !meta(stack=0->0)
+  and
   push 248
-  shr !meta(stack=0->0)
+  shr
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  mstore8 !meta(stack=0->0)
+  mload
+  add
+  mstore8
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 1
   dup2
-  and !meta(stack=0->0)
+  and
   push 1
   swap1
-  eq !meta(stack=0->0)
+  eq
   push 255
   dup3
-  and !meta(stack=0->0)
+  and
   push 1
-  shr !meta(stack=0->0)
+  shr
   dup3
   push 1
-  shr !meta(stack=0->0)
+  shr
   swap3
   pop
   dup3
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 31
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   dup3
-  and !meta(stack=0->0)
+  and
   swap2
   pop
   dup2
   push 5
-  shr !meta(stack=0->0)
+  shr
   swap2
   pop
   push 0
@@ -373,72 +373,72 @@ bb8:
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   pop
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup3
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   push 5
-  shr !meta(stack=0->0)
+  shr
   push 31
   dup4
-  gt !meta(stack=0->0)
+  gt
   push 0
   dup3
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup2
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  keccak256 !meta(stack=0->0)
+  keccak256
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   dup3
   swap2
   pop
@@ -450,363 +450,363 @@ bb8:
   pop
   pop
   push bb13
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb12
 bb9:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   pop
   pop
   push 65
   fallthrough bb10
 bb10:
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb11:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   jump bb10
 bb12:
   push 352
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 3
-  shl !meta(stack=0->0)
+  shl
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   swap1
-  shr !meta(stack=0->0)
-  not !meta(stack=0->0)
-  and !meta(stack=0->0)
+  shr
+  not
+  and
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
-  or !meta(stack=0->0)
+  shl
+  or
   push 256
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   jump bb15
 bb13:
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   push 1
   swap1
-  or !meta(stack=0->0)
+  or
   push 256
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   push 0
   push 224
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 0
   fallthrough bb14
 bb14:
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb15
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 448
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  add
+  mload
   swap1
-  sstore !meta(stack=0->0)
+  sstore
   push 1
   push 448
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 736
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 736
-  mload !meta(stack=0->0)
+  mload
   jump bb14
 bb15:
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 320
-  mload !meta(stack=0->0)
+  mload
   fallthrough bb16
 bb16:
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 768
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 0
   dup2
-  sstore !meta(stack=0->0)
+  sstore
   pop
   push 1
   push 768
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 704
-  mload !meta(stack=0->0)
+  mload
   jump bb16
 bb17:
-  caller !meta(stack=0->0)
+  caller
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb18
   jump bb36
 bb18:
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 352
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 448
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push bb19
-  jumpi !meta(stack=0->0)
+  jumpi
   push 1
   push 448
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   push 30
   push 448
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   dup1
   push 640
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 640
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap1
   pop
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup2
   dup2
   dup1
   push 512
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   swap2
   pop
   dup2
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup3
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 320
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup4
-  sub !meta(stack=0->0)
+  sub
   swap3
   pop
   dup3
   dup2
-  add !meta(stack=0->0)
+  add
   swap3
   pop
   push 0
   dup4
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   push 32
   push 352
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup4
   dup2
   dup5
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  mcopy !meta(stack=0->0)
+  mstore
+  mcopy
   pop
   swap2
   pop
   dup2
   dup1
   push 512
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup2
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 1
   dup2
-  and !meta(stack=0->0)
+  and
   push 1
   swap1
-  eq !meta(stack=0->0)
+  eq
   push 255
   dup3
-  and !meta(stack=0->0)
+  and
   push 1
-  shr !meta(stack=0->0)
+  shr
   dup3
   push 1
-  shr !meta(stack=0->0)
+  shr
   swap3
   pop
   dup3
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 31
   dup3
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   dup3
-  and !meta(stack=0->0)
+  and
   swap2
   pop
   dup2
   push 5
-  shr !meta(stack=0->0)
+  shr
   swap2
   pop
   push 0
@@ -814,62 +814,62 @@ bb18:
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   pop
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup4
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   push 5
-  shr !meta(stack=0->0)
+  shr
   push 31
   dup5
-  gt !meta(stack=0->0)
+  gt
   push 0
   dup3
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup2
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
-  keccak256 !meta(stack=0->0)
+  keccak256
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   swap2
   pop
@@ -881,335 +881,335 @@ bb18:
   pop
   pop
   push bb21
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb20
 bb19:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 49
   jump bb10
 bb20:
   push 320
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 320
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 3
-  shl !meta(stack=0->0)
+  shl
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   swap1
-  shr !meta(stack=0->0)
-  not !meta(stack=0->0)
-  and !meta(stack=0->0)
+  shr
+  not
+  and
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
-  or !meta(stack=0->0)
+  shl
+  or
   push 224
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   jump bb23
 bb21:
   push 256
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shl !meta(stack=0->0)
+  shl
   push 1
   swap1
-  or !meta(stack=0->0)
+  or
   push 224
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   fallthrough bb22
 bb22:
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb23
-  jumpi !meta(stack=0->0)
+  jumpi
   push 128
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 384
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 384
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shl !meta(stack=0->0)
+  shl
   push 320
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  add
+  mload
   swap1
-  sstore !meta(stack=0->0)
+  sstore
   push 1
   push 384
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
+  mload
   jump bb22
 bb23:
   push 288
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 288
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 288
-  mload !meta(stack=0->0)
+  mload
   fallthrough bb24
 bb24:
   push 416
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 416
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  lt
+  iszero
   push bb5
-  jumpi !meta(stack=0->0)
+  jumpi
   push 128
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 0
   dup2
-  sstore !meta(stack=0->0)
+  sstore
   pop
   push 1
   push 544
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 608
-  mload !meta(stack=0->0)
+  mload
   jump bb24
 bb25:
   push 0
   push 128
-  mstore !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  mstore
+  caller
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 1
   swap1
-  add !meta(stack=0->0)
+  add
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb26
   jump bb36
 bb26:
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   fallthrough bb27
 bb27:
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb28:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  mstore
+  caller
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 1
   swap1
-  add !meta(stack=0->0)
+  add
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb29
   jump bb36
 bb29:
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mstore
+  mload
   push 4
-  calldataload !meta(stack=0->0)
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  calldataload
+  lt
+  iszero
   push bb40
-  jumpi !meta(stack=0->0)
+  jumpi
   push 32
   push 224
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  add !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  add
+  mload
   push 0xff00000000000000000000000000000000000000000000000000000000000000
   swap1
-  and !meta(stack=0->0)
+  and
   jump bb27
 bb30:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xff00000000000000000000000000000000000000000000000000000000000000
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  jumpi
+  caller
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 128
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   dup2
-  and !meta(stack=0->0)
+  and
   push 1
   swap1
-  eq !meta(stack=0->0)
+  eq
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   push 255
   dup3
-  and !meta(stack=0->0)
+  and
   push 1
-  shr !meta(stack=0->0)
+  shr
   dup3
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   dup2
   dup2
   dup5
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   pop
   push 4
-  calldataload !meta(stack=0->0)
-  lt !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  calldataload
+  lt
+  iszero
   push bb40
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 248
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   swap2
   pop
@@ -1217,154 +1217,154 @@ bb30:
   swap1
   pop
   push bb32
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb31
 bb31:
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 31
-  sub !meta(stack=0->0)
+  sub
   push 3
-  shl !meta(stack=0->0)
+  shl
   push 255
   dup2
-  shl !meta(stack=0->0)
-  not !meta(stack=0->0)
+  shl
+  not
   push 192
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  shl !meta(stack=0->0)
+  shl
   swap2
   pop
-  or !meta(stack=0->0)
+  or
   push 128
-  mload !meta(stack=0->0)
-  sstore !meta(stack=0->0)
+  mload
+  sstore
   jump bb33
 bb32:
   push 128
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 5
-  shr !meta(stack=0->0)
-  add !meta(stack=0->0)
+  shr
+  add
   push 31
   push 4
-  calldataload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  calldataload
+  and
   dup2
-  sload !meta(stack=0->0)
+  sload
   dup2
   push 31
-  sub !meta(stack=0->0)
+  sub
   swap2
   pop
   dup2
   push 3
-  shl !meta(stack=0->0)
+  shl
   swap2
   pop
   push 255
   dup3
-  shl !meta(stack=0->0)
-  not !meta(stack=0->0)
-  and !meta(stack=0->0)
+  shl
+  not
+  and
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  shl !meta(stack=0->0)
+  shl
   swap2
   pop
-  or !meta(stack=0->0)
+  or
   swap1
-  sstore !meta(stack=0->0)
+  sstore
   fallthrough bb33
 bb33:
   terminal stop
 bb34:
   push 0
   push 128
-  mstore !meta(stack=0->0)
-  caller !meta(stack=0->0)
+  mstore
+  caller
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 0
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 0
-  keccak256 !meta(stack=0->0)
+  keccak256
   push 1
   swap1
-  add !meta(stack=0->0)
+  add
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push bb35
   jump bb36
 bb35:
   push 0x440
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup1
   push 0x420
-  mstore !meta(stack=0->0)
+  mstore
   jump bb39
 bb36:
   push 0x420
-  mload !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mload
+  sload
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   push 1
   dup2
-  and !meta(stack=0->0)
+  and
   push 1
   swap1
-  eq !meta(stack=0->0)
+  eq
   push 255
   dup3
-  and !meta(stack=0->0)
+  and
   push 1
-  shr !meta(stack=0->0)
+  shr
   dup3
   dup1
   push 0x500
-  mstore !meta(stack=0->0)
+  mstore
   push 1
-  shr !meta(stack=0->0)
+  shr
   dup2
   dup2
   dup5
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap2
   pop
   pop
@@ -1372,66 +1372,66 @@ bb36:
   dup2
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   dup1
   push 0x4c0
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 0x4c0
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   swap1
   pop
   push 32
   swap1
-  add !meta(stack=0->0)
+  add
   push 64
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x540
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 0x5c0
-  mstore !meta(stack=0->0)
+  mstore
   dup3
   dup2
-  add !meta(stack=0->0)
+  add
   swap3
   pop
   dup3
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   dup3
   dup1
   push 0x4a0
-  mstore !meta(stack=0->0)
+  mstore
   dup3
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   push 64
   dup3
-  add !meta(stack=0->0)
+  add
   dup1
   push 0x5a0
-  mstore !meta(stack=0->0)
+  mstore
   dup4
   swap2
   pop
@@ -1442,132 +1442,132 @@ bb36:
   swap1
   pop
   push bb37
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
   push 0x500
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   push 0x5a0
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   jump bb2
 bb37:
   push 0x420
-  mload !meta(stack=0->0)
+  mload
   push 0x540
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 32
   push 0x540
-  mload !meta(stack=0->0)
-  keccak256 !meta(stack=0->0)
+  mload
+  keccak256
   push 0x4c0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4c0
-  mstore !meta(stack=0->0)
+  mstore
   push 5
-  shr !meta(stack=0->0)
+  shr
   push 0x5a0
-  mload !meta(stack=0->0)
+  mload
   swap2
   swap1
   jump bb38
 bb38:
   dup1
   push 0x5e0
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   push 0x4e0
-  mstore !meta(stack=0->0)
+  mstore
   dup3
   push 0x460
-  mstore !meta(stack=0->0)
+  mstore
   swap2
   pop
   pop
-  iszero !meta(stack=0->0)
+  iszero
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0x4e0
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 0x4e0
-  mstore !meta(stack=0->0)
-  sload !meta(stack=0->0)
+  mstore
+  sload
   push 0x460
-  mload !meta(stack=0->0)
-  mstore !meta(stack=0->0)
+  mload
+  mstore
   push 1
   push 0x4e0
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 32
   push 0x460
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   push 1
   push 0x5e0
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   swap1
   swap2
   swap1
   jump bb38
 bb39:
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 0x420
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  mload
   push 32
   dup3
-  add !meta(stack=0->0)
+  add
   dup2
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   swap1
-  and !meta(stack=0->0)
+  and
   push 64
   dup4
-  add !meta(stack=0->0)
+  add
   push 32
   dup3
-  sub !meta(stack=0->0)
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 32
   push 0x420
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup4
   dup2
   dup4
-  mcopy !meta(stack=0->0)
+  mcopy
   pop
   pop
   swap1
   pop
   push 64
   swap1
-  add !meta(stack=0->0)
+  add
   dup2
   terminal return
 bb40:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 50
   jump bb10

--- a/tests/ui/codegen/storage_bytes_member.stdout
+++ b/tests/ui/codegen/storage_bytes_member.stdout
@@ -1,1 +1,1573 @@
-{"contracts":{"ROOT/tests/ui/codegen/storage_bytes_member.sol:StorageBytesMember":{"bin-runtime":"6106206040523460585736156058575f3560e01c80634407bb9514606657806353b8a6c6146103a757806356d88e27146105f257806372bd964d14610765578063bee6975a1461067d578063e0886f9014610626576058565b5f80fd5b6105c05161044052565b36600490036040901260585760043560ff81160360585760243560ff811603605857335f525f60205260405f205f60805260018101806101005290508061010052505f60ad565b602435901060ef575b005b608051600181806102a05201806101a05281806102a05281109150819150506102a8576101a051806101a0526080526101a05160ad565b610100516104205260fe610798565b61044051806102405251806101805260018101806102805281806101805281106102915760208201601f1990168061032052156103205160208282820302905001905060208101604051806101e05281810191508160405290508280610280528152915060208201806101605260208203915081810191505f8252905060206102405101838061018052818380610160525e506080518061034052600435018061026052600435901091505090506102a85760ff610260511660f81b60ff60f81b901660f81c6101805180610180526101605101536101e051806101e05251806101205261010051806101005254600181166001901460ff821660011c8260011c92508282828203029050019150601f82019150601f19821691508160051c91505f82828282030290500180610220529150508061022052601f8201601f19901660051c601f83115f8282828203029050018061014052915081610140526040518060e052602081016040526101005180610100528152602081208061020052829150509150509150506102ec576102b9565b634e487b7160e01b5f52505060415b60045260245ffd5b634e487b7160e01b5f5260116102a0565b6101605180610160525161012051806101205260031b5f19901c191661012051806101205260011b176101005155610357565b61012051806101205260011b6001901761010051555f60e051525f5b6101405180610140529010156103575760e0518060e05251806101c05261020051016101c051806101c05260051b610160510151905560016101c05101806102e05260e051526102e051610308565b61014051806101405260e05152610140515b61022051806102205290101560b85760e0518060e05251806103005261020051015f81555060016103005101806102c05260e051526102c051610369565b335f525f60205260405f20600181018060e05290508060e0528061042052506103ce610798565b61044051806101605251806101c052156105035760016101c05103601e6101c05101601f19901680610280521561028051602082828203029050019050602081016040518181806102005201915081604052905082815260208101806101405260208303925082810192505f835291506020610160510183818480610140525e5091508180610200525180610100529150816101005260e0518060e05254600181166001901460ff821660011c8260011c92508282828203029050019150601f82019150601f19821691508160051c91505f828282820302905001806101a052915050806101a052601f8301601f19901660051c601f84115f82828282030290500180610120529150816101205260e0518060e0526080526020608020806101e0528191505091505091505061054657610514565b634e487b7160e01b5f5260316102a0565b6101405180610140525161010051806101005260031b5f19901c191661010051806101005260011b1760e051556105a9565b61010051806101005260011b6001901760e051555f6080525f5b6101205180610120529010156105a95760805180610180526101e0510161018051806101805260051b610140510151905560016101805101806102405260805261024051610560565b610120518061012052608052610120515b6101a051806101a05290101560b65760805180610220526101e051015f815550600161022051018061026052608052610260516105ba565b5f608052335f525f60205260405f2060019001806104205250610613610798565b610440518060e052515b60805260206080f35b3660049003602090126058575f608052335f525f60205260405f2060019001806104205250610653610798565b610440518060e0525160043510156108e657602060e0510160043590015160ff60f81b901661061d565b36600490036040901260585760243560ff60f81b811603605857335f525f60205260405f206001810180608052905080608052548060c05260018116600190148060e05260ff821660011c828060c05260011c8181848282030290500191505060043510156108e65760243560f81c8060a052819150509050610726576106ff565b600435601f0360031b60ff811b1960c0511660a0518060a052821b91501760805155610763565b608051806080525f5260205f2060043560051c01601f60043516815481601f0391508160031b915060ff821b191660a0518060a052821b91501790555b005b5f608052335f525f60205260405f2060019001806104205250610786610798565b610440518060e05280610420526108a5565b61042051548061050052600181166001901460ff821660011c82806105005260011c81818482820302905001915050601f81806104a05201601f199016806104c052156104c05160208282820302905001905060209001604051806105405260208101806105c052828101925082604052915082806104a0528252915060408201806105a05283915050915050905061083c5760ff1961050051166105a05152605c565b610420516105405152602061054051206104c051806104c05260051c6105a0519190610863565b806105e052816104e052826104605291505015605c576104e051806104e05254610460515260016104e051016020610460510160016105e05103909190610863565b6040516020815261042051516020820181815250601f8101601f199016604083016020820381015f815250602061042051018381835e505090506040900181f35b634e487b7160e01b5f5260326102a056"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/storage_bytes_member.sol:StorageBytesMember (runtime) ===
+bb0 (entry):
+  push 0x620
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x4407bb95
+  eq
+  push bb3
+  jumpi
+  dup1
+  push 0x53b8a6c6
+  eq
+  push bb17
+  jumpi
+  dup1
+  push 0x56d88e27
+  eq
+  push bb25
+  jumpi
+  dup1
+  push 0x72bd964d
+  eq
+  push bb34
+  jumpi
+  dup1
+  push 0xbee6975a
+  eq
+  push bb30
+  jumpi
+  dup1
+  push 0xe0886f90
+  eq
+  push bb28
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  push 0x5c0
+  mload
+  push 0x440
+  mstore
+  terminal jump
+bb3:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 255
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 255
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  caller
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 0
+  push 128
+  mstore
+  push 1
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  swap1
+  pop
+  dup1
+  push 256
+  mstore
+  pop
+  push 0
+  jump bb4
+bb4:
+  push 36
+  calldataload
+  swap1
+  lt
+  push bb7
+  jumpi
+  fallthrough bb5
+bb5:
+  terminal stop
+bb6:
+  push 128
+  mload
+  push 1
+  dup2
+  dup1
+  push 672
+  mstore
+  add
+  dup1
+  push 416
+  mstore
+  dup2
+  dup1
+  push 672
+  mstore
+  dup2
+  lt
+  swap2
+  pop
+  dup2
+  swap2
+  pop
+  pop
+  push bb11
+  jumpi
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  push 128
+  mstore
+  push 416
+  mload
+  jump bb4
+bb7:
+  push 256
+  mload
+  push 0x420
+  mstore
+  push bb8
+  jump bb36
+bb8:
+  push 0x440
+  mload
+  dup1
+  push 576
+  mstore
+  mload
+  dup1
+  push 384
+  mstore
+  push 1
+  dup2
+  add
+  dup1
+  push 640
+  mstore
+  dup2
+  dup1
+  push 384
+  mstore
+  dup2
+  lt
+  push bb9
+  jumpi
+  push 32
+  dup3
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  dup1
+  push 800
+  mstore
+  iszero
+  push 800
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap1
+  pop
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup1
+  push 480
+  mstore
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  dup3
+  dup1
+  push 640
+  mstore
+  dup2
+  mstore
+  swap2
+  pop
+  push 32
+  dup3
+  add
+  dup1
+  push 352
+  mstore
+  push 32
+  dup3
+  sub
+  swap2
+  pop
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  push 0
+  dup3
+  mstore
+  swap1
+  pop
+  push 32
+  push 576
+  mload
+  add
+  dup4
+  dup1
+  push 384
+  mstore
+  dup2
+  dup4
+  dup1
+  push 352
+  mstore
+  mcopy
+  pop
+  push 128
+  mload
+  dup1
+  push 832
+  mstore
+  push 4
+  calldataload
+  add
+  dup1
+  push 608
+  mstore
+  push 4
+  calldataload
+  swap1
+  lt
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb11
+  jumpi
+  push 255
+  push 608
+  mload
+  and
+  push 248
+  shl
+  push 0xff00000000000000000000000000000000000000000000000000000000000000
+  swap1
+  and
+  push 248
+  shr
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  push 352
+  mload
+  add
+  mstore8
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  mload
+  dup1
+  push 288
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  sload
+  push 1
+  dup2
+  and
+  push 1
+  swap1
+  eq
+  push 255
+  dup3
+  and
+  push 1
+  shr
+  dup3
+  push 1
+  shr
+  swap3
+  pop
+  dup3
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap2
+  pop
+  push 31
+  dup3
+  add
+  swap2
+  pop
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  dup3
+  and
+  swap2
+  pop
+  dup2
+  push 5
+  shr
+  swap2
+  pop
+  push 0
+  dup3
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 544
+  mstore
+  swap2
+  pop
+  pop
+  dup1
+  push 544
+  mstore
+  push 31
+  dup3
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  push 5
+  shr
+  push 31
+  dup4
+  gt
+  push 0
+  dup3
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 320
+  mstore
+  swap2
+  pop
+  dup2
+  push 320
+  mstore
+  push 64
+  mload
+  dup1
+  push 224
+  mstore
+  push 32
+  dup2
+  add
+  push 64
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  keccak256
+  dup1
+  push 512
+  mstore
+  dup3
+  swap2
+  pop
+  pop
+  swap2
+  pop
+  pop
+  swap2
+  pop
+  pop
+  push bb13
+  jumpi
+  jump bb12
+bb9:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  pop
+  pop
+  push 65
+  fallthrough bb10
+bb10:
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb11:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  jump bb10
+bb12:
+  push 352
+  mload
+  dup1
+  push 352
+  mstore
+  mload
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  push 3
+  shl
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  swap1
+  shr
+  not
+  and
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  push 1
+  shl
+  or
+  push 256
+  mload
+  sstore
+  jump bb15
+bb13:
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  push 1
+  shl
+  push 1
+  swap1
+  or
+  push 256
+  mload
+  sstore
+  push 0
+  push 224
+  mload
+  mstore
+  push 0
+  fallthrough bb14
+bb14:
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  swap1
+  lt
+  iszero
+  push bb15
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  dup1
+  push 448
+  mstore
+  push 512
+  mload
+  add
+  push 448
+  mload
+  dup1
+  push 448
+  mstore
+  push 5
+  shl
+  push 352
+  mload
+  add
+  mload
+  swap1
+  sstore
+  push 1
+  push 448
+  mload
+  add
+  dup1
+  push 736
+  mstore
+  push 224
+  mload
+  mstore
+  push 736
+  mload
+  jump bb14
+bb15:
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  push 224
+  mload
+  mstore
+  push 320
+  mload
+  fallthrough bb16
+bb16:
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  swap1
+  lt
+  iszero
+  push bb6
+  jumpi
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  dup1
+  push 768
+  mstore
+  push 512
+  mload
+  add
+  push 0
+  dup2
+  sstore
+  pop
+  push 1
+  push 768
+  mload
+  add
+  dup1
+  push 704
+  mstore
+  push 224
+  mload
+  mstore
+  push 704
+  mload
+  jump bb16
+bb17:
+  caller
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 1
+  dup2
+  add
+  dup1
+  push 224
+  mstore
+  swap1
+  pop
+  dup1
+  push 224
+  mstore
+  dup1
+  push 0x420
+  mstore
+  pop
+  push bb18
+  jump bb36
+bb18:
+  push 0x440
+  mload
+  dup1
+  push 352
+  mstore
+  mload
+  dup1
+  push 448
+  mstore
+  iszero
+  push bb19
+  jumpi
+  push 1
+  push 448
+  mload
+  sub
+  push 30
+  push 448
+  mload
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  dup1
+  push 640
+  mstore
+  iszero
+  push 640
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap1
+  pop
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup2
+  dup2
+  dup1
+  push 512
+  mstore
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  dup3
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 320
+  mstore
+  push 32
+  dup4
+  sub
+  swap3
+  pop
+  dup3
+  dup2
+  add
+  swap3
+  pop
+  push 0
+  dup4
+  mstore
+  swap2
+  pop
+  push 32
+  push 352
+  mload
+  add
+  dup4
+  dup2
+  dup5
+  dup1
+  push 320
+  mstore
+  mcopy
+  pop
+  swap2
+  pop
+  dup2
+  dup1
+  push 512
+  mstore
+  mload
+  dup1
+  push 256
+  mstore
+  swap2
+  pop
+  dup2
+  push 256
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  sload
+  push 1
+  dup2
+  and
+  push 1
+  swap1
+  eq
+  push 255
+  dup3
+  and
+  push 1
+  shr
+  dup3
+  push 1
+  shr
+  swap3
+  pop
+  dup3
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap2
+  pop
+  push 31
+  dup3
+  add
+  swap2
+  pop
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  dup3
+  and
+  swap2
+  pop
+  dup2
+  push 5
+  shr
+  swap2
+  pop
+  push 0
+  dup3
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 416
+  mstore
+  swap2
+  pop
+  pop
+  dup1
+  push 416
+  mstore
+  push 31
+  dup4
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  push 5
+  shr
+  push 31
+  dup5
+  gt
+  push 0
+  dup3
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 288
+  mstore
+  swap2
+  pop
+  dup2
+  push 288
+  mstore
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  keccak256
+  dup1
+  push 480
+  mstore
+  dup2
+  swap2
+  pop
+  pop
+  swap2
+  pop
+  pop
+  swap2
+  pop
+  pop
+  push bb21
+  jumpi
+  jump bb20
+bb19:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 49
+  jump bb10
+bb20:
+  push 320
+  mload
+  dup1
+  push 320
+  mstore
+  mload
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 3
+  shl
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  swap1
+  shr
+  not
+  and
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 1
+  shl
+  or
+  push 224
+  mload
+  sstore
+  jump bb23
+bb21:
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  push 1
+  shl
+  push 1
+  swap1
+  or
+  push 224
+  mload
+  sstore
+  push 0
+  push 128
+  mstore
+  push 0
+  fallthrough bb22
+bb22:
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  swap1
+  lt
+  iszero
+  push bb23
+  jumpi
+  push 128
+  mload
+  dup1
+  push 384
+  mstore
+  push 480
+  mload
+  add
+  push 384
+  mload
+  dup1
+  push 384
+  mstore
+  push 5
+  shl
+  push 320
+  mload
+  add
+  mload
+  swap1
+  sstore
+  push 1
+  push 384
+  mload
+  add
+  dup1
+  push 576
+  mstore
+  push 128
+  mstore
+  push 576
+  mload
+  jump bb22
+bb23:
+  push 288
+  mload
+  dup1
+  push 288
+  mstore
+  push 128
+  mstore
+  push 288
+  mload
+  fallthrough bb24
+bb24:
+  push 416
+  mload
+  dup1
+  push 416
+  mstore
+  swap1
+  lt
+  iszero
+  push bb5
+  jumpi
+  push 128
+  mload
+  dup1
+  push 544
+  mstore
+  push 480
+  mload
+  add
+  push 0
+  dup2
+  sstore
+  pop
+  push 1
+  push 544
+  mload
+  add
+  dup1
+  push 608
+  mstore
+  push 128
+  mstore
+  push 608
+  mload
+  jump bb24
+bb25:
+  push 0
+  push 128
+  mstore
+  caller
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 1
+  swap1
+  add
+  dup1
+  push 0x420
+  mstore
+  pop
+  push bb26
+  jump bb36
+bb26:
+  push 0x440
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  fallthrough bb27
+bb27:
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb28:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  caller
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 1
+  swap1
+  add
+  dup1
+  push 0x420
+  mstore
+  pop
+  push bb29
+  jump bb36
+bb29:
+  push 0x440
+  mload
+  dup1
+  push 224
+  mstore
+  mload
+  push 4
+  calldataload
+  lt
+  iszero
+  push bb40
+  jumpi
+  push 32
+  push 224
+  mload
+  add
+  push 4
+  calldataload
+  swap1
+  add
+  mload
+  push 0xff00000000000000000000000000000000000000000000000000000000000000
+  swap1
+  and
+  jump bb27
+bb30:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 0xff00000000000000000000000000000000000000000000000000000000000000
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  caller
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 1
+  dup2
+  add
+  dup1
+  push 128
+  mstore
+  swap1
+  pop
+  dup1
+  push 128
+  mstore
+  sload
+  dup1
+  push 192
+  mstore
+  push 1
+  dup2
+  and
+  push 1
+  swap1
+  eq
+  dup1
+  push 224
+  mstore
+  push 255
+  dup3
+  and
+  push 1
+  shr
+  dup3
+  dup1
+  push 192
+  mstore
+  push 1
+  shr
+  dup2
+  dup2
+  dup5
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap2
+  pop
+  pop
+  push 4
+  calldataload
+  lt
+  iszero
+  push bb40
+  jumpi
+  push 36
+  calldataload
+  push 248
+  shr
+  dup1
+  push 160
+  mstore
+  dup2
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb32
+  jumpi
+  jump bb31
+bb31:
+  push 4
+  calldataload
+  push 31
+  sub
+  push 3
+  shl
+  push 255
+  dup2
+  shl
+  not
+  push 192
+  mload
+  and
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup3
+  shl
+  swap2
+  pop
+  or
+  push 128
+  mload
+  sstore
+  jump bb33
+bb32:
+  push 128
+  mload
+  dup1
+  push 128
+  mstore
+  push 0
+  mstore
+  push 32
+  push 0
+  keccak256
+  push 4
+  calldataload
+  push 5
+  shr
+  add
+  push 31
+  push 4
+  calldataload
+  and
+  dup2
+  sload
+  dup2
+  push 31
+  sub
+  swap2
+  pop
+  dup2
+  push 3
+  shl
+  swap2
+  pop
+  push 255
+  dup3
+  shl
+  not
+  and
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup3
+  shl
+  swap2
+  pop
+  or
+  swap1
+  sstore
+  fallthrough bb33
+bb33:
+  terminal stop
+bb34:
+  push 0
+  push 128
+  mstore
+  caller
+  push 0
+  mstore
+  push 0
+  push 32
+  mstore
+  push 64
+  push 0
+  keccak256
+  push 1
+  swap1
+  add
+  dup1
+  push 0x420
+  mstore
+  pop
+  push bb35
+  jump bb36
+bb35:
+  push 0x440
+  mload
+  dup1
+  push 224
+  mstore
+  dup1
+  push 0x420
+  mstore
+  jump bb39
+bb36:
+  push 0x420
+  mload
+  sload
+  dup1
+  push 0x500
+  mstore
+  push 1
+  dup2
+  and
+  push 1
+  swap1
+  eq
+  push 255
+  dup3
+  and
+  push 1
+  shr
+  dup3
+  dup1
+  push 0x500
+  mstore
+  push 1
+  shr
+  dup2
+  dup2
+  dup5
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap2
+  pop
+  pop
+  push 31
+  dup2
+  dup1
+  push 0x4a0
+  mstore
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  dup1
+  push 0x4c0
+  mstore
+  iszero
+  push 0x4c0
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap1
+  pop
+  push 32
+  swap1
+  add
+  push 64
+  mload
+  dup1
+  push 0x540
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 0x5c0
+  mstore
+  dup3
+  dup2
+  add
+  swap3
+  pop
+  dup3
+  push 64
+  mstore
+  swap2
+  pop
+  dup3
+  dup1
+  push 0x4a0
+  mstore
+  dup3
+  mstore
+  swap2
+  pop
+  push 64
+  dup3
+  add
+  dup1
+  push 0x5a0
+  mstore
+  dup4
+  swap2
+  pop
+  pop
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push bb37
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
+  push 0x500
+  mload
+  and
+  push 0x5a0
+  mload
+  mstore
+  jump bb2
+bb37:
+  push 0x420
+  mload
+  push 0x540
+  mload
+  mstore
+  push 32
+  push 0x540
+  mload
+  keccak256
+  push 0x4c0
+  mload
+  dup1
+  push 0x4c0
+  mstore
+  push 5
+  shr
+  push 0x5a0
+  mload
+  swap2
+  swap1
+  jump bb38
+bb38:
+  dup1
+  push 0x5e0
+  mstore
+  dup2
+  push 0x4e0
+  mstore
+  dup3
+  push 0x460
+  mstore
+  swap2
+  pop
+  pop
+  iszero
+  push bb2
+  jumpi
+  push 0x4e0
+  mload
+  dup1
+  push 0x4e0
+  mstore
+  sload
+  push 0x460
+  mload
+  mstore
+  push 1
+  push 0x4e0
+  mload
+  add
+  push 32
+  push 0x460
+  mload
+  add
+  push 1
+  push 0x5e0
+  mload
+  sub
+  swap1
+  swap2
+  swap1
+  jump bb38
+bb39:
+  push 64
+  mload
+  push 32
+  dup2
+  mstore
+  push 0x420
+  mload
+  mload
+  push 32
+  dup3
+  add
+  dup2
+  dup2
+  mstore
+  pop
+  push 31
+  dup2
+  add
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  swap1
+  and
+  push 64
+  dup4
+  add
+  push 32
+  dup3
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 32
+  push 0x420
+  mload
+  add
+  dup4
+  dup2
+  dup4
+  mcopy
+  pop
+  pop
+  swap1
+  pop
+  push 64
+  swap1
+  add
+  dup2
+  terminal return
+bb40:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 50
+  jump bb10

--- a/tests/ui/codegen/tuple_assign_branch_leak.sol
+++ b/tests/ui/codegen/tuple_assign_branch_leak.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen --emit=bin-runtime
+//@ compile-flags: -Zcodegen --emit=evm-ir-runtime
 // A multi-return tuple assignment inside one branch arm must not leak its
 // values into the sibling arm: `off` below is reassigned only in the `then`
 // arm, so the `else` arm must read the pre-branch value, not the pickup from

--- a/tests/ui/codegen/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/tuple_assign_branch_leak.stdout
@@ -2,258 +2,258 @@
 bb0 (entry):
   push 0x420
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x2143aa9
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup1
   push 736
-  mstore
-  iszero
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 736
-  mload
-  eq
+  mload !meta(stack=0->0)
+  eq !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  iszero
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push bb8
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb4
 bb3:
   push 128
-  mload
+  mload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb4:
   push 7
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 8
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 9
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 480
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 480
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   push 512
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 512
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   push 576
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 576
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 544
-  mload
-  add
+  mload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 608
-  mstore
+  mstore !meta(stack=0->0)
   push 544
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 544
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 608
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 608
   fallthrough bb5
 bb5:
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   pop
   jump bb3
 bb6:
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 1
-  add
+  add !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 2
-  add
-  add
+  add !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 704
   jump bb5
 bb7:
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 2
-  add
+  add !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   push 32
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 640
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 1
-  add
+  add !meta(stack=0->0)
   dup1
   push 672
-  mstore
-  add
+  mstore !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 704
-  mstore
+  mstore !meta(stack=0->0)
   push 672
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  iszero
+  iszero !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb9
 bb8:
   push 1
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 672
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   swap1
-  lt
+  lt !meta(stack=0->0)
   push bb9
-  jumpi
+  jumpi !meta(stack=0->0)
   push 2
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 640
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup2
-  lt
+  lt !meta(stack=0->0)
   swap2
   pop
   pop
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   swap1
-  iszero
+  iszero !meta(stack=0->0)
   push bb7
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb9
 bb9:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/tuple_assign_branch_leak.stdout
@@ -1,1 +1,259 @@
-{"contracts":{"ROOT/tests/ui/codegen/tuple_assign_branch_leak.sol:TupleAssignBranchLeak":{"bin-runtime":"6104206040523460215736156021575f3560e01c806302143aa9146025576021565b5f80fd5b36600490036040901260243590602157600435806102e05215156102e051146004359015602157610153576060565b60805160805260206080f35b60078101806101e052819010610180576008810180610240526101e051806101e0529010610180576009810180610200526101e051806101e05290106101805761020051806102005260205261020051806102005261024051018061022052610240518061024052901061018057610220510180610260526102205180610220529010602435906101805761026051806102605b52608052506054565b60243560010160243560020101806102c060f4565b602435600201806102805260205250610280518061028052602435600101806102a05201806102c0526102a051806102a0529010602435901560fd57610180565b60018101806102a05281901061018057600281018061028052818110915050602435901561011257610180565b634e487b7160e01b5f52601160045260245ffd"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/tuple_assign_branch_leak.sol:TupleAssignBranchLeak (runtime) ===
+bb0 (entry):
+  push 0x420
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x2143aa9
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push 36
+  calldataload
+  swap1
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  dup1
+  push 736
+  mstore
+  iszero
+  iszero
+  push 736
+  mload
+  eq
+  push 4
+  calldataload
+  swap1
+  iszero
+  push bb1
+  jumpi
+  push bb8
+  jumpi
+  jump bb4
+bb3:
+  push 128
+  mload
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb4:
+  push 7
+  dup2
+  add
+  dup1
+  push 480
+  mstore
+  dup2
+  swap1
+  lt
+  push bb9
+  jumpi
+  push 8
+  dup2
+  add
+  dup1
+  push 576
+  mstore
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  swap1
+  lt
+  push bb9
+  jumpi
+  push 9
+  dup2
+  add
+  dup1
+  push 512
+  mstore
+  push 480
+  mload
+  dup1
+  push 480
+  mstore
+  swap1
+  lt
+  push bb9
+  jumpi
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  push 32
+  mstore
+  push 512
+  mload
+  dup1
+  push 512
+  mstore
+  push 576
+  mload
+  add
+  dup1
+  push 544
+  mstore
+  push 576
+  mload
+  dup1
+  push 576
+  mstore
+  swap1
+  lt
+  push bb9
+  jumpi
+  push 544
+  mload
+  add
+  dup1
+  push 608
+  mstore
+  push 544
+  mload
+  dup1
+  push 544
+  mstore
+  swap1
+  lt
+  push 36
+  calldataload
+  swap1
+  push bb9
+  jumpi
+  push 608
+  mload
+  dup1
+  push 608
+  fallthrough bb5
+bb5:
+  mstore
+  push 128
+  mstore
+  pop
+  jump bb3
+bb6:
+  push 36
+  calldataload
+  push 1
+  add
+  push 36
+  calldataload
+  push 2
+  add
+  add
+  dup1
+  push 704
+  jump bb5
+bb7:
+  push 36
+  calldataload
+  push 2
+  add
+  dup1
+  push 640
+  mstore
+  push 32
+  mstore
+  pop
+  push 640
+  mload
+  dup1
+  push 640
+  mstore
+  push 36
+  calldataload
+  push 1
+  add
+  dup1
+  push 672
+  mstore
+  add
+  dup1
+  push 704
+  mstore
+  push 672
+  mload
+  dup1
+  push 672
+  mstore
+  swap1
+  lt
+  push 36
+  calldataload
+  swap1
+  iszero
+  push bb6
+  jumpi
+  jump bb9
+bb8:
+  push 1
+  dup2
+  add
+  dup1
+  push 672
+  mstore
+  dup2
+  swap1
+  lt
+  push bb9
+  jumpi
+  push 2
+  dup2
+  add
+  dup1
+  push 640
+  mstore
+  dup2
+  dup2
+  lt
+  swap2
+  pop
+  pop
+  push 36
+  calldataload
+  swap1
+  iszero
+  push bb7
+  jumpi
+  jump bb9
+bb9:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/tuple_assign_branch_leak.stdout
@@ -2,258 +2,258 @@
 bb0 (entry):
   push 0x420
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x2143aa9
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup1
   push 736
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
+  iszero
   push 736
-  mload !meta(stack=0->0)
-  eq !meta(stack=0->0)
+  mload
+  eq
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  iszero !meta(stack=0->0)
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push bb8
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb4
 bb3:
   push 128
-  mload !meta(stack=0->0)
+  mload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb4:
   push 7
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 8
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 9
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 480
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 480
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   push 512
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 512
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   push 576
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 576
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 544
-  mload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mload
+  add
   dup1
   push 608
-  mstore !meta(stack=0->0)
+  mstore
   push 544
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 544
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 608
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 608
   fallthrough bb5
 bb5:
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   pop
   jump bb3
 bb6:
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 1
-  add !meta(stack=0->0)
+  add
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 2
-  add !meta(stack=0->0)
-  add !meta(stack=0->0)
+  add
+  add
   dup1
   push 704
   jump bb5
 bb7:
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 2
-  add !meta(stack=0->0)
+  add
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   push 32
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 640
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 1
-  add !meta(stack=0->0)
+  add
   dup1
   push 672
-  mstore !meta(stack=0->0)
-  add !meta(stack=0->0)
+  mstore
+  add
   dup1
   push 704
-  mstore !meta(stack=0->0)
+  mstore
   push 672
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  iszero !meta(stack=0->0)
+  iszero
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb9
 bb8:
   push 1
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 672
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   swap1
-  lt !meta(stack=0->0)
+  lt
   push bb9
-  jumpi !meta(stack=0->0)
+  jumpi
   push 2
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 640
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup2
-  lt !meta(stack=0->0)
+  lt
   swap2
   pop
   pop
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   swap1
-  iszero !meta(stack=0->0)
+  iszero
   push bb7
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb9
 bb9:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/tuple_assignment.sol
+++ b/tests/ui/codegen/tuple_assignment.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // Tuple assignment to EXISTING lvalues, `(a, b) = rhs`. `lower_assign` had no
 // tuple case, so these silently assigned nothing (e.g. `(ok, ) = addr.call(d)`

--- a/tests/ui/codegen/tuple_assignment.stdout
+++ b/tests/ui/codegen/tuple_assignment.stdout
@@ -2,235 +2,235 @@
 bb0 (entry):
   push 512
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x1b8f5d50
-  eq !meta(stack=0->0)
+  eq
   push bb6
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0x5030da75
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 0xd96073cf
-  eq !meta(stack=0->0)
+  eq
   push bb4
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  and
+  sub
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
-  calldataload !meta(stack=0->0)
+  calldataload
+  add
+  calldataload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 31
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 256
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
-  mload !meta(stack=0->0)
-  and !meta(stack=0->0)
+  mload
+  and
   dup1
   push 288
-  mstore !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  mstore
+  iszero
   push 288
-  mload !meta(stack=0->0)
+  mload
   push 32
   dup3
   dup3
   dup3
-  sub !meta(stack=0->0)
-  mul !meta(stack=0->0)
+  sub
+  mul
   swap1
   pop
-  add !meta(stack=0->0)
+  add
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
   pop
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup1
   push 192
-  mstore !meta(stack=0->0)
+  mstore
   swap1
-  lt !meta(stack=0->0)
+  lt
   swap1
   pop
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 224
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 224
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  add !meta(stack=0->0)
+  add
   push 64
-  mstore !meta(stack=0->0)
+  mstore
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   dup2
-  add !meta(stack=0->0)
+  add
   push 32
   push 192
-  mload !meta(stack=0->0)
-  sub !meta(stack=0->0)
+  mload
+  sub
   dup2
-  add !meta(stack=0->0)
+  add
   push 0
   dup2
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 36
   push 36
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   push 160
-  mload !meta(stack=0->0)
+  mload
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   dup2
   dup4
-  calldatacopy !meta(stack=0->0)
+  calldatacopy
   pop
   dup2
-  mload !meta(stack=0->0)
+  mload
   swap2
   pop
-  gas !meta(stack=0->0)
+  gas
   push 0
   push 0
   push 64
-  mload !meta(stack=0->0)
-  mload !meta(stack=0->0)
+  mload
+  mload
   push 64
-  mload !meta(stack=0->0)
+  mload
   push 32
-  add !meta(stack=0->0)
+  add
   push 0
   push 4
-  calldataload !meta(stack=0->0)
-  gas !meta(stack=0->0)
-  call !meta(stack=0->0)
+  calldataload
+  gas
+  call
   swap2
   pop
   pop
   swap1
   pop
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 65
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert
 bb4:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   fallthrough bb5
 bb5:
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 64
   push 128
   terminal return
 bb6:
   push 7
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 9
   jump bb5

--- a/tests/ui/codegen/tuple_assignment.stdout
+++ b/tests/ui/codegen/tuple_assignment.stdout
@@ -2,235 +2,235 @@
 bb0 (entry):
   push 512
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x1b8f5d50
-  eq
+  eq !meta(stack=0->0)
   push bb6
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0x5030da75
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 0xd96073cf
-  eq
+  eq !meta(stack=0->0)
   push bb4
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffff
   dup2
-  and
-  sub
+  and !meta(stack=0->0)
+  sub !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
   push 36
-  calldataload
-  add
-  calldataload
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
+  calldataload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 31
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 256
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
-  mload
-  and
+  mload !meta(stack=0->0)
+  and !meta(stack=0->0)
   dup1
   push 288
-  mstore
-  iszero
+  mstore !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push 288
-  mload
+  mload !meta(stack=0->0)
   push 32
   dup3
   dup3
   dup3
-  sub
-  mul
+  sub !meta(stack=0->0)
+  mul !meta(stack=0->0)
   swap1
   pop
-  add
+  add !meta(stack=0->0)
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
   pop
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup1
   push 192
-  mstore
+  mstore !meta(stack=0->0)
   swap1
-  lt
+  lt !meta(stack=0->0)
   swap1
   pop
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 224
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 224
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 64
-  mstore
+  mstore !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   dup2
-  add
+  add !meta(stack=0->0)
   push 32
   push 192
-  mload
-  sub
+  mload !meta(stack=0->0)
+  sub !meta(stack=0->0)
   dup2
-  add
+  add !meta(stack=0->0)
   push 0
   dup2
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 36
   push 36
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   push 160
-  mload
+  mload !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   dup2
   dup4
-  calldatacopy
+  calldatacopy !meta(stack=0->0)
   pop
   dup2
-  mload
+  mload !meta(stack=0->0)
   swap2
   pop
-  gas
+  gas !meta(stack=0->0)
   push 0
   push 0
   push 64
-  mload
-  mload
+  mload !meta(stack=0->0)
+  mload !meta(stack=0->0)
   push 64
-  mload
+  mload !meta(stack=0->0)
   push 32
-  add
+  add !meta(stack=0->0)
   push 0
   push 4
-  calldataload
-  gas
-  call
+  calldataload !meta(stack=0->0)
+  gas !meta(stack=0->0)
+  call !meta(stack=0->0)
   swap2
   pop
   pop
   swap1
   pop
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 65
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert
 bb4:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   fallthrough bb5
 bb5:
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 64
   push 128
   terminal return
 bb6:
   push 7
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 9
   jump bb5

--- a/tests/ui/codegen/tuple_assignment.stdout
+++ b/tests/ui/codegen/tuple_assignment.stdout
@@ -1,1 +1,236 @@
-{"contracts":{"ROOT/tests/ui/codegen/tuple_assignment.sol:C":{"bin-runtime":"6102006040523460375736156037575f3560e01c80631b8f5d50146101465780635030da7514603b578063d96073cf14610127576037565b5f80fd5b3660049003604090126037576004355f1960601c8116036037575f608052600460243501358060a052601f81018061010052818060a0529010905061011357601f19610100511680610120521561012051602082828203029050018060c05290508060c052602081018060e052818060c052901090506101135760405160e0518060e052810160405260a0518060a052815260208101602060c0510381015f81525060246024350160a0518060a05281833750815191505a5f5f604051516040516020015f6004355af1915050905060805260206080f35b634e487b7160e01b5f52604160045260245ffd5b3660049003604090126037576024356080526004355b60a05260406080f35b6007608052600961013d56"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/tuple_assignment.sol:C (runtime) ===
+bb0 (entry):
+  push 512
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x1b8f5d50
+  eq
+  push bb6
+  jumpi
+  dup1
+  push 0x5030da75
+  eq
+  push bb2
+  jumpi
+  dup1
+  push 0xd96073cf
+  eq
+  push bb4
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0xffffffffffffffffffffffffffffffffffffffff
+  dup2
+  and
+  sub
+  push bb1
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 4
+  push 36
+  calldataload
+  add
+  calldataload
+  dup1
+  push 160
+  mstore
+  push 31
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 160
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb3
+  jumpi
+  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+  push 256
+  mload
+  and
+  dup1
+  push 288
+  mstore
+  iszero
+  push 288
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 192
+  mstore
+  swap1
+  pop
+  dup1
+  push 192
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 224
+  mstore
+  dup2
+  dup1
+  push 192
+  mstore
+  swap1
+  lt
+  swap1
+  pop
+  push bb3
+  jumpi
+  push 64
+  mload
+  push 224
+  mload
+  dup1
+  push 224
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 192
+  mload
+  sub
+  dup2
+  add
+  push 0
+  dup2
+  mstore
+  pop
+  push 36
+  push 36
+  calldataload
+  add
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  dup4
+  calldatacopy
+  pop
+  dup2
+  mload
+  swap2
+  pop
+  gas
+  push 0
+  push 0
+  push 64
+  mload
+  mload
+  push 64
+  mload
+  push 32
+  add
+  push 0
+  push 4
+  calldataload
+  gas
+  call
+  swap2
+  pop
+  pop
+  swap1
+  pop
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 65
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert
+bb4:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 128
+  mstore
+  push 4
+  calldataload
+  fallthrough bb5
+bb5:
+  push 160
+  mstore
+  push 64
+  push 128
+  terminal return
+bb6:
+  push 7
+  push 128
+  mstore
+  push 9
+  jump bb5

--- a/tests/ui/codegen/udvt_selector.sol
+++ b/tests/ui/codegen/udvt_selector.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=hashes,bin-runtime --pretty-json
+//@compile-flags: -Zcodegen --emit=hashes,evm-ir-runtime --pretty-json
 
 type Wad is uint256;
 

--- a/tests/ui/codegen/udvt_selector.stdout
+++ b/tests/ui/codegen/udvt_selector.stdout
@@ -12,68 +12,68 @@
 bb0 (entry):
   push 192
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x8d2f9995
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 64
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 36
-  calldataload
+  calldataload !meta(stack=0->0)
   push 4
-  calldataload
-  add
+  calldataload !meta(stack=0->0)
+  add !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   dup2
-  lt
+  lt !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   dup1
   push 160
-  mstore
+  mstore !meta(stack=0->0)
   push 128
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   pop
   push 17
   push 4
-  mstore
+  mstore !meta(stack=0->0)
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/udvt_selector.stdout
+++ b/tests/ui/codegen/udvt_selector.stdout
@@ -7,14 +7,73 @@
     }
   },
   "version": "VERSION"
-}{
-  "contracts": {
-    "ROOT/tests/ui/codegen/udvt_selector.sol:UdvtSelector": {
-      "bin-runtime": "60c06040523460205736156020575f3560e01c80638d2f9995146024576020565b5f80fd5b366004900360409012602057602435600435018060a05260043581106050578060a05260805260206080f35b634e487b7160e01b5f5250601160045260245ffd",
-      "hashes": {
-        "unwrapAndAdd(uint256,uint256)": "8d2f9995"
-      }
-    }
-  },
-  "version": "VERSION"
 }
+// === ROOT/tests/ui/codegen/udvt_selector.sol:UdvtSelector (runtime) ===
+bb0 (entry):
+  push 192
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x8d2f9995
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 64
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 36
+  calldataload
+  push 4
+  calldataload
+  add
+  dup1
+  push 160
+  mstore
+  push 4
+  calldataload
+  dup2
+  lt
+  push bb3
+  jumpi
+  dup1
+  push 160
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  terminal return
+bb3:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  pop
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  terminal revert

--- a/tests/ui/codegen/udvt_selector.stdout
+++ b/tests/ui/codegen/udvt_selector.stdout
@@ -12,68 +12,68 @@
 bb0 (entry):
   push 192
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x8d2f9995
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 64
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 36
-  calldataload !meta(stack=0->0)
+  calldataload
   push 4
-  calldataload !meta(stack=0->0)
-  add !meta(stack=0->0)
+  calldataload
+  add
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   dup2
-  lt !meta(stack=0->0)
+  lt
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   dup1
   push 160
-  mstore !meta(stack=0->0)
+  mstore
   push 128
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 128
   terminal return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   pop
   push 17
   push 4
-  mstore !meta(stack=0->0)
+  mstore
   push 36
   push 0
   terminal revert

--- a/tests/ui/codegen/while_empty_body.sol
+++ b/tests/ui/codegen/while_empty_body.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=bin
+//@compile-flags: -Zcodegen --emit=evm-ir
 
 contract WhileEmptyBody {
     function f(uint256 x) public pure {

--- a/tests/ui/codegen/while_empty_body.stdout
+++ b/tests/ui/codegen/while_empty_body.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 9
   push 0
-  codecopy
+  codecopy !meta(stack=0->0)
   push 0
   terminal return
 
@@ -13,44 +13,44 @@ bb0 (entry):
 bb0 (entry):
   push 128
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0xb3de648b
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   fallthrough bb3
 bb3:
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push bb3
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb4
 bb4:
   terminal stop

--- a/tests/ui/codegen/while_empty_body.stdout
+++ b/tests/ui/codegen/while_empty_body.stdout
@@ -1,1 +1,56 @@
-{"contracts":{"ROOT/tests/ui/codegen/while_empty_body.sol:WhileEmptyBody":{"bin":"603d8060095f395ff360806040523460205736156020575f3560e01c8063b3de648b146024576020565b5f80fd5b3660049003602090126020575b600435603157603b565b00"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/while_empty_body.sol:WhileEmptyBody (creation) ===
+// === deployment ===
+bb0 (entry):
+  push 61
+  dup1
+  push 9
+  push 0
+  codecopy
+  push 0
+  terminal return
+
+// === runtime ===
+bb0 (entry):
+  push 128
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xb3de648b
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  fallthrough bb3
+bb3:
+  push 4
+  calldataload
+  push bb3
+  jumpi
+  jump bb4
+bb4:
+  terminal stop

--- a/tests/ui/codegen/while_empty_body.stdout
+++ b/tests/ui/codegen/while_empty_body.stdout
@@ -5,7 +5,7 @@ bb0 (entry):
   dup1
   push 9
   push 0
-  codecopy !meta(stack=0->0)
+  codecopy
   push 0
   terminal return
 
@@ -13,44 +13,44 @@ bb0 (entry):
 bb0 (entry):
   push 128
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0xb3de648b
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   fallthrough bb3
 bb3:
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push bb3
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb4
 bb4:
   terminal stop

--- a/tests/ui/codegen/yul_return.sol
+++ b/tests/ui/codegen/yul_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: -Zcodegen --emit=evm-ir-runtime
 
 // The Yul `return(offset, size)` builtin halts execution and returns `size`
 // bytes of memory (the `RETURN` opcode), like the `ret_data` terminator. It is

--- a/tests/ui/codegen/yul_return.stdout
+++ b/tests/ui/codegen/yul_return.stdout
@@ -2,42 +2,42 @@
 bb0 (entry):
   push 160
   push 64
-  mstore
-  callvalue
+  mstore !meta(stack=0->0)
+  callvalue !meta(stack=0->0)
   push bb1
-  jumpi
-  calldatasize
-  iszero
+  jumpi !meta(stack=0->0)
+  calldatasize !meta(stack=0->0)
+  iszero !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 0
-  calldataload
+  calldataload !meta(stack=0->0)
   push 224
-  shr
+  shr !meta(stack=0->0)
   dup1
   push 0x6279e43c
-  eq
+  eq !meta(stack=0->0)
   push bb2
-  jumpi
+  jumpi !meta(stack=0->0)
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize
+  calldatasize !meta(stack=0->0)
   push 4
   swap1
-  sub
+  sub !meta(stack=0->0)
   push 32
   swap1
-  slt
+  slt !meta(stack=0->0)
   push bb1
-  jumpi
+  jumpi !meta(stack=0->0)
   push 4
-  calldataload
+  calldataload !meta(stack=0->0)
   push 0
-  mstore
+  mstore !meta(stack=0->0)
   push 32
   push 0
   terminal return

--- a/tests/ui/codegen/yul_return.stdout
+++ b/tests/ui/codegen/yul_return.stdout
@@ -1,1 +1,43 @@
-{"contracts":{"ROOT/tests/ui/codegen/yul_return.sol:R":{"bin-runtime":"60a06040523460205736156020575f3560e01c80636279e43c146024576020565b5f80fd5b3660049003602090126020576004355f5260205ff3"}},"version":"VERSION"}
+// === ROOT/tests/ui/codegen/yul_return.sol:R (runtime) ===
+bb0 (entry):
+  push 160
+  push 64
+  mstore
+  callvalue
+  push bb1
+  jumpi
+  calldatasize
+  iszero
+  push bb1
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x6279e43c
+  eq
+  push bb2
+  jumpi
+  jump bb1
+bb1:
+  push 0
+  dup1
+  terminal revert
+bb2:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  swap1
+  slt
+  push bb1
+  jumpi
+  push 4
+  calldataload
+  push 0
+  mstore
+  push 32
+  push 0
+  terminal return

--- a/tests/ui/codegen/yul_return.stdout
+++ b/tests/ui/codegen/yul_return.stdout
@@ -2,42 +2,42 @@
 bb0 (entry):
   push 160
   push 64
-  mstore !meta(stack=0->0)
-  callvalue !meta(stack=0->0)
+  mstore
+  callvalue
   push bb1
-  jumpi !meta(stack=0->0)
-  calldatasize !meta(stack=0->0)
-  iszero !meta(stack=0->0)
+  jumpi
+  calldatasize
+  iszero
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 0
-  calldataload !meta(stack=0->0)
+  calldataload
   push 224
-  shr !meta(stack=0->0)
+  shr
   dup1
   push 0x6279e43c
-  eq !meta(stack=0->0)
+  eq
   push bb2
-  jumpi !meta(stack=0->0)
+  jumpi
   jump bb1
 bb1:
   push 0
   dup1
   terminal revert
 bb2:
-  calldatasize !meta(stack=0->0)
+  calldatasize
   push 4
   swap1
-  sub !meta(stack=0->0)
+  sub
   push 32
   swap1
-  slt !meta(stack=0->0)
+  slt
   push bb1
-  jumpi !meta(stack=0->0)
+  jumpi
   push 4
-  calldataload !meta(stack=0->0)
+  calldataload
   push 0
-  mstore !meta(stack=0->0)
+  mstore
   push 32
   push 0
   terminal return


### PR DESCRIPTION
Codegen UI tests currently snapshot opaque bytecode hex, which makes backend changes difficult to review. This adds plain-text creation and runtime EVM IR emit modes captured after assembler rewrites and immediately before byte emission, without running additional EVM IR passes. Creation output preserves constructor, deployment postlude, and runtime segments in byte order, while canonical opcode mnemonics keep the machine-level output readable. Existing bytecode snapshot fixtures now use these emit modes instead.