### PR TITLE
feat(codegen): add pass timing flag

### DIFF
--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -6,7 +6,8 @@
 
 use clap::ValueHint;
 use solar_codegen::backend::evm::{
-    EVM_IR_PASSES, EvmIrModule, EvmIrPass, parse_evm_ir_module, verify_evm_ir_module,
+    EVM_IR_PASSES, EvmIrModule, EvmIrPass, EvmIrPassOptions, parse_evm_ir_module,
+    verify_evm_ir_module,
 };
 use solar_interface::{Ident, Session, Symbol};
 use std::{path::Path, process::ExitCode};
@@ -30,6 +31,8 @@ pub(crate) struct EvmOptArgs {
     /// Path to input file. Extension determines whether it's .evmir.
     #[arg(value_hint = ValueHint::FilePath)]
     input: String,
+    #[arg(skip)]
+    time_passes: bool,
 }
 
 fn parse_pass(name: &str) -> Result<EvmIrPass, String> {
@@ -54,16 +57,17 @@ fn print_module(module: &EvmIrModule, name: &str, after: &str) {
 }
 
 fn run_pipeline(module: &mut EvmIrModule, name: &str, args: &EvmOptArgs) -> Result<(), String> {
+    let options = EvmIrPassOptions { time_passes: args.time_passes };
     if args.print_after_each {
         for &pass in &args.passes {
-            pass.run(module);
+            pass.run_with_options(module, options);
             verify_evm_ir_module(module)
                 .map_err(|e| format!("EVM IR pass `{}` produced invalid IR: {e}", pass.name()))?;
             print_module(module, name, pass.name());
         }
     } else {
         for &pass in &args.passes {
-            pass.run(module);
+            pass.run_with_options(module, options);
         }
         verify_evm_ir_module(module)
             .map_err(|e| format!("EVM IR pipeline produced invalid IR: {e}"))?;
@@ -99,7 +103,8 @@ fn process_evmir(args: &EvmOptArgs) -> Result<(), String> {
     result
 }
 
-pub(crate) fn run(args: EvmOptArgs) -> ExitCode {
+pub(crate) fn run(mut args: EvmOptArgs, time_passes: bool) -> ExitCode {
+    args.time_passes = time_passes;
     let ext = Path::new(&args.input).extension().and_then(|s| s.to_str()).unwrap_or("");
     let result = match ext {
         "evmir" => process_evmir(&args),

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -60,14 +60,14 @@ fn run_pipeline(module: &mut EvmIrModule, name: &str, args: &EvmOptArgs) -> Resu
     let options = EvmIrPassOptions { time_passes: args.time_passes };
     if args.print_after_each {
         for &pass in &args.passes {
-            pass.run_with_options(module, options);
+            pass.run(module, options);
             verify_evm_ir_module(module)
                 .map_err(|e| format!("EVM IR pass `{}` produced invalid IR: {e}", pass.name()))?;
             print_module(module, name, pass.name());
         }
     } else {
         for &pass in &args.passes {
-            pass.run_with_options(module, options);
+            pass.run(module, options);
         }
         verify_evm_ir_module(module)
             .map_err(|e| format!("EVM IR pipeline produced invalid IR: {e}"))?;

--- a/crates/cli/src/commands/mir_opt.rs
+++ b/crates/cli/src/commands/mir_opt.rs
@@ -15,7 +15,7 @@ use solar_codegen::{
     mir::{Module, parse_module},
     pass::{
         DEFAULT_CLEANUP_PIPELINE, DEFAULT_PIPELINE, PASS_REGISTRY, PassInfo, PipelineOptions,
-        lookup_pass, run_default_pipeline_with_options, run_pass as run_codegen_pass,
+        lookup_pass, run_default_pipeline_with_options, run_pass_with_options,
     },
 };
 use solar_data_structures::fmt::{self, FmtIteratorExt};
@@ -86,6 +86,8 @@ pub(crate) struct MirOptArgs {
     /// Path to input file. Extension determines whether it's .sol or .mir.
     #[arg(value_hint = ValueHint::FilePath)]
     input: String,
+    #[arg(skip)]
+    time_passes: bool,
 }
 
 impl MirOptArgs {
@@ -134,6 +136,7 @@ fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs) -> Result<()
             module,
             PipelineOptions {
                 print_after_each: args.print_after_each,
+                time_passes: args.time_passes,
                 ..PipelineOptions::default()
             },
         );
@@ -144,17 +147,18 @@ fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs) -> Result<()
     }
 
     let passes = args.selected_passes();
+    let options = PipelineOptions { time_passes: args.time_passes, ..PipelineOptions::default() };
     if args.print_after_each {
         for pass in &passes {
             if let Some(pass) = *pass {
-                run_codegen_pass(module, pass);
+                run_pass_with_options(module, pass, options);
             }
             print_module(module, name, pass_label(*pass));
         }
     } else {
         for &pass in &passes {
             if let Some(pass) = pass {
-                run_codegen_pass(module, pass);
+                run_pass_with_options(module, pass, options);
             }
         }
         let label = args.pipeline_label(&passes);
@@ -246,7 +250,8 @@ fn process_sol(args: &MirOptArgs) -> Result<(), String> {
 }
 
 /// Entry point for the `mir-opt` subcommand.
-pub(super) fn run(args: MirOptArgs) -> ExitCode {
+pub(super) fn run(mut args: MirOptArgs, time_passes: bool) -> ExitCode {
+    args.time_passes = time_passes;
     // Dispatch on input file extension.
     let ext = Path::new(&args.input).extension().and_then(|s| s.to_str()).unwrap_or("");
     let result = match ext {

--- a/crates/cli/src/commands/mir_opt.rs
+++ b/crates/cli/src/commands/mir_opt.rs
@@ -15,7 +15,7 @@ use solar_codegen::{
     mir::{Module, parse_module},
     pass::{
         DEFAULT_CLEANUP_PIPELINE, DEFAULT_PIPELINE, PASS_REGISTRY, PassInfo, PipelineOptions,
-        lookup_pass, run_default_pipeline_with_options, run_pass_with_options,
+        lookup_pass, run_default_pipeline, run_pass,
     },
 };
 use solar_data_structures::fmt::{self, FmtIteratorExt};
@@ -132,7 +132,7 @@ fn print_module(module: &Module, name: &str, after: &str) {
 /// Used for both .sol contracts and .mir input.
 fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs) -> Result<(), String> {
     if args.pipeline_default {
-        run_default_pipeline_with_options(
+        run_default_pipeline(
             module,
             PipelineOptions {
                 print_after_each: args.print_after_each,
@@ -151,14 +151,14 @@ fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs) -> Result<()
     if args.print_after_each {
         for pass in &passes {
             if let Some(pass) = *pass {
-                run_pass_with_options(module, pass, options);
+                run_pass(module, pass, options);
             }
             print_module(module, name, pass_label(*pass));
         }
     } else {
         for &pass in &passes {
             if let Some(pass) = pass {
-                run_pass_with_options(module, pass, options);
+                run_pass(module, pass, options);
             }
         }
         let label = args.pipeline_label(&passes);

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -11,11 +11,12 @@ pub(crate) mod mir_opt;
 
 pub(crate) fn run(args: Args) -> ExitCode {
     let Args { commands, compile } = args;
+    let time_passes = compile.unstable.time_passes;
     match commands {
         #[cfg(feature = "lsp")]
         Some(Subcommands::Lsp(args)) => lsp::run(args),
-        Some(Subcommands::MirOpt(args)) => mir_opt::run(args),
-        Some(Subcommands::EvmOpt(args)) => evm_opt::run(args),
+        Some(Subcommands::MirOpt(args)) => mir_opt::run(args, time_passes),
+        Some(Subcommands::EvmOpt(args)) => evm_opt::run(args, time_passes),
         None => compile::run(compile),
     }
 }

--- a/crates/codegen/src/backend/evm/assembler.rs
+++ b/crates/codegen/src/backend/evm/assembler.rs
@@ -71,6 +71,8 @@ pub struct AssemblerConfig {
     pub evm_version: EvmVersion,
     /// Optimization mode for alternate byte encodings.
     pub optimization: OptimizationMode,
+    /// Print the time spent in each EVM IR pass.
+    pub time_passes: bool,
     /// Run the experimental EVM IR `StackSchedule` pass in the assembler bridge.
     ///
     /// Off by default. See `StructuredAsmProgram::optimize_with_evm_ir` for why
@@ -1223,6 +1225,10 @@ impl StructuredAsmContext for Assembler {
 
     fn new_label(&mut self) -> Label {
         self.new_label()
+    }
+
+    fn time_passes(&self) -> bool {
+        self.config.time_passes
     }
 
     fn run_evm_ir_stack_schedule(&self) -> bool {

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -146,7 +146,7 @@ impl StructuredAsmProgram {
             // always holds (the pass is a near no-op), but the guard means an
             // unexpected rewrite is dropped instead of changing produced code.
             let mut scheduled = module.clone();
-            if EvmIrPass::StackSchedule.run_with_options(&mut scheduled, pass_options)
+            if EvmIrPass::StackSchedule.run(&mut scheduled, pass_options)
                 && verify_evm_ir_module(&scheduled).is_ok()
                 && modules_have_equal_code(&module, &scheduled)
             {
@@ -157,7 +157,7 @@ impl StructuredAsmProgram {
 
         if context.run_evm_ir_layout_passes() {
             for pass in [EvmIrPass::ColdLayout, EvmIrPass::TerminalDedup] {
-                changed += usize::from(pass.run_with_options(&mut module, pass_options));
+                changed += usize::from(pass.run(&mut module, pass_options));
             }
         }
         debug_assert!(verify_evm_ir_module(&module).is_ok());

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -3,8 +3,8 @@
 use super::{AsmInst, AsmInstKind, DeferredConst, Label, op};
 use crate::backend::evm::ir::{
     EvmIrBlock, EvmIrBlockHotness, EvmIrInstruction, EvmIrInstructionKind, EvmIrModule,
-    EvmIrOperand, EvmIrPass, EvmIrStackEffect, EvmIrStackOp, EvmIrTerminator, EvmIrTerminatorKind,
-    verify_evm_ir_module,
+    EvmIrOperand, EvmIrPass, EvmIrPassOptions, EvmIrStackEffect, EvmIrStackOp, EvmIrTerminator,
+    EvmIrTerminatorKind, verify_evm_ir_module,
 };
 use alloy_primitives::U256;
 use solar_data_structures::map::FxHashSet;
@@ -18,6 +18,10 @@ pub(in crate::backend::evm) trait StructuredAsmContext {
     fn push_value(&self, index: super::PushValueId) -> U256;
     fn push_inst(&mut self, value: U256) -> AsmInst;
     fn new_label(&mut self) -> Label;
+    /// Whether EVM IR pass timings should be printed.
+    fn time_passes(&self) -> bool {
+        false
+    }
     /// Whether the bridge should run the experimental EVM IR `StackSchedule`
     /// pass. Off by default; see [`StructuredAsmProgram::optimize_with_evm_ir`].
     fn run_evm_ir_stack_schedule(&self) -> bool {
@@ -133,6 +137,7 @@ impl StructuredAsmProgram {
 
         debug_assert!(verify_evm_ir_module(&module).is_ok());
         let mut changed = 0;
+        let pass_options = EvmIrPassOptions { time_passes: context.time_passes() };
 
         if context.run_evm_ir_stack_schedule() {
             // Differential safety net: schedule a clone, and only adopt it if the
@@ -141,7 +146,7 @@ impl StructuredAsmProgram {
             // always holds (the pass is a near no-op), but the guard means an
             // unexpected rewrite is dropped instead of changing produced code.
             let mut scheduled = module.clone();
-            if EvmIrPass::StackSchedule.run(&mut scheduled)
+            if EvmIrPass::StackSchedule.run_with_options(&mut scheduled, pass_options)
                 && verify_evm_ir_module(&scheduled).is_ok()
                 && modules_have_equal_code(&module, &scheduled)
             {
@@ -152,7 +157,7 @@ impl StructuredAsmProgram {
 
         if context.run_evm_ir_layout_passes() {
             for pass in [EvmIrPass::ColdLayout, EvmIrPass::TerminalDedup] {
-                changed += usize::from(pass.run(&mut module));
+                changed += usize::from(pass.run_with_options(&mut module, pass_options));
             }
         }
         debug_assert!(verify_evm_ir_module(&module).is_ok());

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -19,7 +19,7 @@ use crate::{
         PhiEliminator, reachable_blocks,
     },
     mir::{BlockId, Function, FunctionId, InstId, InstKind, MirType, Module, Terminator, ValueId},
-    pass::{PipelineOptions, run_default_pipeline_with_options, run_pass_with_options},
+    pass::{PipelineOptions, run_default_pipeline, run_pass},
 };
 use alloy_primitives::U256;
 use solar_config::{EvmVersion, OptimizationMode};
@@ -1003,22 +1003,22 @@ impl EvmCodegen {
             ..PipelineOptions::default()
         };
         if self.optimization != OptimizationMode::None {
-            run_default_pipeline_with_options(module, options);
+            run_default_pipeline(module, options);
             // MIR outlining remains profitable even though the assembler can
             // merge byte-identical terminal spans: lowering and stack layout
             // can make equivalent revert blocks differ before they reach that
             // late pass.
-            run_pass_with_options(module, &crate::pass::OUTLINE_REVERTS_PASS, options);
+            run_pass(module, &crate::pass::OUTLINE_REVERTS_PASS, options);
         }
-        run_pass_with_options(module, &crate::pass::LOWER_MAPPING_SLOTS_PASS, options);
+        run_pass(module, &crate::pass::LOWER_MAPPING_SLOTS_PASS, options);
         // Progressive lowering: materialize ABI wrappers, the dispatcher, and
         // tail-call edges as MIR. Each pass bails without advancing the phase
         // when the module is outside its scope, in which case runtime
         // generation falls back to the backend dispatcher.
         if self.mir_dispatch {
-            run_pass_with_options(module, &crate::pass::LOWER_ABI_PASS, options);
-            run_pass_with_options(module, &crate::pass::LOWER_DISPATCH_PASS, options);
-            run_pass_with_options(module, &crate::pass::LOWER_EVM_SHAPED_PASS, options);
+            run_pass(module, &crate::pass::LOWER_ABI_PASS, options);
+            run_pass(module, &crate::pass::LOWER_DISPATCH_PASS, options);
+            run_pass(module, &crate::pass::LOWER_EVM_SHAPED_PASS, options);
         }
     }
 

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -19,7 +19,7 @@ use crate::{
         PhiEliminator, reachable_blocks,
     },
     mir::{BlockId, Function, FunctionId, InstId, InstKind, MirType, Module, Terminator, ValueId},
-    pass::{PipelineOptions, run_default_pipeline_with_options},
+    pass::{PipelineOptions, run_default_pipeline_with_options, run_pass_with_options},
 };
 use alloy_primitives::U256;
 use solar_config::{EvmVersion, OptimizationMode};
@@ -50,6 +50,8 @@ pub struct EvmCodegenConfig {
     pub optimization: OptimizationMode,
     /// Print MIR after each pass before bytecode generation.
     pub mir_print_after_each: bool,
+    /// Print the time spent in each MIR and EVM IR pass.
+    pub time_passes: bool,
     /// Lower dispatch/ABI as MIR phases and consume them here.
     pub mir_dispatch: bool,
     /// Run the experimental EVM IR `StackSchedule` pass in the assembler bridge.
@@ -71,6 +73,7 @@ impl EvmCodegenConfig {
             evm_version: sess.opts.evm_version,
             optimization: sess.opts.optimization,
             mir_print_after_each: sess.opts.unstable.mir_print_after_each,
+            time_passes: sess.opts.unstable.time_passes,
             mir_dispatch: !sess.opts.unstable.no_mir_dispatch,
             // Keep the experimental EVM IR stack scheduler off in every default
             // compilation path so produced bytecode is unchanged.
@@ -83,6 +86,7 @@ impl EvmCodegenConfig {
         AssemblerConfig {
             evm_version: self.evm_version,
             optimization: self.optimization,
+            time_passes: self.time_passes,
             evm_ir_stack_schedule: self.evm_ir_stack_schedule,
             evm_ir_layout_passes: self.evm_ir_layout_passes,
         }
@@ -627,6 +631,7 @@ pub struct EvmCodegen {
     optimization: OptimizationMode,
     /// Print MIR after each pass before bytecode generation.
     mir_print_after_each: bool,
+    time_passes: bool,
     mir_dispatch: bool,
 }
 
@@ -665,6 +670,7 @@ impl EvmCodegen {
             emitting_dispatch_entry: false,
             optimization: config.optimization,
             mir_print_after_each: config.mir_print_after_each,
+            time_passes: config.time_passes,
             mir_dispatch: config.mir_dispatch,
         }
     }
@@ -991,29 +997,28 @@ impl EvmCodegen {
     /// Runs the canonical MIR optimization pipeline on the module.
     fn run_optimization_passes(&mut self, module: &mut Module) {
         module.optimize_for_size = self.optimization == OptimizationMode::Size;
+        let options = PipelineOptions {
+            print_after_each: self.mir_print_after_each,
+            time_passes: self.time_passes,
+            ..PipelineOptions::default()
+        };
         if self.optimization != OptimizationMode::None {
-            run_default_pipeline_with_options(
-                module,
-                PipelineOptions {
-                    print_after_each: self.mir_print_after_each,
-                    ..PipelineOptions::default()
-                },
-            );
+            run_default_pipeline_with_options(module, options);
             // MIR outlining remains profitable even though the assembler can
             // merge byte-identical terminal spans: lowering and stack layout
             // can make equivalent revert blocks differ before they reach that
             // late pass.
-            crate::pass::run_pass(module, &crate::pass::OUTLINE_REVERTS_PASS);
+            run_pass_with_options(module, &crate::pass::OUTLINE_REVERTS_PASS, options);
         }
-        crate::pass::run_pass(module, &crate::pass::LOWER_MAPPING_SLOTS_PASS);
+        run_pass_with_options(module, &crate::pass::LOWER_MAPPING_SLOTS_PASS, options);
         // Progressive lowering: materialize ABI wrappers, the dispatcher, and
         // tail-call edges as MIR. Each pass bails without advancing the phase
         // when the module is outside its scope, in which case runtime
         // generation falls back to the backend dispatcher.
         if self.mir_dispatch {
-            crate::pass::run_pass(module, &crate::pass::LOWER_ABI_PASS);
-            crate::pass::run_pass(module, &crate::pass::LOWER_DISPATCH_PASS);
-            crate::pass::run_pass(module, &crate::pass::LOWER_EVM_SHAPED_PASS);
+            run_pass_with_options(module, &crate::pass::LOWER_ABI_PASS, options);
+            run_pass_with_options(module, &crate::pass::LOWER_DISPATCH_PASS, options);
+            run_pass_with_options(module, &crate::pass::LOWER_EVM_SHAPED_PASS, options);
         }
     }
 

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -17,7 +17,7 @@ mod passes;
 mod verify;
 
 pub use parse::{EvmIrParseError, parse_evm_ir_module};
-pub use passes::{EVM_IR_PASSES, EvmIrPass};
+pub use passes::{EVM_IR_PASSES, EvmIrPass, EvmIrPassOptions};
 pub use verify::{EvmIrVerifyError, verify_evm_ir_module};
 
 newtype_index! {

--- a/crates/codegen/src/backend/evm/ir/passes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes.rs
@@ -1,6 +1,7 @@
 //! EVM IR optimization and layout passes.
 
 use super::*;
+use crate::timing::PassTimer;
 use alloy_primitives::U256;
 use solar_data_structures::{index::IndexVec, map::FxHashMap};
 
@@ -17,6 +18,13 @@ pub enum EvmIrPass {
     TerminalDedup,
 }
 
+/// Options for running an EVM IR pass.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EvmIrPassOptions {
+    /// Print the time spent in the pass.
+    pub time_passes: bool,
+}
+
 impl EvmIrPass {
     /// Stable command-line pass name.
     #[must_use]
@@ -31,12 +39,20 @@ impl EvmIrPass {
 
     /// Runs this pass on an EVM IR module.
     pub fn run(self, module: &mut EvmIrModule) -> bool {
-        match self {
+        self.run_with_options(module, EvmIrPassOptions::default())
+    }
+
+    /// Runs this pass on an EVM IR module with observer options.
+    pub fn run_with_options(self, module: &mut EvmIrModule, options: EvmIrPassOptions) -> bool {
+        let timer = PassTimer::new(options.time_passes);
+        let changed = match self {
             Self::None => false,
             Self::StackSchedule => super::super::ir_stack_schedule::schedule_stack_ops(module),
             Self::ColdLayout => move_cold_terminal_blocks(module),
             Self::TerminalDedup => deduplicate_terminal_blocks(module),
-        }
+        };
+        timer.finish("EVM IR", &module.name, self.name(), changed);
+        changed
     }
 
     /// Looks up a pass by command-line name.

--- a/crates/codegen/src/backend/evm/ir/passes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes.rs
@@ -38,12 +38,7 @@ impl EvmIrPass {
     }
 
     /// Runs this pass on an EVM IR module.
-    pub fn run(self, module: &mut EvmIrModule) -> bool {
-        self.run_with_options(module, EvmIrPassOptions::default())
-    }
-
-    /// Runs this pass on an EVM IR module with observer options.
-    pub fn run_with_options(self, module: &mut EvmIrModule, options: EvmIrPassOptions) -> bool {
+    pub fn run(self, module: &mut EvmIrModule, options: EvmIrPassOptions) -> bool {
         let timer = PassTimer::new(options.time_passes);
         let changed = match self {
             Self::None => false,

--- a/crates/codegen/src/backend/evm/mod.rs
+++ b/crates/codegen/src/backend/evm/mod.rs
@@ -15,9 +15,9 @@ mod ir_stack_schedule;
 pub use ir::{
     EVM_IR_PASSES, EvmIrBlock, EvmIrBlockHotness, EvmIrBlockId, EvmIrBlockMetadata,
     EvmIrInstruction, EvmIrInstructionKind, EvmIrMetadata, EvmIrMetadataItem, EvmIrModule,
-    EvmIrOperand, EvmIrParseError, EvmIrPass, EvmIrStackEffect, EvmIrStackOp, EvmIrTerminator,
-    EvmIrTerminatorKind, EvmIrValue, EvmIrValueId, EvmIrVerifyError, parse_evm_ir_module,
-    verify_evm_ir_module,
+    EvmIrOperand, EvmIrParseError, EvmIrPass, EvmIrPassOptions, EvmIrStackEffect, EvmIrStackOp,
+    EvmIrTerminator, EvmIrTerminatorKind, EvmIrValue, EvmIrValueId, EvmIrVerifyError,
+    parse_evm_ir_module, verify_evm_ir_module,
 };
 
 pub mod assembler;

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -42,6 +42,7 @@ pub mod lower;
 pub use lower::Lowerer;
 
 pub mod pass;
+mod timing;
 pub mod transform;
 pub(crate) mod utils;
 pub use transform::{

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -310,15 +310,7 @@ impl Default for PipelineOptions {
 }
 
 /// Runs a named MIR pass over a module.
-pub fn run_pass(module: &mut Module, pass: &PassInfo) -> bool {
-    run_pass_with_options(module, pass, PipelineOptions::default())
-}
-
-pub fn run_pass_with_options(
-    module: &mut Module,
-    pass: &PassInfo,
-    options: PipelineOptions,
-) -> bool {
+pub fn run_pass(module: &mut Module, pass: &PassInfo, options: PipelineOptions) -> bool {
     // Passes declare which phases they operate on; the manager enforces it so a
     // pipeline entry cannot silently corrupt a module in the wrong phase.
     if !pass.admits(module) {
@@ -337,23 +329,10 @@ pub fn run_pass_with_options(
 }
 
 /// Runs a named MIR pass pipeline over a module.
-pub fn run_pipeline(module: &mut Module, passes: &[PassInfo]) -> bool {
+pub fn run_pipeline(module: &mut Module, passes: &[PassInfo], options: PipelineOptions) -> bool {
     let mut changed = false;
     for pass in passes {
-        changed |= run_pass(module, pass);
-    }
-    changed
-}
-
-/// Runs a named MIR pass pipeline over a module with observer options.
-pub fn run_pipeline_with_options(
-    module: &mut Module,
-    passes: &[PassInfo],
-    options: PipelineOptions,
-) -> bool {
-    let mut changed = false;
-    for pass in passes {
-        changed |= run_pass_with_options(module, pass, options);
+        changed |= run_pass(module, pass, options);
         if options.print_after_each {
             println!("// === {} (after {}) ===", module.name, pass.name);
             print!("{}", module.to_text());
@@ -363,17 +342,12 @@ pub fn run_pipeline_with_options(
 }
 
 /// Runs the canonical MIR optimization pipeline used by EVM codegen.
-pub fn run_default_pipeline(module: &mut Module) -> bool {
-    run_default_pipeline_with_options(module, PipelineOptions::default())
-}
-
-/// Runs the canonical MIR optimization pipeline used by EVM codegen with options.
 ///
 /// This is a phase transition: the module comes out in [`MirPhase::Optimized`].
 /// Ad-hoc pass lists run through [`run_pipeline`], such as `solar mir-opt`
 /// invocations, deliberately do not advance the phase.
-pub fn run_default_pipeline_with_options(module: &mut Module, options: PipelineOptions) -> bool {
-    let mut changed = run_pipeline_with_options(module, DEFAULT_PIPELINE, options);
+pub fn run_default_pipeline(module: &mut Module, options: PipelineOptions) -> bool {
+    let mut changed = run_pipeline(module, DEFAULT_PIPELINE, options);
     changed |=
         run_cleanup_pipeline_to_fixpoint(module, DEFAULT_CLEANUP_PIPELINE, options, "cleanup");
     module.advance_phase(crate::mir::MirPhase::Optimized);
@@ -390,7 +364,7 @@ fn run_cleanup_pipeline_to_fixpoint(
     for round in 1..=DEFAULT_CLEANUP_MAX_ROUNDS {
         let mut round_changed = false;
         for pass in passes {
-            let pass_changed = run_pass_with_options(module, pass, options);
+            let pass_changed = run_pass(module, pass, options);
             round_changed |= pass_changed;
             if options.print_after_each {
                 println!("// === {} (after {label}-{round}:{}) ===", module.name, pass.name);

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -22,6 +22,7 @@
 use crate::{
     analysis::Validator,
     mir::{Function, MirPhase, Module},
+    timing::PassTimer,
     transform::{
         AdcePass, CfgSimplifyPass, CheckElimPass, CsePass, DcePass, FrameSlotPromotionPass,
         FunctionDcePass, GvnPass, IndVarSimplifyPass, InlinePass, InstSimplifyPass,
@@ -292,13 +293,19 @@ const DEFAULT_CLEANUP_MAX_ROUNDS: usize = 3;
 pub struct PipelineOptions {
     /// Print the full module after every pass in the pipeline.
     pub print_after_each: bool,
+    /// Print the time spent in each pass.
+    pub time_passes: bool,
     /// Validate MIR after every pass.
     pub validate_after_each: bool,
 }
 
 impl Default for PipelineOptions {
     fn default() -> Self {
-        Self { print_after_each: false, validate_after_each: cfg!(debug_assertions) }
+        Self {
+            print_after_each: false,
+            time_passes: false,
+            validate_after_each: cfg!(debug_assertions),
+        }
     }
 }
 
@@ -307,7 +314,11 @@ pub fn run_pass(module: &mut Module, pass: &PassInfo) -> bool {
     run_pass_with_options(module, pass, PipelineOptions::default())
 }
 
-fn run_pass_with_options(module: &mut Module, pass: &PassInfo, options: PipelineOptions) -> bool {
+pub fn run_pass_with_options(
+    module: &mut Module,
+    pass: &PassInfo,
+    options: PipelineOptions,
+) -> bool {
     // Passes declare which phases they operate on; the manager enforces it so a
     // pipeline entry cannot silently corrupt a module in the wrong phase.
     if !pass.admits(module) {
@@ -316,7 +327,9 @@ fn run_pass_with_options(module: &mut Module, pass: &PassInfo, options: Pipeline
     if options.validate_after_each {
         validate_module_after_pass(module, "input");
     }
+    let timer = PassTimer::new(options.time_passes);
     let changed = (pass.run_pass)(module);
+    timer.finish("MIR", module.name, pass.name, changed);
     if options.validate_after_each {
         validate_module_after_pass(module, pass.name);
     }

--- a/crates/codegen/src/timing.rs
+++ b/crates/codegen/src/timing.rs
@@ -1,0 +1,20 @@
+//! Shared pass timing output.
+
+use std::{fmt, time::Instant};
+
+pub(crate) struct PassTimer(Option<Instant>);
+
+impl PassTimer {
+    #[inline]
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self(enabled.then(Instant::now))
+    }
+
+    pub(crate) fn finish(self, layer: &str, module: impl fmt::Display, pass: &str, changed: bool) {
+        let Some(start) = self.0 else { return };
+        eprintln!(
+            "time: {:>10.3} ms\t{layer}\t{module}\t{pass}\tchanged={changed}",
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+}

--- a/crates/codegen/src/timing.rs
+++ b/crates/codegen/src/timing.rs
@@ -13,8 +13,8 @@ impl PassTimer {
     pub(crate) fn finish(self, layer: &str, module: impl fmt::Display, pass: &str, changed: bool) {
         let Some(start) = self.0 else { return };
         eprintln!(
-            "time: {:>10.3} ms\t{layer}\t{module}\t{pass}\tchanged={changed}",
-            start.elapsed().as_secs_f64() * 1000.0
+            "time: {:>7.3}\t{layer} {module} {pass} changed={changed}",
+            start.elapsed().as_secs_f64()
         );
     }
 }

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -177,7 +177,10 @@ pub struct CompileOpts {
     ///
     /// See `-Zhelp` for more details.
     #[doc(hidden)]
-    #[cfg_attr(feature = "clap", arg(id = "unstable-features", value_name = "FLAG", short = 'Z'))]
+    #[cfg_attr(
+        feature = "clap",
+        arg(id = "unstable-features", value_name = "FLAG", short = 'Z', global = true)
+    )]
     pub _unstable: Vec<String>,
 
     /// Parsed unstable flags.
@@ -360,6 +363,10 @@ pub struct UnstableOpts {
     /// Print MIR after every MIR optimization pass during codegen.
     #[cfg_attr(feature = "clap", arg(long))]
     pub mir_print_after_each: bool,
+
+    /// Print the time spent in each MIR and EVM IR pass.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub time_passes: bool,
 
     /// Enable the experimental EVM code generator (MIR lowering and backend).
     ///

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -45,6 +45,9 @@ Options:
       -Zmir-print-after-each
           Print MIR after every MIR optimization pass during codegen
 
+      -Ztime-passes
+          Print the time spent in each MIR and EVM IR pass
+
       -Zcodegen
           Enable the experimental EVM code generator (MIR lowering and backend).
           

--- a/tests/ui/codegen/evm-ir/time_passes.evmir
+++ b/tests/ui/codegen/evm-ir/time_passes.evmir
@@ -1,5 +1,5 @@
 //@ compile-flags: -Ztime-passes --pass cold-layout
-//@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3} ms" -> "time: <TIME>"
+//@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3}" -> "time: <TIME>"
 
 bb0 (entry):
   jump bb2

--- a/tests/ui/codegen/evm-ir/time_passes.evmir
+++ b/tests/ui/codegen/evm-ir/time_passes.evmir
@@ -1,0 +1,11 @@
+//@ compile-flags: -Ztime-passes --pass cold-layout
+//@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3} ms" -> "time: <TIME>"
+
+bb0 (entry):
+  jump bb2
+bb1 [cold]:
+  %offset = push 0
+  %size = push 0
+  revert %offset, %size
+bb2:
+  stop

--- a/tests/ui/codegen/evm-ir/time_passes.stderr
+++ b/tests/ui/codegen/evm-ir/time_passes.stderr
@@ -1,1 +1,1 @@
-time: <TIME>	EVM IR	module	cold-layout	changed=true
+time: <TIME>	EVM IR module cold-layout changed=true

--- a/tests/ui/codegen/evm-ir/time_passes.stderr
+++ b/tests/ui/codegen/evm-ir/time_passes.stderr
@@ -1,0 +1,1 @@
+time: <TIME>	EVM IR	module	cold-layout	changed=true

--- a/tests/ui/codegen/evm-ir/time_passes.stdout
+++ b/tests/ui/codegen/evm-ir/time_passes.stdout
@@ -1,0 +1,9 @@
+// === ROOT/tests/ui/codegen/evm-ir/time_passes.evmir (after cold-layout) ===
+bb0 (entry):
+  jump bb2
+bb2:
+  stop
+bb1 [cold]:
+  %offset = push 0
+  %size = push 0
+  revert %offset, %size

--- a/tests/ui/codegen/time_passes.sol
+++ b/tests/ui/codegen/time_passes.sol
@@ -1,0 +1,6 @@
+//@ compile-flags: -Ztime-passes -Zcodegen -O none --emit=bin
+//@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3} ms" -> "time: <TIME>"
+
+contract TimePasses {
+    function f() external pure {}
+}

--- a/tests/ui/codegen/time_passes.sol
+++ b/tests/ui/codegen/time_passes.sol
@@ -1,5 +1,5 @@
 //@ compile-flags: -Ztime-passes -Zcodegen -O none --emit=bin
-//@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3} ms" -> "time: <TIME>"
+//@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3}" -> "time: <TIME>"
 
 contract TimePasses {
     function f() external pure {}

--- a/tests/ui/codegen/time_passes.stderr
+++ b/tests/ui/codegen/time_passes.stderr
@@ -1,8 +1,8 @@
-time: <TIME>	MIR	TimePasses	lower-mapping-slots	changed=false
-time: <TIME>	MIR	TimePasses	lower-abi	changed=true
-time: <TIME>	MIR	TimePasses	lower-dispatch	changed=true
-time: <TIME>	MIR	TimePasses	lower-evm-shaped	changed=false
-time: <TIME>	MIR	TimePasses	lower-mapping-slots	changed=false
-time: <TIME>	MIR	TimePasses	lower-abi	changed=true
-time: <TIME>	MIR	TimePasses	lower-dispatch	changed=true
-time: <TIME>	MIR	TimePasses	lower-evm-shaped	changed=false
+time: <TIME>	MIR TimePasses lower-mapping-slots changed=false
+time: <TIME>	MIR TimePasses lower-abi changed=true
+time: <TIME>	MIR TimePasses lower-dispatch changed=true
+time: <TIME>	MIR TimePasses lower-evm-shaped changed=false
+time: <TIME>	MIR TimePasses lower-mapping-slots changed=false
+time: <TIME>	MIR TimePasses lower-abi changed=true
+time: <TIME>	MIR TimePasses lower-dispatch changed=true
+time: <TIME>	MIR TimePasses lower-evm-shaped changed=false

--- a/tests/ui/codegen/time_passes.stderr
+++ b/tests/ui/codegen/time_passes.stderr
@@ -1,0 +1,8 @@
+time: <TIME>	MIR	TimePasses	lower-mapping-slots	changed=false
+time: <TIME>	MIR	TimePasses	lower-abi	changed=true
+time: <TIME>	MIR	TimePasses	lower-dispatch	changed=true
+time: <TIME>	MIR	TimePasses	lower-evm-shaped	changed=false
+time: <TIME>	MIR	TimePasses	lower-mapping-slots	changed=false
+time: <TIME>	MIR	TimePasses	lower-abi	changed=true
+time: <TIME>	MIR	TimePasses	lower-dispatch	changed=true
+time: <TIME>	MIR	TimePasses	lower-evm-shaped	changed=false

--- a/tests/ui/codegen/time_passes.stdout
+++ b/tests/ui/codegen/time_passes.stdout
@@ -1,0 +1,1 @@
+{"contracts":{"ROOT/tests/ui/codegen/time_passes.sol:TimePasses":{"bin":"60268060095f395ff360806040523460205736156020575f3560e01c806326121ff0146024576020565b5f80fd5b00"}},"version":"VERSION"}


### PR DESCRIPTION
Adds a global `-Ztime-passes` flag that reports elapsed time and change status for every MIR and EVM IR pass. The option is threaded through normal codegen, `mir-opt`, `evm-opt`, and the assembler bridge, while timing only the transform itself so validation and printing do not distort pass measurements.