### PR TITLE
perf(codegen): speed up MIR validation

### DIFF
--- a/crates/codegen/src/analysis/cfg.rs
+++ b/crates/codegen/src/analysis/cfg.rs
@@ -9,13 +9,14 @@
 use std::cell::OnceCell;
 
 use crate::mir::{BlockId, Function};
+use smallvec::SmallVec;
 use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
 
 /// Control-flow facts for one MIR function.
 #[derive(Clone, Debug)]
 pub struct CfgInfo {
     entry_block: BlockId,
-    successors: Vec<Vec<BlockId>>,
+    successors: Vec<SmallVec<[BlockId; 2]>>,
     reachable: OnceCell<DenseBitSet<BlockId>>,
     rpo: OnceCell<Vec<BlockId>>,
     dominators: OnceCell<DominatorTree>,
@@ -30,11 +31,7 @@ impl CfgInfo {
             .blocks
             .iter()
             .map(|block| {
-                block
-                    .terminator
-                    .as_ref()
-                    .map(|term| term.successors().into_iter().collect())
-                    .unwrap_or_default()
+                block.terminator.as_ref().map(|term| term.successors()).unwrap_or_default()
             })
             .collect();
         Self {
@@ -58,7 +55,8 @@ impl CfgInfo {
     pub fn reachable(&self) -> &DenseBitSet<BlockId> {
         self.reachable.get_or_init(|| {
             let mut reachable = DenseBitSet::new_empty(self.successors.len());
-            let mut stack = vec![self.entry_block];
+            let mut stack = Vec::new();
+            stack.push(self.entry_block);
             while let Some(block) = stack.pop() {
                 if reachable.insert(block) {
                     stack.extend(self.successors[block.index()].iter().copied());
@@ -139,7 +137,11 @@ pub struct DominatorTree {
 }
 
 impl DominatorTree {
-    fn compute(entry_block: BlockId, successors: &[Vec<BlockId>], rpo: &[BlockId]) -> Self {
+    fn compute(
+        entry_block: BlockId,
+        successors: &[SmallVec<[BlockId; 2]>],
+        rpo: &[BlockId],
+    ) -> Self {
         let block_count = successors.len();
         let mut predecessors = vec![Vec::new(); block_count];
         for (block_index, block_successors) in successors.iter().enumerate() {

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -47,7 +47,11 @@ use crate::{
     mir::{BlockId, Function, InstId, InstKind, Module, Value, ValueId},
     pass::AnalysisPass,
 };
-use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
+use solar_data_structures::{
+    bit_set::DenseBitSet,
+    index::{IndexVec, index_vec},
+    map::FxHashMap,
+};
 use solar_interface::sym;
 use std::fmt;
 
@@ -106,25 +110,40 @@ impl Validator {
 
         // ----- Single-definition check -----
         // Count how many Value entries claim to be the result of each InstId.
-        let mut inst_def_count: FxHashMap<InstId, usize> = FxHashMap::default();
-        for v in func.values.iter() {
+        let mut inst_def_count: IndexVec<InstId, usize> = index_vec![0; num_insts];
+        let mut invalid_inst_def_count: FxHashMap<InstId, usize> = FxHashMap::default();
+        let mut inst_results: IndexVec<InstId, Option<ValueId>> = index_vec![None; num_insts];
+        for (value_id, v) in func.values.iter_enumerated() {
             if let Value::Inst(inst_id) = v {
-                *inst_def_count.entry(*inst_id).or_default() += 1;
+                if inst_id.index() < num_insts {
+                    inst_def_count[*inst_id] += 1;
+                    inst_results[*inst_id] = Some(value_id);
+                } else {
+                    *invalid_inst_def_count.entry(*inst_id).or_default() += 1;
+                }
             }
         }
-        for (inst_id, count) in inst_def_count.iter() {
-            if *count > 1 {
+        for (inst_id, &count) in inst_def_count.iter_enumerated() {
+            if count > 1 {
                 errors.push(ValidationError::new(format!(
                     "instruction inst{} is defined by {count} Value entries (must be 1)",
                     inst_id.index()
                 )));
             }
             // Only value-producing instructions may have a result value.
-            if inst_id.index() < num_insts && func.instructions[*inst_id].result_ty.is_none() {
+            if count != 0 && func.instructions[inst_id].result_ty.is_none() {
                 errors.push(ValidationError::new(format!(
                     "instruction inst{} (`{:?}`) has a result Value entry but no result type",
                     inst_id.index(),
-                    func.instructions[*inst_id].kind
+                    func.instructions[inst_id].kind
+                )));
+            }
+        }
+        for (inst_id, count) in invalid_inst_def_count {
+            if count > 1 {
+                errors.push(ValidationError::new(format!(
+                    "instruction inst{} is defined by {count} Value entries (must be 1)",
+                    inst_id.index()
                 )));
             }
         }
@@ -319,11 +338,11 @@ impl Validator {
             return errors;
         }
         let cfg = CfgInfo::new(func);
-        let mut def_block_of: FxHashMap<ValueId, BlockId> = FxHashMap::default();
+        let mut def_block_of: IndexVec<ValueId, Option<BlockId>> = index_vec![None; num_values];
         for (block_id, block) in func.blocks.iter_enumerated() {
             for &inst_id in &block.instructions {
-                if let Some(result) = func.inst_result_value(inst_id) {
-                    def_block_of.insert(result, block_id);
+                if let Some(result) = inst_results[inst_id] {
+                    def_block_of[result] = Some(block_id);
                 }
             }
         }
@@ -356,7 +375,7 @@ impl Validator {
                 match &func.instructions[inst_id].kind {
                     InstKind::Phi(incoming) => {
                         for &(pred, value) in incoming {
-                            if let Some(&def) = def_block_of.get(&value)
+                            if let Some(def) = def_block_of[value]
                                 && !reaches(def, pred)
                             {
                                 errors.push(ValidationError::at_inst(
@@ -374,7 +393,7 @@ impl Validator {
                     }
                     kind => {
                         for &operand in kind.operands().iter() {
-                            if let Some(&def) = def_block_of.get(&operand)
+                            if let Some(def) = def_block_of[operand]
                                 && def != block_id
                                 && !reaches(def, block_id)
                             {
@@ -394,7 +413,7 @@ impl Validator {
             }
             if let Some(term) = &block.terminator {
                 for &operand in term.operands().iter() {
-                    if let Some(&def) = def_block_of.get(&operand)
+                    if let Some(def) = def_block_of[operand]
                         && def != block_id
                         && !reaches(def, block_id)
                     {


### PR DESCRIPTION
Repeated MIR validation was dominated by looking up each instruction result with a linear scan over all values. Build dense instruction-result, definition-count, and definition-block maps in one pass instead, while retaining the sparse fallback needed for malformed out-of-range instruction IDs. CFG snapshots now also preserve the terminator successor `SmallVec` rather than collecting it into another allocation.

On an OptimizorClub debug codegen profile sampled at 9999 Hz, the sample count fell from 20,250 to 8,093. The final compile benchmark averaged 740.7 ms ± 4.8 ms over 10 runs.
