### PR TITLE
fix(bench): manage codegen PR comments

### DIFF
--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -336,6 +336,16 @@ def append_github_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
+def format_report(markdown: str, has_changes: bool) -> str:
+    if has_changes:
+        return markdown
+    return (
+        "> [!NOTE]\n"
+        "> Codegen benchmark output is unchanged from `main`.\n\n"
+        f"{markdown}"
+    )
+
+
 def metric(value: int | float, unit: str, statistic: str) -> dict[str, Any]:
     return {"value": value, "unit": unit, "statistic": statistic}
 
@@ -501,12 +511,12 @@ def main() -> int:
     if not sections:
         sections.append("## Codegen benchmark\n\nNo benchmark inputs were configured.\n")
 
-    markdown = "\n".join(sections)
-    print(markdown)
-    append_step_summary(markdown)
     should_comment = has_baseline_changes(
         micro_results, baseline_micro
     ) or has_baseline_changes(repo_results, baseline_repo)
+    markdown = format_report("\n".join(sections), should_comment)
+    print(markdown)
+    append_step_summary(markdown)
     append_github_output("should_comment", "true" if should_comment else "false")
     if args.common_output is not None:
         write_common_result(

--- a/.github/scripts/test_check_codegen_benchmark.py
+++ b/.github/scripts/test_check_codegen_benchmark.py
@@ -23,6 +23,18 @@ def result(**compiler):
 
 
 class ReportFormattingTests(unittest.TestCase):
+    def test_unchanged_report_has_note(self):
+        report = benchmark.format_report("## Results", False)
+        self.assertEqual(
+            report,
+            "> [!NOTE]\n"
+            "> Codegen benchmark output is unchanged from `main`.\n\n"
+            "## Results",
+        )
+
+    def test_changed_report_has_no_note(self):
+        self.assertEqual(benchmark.format_report("## Results", True), "## Results")
+
     def test_size_delta_uses_conventional_sign(self):
         self.assertEqual(
             benchmark.fmt_value_with_size_delta(95, 95, 100, "B"),

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -210,11 +210,23 @@ jobs:
       - name: Comment on PR
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.runtime-report.outputs.should_comment == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: codegen-runtime-bench
           message: ${{ steps.runtime-report.outputs.report }}
+
+      - name: Update unchanged PR comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.runtime-report.outputs.should_comment != 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: codegen-runtime-bench
+          message: ${{ steps.runtime-report.outputs.report }}
+          only_update: true
 
       - name: Upload results as artifact
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -210,23 +210,12 @@ jobs:
       - name: Comment on PR
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.runtime-report.outputs.should_comment == 'true'
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: codegen-runtime-bench
           message: ${{ steps.runtime-report.outputs.report }}
-
-      - name: Update unchanged PR comment
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.runtime-report.outputs.should_comment != 'true'
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          header: codegen-runtime-bench
-          message: ${{ steps.runtime-report.outputs.report }}
-          only_update: true
+          only_update: ${{ steps.runtime-report.outputs.should_comment != 'true' }}
 
       - name: Upload results as artifact
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -207,32 +207,25 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Find existing runtime benchmark comment
-        id: runtime-comment
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          exists="$(
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
-              --jq 'any(.[].body; contains("codegen-runtime-bench"))'
-          )"
-          echo "exists=${exists}" >> "$GITHUB_OUTPUT"
-
       - name: Comment on PR
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
-          (steps.runtime-report.outputs.should_comment == 'true' ||
-          steps.runtime-comment.outputs.exists == 'true')
+          steps.runtime-report.outputs.should_comment == 'true'
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: codegen-runtime-bench
           message: ${{ steps.runtime-report.outputs.report }}
+
+      - name: Delete unchanged PR comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.runtime-report.outputs.should_comment != 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: codegen-runtime-bench
+          delete: true
 
       - name: Upload results as artifact
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -210,22 +210,11 @@ jobs:
       - name: Comment on PR
         if: >-
           github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.runtime-report.outputs.should_comment == 'true'
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: codegen-runtime-bench
           message: ${{ steps.runtime-report.outputs.report }}
-
-      - name: Delete unchanged PR comment
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.runtime-report.outputs.should_comment != 'true'
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          header: codegen-runtime-bench
-          delete: true
 
       - name: Upload results as artifact
         if: always()


### PR DESCRIPTION
Post the codegen benchmark report only when a pull request changes benchmark output. Later changed runs create or update the sticky report normally, while unchanged runs use the action’s update-only mode: they do nothing when no report exists and add an unchanged-from-main note when one does. This also removes the separate REST API lookup whose transient HTML 503 responses caused benchmark jobs to fail, as seen on #961.