### PR TITLE
refactor(codegen): normalize EVM IR

### DIFF
--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -22,7 +22,7 @@ pub(crate) struct EvmOptArgs {
         value_parser = parse_pass,
         default_value = "none"
     )]
-    passes: Vec<ir::Pass>,
+    passes: Vec<Option<&'static ir::PassInfo>>,
     /// If true, print EVM IR after every pass; otherwise only after the last.
     #[arg(long)]
     print_after_each: bool,
@@ -31,19 +31,36 @@ pub(crate) struct EvmOptArgs {
     input: String,
 }
 
-fn parse_pass(name: &str) -> Result<ir::Pass, String> {
-    ir::Pass::by_name(name).ok_or_else(|| format!("unknown EVM IR pass: {name}"))
+fn parse_pass(name: &str) -> Result<Option<&'static ir::PassInfo>, String> {
+    match name {
+        "none" => Ok(None),
+        other => {
+            ir::lookup_pass(other).map(Some).ok_or_else(|| format!("unknown EVM IR pass: {other}"))
+        }
+    }
 }
 
 fn after_help() -> String {
     format!(
-        "Passes:\n  {}\n\nInput formats:\n  *.evmir  EVM IR",
-        ir::PASSES.iter().map(|pass| pass.name()).collect::<Vec<_>>().join("\n  ")
+        "Passes:\n  {}\n  {:<20} No transform; validate and print the module\n\nInput formats:\n  *.evmir  EVM IR",
+        ir::PASS_REGISTRY
+            .iter()
+            .map(|pass| format!("{:<20} {}", pass.name, pass.description))
+            .collect::<Vec<_>>()
+            .join("\n  "),
+        "none",
     )
 }
 
-fn selected_pass_list_label(passes: &[ir::Pass], separator: &str) -> String {
-    passes.iter().map(|pass| pass.name()).collect::<Vec<_>>().join(separator)
+fn pass_label(pass: Option<&ir::PassInfo>) -> &'static str {
+    match pass {
+        Some(pass) => pass.name,
+        None => "none",
+    }
+}
+
+fn selected_pass_list_label(passes: &[Option<&ir::PassInfo>], separator: &str) -> String {
+    passes.iter().copied().map(pass_label).collect::<Vec<_>>().join(separator)
 }
 
 /// Prints a module with a header indicating which pass(es) produced it.
@@ -57,13 +74,15 @@ fn run_pipeline(sess: &Session, module: &mut ir::Module, name: &str, args: &EvmO
     let options = ir::PassOptions { time_passes: sess.opts.unstable.time_passes };
     let pipeline_label = selected_pass_list_label(&args.passes, ",");
     for (index, &pass) in args.passes.iter().enumerate() {
-        pass.run(module, options);
+        if let Some(pass) = pass {
+            ir::run_pass(module, pass, options);
+        }
         if args.print_after_each || index + 1 == args.passes.len() {
             ir::Verifier::new(dcx).verify_module(module);
             if dcx.has_errors().is_err() {
                 break;
             }
-            let label = if args.print_after_each { pass.name() } else { &pipeline_label };
+            let label = if args.print_after_each { pass_label(pass) } else { &pipeline_label };
             print_module(module, name, label);
         }
     }

--- a/crates/codegen/src/backend/evm/assembler/program.rs
+++ b/crates/codegen/src/backend/evm/assembler/program.rs
@@ -109,7 +109,7 @@ impl StructuredAsmProgram {
     /// # Experimental `StackSchedule` gating
     ///
     /// When `context.run_evm_ir_stack_schedule()` is true (off by default) the
-    /// bridge runs [`ir::Pass::StackSchedule`]. The reality of what the bridge
+    /// bridge runs [`ir::STACK_SCHEDULE_PASS`]. The reality of what the bridge
     /// feeds the scheduler matters here: MIR lowering has already materialized
     /// every virtual stack-word operand into physical `dup`/`swap`/`pop` and
     /// `push`/opcode instructions, so `to_evm_ir_module` produces
@@ -147,7 +147,7 @@ impl StructuredAsmProgram {
             // always holds (the pass is a near no-op), but the guard means an
             // unexpected rewrite is dropped instead of changing produced code.
             let mut scheduled = module.clone();
-            if ir::Pass::StackSchedule.run(&mut scheduled, pass_options)
+            if ir::run_pass(&mut scheduled, &ir::STACK_SCHEDULE_PASS, pass_options)
                 && is_valid_evm_ir(&scheduled)
                 && modules_have_equal_code(&module, &scheduled)
             {
@@ -157,8 +157,8 @@ impl StructuredAsmProgram {
         }
 
         if context.run_evm_ir_layout_passes() {
-            for pass in [ir::Pass::ColdLayout, ir::Pass::TerminalDedup] {
-                changed += usize::from(pass.run(&mut module, pass_options));
+            for pass in ir::DEFAULT_LAYOUT_PIPELINE {
+                changed += usize::from(ir::run_pass(&mut module, pass, pass_options));
             }
         }
         debug_assert!(is_valid_evm_ir(&module));

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -67,7 +67,7 @@ pub struct EvmCodegenConfig {
     /// Run the experimental EVM IR `StackSchedule` pass in the assembler bridge.
     ///
     /// Off by default: the default bytecode path must stay byte-for-byte
-    /// unchanged. When enabled the bridge runs `ir::Pass::StackSchedule` on the
+    /// unchanged. When enabled the bridge runs [`ir::STACK_SCHEDULE_PASS`] on the
     /// operand-cleared block IR. On that already-stack-scheduled input the pass
     /// is a verified near no-op in `StructuredAsmProgram::optimize_with_evm_ir`.
     pub evm_ir_stack_schedule: bool,

--- a/crates/codegen/src/backend/evm/ir.rs
+++ b/crates/codegen/src/backend/evm/ir.rs
@@ -17,7 +17,10 @@ mod passes;
 mod verify;
 
 pub use parse::ParseError;
-pub use passes::{PASSES, Pass, PassOptions};
+pub use passes::{
+    COLD_LAYOUT_PASS, DEFAULT_LAYOUT_PIPELINE, PASS_REGISTRY, PassInfo, PassOptions,
+    STACK_SCHEDULE_PASS, TERMINAL_DEDUP_PASS, lookup_pass, run_pass,
+};
 pub use verify::Verifier;
 
 newtype_index! {

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -1,6 +1,7 @@
 //! EVM IR text formatting.
 
 use super::*;
+use crate::backend::evm::assembler::op;
 use solar_data_structures::fmt::FmtIteratorExt;
 
 impl Module {
@@ -131,10 +132,10 @@ fn display_terminator<'a>(module: &'a Module, term: &'a Terminator) -> impl fmt:
                 write!(f, "selfdestruct {}", display_operand(module, recipient))?;
             }
             TerminatorKind::RawOpcode(opcode) => {
-                if let Some(mnemonic) = super::super::assembler::op::mnemonic(*opcode) {
-                    write!(f, "terminal {mnemonic}")?;
+                if let Some(mnemonic) = op::mnemonic(*opcode) {
+                    write!(f, "{mnemonic}")?;
                 } else {
-                    write!(f, "terminal 0x{opcode:02x}")?;
+                    write!(f, "raw 0x{opcode:02x}")?;
                 }
             }
         }

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -1,6 +1,7 @@
 //! EVM IR text parser.
 
 use super::*;
+use crate::backend::evm::assembler::op;
 use solar_data_structures::{bit_set::GrowableBitSet, map::FxHashMap};
 use std::fmt as std_fmt;
 
@@ -578,6 +579,7 @@ impl<'a> Parser<'a> {
                 }
                 TerminatorKind::Switch { value, default, cases }
             }
+            "return" if self.at_end_of_operation() => TerminatorKind::RawOpcode(op::RETURN),
             "return" => {
                 let offset =
                     self.parse_operand(module, block_labels, value_labels, defined_values)?;
@@ -586,6 +588,7 @@ impl<'a> Parser<'a> {
                     self.parse_operand(module, block_labels, value_labels, defined_values)?;
                 TerminatorKind::Return { offset, size }
             }
+            "revert" if self.at_end_of_operation() => TerminatorKind::RawOpcode(op::REVERT),
             "revert" => {
                 let offset =
                     self.parse_operand(module, block_labels, value_labels, defined_values)?;
@@ -596,6 +599,9 @@ impl<'a> Parser<'a> {
             }
             "stop" => TerminatorKind::Stop,
             "invalid" => TerminatorKind::Invalid,
+            "selfdestruct" if self.at_end_of_operation() => {
+                TerminatorKind::RawOpcode(op::SELFDESTRUCT)
+            }
             "selfdestruct" => {
                 let recipient =
                     self.parse_operand(module, block_labels, value_labels, defined_values)?;
@@ -611,10 +617,17 @@ impl<'a> Parser<'a> {
                     opcode
                 } else {
                     let mnemonic = self.parse_ident()?;
-                    let Some(opcode) = super::super::assembler::op::from_mnemonic(mnemonic) else {
+                    let Some(opcode) = op::from_mnemonic(mnemonic) else {
                         return Err(self.error(format!("unknown terminal opcode `{mnemonic}`")));
                     };
                     opcode
+                };
+                TerminatorKind::RawOpcode(opcode)
+            }
+            "raw" => {
+                let opcode = self.parse_uint_literal()?;
+                let Ok(opcode) = u8::try_from(opcode) else {
+                    return Err(self.error("raw opcode must fit in one byte"));
                 };
                 TerminatorKind::RawOpcode(opcode)
             }

--- a/crates/codegen/src/backend/evm/ir/passes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes.rs
@@ -1,21 +1,57 @@
 //! EVM IR optimization and layout passes.
 
 use super::*;
-use crate::timing::PassTimer;
+use crate::{
+    backend::evm::{assembler::op, ir_stack_schedule},
+    timing::PassTimer,
+};
 use alloy_primitives::U256;
 use solar_data_structures::{index::IndexVec, map::FxHashMap};
 
-/// A named EVM IR pass exposed to `solar evm-opt`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum Pass {
-    /// No transform; validate and print the module.
-    None,
+type PassRunner = fn(&mut Module) -> bool;
+
+/// Registry entry for an EVM IR transform pass.
+#[derive(Clone, Copy, Debug)]
+pub struct PassInfo {
+    /// Command-line and pipeline name.
+    pub name: &'static str,
+    /// Human-readable help text.
+    pub description: &'static str,
+    run_pass: PassRunner,
+}
+
+impl PassInfo {
+    const fn new(name: &'static str, description: &'static str, run_pass: PassRunner) -> Self {
+        Self { name, description, run_pass }
+    }
+}
+
+macro_rules! declare_passes {
+    ($(
+        $(#[doc = $description:literal])+
+        $vis:vis const $const_name:ident -> $name:literal = $run_pass:path;
+    )+) => {
+        $(
+            $(#[doc = $description])+
+            $vis const $const_name: PassInfo = PassInfo::new(
+                $name,
+                concat!($($description, "\n"),+).trim_ascii(),
+                $run_pass,
+            );
+        )+
+    };
+}
+
+declare_passes! {
     /// Materialize virtual instruction operands with physical stack operations.
-    StackSchedule,
+    pub const STACK_SCHEDULE_PASS -> "stack-schedule" = ir_stack_schedule::schedule_stack_ops;
+
     /// Move cold terminal blocks after hot fallthrough code when this preserves fallthrough edges.
-    ColdLayout,
+    pub const COLD_LAYOUT_PASS -> "cold-layout" = move_cold_terminal_blocks;
+
     /// Replace duplicate terminal block bodies with jumps to the first copy when profitable.
-    TerminalDedup,
+    pub const TERMINAL_DEDUP_PASS -> "terminal-dedup" = deduplicate_terminal_blocks;
+
 }
 
 /// Options for running an EVM IR pass.
@@ -25,47 +61,25 @@ pub struct PassOptions {
     pub time_passes: bool,
 }
 
-impl Pass {
-    /// Stable command-line pass name.
-    #[must_use]
-    pub const fn name(self) -> &'static str {
-        match self {
-            Self::None => "none",
-            Self::StackSchedule => "stack-schedule",
-            Self::ColdLayout => "cold-layout",
-            Self::TerminalDedup => "terminal-dedup",
-        }
-    }
+/// All EVM IR passes exposed by `solar evm-opt`.
+pub const PASS_REGISTRY: &[PassInfo] =
+    &[STACK_SCHEDULE_PASS, COLD_LAYOUT_PASS, TERMINAL_DEDUP_PASS];
 
-    /// Runs this pass on an EVM IR module.
-    pub fn run(self, module: &mut Module, options: PassOptions) -> bool {
-        let timer = PassTimer::new(options.time_passes);
-        let changed = match self {
-            Self::None => false,
-            Self::StackSchedule => super::super::ir_stack_schedule::schedule_stack_ops(module),
-            Self::ColdLayout => move_cold_terminal_blocks(module),
-            Self::TerminalDedup => deduplicate_terminal_blocks(module),
-        };
-        timer.finish("EVM IR", &module.name, self.name(), changed);
-        changed
-    }
+/// The canonical EVM IR layout and code-size pipeline used by EVM codegen.
+pub const DEFAULT_LAYOUT_PIPELINE: &[PassInfo] = &[COLD_LAYOUT_PASS, TERMINAL_DEDUP_PASS];
 
-    /// Looks up a pass by command-line name.
-    #[must_use]
-    pub fn by_name(name: &str) -> Option<Self> {
-        Some(match name {
-            "none" => Self::None,
-            "stack-schedule" => Self::StackSchedule,
-            "cold-layout" => Self::ColdLayout,
-            "terminal-dedup" => Self::TerminalDedup,
-            _ => return None,
-        })
-    }
+/// Finds a pass in the EVM IR pass registry by command-line name.
+pub fn lookup_pass(name: &str) -> Option<&'static PassInfo> {
+    PASS_REGISTRY.iter().find(|pass| pass.name == name)
 }
 
-/// All EVM IR passes exposed by `solar evm-opt`.
-pub const PASSES: &[Pass] =
-    &[Pass::None, Pass::StackSchedule, Pass::ColdLayout, Pass::TerminalDedup];
+/// Runs a named EVM IR pass over a module.
+pub fn run_pass(module: &mut Module, pass: &PassInfo, options: PassOptions) -> bool {
+    let timer = PassTimer::new(options.time_passes);
+    let changed = (pass.run_pass)(module);
+    timer.finish("EVM IR", &module.name, pass.name, changed);
+    changed
+}
 
 fn move_cold_terminal_blocks(module: &mut Module) -> bool {
     let mut kept = Vec::with_capacity(module.blocks.len());
@@ -194,7 +208,7 @@ fn is_evm_terminal(kind: &TerminatorKind) -> bool {
             | TerminatorKind::Stop
             | TerminatorKind::Invalid
             | TerminatorKind::SelfDestruct { .. }
-    ) || matches!(kind, TerminatorKind::RawOpcode(opcode) if super::super::assembler::op::is_terminal(*opcode))
+    ) || matches!(kind, TerminatorKind::RawOpcode(opcode) if op::is_terminal(*opcode))
 }
 
 fn terminal_block_key(block: &Block) -> Option<TerminalBlockKey> {

--- a/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
+++ b/tests/ui/codegen/abi_encode_packed_calldata_slice.stdout
@@ -28,7 +28,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 64
   mload
@@ -49,7 +49,7 @@ bb2:
   dup2
   mstore
   swap1
-  terminal jump
+  jump
 bb3:
   calldatasize
   push 4
@@ -168,7 +168,7 @@ bb6:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb7:
   calldatasize
   push 4
@@ -305,7 +305,7 @@ bb10:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb11:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
@@ -349,4 +349,4 @@ bb11:
   swap1
   pop
   swap1
-  terminal jump
+  jump

--- a/tests/ui/codegen/abi_packed_calldata_bytes.stdout
+++ b/tests/ui/codegen/abi_packed_calldata_bytes.stdout
@@ -28,7 +28,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 64
   mload
@@ -49,7 +49,7 @@ bb2:
   dup2
   mstore
   swap1
-  terminal jump
+  jump
 bb3:
   calldatasize
   push 4
@@ -139,7 +139,7 @@ bb7:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb8:
   calldatasize
   push 4
@@ -245,7 +245,7 @@ bb12:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb13:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 256
@@ -289,7 +289,7 @@ bb13:
   swap1
   pop
   swap1
-  terminal jump
+  jump
 bb14:
   push 0
   push 128
@@ -317,4 +317,4 @@ bb14:
   swap1
   pop
   swap1
-  terminal jump
+  jump

--- a/tests/ui/codegen/assembler_block_dedup.stdout
+++ b/tests/ui/codegen/assembler_block_dedup.stdout
@@ -38,7 +38,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 1
   fallthrough bb3
@@ -47,7 +47,7 @@ bb3:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb4:
   calldatasize
   push 4

--- a/tests/ui/codegen/calldata_array_to_memory.stdout
+++ b/tests/ui/codegen/calldata_array_to_memory.stdout
@@ -38,7 +38,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   sload
@@ -48,7 +48,7 @@ bb3:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb4:
   calldatasize
   push 4
@@ -270,7 +270,7 @@ bb8:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb9:
   calldatasize
   push 4

--- a/tests/ui/codegen/cold_call_hot_fallthrough.stdout
+++ b/tests/ui/codegen/cold_call_hot_fallthrough.stdout
@@ -26,17 +26,17 @@ bb0 (entry):
   jumpi
   push 0
   push 0
-  terminal revert
+  revert
 bb1:
-  terminal invalid
+  invalid
 bb2:
   push 0
   dup1
-  terminal revert
+  revert
 bb3:
   push 0
   push 0
-  terminal revert
+  revert
 bb4:
   calldatasize
   push 4
@@ -63,7 +63,7 @@ bb5:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb6:
   fallthrough bb7
 bb7:
@@ -150,4 +150,4 @@ bb13:
   mstore
   push 100
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/constructor_internal_call_bin.stdout
+++ b/tests/ui/codegen/constructor_internal_call_bin.stdout
@@ -35,7 +35,7 @@ bb2:
   push 96
   add
   mstore
-  terminal jump
+  jump
 bb3:
   push 11
   push 160
@@ -184,7 +184,7 @@ bb5:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb6:
   push 7
   push 128
@@ -248,7 +248,7 @@ bb0 (entry):
   push 0
   codecopy
   push 0
-  terminal return
+  return
 
 // === runtime ===
 bb0 (entry):
@@ -275,7 +275,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   sload
@@ -283,4 +283,4 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return

--- a/tests/ui/codegen/emit_abi_bin.evmir.stdout
+++ b/tests/ui/codegen/emit_abi_bin.evmir.stdout
@@ -57,7 +57,7 @@ bb0 (entry):
   push 0
   codecopy
   push 0
-  terminal return
+  return
 
 // === runtime ===
 bb0 (entry):
@@ -84,7 +84,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   sload
@@ -92,7 +92,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 // === ROOT/tests/ui/codegen/emit_abi_bin.sol:C (runtime) ===
 bb0 (entry):
   push 160
@@ -118,7 +118,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   sload
@@ -126,4 +126,4 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return

--- a/tests/ui/codegen/enum_conversion_qualified.stdout
+++ b/tests/ui/codegen/enum_conversion_qualified.stdout
@@ -24,7 +24,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -42,4 +42,4 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return

--- a/tests/ui/codegen/global_stack_calldata_alias.stdout
+++ b/tests/ui/codegen/global_stack_calldata_alias.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -88,7 +88,7 @@ bb5:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb6:
   push 2
   dup2
@@ -105,7 +105,7 @@ bb7:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb8:
   push 2
   dup3

--- a/tests/ui/codegen/internal_call_frame_dealloc.stdout
+++ b/tests/ui/codegen/internal_call_frame_dealloc.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 160
   mload
@@ -36,7 +36,7 @@ bb2:
   mload
   push 160
   mstore
-  terminal jump
+  jump
 bb3:
   push 160
   mload
@@ -59,7 +59,7 @@ bb3:
   push 96
   add
   mstore
-  terminal jump
+  jump
 bb4:
   calldatasize
   push 4
@@ -188,7 +188,7 @@ bb8:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb9:
   push 1
   push 160
@@ -281,7 +281,7 @@ bb11:
   add
   mstore
   pop
-  terminal jump
+  jump
 bb12:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -291,4 +291,4 @@ bb12:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/library_mapping_storage_param.stdout
+++ b/tests/ui/codegen/library_mapping_storage_param.stdout
@@ -13,11 +13,11 @@ bb0 (entry):
   shr
   push 0
   push 0
-  terminal revert
+  revert
 bb1:
   push 0
   push 0
-  terminal revert
+  revert
 // === ROOT/tests/ui/codegen/library_mapping_storage_param.sol:C (runtime) ===
 bb0 (entry):
   push 704
@@ -43,7 +43,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -115,7 +115,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -125,4 +125,4 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/library_wrapper_storage_param.stdout
+++ b/tests/ui/codegen/library_wrapper_storage_param.stdout
@@ -24,7 +24,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -141,7 +141,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -151,4 +151,4 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/linked_library_call.stdout
+++ b/tests/ui/codegen/linked_library_call.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -99,7 +99,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -109,7 +109,7 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 // === ROOT/tests/ui/codegen/linked_library_call.sol:C (runtime) ===
 bb0 (entry):
   push 224
@@ -135,7 +135,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -214,7 +214,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   returndatasize
   dup1
@@ -226,4 +226,4 @@ bb3:
   push 192
   mload
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/linked_library_chain.stdout
+++ b/tests/ui/codegen/linked_library_chain.stdout
@@ -24,7 +24,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -77,7 +77,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -87,7 +87,7 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 // === ROOT/tests/ui/codegen/linked_library_chain.sol:Outer (runtime) ===
 bb0 (entry):
   push 224
@@ -113,7 +113,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -135,7 +135,7 @@ bb2:
 bb3:
   push 32
   push 128
-  terminal return
+  return
 bb4:
   push 64
   mload
@@ -186,7 +186,7 @@ bb4:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb5:
   returndatasize
   dup1
@@ -198,7 +198,7 @@ bb5:
   push 192
   mload
   push 0
-  terminal revert
+  revert
 // === ROOT/tests/ui/codegen/linked_library_chain.sol:C (runtime) ===
 bb0 (entry):
   push 224
@@ -224,7 +224,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -286,7 +286,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   returndatasize
   dup1
@@ -298,4 +298,4 @@ bb3:
   push 192
   mload
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/linked_library_dynamic_fields.stdout
+++ b/tests/ui/codegen/linked_library_dynamic_fields.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -301,7 +301,7 @@ bb3:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb4:
   push 288
   mload
@@ -494,7 +494,7 @@ bb6:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb7:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -531,7 +531,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -567,7 +567,7 @@ bb3:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb4:
   calldatasize
   push 4
@@ -982,7 +982,7 @@ bb5:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb6:
   returndatasize
   dup1
@@ -994,4 +994,4 @@ bb6:
   push 512
   mload
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/log_topic_reuse.stdout
+++ b/tests/ui/codegen/log_topic_reuse.stdout
@@ -28,7 +28,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   sload
@@ -36,7 +36,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   calldatasize
   push 4
@@ -72,4 +72,4 @@ bb3:
   mstore
   push 0
   sstore
-  terminal stop
+  stop

--- a/tests/ui/codegen/low_level_call_calldata_bytes.stdout
+++ b/tests/ui/codegen/low_level_call_calldata_bytes.stdout
@@ -28,7 +28,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 64
   mload
@@ -49,7 +49,7 @@ bb2:
   dup2
   mstore
   swap1
-  terminal jump
+  jump
 bb3:
   calldatasize
   push 4
@@ -137,7 +137,7 @@ bb7:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb8:
   calldatasize
   push 4
@@ -223,7 +223,7 @@ bb12:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb13:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
   push 288
@@ -267,7 +267,7 @@ bb13:
   swap1
   pop
   swap1
-  terminal jump
+  jump
 bb14:
   push 0
   push 128
@@ -295,4 +295,4 @@ bb14:
   swap1
   pop
   swap1
-  terminal jump
+  jump

--- a/tests/ui/codegen/public_library_call.stdout
+++ b/tests/ui/codegen/public_library_call.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -129,7 +129,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -139,7 +139,7 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 // === ROOT/tests/ui/codegen/public_library_call.sol:C (runtime) ===
 bb0 (entry):
   push 672
@@ -165,7 +165,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -210,7 +210,7 @@ bb3:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb4:
   push 352
   mload
@@ -294,7 +294,7 @@ bb4:
   mload
   push 416
   mstore
-  terminal jump
+  jump
 bb5:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -304,4 +304,4 @@ bb5:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/revert_error_helper.stdout
+++ b/tests/ui/codegen/revert_error_helper.stdout
@@ -28,7 +28,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   push 128
@@ -95,7 +95,7 @@ bb5:
   swap1
   add
   dup2
-  terminal return
+  return
 // === ROOT/tests/ui/codegen/revert_error_helper.sol:R (runtime) ===
 bb0 (entry):
   push 352
@@ -141,7 +141,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0
   push 128
@@ -152,7 +152,7 @@ bb2:
   gt
   iszero
   swap1
-  terminal jump
+  jump
 bb3:
   calldatasize
   push 4
@@ -176,7 +176,7 @@ bb5:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb6:
   push 2
   push 288
@@ -293,7 +293,7 @@ bb16:
   pop
   push 132
   push 0
-  terminal revert
+  revert
 bb17:
   calldatasize
   push 4
@@ -333,4 +333,4 @@ bb20:
   mstore
   push 100
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/stack-too-deep/call_args.stdout
@@ -7,7 +7,7 @@ bb0 (entry):
   push 0
   codecopy
   push 0
-  terminal return
+  return
 
 // === runtime ===
 bb0 (entry):
@@ -34,7 +34,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -678,7 +678,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -688,4 +688,4 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/stack-too-deep/locals.stdout
@@ -7,7 +7,7 @@ bb0 (entry):
   push 0
   codecopy
   push 0
-  terminal return
+  return
 
 // === runtime ===
 bb0 (entry):
@@ -34,7 +34,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -744,7 +744,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -754,4 +754,4 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/stack-too-deep/params.stdout
+++ b/tests/ui/codegen/stack-too-deep/params.stdout
@@ -7,7 +7,7 @@ bb0 (entry):
   push 0
   codecopy
   push 0
-  terminal return
+  return
 
 // === runtime ===
 bb0 (entry):
@@ -34,7 +34,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -374,7 +374,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -384,4 +384,4 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/stack_phi_loop.stdout
+++ b/tests/ui/codegen/stack_phi_loop.stdout
@@ -33,7 +33,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   dup1
   push 288
@@ -132,7 +132,7 @@ bb9:
   pop
   push 32
   push 128
-  terminal return
+  return
 bb10:
   push 1
   push 352
@@ -492,4 +492,4 @@ bb23:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/static_frames.stdout
+++ b/tests/ui/codegen/static_frames.stdout
@@ -28,7 +28,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 64
   mload
@@ -39,7 +39,7 @@ bb2:
   add
   mstore
   swap1
-  terminal jump
+  jump
 bb3:
   push 160
   mload
@@ -52,7 +52,7 @@ bb3:
   mload
   push 160
   mstore
-  terminal jump
+  jump
 bb4:
   push bb19
   jump bb6
@@ -74,7 +74,7 @@ bb6:
   add
   mload
   swap1
-  terminal jump
+  jump
 bb7:
   push 160
   mload
@@ -88,7 +88,7 @@ bb7:
   add
   mstore
   swap1
-  terminal jump
+  jump
 bb8:
   push 0
   sload
@@ -98,7 +98,7 @@ bb9:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb10:
   calldatasize
   push 4
@@ -583,7 +583,7 @@ bb18:
   mload
   push 736
   mstore
-  terminal jump
+  jump
 bb19:
   push 160
   mload
@@ -753,7 +753,7 @@ bb21:
   push 128
   add
   mstore
-  terminal jump
+  jump
 bb22:
   push 1
   push 160
@@ -1110,7 +1110,7 @@ bb29:
   add
   mstore
   pop
-  terminal jump
+  jump
 bb30:
   push 3
   push 160
@@ -1486,4 +1486,4 @@ bb41:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/storage_bytes_member.stdout
+++ b/tests/ui/codegen/storage_bytes_member.stdout
@@ -48,13 +48,13 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   push 0x4e0
   mload
   push 0x440
   mstore
-  terminal jump
+  jump
 bb3:
   calldatasize
   push 4
@@ -116,7 +116,7 @@ bb4:
   jumpi
   fallthrough bb5
 bb5:
-  terminal stop
+  stop
 bb6:
   push 128
   mload
@@ -465,7 +465,7 @@ bb10:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb11:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -1064,7 +1064,7 @@ bb27:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb28:
   calldatasize
   push 4
@@ -1298,7 +1298,7 @@ bb32:
   sstore
   fallthrough bb33
 bb33:
-  terminal stop
+  stop
 bb34:
   push 0
   push 128
@@ -1564,7 +1564,7 @@ bb39:
   swap1
   add
   dup2
-  terminal return
+  return
 bb40:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0

--- a/tests/ui/codegen/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/tuple_assign_branch_leak.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -63,7 +63,7 @@ bb3:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb4:
   push 7
   dup2
@@ -256,4 +256,4 @@ bb9:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/tuple_assignment.stdout
+++ b/tests/ui/codegen/tuple_assignment.stdout
@@ -33,7 +33,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -194,7 +194,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -204,7 +204,7 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert
 bb4:
   calldatasize
   push 4
@@ -227,7 +227,7 @@ bb5:
   mstore
   push 64
   push 128
-  terminal return
+  return
 bb6:
   push 7
   push 128

--- a/tests/ui/codegen/udvt_selector.stdout
+++ b/tests/ui/codegen/udvt_selector.stdout
@@ -33,7 +33,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -65,7 +65,7 @@ bb2:
   mstore
   push 32
   push 128
-  terminal return
+  return
 bb3:
   push 0x4e487b7100000000000000000000000000000000000000000000000000000000
   push 0
@@ -76,4 +76,4 @@ bb3:
   mstore
   push 36
   push 0
-  terminal revert
+  revert

--- a/tests/ui/codegen/while_empty_body.stdout
+++ b/tests/ui/codegen/while_empty_body.stdout
@@ -7,7 +7,7 @@ bb0 (entry):
   push 0
   codecopy
   push 0
-  terminal return
+  return
 
 // === runtime ===
 bb0 (entry):
@@ -34,7 +34,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -53,4 +53,4 @@ bb3:
   jumpi
   jump bb4
 bb4:
-  terminal stop
+  stop

--- a/tests/ui/codegen/yul_return.stdout
+++ b/tests/ui/codegen/yul_return.stdout
@@ -23,7 +23,7 @@ bb0 (entry):
 bb1:
   push 0
   dup1
-  terminal revert
+  revert
 bb2:
   calldatasize
   push 4
@@ -40,4 +40,4 @@ bb2:
   mstore
   push 32
   push 0
-  terminal return
+  return


### PR DESCRIPTION
Replace the EVM IR pass enum with the same constant registry and named pipeline structure used by MIR. This also prints machine-level terminal opcodes using their normal mnemonics while retaining compatibility with the legacy textual syntax.