### PR TITLE
feat(lsp): add document links

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -4,9 +4,10 @@ use crate::{
     workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest},
 };
 use lsp_types::{
-    CompletionOptions, DeclarationCapability, InitializeParams, OneOf, RenameOptions, SaveOptions,
-    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, WorkDoneProgressOptions,
+    CompletionOptions, DeclarationCapability, DocumentLinkOptions, InitializeParams, OneOf,
+    RenameOptions, SaveOptions, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, WorkDoneProgressOptions,
 };
 use solar_interface::data_structures::map::FxHashSet;
 use std::{
@@ -249,6 +250,10 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             declaration_provider: Some(DeclarationCapability::Simple(true)),
             definition_provider: Some(OneOf::Left(true)),
             document_formatting_provider: Some(OneOf::Left(true)),
+            document_link_provider: Some(DocumentLinkOptions {
+                resolve_provider: Some(false),
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+            }),
             document_symbol_provider: Some(OneOf::Left(true)),
             inlay_hint_provider: Some(OneOf::Left(true)),
             references_provider: Some(OneOf::Left(true)),
@@ -345,6 +350,8 @@ mod tests {
         assert_eq!(capabilities.definition_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.document_formatting_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.document_symbol_provider, Some(OneOf::Left(true)));
+        let document_link_provider = capabilities.document_link_provider.unwrap();
+        assert_eq!(document_link_provider.resolve_provider, Some(false));
         assert_eq!(capabilities.inlay_hint_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.references_provider, Some(OneOf::Left(true)));
         assert_eq!(

--- a/crates/lsp/src/document_links.rs
+++ b/crates/lsp/src/document_links.rs
@@ -4,13 +4,13 @@ use solar_interface::{
     data_structures::map::{FxHashMap, FxHashSet},
 };
 use solar_sema::{Gcx, ast};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::proto;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DocumentLinkIndex {
-    by_file: FxHashMap<Url, Vec<StoredDocumentLink>>,
+    by_file: FxHashMap<PathBuf, Vec<StoredDocumentLink>>,
 }
 
 #[derive(Clone, Debug)]
@@ -27,6 +27,7 @@ impl DocumentLinkIndex {
             if !source_paths.contains(source_path) {
                 continue;
             }
+            let source_path = source_path.to_path_buf();
             let Some(ast) = &source.ast else { continue };
             for &(item_id, target_source_id) in &source.imports {
                 let ast::ItemKind::Import(import) = &ast.items[item_id].kind else { continue };
@@ -42,7 +43,7 @@ impl DocumentLinkIndex {
                 let Some(target_path) = target.file.name.as_real() else { continue };
                 let Ok(target_uri) = Url::from_file_path(target_path) else { continue };
                 index.push(
-                    location.uri,
+                    source_path.clone(),
                     StoredDocumentLink { range: location.range, target: target_uri },
                 );
             }
@@ -51,22 +52,22 @@ impl DocumentLinkIndex {
         index
     }
 
-    fn push(&mut self, source: Url, link: StoredDocumentLink) {
+    fn push(&mut self, source: PathBuf, link: StoredDocumentLink) {
         self.by_file.entry(source).or_default().push(link);
     }
 
     #[cfg(test)]
-    pub(crate) fn insert_for_test(&mut self, source: Url, range: Range, target: Url) {
+    pub(crate) fn insert_for_test(&mut self, source: PathBuf, range: Range, target: Url) {
         self.push(source, StoredDocumentLink { range, target });
     }
 
     pub(crate) fn extend(&mut self, other: Self) {
-        debug_assert!(other.by_file.keys().all(|uri| !self.by_file.contains_key(uri)));
+        debug_assert!(other.by_file.keys().all(|path| !self.by_file.contains_key(path)));
         self.by_file.extend(other.by_file);
     }
 
-    pub(crate) fn links(&self, uri: &Url) -> Vec<DocumentLink> {
-        let Some(links) = self.by_file.get(uri) else { return Vec::new() };
+    pub(crate) fn links(&self, path: &Path) -> Vec<DocumentLink> {
+        let Some(links) = self.by_file.get(path) else { return Vec::new() };
         links.iter().map(StoredDocumentLink::to_lsp).collect()
     }
 

--- a/crates/lsp/src/document_links.rs
+++ b/crates/lsp/src/document_links.rs
@@ -1,25 +1,30 @@
 use lsp_types::{DocumentLink, Range, Url};
-use solar_interface::{Span, data_structures::map::FxHashMap};
+use solar_interface::{
+    Span,
+    data_structures::map::{FxHashMap, FxHashSet},
+};
 use solar_sema::{Gcx, ast};
+use std::path::PathBuf;
 
 use crate::proto;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DocumentLinkIndex {
-    by_file: FxHashMap<Url, FxHashMap<Range, LinkTarget>>,
+    by_file: FxHashMap<Url, Vec<StoredDocumentLink>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum LinkTarget {
-    Resolved(Url),
-    Ambiguous,
+#[derive(Clone, Debug)]
+struct StoredDocumentLink {
+    range: Range,
+    target: Url,
 }
 
 impl DocumentLinkIndex {
-    pub(crate) fn build(gcx: Gcx<'_>) -> Self {
+    pub(crate) fn build(gcx: Gcx<'_>, source_paths: &FxHashSet<PathBuf>) -> Self {
         let mut index = Self::default();
         for source in gcx.sources.iter() {
-            if source.file.name.as_real().is_none() {
+            let Some(source_path) = source.file.name.as_real() else { continue };
+            if !source_paths.contains(source_path) {
                 continue;
             }
             let Some(ast) = &source.ast else { continue };
@@ -36,120 +41,49 @@ impl DocumentLinkIndex {
                 let Some(target) = gcx.sources.get(target_source_id) else { continue };
                 let Some(target_path) = target.file.name.as_real() else { continue };
                 let Ok(target_uri) = Url::from_file_path(target_path) else { continue };
-                index.insert(location.uri, location.range, target_uri);
+                index.push(
+                    location.uri,
+                    StoredDocumentLink { range: location.range, target: target_uri },
+                );
             }
         }
+        index.sort();
         index
     }
 
-    fn insert(&mut self, source: Url, range: Range, target: Url) {
-        let links = self.by_file.entry(source).or_default();
-        merge_target(links, range, LinkTarget::Resolved(target));
+    fn push(&mut self, source: Url, link: StoredDocumentLink) {
+        self.by_file.entry(source).or_default().push(link);
     }
 
     #[cfg(test)]
     pub(crate) fn insert_for_test(&mut self, source: Url, range: Range, target: Url) {
-        self.insert(source, range, target);
+        self.push(source, StoredDocumentLink { range, target });
     }
 
     pub(crate) fn extend(&mut self, other: Self) {
-        for (source, links) in other.by_file {
-            let destination = self.by_file.entry(source).or_default();
-            for (range, target) in links {
-                merge_target(destination, range, target);
-            }
-        }
+        debug_assert!(other.by_file.keys().all(|uri| !self.by_file.contains_key(uri)));
+        self.by_file.extend(other.by_file);
     }
 
     pub(crate) fn links(&self, uri: &Url) -> Vec<DocumentLink> {
         let Some(links) = self.by_file.get(uri) else { return Vec::new() };
-        let mut links = links
-            .iter()
-            .filter_map(|(&range, target)| {
-                let LinkTarget::Resolved(target) = target else { return None };
-                Some(DocumentLink {
-                    range,
-                    target: Some(target.clone()),
-                    tooltip: None,
-                    data: None,
-                })
-            })
-            .collect::<Vec<_>>();
-        links.sort_by_key(|link| {
-            (
-                link.range.start.line,
-                link.range.start.character,
-                link.range.end.line,
-                link.range.end.character,
-            )
-        });
-        links
+        links.iter().map(StoredDocumentLink::to_lsp).collect()
     }
-}
 
-fn merge_target(links: &mut FxHashMap<Range, LinkTarget>, range: Range, target: LinkTarget) {
-    match links.get_mut(&range) {
-        None => {
-            links.insert(range, target);
+    fn sort(&mut self) {
+        for links in self.by_file.values_mut() {
+            links.sort_unstable_by_key(|link| (link.range.start, link.range.end));
         }
-        Some(existing) if *existing == target => {}
-        Some(existing) => *existing = LinkTarget::Ambiguous,
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use lsp_types::{DocumentLink, Position, Range, Url};
-
-    #[test]
-    fn identical_links_are_deduplicated() {
-        let source = uri("file:///workspace/src/Main.sol");
-        let target = uri("file:///workspace/src/Dependency.sol");
-        let range = Range::new(Position::new(1, 8), Position::new(1, 24));
-        let mut index = DocumentLinkIndex::default();
-
-        index.insert(source.clone(), range, target.clone());
-        index.insert(source.clone(), range, target.clone());
-
-        assert_eq!(index.links(&source), vec![link(range, target)]);
-    }
-
-    #[test]
-    fn conflicting_targets_are_omitted() {
-        let source = uri("file:///workspace/src/Main.sol");
-        let range = Range::new(Position::new(1, 8), Position::new(1, 24));
-        let mut index = DocumentLinkIndex::default();
-
-        index.insert(source.clone(), range, uri("file:///workspace-a/src/Dependency.sol"));
-        index.insert(source.clone(), range, uri("file:///workspace-b/src/Dependency.sol"));
-
-        assert!(index.links(&source).is_empty());
-    }
-
-    #[test]
-    fn extending_deduplicates_equal_links_and_omits_conflicts() {
-        let source = uri("file:///workspace/src/Main.sol");
-        let first_range = Range::new(Position::new(1, 8), Position::new(1, 24));
-        let second_range = Range::new(Position::new(2, 8), Position::new(2, 24));
-        let shared_target = uri("file:///workspace/src/Shared.sol");
-        let mut index = DocumentLinkIndex::default();
-        index.insert(source.clone(), first_range, shared_target.clone());
-        index.insert(source.clone(), second_range, uri("file:///workspace-a/src/Dependency.sol"));
-        let mut other = DocumentLinkIndex::default();
-        other.insert(source.clone(), first_range, shared_target.clone());
-        other.insert(source.clone(), second_range, uri("file:///workspace-b/src/Dependency.sol"));
-
-        index.extend(other);
-
-        assert_eq!(index.links(&source), vec![link(first_range, shared_target)]);
-    }
-
-    fn uri(value: &str) -> Url {
-        Url::parse(value).unwrap()
-    }
-
-    fn link(range: Range, target: Url) -> DocumentLink {
-        DocumentLink { range, target: Some(target), tooltip: None, data: None }
+impl StoredDocumentLink {
+    fn to_lsp(&self) -> DocumentLink {
+        DocumentLink {
+            range: self.range,
+            target: Some(self.target.clone()),
+            tooltip: None,
+            data: None,
+        }
     }
 }

--- a/crates/lsp/src/document_links.rs
+++ b/crates/lsp/src/document_links.rs
@@ -1,0 +1,155 @@
+use lsp_types::{DocumentLink, Range, Url};
+use solar_interface::{Span, data_structures::map::FxHashMap};
+use solar_sema::{Gcx, ast};
+
+use crate::proto;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct DocumentLinkIndex {
+    by_file: FxHashMap<Url, FxHashMap<Range, LinkTarget>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum LinkTarget {
+    Resolved(Url),
+    Ambiguous,
+}
+
+impl DocumentLinkIndex {
+    pub(crate) fn build(gcx: Gcx<'_>) -> Self {
+        let mut index = Self::default();
+        for source in gcx.sources.iter() {
+            if source.file.name.as_real().is_none() {
+                continue;
+            }
+            let Some(ast) = &source.ast else { continue };
+            for &(item_id, target_source_id) in &source.imports {
+                let ast::ItemKind::Import(import) = &ast.items[item_id].kind else { continue };
+                let span = import.path.span;
+                if span.hi().to_u32().saturating_sub(span.lo().to_u32()) < 2 {
+                    continue;
+                }
+                let span = Span::new(span.lo() + 1, span.hi() - 1);
+                let Some(location) = proto::span_to_location(gcx.sess.source_map(), span) else {
+                    continue;
+                };
+                let Some(target) = gcx.sources.get(target_source_id) else { continue };
+                let Some(target_path) = target.file.name.as_real() else { continue };
+                let Ok(target_uri) = Url::from_file_path(target_path) else { continue };
+                index.insert(location.uri, location.range, target_uri);
+            }
+        }
+        index
+    }
+
+    fn insert(&mut self, source: Url, range: Range, target: Url) {
+        let links = self.by_file.entry(source).or_default();
+        merge_target(links, range, LinkTarget::Resolved(target));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_for_test(&mut self, source: Url, range: Range, target: Url) {
+        self.insert(source, range, target);
+    }
+
+    pub(crate) fn extend(&mut self, other: Self) {
+        for (source, links) in other.by_file {
+            let destination = self.by_file.entry(source).or_default();
+            for (range, target) in links {
+                merge_target(destination, range, target);
+            }
+        }
+    }
+
+    pub(crate) fn links(&self, uri: &Url) -> Vec<DocumentLink> {
+        let Some(links) = self.by_file.get(uri) else { return Vec::new() };
+        let mut links = links
+            .iter()
+            .filter_map(|(&range, target)| {
+                let LinkTarget::Resolved(target) = target else { return None };
+                Some(DocumentLink {
+                    range,
+                    target: Some(target.clone()),
+                    tooltip: None,
+                    data: None,
+                })
+            })
+            .collect::<Vec<_>>();
+        links.sort_by_key(|link| {
+            (
+                link.range.start.line,
+                link.range.start.character,
+                link.range.end.line,
+                link.range.end.character,
+            )
+        });
+        links
+    }
+}
+
+fn merge_target(links: &mut FxHashMap<Range, LinkTarget>, range: Range, target: LinkTarget) {
+    match links.get_mut(&range) {
+        None => {
+            links.insert(range, target);
+        }
+        Some(existing) if *existing == target => {}
+        Some(existing) => *existing = LinkTarget::Ambiguous,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::{DocumentLink, Position, Range, Url};
+
+    #[test]
+    fn identical_links_are_deduplicated() {
+        let source = uri("file:///workspace/src/Main.sol");
+        let target = uri("file:///workspace/src/Dependency.sol");
+        let range = Range::new(Position::new(1, 8), Position::new(1, 24));
+        let mut index = DocumentLinkIndex::default();
+
+        index.insert(source.clone(), range, target.clone());
+        index.insert(source.clone(), range, target.clone());
+
+        assert_eq!(index.links(&source), vec![link(range, target)]);
+    }
+
+    #[test]
+    fn conflicting_targets_are_omitted() {
+        let source = uri("file:///workspace/src/Main.sol");
+        let range = Range::new(Position::new(1, 8), Position::new(1, 24));
+        let mut index = DocumentLinkIndex::default();
+
+        index.insert(source.clone(), range, uri("file:///workspace-a/src/Dependency.sol"));
+        index.insert(source.clone(), range, uri("file:///workspace-b/src/Dependency.sol"));
+
+        assert!(index.links(&source).is_empty());
+    }
+
+    #[test]
+    fn extending_deduplicates_equal_links_and_omits_conflicts() {
+        let source = uri("file:///workspace/src/Main.sol");
+        let first_range = Range::new(Position::new(1, 8), Position::new(1, 24));
+        let second_range = Range::new(Position::new(2, 8), Position::new(2, 24));
+        let shared_target = uri("file:///workspace/src/Shared.sol");
+        let mut index = DocumentLinkIndex::default();
+        index.insert(source.clone(), first_range, shared_target.clone());
+        index.insert(source.clone(), second_range, uri("file:///workspace-a/src/Dependency.sol"));
+        let mut other = DocumentLinkIndex::default();
+        other.insert(source.clone(), first_range, shared_target.clone());
+        other.insert(source.clone(), second_range, uri("file:///workspace-b/src/Dependency.sol"));
+
+        index.extend(other);
+
+        assert_eq!(index.links(&source), vec![link(first_range, shared_target)]);
+    }
+
+    fn uri(value: &str) -> Url {
+        Url::parse(value).unwrap()
+    }
+
+    fn link(range: Range, target: Url) -> DocumentLink {
+        DocumentLink { range, target: Some(target), tooltip: None, data: None }
+    }
+}

--- a/crates/lsp/src/document_links.rs
+++ b/crates/lsp/src/document_links.rs
@@ -1,8 +1,5 @@
 use lsp_types::{DocumentLink, Range, Url};
-use solar_interface::{
-    Span,
-    data_structures::map::{FxHashMap, FxHashSet},
-};
+use solar_interface::data_structures::map::{FxHashMap, FxHashSet};
 use solar_sema::{Gcx, ast};
 use std::path::{Path, PathBuf};
 
@@ -31,12 +28,9 @@ impl DocumentLinkIndex {
             let Some(ast) = &source.ast else { continue };
             for &(item_id, target_source_id) in &source.imports {
                 let ast::ItemKind::Import(import) = &ast.items[item_id].kind else { continue };
-                let span = import.path.span;
-                if span.hi().to_u32().saturating_sub(span.lo().to_u32()) < 2 {
-                    continue;
-                }
-                let span = Span::new(span.lo() + 1, span.hi() - 1);
-                let Some(location) = proto::span_to_location(gcx.sess.source_map(), span) else {
+                let Some(location) =
+                    proto::span_to_location(gcx.sess.source_map(), import.path.span)
+                else {
                     continue;
                 };
                 let Some(target) = gcx.sources.get(target_source_id) else { continue };

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -418,6 +418,8 @@ impl AnalysisBatch {
 
 fn analyze(batch: AnalysisBatch) -> AnalysisResult {
     let (emitter, diag_buffer) = InMemoryEmitter::new();
+    let document_link_sources =
+        batch.files.iter().map(|(path, _)| path.clone()).collect::<FxHashSet<_>>();
     let mut opts = batch.opts;
     opts.unstable.recover_incomplete_input = true;
     let sess = Session::builder().opts(opts).dcx(DiagCtxt::new(Box::new(emitter))).build();
@@ -453,7 +455,7 @@ fn analyze(batch: AnalysisBatch) -> AnalysisResult {
             }
         }
 
-        let symbol_tables = SymbolTables::build(compiler.gcx());
+        let symbol_tables = SymbolTables::build(compiler.gcx(), &document_link_sources);
         let diagnostics = diag_buffer
             .read()
             .iter()

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -34,13 +34,17 @@ use std::{
         atomic::{AtomicUsize, Ordering},
     },
 };
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::{
+    sync::{oneshot, watch},
+    task::JoinHandle,
+};
 
 pub(crate) struct GlobalState {
     client: ClientSocket,
     pub(crate) vfs: Arc<RwLock<Vfs>>,
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
+    published_analysis_version: watch::Sender<usize>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     flycheck_cancels: FxHashMap<DiagnosticOwner, oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
@@ -49,10 +53,12 @@ pub(crate) struct GlobalState {
 
 impl GlobalState {
     pub(crate) fn new(client: ClientSocket) -> Self {
+        let (published_analysis_version, _) = watch::channel(0);
         Self {
             client,
             vfs: Arc::new(Default::default()),
             analysis_version: Arc::new(AtomicUsize::new(0)),
+            published_analysis_version,
             flycheck_versions: Arc::new(Default::default()),
             flycheck_cancels: FxHashMap::default(),
             symbol_tables: Arc::new(Default::default()),
@@ -149,11 +155,16 @@ impl GlobalState {
                 }
             }
 
-            if snapshot.is_current(version) {
-                snapshot.set_symbol_tables(symbol_tables);
+            if snapshot.publish_symbol_tables(version, symbol_tables) {
                 snapshot.publish_diagnostics(DiagnosticOwner::Compiler, diagnostics);
             }
         });
+    }
+
+    pub(crate) fn current_analysis(&self) -> (usize, watch::Receiver<usize>) {
+        let published = self.published_analysis_version.subscribe();
+        let version = self.analysis_version.load(Ordering::Acquire);
+        (version, published)
     }
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
@@ -249,6 +260,7 @@ impl GlobalState {
             vfs: self.vfs.clone(),
             config: self.config.clone(),
             analysis_version: self.analysis_version.clone(),
+            published_analysis_version: self.published_analysis_version.clone(),
             flycheck_versions: self.flycheck_versions.clone(),
             symbol_tables: self.symbol_tables.clone(),
             diagnostics: self.diagnostics.clone(),
@@ -302,6 +314,7 @@ pub(crate) struct GlobalStateSnapshot {
     vfs: Arc<RwLock<Vfs>>,
     config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
+    published_analysis_version: watch::Sender<usize>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     symbol_tables: Arc<RwLock<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
@@ -375,8 +388,17 @@ impl GlobalStateSnapshot {
         batches
     }
 
-    fn set_symbol_tables(&mut self, symbol_tables: SymbolTables) {
-        *self.symbol_tables.write() = symbol_tables;
+    fn publish_symbol_tables(&mut self, version: usize, symbol_tables: SymbolTables) -> bool {
+        // Serialize the version check, table swap, and notification so stale tasks cannot publish
+        // last.
+        let mut current_tables = self.symbol_tables.write();
+        if !self.is_current(version) {
+            return false;
+        }
+
+        *current_tables = symbol_tables;
+        self.published_analysis_version.send_replace(version);
+        true
     }
 
     fn analysis_workspaces(&self) -> Cow<'_, [crate::workspace::Workspace]> {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -7,12 +7,12 @@ use crate::{
 use async_lsp::{ErrorCode, ResponseError};
 use crop::Rope;
 use lsp_types::{
-    CompletionParams, CompletionResponse, DocumentChanges, DocumentFormattingParams,
-    DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams, GotoDefinitionResponse,
-    InlayHint, InlayHintParams, OneOf, OptionalVersionedTextDocumentIdentifier, Position,
-    PrepareRenameResponse, ReferenceParams, RenameParams, SignatureHelp, SignatureHelpParams,
-    TextDocumentEdit, TextDocumentPositionParams, TextEdit, Url, WorkspaceEdit,
-    WorkspaceSymbolParams, WorkspaceSymbolResponse,
+    CompletionParams, CompletionResponse, DocumentChanges, DocumentFormattingParams, DocumentLink,
+    DocumentLinkParams, DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams,
+    GotoDefinitionResponse, InlayHint, InlayHintParams, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Position, PrepareRenameResponse, ReferenceParams,
+    RenameParams, SignatureHelp, SignatureHelpParams, TextDocumentEdit, TextDocumentPositionParams,
+    TextEdit, Url, WorkspaceEdit, WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
 use solar_interface::{Symbol, data_structures::sync::RwLock, enter, source_map::SourceMap};
 use solar_parse::lexer::is_ident;
@@ -165,6 +165,14 @@ pub(crate) fn document_symbol(
         DocumentSymbolResponse::Flat(symbol_tables.flat_document_symbols(&params.text_document.uri))
     };
     ready(Ok(Some(response)))
+}
+
+pub(crate) fn document_links(
+    state: &mut GlobalState,
+    params: DocumentLinkParams,
+) -> impl Future<Output = Result<Option<Vec<DocumentLink>>, ResponseError>> + use<> {
+    let links = state.symbol_tables.read().document_links(&params.text_document.uri);
+    ready(Ok(Some(links)))
 }
 
 pub(crate) fn workspace_symbol(

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -171,8 +171,17 @@ pub(crate) fn document_links(
     state: &mut GlobalState,
     params: DocumentLinkParams,
 ) -> impl Future<Output = Result<Option<Vec<DocumentLink>>, ResponseError>> + use<> {
-    let links = state.symbol_tables.read().document_links(&params.text_document.uri);
-    ready(Ok(Some(links)))
+    let symbol_tables = state.symbol_tables.clone();
+    let (version, mut published) = state.current_analysis();
+    let uri = params.text_document.uri;
+    async move {
+        published
+            .wait_for(|published| *published >= version)
+            .await
+            .map_err(|_| request_failed("analysis was cancelled"))?;
+        let links = symbol_tables.read().document_links(&uri);
+        Ok(Some(links))
+    }
 }
 
 pub(crate) fn workspace_symbol(

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -173,13 +173,14 @@ pub(crate) fn document_links(
 ) -> impl Future<Output = Result<Option<Vec<DocumentLink>>, ResponseError>> + use<> {
     let symbol_tables = state.symbol_tables.clone();
     let (version, mut published) = state.current_analysis();
-    let uri = params.text_document.uri;
+    let path = params.text_document.uri.to_file_path().ok();
     async move {
         published
             .wait_for(|published| *published >= version)
             .await
             .map_err(|_| request_failed("analysis was cancelled"))?;
-        let links = symbol_tables.read().document_links(&uri);
+        let links =
+            path.as_ref().map_or_else(Vec::new, |path| symbol_tables.read().document_links(path));
         Ok(Some(links))
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -18,6 +18,7 @@ use tower::ServiceBuilder;
 
 mod config;
 mod diagnostics;
+mod document_links;
 mod flycheck;
 mod formatter;
 mod global_state;
@@ -51,6 +52,7 @@ fn new_router(client: ClientSocket) -> Router<GlobalState> {
     // Requests
     router
         .request::<req::DocumentSymbolRequest, _>(handlers::document_symbol)
+        .request::<req::DocumentLinkRequest, _>(handlers::document_links)
         .request::<req::WorkspaceSymbolRequest, _>(handlers::workspace_symbol)
         .request::<req::GotoDefinition, _>(handlers::goto_definition)
         .request::<req::GotoDeclaration, _>(handlers::goto_declaration)
@@ -113,11 +115,11 @@ mod tests {
     use async_lsp::{AnyNotification, AnyRequest, LanguageServer, LspService, router::Router};
     use lsp_types::{
         DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
-        DidSaveTextDocumentParams, DocumentFormattingParams, FileChangeType, FileEvent,
-        FormattingOptions, InitializeParams, InitializedParams, Position, SignatureHelpParams,
-        TextDocumentIdentifier, TextDocumentPositionParams, WorkDoneProgressParams,
-        WorkspaceClientCapabilities, notification as notif, notification::Notification, request,
-        request::Request,
+        DidSaveTextDocumentParams, DocumentFormattingParams, DocumentLinkParams, FileChangeType,
+        FileEvent, FormattingOptions, InitializeParams, InitializedParams, PartialResultParams,
+        Position, SignatureHelpParams, TextDocumentIdentifier, TextDocumentPositionParams,
+        WorkDoneProgressParams, WorkspaceClientCapabilities, notification as notif,
+        notification::Notification, request, request::Request,
     };
     use std::ops::ControlFlow;
     use tokio::sync::oneshot;
@@ -158,6 +160,28 @@ mod tests {
         .unwrap();
 
         assert!(matches!(router.notify(notification), ControlFlow::Continue(())));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_document_link_requests() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let params = DocumentLinkParams {
+            text_document: TextDocumentIdentifier {
+                uri: lsp_types::Url::parse("file:///workspace/src/Test.sol").unwrap(),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
+            "id": 1,
+            "method": request::DocumentLinkRequest::METHOD,
+            "params": params,
+        }))
+        .unwrap();
+
+        let response = router.call(request).await.unwrap();
+
+        assert_eq!(response, serde_json::json!([]));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -23,6 +23,7 @@ use solar_sema::{
 use std::ops::ControlFlow;
 
 use crate::{
+    document_links::DocumentLinkIndex,
     inlay_hints::InlayHintIndex,
     proto,
     rename::{
@@ -48,6 +49,7 @@ pub(crate) struct SymbolTables {
     file_references: FxHashMap<Url, Vec<usize>>,
     symbol_references: FxHashMap<SymbolId, Vec<Location>>,
     rename: RenameIndex,
+    document_links: DocumentLinkIndex,
     inlay_hints: InlayHintIndex,
     signature_help: SignatureHelpIndex,
 }
@@ -242,6 +244,7 @@ impl SymbolTables {
         tables.build_receiver_member_completions(gcx);
         tables.build_member_completions(gcx);
         tables.build_references(gcx, &item_symbols);
+        tables.document_links = DocumentLinkIndex::build(gcx);
         tables.inlay_hints = InlayHintIndex::build(gcx);
         tables.signature_help = SignatureHelpIndex::build(gcx);
         tables.rebuild_indexes();
@@ -271,6 +274,7 @@ impl SymbolTables {
         if self.builtin_member_completions.is_empty() {
             self.builtin_member_completions = std::mem::take(&mut other.builtin_member_completions);
         }
+        self.document_links.extend(other.document_links);
         self.inlay_hints.extend(other.inlay_hints);
         self.signature_help.extend(other.signature_help);
 
@@ -317,6 +321,10 @@ impl SymbolTables {
 
     pub(crate) fn inlay_hints(&self, uri: &Url, range: Range) -> Vec<InlayHint> {
         self.inlay_hints.hints(uri, range)
+    }
+
+    pub(crate) fn document_links(&self, uri: &Url) -> Vec<lsp_types::DocumentLink> {
+        self.document_links.links(uri)
     }
 
     pub(crate) fn signature_help(
@@ -1971,6 +1979,23 @@ mod tests {
                 ("Lib", SymbolKind::MODULE)
             ]
         );
+    }
+
+    #[test]
+    fn extend_preserves_document_links_without_declarations() {
+        let source = parse_uri("file:///workspace/src/Imports.sol");
+        let target = parse_uri("file:///workspace/src/Dependency.sol");
+        let link_range = range(0, 8, 0, 24);
+        let mut tables = SymbolTables::default();
+        let mut other = SymbolTables::default();
+        other.document_links.insert_for_test(source.clone(), link_range, target.clone());
+
+        tables.extend(other);
+
+        let links = tables.document_links(&source);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].range, link_range);
+        assert_eq!(links[0].target, Some(target));
     }
 
     fn sample_tables(uri: &Url, other_uri: &Url) -> SymbolTables {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -20,7 +20,7 @@ use solar_sema::{
     },
     ty::{CallableParamSource, MemberCompletion, ResolvedMember, Ty, TyKind},
 };
-use std::ops::ControlFlow;
+use std::{ops::ControlFlow, path::PathBuf};
 
 use crate::{
     document_links::DocumentLinkIndex,
@@ -139,7 +139,9 @@ impl SymbolTables {
     ///
     /// The compiler's resolver data is scoped to one analysis run. This table copies out the
     /// source-level declarations that LSP requests can query after that run has finished.
-    pub(crate) fn build(gcx: Gcx<'_>) -> Self {
+    /// `document_link_sources` restricts link sources to files owned by this analysis batch;
+    /// every other table still includes transitive dependencies.
+    pub(crate) fn build(gcx: Gcx<'_>, document_link_sources: &FxHashSet<PathBuf>) -> Self {
         let mut tables = Self::default();
         tables.rename.record_source_contents(gcx);
         tables.build_builtin_completions();
@@ -244,7 +246,7 @@ impl SymbolTables {
         tables.build_receiver_member_completions(gcx);
         tables.build_member_completions(gcx);
         tables.build_references(gcx, &item_symbols);
-        tables.document_links = DocumentLinkIndex::build(gcx);
+        tables.document_links = DocumentLinkIndex::build(gcx, document_link_sources);
         tables.inlay_hints = InlayHintIndex::build(gcx);
         tables.signature_help = SignatureHelpIndex::build(gcx);
         tables.rebuild_indexes();

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -20,7 +20,10 @@ use solar_sema::{
     },
     ty::{CallableParamSource, MemberCompletion, ResolvedMember, Ty, TyKind},
 };
-use std::{ops::ControlFlow, path::PathBuf};
+use std::{
+    ops::ControlFlow,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     document_links::DocumentLinkIndex,
@@ -325,8 +328,8 @@ impl SymbolTables {
         self.inlay_hints.hints(uri, range)
     }
 
-    pub(crate) fn document_links(&self, uri: &Url) -> Vec<lsp_types::DocumentLink> {
-        self.document_links.links(uri)
+    pub(crate) fn document_links(&self, path: &Path) -> Vec<lsp_types::DocumentLink> {
+        self.document_links.links(path)
     }
 
     pub(crate) fn signature_help(
@@ -1985,16 +1988,16 @@ mod tests {
 
     #[test]
     fn extend_preserves_document_links_without_declarations() {
-        let source = parse_uri("file:///workspace/src/Imports.sol");
+        let source_path = PathBuf::from("/workspace/src/Imports.sol");
         let target = parse_uri("file:///workspace/src/Dependency.sol");
         let link_range = range(0, 8, 0, 24);
         let mut tables = SymbolTables::default();
         let mut other = SymbolTables::default();
-        other.document_links.insert_for_test(source.clone(), link_range, target.clone());
+        other.document_links.insert_for_test(source_path.clone(), link_range, target.clone());
 
         tables.extend(other);
 
-        let links = tables.document_links(&source);
+        let links = tables.document_links(&source_path);
         assert_eq!(links.len(), 1);
         assert_eq!(links[0].range, link_range);
         assert_eq!(links[0].target, Some(target));

--- a/crates/lsp/src/tests/document_link.rs
+++ b/crates/lsp/src/tests/document_link.rs
@@ -1,4 +1,6 @@
-use super::support::RequestFixture;
+use super::{SymbolTables, analyze, snapshot_with_config, support::RequestFixture};
+use crate::test_support::TestProject;
+use lsp_types::{Position, Range, Url};
 use snapbox::str;
 
 #[test]
@@ -53,5 +55,63 @@ fn returns_only_successfully_resolved_imports() {
 0:8..0:19 -> /Valid.sol
 
 "#]],
+    );
+}
+
+#[test]
+fn overlapping_workspaces_prefer_vfs_document_links() {
+    let mut project = TestProject::from_fixture(
+        r#"
+        //- /Root.sol open
+        import "./nested/A.sol";
+
+        //- /nested/A.sol
+        import "./Disk.sol";
+        import "./Old.sol";
+
+        //- /nested/Disk.sol
+        contract Disk {}
+
+        //- /nested/Old.sol
+        contract Old {}
+
+        //- /nested/OverlayLonger.sol
+        contract OverlayLonger {}
+
+        //- /nested/New.sol
+        contract New {}
+        "#,
+    );
+    project.open_file("/nested/A.sol", "import \"./OverlayLonger.sol\";\nimport \"./New.sol\";");
+
+    let config = project.config_with_roots(&["/", "/nested"]);
+    let snapshot = snapshot_with_config(config, project.vfs());
+    let mut tables = SymbolTables::default();
+
+    for batch in snapshot.analysis_batches(Vec::new()) {
+        if !batch.files.is_empty() {
+            tables.extend(analyze(batch).symbol_tables);
+        }
+    }
+
+    let uri = Url::from_file_path(project.path("/nested/A.sol")).unwrap();
+    let links = tables
+        .document_links(&uri)
+        .into_iter()
+        .map(|link| (link.range, link.target.unwrap()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        links,
+        [
+            (
+                Range::new(Position::new(0, 8), Position::new(0, 27)),
+                Url::from_file_path(project.path("/nested/OverlayLonger.sol")).unwrap(),
+            ),
+            (
+                Range::new(Position::new(1, 8), Position::new(1, 17)),
+                Url::from_file_path(project.path("/nested/New.sol")).unwrap(),
+            ),
+        ]
     );
 }

--- a/crates/lsp/src/tests/document_link.rs
+++ b/crates/lsp/src/tests/document_link.rs
@@ -1,7 +1,21 @@
-use super::{SymbolTables, analyze, snapshot_with_config, support::RequestFixture};
+use super::{
+    AnalysisBatch, GlobalState, SymbolTables, analyze, snapshot_with_config,
+    support::RequestFixture,
+};
 use crate::test_support::TestProject;
-use lsp_types::{Position, Range, Url};
+use async_lsp::ClientSocket;
+use lsp_types::{
+    DocumentLinkParams, PartialResultParams, Position, Range, TextDocumentIdentifier, Url,
+    WorkDoneProgressParams,
+};
 use snapbox::str;
+use solar_config::CompileOpts;
+use solar_interface::data_structures::map::FxHashSet;
+use std::{
+    future::Future,
+    sync::atomic::Ordering,
+    task::{Context, Waker},
+};
 
 #[test]
 fn all_import_forms_use_content_only_utf16_ranges() {
@@ -114,4 +128,59 @@ fn overlapping_workspaces_prefer_vfs_document_links() {
             ),
         ]
     );
+}
+
+#[test]
+fn waits_for_current_analysis_before_returning_document_links() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Imports.sol
+        import "./Old.sol";
+
+        //- /Old.sol
+        contract Old {}
+
+        //- /New.sol
+        contract New {}
+        "#,
+    );
+    let path = project.path("/Imports.sol");
+    let old_tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(path.clone(), project.read_file("/Imports.sol"))],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let new_tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(path.clone(), "import \"./New.sol\";".into())],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let params = DocumentLinkParams {
+        text_document: TextDocumentIdentifier::new(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    *state.symbol_tables.write() = old_tables;
+    state.analysis_version.fetch_add(1, Ordering::AcqRel);
+
+    let mut request = std::pin::pin!(crate::handlers::document_links(&mut state, params));
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+
+    assert!(request.as_mut().poll(&mut context).is_pending());
+
+    state.analysis_version.fetch_add(1, Ordering::AcqRel);
+    let mut snapshot = state.snapshot();
+    assert!(snapshot.publish_symbol_tables(2, new_tables));
+    assert!(!snapshot.publish_symbol_tables(1, SymbolTables::default()));
+    let std::task::Poll::Ready(response) = request.as_mut().poll(&mut context) else {
+        panic!("document-link request should complete after analysis is published");
+    };
+    let links = response.unwrap().unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].target, Some(Url::from_file_path(project.path("/New.sol")).unwrap()));
 }

--- a/crates/lsp/src/tests/document_link.rs
+++ b/crates/lsp/src/tests/document_link.rs
@@ -73,6 +73,50 @@ fn returns_only_successfully_resolved_imports() {
 }
 
 #[test]
+fn equivalent_percent_encoded_uri_returns_document_links() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Imports.sol
+        import "./Target.sol";
+
+        //- /Target.sol
+        contract Target {}
+        "#,
+    );
+    let path = project.path("/Imports.sol");
+    let tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(path.clone(), project.read_file("/Imports.sol"))],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let canonical_uri = Url::from_file_path(&path).unwrap();
+    let encoded_uri =
+        Url::parse(&canonical_uri.as_str().replacen("Imports.sol", "%49mports.sol", 1)).unwrap();
+
+    assert_ne!(canonical_uri, encoded_uri);
+    assert_eq!(canonical_uri.to_file_path(), encoded_uri.to_file_path());
+
+    let params = DocumentLinkParams {
+        text_document: TextDocumentIdentifier::new(encoded_uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    *state.symbol_tables.write() = tables;
+    let mut request = std::pin::pin!(crate::handlers::document_links(&mut state, params));
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    let std::task::Poll::Ready(response) = request.as_mut().poll(&mut context) else {
+        panic!("document-link request should be ready");
+    };
+
+    let links = response.unwrap().unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].target, Some(Url::from_file_path(project.path("/Target.sol")).unwrap()));
+}
+
+#[test]
 fn overlapping_workspaces_prefer_vfs_document_links() {
     let mut project = TestProject::from_fixture(
         r#"
@@ -108,9 +152,9 @@ fn overlapping_workspaces_prefer_vfs_document_links() {
         }
     }
 
-    let uri = Url::from_file_path(project.path("/nested/A.sol")).unwrap();
+    let path = project.path("/nested/A.sol");
     let links = tables
-        .document_links(&uri)
+        .document_links(&path)
         .into_iter()
         .map(|link| (link.range, link.target.unwrap()))
         .collect::<Vec<_>>();

--- a/crates/lsp/src/tests/document_link.rs
+++ b/crates/lsp/src/tests/document_link.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 #[test]
-fn all_import_forms_use_content_only_utf16_ranges() {
+fn all_import_forms_use_full_literal_utf16_ranges() {
     let fixture = RequestFixture::new(
         r#"
         //- /Imports.sol
@@ -41,9 +41,9 @@ fn all_import_forms_use_content_only_utf16_ranges() {
     fixture.check_document_links(
         "/Imports.sol",
         str![[r#"
-0:17..0:28 -> /Plain.sol
-1:23..1:33 -> /Glob.sol
-2:30..2:41 -> /Named.sol
+0:16..0:29 -> /Plain.sol
+1:22..1:34 -> /Glob.sol
+2:29..2:42 -> /Named.sol
 
 "#]],
     );
@@ -66,7 +66,7 @@ fn returns_only_successfully_resolved_imports() {
     fixture.check_document_links(
         "/Imports.sol",
         str![[r#"
-0:8..0:19 -> /Valid.sol
+0:7..0:20 -> /Valid.sol
 
 "#]],
     );
@@ -163,11 +163,11 @@ fn overlapping_workspaces_prefer_vfs_document_links() {
         links,
         [
             (
-                Range::new(Position::new(0, 8), Position::new(0, 27)),
+                Range::new(Position::new(0, 7), Position::new(0, 28)),
                 Url::from_file_path(project.path("/nested/OverlayLonger.sol")).unwrap(),
             ),
             (
-                Range::new(Position::new(1, 8), Position::new(1, 17)),
+                Range::new(Position::new(1, 7), Position::new(1, 18)),
                 Url::from_file_path(project.path("/nested/New.sol")).unwrap(),
             ),
         ]

--- a/crates/lsp/src/tests/document_link.rs
+++ b/crates/lsp/src/tests/document_link.rs
@@ -1,0 +1,57 @@
+use super::support::RequestFixture;
+use snapbox::str;
+
+#[test]
+fn all_import_forms_use_content_only_utf16_ranges() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Imports.sol
+        /* 😀 */ import "./Plain.sol";
+        import * as Glob from "./Glob.sol";
+        import {Named as Alias} from "./Named.sol";
+
+        //- /Plain.sol
+        contract Plain {}
+
+        //- /Glob.sol
+        contract Glob {}
+
+        //- /Named.sol
+        contract Named {}
+        "#,
+        "/Imports.sol",
+    );
+
+    fixture.check_document_links(
+        "/Imports.sol",
+        str![[r#"
+0:17..0:28 -> /Plain.sol
+1:23..1:33 -> /Glob.sol
+2:30..2:41 -> /Named.sol
+
+"#]],
+    );
+}
+
+#[test]
+fn returns_only_successfully_resolved_imports() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Imports.sol
+        import "./Valid.sol";
+        import "./Missing.sol";
+
+        //- /Valid.sol
+        contract Valid {}
+        "#,
+        "/Imports.sol",
+    );
+
+    fixture.check_document_links(
+        "/Imports.sol",
+        str![[r#"
+0:8..0:19 -> /Valid.sol
+
+"#]],
+    );
+}

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -309,8 +309,8 @@ fn document_links_use_vfs_overlay() {
     let result = analyze(batches.pop().unwrap());
 
     assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
-    let uri = Url::from_file_path(project.path("/src/A.sol")).unwrap();
-    let links = result.symbol_tables.document_links(&uri);
+    let path = project.path("/src/A.sol");
+    let links = result.symbol_tables.document_links(&path);
     assert_eq!(links.len(), 1);
     assert_eq!(links[0].target, Some(Url::from_file_path(project.path("/src/New.sol")).unwrap()));
 }
@@ -400,8 +400,8 @@ fn analysis_uses_workspace_remappings_for_import_resolution() {
     let result = analyze(batches.pop().unwrap());
 
     assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
-    let uri = Url::from_file_path(project.path("/src/A.sol")).unwrap();
-    let links = result.symbol_tables.document_links(&uri);
+    let path = project.path("/src/A.sol");
+    let links = result.symbol_tables.document_links(&path);
     assert_eq!(links.len(), 1);
     assert_eq!(links[0].target, Some(Url::from_file_path(project.path("/lib/B.sol")).unwrap()));
 }

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -9,6 +9,7 @@ use lsp_types::{
 use std::{path::Path, time::Duration};
 
 mod completion;
+mod document_link;
 mod goto_definition;
 mod inlay_hint;
 mod references;
@@ -282,6 +283,37 @@ fn analysis_batches_scan_workspace_source_roots_and_apply_vfs_overlay() {
 }
 
 #[test]
+fn document_links_use_vfs_overlay() {
+    let mut project = TestProject::from_fixture(
+        r#"
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /src/A.sol
+        import "./Old.sol";
+
+        //- /src/Old.sol
+        contract Old {}
+
+        //- /src/New.sol
+        contract New {}
+        "#,
+    );
+    project.open_file("/src/A.sol", "import \"./New.sol\";");
+    let snapshot = snapshot(&project);
+
+    let mut batches = snapshot.analysis_batches(Vec::new());
+    let result = analyze(batches.pop().unwrap());
+
+    assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
+    let uri = Url::from_file_path(project.path("/src/A.sol")).unwrap();
+    let links = result.symbol_tables.document_links(&uri);
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].target, Some(Url::from_file_path(project.path("/src/New.sol")).unwrap()));
+}
+
+#[test]
 fn analysis_batches_use_cached_workspace_source_files() {
     let project = TestProject::from_fixture(
         r#"
@@ -366,6 +398,10 @@ fn analysis_uses_workspace_remappings_for_import_resolution() {
     let result = analyze(batches.pop().unwrap());
 
     assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
+    let uri = Url::from_file_path(project.path("/src/A.sol")).unwrap();
+    let links = result.symbol_tables.document_links(&uri);
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0].target, Some(Url::from_file_path(project.path("/lib/B.sol")).unwrap()));
 }
 
 #[test]

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -22,11 +22,13 @@ fn snapshot(project: &TestProject) -> GlobalStateSnapshot {
 }
 
 fn snapshot_with_config(config: Config, vfs: Vfs) -> GlobalStateSnapshot {
+    let (published_analysis_version, _) = watch::channel(1);
     GlobalStateSnapshot {
         client: ClientSocket::new_closed(),
         vfs: Arc::new(RwLock::new(vfs)),
         config: Arc::new(config),
         analysis_version: Arc::new(AtomicUsize::new(1)),
+        published_analysis_version,
         flycheck_versions: Arc::new(Default::default()),
         symbol_tables: Arc::new(Default::default()),
         diagnostics: Arc::new(Default::default()),

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -2,11 +2,12 @@ use super::super::{AnalysisBatch, AnalysisResult, GlobalState, analyze};
 use crate::test_support::MarkedProject;
 use async_lsp::{ClientSocket, ErrorCode};
 use lsp_types::{
-    CompletionItem, CompletionParams, CompletionResponse, Documentation, GotoDefinitionParams,
-    GotoDefinitionResponse, InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Location,
-    ParameterLabel, PartialResultParams, Position, PrepareRenameResponse, Range, ReferenceContext,
-    ReferenceParams, RenameParams, SignatureHelp, SignatureHelpParams, TextDocumentIdentifier,
-    TextDocumentPositionParams, Url, WorkDoneProgressParams, WorkspaceEdit,
+    CompletionItem, CompletionParams, CompletionResponse, DocumentLink, DocumentLinkParams,
+    Documentation, GotoDefinitionParams, GotoDefinitionResponse, InlayHint, InlayHintKind,
+    InlayHintLabel, InlayHintParams, Location, ParameterLabel, PartialResultParams, Position,
+    PrepareRenameResponse, Range, ReferenceContext, ReferenceParams, RenameParams, SignatureHelp,
+    SignatureHelpParams, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+    WorkDoneProgressParams, WorkspaceEdit,
 };
 use snapbox::{IntoData, assert_data_eq};
 use solar_config::CompileOpts;
@@ -190,6 +191,16 @@ impl RequestFixture {
         assert_data_eq!(inlay_hint_output(&self.inlay_hints(uri, full_range())), expected);
     }
 
+    pub(super) fn check_document_links(&self, path: &str, expected: impl IntoData) {
+        let mut state = self.state();
+        let uri = Url::from_file_path(self.marked.project().path(path)).unwrap();
+        let links =
+            expect_ready(crate::handlers::document_links(&mut state, document_link_params(uri)))
+                .unwrap()
+                .unwrap_or_default();
+        assert_data_eq!(self.document_links_output(links), expected);
+    }
+
     pub(super) fn check_signature_help(&self, marker: &str, expected: impl IntoData) {
         let mut state = self.state();
         let (uri, position) = self.marker_location(marker);
@@ -326,6 +337,24 @@ impl RequestFixture {
         let mut output = String::new();
         for location in locations {
             writeln!(output, "{}", self.location_output(location)).unwrap();
+        }
+        output
+    }
+
+    fn document_links_output(&self, links: Vec<DocumentLink>) -> String {
+        let mut output = String::new();
+        for link in links {
+            let target = link.target.unwrap().to_file_path().unwrap();
+            let target = display_path(self.marked.project().root(), &target);
+            writeln!(
+                output,
+                "{}:{}..{}:{} -> {target}",
+                link.range.start.line,
+                link.range.start.character,
+                link.range.end.line,
+                link.range.end.character,
+            )
+            .unwrap();
         }
         output
     }
@@ -533,6 +562,14 @@ fn inlay_hint_params(uri: Url, range: Range) -> InlayHintParams {
         text_document: TextDocumentIdentifier { uri },
         range,
         work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn document_link_params(uri: Url) -> DocumentLinkParams {
+    DocumentLinkParams {
+        text_document: TextDocumentIdentifier { uri },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
     }
 }
 


### PR DESCRIPTION
Add support for `textDocument/documentLink` so editors can navigate directly from Solidity import paths to their resolved source files.