### PR TITLE
fix(bench): clarify PR benchmark reports

### DIFF
--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -321,7 +321,9 @@ def memory_benchmark_rows(results: list[dict[str, Any]]) -> list[str]:
             *(fmt_bytes(values[compiler_id]) for compiler_id in ids),
         ]
         if "solar" in values and "solc" in values:
-            cells.append(fmt_pct_improvement(values["solar"], values["solc"]))
+            cells.append(
+                fmt_pct_change_lower_is_better(values["solar"], values["solc"])
+            )
         rows.append("| " + " | ".join(cells) + " |")
     return rows
 

--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -628,8 +628,7 @@ def main() -> int:
     should_comment = has_baseline_changes(
         micro_results, baseline_micro
     ) or has_baseline_changes(repo_results, baseline_repo)
-    markdown = format_report(report, should_comment, branch_is_behind_main()
-    )
+    markdown = format_report(report, should_comment, branch_is_behind_main())
     print(markdown)
     append_step_summary(markdown)
     append_github_output("should_comment", "true" if should_comment else "false")

--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -174,19 +174,6 @@ def fmt_int(value: int | None, suffix: str = "") -> str:
     return f"{value:,}{suffix}"
 
 
-def pct_improvement(current: int | None, baseline: int | None) -> float | None:
-    if current is None or baseline in (None, 0):
-        return None
-    return (baseline - current) / baseline * 100
-
-
-def fmt_pct_improvement(current: int | None, baseline: int | None) -> str:
-    delta = pct_improvement(current, baseline)
-    if delta is None:
-        return "n/a"
-    return fmt_pct(delta)
-
-
 def pct_change(current: int | None, baseline: int | None) -> float | None:
     if current is None or baseline in (None, 0):
         return None
@@ -235,13 +222,7 @@ def absolute_delta(current: int | None, baseline: int | None) -> str:
     return f"{delta:+,}"
 
 
-def fmt_value_with_delta(
-    value: int | None, current: int | None, baseline: int | None, suffix: str = ""
-) -> str:
-    return f"{fmt_int(value, suffix)} ({fmt_pct_improvement(current, baseline)})"
-
-
-def fmt_value_with_size_delta(
+def fmt_value_with_lower_is_better_delta(
     value: int | None, current: int | None, baseline: int | None, suffix: str = ""
 ) -> str:
     return f"{fmt_int(value, suffix)} ({fmt_pct_change_lower_is_better(current, baseline)})"
@@ -272,9 +253,13 @@ def benchmark_rows(
             + " | ".join(
                 [
                     markdown_cell(test_id),
-                    fmt_value_with_delta(solar_gas, solar_gas, base_solar_gas),
+                    fmt_value_with_lower_is_better_delta(
+                        solar_gas, solar_gas, base_solar_gas
+                    ),
                     fmt_value_with_delta_vs_current(solc_gas, solar_gas, solc_gas),
-                    fmt_value_with_size_delta(solar_size, solar_size, base_solar_size, "B"),
+                    fmt_value_with_lower_is_better_delta(
+                        solar_size, solar_size, base_solar_size, "B"
+                    ),
                     fmt_value_with_delta_vs_current(solc_size, solar_size, solc_size, "B"),
                 ]
             )
@@ -336,14 +321,44 @@ def append_github_output(name: str, value: str) -> None:
         f.write(f"{name}={value}\n")
 
 
-def format_report(markdown: str, has_changes: bool) -> str:
-    if has_changes:
+def branch_is_behind_main() -> bool:
+    head_sha = os.environ.get("BENCHMARK_PR_HEAD_SHA")
+    if not head_sha:
+        return False
+    try:
+        count = subprocess.check_output(
+            ["git", "rev-list", "--count", f"{head_sha}..origin/main"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        warning("could not determine whether the branch is behind main")
+        return False
+    return int(count) > 0
+
+
+def format_report(markdown: str, has_changes: bool, behind_main: bool) -> str:
+    if has_changes and not behind_main:
         return markdown
-    return (
-        "> [!NOTE]\n"
-        "> Codegen benchmark output is unchanged from `main`.\n\n"
-        f"{markdown}"
+    if not has_changes:
+        markdown = (
+            "> [!NOTE]\n"
+            "> Codegen benchmark output is unchanged from `main`.\n\n"
+            f"{markdown}"
+        )
+    details = (
+        "<details>\n"
+        "<summary>Codegen benchmark output</summary>\n\n"
+        f"{markdown}\n\n"
+        "</details>"
     )
+    if behind_main:
+        return (
+            "> [!WARNING]\n"
+            "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
+            f"{details}"
+        )
+    return details
 
 
 def metric(value: int | float, unit: str, statistic: str) -> dict[str, Any]:
@@ -514,7 +529,9 @@ def main() -> int:
     should_comment = has_baseline_changes(
         micro_results, baseline_micro
     ) or has_baseline_changes(repo_results, baseline_repo)
-    markdown = format_report("\n".join(sections), should_comment)
+    markdown = format_report(
+        "\n".join(sections), should_comment, branch_is_behind_main()
+    )
     print(markdown)
     append_step_summary(markdown)
     append_github_output("should_comment", "true" if should_comment else "false")

--- a/.github/scripts/test_check_codegen_benchmark.py
+++ b/.github/scripts/test_check_codegen_benchmark.py
@@ -24,24 +24,39 @@ def result(**compiler):
 
 class ReportFormattingTests(unittest.TestCase):
     def test_unchanged_report_has_note(self):
-        report = benchmark.format_report("## Results", False)
+        report = benchmark.format_report("## Results", False, False)
         self.assertEqual(
             report,
+            "<details>\n"
+            "<summary>Codegen benchmark output</summary>\n\n"
             "> [!NOTE]\n"
             "> Codegen benchmark output is unchanged from `main`.\n\n"
-            "## Results",
+            "## Results\n\n"
+            "</details>",
         )
 
-    def test_changed_report_has_no_note(self):
-        self.assertEqual(benchmark.format_report("## Results", True), "## Results")
+    def test_changed_report_has_no_details(self):
+        self.assertEqual(benchmark.format_report("## Results", True, False), "## Results")
 
-    def test_size_delta_uses_conventional_sign(self):
+    def test_behind_main_report_has_warning(self):
+        report = benchmark.format_report("## Results", True, True)
         self.assertEqual(
-            benchmark.fmt_value_with_size_delta(95, 95, 100, "B"),
-            "95B (✅ -5.00%)",
+            report,
+            "> [!WARNING]\n"
+            "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
+            "<details>\n"
+            "<summary>Codegen benchmark output</summary>\n\n"
+            "## Results\n\n"
+            "</details>",
+        )
+
+    def test_lower_is_better_delta_uses_conventional_sign(self):
+        self.assertEqual(
+            benchmark.fmt_value_with_lower_is_better_delta(95, 95, 100),
+            "95 (✅ -5.00%)",
         )
         self.assertEqual(
-            benchmark.fmt_value_with_size_delta(105, 105, 100, "B"),
+            benchmark.fmt_value_with_lower_is_better_delta(105, 105, 100, "B"),
             "105B (❌ +5.00%)",
         )
 

--- a/.github/scripts/test_check_codegen_benchmark.py
+++ b/.github/scripts/test_check_codegen_benchmark.py
@@ -62,7 +62,15 @@ class ReportFormattingTests(unittest.TestCase):
 
     def test_peak_rss_report_is_collapsed(self):
         report = benchmark.memory_report(
-            [result(status="ok", peak_rss_bytes=1024 * 1024)]
+            [
+                {
+                    "test_id": "test",
+                    "compilers": {
+                        "solar": {"status": "ok", "peak_rss_bytes": 1024 * 1024},
+                        "solc": {"status": "ok", "peak_rss_bytes": 2 * 1024 * 1024},
+                    },
+                }
+            ]
         )
         self.assertEqual(
             report,
@@ -73,12 +81,13 @@ class ReportFormattingTests(unittest.TestCase):
                 "| compiler | benches | average peak RSS | maximum peak RSS | maximum bench |",
                 "| -------- | ------- | ---------------- | ---------------- | ------------- |",
                 "| solar | 1 | 1.0 MiB | 1.0 MiB | test |",
+                "| solc | 1 | 2.0 MiB | 2.0 MiB | test |",
                 "",
                 "#### Per-benchmark peak RSS",
                 "",
-                "| bench | solar peak |",
-                "| --- | --- |",
-                "| test | 1.0 MiB |",
+                "| bench | solar peak | solc peak | Solar vs solc |",
+                "| --- | --- | --- | --- |",
+                "| test | 1.0 MiB | 2.0 MiB | ✅ -50.00% |",
                 "",
                 "</details>",
                 "",

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Checkout Solar
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Test common benchmark result adapter
         run: |
@@ -182,6 +184,7 @@ jobs:
         id: runtime-report
         if: always()
         env:
+          BENCHMARK_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BENCHMARK_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Warn when benchmark results come from a branch that is behind main because those comparisons may be inaccurate. Behind or unchanged reports are collapsed while changed results from an up-to-date branch remain expanded, and gas deltas now use the same conventional lower-is-better sign as size deltas.