### PR TITLE
fix(typeck): distinguish storage copies

### DIFF
--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -681,14 +681,8 @@ impl<'gcx> Ty<'gcx> {
                         from_inner.try_convert_implicit_to(to_inner, gcx)
                     }
 
-                    // memory/calldata -> storage: allowed (copy semantics).
-                    (DataLocation::Memory, DataLocation::Storage)
-                    | (DataLocation::Calldata, DataLocation::Storage) => {
-                        from_inner.try_convert_implicit_to(to_inner, gcx)
-                    }
-
-                    // storage -> calldata: never allowed.
-                    // memory -> calldata: never allowed.
+                    // Copies from memory/calldata into direct storage values are handled by
+                    // assignment checking. They cannot convert to storage pointers here.
                     _ => Result::Err(TyConvertError::Incompatible),
                 }
             }

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -234,7 +234,10 @@ impl<'gcx> TypeChecker<'gcx> {
                     );
                     result
                 } else {
-                    let _ = self.expect_ty(rhs, ty);
+                    let rhs_ty = self.check_expr_with_noexpect(rhs, Some(ty));
+                    if !self.can_assign_storage_copy(lhs, rhs_ty, ty) {
+                        let _ = self.check_expected(rhs, rhs_ty, ty);
+                    }
                     ty
                 }
             }
@@ -780,8 +783,9 @@ impl<'gcx> TypeChecker<'gcx> {
         for (i, (&lhs_component, &lhs_component_ty)) in
             lhs_components.iter().zip(lhs_types).enumerate()
         {
-            if let Some(_) = lhs_component
+            if let Some(lhs_component) = lhs_component
                 && let Some(rhs_component) = rhs_components.and_then(|components| components[i])
+                && !self.can_assign_storage_copy(lhs_component, rhs_types[i], lhs_component_ty)
             {
                 let _ = self.check_expected(rhs_component, rhs_types[i], lhs_component_ty);
             }
@@ -798,6 +802,50 @@ impl<'gcx> TypeChecker<'gcx> {
             }
         }
         false
+    }
+
+    /// Returns true if the expression refers to a non-state storage pointer variable.
+    fn is_storage_pointer_variable(&self, expr: &'gcx hir::Expr<'gcx>) -> bool {
+        if let hir::ExprKind::Ident(res_slice) = &expr.peel_parens().kind {
+            let res = self.resolve_overloads(res_slice, expr.span);
+            if let hir::Res::Item(hir::ItemId::Variable(var_id)) = res {
+                return !self.gcx.hir.variable(var_id).is_state_variable();
+            }
+        }
+        false
+    }
+
+    /// Returns whether an assignment performs a copy into a direct storage value.
+    fn can_assign_storage_copy(
+        &self,
+        lhs: &'gcx hir::Expr<'gcx>,
+        from: Ty<'gcx>,
+        to: Ty<'gcx>,
+    ) -> bool {
+        if self.is_storage_pointer_variable(lhs) {
+            return false;
+        }
+        self.can_copy_to_storage(from, to)
+    }
+
+    fn can_copy_to_storage(&self, from: Ty<'gcx>, to: Ty<'gcx>) -> bool {
+        let TyKind::Ref(to, DataLocation::Storage) = to.kind else { return false };
+        self.can_copy_storage_value(from, to)
+    }
+
+    fn can_copy_storage_value(&self, from: Ty<'gcx>, to: Ty<'gcx>) -> bool {
+        let from = from.peel_refs();
+        let to = to.peel_refs();
+        match (from.kind, to.kind) {
+            (TyKind::DynArray(from), TyKind::DynArray(to))
+            | (TyKind::Array(from, _), TyKind::DynArray(to)) => {
+                self.can_copy_storage_value(from, to)
+            }
+            (TyKind::Array(from, from_len), TyKind::Array(to, to_len)) => {
+                from_len <= to_len && self.can_copy_storage_value(from, to)
+            }
+            _ => from.convert_implicit_to(to, self.gcx),
+        }
     }
 
     /// Tries to evaluate an expression made up of int literals.
@@ -2076,7 +2124,13 @@ impl<'gcx> TypeChecker<'gcx> {
                 );
             } else if expect {
                 let _ = if var.is_state_variable() {
-                    self.with_construction_context(|this| this.expect_ty(init, ty))
+                    self.with_construction_context(|this| {
+                        let init_ty = this.check_expr_with_noexpect(init, Some(ty));
+                        if !this.can_copy_to_storage(init_ty, ty) {
+                            let _ = this.check_expected(init, init_ty, ty);
+                        }
+                        init_ty
+                    })
                 } else {
                     self.expect_ty(init, ty)
                 };

--- a/tests/ui/typeck/implicit_array_conversions.sol
+++ b/tests/ui/typeck/implicit_array_conversions.sol
@@ -1,9 +1,22 @@
 // Tests for implicit array conversions.
-// Arrays require exactly the same element type - no widening allowed.
-// Fixed arrays must also have the same length.
+// Outside direct storage copies, arrays require exactly the same element type and length.
 
 contract C {
+    struct Holder {
+        uint32[] children;
+        uint32[][] arrays;
+    }
+
+    Holder holder;
     uint256[] storageArr;
+    uint32[] widerStorageArr;
+    uint8[] narrowerStorageArr;
+    uint32[4] widerFixedStorageArr;
+    uint8[3] narrowerFixedStorageArr;
+    uint256[][] nestedDynamicStorageArr;
+    uint256[4][] nestedFixedStorageArr;
+    uint256[2] shortFixedStorageArr;
+    uint256[3] longFixedStorageArr;
     mapping(int256 => int256) mappingArrElement;
 
     // === Valid: same element type assignment ===
@@ -13,6 +26,59 @@ contract C {
 
     function sameFixedArray(uint256[3] memory a) internal pure {
         uint256[3] memory b = a;
+    }
+
+    // === Valid: element-wise copies into direct storage arrays ===
+
+    function wideningStorageCopy() internal {
+        widerStorageArr = narrowerStorageArr;
+        widerFixedStorageArr = narrowerFixedStorageArr;
+        longFixedStorageArr = shortFixedStorageArr;
+        shortFixedStorageArr = longFixedStorageArr; //~ ERROR: mismatched types
+    }
+
+    function nestedStorageCopies(
+        uint256[][] memory dynamicSource,
+        uint256[2][] memory fixedSource,
+        uint256[2][3] memory fixedToDynamicSource
+    ) internal {
+        nestedDynamicStorageArr = dynamicSource;
+        nestedFixedStorageArr = fixedSource;
+        nestedDynamicStorageArr = fixedToDynamicSource;
+    }
+
+    function tupleStorageCopies(
+        uint256[][] memory dynamicSource,
+        uint256[2][] memory fixedSource
+    ) internal {
+        (nestedDynamicStorageArr, nestedFixedStorageArr) = (dynamicSource, fixedSource);
+    }
+
+    function storagePointerMemberCopies(uint8[] memory source) internal {
+        Holder storage pointer = holder;
+        pointer.children = source;
+        pointer.arrays[0] = source;
+    }
+
+    function memoryToStoragePointer(uint8[] memory a) internal {
+        uint32[] storage b = a; //~ ERROR: mismatched types
+    }
+
+    function memoryToStorageParameter(
+        uint32[] storage pointer,
+        uint8[] memory a,
+        uint32[] memory exact
+    ) internal {
+        pointer = a; //~ ERROR: mismatched types
+        (pointer) = exact; //~ ERROR: mismatched types
+    }
+
+    function tupleMemoryToStorageParameter(
+        uint32[] storage pointer,
+        uint8[] memory a,
+        uint256 value
+    ) internal {
+        (pointer, value) = (a, value); //~ ERROR: mismatched types
     }
 
     function fixedArrayLiteral() internal pure {

--- a/tests/ui/typeck/implicit_array_conversions.stderr
+++ b/tests/ui/typeck/implicit_array_conversions.stderr
@@ -1,3 +1,33 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         shortFixedStorageArr = longFixedStorageArr;
+   ╰╴                               ━━━━━━━━━━━━━━━━━━━ expected `uint256[2] storage`, found `uint256[3] storage`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         uint32[] storage b = a;
+   ╰╴                             ━ expected `uint32[] storage`, found `uint8[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         pointer = a;
+   ╰╴                  ━ expected `uint32[] storage`, found `uint8[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         (pointer) = exact;
+   ╰╴                    ━━━━━ expected `uint32[] storage`, found `uint32[] memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
+   │
+LL │         (pointer, value) = (a, value);
+   ╰╴                            ━ expected `uint32[] storage`, found `uint8[] memory`
+
 error: invalid explicit type conversion
    ╭▸ ROOT/tests/ui/typeck/implicit_array_conversions.sol:LL:CC
    │
@@ -90,5 +120,5 @@ error: mismatched types
 LL │         uint8[] memory b = a;
    ╰╴                           ━ expected `uint8[] memory`, found `uint256[] memory`
 
-error: aborting due to 15 previous errors
+error: aborting due to 20 previous errors
 

--- a/tests/ui/typeck/location_coercion.sol
+++ b/tests/ui/typeck/location_coercion.sol
@@ -7,6 +7,8 @@ contract C {
     }
 
     uint256[] storageArr;
+    string storageString = "initial";
+    S storageStruct;
     S[] structArr;
     S[2] fixedStructArr;
     S[][] nestedStructArr;
@@ -86,6 +88,18 @@ contract C {
     function storageToMemory() internal view returns (uint256[] memory) {
         uint256[] memory a = storageArr;
         return a;
+    }
+
+    function literalToStorage() internal {
+        storageString = "updated";
+    }
+
+    function memoryStructToStorage(S memory value) internal {
+        storageStruct = value;
+    }
+
+    function memoryStructToStoragePointer(S memory value) internal {
+        S storage pointer = value; //~ ERROR: mismatched types
     }
 
     // === Disallowed conversions ===

--- a/tests/ui/typeck/location_coercion.stderr
+++ b/tests/ui/typeck/location_coercion.stderr
@@ -1,6 +1,12 @@
 error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/location_coercion.sol:LL:CC
    │
+LL │         S storage pointer = value;
+   ╰╴                            ━━━━━ expected `struct C.S storage`, found `struct C.S memory`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/location_coercion.sol:LL:CC
+   │
 LL │         uint256[] calldata a = storageArr;
    ╰╴                               ━━━━━━━━━━ expected `uint256[] calldata`, found `uint256[] storage`
 
@@ -22,5 +28,5 @@ error: mismatched types
 LL │         uint128[] memory b = a;
    ╰╴                             ━ expected `uint128[] memory`, found `uint256[] calldata`
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/ui/typeck/var_loc_state.sol
+++ b/tests/ui/typeck/var_loc_state.sol
@@ -5,7 +5,6 @@ struct S {
 contract C {
     uint memory a1 = 0;    //~ ERROR: data location can only be specified for array, struct or mapping types
     uint[] memory b1 = []; //~ ERROR: invalid data location
-    //~^ ERROR: mismatched types
     S memory c1 = S(0);    //~ ERROR: invalid data location
     S[] memory d1 = [];    //~ ERROR: invalid data location
     //~^ ERROR: cannot infer nameable array element type

--- a/tests/ui/typeck/var_loc_state.stderr
+++ b/tests/ui/typeck/var_loc_state.stderr
@@ -28,12 +28,6 @@ LL │     S[] memory d1 = [];
    │
    ╰ note: data location must be `none` or `transient` for state variable, but got `memory`
 
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/var_loc_state.sol:LL:CC
-   │
-LL │     uint[] memory b1 = [];
-   ╰╴                       ━━ expected `uint256[] storage`, found `uint256[0] memory`
-
 error: cannot infer nameable array element type
    ╭▸ ROOT/tests/ui/typeck/var_loc_state.sol:LL:CC
    │
@@ -42,5 +36,5 @@ LL │     S[] memory d1 = [];
    │
    ╰ help: add an explicit type conversion for the first element
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Separates implicit reference conversion from assignment copy semantics so memory and calldata values can be copied into direct storage destinations without becoming assignable to storage pointers. The assignment path recursively validates array shape and element conversions, including fixed-length direction, nested arrays, tuples, state initializers, structs, strings, and member or indexed lvalues reached through storage pointers.