### PR TITLE
fix(typeck): reject non-mobile functions

### DIFF
--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -615,7 +615,7 @@ impl<'gcx> Gcx<'gcx> {
         state_mutability: StateMutability,
         returns: &[Ty<'gcx>],
     ) -> Ty<'gcx> {
-        self.mk_ty_fn_with_kind(TyFnKind::Internal, parameters, state_mutability, returns)
+        self.mk_ty_fn_with_kind(TyFnKind::Builtin, parameters, state_mutability, returns)
     }
 
     pub(crate) fn mk_yul_builtin_fn(self, parameters: usize, returns: usize) -> Ty<'gcx> {

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1104,13 +1104,41 @@ impl<'gcx> Ty<'gcx> {
                 let tys = tys.iter().map(|ty| ty.mobile(gcx)).collect::<Option<Vec<_>>>()?;
                 gcx.mk_ty_tuple(gcx.mk_tys(&tys))
             }
+            TyKind::Fn(f)
+                if f.is_declaration()
+                    || f.attached
+                    || matches!(
+                        f.kind,
+                        TyFnKind::Builtin
+                            | TyFnKind::BareCall
+                            | TyFnKind::BareDelegateCall
+                            | TyFnKind::BareStaticCall
+                            | TyFnKind::Creation
+                    ) =>
+            {
+                return None;
+            }
+            TyKind::Fn(f) => {
+                let kind = if f.kind == TyFnKind::InternalWithSelector {
+                    TyFnKind::Internal
+                } else {
+                    f.kind
+                };
+                gcx.mk_ty_fn(TyFn {
+                    kind,
+                    parameters: f.parameters,
+                    returns: f.returns,
+                    state_mutability: f.state_mutability,
+                    function_id: None,
+                    attached: false,
+                })
+            }
             TyKind::Error(..)
             | TyKind::Event(..)
             | TyKind::Module(..)
             | TyKind::BuiltinModule(..)
             | TyKind::Type(_)
             | TyKind::Meta(_) => return None,
-            // TODO: functions
             _ => self,
         })
     }
@@ -1258,6 +1286,8 @@ pub struct TyFn<'gcx> {
 pub enum TyFnKind {
     /// An ordinary internal function value.
     Internal,
+    /// A builtin or other special function that can only be called directly.
+    Builtin,
     /// An internal function value for a public function accessed through a qualified name.
     ///
     /// It is callable as an internal function, but also has a `.selector` member.
@@ -1337,11 +1367,8 @@ impl<'gcx> TyFn<'gcx> {
     pub fn has_selector(&self) -> bool {
         matches!(
             self.kind,
-            TyFnKind::InternalWithSelector
-                | TyFnKind::External
-                | TyFnKind::Declaration
-                | TyFnKind::DelegateCall
-        )
+            TyFnKind::InternalWithSelector | TyFnKind::External | TyFnKind::Declaration
+        ) || (self.kind == TyFnKind::DelegateCall && self.function_id.is_some())
     }
 
     /// Returns whether this function value has an `.address` member.

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1099,15 +1099,13 @@ impl<'gcx> Ty<'gcx> {
                 gcx.mk_ty_tuple(gcx.mk_tys(&tys))
             }
             TyKind::Fn(f) => {
-                if f.is_declaration()
-                    || f.attached
-                    || matches!(
+                if f.attached
+                    || !matches!(
                         f.kind,
-                        TyFnKind::Builtin
-                            | TyFnKind::BareCall
-                            | TyFnKind::BareDelegateCall
-                            | TyFnKind::BareStaticCall
-                            | TyFnKind::Creation
+                        TyFnKind::Internal
+                            | TyFnKind::InternalWithSelector
+                            | TyFnKind::External
+                            | TyFnKind::DelegateCall
                     )
                 {
                     return None;

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -1104,7 +1104,7 @@ impl<'gcx> Ty<'gcx> {
                 let tys = tys.iter().map(|ty| ty.mobile(gcx)).collect::<Option<Vec<_>>>()?;
                 gcx.mk_ty_tuple(gcx.mk_tys(&tys))
             }
-            TyKind::Fn(f)
+            TyKind::Fn(f) => {
                 if f.is_declaration()
                     || f.attached
                     || matches!(
@@ -1114,11 +1114,10 @@ impl<'gcx> Ty<'gcx> {
                             | TyFnKind::BareDelegateCall
                             | TyFnKind::BareStaticCall
                             | TyFnKind::Creation
-                    ) =>
-            {
-                return None;
-            }
-            TyKind::Fn(f) => {
+                    )
+                {
+                    return None;
+                }
                 let kind = if f.kind == TyFnKind::InternalWithSelector {
                     TyFnKind::Internal
                 } else {

--- a/crates/sema/src/typeck/checker.rs
+++ b/crates/sema/src/typeck/checker.rs
@@ -2750,7 +2750,10 @@ fn abi_encode_call_function_kind_message(kind: TyFnKind) -> &'static str {
         }
         TyFnKind::DelegateCall => "first argument to `abi.encodeCall` cannot be a library function",
         TyFnKind::Creation => "first argument to `abi.encodeCall` cannot be a creation function",
-        TyFnKind::BareCall | TyFnKind::BareDelegateCall | TyFnKind::BareStaticCall => {
+        TyFnKind::Builtin
+        | TyFnKind::BareCall
+        | TyFnKind::BareDelegateCall
+        | TyFnKind::BareStaticCall => {
             "first argument to `abi.encodeCall` cannot be a special function"
         }
         TyFnKind::External | TyFnKind::Declaration => unreachable!(),

--- a/tests/ui/typeck/function_declaration_conversion.sol
+++ b/tests/ui/typeck/function_declaration_conversion.sol
@@ -1,0 +1,69 @@
+// ported-from: test/libsolidity/syntaxTests/functionTypes/declaration_type_conversion.sol
+// ported-from: test/libsolidity/syntaxTests/functionTypes/ternary_with_attached_functions.sol
+// ported-from: test/libsolidity/syntaxTests/functionTypes/from_ternary_expression.sol
+
+library L {
+    function f(uint256) internal pure {}
+    function g(uint256) internal pure {}
+    function publicF(uint256) public pure {}
+    function publicG(uint256) public pure {}
+}
+
+contract D {
+    function f() external {}
+    function g() external {}
+}
+
+contract Base {
+    function publicF(uint256) public pure {}
+    function publicG(uint256) public pure {}
+}
+
+contract C is Base {
+    using L for uint256;
+
+    function internalF() internal pure {}
+    function internalG() internal pure {}
+
+    function f(bool condition, D d) public pure {
+        (condition ? D.f : D.g);
+        //~^ ERROR: invalid true type
+        //~| ERROR: invalid false type
+
+        uint256 value;
+        (condition ? value.f : value.g)();
+        //~^ ERROR: invalid true type
+        //~| ERROR: invalid false type
+
+        uint256 result = (condition ? addmod : addmod)(3, 4, 5);
+        //~^ ERROR: invalid true type
+        //~| ERROR: invalid false type
+
+        function() internal pure mobile = condition ? internalF : internalG;
+        mobile();
+
+        function() external externalMobile = condition ? d.f : d.g;
+        externalMobile;
+
+        (condition ? address(0).call : address(0).call);
+        //~^ ERROR: invalid true type
+        //~| ERROR: invalid false type
+
+        (condition ? new D : new D);
+        //~^ ERROR: invalid true type
+        //~| ERROR: invalid false type
+
+        result;
+    }
+
+    function normalized(bool condition) public pure {
+        function(uint256) internal pure mobile = condition ? Base.publicF : Base.publicG;
+        mobile(1);
+
+        (condition ? Base.publicF : Base.publicG).selector;
+        //~^ ERROR: member `selector` not found
+
+        (condition ? L.publicF : L.publicG).selector;
+        //~^ ERROR: member `selector` not found
+    }
+}

--- a/tests/ui/typeck/function_declaration_conversion.stderr
+++ b/tests/ui/typeck/function_declaration_conversion.stderr
@@ -71,4 +71,3 @@ LL │         (condition ? L.publicF : L.publicG).selector;
    ╰╴                                            ━━━━━━━━
 
 error: aborting due to 12 previous errors
-

--- a/tests/ui/typeck/function_declaration_conversion.stderr
+++ b/tests/ui/typeck/function_declaration_conversion.stderr
@@ -71,3 +71,4 @@ LL │         (condition ? L.publicF : L.publicG).selector;
    ╰╴                                            ━━━━━━━━
 
 error: aborting due to 12 previous errors
+

--- a/tests/ui/typeck/function_declaration_conversion.stderr
+++ b/tests/ui/typeck/function_declaration_conversion.stderr
@@ -1,0 +1,74 @@
+error: invalid true type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? D.f : D.g);
+   ╰╴                     ━━━
+
+error: invalid false type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? D.f : D.g);
+   ╰╴                           ━━━
+
+error: invalid true type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? value.f : value.g)();
+   ╰╴                     ━━━━━━━
+
+error: invalid false type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? value.f : value.g)();
+   ╰╴                               ━━━━━━━
+
+error: invalid true type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         uint256 result = (condition ? addmod : addmod)(3, 4, 5);
+   ╰╴                                      ━━━━━━
+
+error: invalid false type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         uint256 result = (condition ? addmod : addmod)(3, 4, 5);
+   ╰╴                                               ━━━━━━
+
+error: invalid true type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? address(0).call : address(0).call);
+   ╰╴                     ━━━━━━━━━━━━━━━
+
+error: invalid false type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? address(0).call : address(0).call);
+   ╰╴                                       ━━━━━━━━━━━━━━━
+
+error: invalid true type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? new D : new D);
+   ╰╴                     ━━━━━
+
+error: invalid false type
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? new D : new D);
+   ╰╴                             ━━━━━
+
+error: member `selector` not found on type `function (uint256) pure`
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? Base.publicF : Base.publicG).selector;
+   ╰╴                                                  ━━━━━━━━
+
+error: member `selector` not found on type `function (uint256) pure`
+   ╭▸ ROOT/tests/ui/typeck/function_declaration_conversion.sol:LL:CC
+   │
+LL │         (condition ? L.publicF : L.publicG).selector;
+   ╰╴                                            ━━━━━━━━
+
+error: aborting due to 12 previous errors
+


### PR DESCRIPTION
Models builtins as special function values and applies Solidity mobile-type rules in conditional expressions. Declaration, attached, builtin, low-level-call, and creation functions are rejected; allowed function values are normalized by removing declaration-specific identity and selector state while preserving ordinary internal, external, and library-call semantics.