### PR TITLE
feat(lsp): add go to type definition

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -7,7 +7,7 @@ use lsp_types::{
     CompletionOptions, DeclarationCapability, DocumentLinkOptions, InitializeParams, OneOf,
     RenameOptions, SaveOptions, ServerCapabilities, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, WorkDoneProgressOptions,
+    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
 };
 use solar_interface::data_structures::map::FxHashSet;
 use std::{
@@ -249,6 +249,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             }),
             declaration_provider: Some(DeclarationCapability::Simple(true)),
             definition_provider: Some(OneOf::Left(true)),
+            type_definition_provider: Some(TypeDefinitionProviderCapability::Simple(true)),
             document_formatting_provider: Some(OneOf::Left(true)),
             document_link_provider: Some(DocumentLinkOptions {
                 resolve_provider: Some(false),
@@ -299,7 +300,8 @@ mod tests {
         DidChangeWatchedFilesClientCapabilities, DocumentSymbolClientCapabilities, MarkupKind,
         OneOf, ParameterInformationSettings, RenameOptions, SignatureHelpClientCapabilities,
         SignatureInformationSettings, TextDocumentClientCapabilities, TextDocumentSyncCapability,
-        TextDocumentSyncSaveOptions, WorkspaceClientCapabilities, WorkspaceEditClientCapabilities,
+        TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, WorkspaceClientCapabilities,
+        WorkspaceEditClientCapabilities,
     };
     #[test]
     fn negotiate_capabilities_records_watched_file_dynamic_registration_support() {
@@ -347,6 +349,10 @@ mod tests {
         assert_eq!(completion_provider.trigger_characters, Some(vec![".".to_string()]));
         assert_eq!(capabilities.declaration_provider, Some(DeclarationCapability::Simple(true)));
         assert_eq!(capabilities.definition_provider, Some(OneOf::Left(true)));
+        assert_eq!(
+            capabilities.type_definition_provider,
+            Some(TypeDefinitionProviderCapability::Simple(true))
+        );
         assert_eq!(capabilities.document_formatting_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.document_symbol_provider, Some(OneOf::Left(true)));
         let document_link_provider = capabilities.document_link_provider.unwrap();

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -203,6 +203,24 @@ pub(crate) fn goto_definition(
     ready(Ok(response))
 }
 
+pub(crate) fn goto_type_definition(
+    state: &mut GlobalState,
+    params: GotoDefinitionParams,
+) -> impl Future<Output = Result<Option<GotoDefinitionResponse>, ResponseError>> + use<> {
+    let symbol_tables = state.symbol_tables.clone();
+    let (version, mut published) = state.current_analysis();
+    let params = params.text_document_position_params;
+    async move {
+        published
+            .wait_for(|published| *published >= version)
+            .await
+            .map_err(|_| request_failed("analysis was cancelled"))?;
+        let response =
+            symbol_tables.read().goto_type_definition(&params.text_document.uri, params.position);
+        Ok(response)
+    }
+}
+
 pub(crate) fn goto_declaration(
     state: &mut GlobalState,
     params: GotoDefinitionParams,

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -55,6 +55,7 @@ fn new_router(client: ClientSocket) -> Router<GlobalState> {
         .request::<req::DocumentLinkRequest, _>(handlers::document_links)
         .request::<req::WorkspaceSymbolRequest, _>(handlers::workspace_symbol)
         .request::<req::GotoDefinition, _>(handlers::goto_definition)
+        .request::<req::GotoTypeDefinition, _>(handlers::goto_type_definition)
         .request::<req::GotoDeclaration, _>(handlers::goto_declaration)
         .request::<req::References, _>(handlers::references)
         .request::<req::PrepareRenameRequest, _>(handlers::prepare_rename)
@@ -200,6 +201,27 @@ mod tests {
         let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
             "id": 1,
             "method": request::SignatureHelpRequest::METHOD,
+            "params": params,
+        }))
+        .unwrap();
+
+        let response = router.call(request).await.unwrap();
+
+        assert_eq!(response, serde_json::Value::Null);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_type_definition_requests() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let params = TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: lsp_types::Url::parse("file:///workspace/src/Test.sol").unwrap(),
+            },
+            position: Position::new(0, 0),
+        };
+        let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
+            "id": 1,
+            "method": request::GotoTypeDefinition::METHOD,
             "params": params,
         }))
         .unwrap();

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1,6 +1,7 @@
 use lsp_types::{
     CompletionItem, CompletionItemKind, DocumentSymbol, GotoDefinitionResponse, InlayHint,
     Location, OneOf, Position, Range, SymbolInformation, SymbolKind, Url, WorkspaceSymbol,
+    request::GotoTypeDefinitionResponse,
 };
 use solar_interface::{
     Span,
@@ -9,6 +10,7 @@ use solar_interface::{
         index::IndexVec,
         map::{FxHashMap, FxHashSet},
         newtype_index,
+        smallvec::SmallVec,
     },
 };
 use solar_sema::{
@@ -38,6 +40,7 @@ use crate::{
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SymbolTables {
     declarations: IndexVec<SymbolId, DeclarationSymbol>,
+    type_definitions: IndexVec<SymbolId, TypeDefinitionTargets>,
     files: FxHashMap<Url, Vec<SymbolId>>,
     workspace_symbol_ids: Vec<SymbolId>,
     symbols_by_key: FxHashMap<SymbolKey, SymbolId>,
@@ -64,6 +67,8 @@ newtype_index! {
     /// A lexical scope ID in the LSP symbol table.
     pub(crate) struct ScopeId;
 }
+
+type TypeDefinitionTargets = SmallVec<[SymbolId; 1]>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct DeclarationSymbol {
@@ -203,6 +208,8 @@ impl SymbolTables {
                 item_id.parent(&gcx.hir).and_then(|parent| item_symbols.get(&parent).copied());
         }
 
+        tables.build_type_definitions(gcx, &item_symbols);
+
         // Public state-variable getters are compiler-generated functions, but source member calls
         // such as `this.value()` still name the state variable. Point getter resolutions back to
         // the source declaration so navigation and rename do not lose those references.
@@ -240,6 +247,8 @@ impl SymbolTables {
     }
 
     pub(crate) fn extend(&mut self, mut other: Self) {
+        debug_assert_eq!(self.declarations.len(), self.type_definitions.len());
+        debug_assert_eq!(other.declarations.len(), other.type_definitions.len());
         if self.global_completions.is_empty() {
             self.global_completions = std::mem::take(&mut other.global_completions);
         }
@@ -256,6 +265,11 @@ impl SymbolTables {
             declaration.id = remap_symbol_id(declaration.id, symbol_offset);
             declaration.parent =
                 declaration.parent.map(|parent| remap_symbol_id(parent, symbol_offset));
+        }
+        for targets in &mut other.type_definitions {
+            for target in targets {
+                *target = remap_symbol_id(*target, symbol_offset);
+            }
         }
         for scope in &mut other.scopes {
             scope.parent = scope.parent.map(|parent| remap_scope_id(parent, scope_offset));
@@ -275,6 +289,7 @@ impl SymbolTables {
             );
         }
         self.declarations.extend(other.declarations);
+        self.type_definitions.extend(other.type_definitions);
         self.scopes.extend(other.scopes);
         self.receiver_member_completions.extend(
             other
@@ -412,6 +427,27 @@ impl SymbolTables {
         Some(GotoDefinitionResponse::Array(locations))
     }
 
+    pub(crate) fn goto_type_definition(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<GotoTypeDefinitionResponse> {
+        let symbol_ids = self.symbol_ids_at_position(uri, position)?;
+        let mut locations = Vec::new();
+        for symbol_id in symbol_ids {
+            for &target in &self.type_definitions[symbol_id] {
+                let location = self.selection_location(target);
+                if !locations.contains(&location) {
+                    locations.push(location);
+                }
+            }
+        }
+        if locations.is_empty() {
+            return None;
+        }
+        Some(GotoTypeDefinitionResponse::Array(locations))
+    }
+
     pub(crate) fn references(
         &self,
         uri: &Url,
@@ -541,7 +577,9 @@ impl SymbolTables {
         self.files.entry(declaration.location.uri.clone()).or_default().push(id);
         self.symbols_by_key.insert(key, id);
         let pushed_id = self.declarations.push(declaration);
+        let type_definition_id = self.type_definitions.push(TypeDefinitionTargets::new());
         debug_assert_eq!(id, pushed_id);
+        debug_assert_eq!(id, type_definition_id);
         id
     }
 
@@ -550,7 +588,9 @@ impl SymbolTables {
         let id = declaration.id;
         self.files.entry(declaration.location.uri.clone()).or_default().push(id);
         let pushed_id = self.declarations.push(declaration);
+        let type_definition_id = self.type_definitions.push(TypeDefinitionTargets::new());
         debug_assert_eq!(id, pushed_id);
+        debug_assert_eq!(id, type_definition_id);
         id
     }
 
@@ -641,6 +681,44 @@ impl SymbolTables {
             }
             let _ = collector.visit_nested_source(source_id);
             collector.source = None;
+        }
+    }
+
+    fn build_type_definitions(&mut self, gcx: Gcx<'_>, item_symbols: &FxHashMap<ItemId, SymbolId>) {
+        for (&item_id, &symbol_id) in item_symbols {
+            let targets = match item_id {
+                ItemId::Contract(_) | ItemId::Struct(_) | ItemId::Enum(_) | ItemId::Udvt(_) => {
+                    TypeDefinitionTargets::from_iter([symbol_id])
+                }
+                ItemId::Function(function_id) => gcx
+                    .hir
+                    .function(function_id)
+                    .returns
+                    .iter()
+                    .filter_map(|&return_id| {
+                        Self::type_definition_symbol(&gcx.hir.variable(return_id).ty, item_symbols)
+                    })
+                    .collect(),
+                ItemId::Variable(variable_id) => TypeDefinitionTargets::from_iter(
+                    Self::type_definition_symbol(&gcx.hir.variable(variable_id).ty, item_symbols),
+                ),
+                ItemId::Error(_) | ItemId::Event(_) => TypeDefinitionTargets::new(),
+            };
+            self.type_definitions[symbol_id] = targets;
+        }
+    }
+
+    fn type_definition_symbol(
+        mut ty: &hir::Type<'_>,
+        item_symbols: &FxHashMap<ItemId, SymbolId>,
+    ) -> Option<SymbolId> {
+        loop {
+            match ty.kind {
+                TypeKind::Array(array) => ty = &array.element,
+                TypeKind::Mapping(mapping) => ty = &mapping.value,
+                TypeKind::Custom(item_id) => return item_symbols.get(&item_id).copied(),
+                TypeKind::Elementary(_) | TypeKind::Function(_) | TypeKind::Err(_) => return None,
+            }
         }
     }
 

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod references;
 mod rename;
 mod signature_help;
 mod support;
+mod type_definition;
 
 fn snapshot(project: &TestProject) -> GlobalStateSnapshot {
     snapshot_with_config(project.config(), project.vfs())

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -133,6 +133,17 @@ impl RequestFixture {
         assert_data_eq!(self.goto_output(response), expected);
     }
 
+    pub(super) fn check_goto_type_definition(&self, marker: &str, expected: impl IntoData) {
+        let mut state = self.state();
+        let (uri, position) = self.marker_location(marker);
+        let response = expect_ready(crate::handlers::goto_type_definition(
+            &mut state,
+            goto_params(uri, position),
+        ))
+        .unwrap();
+        assert_data_eq!(self.goto_output(response), expected);
+    }
+
     pub(super) fn check_references(
         &self,
         marker: &str,

--- a/crates/lsp/src/tests/type_definition.rs
+++ b/crates/lsp/src/tests/type_definition.rs
@@ -1,0 +1,421 @@
+use super::{AnalysisBatch, GlobalState, SymbolTables, analyze, support::RequestFixture};
+use crate::test_support::TestProject;
+use async_lsp::ClientSocket;
+use lsp_types::{
+    GotoDefinitionParams, GotoDefinitionResponse, PartialResultParams, Position,
+    TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+};
+use snapbox::str;
+use solar_config::CompileOpts;
+use solar_interface::data_structures::map::FxHashSet;
+use std::{
+    future::Future,
+    sync::atomic::Ordering,
+    task::{Context, Waker},
+};
+
+#[test]
+fn resolves_struct_type_from_variable_declaration() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /TypeDefinition.sol
+        contract C {
+            struct Data { uint256 value; }
+            Data $1data;
+        }
+        "#,
+        "/TypeDefinition.sol",
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/TypeDefinition.sol:1:11 struct Data { uint256 value; }
+
+"#]],
+    );
+}
+
+#[test]
+fn user_defined_type_declarations_resolve_to_themselves() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Types.sol
+        interface $1InterfaceType {}
+        library $2LibraryType {}
+        contract $3ContractType {}
+        struct $4StructType { uint256 value; }
+        enum $5EnumType { A }
+        type $6ValueType is uint256;
+        "#,
+        "/Types.sol",
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/Types.sol:0:10 interface InterfaceType {}
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$2",
+        str![[r#"
+/Types.sol:1:8 library LibraryType {}
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$3",
+        str![[r#"
+/Types.sol:2:9 contract ContractType {}
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$4",
+        str![[r#"
+/Types.sol:3:7 struct StructType { uint256 value; }
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$5",
+        str![[r#"
+/Types.sol:4:5 enum EnumType { A }
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$6",
+        str![[r#"
+/Types.sol:5:5 type ValueType is uint256;
+
+"#]],
+    );
+}
+
+#[test]
+fn resolves_variable_declarations_and_references() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Variables.sol
+        struct Data { uint256 value; }
+        contract C {
+            Data $1stored;
+
+            function use(Data memory $2input) public {
+                Data memory $3local = $4input;
+                $5stored = $6local;
+            }
+        }
+        "#,
+        "/Variables.sol",
+    );
+    let expected = str![[r#"
+/Variables.sol:0:7 struct Data { uint256 value; }
+
+"#]];
+
+    for marker in ["$1", "$2", "$3", "$4", "$5", "$6"] {
+        fixture.check_goto_type_definition(marker, expected.clone());
+    }
+}
+
+#[test]
+fn unwraps_arrays_and_mapping_values() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Containers.sol
+        enum Key { A }
+        struct Value { uint256 value; }
+        contract C {
+            Value[][] $1nested;
+            mapping(Key => Value[]) $2values;
+        }
+        "#,
+        "/Containers.sol",
+    );
+    let expected = str![[r#"
+/Containers.sol:1:7 struct Value { uint256 value; }
+
+"#]];
+
+    fixture.check_goto_type_definition("$1", expected.clone());
+    fixture.check_goto_type_definition("$2", expected);
+}
+
+#[test]
+fn function_targets_preserve_return_order_and_stably_deduplicate() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Returns.sol
+        contract C {
+            struct Second { uint256 value; }
+            struct First { uint256 value; }
+
+            function $1pair() public pure returns (First memory, Second memory, First memory) {
+                revert();
+            }
+
+            function use() public pure {
+                $2pair();
+            }
+        }
+        "#,
+        "/Returns.sol",
+    );
+    let expected = str![[r#"
+/Returns.sol:2:11 struct First { uint256 value; }
+/Returns.sol:1:11 struct Second { uint256 value; }
+
+"#]];
+
+    fixture.check_goto_type_definition("$1", expected.clone());
+    fixture.check_goto_type_definition("$2", expected);
+}
+
+#[test]
+fn overloaded_calls_use_the_selected_function_return_type() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Overload.sol
+        contract C {
+            struct NumberResult { uint256 value; }
+            struct TextResult { string value; }
+
+            function pick(uint256) public pure returns (NumberResult memory) { revert(); }
+            function pick(string memory) public pure returns (TextResult memory) { revert(); }
+
+            function use() public pure {
+                $1pick(uint256(1));
+            }
+        }
+        "#,
+        "/Overload.sol",
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/Overload.sol:1:11 struct NumberResult { uint256 value; }
+
+"#]],
+    );
+}
+
+#[test]
+fn public_mapping_getters_use_the_source_variable_type() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Getter.sol
+        struct Data { uint256 value; }
+        contract C {
+            mapping(uint256 => Data) public values;
+
+            function read(uint256 key) external view {
+                this.$1values(key);
+            }
+        }
+        "#,
+        "/Getter.sol",
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/Getter.sol:0:7 struct Data { uint256 value; }
+
+"#]],
+    );
+}
+
+#[test]
+fn resolves_cross_file_and_late_declared_types() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Main.sol
+        import {Shared} from "./Types.sol";
+        import "./Late.sol";
+        contract Main { Shared $1value; }
+
+        //- /Types.sol
+        struct Shared { uint256 value; }
+
+        //- /Late.sol
+        contract UsesLater {
+            Later $2value;
+        }
+        struct Later { uint256 value; }
+        "#,
+        "/Main.sol",
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/Types.sol:0:7 struct Shared { uint256 value; }
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$2",
+        str![[r#"
+/Late.sol:3:7 struct Later { uint256 value; }
+
+"#]],
+    );
+}
+
+#[test]
+fn preserves_type_definitions_across_analysis_batches() {
+    let fixture = RequestFixture::new_in_batches(
+        r#"
+        //- /first/Types.sol
+        struct FirstType { uint256 value; }
+
+        //- /first/Main.sol
+        import "./Types.sol";
+        contract First { FirstType $1value; }
+
+        //- /second/Types.sol
+        struct SecondType { uint256 value; }
+
+        //- /second/Main.sol
+        import "./Types.sol";
+        contract Second { SecondType $2value; }
+        "#,
+        &["/first/Main.sol", "/second/Main.sol"],
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/first/Types.sol:0:7 struct FirstType { uint256 value; }
+
+"#]],
+    );
+    fixture.check_goto_type_definition(
+        "$2",
+        str![[r#"
+/second/Types.sol:0:7 struct SecondType { uint256 value; }
+
+"#]],
+    );
+}
+
+#[test]
+fn primitive_function_and_unresolved_types_have_no_target() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /NoTarget.sol
+        struct Detail { uint256 code; }
+        error $5Error(Detail detail);
+        contract C {
+            event $4Event(Detail detail);
+            uint256 $1count;
+
+            function use(function(uint256) external returns (uint256) $2callback) public {
+                Missing $3missing;
+            }
+
+            modifier $6Modifier(Detail detail) {
+                _;
+            }
+        }
+        "#,
+        "/NoTarget.sol",
+    );
+
+    for marker in ["$1", "$2", "$3", "$4", "$5", "$6"] {
+        fixture.check_goto_type_definition(marker, "<none>\n");
+    }
+}
+
+#[test]
+fn resolves_named_custom_error_parameter_types() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Error.sol
+        struct Detail { uint256 code; }
+        error Failed(Detail detail);
+
+        contract C {
+            function fail() external pure {
+                revert Failed({ $1detail: Detail({ code: 1 }) });
+            }
+        }
+        "#,
+        "/Error.sol",
+    );
+
+    fixture.check_goto_type_definition(
+        "$1",
+        str![[r#"
+/Error.sol:0:7 struct Detail { uint256 code; }
+
+"#]],
+    );
+}
+
+#[test]
+fn waits_for_current_analysis_before_returning_type_definitions() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Types.sol
+        contract C {
+            struct OldType { uint256 value; }
+            struct Placeholder { uint256 value; }
+            OldType $1value;
+        }
+        "#,
+    );
+    let path = project.path("/Types.sol");
+    let old_tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(path.clone(), project.read_file("/Types.sol"))],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let new_tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(
+            path.clone(),
+            "contract C {\n    struct Placeholder { uint256 value; }\n    struct NewType { uint256 value; }\n    NewType value;\n}\n".into(),
+        )],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier::new(uri.clone()),
+            position: Position::new(3, 12),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    *state.symbol_tables.write() = old_tables;
+    state.analysis_version.fetch_add(1, Ordering::AcqRel);
+
+    let mut request = std::pin::pin!(crate::handlers::goto_type_definition(&mut state, params));
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+
+    assert!(request.as_mut().poll(&mut context).is_pending());
+
+    state.analysis_version.fetch_add(1, Ordering::AcqRel);
+    let mut snapshot = state.snapshot();
+    assert!(snapshot.publish_symbol_tables(2, new_tables));
+    assert!(!snapshot.publish_symbol_tables(1, SymbolTables::default()));
+    let std::task::Poll::Ready(response) = request.as_mut().poll(&mut context) else {
+        panic!("type-definition request should complete after analysis is published");
+    };
+    let Some(GotoDefinitionResponse::Array(locations)) = response.unwrap() else {
+        panic!("expected type-definition locations");
+    };
+    assert_eq!(locations.len(), 1);
+    assert_eq!(locations[0].uri, uri);
+    assert_eq!(locations[0].range.start, Position::new(2, 11));
+}


### PR DESCRIPTION
Towards OSS-500 

- Adds Go to Type Definition support for user-defined Solidity types, variables, function returns, getters, and cross-file
references. 
 
- It waits for the latest analysis so results stay fresh, and stores symbol IDs instead of full locations to keep the index
lightweight.

Works well under multi-root workspace 
<img width="696" height="302" alt="截屏2026-07-18 21 05 43" src="https://github.com/user-attachments/assets/bda29fb8-fbdf-4730-a8b0-f8e4cee70685" />

