### PR TITLE
fix(lsp): await latest analysis

### DIFF
--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -161,10 +161,24 @@ impl GlobalState {
         });
     }
 
-    pub(crate) fn current_analysis(&self) -> (usize, watch::Receiver<usize>) {
-        let published = self.published_analysis_version.subscribe();
+    /// Waits for analysis results at least as new as the latest version requested before this call.
+    pub(crate) fn latest_analysis(
+        &self,
+    ) -> impl Future<Output = Result<Arc<RwLock<SymbolTables>>, ResponseError>> + use<> {
+        let mut published = self.published_analysis_version.subscribe();
         let version = self.analysis_version.load(Ordering::Acquire);
-        (version, published)
+        let symbol_tables = self.symbol_tables.clone();
+        async move {
+            published.wait_for(|published| *published >= version).await.map_err(|_| {
+                ResponseError::new(async_lsp::ErrorCode::REQUEST_FAILED, "analysis was cancelled")
+            })?;
+            Ok(symbol_tables)
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mark_analysis_pending_for_test(&self) {
+        self.analysis_version.fetch_add(1, Ordering::AcqRel);
     }
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -41,6 +41,7 @@ use tokio::{
 
 pub(crate) struct GlobalState {
     client: ClientSocket,
+    pub(crate) sess: Session,
     pub(crate) vfs: Arc<RwLock<Vfs>>,
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
@@ -56,6 +57,7 @@ impl GlobalState {
         let (published_analysis_version, _) = watch::channel(0);
         Self {
             client,
+            sess: Session::default(),
             vfs: Arc::new(Default::default()),
             analysis_version: Arc::new(AtomicUsize::new(0)),
             published_analysis_version,

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -14,7 +14,7 @@ use lsp_types::{
     RenameParams, SignatureHelp, SignatureHelpParams, TextDocumentEdit, TextDocumentPositionParams,
     TextEdit, Url, WorkspaceEdit, WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
-use solar_interface::{Symbol, data_structures::sync::RwLock, enter, source_map::SourceMap};
+use solar_interface::{data_structures::sync::RwLock, source_map::SourceMap};
 use solar_parse::lexer::is_ident;
 use std::{collections::HashMap, future::ready, io, path::Path, sync::Arc};
 use tracing::warn;
@@ -295,11 +295,12 @@ pub(crate) fn rename(
     params: RenameParams,
 ) -> impl Future<Output = Result<Option<WorkspaceEdit>, ResponseError>> + use<> {
     let RenameParams { text_document_position: params_position, new_name, .. } = params;
-    let invalid_name = !is_ident(&new_name)
-        || enter(|| {
-            let name = Symbol::intern(&new_name);
-            name.is_reserved(false)
-        });
+    let (invalid_name, invalid_yul_name) = if is_ident(&new_name) {
+        let name = state.sess.intern(&new_name);
+        (name.is_reserved(false), name.is_reserved(true))
+    } else {
+        (true, true)
+    };
     let latest_analysis = if invalid_name {
         None
     } else {
@@ -318,9 +319,7 @@ pub(crate) fn rename(
             .read()
             .rename_candidate(&params_position.text_document.uri, params_position.position);
         let Some(candidate) = candidate else { return Ok(None) };
-        if candidate.requires_yul_validation
-            && enter(|| Symbol::intern(&new_name).is_reserved(true))
-        {
+        if candidate.requires_yul_validation && invalid_yul_name {
             return Err(ResponseError::new(ErrorCode::INVALID_PARAMS, "invalid rename name"));
         }
         if candidate.old_name == new_name {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -1,7 +1,7 @@
 use crate::{
     formatter::{self, FormatterError},
     global_state::GlobalState,
-    symbols::CompletionContext,
+    symbols::{CompletionContext, SymbolTables},
     vfs::{Vfs, VfsPath},
 };
 use async_lsp::{ErrorCode, ResponseError};
@@ -120,6 +120,14 @@ fn request_failed(message: &'static str) -> ResponseError {
     ResponseError::new(ErrorCode::REQUEST_FAILED, message)
 }
 
+fn latest_analysis_for_uri(
+    state: &GlobalState,
+    uri: &Url,
+) -> Option<impl Future<Output = Result<Arc<RwLock<SymbolTables>>, ResponseError>> + use<>> {
+    crate::proto::vfs_path(uri)?;
+    Some(state.latest_analysis())
+}
+
 fn formatting_edits(source: &str, formatted: String) -> Option<Vec<TextEdit>> {
     if source == formatted {
         return None;
@@ -158,29 +166,38 @@ pub(crate) fn document_symbol(
     state: &mut GlobalState,
     params: DocumentSymbolParams,
 ) -> impl Future<Output = Result<Option<DocumentSymbolResponse>, ResponseError>> + use<> {
-    let symbol_tables = state.symbol_tables.read();
-    let response = if state.config.supports_hierarchical_document_symbols() {
-        DocumentSymbolResponse::Nested(symbol_tables.document_symbols(&params.text_document.uri))
-    } else {
-        DocumentSymbolResponse::Flat(symbol_tables.flat_document_symbols(&params.text_document.uri))
-    };
-    ready(Ok(Some(response)))
+    let hierarchical = state.config.supports_hierarchical_document_symbols();
+    let uri = params.text_document.uri;
+    let latest_analysis = latest_analysis_for_uri(state, &uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else {
+            let response = if hierarchical {
+                DocumentSymbolResponse::Nested(Vec::new())
+            } else {
+                DocumentSymbolResponse::Flat(Vec::new())
+            };
+            return Ok(Some(response));
+        };
+        let symbol_tables = latest_analysis.await?;
+        let response = if hierarchical {
+            DocumentSymbolResponse::Nested(symbol_tables.read().document_symbols(&uri))
+        } else {
+            DocumentSymbolResponse::Flat(symbol_tables.read().flat_document_symbols(&uri))
+        };
+        Ok(Some(response))
+    }
 }
 
 pub(crate) fn document_links(
     state: &mut GlobalState,
     params: DocumentLinkParams,
 ) -> impl Future<Output = Result<Option<Vec<DocumentLink>>, ResponseError>> + use<> {
-    let symbol_tables = state.symbol_tables.clone();
-    let (version, mut published) = state.current_analysis();
-    let path = params.text_document.uri.to_file_path().ok();
+    let request =
+        params.text_document.uri.to_file_path().ok().map(|path| (path, state.latest_analysis()));
     async move {
-        published
-            .wait_for(|published| *published >= version)
-            .await
-            .map_err(|_| request_failed("analysis was cancelled"))?;
-        let links =
-            path.as_ref().map_or_else(Vec::new, |path| symbol_tables.read().document_links(path));
+        let Some((path, latest_analysis)) = request else { return Ok(Some(Vec::new())) };
+        let symbol_tables = latest_analysis.await?;
+        let links = symbol_tables.read().document_links(&path);
         Ok(Some(links))
     }
 }
@@ -198,23 +215,25 @@ pub(crate) fn goto_definition(
     params: GotoDefinitionParams,
 ) -> impl Future<Output = Result<Option<GotoDefinitionResponse>, ResponseError>> + use<> {
     let params = params.text_document_position_params;
-    let response =
-        state.symbol_tables.read().goto_definition(&params.text_document.uri, params.position);
-    ready(Ok(response))
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response =
+            symbol_tables.read().goto_definition(&params.text_document.uri, params.position);
+        Ok(response)
+    }
 }
 
 pub(crate) fn goto_type_definition(
     state: &mut GlobalState,
     params: GotoDefinitionParams,
 ) -> impl Future<Output = Result<Option<GotoDefinitionResponse>, ResponseError>> + use<> {
-    let symbol_tables = state.symbol_tables.clone();
-    let (version, mut published) = state.current_analysis();
     let params = params.text_document_position_params;
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
     async move {
-        published
-            .wait_for(|published| *published >= version)
-            .await
-            .map_err(|_| request_failed("analysis was cancelled"))?;
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
         let response =
             symbol_tables.read().goto_type_definition(&params.text_document.uri, params.position);
         Ok(response)
@@ -226,9 +245,14 @@ pub(crate) fn goto_declaration(
     params: GotoDefinitionParams,
 ) -> impl Future<Output = Result<Option<GotoDefinitionResponse>, ResponseError>> + use<> {
     let params = params.text_document_position_params;
-    let response =
-        state.symbol_tables.read().goto_declaration(&params.text_document.uri, params.position);
-    ready(Ok(response))
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response =
+            symbol_tables.read().goto_declaration(&params.text_document.uri, params.position);
+        Ok(response)
+    }
 }
 
 pub(crate) fn references(
@@ -237,57 +261,74 @@ pub(crate) fn references(
 ) -> impl Future<Output = Result<Option<Vec<lsp_types::Location>>, ResponseError>> + use<> {
     let include_declaration = params.context.include_declaration;
     let params = params.text_document_position;
-    let response = state.symbol_tables.read().references(
-        &params.text_document.uri,
-        params.position,
-        include_declaration,
-    );
-    ready(Ok(response))
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response = symbol_tables.read().references(
+            &params.text_document.uri,
+            params.position,
+            include_declaration,
+        );
+        Ok(response)
+    }
 }
 
 pub(crate) fn prepare_rename(
     state: &mut GlobalState,
     params: TextDocumentPositionParams,
 ) -> impl Future<Output = Result<Option<PrepareRenameResponse>, ResponseError>> + use<> {
-    let response = state
-        .symbol_tables
-        .read()
-        .rename_candidate(&params.text_document.uri, params.position)
-        .map(|candidate| PrepareRenameResponse::Range(candidate.range));
-    ready(Ok(response))
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response = symbol_tables
+            .read()
+            .rename_candidate(&params.text_document.uri, params.position)
+            .map(|candidate| PrepareRenameResponse::Range(candidate.range));
+        Ok(response)
+    }
 }
 
 pub(crate) fn rename(
     state: &mut GlobalState,
     params: RenameParams,
 ) -> impl Future<Output = Result<Option<WorkspaceEdit>, ResponseError>> + use<> {
-    let params_position = params.text_document_position;
-    let candidate = state
-        .symbol_tables
-        .read()
-        .rename_candidate(&params_position.text_document.uri, params_position.position);
+    let RenameParams { text_document_position: params_position, new_name, .. } = params;
+    let invalid_name = !is_ident(&new_name)
+        || enter(|| {
+            let name = Symbol::intern(&new_name);
+            name.is_reserved(false)
+        });
+    let latest_analysis = if invalid_name {
+        None
+    } else {
+        latest_analysis_for_uri(state, &params_position.text_document.uri)
+    };
     let vfs = state.vfs.clone();
     let document_changes = state.config.supports_workspace_edit_document_changes();
     async move {
-        if !is_ident(&params.new_name)
-            || enter(|| {
-                let name = Symbol::intern(&params.new_name);
-                name.is_reserved(false)
-                    || candidate.as_ref().is_some_and(|candidate| {
-                        candidate.requires_yul_validation && name.is_reserved(true)
-                    })
-            })
-        {
+        if invalid_name {
             return Err(ResponseError::new(ErrorCode::INVALID_PARAMS, "invalid rename name"));
         }
 
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let candidate = symbol_tables
+            .read()
+            .rename_candidate(&params_position.text_document.uri, params_position.position);
         let Some(candidate) = candidate else { return Ok(None) };
-        if candidate.old_name == params.new_name {
+        if candidate.requires_yul_validation
+            && enter(|| Symbol::intern(&new_name).is_reserved(true))
+        {
+            return Err(ResponseError::new(ErrorCode::INVALID_PARAMS, "invalid rename name"));
+        }
+        if candidate.old_name == new_name {
             return Ok(None);
         }
 
         tokio::task::spawn_blocking(move || {
-            validated_workspace_edit(candidate, params.new_name, vfs, document_changes)
+            validated_workspace_edit(candidate, new_name, vfs, document_changes)
         })
         .await
         .map_err(|error| {
@@ -406,8 +447,13 @@ pub(crate) fn inlay_hints(
     state: &mut GlobalState,
     params: InlayHintParams,
 ) -> impl Future<Output = Result<Option<Vec<InlayHint>>, ResponseError>> + use<> {
-    let response = state.symbol_tables.read().inlay_hints(&params.text_document.uri, params.range);
-    ready(Ok(Some(response)))
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(Some(Vec::new())) };
+        let symbol_tables = latest_analysis.await?;
+        let response = symbol_tables.read().inlay_hints(&params.text_document.uri, params.range);
+        Ok(Some(response))
+    }
 }
 
 pub(crate) fn signature_help(

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -279,14 +279,11 @@ pub(crate) fn document_highlight(
     state: &mut GlobalState,
     params: DocumentHighlightParams,
 ) -> impl Future<Output = Result<Option<Vec<DocumentHighlight>>, ResponseError>> + use<> {
-    let symbol_tables = state.symbol_tables.clone();
-    let (version, mut published) = state.current_analysis();
     let params = params.text_document_position_params;
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
     async move {
-        published
-            .wait_for(|published| *published >= version)
-            .await
-            .map_err(|_| request_failed("analysis was cancelled"))?;
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
         let response =
             symbol_tables.read().document_highlights(&params.text_document.uri, params.position);
         Ok(response)

--- a/crates/lsp/src/tests/requests.rs
+++ b/crates/lsp/src/tests/requests.rs
@@ -25,8 +25,8 @@ fn completion_input_extracts_prefix_and_member_receiver() {
 
 #[test]
 fn document_symbol_returns_flat_symbols_without_hierarchical_client_support() {
-    let uri = parse_uri("file:///workspace/src/Test.sol");
-    let other_uri = parse_uri("file:///workspace/src/Other.sol");
+    let uri = file_uri("Test.sol");
+    let other_uri = file_uri("Other.sol");
     let mut state =
         state_with_symbols(symbol_tables(&uri, &other_uri), InitializeParams::default());
 
@@ -46,8 +46,8 @@ fn document_symbol_returns_flat_symbols_without_hierarchical_client_support() {
 
 #[test]
 fn document_symbol_returns_nested_symbols_with_hierarchical_client_support() {
-    let uri = parse_uri("file:///workspace/src/Test.sol");
-    let other_uri = parse_uri("file:///workspace/src/Other.sol");
+    let uri = file_uri("Test.sol");
+    let other_uri = file_uri("Other.sol");
     let mut state = state_with_symbols(
         symbol_tables(&uri, &other_uri),
         initialize_params_with_hierarchical_document_symbols(),
@@ -74,8 +74,8 @@ fn document_symbol_returns_nested_symbols_with_hierarchical_client_support() {
 
 #[test]
 fn workspace_symbol_returns_matching_symbols() {
-    let uri = parse_uri("file:///workspace/src/Test.sol");
-    let other_uri = parse_uri("file:///workspace/src/Other.sol");
+    let uri = file_uri("Test.sol");
+    let other_uri = file_uri("Other.sol");
     let mut state =
         state_with_symbols(symbol_tables(&uri, &other_uri), InitializeParams::default());
 
@@ -98,7 +98,7 @@ fn workspace_symbol_returns_matching_symbols() {
 
 #[test]
 fn semantic_requests_wait_for_latest_analysis() {
-    let uri = parse_uri("file:///workspace/src/Test.sol");
+    let uri = file_uri("Test.sol");
     let mut state = pending_analysis_state();
 
     assert_pending(document_symbol(&mut state, document_symbol_params(uri.clone())));
@@ -130,7 +130,7 @@ fn semantic_requests_skip_analysis_for_non_file_uris() {
 
 #[test]
 fn invalid_rename_names_and_latency_sensitive_requests_do_not_wait_for_analysis() {
-    let uri = parse_uri("file:///workspace/src/Test.sol");
+    let uri = file_uri("Test.sol");
     let mut state = pending_analysis_state();
 
     let error =
@@ -258,6 +258,10 @@ fn symbol_tables(uri: &lsp_types::Url, other_uri: &lsp_types::Url) -> SymbolTabl
 
 fn parse_uri(uri: &str) -> lsp_types::Url {
     lsp_types::Url::parse(uri).unwrap()
+}
+
+fn file_uri(path: &str) -> lsp_types::Url {
+    lsp_types::Url::from_file_path(std::env::temp_dir().join(path)).unwrap()
 }
 
 fn expect_ready<F: Future>(future: F) -> F::Output {

--- a/crates/lsp/src/tests/requests.rs
+++ b/crates/lsp/src/tests/requests.rs
@@ -6,8 +6,8 @@ use crate::{
 use async_lsp::ClientSocket;
 use lsp_types::{
     DocumentSymbolClientCapabilities, DocumentSymbolResponse, InitializeParams,
-    PartialResultParams, SymbolKind, TextDocumentClientCapabilities, TextDocumentIdentifier, Url,
-    WorkDoneProgressParams, WorkspaceSymbolResponse,
+    PartialResultParams, ReferenceContext, SymbolKind, TextDocumentClientCapabilities,
+    TextDocumentIdentifier, Url, WorkDoneProgressParams, WorkspaceSymbolResponse,
 };
 use std::{
     future::Future,
@@ -96,6 +96,129 @@ fn workspace_symbol_returns_matching_symbols() {
     assert_eq!(symbols.iter().map(|symbol| symbol.name.as_str()).collect::<Vec<_>>(), ["Other"]);
 }
 
+#[test]
+fn semantic_requests_wait_for_latest_analysis() {
+    let uri = parse_uri("file:///workspace/src/Test.sol");
+    let mut state = pending_analysis_state();
+
+    assert_pending(document_symbol(&mut state, document_symbol_params(uri.clone())));
+    assert_pending(document_links(&mut state, document_link_params(uri.clone())));
+    assert_pending(goto_definition(&mut state, goto_params(uri.clone())));
+    assert_pending(goto_type_definition(&mut state, goto_params(uri.clone())));
+    assert_pending(goto_declaration(&mut state, goto_params(uri.clone())));
+    assert_pending(references(&mut state, reference_params(uri.clone())));
+    assert_pending(prepare_rename(&mut state, position_params(uri.clone())));
+    assert_pending(rename(&mut state, rename_params(uri.clone(), "renamed")));
+    assert_pending(inlay_hints(&mut state, inlay_hint_params(uri)));
+}
+
+#[test]
+fn semantic_requests_skip_analysis_for_non_file_uris() {
+    let uri = parse_uri("untitled:Test.sol");
+    let mut state = pending_analysis_state();
+
+    assert_ready(document_symbol(&mut state, document_symbol_params(uri.clone())));
+    assert_ready(document_links(&mut state, document_link_params(uri.clone())));
+    assert_ready(goto_definition(&mut state, goto_params(uri.clone())));
+    assert_ready(goto_type_definition(&mut state, goto_params(uri.clone())));
+    assert_ready(goto_declaration(&mut state, goto_params(uri.clone())));
+    assert_ready(references(&mut state, reference_params(uri.clone())));
+    assert_ready(prepare_rename(&mut state, position_params(uri.clone())));
+    assert_ready(rename(&mut state, rename_params(uri.clone(), "renamed")));
+    assert_ready(inlay_hints(&mut state, inlay_hint_params(uri)));
+}
+
+#[test]
+fn invalid_rename_names_and_latency_sensitive_requests_do_not_wait_for_analysis() {
+    let uri = parse_uri("file:///workspace/src/Test.sol");
+    let mut state = pending_analysis_state();
+
+    let error =
+        expect_ready(rename(&mut state, rename_params(uri.clone(), "not a name"))).unwrap_err();
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+    assert_ready(completion(&mut state, completion_params(uri.clone())));
+    assert_ready(signature_help(&mut state, signature_help_params(uri)));
+    assert_ready(workspace_symbol(
+        &mut state,
+        WorkspaceSymbolParams {
+            query: String::new(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+    ));
+}
+
+fn pending_analysis_state() -> GlobalState {
+    let state = GlobalState::new(ClientSocket::new_closed());
+    state.mark_analysis_pending_for_test();
+    state
+}
+
+fn position_params(uri: Url) -> TextDocumentPositionParams {
+    TextDocumentPositionParams {
+        text_document: TextDocumentIdentifier::new(uri),
+        position: Position::new(0, 0),
+    }
+}
+
+fn goto_params(uri: Url) -> GotoDefinitionParams {
+    GotoDefinitionParams {
+        text_document_position_params: position_params(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn reference_params(uri: Url) -> ReferenceParams {
+    ReferenceParams {
+        text_document_position: position_params(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+        context: ReferenceContext { include_declaration: true },
+    }
+}
+
+fn rename_params(uri: Url, new_name: &str) -> RenameParams {
+    RenameParams {
+        text_document_position: position_params(uri),
+        new_name: new_name.into(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn document_link_params(uri: Url) -> DocumentLinkParams {
+    DocumentLinkParams {
+        text_document: TextDocumentIdentifier::new(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn inlay_hint_params(uri: Url) -> InlayHintParams {
+    InlayHintParams {
+        text_document: TextDocumentIdentifier::new(uri),
+        range: lsp_types::Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn completion_params(uri: Url) -> CompletionParams {
+    CompletionParams {
+        text_document_position: position_params(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+        context: None,
+    }
+}
+
+fn signature_help_params(uri: Url) -> SignatureHelpParams {
+    SignatureHelpParams {
+        context: None,
+        text_document_position_params: position_params(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
 fn state_with_symbols(symbol_tables: SymbolTables, params: InitializeParams) -> GlobalState {
     let (_, config) = negotiate_capabilities(params);
     let mut state = GlobalState::new(ClientSocket::new_closed());
@@ -145,6 +268,17 @@ fn expect_ready<F: Future>(future: F) -> F::Output {
         Poll::Ready(output) => output,
         Poll::Pending => panic!("request handler future should complete immediately"),
     }
+}
+
+fn assert_pending<F: Future>(future: F) {
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    let mut future = std::pin::pin!(future);
+    assert!(future.as_mut().poll(&mut context).is_pending());
+}
+
+fn assert_ready<F: Future>(future: F) {
+    let _ = expect_ready(future);
 }
 
 fn assert_completion_input(


### PR DESCRIPTION
Semantic requests could read previously published symbol tables while a newer whole-project analysis was still running, producing stale navigation targets, ranges, references, and rename candidates.

This adds an awaitable latest-analysis API and uses it for position-sensitive navigation, rename, document symbols and links, references, and inlay hints. Completion, signature help, workspace symbols, and formatting stay non-blocking for responsive typing and search. Requests that cannot resolve to file paths, along with immediately invalid rename names, bypass the analysis barrier.

cc @0xKarl98 