### PR TITLE
feat(lsp): add document highlights

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -256,6 +256,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
                 work_done_progress_options: WorkDoneProgressOptions::default(),
             }),
             document_symbol_provider: Some(OneOf::Left(true)),
+            document_highlight_provider: Some(OneOf::Left(true)),
             inlay_hint_provider: Some(OneOf::Left(true)),
             references_provider: Some(OneOf::Left(true)),
             rename_provider: Some(OneOf::Right(RenameOptions {
@@ -358,6 +359,7 @@ mod tests {
         let document_link_provider = capabilities.document_link_provider.unwrap();
         assert_eq!(document_link_provider.resolve_provider, Some(false));
         assert_eq!(capabilities.inlay_hint_provider, Some(OneOf::Left(true)));
+        assert_eq!(capabilities.document_highlight_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.references_provider, Some(OneOf::Left(true)));
         assert_eq!(
             capabilities.rename_provider,

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -7,12 +7,13 @@ use crate::{
 use async_lsp::{ErrorCode, ResponseError};
 use crop::Rope;
 use lsp_types::{
-    CompletionParams, CompletionResponse, DocumentChanges, DocumentFormattingParams, DocumentLink,
-    DocumentLinkParams, DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams,
-    GotoDefinitionResponse, InlayHint, InlayHintParams, OneOf,
-    OptionalVersionedTextDocumentIdentifier, Position, PrepareRenameResponse, ReferenceParams,
-    RenameParams, SignatureHelp, SignatureHelpParams, TextDocumentEdit, TextDocumentPositionParams,
-    TextEdit, Url, WorkspaceEdit, WorkspaceSymbolParams, WorkspaceSymbolResponse,
+    CompletionParams, CompletionResponse, DocumentChanges, DocumentFormattingParams,
+    DocumentHighlight, DocumentHighlightParams, DocumentLink, DocumentLinkParams,
+    DocumentSymbolParams, DocumentSymbolResponse, GotoDefinitionParams, GotoDefinitionResponse,
+    InlayHint, InlayHintParams, OneOf, OptionalVersionedTextDocumentIdentifier, Position,
+    PrepareRenameResponse, ReferenceParams, RenameParams, SignatureHelp, SignatureHelpParams,
+    TextDocumentEdit, TextDocumentPositionParams, TextEdit, Url, WorkspaceEdit,
+    WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
 use solar_interface::{Symbol, data_structures::sync::RwLock, enter, source_map::SourceMap};
 use solar_parse::lexer::is_ident;
@@ -243,6 +244,24 @@ pub(crate) fn references(
         include_declaration,
     );
     ready(Ok(response))
+}
+
+pub(crate) fn document_highlight(
+    state: &mut GlobalState,
+    params: DocumentHighlightParams,
+) -> impl Future<Output = Result<Option<Vec<DocumentHighlight>>, ResponseError>> + use<> {
+    let symbol_tables = state.symbol_tables.clone();
+    let (version, mut published) = state.current_analysis();
+    let params = params.text_document_position_params;
+    async move {
+        published
+            .wait_for(|published| *published >= version)
+            .await
+            .map_err(|_| request_failed("analysis was cancelled"))?;
+        let response =
+            symbol_tables.read().document_highlights(&params.text_document.uri, params.position);
+        Ok(response)
+    }
 }
 
 pub(crate) fn prepare_rename(

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -58,6 +58,7 @@ fn new_router(client: ClientSocket) -> Router<GlobalState> {
         .request::<req::GotoTypeDefinition, _>(handlers::goto_type_definition)
         .request::<req::GotoDeclaration, _>(handlers::goto_declaration)
         .request::<req::References, _>(handlers::references)
+        .request::<req::DocumentHighlightRequest, _>(handlers::document_highlight)
         .request::<req::PrepareRenameRequest, _>(handlers::prepare_rename)
         .request::<req::Rename, _>(handlers::rename)
         .request::<req::SignatureHelpRequest, _>(handlers::signature_help)
@@ -116,11 +117,12 @@ mod tests {
     use async_lsp::{AnyNotification, AnyRequest, LanguageServer, LspService, router::Router};
     use lsp_types::{
         DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
-        DidSaveTextDocumentParams, DocumentFormattingParams, DocumentLinkParams, FileChangeType,
-        FileEvent, FormattingOptions, InitializeParams, InitializedParams, PartialResultParams,
-        Position, SignatureHelpParams, TextDocumentIdentifier, TextDocumentPositionParams,
-        WorkDoneProgressParams, WorkspaceClientCapabilities, notification as notif,
-        notification::Notification, request, request::Request,
+        DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlightParams,
+        DocumentLinkParams, FileChangeType, FileEvent, FormattingOptions, InitializeParams,
+        InitializedParams, PartialResultParams, Position, SignatureHelpParams,
+        TextDocumentIdentifier, TextDocumentPositionParams, WorkDoneProgressParams,
+        WorkspaceClientCapabilities, notification as notif, notification::Notification, request,
+        request::Request,
     };
     use std::ops::ControlFlow;
     use tokio::sync::oneshot;
@@ -183,6 +185,31 @@ mod tests {
         let response = router.call(request).await.unwrap();
 
         assert_eq!(response, serde_json::json!([]));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_document_highlight_requests() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let params = DocumentHighlightParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: lsp_types::Url::parse("file:///workspace/src/Test.sol").unwrap(),
+                },
+                position: Position::new(0, 0),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
+            "id": 1,
+            "method": request::DocumentHighlightRequest::METHOD,
+            "params": params,
+        }))
+        .unwrap();
+
+        let response = router.call(request).await.unwrap();
+
+        assert_eq!(response, serde_json::Value::Null);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1494,7 +1494,6 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             hir::ExprKind::Member(receiver, ident) | hir::ExprKind::YulMember(receiver, ident) => {
                 self.visit_member_reference(expr, receiver, ident, DocumentHighlightKind::WRITE)?;
             }
-            hir::ExprKind::Index(..) => hir::Visit::walk_expr(self, expr)?,
             hir::ExprKind::Tuple(exprs) => {
                 for expr in exprs.iter().copied().flatten() {
                     self.visit_lvalue(expr)?;
@@ -1537,11 +1536,10 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             return ReferenceTargets::from_buf([symbol_id]);
         }
 
-        if let Some(callee) = self.gcx.resolved_callee(expr.id) {
-            let targets = self.symbol_ids_for_res([callee.res]);
-            if !targets.is_empty() {
-                return targets;
-            }
+        if let Some(callee) = self.gcx.resolved_callee(expr.id)
+            && let Some(symbol_id) = self.symbol_id_for_res(callee.res)
+        {
+            return ReferenceTargets::from_buf([symbol_id]);
         }
 
         ReferenceTargets::new()
@@ -1604,21 +1602,21 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         Some(CallableParamSource::Function { id, skips_receiver: false })
     }
 
-    fn call_param_ids(&self, source: CallableParamSource) -> Vec<VariableId> {
+    fn call_param_ids(&self, source: CallableParamSource) -> &'gcx [VariableId] {
         let (params, skip) = match source {
             CallableParamSource::Function { id, skips_receiver } => {
                 (self.gcx.hir.function(id).parameters, usize::from(skips_receiver))
             }
             CallableParamSource::FunctionType(id) => match self.gcx.hir.variable(id).ty.kind {
                 TypeKind::Function(ty) => (ty.parameters, 0),
-                _ => return Vec::new(),
+                _ => return &[],
             },
             CallableParamSource::Struct(id) => (self.gcx.hir.strukt(id).fields, 0),
             CallableParamSource::Event(id) => (self.gcx.hir.event(id).parameters, 0),
             CallableParamSource::Error(id) => (self.gcx.hir.error(id).parameters, 0),
-            CallableParamSource::Builtin(_) => return Vec::new(),
+            CallableParamSource::Builtin(_) => return &[],
         };
-        params.iter().copied().skip(skip).collect()
+        params.get(skip..).unwrap_or_default()
     }
 
     fn visit_using_directive(&mut self, using: &'gcx hir::UsingDirective<'gcx>) {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1,7 +1,7 @@
 use lsp_types::{
-    CompletionItem, CompletionItemKind, DocumentSymbol, GotoDefinitionResponse, InlayHint,
-    Location, OneOf, Position, Range, SymbolInformation, SymbolKind, Url, WorkspaceSymbol,
-    request::GotoTypeDefinitionResponse,
+    CompletionItem, CompletionItemKind, DocumentHighlight, DocumentHighlightKind, DocumentSymbol,
+    GotoDefinitionResponse, InlayHint, Location, OneOf, Position, Range, SymbolInformation,
+    SymbolKind, Url, WorkspaceSymbol, request::GotoTypeDefinitionResponse,
 };
 use solar_interface::{
     Span,
@@ -124,6 +124,7 @@ impl<'a> CompletionContext<'a> {
 struct SymbolReference {
     location: Location,
     targets: Vec<SymbolId>,
+    kind: DocumentHighlightKind,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -470,6 +471,47 @@ impl SymbolTables {
         sort_locations(&mut locations);
         locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
         Some(locations)
+    }
+
+    pub(crate) fn document_highlights(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Vec<DocumentHighlight>> {
+        let targets = self.symbol_ids_at_position(uri, position)?;
+        let mut highlights = targets
+            .iter()
+            .filter_map(|&symbol_id| {
+                let location = self.selection_location(symbol_id);
+                (&location.uri == uri).then_some(DocumentHighlight {
+                    range: location.range,
+                    kind: Some(DocumentHighlightKind::WRITE),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        if let Some(references) = self.file_references.get(uri) {
+            highlights.extend(references.iter().filter_map(|&index| {
+                let reference = &self.references[index];
+                reference.targets.iter().any(|target| targets.contains(target)).then_some(
+                    DocumentHighlight {
+                        range: reference.location.range,
+                        kind: Some(reference.kind),
+                    },
+                )
+            }));
+        }
+
+        highlights.sort_by_key(|highlight| {
+            (
+                highlight.range.start.line,
+                highlight.range.start.character,
+                highlight.range.end.line,
+                highlight.range.end.character,
+            )
+        });
+        highlights.dedup_by(|a, b| a.range == b.range);
+        Some(highlights)
     }
 
     pub(crate) fn rename_candidate(
@@ -1380,6 +1422,15 @@ struct ReferenceCollector<'a, 'gcx> {
 
 impl<'gcx> ReferenceCollector<'_, 'gcx> {
     fn push_reference(&mut self, span: Span, targets: Vec<SymbolId>) {
+        self.push_reference_with_kind(span, targets, DocumentHighlightKind::READ);
+    }
+
+    fn push_reference_with_kind(
+        &mut self,
+        span: Span,
+        targets: Vec<SymbolId>,
+        kind: DocumentHighlightKind,
+    ) {
         if let Some(source) = self.source {
             if self.in_yul {
                 self.tables.rename.mark_yul_symbols(&targets);
@@ -1403,7 +1454,62 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), span) else {
             return;
         };
-        self.tables.references.push(SymbolReference { location, targets });
+        self.tables.references.push(SymbolReference { location, targets, kind });
+    }
+
+    fn visit_ident_reference(
+        &mut self,
+        expr: &'gcx hir::Expr<'gcx>,
+        resolutions: &[Res],
+        kind: DocumentHighlightKind,
+    ) {
+        let resolutions = if let Some(callee) = self.gcx.resolved_callee(expr.id)
+            && !callee.res.is_err()
+        {
+            vec![callee.res]
+        } else {
+            resolutions.to_vec()
+        };
+        let targets = self.symbol_ids_for_res(resolutions.iter().copied());
+        self.push_reference_with_kind(expr.span, targets, kind);
+        self.push_namespace_references(expr.span, &resolutions);
+    }
+
+    fn visit_member_reference(
+        &mut self,
+        expr: &'gcx hir::Expr<'gcx>,
+        receiver: &'gcx hir::Expr<'gcx>,
+        ident: solar_interface::Ident,
+        kind: DocumentHighlightKind,
+    ) -> ControlFlow<Never> {
+        self.visit_expr(receiver)?;
+        let targets = self.symbol_ids_for_member_expr(expr);
+        self.push_reference_with_kind(ident.span, targets, kind);
+        ControlFlow::Continue(())
+    }
+
+    fn visit_lvalue(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Never> {
+        match expr.kind {
+            hir::ExprKind::Ident(resolutions) => {
+                self.visit_ident_reference(expr, resolutions, DocumentHighlightKind::WRITE);
+            }
+            hir::ExprKind::Member(receiver, ident) | hir::ExprKind::YulMember(receiver, ident) => {
+                self.visit_member_reference(expr, receiver, ident, DocumentHighlightKind::WRITE)?;
+            }
+            hir::ExprKind::Index(receiver, index) => {
+                self.visit_expr(receiver)?;
+                if let Some(index) = index {
+                    self.visit_expr(index)?;
+                }
+            }
+            hir::ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().copied().flatten() {
+                    self.visit_lvalue(expr)?;
+                }
+            }
+            _ => self.visit_expr(expr)?,
+        }
+        ControlFlow::Continue(())
     }
 
     fn push_namespace_references(&mut self, span: Span, resolutions: &[Res]) {
@@ -1607,28 +1713,27 @@ impl<'gcx> hir::Visit<'gcx> for ReferenceCollector<'_, 'gcx> {
 
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         match expr.kind {
+            hir::ExprKind::Assign(lhs, _, rhs) => {
+                self.visit_lvalue(lhs)?;
+                self.visit_expr(rhs)?;
+            }
             hir::ExprKind::Call(callee, ref args, _) => {
                 if let Some(source) = self.call_param_source(callee) {
                     self.push_named_arg_references(source, args);
                 }
                 hir::Visit::walk_expr(self, expr)?;
             }
-            hir::ExprKind::Ident(res) => {
-                let resolutions = if let Some(callee) = self.gcx.resolved_callee(expr.id)
-                    && !callee.res.is_err()
-                {
-                    vec![callee.res]
-                } else {
-                    res.to_vec()
-                };
-                let targets = self.symbol_ids_for_res(resolutions.iter().copied());
-                self.push_reference(expr.span, targets);
-                self.push_namespace_references(expr.span, &resolutions);
+            hir::ExprKind::Delete(inner) => {
+                self.visit_lvalue(inner)?;
+            }
+            hir::ExprKind::Unary(op, inner) if op.kind.has_side_effects() => {
+                self.visit_lvalue(inner)?;
+            }
+            hir::ExprKind::Ident(resolutions) => {
+                self.visit_ident_reference(expr, resolutions, DocumentHighlightKind::READ);
             }
             hir::ExprKind::Member(receiver, ident) | hir::ExprKind::YulMember(receiver, ident) => {
-                self.visit_expr(receiver)?;
-                let targets = self.symbol_ids_for_member_expr(expr);
-                self.push_reference(ident.span, targets);
+                self.visit_member_reference(expr, receiver, ident, DocumentHighlightKind::READ)?;
             }
             _ => {
                 hir::Visit::walk_expr(self, expr)?;

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -53,7 +53,7 @@ pub(crate) struct SymbolTables {
     file_scopes: FxHashMap<Url, Vec<ScopeId>>,
     references: Vec<SymbolReference>,
     file_references: FxHashMap<Url, Vec<usize>>,
-    symbol_references: FxHashMap<SymbolId, Vec<Location>>,
+    symbol_references: FxHashMap<SymbolId, Vec<usize>>,
     rename: RenameIndex,
     document_links: DocumentLinkIndex,
     inlay_hints: InlayHintIndex,
@@ -69,6 +69,7 @@ newtype_index! {
 }
 
 type TypeDefinitionTargets = SmallVec<[SymbolId; 1]>;
+type ReferenceTargets = SmallVec<[SymbolId; 1]>;
 
 #[derive(Clone, Debug)]
 pub(crate) struct DeclarationSymbol {
@@ -123,7 +124,7 @@ impl<'a> CompletionContext<'a> {
 #[derive(Clone, Debug)]
 struct SymbolReference {
     location: Location,
-    targets: Vec<SymbolId>,
+    targets: ReferenceTargets,
     kind: DocumentHighlightKind,
 }
 
@@ -462,11 +463,11 @@ impl SymbolTables {
             locations.extend(target.iter().map(|&symbol_id| self.selection_location(symbol_id)));
         }
 
-        for symbol_id in target {
-            if let Some(references) = self.symbol_references.get(&symbol_id) {
-                locations.extend(references.iter().cloned());
-            }
-        }
+        locations.extend(
+            self.reference_indices_for_targets(&target)
+                .into_iter()
+                .map(|index| self.references[index].location.clone()),
+        );
 
         sort_locations(&mut locations);
         locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
@@ -482,9 +483,9 @@ impl SymbolTables {
         let mut highlights = targets
             .iter()
             .filter_map(|&symbol_id| {
-                let location = self.selection_location(symbol_id);
-                (&location.uri == uri).then_some(DocumentHighlight {
-                    range: location.range,
+                let declaration = &self.declarations[symbol_id];
+                (&declaration.location.uri == uri).then_some(DocumentHighlight {
+                    range: declaration.name_range,
                     kind: Some(DocumentHighlightKind::WRITE),
                 })
             })
@@ -502,14 +503,7 @@ impl SymbolTables {
             }));
         }
 
-        highlights.sort_by_key(|highlight| {
-            (
-                highlight.range.start.line,
-                highlight.range.start.character,
-                highlight.range.end.line,
-                highlight.range.end.character,
-            )
-        });
+        highlights.sort_by_key(|highlight| (highlight.range.start, highlight.range.end));
         highlights.dedup_by(|a, b| a.range == b.range);
         Some(highlights)
     }
@@ -837,13 +831,25 @@ impl SymbolTables {
         Some(locations)
     }
 
-    fn symbol_ids_at_position(&self, uri: &Url, position: Position) -> Option<Vec<SymbolId>> {
+    fn symbol_ids_at_position(&self, uri: &Url, position: Position) -> Option<ReferenceTargets> {
         if let Some(reference) = self.reference_at_position(uri, position) {
             return Some(reference.targets.clone());
         }
 
         let symbol_id = self.declaration_at_position(uri, position)?;
-        Some(vec![symbol_id])
+        Some(ReferenceTargets::from_buf([symbol_id]))
+    }
+
+    fn reference_indices_for_targets(&self, targets: &[SymbolId]) -> Vec<usize> {
+        let mut indices = targets
+            .iter()
+            .filter_map(|target| self.symbol_references.get(target))
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
+        indices.sort_unstable();
+        indices.dedup();
+        indices
     }
 
     fn reference_at_position(&self, uri: &Url, position: Position) -> Option<&SymbolReference> {
@@ -1041,7 +1047,7 @@ impl SymbolTables {
         for (index, reference) in self.references.iter().enumerate() {
             self.file_references.entry(reference.location.uri.clone()).or_default().push(index);
             for &target in &reference.targets {
-                self.symbol_references.entry(target).or_default().push(reference.location.clone());
+                self.symbol_references.entry(target).or_default().push(index);
             }
         }
         for references in self.file_references.values_mut() {
@@ -1055,10 +1061,6 @@ impl SymbolTables {
                     index,
                 )
             });
-        }
-        for locations in self.symbol_references.values_mut() {
-            sort_locations(locations);
-            locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
         }
         self.rename.rebuild(&self.declarations);
     }
@@ -1421,14 +1423,14 @@ struct ReferenceCollector<'a, 'gcx> {
 }
 
 impl<'gcx> ReferenceCollector<'_, 'gcx> {
-    fn push_reference(&mut self, span: Span, targets: Vec<SymbolId>) {
+    fn push_reference(&mut self, span: Span, targets: ReferenceTargets) {
         self.push_reference_with_kind(span, targets, DocumentHighlightKind::READ);
     }
 
     fn push_reference_with_kind(
         &mut self,
         span: Span,
-        targets: Vec<SymbolId>,
+        targets: ReferenceTargets,
         kind: DocumentHighlightKind,
     ) {
         if let Some(source) = self.source {
@@ -1463,16 +1465,12 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         resolutions: &[Res],
         kind: DocumentHighlightKind,
     ) {
-        let resolutions = if let Some(callee) = self.gcx.resolved_callee(expr.id)
-            && !callee.res.is_err()
-        {
-            vec![callee.res]
-        } else {
-            resolutions.to_vec()
-        };
+        let callee = self.gcx.resolved_callee(expr.id).filter(|callee| !callee.res.is_err());
+        let resolutions =
+            callee.as_ref().map_or(resolutions, |callee| std::slice::from_ref(&callee.res));
         let targets = self.symbol_ids_for_res(resolutions.iter().copied());
         self.push_reference_with_kind(expr.span, targets, kind);
-        self.push_namespace_references(expr.span, &resolutions);
+        self.push_namespace_references(expr.span, resolutions);
     }
 
     fn visit_member_reference(
@@ -1496,12 +1494,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             hir::ExprKind::Member(receiver, ident) | hir::ExprKind::YulMember(receiver, ident) => {
                 self.visit_member_reference(expr, receiver, ident, DocumentHighlightKind::WRITE)?;
             }
-            hir::ExprKind::Index(receiver, index) => {
-                self.visit_expr(receiver)?;
-                if let Some(index) = index {
-                    self.visit_expr(index)?;
-                }
-            }
+            hir::ExprKind::Index(..) => hir::Visit::walk_expr(self, expr)?,
             hir::ExprKind::Tuple(exprs) => {
                 for expr in exprs.iter().copied().flatten() {
                     self.visit_lvalue(expr)?;
@@ -1526,7 +1519,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         );
     }
 
-    fn symbol_ids_for_res(&self, res: impl IntoIterator<Item = Res>) -> Vec<SymbolId> {
+    fn symbol_ids_for_res(&self, res: impl IntoIterator<Item = Res>) -> ReferenceTargets {
         res.into_iter().filter_map(|res| self.symbol_id_for_res(res)).collect()
     }
 
@@ -1537,11 +1530,11 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         }
     }
 
-    fn symbol_ids_for_member_expr(&self, expr: &hir::Expr<'gcx>) -> Vec<SymbolId> {
+    fn symbol_ids_for_member_expr(&self, expr: &hir::Expr<'gcx>) -> ReferenceTargets {
         if let Some(res) = self.gcx.resolved_member(expr.id)
             && let Some(symbol_id) = self.symbol_id_for_res(res)
         {
-            return vec![symbol_id];
+            return ReferenceTargets::from_buf([symbol_id]);
         }
 
         if let Some(callee) = self.gcx.resolved_callee(expr.id) {
@@ -1551,7 +1544,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             }
         }
 
-        Vec::new()
+        ReferenceTargets::new()
     }
 
     fn push_type_reference(&mut self, ty: &hir::Type<'gcx>) {
@@ -1559,7 +1552,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             && let Some(symbol_id) =
                 self.tables.symbols_by_key.get(&SymbolKey::Item(item_id)).copied()
         {
-            self.push_reference(ty.span, vec![symbol_id]);
+            self.push_reference(ty.span, ReferenceTargets::from_buf([symbol_id]));
         }
     }
 
@@ -1584,7 +1577,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
             if let Some(symbol_id) =
                 self.tables.symbols_by_key.get(&SymbolKey::Item(param.into())).copied()
             {
-                self.push_reference(arg.name.span, vec![symbol_id]);
+                self.push_reference(arg.name.span, ReferenceTargets::from_buf([symbol_id]));
             }
         }
     }
@@ -1640,7 +1633,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
                         .copied()
                         .map(|function_id| Res::Item(ItemId::Function(function_id))),
                 ),
-                UsingEntryKind::Err(_) => Vec::new(),
+                UsingEntryKind::Err(_) => ReferenceTargets::new(),
             };
             self.push_reference(entry.span, targets);
         }
@@ -1674,7 +1667,10 @@ impl<'gcx> hir::Visit<'gcx> for ReferenceCollector<'_, 'gcx> {
         if let Some(symbol_id) =
             self.tables.symbols_by_key.get(&SymbolKey::Item(modifier.id)).copied()
         {
-            self.push_reference(modifier.span.with_hi(modifier.args.span.lo()), vec![symbol_id]);
+            self.push_reference(
+                modifier.span.with_hi(modifier.args.span.lo()),
+                ReferenceTargets::from_buf([symbol_id]),
+            );
         }
         if let Some(source) = self.item_param_source(modifier.id) {
             self.push_named_arg_references(source, &modifier.args);

--- a/crates/lsp/src/tests/document_highlight.rs
+++ b/crates/lsp/src/tests/document_highlight.rs
@@ -1,0 +1,201 @@
+use super::{AnalysisBatch, GlobalState, SymbolTables, analyze, support::RequestFixture};
+use crate::test_support::TestProject;
+use async_lsp::ClientSocket;
+use lsp_types::{
+    DocumentHighlightKind, DocumentHighlightParams, PartialResultParams, Position,
+    TextDocumentIdentifier, TextDocumentPositionParams, Url, WorkDoneProgressParams,
+};
+use snapbox::str;
+use solar_config::CompileOpts;
+use solar_interface::data_structures::map::FxHashSet;
+use std::{
+    future::Future,
+    sync::atomic::Ordering,
+    task::{Context, Waker},
+};
+
+#[test]
+fn classifies_reads_writes_and_nested_lvalues() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Kinds.sol
+        contract C {
+            struct Box { uint256 $2field; }
+
+            uint256 $1value;
+            uint256 $4index;
+            mapping(uint256 => Box) $3boxes;
+            mapping(uint256 => uint256) $5items;
+
+            function update() external returns (uint256) {
+                uint256 read = value;
+                value = read;
+                value += 1;
+                delete value;
+                ++value;
+                value--;
+                boxes[index].field += 1;
+                items[index] = value;
+                return value;
+            }
+        }
+        "#,
+        "/Kinds.sol",
+    );
+
+    fixture.check_document_highlights(
+        "$1",
+        str![[r#"
+2:12-2:17 WRITE
+7:23-7:28 READ
+8:8-8:13 WRITE
+9:8-9:13 WRITE
+10:15-10:20 WRITE
+11:10-11:15 WRITE
+12:8-12:13 WRITE
+14:23-14:28 READ
+15:15-15:20 READ
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$2",
+        str![[r#"
+1:25-1:30 WRITE
+13:21-13:26 WRITE
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$3",
+        str![[r#"
+4:28-4:33 WRITE
+13:8-13:13 READ
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$4",
+        str![[r#"
+3:12-3:17 WRITE
+13:14-13:19 READ
+14:14-14:19 READ
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$5",
+        str![[r#"
+5:32-5:37 WRITE
+14:8-14:13 READ
+
+"#]],
+    );
+}
+
+#[test]
+fn scopes_semantic_matches_to_the_requested_document() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Base.sol
+        contract Base {
+            uint256 internal shared;
+        }
+
+        //- /Use.sol
+        import {Base} from "./Base.sol";
+        contract Use is Base {
+            function write(uint256 input) external {
+                $1shared = input;
+            }
+            function read() external view returns (uint256) {
+                return shared;
+            }
+            function shadow(uint256 $2shared) external pure returns (uint256) {
+                return shared;
+            }
+        }
+        "#,
+        "/Use.sol",
+    );
+
+    fixture.check_document_highlights(
+        "$1",
+        str![[r#"
+3:8-3:14 WRITE
+6:15-6:21 READ
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$2",
+        str![[r#"
+8:28-8:34 WRITE
+9:15-9:21 READ
+
+"#]],
+    );
+}
+
+#[test]
+fn waits_for_current_analysis_before_returning_highlights() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Highlights.sol
+        contract C {
+            uint256 value;
+            function read() external view returns (uint256) {
+                return value;
+            }
+        }
+        "#,
+    );
+    let path = project.path("/Highlights.sol");
+    let old_tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(path.clone(), project.read_file("/Highlights.sol"))],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let new_tables = analyze(AnalysisBatch {
+        opts: CompileOpts::default(),
+        files: vec![(
+            path.clone(),
+            "contract C {\n    uint256 placeholder;\n    uint256 value;\n    function write() external {\n        value = 1;\n    }\n}\n".into(),
+        )],
+        seen_paths: FxHashSet::default(),
+    })
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let params = DocumentHighlightParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier::new(uri),
+            position: Position::new(4, 8),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    *state.symbol_tables.write() = old_tables;
+    state.analysis_version.fetch_add(1, Ordering::AcqRel);
+
+    let mut request = std::pin::pin!(crate::handlers::document_highlight(&mut state, params));
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+
+    assert!(request.as_mut().poll(&mut context).is_pending());
+
+    state.analysis_version.fetch_add(1, Ordering::AcqRel);
+    let mut snapshot = state.snapshot();
+    assert!(snapshot.publish_symbol_tables(2, new_tables));
+    assert!(!snapshot.publish_symbol_tables(1, SymbolTables::default()));
+    let std::task::Poll::Ready(response) = request.as_mut().poll(&mut context) else {
+        panic!("document-highlight request should complete after analysis is published");
+    };
+    let highlights = response.unwrap().unwrap();
+    assert_eq!(highlights.len(), 2);
+    assert_eq!(highlights[0].range.start, Position::new(2, 12));
+    assert_eq!(highlights[0].kind, Some(DocumentHighlightKind::WRITE));
+    assert_eq!(highlights[1].range.start, Position::new(4, 8));
+    assert_eq!(highlights[1].kind, Some(DocumentHighlightKind::WRITE));
+}

--- a/crates/lsp/src/tests/document_highlight.rs
+++ b/crates/lsp/src/tests/document_highlight.rs
@@ -138,6 +138,108 @@ fn scopes_semantic_matches_to_the_requested_document() {
 }
 
 #[test]
+fn preserves_ambiguous_reference_targets() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Ambiguous.sol
+        contract C {
+            function $1pick(uint8 value) internal pure returns (uint8) {
+                return value;
+            }
+
+            function $2pick(uint256 value) internal pure returns (uint256) {
+                return value;
+            }
+
+            function call(uint8 value) public pure returns (uint256) {
+                return $3pick(value);
+            }
+        }
+        "#,
+        "/Ambiguous.sol",
+    );
+
+    fixture.check_references(
+        "$3",
+        true,
+        str![[r#"
+/Ambiguous.sol:1:13 function pick(uint8 value) internal pure returns (uint8) {
+/Ambiguous.sol:4:13 function pick(uint256 value) internal pure returns (uint256) {
+/Ambiguous.sol:8:15 return pick(value);
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$3",
+        str![[r#"
+1:13-1:17 WRITE
+4:13-4:17 WRITE
+8:15-8:19 READ
+
+"#]],
+    );
+}
+
+#[test]
+fn preserves_references_across_analysis_batches() {
+    let fixture = RequestFixture::new_in_batches(
+        r#"
+        //- /First.sol
+        contract First {
+            uint256 $3value;
+            function read() public view returns (uint256) {
+                return $4value;
+            }
+        }
+
+        //- /Second.sol
+        contract Second {
+            uint256 $1value;
+            function write() public {
+                $2value = 1;
+            }
+        }
+        "#,
+        &["/First.sol", "/Second.sol"],
+    );
+
+    fixture.check_references(
+        "$1",
+        true,
+        str![[r#"
+/Second.sol:1:12 uint256 value;
+/Second.sol:3:8 value = 1;
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$2",
+        str![[r#"
+1:12-1:17 WRITE
+3:8-3:13 WRITE
+
+"#]],
+    );
+    fixture.check_references(
+        "$3",
+        true,
+        str![[r#"
+/First.sol:1:12 uint256 value;
+/First.sol:3:15 return value;
+
+"#]],
+    );
+    fixture.check_document_highlights(
+        "$4",
+        str![[r#"
+1:12-1:17 WRITE
+3:15-3:20 READ
+
+"#]],
+    );
+}
+
+#[test]
 fn waits_for_current_analysis_before_returning_highlights() {
     let project = TestProject::from_fixture(
         r#"

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -9,6 +9,7 @@ use lsp_types::{
 use std::{path::Path, time::Duration};
 
 mod completion;
+mod document_highlight;
 mod document_link;
 mod goto_definition;
 mod inlay_hint;

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -2,12 +2,12 @@ use super::super::{AnalysisBatch, AnalysisResult, GlobalState, analyze};
 use crate::test_support::MarkedProject;
 use async_lsp::{ClientSocket, ErrorCode};
 use lsp_types::{
-    CompletionItem, CompletionParams, CompletionResponse, DocumentLink, DocumentLinkParams,
-    Documentation, GotoDefinitionParams, GotoDefinitionResponse, InlayHint, InlayHintKind,
-    InlayHintLabel, InlayHintParams, Location, ParameterLabel, PartialResultParams, Position,
-    PrepareRenameResponse, Range, ReferenceContext, ReferenceParams, RenameParams, SignatureHelp,
-    SignatureHelpParams, TextDocumentIdentifier, TextDocumentPositionParams, Url,
-    WorkDoneProgressParams, WorkspaceEdit,
+    CompletionItem, CompletionParams, CompletionResponse, DocumentHighlight, DocumentHighlightKind,
+    DocumentHighlightParams, DocumentLink, DocumentLinkParams, Documentation, GotoDefinitionParams,
+    GotoDefinitionResponse, InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Location,
+    ParameterLabel, PartialResultParams, Position, PrepareRenameResponse, Range, ReferenceContext,
+    ReferenceParams, RenameParams, SignatureHelp, SignatureHelpParams, TextDocumentIdentifier,
+    TextDocumentPositionParams, Url, WorkDoneProgressParams, WorkspaceEdit,
 };
 use snapbox::{IntoData, assert_data_eq};
 use solar_config::CompileOpts;
@@ -158,6 +158,17 @@ impl RequestFixture {
         ))
         .unwrap();
         assert_data_eq!(self.locations_output(response), expected);
+    }
+
+    pub(super) fn check_document_highlights(&self, marker: &str, expected: impl IntoData) {
+        let mut state = self.state();
+        let (uri, position) = self.marker_location(marker);
+        let response = expect_ready(crate::handlers::document_highlight(
+            &mut state,
+            document_highlight_params(uri, position),
+        ))
+        .unwrap();
+        assert_data_eq!(document_highlight_output(response), expected);
     }
 
     pub(super) fn check_prepare_rename(&self, marker: &str, expected: impl IntoData) {
@@ -469,6 +480,33 @@ fn prepare_rename_output(response: Option<PrepareRenameResponse>) -> String {
     )
 }
 
+fn document_highlight_output(response: Option<Vec<DocumentHighlight>>) -> String {
+    let Some(highlights) = response else { return "<none>\n".to_string() };
+    let mut output = String::new();
+    for highlight in highlights {
+        writeln!(
+            output,
+            "{}:{}-{}:{} {}",
+            highlight.range.start.line,
+            highlight.range.start.character,
+            highlight.range.end.line,
+            highlight.range.end.character,
+            document_highlight_kind(highlight.kind),
+        )
+        .unwrap();
+    }
+    output
+}
+
+fn document_highlight_kind(kind: Option<DocumentHighlightKind>) -> &'static str {
+    match kind {
+        Some(DocumentHighlightKind::TEXT) => "TEXT",
+        Some(DocumentHighlightKind::READ) => "READ",
+        Some(DocumentHighlightKind::WRITE) => "WRITE",
+        Some(_) | None => "UNKNOWN",
+    }
+}
+
 fn signature_help_output(help: Option<SignatureHelp>) -> String {
     let Some(help) = help else { return "<none>\n".to_string() };
     let mut output = String::new();
@@ -557,6 +595,14 @@ fn reference_params(uri: Url, position: Position, include_declaration: bool) -> 
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),
         context: ReferenceContext { include_declaration },
+    }
+}
+
+fn document_highlight_params(uri: Url, position: Position) -> DocumentHighlightParams {
+    DocumentHighlightParams {
+        text_document_position_params: text_document_position(uri, position),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
     }
 }
 


### PR DESCRIPTION
Add document highlights for Solidity symbols. Reads and writes are reported separately so editors can display them with different highlight colors. Declarations, assignments, compound assignments, deletes, and increment or decrement targets are classified as  writes, while ordinary value uses are classified as reads. 

 <img
    width="500"
    alt="Document highlights showing separate read and write colors"
    src="https://github.com/user-attachments/assets/7e52ce0b-ea04-49dd-b8ef-da93726031fb"
  />
  
 requests use the latest analysis so unsaved edits do not produce stale highlights.
