### PR TITLE
refactor(codegen): streamline EVM IR pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ name = "solar-codegen"
 version = "0.2.0"
 dependencies = [
  "alloy-primitives",
+ "arrayvec",
  "derive_more",
  "smallvec",
  "snapbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,7 @@ lsp-types = "0.95.0"
 tower = "0.5"
 
 # misc
+arrayvec = "0.7"
 bitflags = "2.4"
 bumpalo = "3.14"
 cfg-if = "1.0"

--- a/crates/cli/src/commands/compile.rs
+++ b/crates/cli/src/commands/compile.rs
@@ -1,4 +1,4 @@
-use solar_config::CompileOpts;
+use solar_config::{CompileOpts, DumpKind};
 use solar_interface::{Result, Session};
 use solar_sema::{CompilerRef, ParsingContext};
 use std::{ops::ControlFlow, process::ExitCode};
@@ -87,12 +87,17 @@ pub(crate) fn run_pipeline(
     // Code generation (MIR, EVM IR, and bytecode) is experimental and not part of the
     // stable, solc-compatible pipeline yet, so it is gated behind `-Zcodegen`.
     let needs_codegen = sess.opts.emit.iter().any(|e| e.is_codegen())
-        || sess.opts.unstable.dump.as_ref().is_some_and(|dump| dump.kind.is_codegen());
+        || sess.opts.unstable.dump.as_ref().is_some_and(|dump| {
+            dump.kinds.contains(&DumpKind::Mir)
+                || dump.kinds.contains(&DumpKind::MirCfg)
+                || dump.kinds.contains(&DumpKind::EvmIr)
+                || dump.kinds.contains(&DumpKind::EvmIrRuntime)
+        });
     if needs_codegen && !sess.opts.unstable.codegen {
         return Err(sess
             .dcx
             .err("code generation is experimental")
-            .help("pass `-Zcodegen` to emit or dump MIR, EVM IR, or bytecode")
+            .help("pass `-Zcodegen` to emit bytecode or dump MIR or EVM IR")
             .emit());
     }
 

--- a/crates/cli/src/commands/compile.rs
+++ b/crates/cli/src/commands/compile.rs
@@ -1,4 +1,4 @@
-use solar_config::{CompileOpts, DumpKind};
+use solar_config::CompileOpts;
 use solar_interface::{Result, Session};
 use solar_sema::{CompilerRef, ParsingContext};
 use std::{ops::ControlFlow, process::ExitCode};
@@ -87,12 +87,7 @@ pub(crate) fn run_pipeline(
     // Code generation (MIR, EVM IR, and bytecode) is experimental and not part of the
     // stable, solc-compatible pipeline yet, so it is gated behind `-Zcodegen`.
     let needs_codegen = sess.opts.emit.iter().any(|e| e.is_codegen())
-        || sess.opts.unstable.dump.as_ref().is_some_and(|dump| {
-            dump.kinds.contains(&DumpKind::Mir)
-                || dump.kinds.contains(&DumpKind::MirCfg)
-                || dump.kinds.contains(&DumpKind::EvmIr)
-                || dump.kinds.contains(&DumpKind::EvmIrRuntime)
-        });
+        || sess.opts.unstable.dump.as_ref().is_some_and(|dump| dump.needs_codegen());
     if needs_codegen && !sess.opts.unstable.codegen {
         return Err(sess
             .dcx

--- a/crates/cli/src/emit.rs
+++ b/crates/cli/src/emit.rs
@@ -1,11 +1,8 @@
 use alloy_json_abi::AbiItem;
 use alloy_primitives::Bytes;
 use solar_codegen::{Backend, EvmCodegen, EvmCodegenConfig, backend::evm::ir, lower};
-use solar_config::{CompilerOutput, DumpKind};
-use solar_data_structures::{
-    bit_set::DenseBitSet,
-    map::{FxHashMap, FxHashSet},
-};
+use solar_config::{CompilerOutput, Dump, DumpKind};
+use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
 use solar_interface::Result;
 use solar_sema::{CompilerRef, Gcx, hir::ContractId};
 use std::{
@@ -39,10 +36,9 @@ struct CombinedJsonContract<'a> {
 
 pub(crate) fn emit_requested(compiler: &mut CompilerRef<'_>) -> Result {
     let gcx = compiler.gcx();
-    emit_mir_dump(gcx)?;
+    dump_mir(gcx)?;
     emit_combined_json(gcx)?;
-    emit_mir(gcx)?;
-    emit_evm_ir(gcx)
+    dump_evm_ir(gcx)
 }
 
 fn emit_combined_json(gcx: Gcx<'_>) -> Result {
@@ -125,40 +121,23 @@ fn contract_output_name(gcx: Gcx<'_>, id: ContractId) -> String {
     format!("{}:{}", source.file.name.display().to_string().replace('\\', "/"), contract.name)
 }
 
-fn emit_mir_dump(gcx: Gcx<'_>) -> Result {
+fn dump_mir(gcx: Gcx<'_>) -> Result {
     let sess = gcx.sess;
     let Some(dump) = &sess.opts.unstable.dump else { return Ok(()) };
-    if !matches!(dump.kind, DumpKind::Mir | DumpKind::MirCfg) {
+    if !dump.kinds.contains(&DumpKind::Mir) && !dump.kinds.contains(&DumpKind::MirCfg) {
         return Ok(());
     }
 
     let mut writer = out_writer(None)
         .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
-    if let Some(paths) = dump.paths.as_deref() {
-        let mut seen = FxHashSet::default();
-        for path in paths {
-            let mut matched = false;
-            for id in gcx.hir.contract_ids() {
-                if !is_dumpable_contract(gcx, id) || !contract_dump_path_matches(gcx, id, path) {
-                    continue;
-                }
-                matched = true;
-                if seen.insert(id) {
-                    write_mir_dump_contract(&mut writer, gcx, id, dump.kind)?;
-                }
-            }
-            if !matched {
-                let msg =
-                    format!("`-Zdump={kind}={path}` did not match any contract", kind = dump.kind);
-                let note = format!("available contracts: {}", available_dump_contracts(gcx));
-                return Err(sess.dcx.err(msg).note(note).emit());
-            }
+    for id in matching_dump_contracts(gcx, dump)? {
+        let module = lower::lower_contract(gcx, id);
+        gcx.dcx().has_errors()?;
+        if dump.kinds.contains(&DumpKind::Mir) {
+            write_mir_dump_contract(&mut writer, gcx, id, &module, DumpKind::Mir)?;
         }
-    } else {
-        for id in gcx.hir.contract_ids() {
-            if is_dumpable_contract(gcx, id) {
-                write_mir_dump_contract(&mut writer, gcx, id, dump.kind)?;
-            }
+        if dump.kinds.contains(&DumpKind::MirCfg) {
+            write_mir_dump_contract(&mut writer, gcx, id, &module, DumpKind::MirCfg)?;
         }
     }
     writer.flush().map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
@@ -182,14 +161,41 @@ fn contract_dump_path_matches(gcx: Gcx<'_>, id: ContractId, path: &str) -> bool 
     path == gcx.contract_fully_qualified_name(id).to_string().replace('\\', "/")
 }
 
+fn matching_dump_contracts(gcx: Gcx<'_>, dump: &Dump) -> Result<Vec<ContractId>> {
+    let Some(paths) = dump.paths.as_deref() else {
+        return Ok(gcx.hir.contract_ids().filter(|&id| is_dumpable_contract(gcx, id)).collect());
+    };
+
+    let mut seen = DenseBitSet::new_empty(gcx.hir.contract_ids().len());
+    let mut contracts = Vec::new();
+    for path in paths {
+        let mut matched = false;
+        for id in gcx.hir.contract_ids() {
+            if !is_dumpable_contract(gcx, id) || !contract_dump_path_matches(gcx, id, path) {
+                continue;
+            }
+            matched = true;
+            if seen.insert(id) {
+                contracts.push(id);
+            }
+        }
+        if !matched {
+            let kinds = dump.kinds.iter().map(ToString::to_string).collect::<Vec<_>>().join(",");
+            let msg = format!("`-Zdump={kinds}={path}` did not match any contract");
+            let note = format!("available contracts: {}", available_dump_contracts(gcx));
+            return Err(gcx.sess.dcx.err(msg).note(note).emit());
+        }
+    }
+    Ok(contracts)
+}
+
 fn write_mir_dump_contract(
     writer: &mut impl Write,
     gcx: Gcx<'_>,
     id: ContractId,
+    module: &solar_codegen::mir::Module,
     kind: DumpKind,
 ) -> Result {
-    let module = lower::lower_contract(gcx, id);
-    gcx.dcx().has_errors()?;
     let name = gcx.contract_fully_qualified_name(id);
     writeln!(writer, "// === {name} ===")
         .map_err(|e| gcx.sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
@@ -211,44 +217,16 @@ fn available_dump_contracts(gcx: Gcx<'_>) -> String {
         .join(", ")
 }
 
-fn emit_mir(gcx: Gcx<'_>) -> Result {
+fn dump_evm_ir(gcx: Gcx<'_>) -> Result {
     let sess = gcx.sess;
-    if !sess.opts.emit.contains(&CompilerOutput::Mir) {
+    let Some(dump) = &sess.opts.unstable.dump else { return Ok(()) };
+    if !dump.kinds.contains(&DumpKind::EvmIr) && !dump.kinds.contains(&DumpKind::EvmIrRuntime) {
         return Ok(());
     }
 
-    let out_path = sess.opts.out_dir.as_deref().map(|dir| dir.join("combined.mir"));
-    let mut writer = out_writer(out_path.as_deref())
-        .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
-    for id in gcx.hir.contract_ids() {
-        let contract = gcx.hir.contract(id);
-        if contract.kind.is_interface() || contract.kind.is_abstract_contract() {
-            continue;
-        }
-        let module = lower::lower_contract(gcx, id);
-        gcx.dcx().has_errors()?;
-        let name = gcx.contract_fully_qualified_name(id);
-        writeln!(writer, "// === {name} ===")
-            .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
-        writeln!(writer, "{}", module.to_text())
-            .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
-    }
-    writer.flush().map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
-
-    Ok(())
-}
-
-fn emit_evm_ir(gcx: Gcx<'_>) -> Result {
-    let sess = gcx.sess;
-    let emit_deployment = sess.opts.emit.contains(&CompilerOutput::EvmIr);
-    let emit_runtime = sess.opts.emit.contains(&CompilerOutput::EvmIrRuntime);
-    if !emit_deployment && !emit_runtime {
-        return Ok(());
-    }
-
+    let contracts = matching_dump_contracts(gcx, dump)?;
     let bytecodes = generate_contract_bytecodes(gcx, true)?;
-    let out_path = sess.opts.out_dir.as_deref().map(|dir| dir.join("combined.evmir"));
-    let mut writer = out_writer(out_path.as_deref())
+    let mut writer = out_writer(None)
         .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
     if sess.opts.out_dir.is_none()
         && sess
@@ -260,16 +238,16 @@ fn emit_evm_ir(gcx: Gcx<'_>) -> Result {
         writeln!(writer)
             .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
     }
-    for id in gcx.hir.contract_ids() {
+    for id in contracts {
         let Some(bytecode) = bytecodes.get(&id) else { continue };
         let name = gcx.contract_fully_qualified_name(id);
-        if emit_deployment {
+        if dump.kinds.contains(&DumpKind::EvmIr) {
             writeln!(writer, "// === {name} (creation) ===")
                 .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
             write!(writer, "{}", bytecode.deployment_evm_ir.as_deref().unwrap_or_default())
                 .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
         }
-        if emit_runtime {
+        if dump.kinds.contains(&DumpKind::EvmIrRuntime) {
             writeln!(writer, "// === {name} (runtime) ===")
                 .map_err(|e| sess.dcx.err(format!("failed to write to output: {e}")).emit())?;
             write!(writer, "{}", bytecode.runtime_evm_ir.as_deref().unwrap_or_default())

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -24,6 +24,7 @@ solar-parse.workspace = true
 solar-sema.workspace = true
 
 alloy-primitives.workspace = true
+arrayvec.workspace = true
 derive_more.workspace = true
 smallvec.workspace = true
 tracing.workspace = true

--- a/crates/codegen/src/backend/evm/assembler/mod.rs
+++ b/crates/codegen/src/backend/evm/assembler/mod.rs
@@ -339,7 +339,9 @@ impl Assembler {
                     ir_program = scheduled;
                 }
             }
-            ir::run_default_pipeline(&mut ir_program, pass_options);
+            for pass in ir::DEFAULT_PIPELINE {
+                ir::run_pass(&mut ir_program, pass, pass_options);
+            }
             debug_assert!(!input_is_valid || is_valid_evm_ir(&ir_program));
         }
 

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -25,7 +25,7 @@ pub(in crate::backend::evm) mod assembly;
 
 pub use passes::{PASS_REGISTRY, PassInfo, PassOptions, lookup_pass, run_pass};
 
-pub(crate) use passes::{STACK_SCHEDULE_PASS, run_default_pipeline};
+pub(crate) use passes::{DEFAULT_PIPELINE, STACK_SCHEDULE_PASS};
 
 /// Validates the invariants of an EVM IR module.
 pub fn validate(dcx: &solar_interface::diagnostics::DiagCtxt, module: &Module) {

--- a/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
@@ -13,15 +13,11 @@ use crate::backend::evm::ir::{Block, BlockId, Instruction, Module, Operand, Term
 use alloy_primitives::U256;
 use solar_data_structures::bit_set::DenseBitSet;
 
-pub(super) fn run(
-    module: &mut Module,
-    options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
+pub(super) fn run(module: &mut Module, options: super::PassOptions) -> bool {
     if module.blocks.len() <= 1 {
         return false;
     }
-    let state = &mut pass_state.block_layout;
+    let mut state = RunState::default();
     state.reset(module.blocks.len());
     for block in &module.blocks {
         if let Some(target) = layout_successor(block)
@@ -44,7 +40,7 @@ pub(super) fn run(
         }
     }
 
-    pack_hot_terminal_blocks(module, state, options);
+    pack_hot_terminal_blocks(module, &mut state, options);
     for cold in [false, true] {
         for block in module.blocks.indices() {
             if is_cold_terminal_block(&module.blocks[block]) == cold {
@@ -60,7 +56,7 @@ pub(super) fn run(
     true
 }
 
-pub(super) struct RunState {
+struct RunState {
     predecessor_counts: Vec<usize>,
     order: Vec<BlockId>,
     placed: DenseBitSet<BlockId>,

--- a/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
@@ -7,12 +7,8 @@ use crate::backend::evm::{
 };
 use solar_data_structures::bit_set::DenseBitSet;
 
-pub(super) fn run(
-    module: &mut Module,
-    _options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
-    let state = &mut pass_state.cfg_simplify;
+pub(super) fn run(module: &mut Module, _options: super::PassOptions) -> bool {
+    let mut state = RunState::default();
     state.reserve(module.blocks.len());
     let mut changed = false;
     loop {
@@ -33,7 +29,7 @@ pub(super) fn run(
     }
 }
 
-pub(super) struct RunState {
+struct RunState {
     thunks: Vec<Option<BlockId>>,
     reachable: DenseBitSet<BlockId>,
     pending: Vec<BlockId>,

--- a/crates/codegen/src/backend/evm/ir/passes/compact_pushes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/compact_pushes.rs
@@ -11,18 +11,9 @@ const EVM_WORD_BYTES: usize = 32;
 const EVM_WORD_BITS: usize = EVM_WORD_BYTES * 8;
 const MIN_COMPACT_MASK_WIDTH: u8 = 5;
 
-#[derive(Default)]
-pub(super) struct RunState {
-    scratch: Vec<Instruction>,
-}
-
-pub(super) fn run(
-    module: &mut Module,
-    options: PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
+pub(super) fn run(module: &mut Module, options: PassOptions) -> bool {
     let mut changed = false;
-    let scratch = &mut pass_state.compact_pushes.scratch;
+    let mut scratch = Vec::new();
     for block in &mut module.blocks {
         if !block.instructions.iter().any(|inst| {
             immediate(inst)
@@ -31,7 +22,7 @@ pub(super) fn run(
             continue;
         }
         scratch.clear();
-        std::mem::swap(&mut block.instructions, scratch);
+        std::mem::swap(&mut block.instructions, &mut scratch);
         block.instructions.reserve(scratch.len());
         for inst in scratch.drain(..) {
             let Some(value) = immediate(&inst) else {

--- a/crates/codegen/src/backend/evm/ir/passes/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/mod.rs
@@ -18,19 +18,7 @@ use super::Module;
 use crate::{backend::evm::stack_schedule, timing::PassTimer};
 use solar_config::{EvmVersion, OptimizationMode};
 
-type PassRunner = fn(&mut Module, PassOptions, &mut PassState) -> bool;
-
-#[derive(Default)]
-struct PassState {
-    block_layout: block_layout::RunState,
-    cfg_simplify: cfg_simplify::RunState,
-    compact_pushes: compact_pushes::RunState,
-    outline: outline::RunState,
-    peephole: peephole::RunState,
-    share_reverts: share_reverts::RunState,
-    tail_merge: tail_merge::RunState,
-    terminal_dedup: terminal_dedup::RunState,
-}
+type PassRunner = fn(&mut Module, PassOptions) -> bool;
 
 /// Registry entry for an EVM IR transform pass.
 #[derive(Clone, Copy, Debug)]
@@ -40,24 +28,18 @@ pub struct PassInfo {
     /// Human-readable help text.
     pub description: &'static str,
     run_pass: PassRunner,
-    preserves_cfg: bool,
 }
 
 impl PassInfo {
-    const fn new(
-        name: &'static str,
-        description: &'static str,
-        run_pass: PassRunner,
-        preserves_cfg: bool,
-    ) -> Self {
-        Self { name, description, run_pass, preserves_cfg }
+    const fn new(name: &'static str, description: &'static str, run_pass: PassRunner) -> Self {
+        Self { name, description, run_pass }
     }
 }
 
 macro_rules! declare_passes {
     ($(
         $(#[doc = $description:literal])+
-        $vis:vis const $const_name:ident -> $name:literal = $run_pass:path $(, $preserves_cfg:ident)?;
+        $vis:vis const $const_name:ident -> $name:literal = $run_pass:path;
     )+) => {
         $(
             $(#[doc = $description])+
@@ -65,26 +47,23 @@ macro_rules! declare_passes {
                 $name,
                 concat!($($description, "\n"),+).trim_ascii(),
                 $run_pass,
-                declare_passes!(@preserves_cfg $($preserves_cfg)?),
             );
         )+
     };
-    (@preserves_cfg) => { false };
-    (@preserves_cfg preserves_cfg) => { true };
 }
 
 declare_passes! {
     /// Materialize virtual instruction operands with physical stack operations.
-    pub(crate) const STACK_SCHEDULE_PASS -> "stack-schedule" = run_stack_schedule, preserves_cfg;
+    pub(crate) const STACK_SCHEDULE_PASS -> "stack-schedule" = run_stack_schedule;
 
     /// Simplify local instruction sequences in scheduled EVM IR.
-    pub(crate) const PEEPHOLE_PASS -> "peephole" = peephole::run, preserves_cfg;
+    pub(crate) const PEEPHOLE_PASS -> "peephole" = peephole::run;
 
     /// Share empty revert blocks and invert their conditional branches.
     pub(crate) const SHARE_REVERTS_PASS -> "share-reverts" = share_reverts::run;
 
     /// Select smaller instruction sequences for large immediate pushes.
-    pub(crate) const COMPACT_PUSHES_PASS -> "compact-pushes" = compact_pushes::run, preserves_cfg;
+    pub(crate) const COMPACT_PUSHES_PASS -> "compact-pushes" = compact_pushes::run;
 
     /// Redirect jump thunks, remove unreachable blocks, and coalesce linear control flow.
     pub(crate) const CFG_SIMPLIFY_PASS -> "cfg-simplify" = cfg_simplify::run;
@@ -99,7 +78,7 @@ declare_passes! {
     pub(crate) const TAIL_MERGE_PASS -> "tail-merge" = tail_merge::run;
 
     /// Reorder blocks to maximize jumps assembled as physical fallthroughs.
-    pub(crate) const BLOCK_LAYOUT_PASS -> "block-layout" = block_layout::run, preserves_cfg;
+    pub(crate) const BLOCK_LAYOUT_PASS -> "block-layout" = block_layout::run;
 }
 
 /// Options for running an EVM IR pass.
@@ -162,43 +141,12 @@ pub fn lookup_pass(name: &str) -> Option<&'static PassInfo> {
 
 /// Runs a named EVM IR pass over a module.
 pub fn run_pass(module: &mut Module, pass: &PassInfo, options: PassOptions) -> bool {
-    run_pass_with_state(module, pass, options, &mut PassState::default())
-}
-
-fn run_pass_with_state(
-    module: &mut Module,
-    pass: &PassInfo,
-    options: PassOptions,
-    state: &mut PassState,
-) -> bool {
     let timer = PassTimer::new(options.time_passes);
-    let changed = (pass.run_pass)(module, options, state);
+    let changed = (pass.run_pass)(module, options);
     timer.finish("EVM IR", module.name(), pass.name, changed);
     changed
 }
 
-pub(crate) fn run_default_pipeline(module: &mut Module, options: PassOptions) -> bool {
-    let mut state = PassState::default();
-    let mut cfg_clean = false;
-    let mut changed = false;
-    for pass in DEFAULT_PIPELINE {
-        let pass_changed = if pass.name == CFG_SIMPLIFY_PASS.name && cfg_clean {
-            let timer = PassTimer::new(options.time_passes);
-            timer.finish("EVM IR", module.name(), pass.name, false);
-            false
-        } else {
-            run_pass_with_state(module, pass, options, &mut state)
-        };
-        changed |= pass_changed;
-        if pass.name == CFG_SIMPLIFY_PASS.name {
-            cfg_clean = true;
-        } else if pass_changed && !pass.preserves_cfg {
-            cfg_clean = false;
-        }
-    }
-    changed
-}
-
-fn run_stack_schedule(module: &mut Module, _options: PassOptions, _state: &mut PassState) -> bool {
+fn run_stack_schedule(module: &mut Module, _options: PassOptions) -> bool {
     stack_schedule::schedule_stack_ops(module)
 }

--- a/crates/codegen/src/backend/evm/ir/passes/outline.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/outline.rs
@@ -11,14 +11,10 @@ use std::hash::{Hash, Hasher};
 
 const MIN_CLOSED_RUN: usize = 4;
 
-pub(super) fn run(
-    module: &mut Module,
-    options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
-    let state = &mut pass_state.outline;
-    state.next_label = None;
-    outline_closed_computations(module, state) | outline_repeated_pushes(module, options, state)
+pub(super) fn run(module: &mut Module, options: super::PassOptions) -> bool {
+    let mut state = RunState::default();
+    outline_closed_computations(module, &mut state)
+        | outline_repeated_pushes(module, options, &mut state)
 }
 
 fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> bool {
@@ -273,7 +269,7 @@ impl Hash for MachineInstSlice<'_> {
 }
 
 #[derive(Default)]
-pub(super) struct RunState {
+struct RunState {
     next_label: Option<u32>,
 }
 

--- a/crates/codegen/src/backend/evm/ir/passes/peephole.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/peephole.rs
@@ -5,7 +5,7 @@ use crate::backend::evm::{
     opcode as op,
 };
 use alloy_primitives::U256;
-use smallvec::SmallVec;
+use arrayvec::ArrayVec;
 
 pub(super) fn run(module: &mut Module, _options: super::PassOptions) -> bool {
     let mut changed = false;
@@ -218,12 +218,12 @@ fn is_removable_push(inst: &Instruction) -> bool {
 
 struct Rewrite {
     skip: usize,
-    replacement: SmallVec<[Instruction; 3]>,
+    replacement: ArrayVec<Instruction, 3>,
 }
 
 impl Rewrite {
     fn delete(skip: usize) -> Self {
-        Self { skip, replacement: SmallVec::new() }
+        Self { skip, replacement: ArrayVec::new() }
     }
 
     fn replace<const N: usize>(skip: usize, replacement: [Instruction; N]) -> Self {

--- a/crates/codegen/src/backend/evm/ir/passes/peephole.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/peephole.rs
@@ -7,25 +7,16 @@ use crate::backend::evm::{
 use alloy_primitives::U256;
 use smallvec::SmallVec;
 
-#[derive(Default)]
-pub(super) struct RunState {
-    scratch: Vec<Instruction>,
-}
-
-pub(super) fn run(
-    module: &mut Module,
-    _options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
+pub(super) fn run(module: &mut Module, _options: super::PassOptions) -> bool {
     let mut changed = false;
-    let scratch = &mut pass_state.peephole.scratch;
+    let mut scratch = Vec::new();
     for block in &mut module.blocks {
         if block.instructions.iter().any(|inst| {
             inst.result.is_some() || (!inst.is_encoded_push() && !inst.operands.is_empty())
         }) {
             continue;
         }
-        changed |= optimize(&mut block.instructions, scratch) != 0;
+        changed |= optimize(&mut block.instructions, &mut scratch) != 0;
     }
     changed
 }

--- a/crates/codegen/src/backend/evm/ir/passes/peephole.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/peephole.rs
@@ -41,8 +41,9 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
     let stack = InstStack::new(instructions);
 
     if stack.len() >= 3
+        && let Some(opcode) = raw_opcode(&stack[0])
+        && let Some(value) = push_value(&stack[1])
         && is_removable_push(&stack[2])
-        && let (Some(value), Some(opcode)) = (push_value(&stack[1]), raw_opcode(&stack[0]))
     {
         if value.is_zero()
             && matches!(
@@ -58,7 +59,8 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
     }
 
     if stack.len() >= 2
-        && let (Some(value), Some(opcode)) = (push_value(&stack[1]), raw_opcode(&stack[0]))
+        && let Some(opcode) = raw_opcode(&stack[0])
+        && let Some(value) = push_value(&stack[1])
     {
         if value.is_zero() {
             return match opcode {
@@ -81,12 +83,13 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
         }
     }
 
-    if stack.len() >= 2 && is_removable_push(&stack[1]) && raw_opcode(&stack[0]) == Some(op::POP) {
+    if stack.len() >= 2 && raw_opcode(&stack[0]) == Some(op::POP) && is_removable_push(&stack[1]) {
         return Some(Rewrite::delete(2));
     }
 
     if stack.len() >= 2
-        && let (Some(a), Some(b)) = (raw_opcode(&stack[1]), raw_opcode(&stack[0]))
+        && let Some(b) = raw_opcode(&stack[0])
+        && let Some(a) = raw_opcode(&stack[1])
         && ((a, b) == (op::NOT, op::NOT)
             || (b == op::POP && (op::DUP1..=op::DUP16).contains(&a))
             || (a == b && (op::SWAP1..=op::SWAP16).contains(&a)))
@@ -95,9 +98,9 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
     }
 
     if stack.len() >= 3
-        && raw_opcode(&stack[2]) == Some(op::ISZERO)
-        && raw_opcode(&stack[1]) == Some(op::ISZERO)
         && raw_opcode(&stack[0]) == Some(op::ISZERO)
+        && raw_opcode(&stack[1]) == Some(op::ISZERO)
+        && raw_opcode(&stack[2]) == Some(op::ISZERO)
     {
         return Some(Rewrite::replace(3, [raw(op::ISZERO)]));
     }
@@ -105,8 +108,8 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
     if stack.len() >= 4
         && raw_opcode(&stack[0]) == Some(op::POP)
         && raw_opcode(&stack[1]) == Some(op::SWAP1)
-        && raw_opcode(&stack[3]) == Some(op::DUP2)
         && let Some(binop) = raw_opcode(&stack[2])
+        && raw_opcode(&stack[3]) == Some(op::DUP2)
     {
         if matches!(binop, op::ADD | op::MUL | op::AND | op::OR | op::XOR | op::EQ) {
             return Some(Rewrite::replace(4, [raw(binop)]));
@@ -145,10 +148,11 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
 
     if stack.len() >= 6
         && raw_opcode(&stack[0]) == Some(op::MSTORE)
+        && let Some(a) = push_value(&stack[1])
         && raw_opcode(&stack[2]) == Some(op::DUP1)
         && raw_opcode(&stack[3]) == Some(op::MSTORE)
+        && let Some(b) = push_value(&stack[4])
         && raw_opcode(&stack[5]) == Some(op::DUP1)
-        && let (Some(a), Some(b)) = (push_value(&stack[1]), push_value(&stack[4]))
         && a == b
     {
         return Some(Rewrite::replace(6, [stack[5].clone(), stack[4].clone(), stack[3].clone()]));
@@ -156,10 +160,11 @@ fn try_peephole(instructions: &[Instruction]) -> Option<Rewrite> {
 
     if stack.len() >= 6
         && raw_opcode(&stack[0]) == Some(op::MLOAD)
+        && let Some(a) = push_value(&stack[1])
         && raw_opcode(&stack[2]) == Some(op::POP)
         && raw_opcode(&stack[3]) == Some(op::MSTORE)
+        && let Some(b) = push_value(&stack[4])
         && raw_opcode(&stack[5]) == Some(op::DUP1)
-        && let (Some(a), Some(b)) = (push_value(&stack[1]), push_value(&stack[4]))
         && a == b
     {
         return Some(Rewrite::replace(6, [stack[5].clone(), stack[4].clone(), stack[3].clone()]));

--- a/crates/codegen/src/backend/evm/ir/passes/share_reverts.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/share_reverts.rs
@@ -7,27 +7,8 @@ use crate::backend::evm::{
 use alloy_primitives::U256;
 use solar_data_structures::bit_set::DenseBitSet;
 
-pub(super) struct RunState {
-    empty_reverts: DenseBitSet<BlockId>,
-}
-
-impl Default for RunState {
-    fn default() -> Self {
-        Self { empty_reverts: DenseBitSet::new_empty(0) }
-    }
-}
-
-pub(super) fn run(
-    module: &mut Module,
-    _options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
-    let empty_reverts = &mut pass_state.share_reverts.empty_reverts;
-    if empty_reverts.domain_size() == module.blocks.len() {
-        empty_reverts.clear();
-    } else {
-        *empty_reverts = DenseBitSet::new_empty(module.blocks.len());
-    }
+pub(super) fn run(module: &mut Module, _options: super::PassOptions) -> bool {
+    let mut empty_reverts = DenseBitSet::new_empty(module.blocks.len());
     for block in module.blocks.indices().filter(|&block| is_empty_revert(module, block)) {
         empty_reverts.insert(block);
     }

--- a/crates/codegen/src/backend/evm/ir/passes/tail_merge.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/tail_merge.rs
@@ -6,12 +6,8 @@ use crate::backend::evm::ir::{
 };
 use solar_data_structures::map::FxHashMap;
 
-pub(super) fn run(
-    module: &mut Module,
-    _options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
-    let state = &mut pass_state.tail_merge;
+pub(super) fn run(module: &mut Module, _options: super::PassOptions) -> bool {
+    let mut state = RunState::default();
     state.plan_merges(module);
     if state.merges.is_empty() {
         return false;
@@ -34,7 +30,7 @@ pub(super) fn run(
 }
 
 #[derive(Default)]
-pub(super) struct RunState {
+struct RunState {
     representatives: Vec<BlockId>,
     merges: Vec<Merge>,
     group_indices: FxHashMap<BlockId, usize>,

--- a/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
@@ -14,20 +14,14 @@ use smallvec::SmallVec;
 use solar_data_structures::map::{FxHashMap, StdEntry};
 
 #[derive(Default)]
-pub(super) struct RunState {
+struct RunState {
     canonical: FxHashMap<TerminalBlockKey, BlockId>,
     locals: FxHashMap<ValueId, usize>,
     redirects: Vec<(BlockId, BlockId)>,
 }
 
-pub(super) fn run(
-    module: &mut Module,
-    _options: super::PassOptions,
-    pass_state: &mut super::PassState,
-) -> bool {
-    let state = &mut pass_state.terminal_dedup;
-    state.canonical.clear();
-    state.redirects.clear();
+pub(super) fn run(module: &mut Module, _options: super::PassOptions) -> bool {
+    let mut state = RunState::default();
 
     for block_id in module.blocks.indices() {
         let block = &module.blocks[block_id];

--- a/crates/codegen/src/backend/evm/stack_schedule.rs
+++ b/crates/codegen/src/backend/evm/stack_schedule.rs
@@ -68,6 +68,7 @@
 
 use super::{ir, opcode as op, stack::SpillSlot};
 use alloy_primitives::U256;
+use arrayvec::ArrayVec;
 use smallvec::SmallVec;
 use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
 
@@ -374,7 +375,7 @@ impl<'a> StackScheduler<'a> {
             return true;
         }
 
-        let target: SmallVec<[ScheduledStackItem; 2]> =
+        let target: ArrayVec<ScheduledStackItem, 2> =
             operands.into_iter().map(ScheduledStackItem::Value).collect();
         // Every targeted operand must already be live on the model stack.
         if !target.iter().all(|item| stack.contains(item)) {
@@ -921,8 +922,8 @@ fn instruction_keeps_encoded_operands(inst: &ir::Instruction) -> bool {
 /// Switch case immediates stay encoded and are not arranged, so only the
 /// discriminant is returned for a `switch`. Operand-less terminators (`jump`,
 /// `stop`, `invalid`, raw opcodes) return an empty list.
-fn terminator_arrange_operands(kind: &ir::TerminatorKind) -> SmallVec<[ir::ValueId; 2]> {
-    let mut operands = SmallVec::new();
+fn terminator_arrange_operands(kind: &ir::TerminatorKind) -> ArrayVec<ir::ValueId, 2> {
+    let mut operands = ArrayVec::new();
     let mut push = |operand: &ir::Operand| {
         if let ir::Operand::Value(value) = operand {
             operands.push(*value);

--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -6,7 +6,7 @@ use super::{
     BasicBlock, BlockId, EffectKind, Function, FunctionId, InstId, InstKind, Instruction,
     MemoryRegion, StorageAlias, Terminator, Value, ValueId,
 };
-use smallvec::SmallVec;
+use arrayvec::ArrayVec;
 use solar_data_structures::fmt::{self, FmtIteratorExt};
 use solar_sema::hir;
 
@@ -418,7 +418,7 @@ fn display_metadata<'a>(inst: &'a Instruction, func: &'a Function) -> impl fmt::
 
     fmt::from_fn(move |f| {
         let metadata = &inst.metadata;
-        let mut fields = SmallVec::<[MetadataField<'_>; 8]>::new();
+        let mut fields = ArrayVec::<MetadataField<'_>, 7>::new();
 
         if let Some(storage) = metadata.storage_alias() {
             fields.push(MetadataField::Storage(storage, func));

--- a/crates/codegen/src/transform/loop_opt.rs
+++ b/crates/codegen/src/transform/loop_opt.rs
@@ -19,6 +19,7 @@ use crate::{
     pass::FunctionPass,
 };
 use alloy_primitives::U256;
+use arrayvec::ArrayVec;
 use solar_data_structures::bit_set::DenseBitSet;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -713,7 +714,8 @@ impl LoopOptimizer {
         for block_id in &ctx.loop_data.blocks {
             for &user_inst in &func.blocks[block_id].instructions {
                 let kind = &func.instructions[user_inst].kind;
-                let address_operands: smallvec::SmallVec<[ValueId; 2]> = match kind {
+                let mut address_operands = ArrayVec::<ValueId, 2>::new();
+                match kind {
                     InstKind::MLoad(addr)
                     | InstKind::MStore(addr, _)
                     | InstKind::MStore8(addr, _)
@@ -721,16 +723,19 @@ impl LoopOptimizer {
                     | InstKind::SStore(addr, _)
                     | InstKind::TLoad(addr)
                     | InstKind::TStore(addr, _)
-                    | InstKind::CalldataLoad(addr) => smallvec::smallvec![*addr],
-                    InstKind::Keccak256(addr, _)
+                    | InstKind::CalldataLoad(addr)
+                    | InstKind::Keccak256(addr, _)
                     | InstKind::MappingSlotMemory(addr, _)
                     | InstKind::CalldataCopy(addr, _, _)
                     | InstKind::CodeCopy(addr, _, _)
-                    | InstKind::ReturnDataCopy(addr, _, _) => smallvec::smallvec![*addr],
-                    InstKind::MCopy(dst, src, _) => smallvec::smallvec![*dst, *src],
-                    InstKind::ExtCodeCopy(_, dst, _, _) => smallvec::smallvec![*dst],
+                    | InstKind::ReturnDataCopy(addr, _, _)
+                    | InstKind::ExtCodeCopy(_, addr, _, _) => address_operands.push(*addr),
+                    InstKind::MCopy(dst, src, _) => {
+                        address_operands.push(*dst);
+                        address_operands.push(*src);
+                    }
                     _ => continue,
-                };
+                }
 
                 for address in address_operands {
                     if self.value_feeds_affine_address(func, ctx, result, address, 0) {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{fmt, num::NonZeroUsize, sync::OnceLock};
-use strum::EnumIs;
 
 #[macro_use]
 mod macros;
@@ -184,27 +183,20 @@ str_enum! {
         BinRuntime,
         /// Function signature hashes.
         Hashes,
-        /// Textual Mid-Level IR.
-        Mir,
-        /// Creation EVM IR.
-        EvmIr,
-        /// Runtime EVM IR.
-        EvmIrRuntime,
     }
 }
 
 impl CompilerOutput {
-    /// Returns `true` for outputs produced by the codegen backend (which lowers
-    /// to MIR), i.e. bytecode, EVM IR, and MIR outputs.
+    /// Returns `true` for outputs produced by the codegen backend.
     pub fn is_codegen(self) -> bool {
-        matches!(self, Self::Bin | Self::BinRuntime | Self::EvmIr | Self::EvmIrRuntime | Self::Mir)
+        matches!(self, Self::Bin | Self::BinRuntime)
     }
 }
 
-/// `-Zdump=kind[=paths...]`.
+/// `-Zdump=kind[,kind...][=paths...]`.
 #[derive(Clone, Debug)]
 pub struct Dump {
-    pub kind: DumpKind,
+    pub kinds: Vec<DumpKind>,
     pub paths: Option<Vec<String>>,
 }
 
@@ -212,19 +204,22 @@ impl std::str::FromStr for Dump {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (kind, paths) = if let Some((kind, paths)) = s.split_once('=') {
+        let (kinds, paths) = if let Some((kinds, paths)) = s.split_once('=') {
             let paths = paths.split(',').map(ToString::to_string).collect();
-            (kind, Some(paths))
+            (kinds, Some(paths))
         } else {
             (s, None)
         };
-        Ok(Self { kind: kind.parse::<DumpKind>().map_err(|e| e.to_string())?, paths })
+        let kinds = kinds
+            .split(',')
+            .map(|kind| kind.parse::<DumpKind>().map_err(|e| e.to_string()))
+            .collect::<Result<_, _>>()?;
+        Ok(Self { kinds, paths })
     }
 }
 
 str_enum! {
-    /// What kind of output to dump. See [`Dump`].
-    #[derive(EnumIs)]
+    /// A kind of output to dump. See [`Dump`].
     #[strum(serialize_all = "kebab-case")]
     #[non_exhaustive]
     pub enum DumpKind {
@@ -236,13 +231,10 @@ str_enum! {
         Mir,
         /// Print MIR CFGs in DOT format.
         MirCfg,
-    }
-}
-
-impl DumpKind {
-    /// Returns whether this dump requires MIR/codegen lowering.
-    pub fn is_codegen(self) -> bool {
-        matches!(self, Self::Mir | Self::MirCfg)
+        /// Print creation EVM IR.
+        EvmIr,
+        /// Print runtime EVM IR.
+        EvmIrRuntime,
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -200,6 +200,18 @@ pub struct Dump {
     pub paths: Option<Vec<String>>,
 }
 
+impl Dump {
+    /// Returns whether any requested dump requires the codegen pipeline.
+    pub fn needs_codegen(&self) -> bool {
+        self.kinds.iter().any(|kind| {
+            matches!(
+                kind,
+                DumpKind::Mir | DumpKind::MirCfg | DumpKind::EvmIr | DumpKind::EvmIrRuntime
+            )
+        })
+    }
+}
+
 impl std::str::FromStr for Dump {
     type Err = String;
 

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -332,8 +332,11 @@ pub struct UnstableOpts {
 
     /// Print additional information about the compiler's internal state.
     ///
-    /// Valid kinds are `ast`, `hir`, `mir`, and `mir-cfg`.
-    #[cfg_attr(feature = "clap", arg(long, require_equals = true, value_name = "KIND[=PATHS...]"))]
+    /// Valid kinds are `ast`, `hir`, `mir`, `mir-cfg`, `evm-ir`, and `evm-ir-runtime`.
+    #[cfg_attr(
+        feature = "clap",
+        arg(long, require_equals = true, value_name = "KIND[,KIND...][=PATHS...]")
+    )]
     pub dump: Option<Dump>,
 
     /// Print AST stats.
@@ -370,9 +373,9 @@ pub struct UnstableOpts {
 
     /// Enable the experimental EVM code generator (MIR lowering and backend).
     ///
-    /// Off by default: MIR and bytecode output is only produced when this is
-    /// set. Codegen is a work in progress and not yet part of the compiler's
-    /// stable, solc-compatible behavior.
+    /// Off by default: MIR and EVM IR dumps and bytecode output are only produced
+    /// when this is set. Codegen is a work in progress and not yet part of the
+    /// compiler's stable, solc-compatible behavior.
     #[cfg_attr(feature = "clap", arg(long))]
     pub codegen: bool,
 

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -11,7 +11,10 @@ extern crate tracing;
 
 use indexmap as _;
 use rayon::prelude::*;
-use solar_interface::{Result, Session, config::CompilerStage};
+use solar_interface::{
+    Result, Session,
+    config::{CompilerStage, DumpKind},
+};
 use std::ops::ControlFlow;
 
 // Convenience re-exports.
@@ -59,7 +62,7 @@ pub(crate) fn lower(compiler: &mut CompilerRef<'_>) -> Result<ControlFlow<()>> {
     }
 
     if let Some(dump) = &sess.opts.unstable.dump
-        && dump.kind.is_ast()
+        && dump.kinds.contains(&DumpKind::Ast)
     {
         dump_ast(sess, &gcx.sources, dump.paths.as_deref())?;
     }
@@ -104,7 +107,7 @@ fn analysis(gcx: Gcx<'_>) -> Result<ControlFlow<()>> {
     }
 
     if let Some(dump) = &gcx.sess.opts.unstable.dump
-        && dump.kind.is_hir()
+        && dump.kinds.contains(&DumpKind::Hir)
     {
         dump_hir(gcx, dump.paths.as_deref())?;
     }

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -19,10 +19,10 @@ Options:
       -Zrecover-incomplete-input
           Recovers incomplete input into a partial AST
 
-      -Zdump=<KIND[=PATHS...]>
+      -Zdump=<KIND[,KIND...][=PATHS...]>
           Print additional information about the compiler's internal state.
           
-          Valid kinds are `ast`, `hir`, `mir`, and `mir-cfg`.
+          Valid kinds are `ast`, `hir`, `mir`, `mir-cfg`, `evm-ir`, and `evm-ir-runtime`.
 
       -Zast-stats
           Print AST stats
@@ -51,7 +51,7 @@ Options:
       -Zcodegen
           Enable the experimental EVM code generator (MIR lowering and backend).
           
-          Off by default: MIR and bytecode output is only produced when this is set. Codegen is a work in progress and not yet part of the compiler's stable, solc-compatible behavior.
+          Off by default: MIR and EVM IR dumps and bytecode output are only produced when this is set. Codegen is a work in progress and not yet part of the compiler's stable, solc-compatible behavior.
 
       -Zno-mir-dispatch
           Disable MIR-phase dispatch lowering.

--- a/tests/ui/cli/help.long.stdout
+++ b/tests/ui/cli/help.long.stdout
@@ -53,7 +53,7 @@ Options:
       --emit <EMIT>
           Comma separated list of types of output for the compiler to emit
           
-          [possible values: abi, bin, bin-runtime, hashes, mir, evm-ir, evm-ir-runtime]
+          [possible values: abi, bin, bin-runtime, hashes]
 
       --standard-json
           Switch to Standard JSON input/output mode

--- a/tests/ui/cli/help.short.stdout
+++ b/tests/ui/cli/help.short.stdout
@@ -18,7 +18,7 @@ Options:
   -O, --optimize <OPTIMIZATION>    MIR optimization objective [default: gas] [possible values: none, gas, size]
       --libraries <NAME=ADDRESS>   Library addresses for linking, as `LibraryName=0xADDRESS`
       --out-dir <OUT_DIR>          Directory to write output files
-      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, hashes, mir, evm-ir, evm-ir-runtime]
+      --emit <EMIT>                Comma separated list of types of output for the compiler to emit [possible values: abi, bin, bin-runtime, hashes]
       --standard-json              Switch to Standard JSON input/output mode
   -Z <FLAG>                        Unstable flags. WARNING: these are completely unstable, and may change at any time
   -h, --help                       Print help (see more with '--help')

--- a/tests/ui/codegen/lowering/abi_decode_calldata_slice.sol
+++ b/tests/ui/codegen/lowering/abi_decode_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract AbiDecodeCalldataSlice {
     function decode(bytes calldata data) external pure returns (uint256) {

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.sol
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract AbiDecodeDynamicTuple {
     function decode(bytes memory data)

--- a/tests/ui/codegen/lowering/abi_decode_static_tuple.sol
+++ b/tests/ui/codegen/lowering/abi_decode_static_tuple.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract AbiDecodeStaticTuple {
     function decode(bytes memory data) external pure returns (uint256 a, bool b, address c) {

--- a/tests/ui/codegen/lowering/abi_dynamic_return.sol
+++ b/tests/ui/codegen/lowering/abi_dynamic_return.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract AbiDynamicReturn {
     function bytesLiteral() public pure returns (bytes memory) {

--- a/tests/ui/codegen/lowering/abi_encode_bytes.sol
+++ b/tests/ui/codegen/lowering/abi_encode_bytes.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // `abi.encode(...)` allocates a fresh `bytes memory` `[length][data...]` from
 // the free memory pointer; it must never stage argument words at absolute low

--- a/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // `abi.encodePacked(...)` may include a slice of a `bytes`/`string` calldata
 // value, `data[start:end]` (open bounds default to `0`/`data.length`). The

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Packed encoding writes each value's top `size` bytes: fixed-bytes values
 // are already left-aligned and must not be shifted again, and `bytes`/

--- a/tests/ui/codegen/lowering/abi_encode_packed_static_hash.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_static_hash.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Nitro-style compact hashes should stage small all-static packed data in
 // scratch memory and coalesce adjacent sub-word writes into one word store.

--- a/tests/ui/codegen/lowering/abi_nested_return.sol
+++ b/tests/ui/codegen/lowering/abi_nested_return.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract AbiNestedReturn {
     struct Pair {

--- a/tests/ui/codegen/lowering/abi_packed_calldata_bytes.sol
+++ b/tests/ui/codegen/lowering/abi_packed_calldata_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // `abi.encodePacked(...)` may include a `bytes`/`string` calldata argument,
 // which is packed as its raw data (no length prefix, no padding). The calldata

--- a/tests/ui/codegen/lowering/array_bounds_panic.sol
+++ b/tests/ui/codegen/lowering/array_bounds_panic.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Array indexing emits a bounds check that reverts with Panic(0x32)
 // (selector 0x4e487b71, code 0x32) when `index >= length`, matching solc:

--- a/tests/ui/codegen/lowering/assembler_block_dedup.sol
+++ b/tests/ui/codegen/lowering/assembler_block_dedup.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime --pretty-json
 contract AssemblerBlockDedup {
     function a() public pure returns (uint256) {
         return 1;

--- a/tests/ui/codegen/lowering/base_constructor.sol
+++ b/tests/ui/codegen/lowering/base_constructor.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Base {
     uint256 public value;

--- a/tests/ui/codegen/lowering/branch.sol
+++ b/tests/ui/codegen/lowering/branch.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Branch {
     function max(uint256 a, uint256 b) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract AddmodMulmod {
     function am(uint x, uint y, uint n) public pure returns (uint) {

--- a/tests/ui/codegen/lowering/bytes_memory_elements.sol
+++ b/tests/ui/codegen/lowering/bytes_memory_elements.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Memory `bytes` uses the packed `[length][data...]` layout: `new bytes(n)`
 // allocates 32 + pad32(n) zeroed bytes (not one word per byte), element reads

--- a/tests/ui/codegen/lowering/calldata_array_to_memory.sol
+++ b/tests/ui/codegen/lowering/calldata_array_to_memory.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // A calldata dynamic array converted to memory (declaration initializer,
 // assignment, or a struct-literal field) must materialize as a

--- a/tests/ui/codegen/lowering/calldata_slice_rebind.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_rebind.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 //@filecheck: --check-prefix=SLICE
 
 // Rebinding calldata bytes to a slice materializes a memory `[length][data]`

--- a/tests/ui/codegen/lowering/calldata_validation.sol
+++ b/tests/ui/codegen/lowering/calldata_validation.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Pins the calldata lower-bound check and validators emitted for value-type
 // external parameters.

--- a/tests/ui/codegen/lowering/checked_arithmetic_panic.sol
+++ b/tests/ui/codegen/lowering/checked_arithmetic_panic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract CheckedArithmeticPanic {
     function add(uint256 a, uint256 b) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Pins the per-op checked-arithmetic check shapes so they stay at or below
 // solc's happy-path gas:

--- a/tests/ui/codegen/lowering/checked_pow_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Pins the checked exponentiation shapes ported from solc's `checked_exp_*`
 // Yul helpers:

--- a/tests/ui/codegen/lowering/cold_call_hot_fallthrough.sol
+++ b/tests/ui/codegen/lowering/cold_call_hot_fallthrough.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zno-mir-dispatch -O size --emit=evm-ir-runtime --pretty-json
+//@compile-flags: -Zcodegen -Zno-mir-dispatch -O size -Zdump=evm-ir-runtime --pretty-json
 
 // Calls to the non-returning helper make their blocks cold. The backend should
 // lay out each successful continuation as the branch fallthrough.

--- a/tests/ui/codegen/lowering/comparison.sol
+++ b/tests/ui/codegen/lowering/comparison.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Comparison {
     function eq(uint256 a, uint256 b) public pure returns (bool) {

--- a/tests/ui/codegen/lowering/compound_assign.sol
+++ b/tests/ui/codegen/lowering/compound_assign.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract CompoundAssign {
     uint256 public value;

--- a/tests/ui/codegen/lowering/constructor_abi_validation.sol
+++ b/tests/ui/codegen/lowering/constructor_abi_validation.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract ConstructorAbiValidation {
     bool public flag;

--- a/tests/ui/codegen/lowering/constructor_internal_call.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract ConstructorInternalCall {
     uint256 public value;

--- a/tests/ui/codegen/lowering/constructor_internal_call_bin.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_call_bin.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
 
 contract ConstructorInternalCallBin {
     uint256 public value;

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 library ConstructorLibrary {
     function helper(uint256 n) internal pure returns (uint256) {

--- a/tests/ui/codegen/lowering/custom_error_payloads.sol
+++ b/tests/ui/codegen/lowering/custom_error_payloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract CustomErrorPayloads {
     error EmptyError();

--- a/tests/ui/codegen/lowering/emit_abi_bin.sol
+++ b/tests/ui/codegen/lowering/emit_abi_bin.sol
@@ -1,6 +1,6 @@
 //@ revisions: evmir bin
 //@ignore-host: windows
-//@[evmir] compile-flags: -Zcodegen --emit=abi,evm-ir,evm-ir-runtime --pretty-json
+//@[evmir] compile-flags: -Zcodegen --emit=abi -Zdump=evm-ir,evm-ir-runtime --pretty-json
 //@[bin] compile-flags: -Zcodegen --emit=abi,bin,bin-runtime --pretty-json
 
 contract C {

--- a/tests/ui/codegen/lowering/enum_conversion_qualified.sol
+++ b/tests/ui/codegen/lowering/enum_conversion_qualified.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // An explicit enum conversion written through its container, `Container.Enum(x)`
 // (the callee is a member access resolving to an enum), is the identity on the

--- a/tests/ui/codegen/lowering/event_dynamic_data.sol
+++ b/tests/ui/codegen/lowering/event_dynamic_data.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract EventDynamicData {
     event Text(uint256 indexed id, string message, uint256 count);

--- a/tests/ui/codegen/lowering/event_overloads.sol
+++ b/tests/ui/codegen/lowering/event_overloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 //@filecheck: --check-prefix=MIR
 
 // Emitting an overloaded event must use the overload selected by the type

--- a/tests/ui/codegen/lowering/fixed_bytes_canonical.sol
+++ b/tests/ui/codegen/lowering/fixed_bytes_canonical.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract FixedBytesCanonical {
     function fromUint(uint8 value) external pure returns (bytes1) {

--- a/tests/ui/codegen/lowering/function_call.sol
+++ b/tests/ui/codegen/lowering/function_call.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract FunctionCall {
     function double(uint256 x) internal pure returns (uint256) {

--- a/tests/ui/codegen/lowering/global_stack_calldata_alias.sol
+++ b/tests/ui/codegen/lowering/global_stack_calldata_alias.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 contract Test {
     function select(address account, uint256 value) external pure returns (uint256) {

--- a/tests/ui/codegen/lowering/immutable_getter.sol
+++ b/tests/ui/codegen/lowering/immutable_getter.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract C {
     address public immutable owner;

--- a/tests/ui/codegen/lowering/immutable_keccak_literal.sol
+++ b/tests/ui/codegen/lowering/immutable_keccak_literal.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract ImmutableKeccakLiteral {
     bytes32 immutable value = keccak256("solar");

--- a/tests/ui/codegen/lowering/immutable_reads.sol
+++ b/tests/ui/codegen/lowering/immutable_reads.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract C {
     uint256 public immutable start;

--- a/tests/ui/codegen/lowering/internal_call_fallbacks.sol
+++ b/tests/ui/codegen/lowering/internal_call_fallbacks.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract InternalCallFallbacks {
     function recurse(uint256 x) public returns (uint256) {

--- a/tests/ui/codegen/lowering/internal_call_frame_dealloc.sol
+++ b/tests/ui/codegen/lowering/internal_call_frame_dealloc.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime --pretty-json
 
 contract InternalCallFrameDealloc {
     function f(uint256 x) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/internal_loop_call.sol
+++ b/tests/ui/codegen/lowering/internal_loop_call.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // A same-contract internal function whose body contains a loop, called by bare
 // ident, must be lowered as a real `internal_call` rather than inlined. The SSA

--- a/tests/ui/codegen/lowering/internal_void_call.sol
+++ b/tests/ui/codegen/lowering/internal_void_call.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract InternalVoidCall {
     uint256 public value;

--- a/tests/ui/codegen/lowering/library_mapping_storage_param.sol
+++ b/tests/ui/codegen/lowering/library_mapping_storage_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // A `library` function may take a `mapping`/`storage` reference parameter and
 // bind a storage-reference local from it:

--- a/tests/ui/codegen/lowering/library_wrapper_storage_param.sol
+++ b/tests/ui/codegen/lowering/library_wrapper_storage_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // The external wrapper of a public library function must decode a
 // storage-reference parameter as its slot (one calldata word), not

--- a/tests/ui/codegen/lowering/linear.sol
+++ b/tests/ui/codegen/lowering/linear.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Linear {
     function add(uint256 x, uint256 y) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/linked_library_call.sol
+++ b/tests/ui/codegen/lowering/linked_library_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries Lib=0x1111111111111111111111111111111111111111 --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=evm-ir-runtime
 
 // With `--libraries Lib=0xADDR`, a call to a `public` library function is
 // lowered as an ABI-encoded DELEGATECALL to the linked address (storage

--- a/tests/ui/codegen/lowering/linked_library_chain.sol
+++ b/tests/ui/codegen/lowering/linked_library_chain.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries Inner=0x1000000000000000000000000000000000000001,Outer=0x1000000000000000000000000000000000000002 --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen --libraries Inner=0x1000000000000000000000000000000000000001,Outer=0x1000000000000000000000000000000000000002 -Zdump=evm-ir-runtime
 
 // A linked library may itself call another linked library, forwarding a
 // storage-reference parameter: the storage struct travels as its slot through

--- a/tests/ui/codegen/lowering/linked_library_dynamic_fields.sol
+++ b/tests/ui/codegen/lowering/linked_library_dynamic_fields.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries L=0x1000000000000000000000000000000000000001 --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen --libraries L=0x1000000000000000000000000000000000000001 -Zdump=evm-ir-runtime
 
 // A linked library call whose struct parameter carries dynamic fields:
 // the head word of each dynamic field holds an args-relative offset and the

--- a/tests/ui/codegen/lowering/log_topic_reuse.sol
+++ b/tests/ui/codegen/lowering/log_topic_reuse.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // A value used as a `LOG` topic and then used again *later in the same block*
 // (here `value` is both the event topic and the stored word) must survive the

--- a/tests/ui/codegen/lowering/loop_simple.sol
+++ b/tests/ui/codegen/lowering/loop_simple.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract LoopSimple {
     function sum_to(uint256 n) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/low_level_call_calldata_bytes.sol
+++ b/tests/ui/codegen/lowering/low_level_call_calldata_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // A low-level call may take a `bytes calldata` value as its call data, e.g. a
 // proxy fallback `impl.delegatecall(data)` with `bytes calldata data` (aave-v3

--- a/tests/ui/codegen/lowering/low_level_call_returndata.sol
+++ b/tests/ui/codegen/lowering/low_level_call_returndata.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 interface IERC20Minimal {
     function transfer(address to, uint256 value) external returns (bool);

--- a/tests/ui/codegen/lowering/lowering_error_sentinel.sol
+++ b/tests/ui/codegen/lowering/lowering_error_sentinel.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 //@check-fail
 
 // Unsupported constructs reported during lowering produce an error sentinel

--- a/tests/ui/codegen/lowering/mapping.sol
+++ b/tests/ui/codegen/lowering/mapping.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Mapping {
     mapping(uint256 => uint256) public balances;

--- a/tests/ui/codegen/lowering/mapping_bytes_values.sol
+++ b/tests/ui/codegen/lowering/mapping_bytes_values.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract MappingBytesValues {
     mapping(uint256 => bytes) data;

--- a/tests/ui/codegen/lowering/mapping_dynamic_key.sol
+++ b/tests/ui/codegen/lowering/mapping_dynamic_key.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract MappingDynamicKey {
     mapping(string => address) public lookup;

--- a/tests/ui/codegen/lowering/mapping_nested_struct_copy.sol
+++ b/tests/ui/codegen/lowering/mapping_nested_struct_copy.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 //@filecheck: --check-prefix=STRUCT
 
 // Mapping values that are structs use a runtime-computed base slot. Copy the

--- a/tests/ui/codegen/lowering/mapping_struct_getter.sol
+++ b/tests/ui/codegen/lowering/mapping_struct_getter.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // The auto-generated getter for a `mapping(K => Struct) public` must read the
 // struct fields from the element's storage slot `keccak256(key, slot)`, not from

--- a/tests/ui/codegen/lowering/mcopy_evm_version.sol
+++ b/tests/ui/codegen/lowering/mcopy_evm_version.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --evm-version shanghai --emit=mir
+//@compile-flags: -Zcodegen --evm-version shanghai -Zdump=mir
 
 contract McopyEvmVersion {
     function copy() external pure {

--- a/tests/ui/codegen/lowering/member_call_unresolved.sol
+++ b/tests/ui/codegen/lowering/member_call_unresolved.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir
+//@compile-flags: -Zcodegen -Zdump=evm-ir
 //@check-fail
 // A member call on a receiver whose type is an unresolved import must produce
 // diagnostics, not an ICE in codegen (the typeck-invariant panic).

--- a/tests/ui/codegen/lowering/memory_allocation_panic.sol
+++ b/tests/ui/codegen/lowering/memory_allocation_panic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Dynamic memory allocations must revert with Panic(0x41) when the requested
 // size overflows while computing the padded byte length, element byte length,

--- a/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol
+++ b/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract MemoryFixedArrayAlloc {
     struct Holder {

--- a/tests/ui/codegen/lowering/multi_return.sol
+++ b/tests/ui/codegen/lowering/multi_return.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract MultiReturn {
     function div_mod(uint256 a, uint256 b) public pure returns (uint256, uint256) {

--- a/tests/ui/codegen/lowering/multi_return_call.sol
+++ b/tests/ui/codegen/lowering/multi_return_call.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Multi-value returns from internal *calls* must propagate all N values, not
 // just the first. Previously the non-inlined `internal_call` carried a return

--- a/tests/ui/codegen/lowering/multi_return_named_init.sol
+++ b/tests/ui/codegen/lowering/multi_return_named_init.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 //@filecheck: --check-prefix=INIT
 
 // Finalize the complete return prefix before initializing named return

--- a/tests/ui/codegen/lowering/multi_return_scratch.sol
+++ b/tests/ui/codegen/lowering/multi_return_scratch.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 //@filecheck: --check-prefix=ORDER
 // Multi-return tails live at the free-memory pointer, and every tail word is
 // loaded before the first tuple lvalue is evaluated. Computing `stored[key]`

--- a/tests/ui/codegen/lowering/nested_loops.sol
+++ b/tests/ui/codegen/lowering/nested_loops.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract NestedLoops {
     function sum_grid(uint256 n, uint256 m) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/public_library_call.sol
+++ b/tests/ui/codegen/lowering/public_library_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // A `public`/`external` library function called from another contract is
 // compiled by solc into the library's own runtime and reached via delegatecall

--- a/tests/ui/codegen/lowering/recursive.sol
+++ b/tests/ui/codegen/lowering/recursive.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Recursive functions. A recursive call can't be inlined (the inline path's
 // cycle detector would substitute a `0` placeholder), so the public function is

--- a/tests/ui/codegen/lowering/recursive_memory_return.sol
+++ b/tests/ui/codegen/lowering/recursive_memory_return.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Functions returning a memory reference can now recurse: the return is a
 // 32-byte pointer that flows through the internal-frame slots, and callee heap

--- a/tests/ui/codegen/lowering/revert_error_helper.sol
+++ b/tests/ui/codegen/lowering/revert_error_helper.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // Constant short revert messages share one synthesized `__revert_error`
 // helper per module: each `require`/`revert` site passes the length and the

--- a/tests/ui/codegen/lowering/revert_payloads.sol
+++ b/tests/ui/codegen/lowering/revert_payloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract RevertPayloads {
     function assert_panic(bool ok) public pure {

--- a/tests/ui/codegen/lowering/signed_constant_ops.sol
+++ b/tests/ui/codegen/lowering/signed_constant_ops.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract SignedConstantOps {
     function lt() public pure returns (bool) {

--- a/tests/ui/codegen/lowering/stack-too-deep/call_args.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/call_args.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;
 

--- a/tests/ui/codegen/lowering/stack-too-deep/locals.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/locals.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;
 

--- a/tests/ui/codegen/lowering/stack-too-deep/params.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/params.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;
 

--- a/tests/ui/codegen/lowering/stack_phi_loop.sol
+++ b/tests/ui/codegen/lowering/stack_phi_loop.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime --pretty-json
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime --pretty-json
 
 contract StackPhiLoop {
     function loopCarried(uint256 n, bool flag) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/static_frames.sol
+++ b/tests/ui/codegen/lowering/static_frames.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // Static frame overlays: non-recursive internal functions get
 // compile-time-fixed frame addresses (absolute pushes, no frame-pointer or

--- a/tests/ui/codegen/lowering/storage.sol
+++ b/tests/ui/codegen/lowering/storage.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Storage {
     uint256 public count;

--- a/tests/ui/codegen/lowering/storage_bytes_elements.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract StorageBytesElements {
     bytes public b;

--- a/tests/ui/codegen/lowering/storage_bytes_from_calldata.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_from_calldata.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract StorageBytesFromCalldata {
     string text;

--- a/tests/ui/codegen/lowering/storage_bytes_member.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_member.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // A `bytes` struct field reached through a storage reference bound from a
 // mapping element (`state.part` below) uses Solidity's packed short/long

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract StorageBytesPushPop {
     bytes data;

--- a/tests/ui/codegen/lowering/storage_checked_arithmetic.sol
+++ b/tests/ui/codegen/lowering/storage_checked_arithmetic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract StorageCheckedArithmetic {
     struct Account {

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.sol
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract StorageLongBytesReturn {
     string public s;

--- a/tests/ui/codegen/lowering/storage_packed_bool.sol
+++ b/tests/ui/codegen/lowering/storage_packed_bool.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen --emit=mir
+//@ compile-flags: -Zcodegen -Zdump=mir
 
 contract PackedBool {
     bool public a;

--- a/tests/ui/codegen/lowering/storage_reference.sol
+++ b/tests/ui/codegen/lowering/storage_reference.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // Storage references are modeled as slot values: `Item storage r = items[k]`
 // binds the storage *slot*, so `r.a` reads/writes `sload`/`sstore(slot + off)`

--- a/tests/ui/codegen/lowering/storage_struct_array.sol
+++ b/tests/ui/codegen/lowering/storage_struct_array.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 // Fixed storage arrays of multi-slot elements stride by the element's slot
 // count: arr[i].a lives at base + i*2 and arr[i].b one slot above, so
 // adjacent elements do not overlap.

--- a/tests/ui/codegen/lowering/ternary.sol
+++ b/tests/ui/codegen/lowering/ternary.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract Ternary {
     function max(uint256 a, uint256 b) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol
+++ b/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@ compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 // A multi-return tuple assignment inside one branch arm must not leak its
 // values into the sibling arm: `off` below is reassigned only in the `then`
 // arm, so the `else` arm must read the pre-branch value, not the pickup from

--- a/tests/ui/codegen/lowering/tuple_assignment.sol
+++ b/tests/ui/codegen/lowering/tuple_assignment.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // Tuple assignment to EXISTING lvalues, `(a, b) = rhs`. `lower_assign` had no
 // tuple case, so these silently assigned nothing (e.g. `(ok, ) = addr.call(d)`

--- a/tests/ui/codegen/lowering/type_conversion.sol
+++ b/tests/ui/codegen/lowering/type_conversion.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract TypeConversion {
     function narrowAddress(address asset) public pure returns (uint16) {

--- a/tests/ui/codegen/lowering/udvt_operator_unsupported.sol
+++ b/tests/ui/codegen/lowering/udvt_operator_unsupported.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 type Wad is uint256;
 

--- a/tests/ui/codegen/lowering/udvt_selector.sol
+++ b/tests/ui/codegen/lowering/udvt_selector.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=hashes,evm-ir-runtime --pretty-json
+//@compile-flags: -Zcodegen --emit=hashes -Zdump=evm-ir-runtime --pretty-json
 
 type Wad is uint256;
 

--- a/tests/ui/codegen/lowering/using_for_struct.sol
+++ b/tests/ui/codegen/lowering/using_for_struct.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // `using L for S` attached calls on a struct (a reference type) must resolve to
 // the library function — previously the receiver's `Ref(Struct, loc)` type

--- a/tests/ui/codegen/lowering/while_empty_body.sol
+++ b/tests/ui/codegen/lowering/while_empty_body.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=evm-ir
+//@compile-flags: -Zcodegen -Zdump=evm-ir
 
 contract WhileEmptyBody {
     function f(uint256 x) public pure {

--- a/tests/ui/codegen/lowering/while_loop.sol
+++ b/tests/ui/codegen/lowering/while_loop.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract WhileLoop {
     function count_down(uint256 n) public pure returns (uint256) {

--- a/tests/ui/codegen/lowering/yul_call_errors.sol
+++ b/tests/ui/codegen/lowering/yul_call_errors.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract YulCallErrors {
     function unknownCall() public pure returns (uint256 result) {

--- a/tests/ui/codegen/lowering/yul_calldata_array.sol
+++ b/tests/ui/codegen/lowering/yul_calldata_array.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 // `.length`/`.offset` on a calldata array in inline assembly. The array
 // parameter's value is the ABI head, so `.length` reads the length word at

--- a/tests/ui/codegen/lowering/yul_local_phi.sol
+++ b/tests/ui/codegen/lowering/yul_local_phi.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract YulLocalPhi {
     function branchLocal(uint256 flag) public pure returns (uint256 result) {

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.sol
@@ -1,5 +1,5 @@
 //@ignore-host: windows
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract YulLowLevelBuiltins {
     function safeCall(address token, bytes4 selector) public returns (bool success) {

--- a/tests/ui/codegen/lowering/yul_return.sol
+++ b/tests/ui/codegen/lowering/yul_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=evm-ir-runtime
+//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
 
 // The Yul `return(offset, size)` builtin halts execution and returns `size`
 // bytes of memory (the `RETURN` opcode), like the `ret_data` terminator. It is

--- a/tests/ui/codegen/lowering/yul_unsupported_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_unsupported_builtins.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 
 contract YulUnsupportedBuiltins {
     function unsupportedBuiltin() public pure returns (uint256 result) {

--- a/tests/ui/erc7201/codegen.sol
+++ b/tests/ui/erc7201/codegen.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=mir
+//@compile-flags: -Zcodegen -Zdump=mir
 // ported-from: test/cmdlineTests/yul_optimizer_erc7201_literal_comptime_evaluation/input.sol
 // ported-from: test/cmdlineTests/yul_optimizer_erc7201_param_memory/input.sol
 // ported-from: test/cmdlineTests/yul_optimizer_erc7201_param_calldata/input.sol


### PR DESCRIPTION
Follow up #982 by keeping EVM IR pass scratch local, using fixed-capacity operand storage where bounds are known, and checking peepholes in operand-count order.

Move MIR and EVM IR output from `--emit` to multi-kind `-Zdump`, including MIR CFG dumps, and centralize whether requested dumps require codegen.
