### PR TITLE
feat(lsp): add project benchmark framework

### DIFF
--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -19,3 +19,11 @@ To add a scenario, prepare the project outside the timed closure, resolve its re
 the request once and assert the expected response, then register only the analysis, edit, or query
 as the measured operation. Full filesystem, JSON-RPC, and process latency belongs in a future
 walltime benchmark.
+
+The benchmark groups intentionally keep separate timing boundaries:
+
+- `analysis-build` preserves the historical single-source workload for comparable BASE results.
+- `project-analysis` and `project-analysis-after-edit` measure compiler and symbol-table rebuilds.
+- `project-edit-application` measures UTF-16 document edit application without analysis.
+- `symbol-table-queries` measures synchronous query kernels, not complete LSP request latency.
+- `workspace-symbols` tracks broad and exact query costs as the symbol count grows.

--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -26,4 +26,3 @@ The benchmark groups intentionally keep separate timing boundaries:
 - `project-analysis` and `project-analysis-after-edit` measure compiler and symbol-table rebuilds.
 - `project-edit-application` measures UTF-16 document edit application without analysis.
 - `symbol-table-queries` measures synchronous query kernels, not complete LSP request latency.
-- `workspace-symbols` tracks broad and exact query costs as the symbol count grows.

--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -1,3 +1,21 @@
 # solar-lsp
 
 Solar LSP definitions and implementation.
+
+## Benchmarks
+
+Run the LSP benchmarks locally with:
+
+```console
+cargo bench -p solar-lsp --bench lsp --features bench
+```
+
+The current suite measures in-memory project analysis, edits, and queries. Loading manifests and
+corpora from disk, resolving anchors, constructing requests, and preflight correctness checks stay
+outside the timed closure. Use stable `lsp/<operation>/<case>` names and add new cases instead of
+renaming existing benchmark IDs.
+
+To add a scenario, prepare the project outside the timed closure, resolve its request anchors, run
+the request once and assert the expected response, then register only the analysis, edit, or query
+as the measured operation. Full filesystem, JSON-RPC, and process latency belongs in a future
+walltime benchmark.

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -14,7 +14,7 @@ const UNIFAP_FACTORY: &str = "src/UnifapV2Factory.sol";
 
 struct BenchmarkSource {
     project: BenchmarkProject,
-    hover_requests: Vec<BenchmarkRequest>,
+    hover_positions: Vec<(u32, u32)>,
 }
 
 struct SourceBuilder {
@@ -38,17 +38,17 @@ impl SourceBuilder {
 
     fn finish(self) -> BenchmarkSource {
         let project = BenchmarkProject::from_source(self.source);
-        let hover_requests = self
+        let hover_positions = self
             .hover_anchors
             .into_iter()
             .map(|anchor| {
-                let (uri, position) = project
+                let (_, position) = project
                     .unique_anchor("benchmark.sol", &anchor)
                     .expect("generated hover anchors should be unique");
-                BenchmarkRequest::Hover { uri, position }
+                (position.line, position.character)
             })
             .collect();
-        BenchmarkSource { project, hover_requests }
+        BenchmarkSource { project, hover_positions }
     }
 }
 
@@ -113,22 +113,18 @@ fn analysis_build(c: &mut Criterion) {
 fn burst_hover(c: &mut Criterion) {
     let fixture = benchmark_source(HOVER_FUNCTION_COUNT);
     let analysis = fixture.project.analyze();
-    let requests = fixture.hover_requests;
+    let positions = fixture.hover_positions;
     assert_clean(&analysis);
-    assert_eq!(requests.len(), HOVER_FUNCTION_COUNT * 2);
-    assert!(
-        requests.iter().all(|request| {
-            matches!(analysis.execute(request), BenchmarkResponse::Hover(Some(_)))
-        })
-    );
+    assert_eq!(positions.len(), HOVER_FUNCTION_COUNT * 2);
+    assert!(positions.iter().all(|&(line, character)| analysis.hover(line, character).is_some()));
 
     let mut group = c.benchmark_group("lsp/burst-hover");
-    group.throughput(Throughput::Elements(requests.len() as u64));
+    group.throughput(Throughput::Elements(positions.len() as u64));
     group.bench_function(HOVER_FUNCTION_COUNT.to_string(), |b| {
         b.iter(|| {
             let analysis = black_box(&analysis);
-            for request in black_box(&requests) {
-                black_box(analysis.execute(black_box(request)));
+            for &(line, character) in black_box(&positions) {
+                black_box(analysis.hover(black_box(line), black_box(character)));
             }
         });
     });

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -242,18 +242,16 @@ fn unifap_benches(c: &mut Criterion) {
         assert_clean(&edited_analysis);
     }
 
-    let mut group = c.benchmark_group("lsp/project-analysis");
-    group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
+    let mut group = c.benchmark_group("lsp");
+    group.bench_function(format!("project-analysis/{UNIFAP_PROJECT}"), |b| {
         b.iter_batched(
             || project.clone(),
             |project| black_box(project.analyze()),
             BatchSize::PerIteration,
         );
     });
-    group.finish();
 
-    let mut group = c.benchmark_group("lsp/project-analysis-after-edit");
-    group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
+    group.bench_function(format!("project-analysis-after-edit/{UNIFAP_PROJECT}"), |b| {
         b.iter_batched(
             || {
                 let mut project = project.clone();
@@ -264,24 +262,20 @@ fn unifap_benches(c: &mut Criterion) {
             BatchSize::PerIteration,
         );
     });
-    group.finish();
 
-    let mut group = c.benchmark_group("lsp/project-edit-application");
     group.throughput(Throughput::Elements(1));
-    group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
+    group.bench_function(format!("project-edit-application/{UNIFAP_PROJECT}"), |b| {
         b.iter_batched(
             || document_change.clone(),
             |change| black_box(change.apply()),
             BatchSize::PerIteration,
         );
     });
-    group.finish();
 
-    let mut group = c.benchmark_group("lsp/symbol-table-queries/unifap-v2");
-    group.throughput(Throughput::Elements(1));
     for (name, request) in &requests {
-        group.bench_with_input(BenchmarkId::from_parameter(name), request, |b, request| {
-            b.iter(|| black_box(analysis.execute(black_box(request))));
+        let id = format!("symbol-table-queries/{UNIFAP_PROJECT}/{name}");
+        group.bench_with_input(id, request, |b, request| {
+            b.iter(|| black_box(analysis.execute(black_box(request))))
         });
     }
     group.finish();

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -223,7 +223,7 @@ fn project_analysis(c: &mut Criterion) {
     assert_clean(&analysis);
 
     let mut group = c.benchmark_group("lsp/project-analysis");
-    group.bench_function(UNIFAP_PROJECT, |b| {
+    group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
         b.iter_batched(
             || project.clone(),
             |project| black_box(project.analyze()),
@@ -248,7 +248,7 @@ fn project_analysis_after_edit(c: &mut Criterion) {
     assert_clean(&analysis);
 
     let mut group = c.benchmark_group("lsp/project-analysis-after-edit");
-    group.bench_function(UNIFAP_PROJECT, |b| {
+    group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
         b.iter_batched(
             || {
                 let mut project = project.clone();
@@ -278,7 +278,7 @@ fn project_edit_application(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("lsp/project-edit-application");
     group.throughput(Throughput::Elements(1));
-    group.bench_function(UNIFAP_PROJECT, |b| {
+    group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
         b.iter_batched(
             || document_change.clone(),
             |change| black_box(change.apply()),

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -219,12 +219,10 @@ fn assert_clean(analysis: &solar_lsp::BenchmarkAnalysis) {
 
 fn project_analysis(c: &mut Criterion) {
     let project = unifap_project();
-    let source_bytes = project.source_bytes() as u64;
     let analysis = project.clone().analyze();
     assert_clean(&analysis);
 
     let mut group = c.benchmark_group("lsp/project-analysis");
-    group.throughput(Throughput::Bytes(source_bytes));
     group.bench_function(UNIFAP_PROJECT, |b| {
         b.iter_batched(
             || project.clone(),
@@ -243,7 +241,6 @@ fn project_analysis_after_edit(c: &mut Criterion) {
 
     let mut preflight = project.clone();
     preflight.apply_edit(&edit).expect("the benchmark edit should apply");
-    let source_bytes = preflight.source_bytes() as u64;
     preflight
         .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
         .expect("the edited source should contain the replacement");
@@ -251,7 +248,6 @@ fn project_analysis_after_edit(c: &mut Criterion) {
     assert_clean(&analysis);
 
     let mut group = c.benchmark_group("lsp/project-analysis-after-edit");
-    group.throughput(Throughput::Bytes(source_bytes));
     group.bench_function(UNIFAP_PROJECT, |b| {
         b.iter_batched(
             || {
@@ -311,32 +307,6 @@ fn symbol_table_queries(c: &mut Criterion) {
     group.finish();
 }
 
-fn workspace_symbol_scaling(c: &mut Criterion) {
-    let mut group = c.benchmark_group("lsp/workspace-symbols");
-    for function_count in ANALYSIS_FUNCTION_COUNTS {
-        let analysis = benchmark_source(function_count).project.analyze();
-        assert_clean(&analysis);
-        let exact_query = format!("function_{:04}", function_count - 1);
-        for (case, query, expected) in
-            [("all", "function_", function_count), ("exact", exact_query.as_str(), 1)]
-        {
-            let request = BenchmarkRequest::WorkspaceSymbols { query: query.into() };
-            let BenchmarkResponse::WorkspaceSymbols(symbols) = analysis.execute(&request) else {
-                panic!("workspace-symbols benchmark returned the wrong response type")
-            };
-            assert_eq!(symbols.len(), expected);
-
-            group.throughput(Throughput::Elements(expected as u64));
-            group.bench_with_input(
-                BenchmarkId::new(case, function_count),
-                &request,
-                |b, request| b.iter(|| black_box(analysis.execute(black_box(request)))),
-            );
-        }
-    }
-    group.finish();
-}
-
 criterion_group!(
     benches,
     analysis_build,
@@ -344,7 +314,6 @@ criterion_group!(
     project_analysis,
     project_analysis_after_edit,
     project_edit_application,
-    symbol_table_queries,
-    workspace_symbol_scaling
+    symbol_table_queries
 );
 criterion_main!(benches);

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -1,47 +1,54 @@
 #![allow(unused_crate_dependencies)]
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use solar_lsp::BenchmarkAnalysis;
-use std::hint::black_box;
+use lsp_types::{GotoDefinitionResponse, HoverContents};
+use solar_lsp::{BenchmarkProject, BenchmarkRequest, BenchmarkResponse};
+use std::{hint::black_box, path::PathBuf};
 
 const ANALYSIS_FUNCTION_COUNTS: [usize; 2] = [64, 256];
 const HOVER_FUNCTION_COUNT: usize = 256;
+const UNIFAP_PROJECT: &str = "unifap-v2";
+const UNIFAP_ROUTER: &str = "src/UnifapV2Router.sol";
+const UNIFAP_PAIR: &str = "src/UnifapV2Pair.sol";
+const UNIFAP_FACTORY: &str = "src/UnifapV2Factory.sol";
 
 struct BenchmarkSource {
-    source: String,
-    hover_positions: Vec<(u32, u32)>,
+    project: BenchmarkProject,
+    hover_requests: Vec<BenchmarkRequest>,
 }
 
 struct SourceBuilder {
     source: String,
-    hover_positions: Vec<(u32, u32)>,
-    next_line: u32,
+    hover_anchors: Vec<String>,
 }
 
 impl SourceBuilder {
     fn new(function_count: usize) -> Self {
-        Self {
-            source: String::new(),
-            hover_positions: Vec::with_capacity(function_count * 2),
-            next_line: 0,
-        }
+        Self { source: String::new(), hover_anchors: Vec::with_capacity(function_count * 2) }
     }
 
-    fn push_line(&mut self, line: &str) -> u32 {
-        let line_number = self.next_line;
+    fn push_line(&mut self, line: &str) {
         self.source.push_str(line);
         self.source.push('\n');
-        self.next_line += 1;
-        line_number
     }
 
-    fn push_hover_position(&mut self, line: u32, source_line: &str, name: &str) {
-        let character = source_line.find(name).expect("benchmark symbol should be present") as u32;
-        self.hover_positions.push((line, character));
+    fn push_hover_anchor(&mut self, anchor: String) {
+        self.hover_anchors.push(anchor);
     }
 
     fn finish(self) -> BenchmarkSource {
-        BenchmarkSource { source: self.source, hover_positions: self.hover_positions }
+        let project = BenchmarkProject::from_source(self.source);
+        let hover_requests = self
+            .hover_anchors
+            .into_iter()
+            .map(|anchor| {
+                let (uri, position) = project
+                    .unique_anchor("benchmark.sol", &anchor)
+                    .expect("generated hover anchors should be unique");
+                BenchmarkRequest::Hover { uri, position }
+            })
+            .collect();
+        BenchmarkSource { project, hover_requests }
     }
 }
 
@@ -62,8 +69,8 @@ fn benchmark_source(function_count: usize) -> BenchmarkSource {
         let declaration = format!(
             "    function {name}(uint256 first, uint256 second, address account) public pure returns (uint256 total, address owner) {{"
         );
-        let line = builder.push_line(&declaration);
-        builder.push_hover_position(line, &declaration, &name);
+        builder.push_line(&declaration);
+        builder.push_hover_anchor(format!("{name}(uint256 first"));
         builder.push_line("        total = first + second;");
         builder.push_line("        owner = account;");
         builder.push_line("    }");
@@ -73,8 +80,8 @@ fn benchmark_source(function_count: usize) -> BenchmarkSource {
     for index in 0..function_count {
         let name = format!("function_{index:04}");
         let call = format!("        {name}(1, 2, address(0));");
-        let line = builder.push_line(&call);
-        builder.push_hover_position(line, &call, &name);
+        builder.push_line(&call);
+        builder.push_hover_anchor(format!("{name}(1, 2, address(0))"));
     }
     builder.push_line("    }");
     builder.push_line("}");
@@ -85,14 +92,16 @@ fn analysis_build(c: &mut Criterion) {
     let mut group = c.benchmark_group("lsp/analysis-build");
     for function_count in ANALYSIS_FUNCTION_COUNTS {
         let fixture = benchmark_source(function_count);
-        group.throughput(Throughput::Bytes(fixture.source.len() as u64));
+        let analysis = fixture.project.clone().analyze();
+        assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+        group.throughput(Throughput::Bytes(fixture.project.source_bytes() as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(function_count),
-            &fixture.source,
-            |b, source| {
+            &fixture.project,
+            |b, project| {
                 b.iter_batched(
-                    || source.clone(),
-                    |source| black_box(BenchmarkAnalysis::from_source(black_box(source))),
+                    || project.clone(),
+                    |project| black_box(project.analyze()),
                     BatchSize::PerIteration,
                 );
             },
@@ -103,23 +112,187 @@ fn analysis_build(c: &mut Criterion) {
 
 fn burst_hover(c: &mut Criterion) {
     let fixture = benchmark_source(HOVER_FUNCTION_COUNT);
-    let analysis = BenchmarkAnalysis::from_source(fixture.source);
-    let positions = fixture.hover_positions;
-    assert_eq!(positions.len(), HOVER_FUNCTION_COUNT * 2);
-    assert!(positions.iter().all(|&(line, character)| analysis.hover(line, character).is_some()));
+    let analysis = fixture.project.analyze();
+    let requests = fixture.hover_requests;
+    assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+    assert_eq!(requests.len(), HOVER_FUNCTION_COUNT * 2);
+    assert!(
+        requests.iter().all(|request| {
+            matches!(analysis.execute(request), BenchmarkResponse::Hover(Some(_)))
+        })
+    );
 
     let mut group = c.benchmark_group("lsp/burst-hover");
-    group.throughput(Throughput::Elements(positions.len() as u64));
+    group.throughput(Throughput::Elements(requests.len() as u64));
     group.bench_function(HOVER_FUNCTION_COUNT.to_string(), |b| {
         b.iter(|| {
             let analysis = black_box(&analysis);
-            for &(line, character) in black_box(&positions) {
-                black_box(analysis.hover(black_box(line), black_box(character)));
+            for request in black_box(&requests) {
+                black_box(analysis.execute(black_box(request)));
             }
         });
     });
     group.finish();
 }
 
-criterion_group!(benches, analysis_build, burst_hover);
+fn unifap_project() -> BenchmarkProject {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("tests/foundry/unifap-v2/foundry.toml");
+    let project = BenchmarkProject::from_foundry_manifest(manifest)
+        .expect("the tracked unifap-v2 benchmark project should load");
+    assert_eq!(project.file_count(), 14);
+    project
+}
+
+fn unifap_requests(project: &BenchmarkProject) -> [(&'static str, BenchmarkRequest); 4] {
+    let (hover_uri, hover_position) =
+        project.unique_anchor(UNIFAP_PAIR, "SELECTOR").expect("the hover anchor should be unique");
+    let (definition_uri, definition_position) = project
+        .unique_anchor(UNIFAP_ROUTER, "sortPairs")
+        .expect("the definition anchor should be unique");
+    let (references_uri, references_position) = project
+        .unique_anchor(UNIFAP_FACTORY, "getAllPairLength")
+        .expect("the references anchor should be unique");
+
+    [
+        ("hover", BenchmarkRequest::Hover { uri: hover_uri, position: hover_position }),
+        (
+            "goto-definition",
+            BenchmarkRequest::GotoDefinition { uri: definition_uri, position: definition_position },
+        ),
+        (
+            "references",
+            BenchmarkRequest::References {
+                uri: references_uri,
+                position: references_position,
+                include_declaration: true,
+            },
+        ),
+        ("workspace-symbols", BenchmarkRequest::WorkspaceSymbols { query: "UnifapV2Pair".into() }),
+    ]
+}
+
+fn assert_unifap_response(name: &str, response: BenchmarkResponse) {
+    match (name, response) {
+        ("hover", BenchmarkResponse::Hover(Some(hover))) => {
+            let HoverContents::Markup(markup) = hover.contents else {
+                panic!("the SELECTOR hover should contain markup")
+            };
+            assert!(markup.value.contains("SELECTOR"));
+        }
+        (
+            "goto-definition",
+            BenchmarkResponse::GotoDefinition(Some(GotoDefinitionResponse::Array(locations))),
+        ) => {
+            assert_eq!(locations.len(), 1);
+            assert!(locations[0].uri.path().ends_with("/src/libraries/UnifapV2Library.sol"));
+        }
+        ("references", BenchmarkResponse::References(Some(locations))) => {
+            assert_eq!(locations.len(), 4);
+            assert_eq!(
+                locations
+                    .iter()
+                    .filter(|location| location.uri.path().ends_with("/src/UnifapV2Factory.sol"))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                locations
+                    .iter()
+                    .filter(|location| {
+                        location.uri.path().ends_with("/src/test/UnifapV2Factory.t.sol")
+                    })
+                    .count(),
+                3
+            );
+        }
+        ("workspace-symbols", BenchmarkResponse::WorkspaceSymbols(symbols)) => {
+            assert_eq!(symbols.len(), 3);
+            assert!(symbols.iter().all(|symbol| symbol.name.contains("UnifapV2Pair")));
+            assert!(symbols.iter().any(|symbol| symbol.name == "UnifapV2Pair"));
+        }
+        _ => panic!("unexpected `{name}` response for the unifap-v2 benchmark"),
+    }
+}
+
+fn assert_clean(analysis: &solar_lsp::BenchmarkAnalysis) {
+    assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+}
+
+fn project_analysis(c: &mut Criterion) {
+    let project = unifap_project();
+    let source_bytes = project.source_bytes() as u64;
+    let analysis = project.clone().analyze();
+    assert_clean(&analysis);
+
+    let mut group = c.benchmark_group("lsp/project-analysis");
+    group.throughput(Throughput::Bytes(source_bytes));
+    group.bench_function(UNIFAP_PROJECT, |b| {
+        b.iter_batched(
+            || project.clone(),
+            |project| black_box(project.analyze()),
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn project_reanalysis_after_change(c: &mut Criterion) {
+    let project = unifap_project();
+    let edit = project
+        .replacement_edit(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e3", "MINIMUM_LIQUIDITY = 1e4")
+        .expect("the edit anchor should be unique");
+    let source_bytes = project.source_bytes() as u64;
+
+    let mut preflight = project.clone();
+    preflight.apply_edit(&edit).expect("the benchmark edit should apply");
+    preflight
+        .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
+        .expect("the edited source should contain the replacement");
+    let analysis = preflight.analyze();
+    assert_clean(&analysis);
+
+    let mut group = c.benchmark_group("lsp/project-reanalysis-after-change");
+    group.throughput(Throughput::Bytes(source_bytes));
+    group.bench_function(UNIFAP_PROJECT, |b| {
+        b.iter_batched(
+            || project.clone(),
+            |mut project| {
+                project.apply_edit(black_box(&edit)).expect("the benchmark edit should apply");
+                black_box(project.analyze())
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn project_requests(c: &mut Criterion) {
+    let project = unifap_project();
+    let requests = unifap_requests(&project);
+    let analysis = project.analyze();
+    assert_clean(&analysis);
+    for (name, request) in &requests {
+        assert_unifap_response(name, analysis.execute(request));
+    }
+
+    let mut group = c.benchmark_group("lsp/project-requests/unifap-v2");
+    group.throughput(Throughput::Elements(1));
+    for (name, request) in &requests {
+        group.bench_with_input(BenchmarkId::from_parameter(name), request, |b, request| {
+            b.iter(|| black_box(analysis.execute(black_box(request))));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    analysis_build,
+    burst_hover,
+    project_analysis,
+    project_reanalysis_after_change,
+    project_requests
+);
 criterion_main!(benches);

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -217,10 +217,30 @@ fn assert_clean(analysis: &solar_lsp::BenchmarkAnalysis) {
     assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
 }
 
-fn project_analysis(c: &mut Criterion) {
+fn unifap_benches(c: &mut Criterion) {
     let project = unifap_project();
+    let edit = project
+        .replacement_edit(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e3", "MINIMUM_LIQUIDITY = 1e4")
+        .expect("the edit anchor should be unique");
+    let document_change =
+        project.document_change(&edit).expect("the benchmark document change should be prepared");
+    let requests = unifap_requests(&project);
+
     let analysis = project.clone().analyze();
     assert_clean(&analysis);
+    for (name, request) in &requests {
+        assert_unifap_response(name, analysis.execute(request));
+    }
+
+    {
+        let mut edited_project = project.clone();
+        edited_project.apply_edit(&edit).expect("the benchmark edit should apply");
+        edited_project
+            .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
+            .expect("the edited source should contain the replacement");
+        let edited_analysis = edited_project.analyze();
+        assert_clean(&edited_analysis);
+    }
 
     let mut group = c.benchmark_group("lsp/project-analysis");
     group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
@@ -231,21 +251,6 @@ fn project_analysis(c: &mut Criterion) {
         );
     });
     group.finish();
-}
-
-fn project_analysis_after_edit(c: &mut Criterion) {
-    let project = unifap_project();
-    let edit = project
-        .replacement_edit(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e3", "MINIMUM_LIQUIDITY = 1e4")
-        .expect("the edit anchor should be unique");
-
-    let mut preflight = project.clone();
-    preflight.apply_edit(&edit).expect("the benchmark edit should apply");
-    preflight
-        .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
-        .expect("the edited source should contain the replacement");
-    let analysis = preflight.analyze();
-    assert_clean(&analysis);
 
     let mut group = c.benchmark_group("lsp/project-analysis-after-edit");
     group.bench_function(BenchmarkId::from_parameter(UNIFAP_PROJECT), |b| {
@@ -260,21 +265,6 @@ fn project_analysis_after_edit(c: &mut Criterion) {
         );
     });
     group.finish();
-}
-
-fn project_edit_application(c: &mut Criterion) {
-    let project = unifap_project();
-    let edit = project
-        .replacement_edit(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e3", "MINIMUM_LIQUIDITY = 1e4")
-        .expect("the edit anchor should be unique");
-
-    let mut preflight = project.clone();
-    preflight.apply_edit(&edit).expect("the benchmark edit should apply");
-    preflight
-        .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
-        .expect("the edited source should contain the replacement");
-    let document_change =
-        project.document_change(&edit).expect("the benchmark document change should be prepared");
 
     let mut group = c.benchmark_group("lsp/project-edit-application");
     group.throughput(Throughput::Elements(1));
@@ -286,16 +276,6 @@ fn project_edit_application(c: &mut Criterion) {
         );
     });
     group.finish();
-}
-
-fn symbol_table_queries(c: &mut Criterion) {
-    let project = unifap_project();
-    let requests = unifap_requests(&project);
-    let analysis = project.analyze();
-    assert_clean(&analysis);
-    for (name, request) in &requests {
-        assert_unifap_response(name, analysis.execute(request));
-    }
 
     let mut group = c.benchmark_group("lsp/symbol-table-queries/unifap-v2");
     group.throughput(Throughput::Elements(1));
@@ -307,13 +287,5 @@ fn symbol_table_queries(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    analysis_build,
-    burst_hover,
-    project_analysis,
-    project_analysis_after_edit,
-    project_edit_application,
-    symbol_table_queries
-);
+criterion_group!(benches, analysis_build, burst_hover, unifap_benches);
 criterion_main!(benches);

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -93,7 +93,7 @@ fn analysis_build(c: &mut Criterion) {
     for function_count in ANALYSIS_FUNCTION_COUNTS {
         let fixture = benchmark_source(function_count);
         let analysis = fixture.project.clone().analyze();
-        assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+        assert_clean(&analysis);
         group.throughput(Throughput::Bytes(fixture.project.source_bytes() as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(function_count),
@@ -114,7 +114,7 @@ fn burst_hover(c: &mut Criterion) {
     let fixture = benchmark_source(HOVER_FUNCTION_COUNT);
     let analysis = fixture.project.analyze();
     let requests = fixture.hover_requests;
-    assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+    assert_clean(&analysis);
     assert_eq!(requests.len(), HOVER_FUNCTION_COUNT * 2);
     assert!(
         requests.iter().all(|request| {

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -2,7 +2,7 @@
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use lsp_types::{GotoDefinitionResponse, HoverContents};
-use solar_lsp::{BenchmarkProject, BenchmarkRequest, BenchmarkResponse};
+use solar_lsp::{BenchmarkAnalysis, BenchmarkProject, BenchmarkRequest, BenchmarkResponse};
 use std::{hint::black_box, path::PathBuf};
 
 const ANALYSIS_FUNCTION_COUNTS: [usize; 2] = [64, 256];
@@ -13,6 +13,7 @@ const UNIFAP_PAIR: &str = "src/UnifapV2Pair.sol";
 const UNIFAP_FACTORY: &str = "src/UnifapV2Factory.sol";
 
 struct BenchmarkSource {
+    source: String,
     project: BenchmarkProject,
     hover_positions: Vec<(u32, u32)>,
 }
@@ -37,7 +38,7 @@ impl SourceBuilder {
     }
 
     fn finish(self) -> BenchmarkSource {
-        let project = BenchmarkProject::from_source(self.source);
+        let project = BenchmarkProject::from_source(self.source.clone());
         let hover_positions = self
             .hover_anchors
             .into_iter()
@@ -48,7 +49,7 @@ impl SourceBuilder {
                 (position.line, position.character)
             })
             .collect();
-        BenchmarkSource { project, hover_positions }
+        BenchmarkSource { source: self.source, project, hover_positions }
     }
 }
 
@@ -92,16 +93,16 @@ fn analysis_build(c: &mut Criterion) {
     let mut group = c.benchmark_group("lsp/analysis-build");
     for function_count in ANALYSIS_FUNCTION_COUNTS {
         let fixture = benchmark_source(function_count);
-        let analysis = fixture.project.clone().analyze();
+        let analysis = BenchmarkAnalysis::from_source(fixture.source.clone());
         assert_clean(&analysis);
-        group.throughput(Throughput::Bytes(fixture.project.source_bytes() as u64));
+        group.throughput(Throughput::Bytes(fixture.source.len() as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(function_count),
-            &fixture.project,
-            |b, project| {
+            &fixture.source,
+            |b, source| {
                 b.iter_batched(
-                    || project.clone(),
-                    |project| black_box(project.analyze()),
+                    || source.clone(),
+                    |source| black_box(BenchmarkAnalysis::from_source(black_box(source))),
                     BatchSize::PerIteration,
                 );
             },
@@ -234,37 +235,64 @@ fn project_analysis(c: &mut Criterion) {
     group.finish();
 }
 
-fn project_reanalysis_after_change(c: &mut Criterion) {
+fn project_analysis_after_edit(c: &mut Criterion) {
     let project = unifap_project();
     let edit = project
         .replacement_edit(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e3", "MINIMUM_LIQUIDITY = 1e4")
         .expect("the edit anchor should be unique");
-    let source_bytes = project.source_bytes() as u64;
 
     let mut preflight = project.clone();
     preflight.apply_edit(&edit).expect("the benchmark edit should apply");
+    let source_bytes = preflight.source_bytes() as u64;
     preflight
         .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
         .expect("the edited source should contain the replacement");
     let analysis = preflight.analyze();
     assert_clean(&analysis);
 
-    let mut group = c.benchmark_group("lsp/project-reanalysis-after-change");
+    let mut group = c.benchmark_group("lsp/project-analysis-after-edit");
     group.throughput(Throughput::Bytes(source_bytes));
     group.bench_function(UNIFAP_PROJECT, |b| {
         b.iter_batched(
-            || project.clone(),
-            |mut project| {
-                project.apply_edit(black_box(&edit)).expect("the benchmark edit should apply");
-                black_box(project.analyze())
+            || {
+                let mut project = project.clone();
+                project.apply_edit(&edit).expect("the benchmark edit should apply");
+                project
             },
+            |project| black_box(project.analyze()),
             BatchSize::PerIteration,
         );
     });
     group.finish();
 }
 
-fn project_requests(c: &mut Criterion) {
+fn project_edit_application(c: &mut Criterion) {
+    let project = unifap_project();
+    let edit = project
+        .replacement_edit(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e3", "MINIMUM_LIQUIDITY = 1e4")
+        .expect("the edit anchor should be unique");
+
+    let mut preflight = project.clone();
+    preflight.apply_edit(&edit).expect("the benchmark edit should apply");
+    preflight
+        .unique_anchor(UNIFAP_PAIR, "MINIMUM_LIQUIDITY = 1e4")
+        .expect("the edited source should contain the replacement");
+    let document_change =
+        project.document_change(&edit).expect("the benchmark document change should be prepared");
+
+    let mut group = c.benchmark_group("lsp/project-edit-application");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function(UNIFAP_PROJECT, |b| {
+        b.iter_batched(
+            || document_change.clone(),
+            |change| black_box(change.apply()),
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+}
+
+fn symbol_table_queries(c: &mut Criterion) {
     let project = unifap_project();
     let requests = unifap_requests(&project);
     let analysis = project.analyze();
@@ -273,7 +301,7 @@ fn project_requests(c: &mut Criterion) {
         assert_unifap_response(name, analysis.execute(request));
     }
 
-    let mut group = c.benchmark_group("lsp/project-requests/unifap-v2");
+    let mut group = c.benchmark_group("lsp/symbol-table-queries/unifap-v2");
     group.throughput(Throughput::Elements(1));
     for (name, request) in &requests {
         group.bench_with_input(BenchmarkId::from_parameter(name), request, |b, request| {
@@ -283,12 +311,40 @@ fn project_requests(c: &mut Criterion) {
     group.finish();
 }
 
+fn workspace_symbol_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lsp/workspace-symbols");
+    for function_count in ANALYSIS_FUNCTION_COUNTS {
+        let analysis = benchmark_source(function_count).project.analyze();
+        assert_clean(&analysis);
+        let exact_query = format!("function_{:04}", function_count - 1);
+        for (case, query, expected) in
+            [("all", "function_", function_count), ("exact", exact_query.as_str(), 1)]
+        {
+            let request = BenchmarkRequest::WorkspaceSymbols { query: query.into() };
+            let BenchmarkResponse::WorkspaceSymbols(symbols) = analysis.execute(&request) else {
+                panic!("workspace-symbols benchmark returned the wrong response type")
+            };
+            assert_eq!(symbols.len(), expected);
+
+            group.throughput(Throughput::Elements(expected as u64));
+            group.bench_with_input(
+                BenchmarkId::new(case, function_count),
+                &request,
+                |b, request| b.iter(|| black_box(analysis.execute(black_box(request)))),
+            );
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     analysis_build,
     burst_hover,
     project_analysis,
-    project_reanalysis_after_change,
-    project_requests
+    project_analysis_after_edit,
+    project_edit_application,
+    symbol_table_queries,
+    workspace_symbol_scaling
 );
 criterion_main!(benches);

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -515,8 +515,9 @@ fn analyze_with_source_map(batch: AnalysisBatch, source_map: Arc<SourceMap>) -> 
     })
 }
 
-/// Benchmark-only access to prepared, fully analyzed in-memory projects.
-#[cfg(feature = "bench")]
+/// Access to prepared, fully analyzed in-memory projects for benchmarks and tests.
+#[cfg(any(test, feature = "bench"))]
+#[cfg_attr(all(test, not(feature = "bench")), allow(dead_code, unreachable_pub))]
 pub(crate) mod benchmark;
 #[cfg(test)]
 #[path = "tests/mod.rs"]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -455,12 +455,20 @@ impl AnalysisBatch {
 }
 
 fn analyze(batch: AnalysisBatch) -> AnalysisResult {
+    analyze_with_source_map(batch, Arc::new(SourceMap::empty()))
+}
+
+fn analyze_with_source_map(batch: AnalysisBatch, source_map: Arc<SourceMap>) -> AnalysisResult {
     let (emitter, diag_buffer) = InMemoryEmitter::new();
     let document_link_sources =
         batch.files.iter().map(|(path, _)| path.clone()).collect::<FxHashSet<_>>();
     let mut opts = batch.opts;
     opts.unstable.recover_incomplete_input = true;
-    let sess = Session::builder().opts(opts).dcx(DiagCtxt::new(Box::new(emitter))).build();
+    let sess = Session::builder()
+        .opts(opts)
+        .source_map(source_map)
+        .dcx(DiagCtxt::new(Box::new(emitter)))
+        .build();
 
     let mut compiler = Compiler::new(sess);
     compiler.enter_mut(move |compiler| {
@@ -507,48 +515,9 @@ fn analyze(batch: AnalysisBatch) -> AnalysisResult {
     })
 }
 
-/// Benchmark-only access to a fully analyzed, in-memory source.
+/// Benchmark-only access to prepared, fully analyzed in-memory projects.
 #[cfg(feature = "bench")]
-pub(crate) mod benchmark {
-    use super::{AnalysisBatch, SymbolTables, analyze};
-    use lsp_types::{HoverContents, Position, Url};
-    use solar_config::CompileOpts;
-    use solar_interface::data_structures::map::FxHashSet;
-    use std::path::PathBuf;
-
-    /// An opaque analysis snapshot used by the LSP Criterion benchmarks.
-    #[doc(hidden)]
-    pub struct BenchmarkAnalysis {
-        symbol_tables: SymbolTables,
-        uri: Url,
-    }
-
-    impl BenchmarkAnalysis {
-        /// Analyze one in-memory Solidity source without touching the filesystem.
-        pub fn from_source(source: String) -> Self {
-            let path =
-                PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches").join("benchmark.sol");
-            let uri = Url::from_file_path(&path).expect("benchmark path should be a file URL");
-            let result = analyze(AnalysisBatch {
-                opts: CompileOpts::default(),
-                files: vec![(path, source)],
-                seen_paths: FxHashSet::default(),
-            });
-            Self { symbol_tables: result.symbol_tables, uri }
-        }
-
-        /// Resolve one declaration or reference position synchronously.
-        #[inline(never)]
-        pub fn hover(&self, line: u32, character: u32) -> Option<usize> {
-            let hover = std::hint::black_box(
-                self.symbol_tables.hover(&self.uri, Position::new(line, character)),
-            )?;
-            let HoverContents::Markup(content) = hover.contents else { return None };
-            Some(content.value.len())
-        }
-    }
-}
-
+pub(crate) mod benchmark;
 #[cfg(test)]
 #[path = "tests/mod.rs"]
 mod tests;

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -358,11 +358,7 @@ impl GlobalStateSnapshot {
         let workspace_path_index = WorkspacePathIndex::new(&workspaces);
         let mut batches = workspaces
             .iter()
-            .map(|workspace| AnalysisBatch {
-                opts: workspace.compile_opts().clone(),
-                files: Vec::new(),
-                seen_paths: FxHashSet::default(),
-            })
+            .map(|workspace| AnalysisBatch::new(workspace.compile_opts().clone()))
             .collect::<Vec<_>>();
         let source_map = SourceMap::empty();
 
@@ -443,6 +439,20 @@ struct AnalysisBatch {
 }
 
 impl AnalysisBatch {
+    fn new(opts: CompileOpts) -> Self {
+        Self { opts, files: Vec::new(), seen_paths: FxHashSet::default() }
+    }
+
+    #[cfg(any(test, feature = "bench"))]
+    fn from_files(opts: CompileOpts, files: impl IntoIterator<Item = (PathBuf, String)>) -> Self {
+        let mut batch = Self::new(opts);
+        for (path, contents) in files {
+            batch.push_file(path, contents);
+        }
+        batch.finish();
+        batch
+    }
+
     fn push_file(&mut self, path: PathBuf, contents: String) {
         if self.seen_paths.insert(path.clone()) {
             self.files.push((path, contents));
@@ -454,15 +464,39 @@ impl AnalysisBatch {
     }
 }
 
+#[cfg(test)]
+mod analysis_batch_tests {
+    use super::*;
+
+    #[test]
+    fn from_files_tracks_unique_sorted_paths() {
+        let a = PathBuf::from("a.sol");
+        let b = PathBuf::from("b.sol");
+        let batch = AnalysisBatch::from_files(
+            CompileOpts::default(),
+            [
+                (b.clone(), "contract B {}".into()),
+                (a.clone(), "contract A {}".into()),
+                (b.clone(), "contract Duplicate {}".into()),
+            ],
+        );
+
+        assert_eq!(batch.files.len(), 2);
+        assert_eq!(batch.files[0], (a.clone(), "contract A {}".into()));
+        assert_eq!(batch.files[1], (b.clone(), "contract B {}".into()));
+        assert_eq!(batch.seen_paths, FxHashSet::from_iter([a, b]));
+    }
+}
+
 fn analyze(batch: AnalysisBatch) -> AnalysisResult {
     analyze_with_source_map(batch, Arc::new(SourceMap::empty()))
 }
 
 fn analyze_with_source_map(batch: AnalysisBatch, source_map: Arc<SourceMap>) -> AnalysisResult {
     let (emitter, diag_buffer) = InMemoryEmitter::new();
-    let document_link_sources =
-        batch.files.iter().map(|(path, _)| path.clone()).collect::<FxHashSet<_>>();
-    let mut opts = batch.opts;
+    let AnalysisBatch { mut opts, files, seen_paths: document_link_sources } = batch;
+    debug_assert_eq!(files.len(), document_link_sources.len());
+    debug_assert!(files.iter().all(|(path, _)| document_link_sources.contains(path)));
     opts.unstable.recover_incomplete_input = true;
     let sess = Session::builder()
         .opts(opts)
@@ -474,8 +508,7 @@ fn analyze_with_source_map(batch: AnalysisBatch, source_map: Arc<SourceMap>) -> 
     compiler.enter_mut(move |compiler| {
         {
             let mut parsing_context = compiler.parse();
-            let files = batch
-                .files
+            let files = files
                 .into_iter()
                 .map(|(path, contents)| {
                     parsing_context

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -8,7 +8,7 @@ use lsp_types::{
     TextDocumentContentChangeEvent, Url, WorkspaceSymbol,
 };
 use normalize_path::NormalizePath;
-use solar_config::CompileOpts;
+use solar_config::{CompileOpts, Threads};
 use solar_interface::{
     data_structures::map::{FxHashMap, FxHashSet},
     source_map::{FileLoader, SourceMap},
@@ -287,7 +287,8 @@ impl BenchmarkProject {
 
     /// Consume this prepared project and run the production compiler analysis pipeline.
     pub fn analyze(self) -> BenchmarkAnalysis {
-        let Self { root, opts, files, loader, markers: _ } = self;
+        let Self { root, mut opts, files, loader, markers: _ } = self;
+        opts.threads = Threads::resolve(1);
         let default_uri = files.first().and_then(|(path, _)| Url::from_file_path(path).ok());
         let source_map = Arc::new(SourceMap::empty());
         source_map.set_file_loader(loader);
@@ -375,7 +376,8 @@ impl BenchmarkAnalysis {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches");
         let path = root.join("benchmark.sol");
         let uri = Url::from_file_path(&path).expect("benchmark path should be a file URL");
-        let mut batch = AnalysisBatch::new(CompileOpts::default());
+        let opts = CompileOpts { threads: Threads::resolve(1), ..Default::default() };
+        let mut batch = AnalysisBatch::new(opts);
         batch.push_file(path, source);
         let result = analyze(batch);
         Self {

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -1,6 +1,6 @@
 //! Benchmark-only, in-memory LSP analysis support.
 
-use super::{AnalysisBatch, DiagnosticMap, SymbolTables, analyze_with_source_map};
+use super::{AnalysisBatch, DiagnosticMap, SymbolTables, analyze, analyze_with_source_map};
 use crate::{project_fixture::ProjectFixture, utils::apply_document_changes, workspace::Workspace};
 use crop::Rope;
 use lsp_types::{
@@ -164,8 +164,15 @@ impl BenchmarkProject {
             loader_sources.insert(path.normalize(), source.clone());
             files.push((path.clone(), source));
         }
-        for include_path in &opts.include_paths {
-            collect_dependency_sources(file_loader, include_path, &mut loader_sources)?;
+        let mut dependency_roots = opts.include_paths.clone();
+        for remapping in &opts.import_remappings {
+            let target = Path::new(&remapping.path);
+            let target =
+                if target.is_absolute() { target.to_path_buf() } else { root.join(target) };
+            dependency_roots.push(target);
+        }
+        for dependency_root in deduplicate_dependency_roots(dependency_roots) {
+            collect_dependency_sources(file_loader, &dependency_root, &mut loader_sources)?;
         }
         if files.is_empty() {
             return Err(BenchmarkError::new(format!(
@@ -173,6 +180,7 @@ impl BenchmarkProject {
                 root.display()
             )));
         }
+        files.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
 
         let root = root.normalize();
         let loader = InMemoryFileLoader::new(root.clone(), loader_sources);
@@ -186,7 +194,14 @@ impl BenchmarkProject {
 
     /// The total number of bytes in all prepared primary and dependency sources.
     pub fn source_bytes(&self) -> usize {
-        self.loader.sources.values().map(String::len).sum()
+        let mut bytes = self.loader.corpus.sources.values().map(String::len).sum::<usize>();
+        for (path, source) in &self.loader.overlays {
+            if let Some(original) = self.loader.corpus.sources.get(path) {
+                bytes -= original.len();
+            }
+            bytes += source.len();
+        }
+        bytes
     }
 
     /// Resolve a unique source substring to its LSP URI and UTF-16 position.
@@ -236,19 +251,38 @@ impl BenchmarkProject {
 
     /// Apply an edit with the same UTF-16 range logic used by document-change notifications.
     pub fn apply_edit(&mut self, edit: &BenchmarkEdit) -> Result<(), BenchmarkError> {
-        let (_, source) =
-            self.files.iter_mut().find(|(path, _)| path == &edit.path).ok_or_else(|| {
+        let index =
+            self.files.binary_search_by(|(path, _)| path.cmp(&edit.path)).map_err(|_| {
                 BenchmarkError::new(format!(
                     "benchmark edit targets unknown source `{}`",
                     edit.path.display()
                 ))
             })?;
+        let source = &mut self.files[index].1;
         let updated =
             apply_document_changes(&Rope::from(source.as_str()), vec![edit.change.clone()])
                 .to_string();
         *source = updated.clone();
-        self.loader.sources.insert(edit.path.clone(), updated);
+        self.loader.overlays.insert(edit.path.clone(), updated);
         Ok(())
+    }
+
+    /// Prepare one production document change without including project harness conversions.
+    pub fn document_change(
+        &self,
+        edit: &BenchmarkEdit,
+    ) -> Result<BenchmarkDocumentChange, BenchmarkError> {
+        let index =
+            self.files.binary_search_by(|(path, _)| path.cmp(&edit.path)).map_err(|_| {
+                BenchmarkError::new(format!(
+                    "benchmark edit targets unknown source `{}`",
+                    edit.path.display()
+                ))
+            })?;
+        Ok(BenchmarkDocumentChange {
+            contents: Rope::from(self.files[index].1.as_str()),
+            changes: vec![edit.change.clone()],
+        })
     }
 
     /// Consume this prepared project and run the production compiler analysis pipeline.
@@ -257,10 +291,7 @@ impl BenchmarkProject {
         let default_uri = files.first().and_then(|(path, _)| Url::from_file_path(path).ok());
         let source_map = Arc::new(SourceMap::empty());
         source_map.set_file_loader(loader);
-        let result = analyze_with_source_map(
-            AnalysisBatch { opts, files, seen_paths: FxHashSet::default() },
-            source_map,
-        );
+        let result = analyze_with_source_map(AnalysisBatch::from_files(opts, files), source_map);
         BenchmarkAnalysis {
             root,
             diagnostics: result.diagnostics,
@@ -290,6 +321,23 @@ impl BenchmarkProject {
 pub struct BenchmarkEdit {
     path: PathBuf,
     change: TextDocumentContentChangeEvent,
+}
+
+/// An opaque document change input using the same Rope path as production notifications.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct BenchmarkDocumentChange {
+    contents: Rope,
+    changes: Vec<TextDocumentContentChangeEvent>,
+}
+
+impl BenchmarkDocumentChange {
+    /// Apply this prepared document change and return the edited document.
+    #[inline(never)]
+    pub fn apply(self) -> Self {
+        let Self { contents, changes } = self;
+        Self { contents: apply_document_changes(&contents, changes), changes: Vec::new() }
+    }
 }
 
 /// A synchronous LSP query against an analyzed benchmark project.
@@ -322,9 +370,20 @@ pub struct BenchmarkAnalysis {
 }
 
 impl BenchmarkAnalysis {
-    /// Analyze one in-memory Solidity source without touching the filesystem.
+    /// Analyze one in-memory Solidity source with the historical benchmark workload.
     pub fn from_source(source: String) -> Self {
-        BenchmarkProject::from_source(source).analyze()
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches");
+        let path = root.join("benchmark.sol");
+        let uri = Url::from_file_path(&path).expect("benchmark path should be a file URL");
+        let mut batch = AnalysisBatch::new(CompileOpts::default());
+        batch.push_file(path, source);
+        let result = analyze(batch);
+        Self {
+            root,
+            diagnostics: result.diagnostics,
+            symbol_tables: result.symbol_tables,
+            default_uri: Some(uri),
+        }
     }
 
     /// The number of diagnostics emitted for this analysis.
@@ -384,6 +443,11 @@ impl BenchmarkAnalysis {
 #[derive(Clone)]
 struct InMemoryFileLoader {
     root: PathBuf,
+    corpus: Arc<InMemoryCorpus>,
+    overlays: FxHashMap<PathBuf, String>,
+}
+
+struct InMemoryCorpus {
     sources: FxHashMap<PathBuf, String>,
     directories: FxHashSet<PathBuf>,
 }
@@ -402,11 +466,15 @@ impl InMemoryFileLoader {
                 current = directory.parent();
             }
         }
-        Self { root, sources, directories }
+        Self {
+            root,
+            corpus: Arc::new(InMemoryCorpus { sources, directories }),
+            overlays: FxHashMap::default(),
+        }
     }
 
     fn normalized(&self, path: &Path) -> PathBuf {
-        self.root.join(path).normalize()
+        if path.is_absolute() { path.normalize() } else { self.root.join(path).normalize() }
     }
 
     fn not_found(path: &Path) -> io::Error {
@@ -420,7 +488,10 @@ impl InMemoryFileLoader {
 impl FileLoader for InMemoryFileLoader {
     fn canonicalize_path(&self, path: &Path) -> io::Result<PathBuf> {
         let path = self.normalized(path);
-        if self.sources.contains_key(&path) || self.directories.contains(&path) {
+        if self.overlays.contains_key(&path)
+            || self.corpus.sources.contains_key(&path)
+            || self.corpus.directories.contains(&path)
+        {
             Ok(path)
         } else {
             Err(Self::not_found(&path))
@@ -436,7 +507,11 @@ impl FileLoader for InMemoryFileLoader {
 
     fn load_file(&self, path: &Path) -> io::Result<String> {
         let path = self.normalized(path);
-        self.sources.get(&path).cloned().ok_or_else(|| Self::not_found(&path))
+        self.overlays
+            .get(&path)
+            .or_else(|| self.corpus.sources.get(&path))
+            .cloned()
+            .ok_or_else(|| Self::not_found(&path))
     }
 
     fn load_binary_file(&self, path: &Path) -> io::Result<Vec<u8>> {
@@ -526,6 +601,19 @@ fn collect_dependency_sources(
     collect_dependency_sources_inner(file_loader, path, sources, &mut directory_stack)
 }
 
+fn deduplicate_dependency_roots(mut roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    roots.iter_mut().for_each(|path| *path = path.normalize());
+    roots.sort();
+
+    let mut deduplicated = Vec::<PathBuf>::new();
+    for root in roots {
+        if !deduplicated.iter().any(|parent| root.starts_with(parent)) {
+            deduplicated.push(root);
+        }
+    }
+    deduplicated
+}
+
 fn collect_dependency_sources_inner(
     file_loader: &dyn FileLoader,
     path: &Path,
@@ -595,9 +683,10 @@ fn diagnostic_line(root: &Path, uri: &Url, diagnostic: &Diagnostic) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[cfg(unix)]
-    use std::{fs, os::unix::fs::symlink};
+    use std::os::unix::fs::symlink;
 
     #[cfg(unix)]
     #[test]
@@ -621,6 +710,23 @@ mod tests {
     }
 
     #[test]
+    fn dependency_roots_are_normalized_and_covered_children_are_removed() {
+        let root = PathBuf::from("/workspace");
+        let roots = vec![
+            root.join("vendor/package"),
+            root.join("lib/package/src"),
+            root.join("lib/./package"),
+            root.join("lib"),
+            root.join("vendor/package"),
+        ];
+
+        assert_eq!(
+            deduplicate_dependency_roots(roots),
+            [root.join("lib"), root.join("vendor/package")]
+        );
+    }
+
+    #[test]
     fn anchors_use_utf16_positions_and_require_uniqueness() {
         let project = BenchmarkProject::from_source("contract C { string s = \"中😀x\"; }".into());
         let (_, position) = project.unique_anchor("benchmark.sol", "x").unwrap();
@@ -640,6 +746,68 @@ mod tests {
     }
 
     #[test]
+    fn cloned_projects_share_prepared_loader_sources() {
+        let project = BenchmarkProject::from_source("contract C { uint x; }".into());
+        let cloned = project.clone();
+
+        assert!(Arc::ptr_eq(&project.loader.corpus, &cloned.loader.corpus));
+    }
+
+    #[test]
+    fn editing_a_clone_does_not_change_the_original_project() {
+        let project = BenchmarkProject::from_source("contract C { uint x; }".into());
+        let edit = project.replacement_edit("benchmark.sol", "uint x", "address x").unwrap();
+        let mut edited = project.clone();
+        edited.apply_edit(&edit).unwrap();
+
+        assert_eq!(project.source(Path::new("benchmark.sol")).unwrap().1, "contract C { uint x; }");
+        assert_eq!(
+            edited.source(Path::new("benchmark.sol")).unwrap().1,
+            "contract C { address x; }"
+        );
+        assert_eq!(
+            project.loader.load_file(Path::new("benchmark.sol")).unwrap(),
+            "contract C { uint x; }"
+        );
+        assert_eq!(
+            edited.loader.load_file(Path::new("benchmark.sol")).unwrap(),
+            "contract C { address x; }"
+        );
+    }
+
+    #[test]
+    fn edited_sources_are_loaded_from_the_project_overlay() {
+        let mut project = BenchmarkProject::from_source("contract C { uint x; }".into());
+        let edit = project.replacement_edit("benchmark.sol", "uint x", "address x").unwrap();
+        project.apply_edit(&edit).unwrap();
+
+        assert_eq!(
+            project.loader.load_file(Path::new("benchmark.sol")).unwrap(),
+            "contract C { address x; }"
+        );
+    }
+
+    #[test]
+    fn document_changes_use_the_production_rope_path() {
+        let project = BenchmarkProject::from_source("contract C { uint x; }".into());
+        let edit = project.replacement_edit("benchmark.sol", "uint x", "address value").unwrap();
+
+        let changed = project.document_change(&edit).unwrap().apply();
+
+        assert_eq!(changed.contents.to_string(), "contract C { address value; }");
+    }
+
+    #[test]
+    fn source_bytes_include_edit_overlays() {
+        let mut project = BenchmarkProject::from_source("contract C { uint x; }".into());
+        let original_bytes = project.source_bytes();
+        let edit = project.replacement_edit("benchmark.sol", "uint x", "address value").unwrap();
+        project.apply_edit(&edit).unwrap();
+
+        assert_eq!(project.source_bytes(), original_bytes + "address value".len() - "uint x".len());
+    }
+
+    #[test]
     fn foundry_benchmark_corpus_resolves_from_memory() {
         let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../..")
@@ -655,6 +823,36 @@ mod tests {
             analysis.execute(&BenchmarkRequest::Hover { uri: hover.0, position: hover.1 }),
             BenchmarkResponse::Hover(Some(_))
         ));
+    }
+
+    #[test]
+    fn foundry_benchmark_corpus_loads_explicit_remapping_targets() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::create_dir_all(root.join("vendor/dep/src")).unwrap();
+        fs::write(
+            root.join("foundry.toml"),
+            r#"
+                [profile.default]
+                src = "src"
+                libs = []
+                auto_detect_remappings = false
+                remappings = ["@dep/=vendor/dep/src/"]
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("src/Main.sol"),
+            "import \"@dep/Dependency.sol\"; contract Main is Dependency {}",
+        )
+        .unwrap();
+        fs::write(root.join("vendor/dep/src/Dependency.sol"), "contract Dependency {}").unwrap();
+
+        let project = BenchmarkProject::from_foundry_manifest(root.join("foundry.toml")).unwrap();
+        let analysis = project.analyze();
+
+        assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
     }
 
     #[test]

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -1,0 +1,687 @@
+//! Benchmark-only, in-memory LSP analysis support.
+
+use super::{AnalysisBatch, DiagnosticMap, SymbolTables, analyze_with_source_map};
+use crate::{project_fixture::ProjectFixture, utils::apply_document_changes, workspace::Workspace};
+use crop::Rope;
+use lsp_types::{
+    Diagnostic, GotoDefinitionResponse, Hover, HoverContents, Location, Position, Range,
+    TextDocumentContentChangeEvent, Url, WorkspaceSymbol,
+};
+use normalize_path::NormalizePath;
+use solar_config::CompileOpts;
+use solar_interface::{
+    data_structures::map::{FxHashMap, FxHashSet},
+    source_map::{FileLoader, SourceMap},
+};
+use std::{
+    collections::BTreeMap,
+    fmt, io,
+    path::{Component, Path, PathBuf},
+    sync::Arc,
+};
+
+/// An opaque error returned while preparing an LSP benchmark project.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct BenchmarkError {
+    message: String,
+}
+
+impl BenchmarkError {
+    fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
+    }
+}
+
+impl fmt::Display for BenchmarkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for BenchmarkError {}
+
+/// A prepared, entirely in-memory LSP benchmark project.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct BenchmarkProject {
+    root: PathBuf,
+    opts: CompileOpts,
+    files: Vec<(PathBuf, String)>,
+    loader_sources: FxHashMap<PathBuf, String>,
+    markers: BTreeMap<String, Vec<(PathBuf, Position)>>,
+}
+
+impl BenchmarkProject {
+    /// Prepare the historical single-source benchmark project.
+    pub fn from_source(source: String) -> Self {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches");
+        let opts = CompileOpts { base_path: Some(root.clone()), ..Default::default() };
+        Self::from_sources(opts, [(root.join("benchmark.sol"), source)])
+            .expect("the built-in benchmark source path should be valid")
+    }
+
+    /// Prepare ordered primary sources and compiler options for repeated analysis.
+    pub fn from_sources(
+        mut opts: CompileOpts,
+        sources: impl IntoIterator<Item = (PathBuf, String)>,
+    ) -> Result<Self, BenchmarkError> {
+        let root = opts
+            .base_path
+            .take()
+            .ok_or_else(|| BenchmarkError::new("benchmark compiler options need a base path"))?;
+        let root = absolute_normalized(&root)?;
+        opts.base_path = Some(root.clone());
+
+        let mut files = sources
+            .into_iter()
+            .map(|(path, source)| {
+                let path = if path.is_absolute() { path } else { root.join(path) };
+                let path = path.normalize();
+                if !path.starts_with(&root) {
+                    return Err(BenchmarkError::new(format!(
+                        "benchmark source `{}` is outside project root `{}`",
+                        path.display(),
+                        root.display()
+                    )));
+                }
+                Ok((path, source))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        files.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+        if files.is_empty() {
+            return Err(BenchmarkError::new("benchmark project has no primary sources"));
+        }
+        if files.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+            return Err(BenchmarkError::new("benchmark project contains duplicate source paths"));
+        }
+
+        let loader_sources = files.iter().cloned().collect();
+        Ok(Self { root, opts, files, loader_sources, markers: BTreeMap::new() })
+    }
+
+    /// Prepare a stable multi-file project from the fixture format shared with LSP tests.
+    pub fn from_fixture(name: &str, fixture: &str) -> Result<Self, BenchmarkError> {
+        if name.is_empty() {
+            return Err(BenchmarkError::new("benchmark fixture name cannot be empty"));
+        }
+        let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/fixtures");
+        let root = resolve_relative_path(&fixture_root, Path::new(name))?;
+        let fixture = ProjectFixture::try_parse(fixture)
+            .map_err(|error| BenchmarkError::new(error.to_string()))?;
+        let sources = fixture
+            .files()
+            .iter()
+            .filter_map(|file| {
+                let path = Path::new(file.path());
+                (path.extension().is_some_and(|extension| extension == "sol")).then(|| {
+                    let relative = path.strip_prefix("/").expect("fixture paths start with `/`");
+                    (relative.to_path_buf(), file.text().to_string())
+                })
+            })
+            .collect::<Vec<_>>();
+        let opts = CompileOpts { base_path: Some(root), ..Default::default() };
+        let mut project = Self::from_sources(opts, sources)?;
+        for (name, markers) in fixture.markers() {
+            let resolved = markers
+                .iter()
+                .map(|marker| {
+                    let relative = Path::new(marker.path())
+                        .strip_prefix("/")
+                        .expect("fixture paths start with `/`");
+                    let (path, _) = project.source(relative)?;
+                    Ok((path.clone(), marker.position()))
+                })
+                .collect::<Result<Vec<_>, BenchmarkError>>()?;
+            project.markers.insert(name.clone(), resolved);
+        }
+        Ok(project)
+    }
+
+    /// Load a Foundry project's manifest, primary sources, and import dependencies.
+    ///
+    /// All filesystem access happens during this constructor, before benchmark timing starts.
+    pub fn from_foundry_manifest(path: impl AsRef<Path>) -> Result<Self, BenchmarkError> {
+        let preparation_source_map = SourceMap::empty();
+        let file_loader = preparation_source_map.file_loader();
+        let manifest = file_loader.canonicalize_path(path.as_ref()).map_err(|error| {
+            BenchmarkError::new(format!(
+                "failed to resolve Foundry manifest `{}`: {error}",
+                path.as_ref().display()
+            ))
+        })?;
+        let mut workspace = Workspace::load_foundry(manifest.clone()).map_err(|error| {
+            BenchmarkError::new(format!(
+                "failed to load Foundry manifest `{}`: {error}",
+                manifest.display()
+            ))
+        })?;
+        workspace.refresh_source_files();
+
+        let opts = workspace.compile_opts().clone();
+        let root = opts
+            .base_path
+            .clone()
+            .ok_or_else(|| BenchmarkError::new("Foundry benchmark project has no base path"))?;
+        let mut loader_sources = FxHashMap::default();
+        let mut files = Vec::with_capacity(workspace.source_files().len());
+        for path in workspace.source_files() {
+            let source = read_source(file_loader, path)?;
+            loader_sources.insert(path.normalize(), source.clone());
+            files.push((path.clone(), source));
+        }
+        for include_path in &opts.include_paths {
+            collect_dependency_sources(file_loader, include_path, &mut loader_sources)?;
+        }
+        if files.is_empty() {
+            return Err(BenchmarkError::new(format!(
+                "Foundry benchmark project `{}` has no Solidity sources",
+                root.display()
+            )));
+        }
+
+        files.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+        Ok(Self { root: root.normalize(), opts, files, loader_sources, markers: BTreeMap::new() })
+    }
+
+    /// The number of primary Solidity source files in this project.
+    pub fn file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    /// The total number of bytes in all prepared primary and dependency sources.
+    pub fn source_bytes(&self) -> usize {
+        self.loader_sources.values().map(String::len).sum()
+    }
+
+    /// Resolve a unique source substring to its LSP URI and UTF-16 position.
+    pub fn unique_anchor(
+        &self,
+        relative_path: impl AsRef<Path>,
+        needle: &str,
+    ) -> Result<(Url, Position), BenchmarkError> {
+        let (path, source) = self.source(relative_path.as_ref())?;
+        let start = unique_offset(source, needle, path)?;
+        Ok((file_url(path)?, position_at(source, start)))
+    }
+
+    /// Resolve one fixture `$N` marker to its LSP URI and UTF-16 position.
+    pub fn marker(&self, name: &str) -> Result<(Url, Position), BenchmarkError> {
+        let name = name.strip_prefix('$').unwrap_or(name);
+        let markers = self
+            .markers
+            .get(name)
+            .ok_or_else(|| BenchmarkError::new(format!("missing benchmark marker `${name}`")))?;
+        if markers.len() != 1 {
+            return Err(BenchmarkError::new(format!("benchmark marker `${name}` is ambiguous")));
+        }
+        let (path, position) = &markers[0];
+        Ok((file_url(path)?, *position))
+    }
+
+    /// Create a validated LSP range edit replacing one unique source substring.
+    pub fn replacement_edit(
+        &self,
+        relative_path: impl AsRef<Path>,
+        needle: &str,
+        replacement: impl Into<String>,
+    ) -> Result<BenchmarkEdit, BenchmarkError> {
+        let (path, source) = self.source(relative_path.as_ref())?;
+        let start = unique_offset(source, needle, path)?;
+        let end = start + needle.len();
+        Ok(BenchmarkEdit {
+            path: path.clone(),
+            change: TextDocumentContentChangeEvent {
+                range: Some(Range::new(position_at(source, start), position_at(source, end))),
+                range_length: None,
+                text: replacement.into(),
+            },
+        })
+    }
+
+    /// Apply an edit with the same UTF-16 range logic used by document-change notifications.
+    pub fn apply_edit(&mut self, edit: &BenchmarkEdit) -> Result<(), BenchmarkError> {
+        let (_, source) =
+            self.files.iter_mut().find(|(path, _)| path == &edit.path).ok_or_else(|| {
+                BenchmarkError::new(format!(
+                    "benchmark edit targets unknown source `{}`",
+                    edit.path.display()
+                ))
+            })?;
+        let updated =
+            apply_document_changes(&Rope::from(source.as_str()), vec![edit.change.clone()])
+                .to_string();
+        *source = updated.clone();
+        self.loader_sources.insert(edit.path.clone(), updated);
+        Ok(())
+    }
+
+    /// Consume this prepared project and run the production compiler analysis pipeline.
+    pub fn analyze(self) -> BenchmarkAnalysis {
+        let default_uri = self.files.first().and_then(|(path, _)| Url::from_file_path(path).ok());
+        let source_map = Arc::new(SourceMap::empty());
+        source_map.set_file_loader(InMemoryFileLoader::new(
+            self.root.clone(),
+            Arc::new(self.loader_sources),
+        ));
+        let result = analyze_with_source_map(
+            AnalysisBatch { opts: self.opts, files: self.files, seen_paths: FxHashSet::default() },
+            source_map,
+        );
+        BenchmarkAnalysis {
+            root: self.root,
+            diagnostics: result.diagnostics,
+            symbol_tables: result.symbol_tables,
+            default_uri,
+        }
+    }
+
+    fn source(&self, relative_path: &Path) -> Result<(&PathBuf, &str), BenchmarkError> {
+        let path = resolve_relative_path(&self.root, relative_path)?;
+        self.files
+            .binary_search_by(|(candidate, _)| candidate.cmp(&path))
+            .ok()
+            .map(|index| (&self.files[index].0, self.files[index].1.as_str()))
+            .ok_or_else(|| {
+                BenchmarkError::new(format!(
+                    "benchmark source `{}` is not a primary project file",
+                    relative_path.display()
+                ))
+            })
+    }
+}
+
+/// A validated document edit for a prepared benchmark project.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct BenchmarkEdit {
+    path: PathBuf,
+    change: TextDocumentContentChangeEvent,
+}
+
+/// A synchronous LSP query against an analyzed benchmark project.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub enum BenchmarkRequest {
+    Hover { uri: Url, position: Position },
+    GotoDefinition { uri: Url, position: Position },
+    References { uri: Url, position: Position, include_declaration: bool },
+    WorkspaceSymbols { query: String },
+}
+
+/// The typed response to a [`BenchmarkRequest`].
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub enum BenchmarkResponse {
+    Hover(Option<Hover>),
+    GotoDefinition(Option<GotoDefinitionResponse>),
+    References(Option<Vec<Location>>),
+    WorkspaceSymbols(Vec<WorkspaceSymbol>),
+}
+
+/// An opaque analysis snapshot used by the LSP Criterion benchmarks.
+#[doc(hidden)]
+pub struct BenchmarkAnalysis {
+    root: PathBuf,
+    diagnostics: DiagnosticMap,
+    symbol_tables: SymbolTables,
+    default_uri: Option<Url>,
+}
+
+impl BenchmarkAnalysis {
+    /// Analyze one in-memory Solidity source without touching the filesystem.
+    pub fn from_source(source: String) -> Self {
+        BenchmarkProject::from_source(source).analyze()
+    }
+
+    /// The number of diagnostics emitted for this analysis.
+    pub fn diagnostic_count(&self) -> usize {
+        self.diagnostics.values().map(Vec::len).sum()
+    }
+
+    /// A stable, project-relative representation of all diagnostics.
+    pub fn diagnostic_fingerprint(&self) -> String {
+        let mut diagnostics = self
+            .diagnostics
+            .iter()
+            .flat_map(|(uri, diagnostics)| {
+                diagnostics.iter().map(|diagnostic| diagnostic_line(&self.root, uri, diagnostic))
+            })
+            .collect::<Vec<_>>();
+        diagnostics.sort();
+        diagnostics.join("\n")
+    }
+
+    /// Execute one synchronous query against the analyzed symbol tables.
+    #[inline(never)]
+    pub fn execute(&self, request: &BenchmarkRequest) -> BenchmarkResponse {
+        match request {
+            BenchmarkRequest::Hover { uri, position } => {
+                BenchmarkResponse::Hover(self.symbol_tables.hover(uri, *position))
+            }
+            BenchmarkRequest::GotoDefinition { uri, position } => {
+                BenchmarkResponse::GotoDefinition(
+                    self.symbol_tables.goto_definition(uri, *position),
+                )
+            }
+            BenchmarkRequest::References { uri, position, include_declaration } => {
+                BenchmarkResponse::References(self.symbol_tables.references(
+                    uri,
+                    *position,
+                    *include_declaration,
+                ))
+            }
+            BenchmarkRequest::WorkspaceSymbols { query } => {
+                BenchmarkResponse::WorkspaceSymbols(self.symbol_tables.workspace_symbols(query))
+            }
+        }
+    }
+
+    /// Resolve one declaration or reference position synchronously.
+    #[inline(never)]
+    pub fn hover(&self, line: u32, character: u32) -> Option<usize> {
+        let uri = self.default_uri.as_ref()?;
+        let hover =
+            std::hint::black_box(self.symbol_tables.hover(uri, Position::new(line, character)))?;
+        let HoverContents::Markup(content) = hover.contents else { return None };
+        Some(content.value.len())
+    }
+}
+
+#[derive(Clone)]
+struct InMemoryFileLoader {
+    root: PathBuf,
+    sources: Arc<FxHashMap<PathBuf, String>>,
+    directories: Arc<FxHashSet<PathBuf>>,
+}
+
+impl InMemoryFileLoader {
+    fn new(root: PathBuf, sources: Arc<FxHashMap<PathBuf, String>>) -> Self {
+        let mut directories = FxHashSet::default();
+        directories.insert(root.clone());
+        for path in sources.keys() {
+            let mut current = path.parent();
+            while let Some(directory) = current {
+                directories.insert(directory.to_path_buf());
+                if directory == root {
+                    break;
+                }
+                current = directory.parent();
+            }
+        }
+        Self { root, sources, directories: Arc::new(directories) }
+    }
+
+    fn normalized(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() { path.normalize() } else { self.root.join(path).normalize() }
+    }
+
+    fn not_found(path: &Path) -> io::Error {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("benchmark file `{}` was not prepared", path.display()),
+        )
+    }
+}
+
+impl FileLoader for InMemoryFileLoader {
+    fn canonicalize_path(&self, path: &Path) -> io::Result<PathBuf> {
+        let path = self.normalized(path);
+        if self.sources.contains_key(&path) || self.directories.contains(&path) {
+            Ok(path)
+        } else {
+            Err(Self::not_found(&path))
+        }
+    }
+
+    fn load_stdin(&self) -> io::Result<String> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "stdin is unavailable in an in-memory LSP benchmark",
+        ))
+    }
+
+    fn load_file(&self, path: &Path) -> io::Result<String> {
+        let path = self.normalized(path);
+        self.sources.get(&path).cloned().ok_or_else(|| Self::not_found(&path))
+    }
+
+    fn load_binary_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "binary file `{}` is unavailable in an in-memory LSP benchmark",
+                path.display()
+            ),
+        ))
+    }
+}
+
+fn absolute_normalized(path: &Path) -> Result<PathBuf, BenchmarkError> {
+    if !path.is_absolute() {
+        return Err(BenchmarkError::new(format!(
+            "benchmark base path `{}` is not absolute",
+            path.display()
+        )));
+    }
+    Ok(path.normalize())
+}
+
+fn resolve_relative_path(root: &Path, relative_path: &Path) -> Result<PathBuf, BenchmarkError> {
+    if relative_path.is_absolute()
+        || relative_path.components().any(|component| {
+            matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+        })
+    {
+        return Err(BenchmarkError::new(format!(
+            "benchmark source path `{}` is not project-relative",
+            relative_path.display()
+        )));
+    }
+    Ok(root.join(relative_path).normalize())
+}
+
+fn unique_offset(source: &str, needle: &str, path: &Path) -> Result<usize, BenchmarkError> {
+    if needle.is_empty() {
+        return Err(BenchmarkError::new("benchmark anchor cannot be empty"));
+    }
+    let Some(start) = source.find(needle) else {
+        return Err(BenchmarkError::new(format!(
+            "benchmark anchor `{needle}` was not found in `{}`",
+            path.display()
+        )));
+    };
+    if source[start + needle.len()..].contains(needle) {
+        return Err(BenchmarkError::new(format!(
+            "benchmark anchor `{needle}` is not unique in `{}`",
+            path.display()
+        )));
+    }
+    Ok(start)
+}
+
+fn position_at(source: &str, offset: usize) -> Position {
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|&byte| byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+    let character = prefix[line_start..].encode_utf16().count() as u32;
+    Position::new(line, character)
+}
+
+fn file_url(path: &Path) -> Result<Url, BenchmarkError> {
+    Url::from_file_path(path).map_err(|()| {
+        BenchmarkError::new(format!(
+            "benchmark source `{}` cannot be represented as a file URI",
+            path.display()
+        ))
+    })
+}
+
+fn read_source(file_loader: &dyn FileLoader, path: &Path) -> Result<String, BenchmarkError> {
+    file_loader.load_file(path).map_err(|error| {
+        BenchmarkError::new(format!(
+            "failed to read benchmark source `{}`: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn collect_dependency_sources(
+    file_loader: &dyn FileLoader,
+    path: &Path,
+    sources: &mut FxHashMap<PathBuf, String>,
+) -> Result<(), BenchmarkError> {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else { return Ok(()) };
+    if metadata.is_file() {
+        if path.extension().is_some_and(|extension| extension == "sol") {
+            sources.insert(path.normalize(), read_source(file_loader, path)?);
+        }
+        return Ok(());
+    }
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+    let entries = std::fs::read_dir(path).map_err(|error| {
+        BenchmarkError::new(format!(
+            "failed to enumerate benchmark dependency directory `{}`: {error}",
+            path.display()
+        ))
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            BenchmarkError::new(format!(
+                "failed to enumerate benchmark dependency directory `{}`: {error}",
+                path.display()
+            ))
+        })?;
+        collect_dependency_sources(file_loader, &entry.path(), sources)?;
+    }
+    Ok(())
+}
+
+fn diagnostic_line(root: &Path, uri: &Url, diagnostic: &Diagnostic) -> String {
+    let path = uri
+        .to_file_path()
+        .ok()
+        .and_then(|path| path.strip_prefix(root).ok().map(Path::to_path_buf))
+        .map(|path| path.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|| uri.as_str().to_string());
+    let range = diagnostic.range;
+    let root = root.to_string_lossy();
+    let message = diagnostic.message.replace(root.as_ref(), ".").replace('\n', "\\n");
+    format!(
+        "{path}:{}:{}:{}:{}:{:?}:{:?}:{}",
+        range.start.line,
+        range.start.character,
+        range.end.line,
+        range.end.character,
+        diagnostic.severity,
+        diagnostic.code,
+        message
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anchors_use_utf16_positions_and_require_uniqueness() {
+        let project = BenchmarkProject::from_source("contract C { string s = \"中😀x\"; }".into());
+        let (_, position) = project.unique_anchor("benchmark.sol", "x").unwrap();
+        assert_eq!(position, Position::new(0, 28));
+
+        let duplicate = BenchmarkProject::from_source("contract C { uint x; uint x; }".into());
+        assert!(duplicate.unique_anchor("benchmark.sol", "x").is_err());
+    }
+
+    #[test]
+    fn replacement_edits_feed_the_next_analysis() {
+        let mut project = BenchmarkProject::from_source("contract C { uint x; }".into());
+        let edit = project.replacement_edit("benchmark.sol", "uint x", "address x").unwrap();
+        project.apply_edit(&edit).unwrap();
+        let analysis = project.analyze();
+        assert_eq!(analysis.diagnostic_count(), 0);
+    }
+
+    #[test]
+    fn foundry_benchmark_corpus_resolves_from_memory() {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("tests/foundry/unifap-v2/foundry.toml");
+        let project = BenchmarkProject::from_foundry_manifest(manifest).unwrap();
+        let hover = project.unique_anchor("src/UnifapV2Pair.sol", "SELECTOR").unwrap();
+        assert_eq!(project.file_count(), 14);
+        assert_eq!(project.source_bytes(), 290_811);
+
+        let analysis = project.analyze();
+        assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+        assert!(matches!(
+            analysis.execute(&BenchmarkRequest::Hover { uri: hover.0, position: hover.1 }),
+            BenchmarkResponse::Hover(Some(_))
+        ));
+    }
+
+    #[test]
+    fn fixture_projects_support_relative_imports() {
+        let project = BenchmarkProject::from_fixture(
+            "relative-imports",
+            r#"
+                    //- /src/Imported.sol
+                    contract Imported {}
+
+                    //- /src/Main.sol
+                    import "./Imported.sol";
+                    contract Main is Imported {}
+                "#,
+        )
+        .unwrap();
+        assert_eq!(project.file_count(), 2);
+        let analysis = project.analyze();
+        assert_eq!(analysis.diagnostic_count(), 0, "{}", analysis.diagnostic_fingerprint());
+    }
+
+    #[test]
+    fn fixture_projects_expose_markers() {
+        let project = BenchmarkProject::from_fixture(
+            "markers",
+            r#"
+                //- /src/Main.sol
+                contract Main {
+                    function $12run() external {}
+                }
+            "#,
+        )
+        .unwrap();
+
+        let (uri, position) = project.marker("$12").unwrap();
+        assert!(uri.path().ends_with("/src/Main.sol"));
+        assert_eq!(position, Position::new(1, 13));
+    }
+
+    #[test]
+    fn fixture_markers_must_target_primary_sources() {
+        let result = BenchmarkProject::from_fixture(
+            "non-source-marker",
+            concat!(
+                "//- /src/Main.sol\n",
+                "contract Main {}\n",
+                "//- /foundry.toml\n",
+                "$0[profile.default]",
+            ),
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn malformed_fixtures_return_errors() {
+        for fixture in [
+            "contract BeforeMarker {}",
+            "//-\ncontract MissingPath {}",
+            "//- /Unknown.sol unsupported\ncontract Unknown {}",
+        ] {
+            assert!(BenchmarkProject::from_fixture("malformed", fixture).is_err());
+        }
+    }
+}

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -15,14 +15,15 @@ use solar_interface::{
 };
 use std::{
     collections::BTreeMap,
-    fmt, io,
+    io,
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
 
 /// An opaque error returned while preparing an LSP benchmark project.
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
 pub struct BenchmarkError {
     message: String,
 }
@@ -33,14 +34,6 @@ impl BenchmarkError {
     }
 }
 
-impl fmt::Display for BenchmarkError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
-    }
-}
-
-impl std::error::Error for BenchmarkError {}
-
 /// A prepared, entirely in-memory LSP benchmark project.
 #[doc(hidden)]
 #[derive(Clone)]
@@ -48,7 +41,7 @@ pub struct BenchmarkProject {
     root: PathBuf,
     opts: CompileOpts,
     files: Vec<(PathBuf, String)>,
-    loader_sources: FxHashMap<PathBuf, String>,
+    loader: InMemoryFileLoader,
     markers: BTreeMap<String, Vec<(PathBuf, Position)>>,
 }
 
@@ -97,7 +90,8 @@ impl BenchmarkProject {
         }
 
         let loader_sources = files.iter().cloned().collect();
-        Ok(Self { root, opts, files, loader_sources, markers: BTreeMap::new() })
+        let loader = InMemoryFileLoader::new(root.clone(), loader_sources);
+        Ok(Self { root, opts, files, loader, markers: BTreeMap::new() })
     }
 
     /// Prepare a stable multi-file project from the fixture format shared with LSP tests.
@@ -180,8 +174,9 @@ impl BenchmarkProject {
             )));
         }
 
-        files.sort_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
-        Ok(Self { root: root.normalize(), opts, files, loader_sources, markers: BTreeMap::new() })
+        let root = root.normalize();
+        let loader = InMemoryFileLoader::new(root.clone(), loader_sources);
+        Ok(Self { root, opts, files, loader, markers: BTreeMap::new() })
     }
 
     /// The number of primary Solidity source files in this project.
@@ -191,7 +186,7 @@ impl BenchmarkProject {
 
     /// The total number of bytes in all prepared primary and dependency sources.
     pub fn source_bytes(&self) -> usize {
-        self.loader_sources.values().map(String::len).sum()
+        self.loader.sources.values().map(String::len).sum()
     }
 
     /// Resolve a unique source substring to its LSP URI and UTF-16 position.
@@ -252,24 +247,22 @@ impl BenchmarkProject {
             apply_document_changes(&Rope::from(source.as_str()), vec![edit.change.clone()])
                 .to_string();
         *source = updated.clone();
-        self.loader_sources.insert(edit.path.clone(), updated);
+        self.loader.sources.insert(edit.path.clone(), updated);
         Ok(())
     }
 
     /// Consume this prepared project and run the production compiler analysis pipeline.
     pub fn analyze(self) -> BenchmarkAnalysis {
-        let default_uri = self.files.first().and_then(|(path, _)| Url::from_file_path(path).ok());
+        let Self { root, opts, files, loader, markers: _ } = self;
+        let default_uri = files.first().and_then(|(path, _)| Url::from_file_path(path).ok());
         let source_map = Arc::new(SourceMap::empty());
-        source_map.set_file_loader(InMemoryFileLoader::new(
-            self.root.clone(),
-            Arc::new(self.loader_sources),
-        ));
+        source_map.set_file_loader(loader);
         let result = analyze_with_source_map(
-            AnalysisBatch { opts: self.opts, files: self.files, seen_paths: FxHashSet::default() },
+            AnalysisBatch { opts, files, seen_paths: FxHashSet::default() },
             source_map,
         );
         BenchmarkAnalysis {
-            root: self.root,
+            root,
             diagnostics: result.diagnostics,
             symbol_tables: result.symbol_tables,
             default_uri,
@@ -391,12 +384,12 @@ impl BenchmarkAnalysis {
 #[derive(Clone)]
 struct InMemoryFileLoader {
     root: PathBuf,
-    sources: Arc<FxHashMap<PathBuf, String>>,
-    directories: Arc<FxHashSet<PathBuf>>,
+    sources: FxHashMap<PathBuf, String>,
+    directories: FxHashSet<PathBuf>,
 }
 
 impl InMemoryFileLoader {
-    fn new(root: PathBuf, sources: Arc<FxHashMap<PathBuf, String>>) -> Self {
+    fn new(root: PathBuf, sources: FxHashMap<PathBuf, String>) -> Self {
         let mut directories = FxHashSet::default();
         directories.insert(root.clone());
         for path in sources.keys() {
@@ -409,11 +402,11 @@ impl InMemoryFileLoader {
                 current = directory.parent();
             }
         }
-        Self { root, sources, directories: Arc::new(directories) }
+        Self { root, sources, directories }
     }
 
     fn normalized(&self, path: &Path) -> PathBuf {
-        if path.is_absolute() { path.normalize() } else { self.root.join(path).normalize() }
+        self.root.join(path).normalize()
     }
 
     fn not_found(path: &Path) -> io::Error {
@@ -468,11 +461,9 @@ fn absolute_normalized(path: &Path) -> Result<PathBuf, BenchmarkError> {
 }
 
 fn resolve_relative_path(root: &Path, relative_path: &Path) -> Result<PathBuf, BenchmarkError> {
-    if relative_path.is_absolute()
-        || relative_path.components().any(|component| {
-            matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
-        })
-    {
+    if relative_path.components().any(|component| {
+        matches!(component, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+    }) {
         return Err(BenchmarkError::new(format!(
             "benchmark source path `{}` is not project-relative",
             relative_path.display()
@@ -531,7 +522,17 @@ fn collect_dependency_sources(
     path: &Path,
     sources: &mut FxHashMap<PathBuf, String>,
 ) -> Result<(), BenchmarkError> {
-    let Ok(metadata) = std::fs::symlink_metadata(path) else { return Ok(()) };
+    let mut directory_stack = FxHashSet::default();
+    collect_dependency_sources_inner(file_loader, path, sources, &mut directory_stack)
+}
+
+fn collect_dependency_sources_inner(
+    file_loader: &dyn FileLoader,
+    path: &Path,
+    sources: &mut FxHashMap<PathBuf, String>,
+    directory_stack: &mut FxHashSet<PathBuf>,
+) -> Result<(), BenchmarkError> {
+    let Ok(metadata) = std::fs::metadata(path) else { return Ok(()) };
     if metadata.is_file() {
         if path.extension().is_some_and(|extension| extension == "sol") {
             sources.insert(path.normalize(), read_source(file_loader, path)?);
@@ -539,6 +540,15 @@ fn collect_dependency_sources(
         return Ok(());
     }
     if !metadata.is_dir() {
+        return Ok(());
+    }
+    let canonical = file_loader.canonicalize_path(path).map_err(|error| {
+        BenchmarkError::new(format!(
+            "failed to resolve benchmark dependency directory `{}`: {error}",
+            path.display()
+        ))
+    })?;
+    if !directory_stack.insert(canonical.clone()) {
         return Ok(());
     }
     let entries = std::fs::read_dir(path).map_err(|error| {
@@ -554,8 +564,9 @@ fn collect_dependency_sources(
                 path.display()
             ))
         })?;
-        collect_dependency_sources(file_loader, &entry.path(), sources)?;
+        collect_dependency_sources_inner(file_loader, &entry.path(), sources, directory_stack)?;
     }
+    directory_stack.remove(&canonical);
     Ok(())
 }
 
@@ -584,6 +595,30 @@ fn diagnostic_line(root: &Path, uri: &Url, diagnostic: &Diagnostic) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    use std::{fs, os::unix::fs::symlink};
+
+    #[cfg(unix)]
+    #[test]
+    fn dependency_collection_follows_directory_symlinks_without_cycles() {
+        let temp = tempfile::tempdir().unwrap();
+        let dependency = temp.path().join("vendor/package");
+        fs::create_dir_all(&dependency).unwrap();
+        fs::write(dependency.join("Dependency.sol"), "contract Dependency {}").unwrap();
+        symlink(&dependency, dependency.join("cycle")).unwrap();
+
+        let alias = temp.path().join("lib/package");
+        fs::create_dir_all(alias.parent().unwrap()).unwrap();
+        symlink(&dependency, &alias).unwrap();
+
+        let source_map = SourceMap::empty();
+        let mut sources = FxHashMap::default();
+        collect_dependency_sources(source_map.file_loader(), &alias, &mut sources).unwrap();
+
+        assert_eq!(sources.get(&alias.join("Dependency.sol")).unwrap(), "contract Dependency {}");
+        assert_eq!(sources.len(), 1);
+    }
 
     #[test]
     fn anchors_use_utf16_positions_and_require_uniqueness() {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -44,8 +44,8 @@ mod workspace;
 #[cfg(feature = "bench")]
 #[doc(hidden)]
 pub use global_state::benchmark::{
-    BenchmarkAnalysis, BenchmarkEdit, BenchmarkError, BenchmarkProject, BenchmarkRequest,
-    BenchmarkResponse,
+    BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkEdit, BenchmarkError, BenchmarkProject,
+    BenchmarkRequest, BenchmarkResponse,
 };
 
 #[cfg(test)]

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -28,6 +28,9 @@ mod handlers;
 mod hover;
 mod inlay_hints;
 mod override_index;
+#[cfg(any(test, feature = "bench"))]
+#[cfg_attr(all(feature = "bench", not(test)), allow(dead_code))]
+mod project_fixture;
 mod proto;
 mod rename;
 mod serde;
@@ -37,10 +40,13 @@ mod utils;
 mod vfs;
 mod workspace;
 
-/// Benchmark-only access to an opaque LSP analysis snapshot.
+/// Benchmark-only access to prepared LSP projects and opaque analysis snapshots.
 #[cfg(feature = "bench")]
 #[doc(hidden)]
-pub use global_state::benchmark::BenchmarkAnalysis;
+pub use global_state::benchmark::{
+    BenchmarkAnalysis, BenchmarkEdit, BenchmarkError, BenchmarkProject, BenchmarkRequest,
+    BenchmarkResponse,
+};
 
 #[cfg(test)]
 mod test_support;

--- a/crates/lsp/src/project_fixture.rs
+++ b/crates/lsp/src/project_fixture.rs
@@ -1,7 +1,7 @@
 //! Pure in-memory project fixtures shared by tests and benchmarks.
 
 use lsp_types::Position;
-use std::{collections::BTreeMap, fmt};
+use std::collections::BTreeMap;
 
 /// An ordered collection of in-memory fixture files and source markers.
 #[derive(Clone, Debug)]
@@ -25,7 +25,8 @@ pub(crate) struct FixtureMarker {
     position: Position,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("{message}")]
 pub(crate) struct FixtureError {
     message: String,
 }
@@ -35,14 +36,6 @@ impl FixtureError {
         Self { message: message.into() }
     }
 }
-
-impl fmt::Display for FixtureError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.message)
-    }
-}
-
-impl std::error::Error for FixtureError {}
 
 impl ProjectFixture {
     /// Parses a fixture and removes its `$N` markers from the file contents.
@@ -91,16 +84,15 @@ impl ProjectFixture {
         &self.files
     }
 
-    #[cfg(feature = "bench")]
     pub(crate) fn markers(&self) -> &BTreeMap<String, Vec<FixtureMarker>> {
         &self.markers
     }
 
-    pub(crate) fn marker(&self, name: &str) -> FixtureMarker {
+    pub(crate) fn marker(&self, name: &str) -> &FixtureMarker {
         let name = normalize_marker_name(name);
         let markers = self.markers.get(name).unwrap_or_else(|| panic!("missing marker `${name}`"));
         assert_eq!(markers.len(), 1, "marker `${name}` is ambiguous: {markers:?}");
-        markers[0].clone()
+        &markers[0]
     }
 }
 
@@ -235,7 +227,7 @@ fn trim_indent(text: &str) -> String {
         .min()
         .unwrap_or(0);
 
-    let mut trimmed = String::new();
+    let mut trimmed = String::with_capacity(text.len());
     for line in text.split_inclusive('\n') {
         if line.trim().is_empty() {
             trimmed.push_str(line.trim_start());

--- a/crates/lsp/src/project_fixture.rs
+++ b/crates/lsp/src/project_fixture.rs
@@ -1,0 +1,335 @@
+//! Pure in-memory project fixtures shared by tests and benchmarks.
+
+use lsp_types::Position;
+use std::{collections::BTreeMap, fmt};
+
+/// An ordered collection of in-memory fixture files and source markers.
+#[derive(Clone, Debug)]
+pub(crate) struct ProjectFixture {
+    files: Vec<FixtureFile>,
+    markers: BTreeMap<String, Vec<FixtureMarker>>,
+}
+
+/// A file declared by a [`ProjectFixture`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct FixtureFile {
+    path: String,
+    text: String,
+    open: bool,
+}
+
+/// A named position in a [`ProjectFixture`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct FixtureMarker {
+    path: String,
+    position: Position,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct FixtureError {
+    message: String,
+}
+
+impl FixtureError {
+    fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
+    }
+}
+
+impl fmt::Display for FixtureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for FixtureError {}
+
+impl ProjectFixture {
+    /// Parses a fixture and removes its `$N` markers from the file contents.
+    pub(crate) fn parse(fixture: &str) -> Self {
+        Self::try_parse(fixture).unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    pub(crate) fn try_parse(fixture: &str) -> Result<Self, FixtureError> {
+        Self::parse_inner(fixture, true)
+    }
+
+    /// Parses a fixture without interpreting `$N` sequences as markers.
+    pub(crate) fn parse_without_markers(fixture: &str) -> Self {
+        Self::parse_inner(fixture, false).unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    fn parse_inner(fixture: &str, extract_markers: bool) -> Result<Self, FixtureError> {
+        let fixture = trim_indent(fixture);
+        let mut files = Vec::new();
+        let mut markers = BTreeMap::<String, Vec<FixtureMarker>>::new();
+        let mut current = Option::<FixtureFile>::None;
+
+        for line in fixture.split_inclusive('\n') {
+            let marker_line = line.trim_end_matches(['\r', '\n']).trim_start();
+            if let Some(meta) = marker_line.strip_prefix("//-") {
+                if let Some(file) = current.take() {
+                    files.push(finish_file(file, extract_markers, &mut markers));
+                }
+                current = Some(parse_meta(meta.trim())?);
+            } else if let Some(file) = &mut current {
+                file.text.push_str(line);
+            } else if !line.trim().is_empty() {
+                return Err(FixtureError::new(format!(
+                    "fixture contents before first file marker: {line:?}"
+                )));
+            }
+        }
+
+        if let Some(file) = current {
+            files.push(finish_file(file, extract_markers, &mut markers));
+        }
+        Ok(Self { files, markers })
+    }
+
+    pub(crate) fn files(&self) -> &[FixtureFile] {
+        &self.files
+    }
+
+    #[cfg(feature = "bench")]
+    pub(crate) fn markers(&self) -> &BTreeMap<String, Vec<FixtureMarker>> {
+        &self.markers
+    }
+
+    pub(crate) fn marker(&self, name: &str) -> FixtureMarker {
+        let name = normalize_marker_name(name);
+        let markers = self.markers.get(name).unwrap_or_else(|| panic!("missing marker `${name}`"));
+        assert_eq!(markers.len(), 1, "marker `${name}` is ambiguous: {markers:?}");
+        markers[0].clone()
+    }
+}
+
+impl FixtureFile {
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub(crate) fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub(crate) fn is_open(&self) -> bool {
+        self.open
+    }
+}
+
+impl FixtureMarker {
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub(crate) fn position(&self) -> Position {
+        self.position
+    }
+}
+
+fn finish_file(
+    mut file: FixtureFile,
+    extract_markers: bool,
+    markers: &mut BTreeMap<String, Vec<FixtureMarker>>,
+) -> FixtureFile {
+    if file.text.ends_with('\n') {
+        file.text.pop();
+        if file.text.ends_with('\r') {
+            file.text.pop();
+        }
+    }
+
+    if extract_markers {
+        for (name, position) in strip_markers(&mut file.text) {
+            markers
+                .entry(name)
+                .or_default()
+                .push(FixtureMarker { path: file.path.clone(), position });
+        }
+    }
+    file
+}
+
+fn parse_meta(meta: &str) -> Result<FixtureFile, FixtureError> {
+    let mut parts = meta.split_whitespace();
+    let path = parts
+        .next()
+        .ok_or_else(|| FixtureError::new("fixture marker must contain a path"))?
+        .to_string();
+    validate_path(&path)?;
+
+    let mut open = false;
+    for part in parts {
+        match part {
+            "open" => open = true,
+            other => return Err(FixtureError::new(format!("unknown fixture option `{other}`"))),
+        }
+    }
+
+    Ok(FixtureFile { path, text: String::new(), open })
+}
+
+fn validate_path(path: &str) -> Result<(), FixtureError> {
+    let Some(relative) = path.strip_prefix('/') else {
+        return Err(FixtureError::new(format!("fixture path must start with `/`: {path}")));
+    };
+    if relative.is_empty()
+        || relative.split('/').any(|component| {
+            component.is_empty()
+                || matches!(component, "." | "..")
+                || component.contains(['\\', ':'])
+        })
+    {
+        return Err(FixtureError::new(format!(
+            "fixture path must stay within the project root: {path}"
+        )));
+    }
+    Ok(())
+}
+
+fn strip_markers(text: &mut String) -> Vec<(String, Position)> {
+    let mut stripped = String::with_capacity(text.len());
+    let mut markers = Vec::new();
+    let mut chars = text.chars().peekable();
+    let mut line = 0;
+    let mut character = 0;
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' && chars.peek().is_some_and(|next| next.is_ascii_digit()) {
+            let mut name = String::new();
+            while let Some(next) = chars.peek() {
+                if next.is_ascii_digit() {
+                    name.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+            markers.push((name, Position { line, character }));
+            continue;
+        }
+
+        stripped.push(ch);
+        if ch == '\n' {
+            line += 1;
+            character = 0;
+        } else {
+            character += ch.len_utf16() as u32;
+        }
+    }
+
+    *text = stripped;
+    markers
+}
+
+fn normalize_marker_name(name: &str) -> &str {
+    name.strip_prefix('$').unwrap_or(name)
+}
+
+fn trim_indent(text: &str) -> String {
+    let text = text.trim_matches('\n');
+    let indent = text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    let mut trimmed = String::new();
+    for line in text.split_inclusive('\n') {
+        if line.trim().is_empty() {
+            trimmed.push_str(line.trim_start());
+        } else {
+            trimmed.push_str(line.get(indent..).unwrap_or(line));
+        }
+    }
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ordered_multi_file_fixture() {
+        let fixture = ProjectFixture::parse(
+            r#"
+                //- /src/First.sol open
+                contract First {}
+                //- /src/Second.sol
+                contract Second {}
+                //- /foundry.toml
+                [profile.default]
+            "#,
+        );
+
+        let files = fixture.files();
+        assert_eq!(files.len(), 3);
+        assert_eq!(files[0].path(), "/src/First.sol");
+        assert_eq!(files[0].text(), "contract First {}");
+        assert!(files[0].is_open());
+        assert_eq!(files[1].path(), "/src/Second.sol");
+        assert_eq!(files[1].text(), "contract Second {}");
+        assert!(!files[1].is_open());
+        assert_eq!(files[2].path(), "/foundry.toml");
+        assert_eq!(files[2].text(), "[profile.default]");
+    }
+
+    #[test]
+    fn markers_use_utf16_positions() {
+        let fixture = ProjectFixture::parse(concat!(
+            "//- /Unicode.sol\n",
+            "contract Unicode {\n",
+            "    string value = \"\u{1F600}\";$0\n",
+            "    function $12read() external {}\n",
+            "}\n",
+        ));
+
+        let file = &fixture.files()[0];
+        assert_eq!(
+            file.text(),
+            "contract Unicode {\n    string value = \"\u{1F600}\";\n    function read() external {}\n}"
+        );
+        assert_eq!(fixture.marker("0").position(), Position::new(1, 24));
+        assert_eq!(fixture.marker("$12").position(), Position::new(2, 13));
+        assert_eq!(fixture.marker("12").path(), "/Unicode.sol");
+    }
+
+    #[test]
+    fn parsing_without_markers_preserves_marker_text() {
+        let fixture = ProjectFixture::parse_without_markers(
+            r#"
+                //- /Raw.sol
+                contract $0Raw {}
+            "#,
+        );
+
+        assert_eq!(fixture.files()[0].text(), "contract $0Raw {}");
+    }
+
+    #[test]
+    fn rejects_paths_that_can_escape_the_project_root() {
+        for path in [
+            "/../Outside.sol",
+            "/src/../../Outside.sol",
+            "/C:/Outside.sol",
+            r"/src\..\Outside.sol",
+            "//server/Outside.sol",
+        ] {
+            let fixture = format!("//- {path}\ncontract Outside {{}}");
+            assert!(ProjectFixture::try_parse(&fixture).is_err(), "accepted `{path}`");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "missing marker `$9`")]
+    fn missing_marker_is_rejected() {
+        ProjectFixture::parse("//- /Empty.sol\n").marker("$9");
+    }
+
+    #[test]
+    #[should_panic(expected = "marker `$0` is ambiguous")]
+    fn ambiguous_marker_is_rejected() {
+        ProjectFixture::parse("//- /First.sol\n$0\n//- /Second.sol\n$0").marker("0");
+    }
+}

--- a/crates/lsp/src/test_support.rs
+++ b/crates/lsp/src/test_support.rs
@@ -157,7 +157,7 @@ impl MarkedProject {
         &mut self.project
     }
 
-    pub(crate) fn marker(&self, name: &str) -> FixtureMarker {
+    pub(crate) fn marker(&self, name: &str) -> &FixtureMarker {
         self.fixture.marker(name)
     }
 }

--- a/crates/lsp/src/test_support.rs
+++ b/crates/lsp/src/test_support.rs
@@ -1,11 +1,11 @@
 use crate::{
     config::{Config, negotiate_capabilities},
+    project_fixture::{FixtureMarker, ProjectFixture},
     vfs::{Vfs, VfsPath},
 };
 use crop::Rope;
-use lsp_types::{InitializeParams, Position, Url, WorkspaceFolder};
+use lsp_types::{InitializeParams, Url, WorkspaceFolder};
 use std::{
-    collections::BTreeMap,
     fs,
     io::Read,
     path::{Path, PathBuf},
@@ -30,13 +30,7 @@ pub(crate) struct TestProject {
 
 pub(crate) struct MarkedProject {
     project: TestProject,
-    markers: BTreeMap<String, Vec<Marker>>,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Marker {
-    path: String,
-    position: Position,
+    fixture: ProjectFixture,
 }
 
 impl TestProject {
@@ -45,11 +39,15 @@ impl TestProject {
     }
 
     pub(crate) fn from_fixture(fixture: &str) -> Self {
+        Self::from_project_fixture(&ProjectFixture::parse_without_markers(fixture))
+    }
+
+    fn from_project_fixture(fixture: &ProjectFixture) -> Self {
         let mut project = Self::new();
-        for file in parse_fixture(fixture) {
-            project.write_file(&file.path, &file.text);
-            if file.open {
-                project.open_file(&file.path, &file.text);
+        for file in fixture.files() {
+            project.write_file(file.path(), file.text());
+            if file.is_open() {
+                project.open_file(file.path(), file.text());
             }
         }
         project
@@ -146,19 +144,9 @@ impl TestProject {
 
 impl MarkedProject {
     pub(crate) fn from_fixture(fixture: &str) -> Self {
-        let mut project = TestProject::new();
-        let mut markers = BTreeMap::<String, Vec<Marker>>::new();
-        for mut file in parse_fixture(fixture) {
-            let file_markers = strip_markers(&mut file.text);
-            for (name, position) in file_markers {
-                markers.entry(name).or_default().push(Marker { path: file.path.clone(), position });
-            }
-            project.write_file(&file.path, &file.text);
-            if file.open {
-                project.open_file(&file.path, &file.text);
-            }
-        }
-        Self { project, markers }
+        let fixture = ProjectFixture::parse(fixture);
+        let project = TestProject::from_project_fixture(&fixture);
+        Self { project, fixture }
     }
 
     pub(crate) fn project(&self) -> &TestProject {
@@ -169,135 +157,7 @@ impl MarkedProject {
         &mut self.project
     }
 
-    pub(crate) fn marker(&self, name: &str) -> Marker {
-        let name = normalize_marker_name(name);
-        let markers = self.markers.get(name).unwrap_or_else(|| panic!("missing marker `${name}`"));
-        assert_eq!(markers.len(), 1, "marker `${name}` is ambiguous: {markers:?}");
-        markers[0].clone()
+    pub(crate) fn marker(&self, name: &str) -> FixtureMarker {
+        self.fixture.marker(name)
     }
-}
-
-impl Marker {
-    pub(crate) fn path(&self) -> &str {
-        &self.path
-    }
-
-    pub(crate) fn position(&self) -> Position {
-        self.position
-    }
-}
-
-struct FixtureFile {
-    path: String,
-    text: String,
-    open: bool,
-}
-
-fn parse_fixture(fixture: &str) -> Vec<FixtureFile> {
-    let fixture = trim_indent(fixture);
-    let mut files = Vec::new();
-    let mut current = Option::<FixtureFile>::None;
-
-    for line in fixture.split_inclusive('\n') {
-        let marker_line = line.trim_end_matches(['\r', '\n']).trim_start();
-        if let Some(meta) = marker_line.strip_prefix("//-") {
-            if let Some(file) = current.take() {
-                files.push(finish_file(file));
-            }
-            current = Some(parse_meta(meta.trim()));
-        } else if let Some(file) = &mut current {
-            file.text.push_str(line);
-        } else if !line.trim().is_empty() {
-            panic!("fixture contents before first file marker: {line:?}");
-        }
-    }
-
-    if let Some(file) = current {
-        files.push(finish_file(file));
-    }
-    files
-}
-
-fn finish_file(mut file: FixtureFile) -> FixtureFile {
-    if file.text.ends_with('\n') {
-        file.text.pop();
-        if file.text.ends_with('\r') {
-            file.text.pop();
-        }
-    }
-    file
-}
-
-fn parse_meta(meta: &str) -> FixtureFile {
-    let mut parts = meta.split_whitespace();
-    let path = parts.next().expect("fixture marker must contain a path").to_string();
-    assert!(path.starts_with('/'), "fixture path must start with `/`: {path}");
-
-    let mut open = false;
-    for part in parts {
-        match part {
-            "open" => open = true,
-            other => panic!("unknown fixture option `{other}`"),
-        }
-    }
-
-    FixtureFile { path, text: String::new(), open }
-}
-
-fn strip_markers(text: &mut String) -> Vec<(String, Position)> {
-    let mut stripped = String::with_capacity(text.len());
-    let mut markers = Vec::new();
-    let mut chars = text.chars().peekable();
-    let mut line = 0;
-    let mut character = 0;
-
-    while let Some(ch) = chars.next() {
-        if ch == '$' && chars.peek().is_some_and(|next| next.is_ascii_digit()) {
-            let mut name = String::new();
-            while let Some(next) = chars.peek() {
-                if next.is_ascii_digit() {
-                    name.push(chars.next().unwrap());
-                } else {
-                    break;
-                }
-            }
-            markers.push((name, Position { line, character }));
-            continue;
-        }
-
-        stripped.push(ch);
-        if ch == '\n' {
-            line += 1;
-            character = 0;
-        } else {
-            character += ch.len_utf16() as u32;
-        }
-    }
-
-    *text = stripped;
-    markers
-}
-
-fn normalize_marker_name(name: &str) -> &str {
-    name.strip_prefix('$').unwrap_or(name)
-}
-
-fn trim_indent(text: &str) -> String {
-    let text = text.trim_matches('\n');
-    let indent = text
-        .lines()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| line.len() - line.trim_start().len())
-        .min()
-        .unwrap_or(0);
-
-    let mut trimmed = String::new();
-    for line in text.split_inclusive('\n') {
-        if line.trim().is_empty() {
-            trimmed.push_str(line.trim_start());
-        } else {
-            trimmed.push_str(line.get(indent..).unwrap_or(line));
-        }
-    }
-    trimmed
 }

--- a/crates/lsp/src/tests/document_highlight.rs
+++ b/crates/lsp/src/tests/document_highlight.rs
@@ -7,7 +7,6 @@ use lsp_types::{
 };
 use snapbox::str;
 use solar_config::CompileOpts;
-use solar_interface::data_structures::map::FxHashSet;
 use std::{
     future::Future,
     sync::atomic::Ordering,
@@ -253,20 +252,18 @@ fn waits_for_current_analysis_before_returning_highlights() {
         "#,
     );
     let path = project.path("/Highlights.sol");
-    let old_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), project.read_file("/Highlights.sol"))],
-        seen_paths: FxHashSet::default(),
-    })
+    let old_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Highlights.sol"))],
+    ))
     .symbol_tables;
-    let new_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(
+    let new_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(
             path.clone(),
             "contract C {\n    uint256 placeholder;\n    uint256 value;\n    function write() external {\n        value = 1;\n    }\n}\n".into(),
         )],
-        seen_paths: FxHashSet::default(),
-    })
+    ))
     .symbol_tables;
     let uri = Url::from_file_path(path).unwrap();
     let params = DocumentHighlightParams {

--- a/crates/lsp/src/tests/document_link.rs
+++ b/crates/lsp/src/tests/document_link.rs
@@ -10,7 +10,6 @@ use lsp_types::{
 };
 use snapbox::str;
 use solar_config::CompileOpts;
-use solar_interface::data_structures::map::FxHashSet;
 use std::{
     future::Future,
     sync::atomic::Ordering,
@@ -84,11 +83,10 @@ fn equivalent_percent_encoded_uri_returns_document_links() {
         "#,
     );
     let path = project.path("/Imports.sol");
-    let tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), project.read_file("/Imports.sol"))],
-        seen_paths: FxHashSet::default(),
-    })
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Imports.sol"))],
+    ))
     .symbol_tables;
     let canonical_uri = Url::from_file_path(&path).unwrap();
     let encoded_uri =
@@ -189,17 +187,15 @@ fn waits_for_current_analysis_before_returning_document_links() {
         "#,
     );
     let path = project.path("/Imports.sol");
-    let old_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), project.read_file("/Imports.sol"))],
-        seen_paths: FxHashSet::default(),
-    })
+    let old_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Imports.sol"))],
+    ))
     .symbol_tables;
-    let new_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), "import \"./New.sol\";".into())],
-        seen_paths: FxHashSet::default(),
-    })
+    let new_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), "import \"./New.sol\";".into())],
+    ))
     .symbol_tables;
     let uri = Url::from_file_path(path).unwrap();
     let params = DocumentLinkParams {

--- a/crates/lsp/src/tests/hover.rs
+++ b/crates/lsp/src/tests/hover.rs
@@ -7,7 +7,6 @@ use lsp_types::{
 };
 use snapbox::str;
 use solar_config::CompileOpts;
-use solar_interface::data_structures::map::FxHashSet;
 use std::task::{Context, Poll, Waker};
 
 #[test]
@@ -1026,17 +1025,15 @@ fn waits_for_latest_analysis_before_returning_hover() {
         "#,
     );
     let path = project.path("/Fresh.sol");
-    let old_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), project.read_file("/Fresh.sol"))],
-        seen_paths: FxHashSet::default(),
-    })
+    let old_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Fresh.sol"))],
+    ))
     .symbol_tables;
-    let new_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), "contract C {\n    address newValue;\n}\n".into())],
-        seen_paths: FxHashSet::default(),
-    })
+    let new_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), "contract C {\n    address newValue;\n}\n".into())],
+    ))
     .symbol_tables;
     let uri = Url::from_file_path(path).unwrap();
     let params = HoverParams {

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -567,11 +567,10 @@ fn analyze_builds_declaration_symbol_table() {
     );
     let path = project.path("/Symbols.sol");
     let uri = Url::from_file_path(&path).unwrap();
-    let result = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path, project.read_file("/Symbols.sol"))],
-        seen_paths: FxHashSet::default(),
-    });
+    let result = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path, project.read_file("/Symbols.sol"))],
+    ));
 
     assert!(result.diagnostics.is_empty());
 
@@ -649,11 +648,10 @@ fn analyze_builds_lsp_symbol_responses() {
     );
     let path = project.path("/Symbols.sol");
     let uri = Url::from_file_path(&path).unwrap();
-    let result = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path, project.read_file("/Symbols.sol"))],
-        seen_paths: FxHashSet::default(),
-    });
+    let result = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path, project.read_file("/Symbols.sol"))],
+    ));
 
     assert!(result.diagnostics.is_empty(), "{:#?}", result.diagnostics);
 

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -12,7 +12,6 @@ use lsp_types::{
 };
 use snapbox::{IntoData, assert_data_eq};
 use solar_config::CompileOpts;
-use solar_interface::data_structures::map::FxHashSet;
 use std::{
     fmt::Write as _,
     future::Future,
@@ -38,11 +37,7 @@ impl RequestFixture {
         let marked = MarkedProject::from_fixture(fixture);
         let contents = marked.project().read_file(path);
         let path = marked.project().path(path);
-        let result = analyze(AnalysisBatch {
-            opts: CompileOpts::default(),
-            files: vec![(path, contents)],
-            seen_paths: FxHashSet::default(),
-        });
+        let result = analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, contents)]));
         Self { marked, result }
     }
 
@@ -76,11 +71,8 @@ impl RequestFixture {
                 .filter(|(open_path, _)| open_path == path)
                 .map_or_else(|| marked.project().read_file(path), |(_, contents)| contents.clone());
             let path = marked.project().path(path);
-            let batch = analyze(AnalysisBatch {
-                opts: CompileOpts::default(),
-                files: vec![(path, contents)],
-                seen_paths: FxHashSet::default(),
-            });
+            let batch =
+                analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, contents)]));
             result.symbol_tables.extend(batch.symbol_tables);
             for (uri, mut diagnostics) in batch.diagnostics {
                 result.diagnostics.entry(uri).or_default().append(&mut diagnostics);
@@ -278,11 +270,10 @@ impl RequestFixture {
     ) {
         let path = self.marked.project().path(path);
         let uri = Url::from_file_path(&path).unwrap();
-        let result = analyze(AnalysisBatch {
-            opts: CompileOpts::default(),
-            files: vec![(path.clone(), changed_contents.to_string())],
-            seen_paths: FxHashSet::default(),
-        });
+        let result = analyze(AnalysisBatch::from_files(
+            CompileOpts::default(),
+            [(path.clone(), changed_contents.to_string())],
+        ));
         assert!(!result.diagnostics.is_empty(), "changed source should fail analysis");
 
         let mut state = self.state();

--- a/crates/lsp/src/tests/type_definition.rs
+++ b/crates/lsp/src/tests/type_definition.rs
@@ -7,7 +7,6 @@ use lsp_types::{
 };
 use snapbox::str;
 use solar_config::CompileOpts;
-use solar_interface::data_structures::map::FxHashSet;
 use std::{
     future::Future,
     sync::atomic::Ordering,
@@ -371,20 +370,18 @@ fn waits_for_current_analysis_before_returning_type_definitions() {
         "#,
     );
     let path = project.path("/Types.sol");
-    let old_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(path.clone(), project.read_file("/Types.sol"))],
-        seen_paths: FxHashSet::default(),
-    })
+    let old_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Types.sol"))],
+    ))
     .symbol_tables;
-    let new_tables = analyze(AnalysisBatch {
-        opts: CompileOpts::default(),
-        files: vec![(
+    let new_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(
             path.clone(),
             "contract C {\n    struct Placeholder { uint256 value; }\n    struct NewType { uint256 value; }\n    NewType value;\n}\n".into(),
         )],
-        seen_paths: FxHashSet::default(),
-    })
+    ))
     .symbol_tables;
     let uri = Url::from_file_path(path).unwrap();
     let params = GotoDefinitionParams {


### PR DESCRIPTION
This PR follows up on Dani's comment in #987:
> let's add the benches to codspeed CI and make a framework around it, we probably want to see what other LSPs do and add some project-wide test cases

It extends the existing CodSpeed coverage with a project-wide LSP benchmark framework and realistic `unifap-v2` workloads for full analysis, analysis after a source edit, and common LSP requests. Fixture preparation is kept outside the measured path to provide a stable baseline for future performance tracking and comparisons with other LSP implementations.

### Run it  :
cargo bench -p solar-lsp --bench lsp --features bench

### Open it :
open target/criterion/report/index.html 

### Result :
<img width="1200" height="529" alt="image" src="https://github.com/user-attachments/assets/13f6c0d3-9f4a-4751-bef7-fb4c9b0a3b93" />

Benchmark result also be shown in codSpeed  
 
