### PR TITLE
feat(lsp): add analysis cache commands

### DIFF
--- a/crates/lsp/src/commands.rs
+++ b/crates/lsp/src/commands.rs
@@ -1,0 +1,36 @@
+//! LSP command identifiers and dispatch.
+
+use crate::global_state::GlobalState;
+use async_lsp::{ErrorCode, ResponseError};
+use lsp_types::ExecuteCommandParams;
+use serde_json::{Value, json};
+use std::future::{Ready, ready};
+
+pub(crate) const CLEAR_CACHE: &str = "solar.clearCache";
+pub(crate) const REINDEX: &str = "solar.reindex";
+pub(crate) const ALL: [&str; 2] = [CLEAR_CACHE, REINDEX];
+
+pub(crate) fn execute_command(
+    state: &mut GlobalState,
+    params: ExecuteCommandParams,
+) -> Ready<Result<Option<Value>, ResponseError>> {
+    let result = match params.command.as_str() {
+        CLEAR_CACHE => {
+            state.clear_analysis_cache();
+            Ok(success())
+        }
+        REINDEX => {
+            state.reindex();
+            Ok(success())
+        }
+        command => Err(ResponseError::new(
+            ErrorCode::METHOD_NOT_FOUND,
+            format!("unknown command `{command}`"),
+        )),
+    };
+    ready(result)
+}
+
+fn success() -> Option<Value> {
+    Some(json!({ "success": true }))
+}

--- a/crates/lsp/src/commands.rs
+++ b/crates/lsp/src/commands.rs
@@ -24,7 +24,7 @@ pub(crate) fn execute_command(
             Ok(success())
         }
         command => Err(ResponseError::new(
-            ErrorCode::METHOD_NOT_FOUND,
+            ErrorCode::INVALID_PARAMS,
             format!("unknown command `{command}`"),
         )),
     };

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,14 +1,15 @@
 use crate::{
+    commands,
     diagnostics::DiagnosticOwner,
     flycheck::{FlycheckConfig, FlycheckInitializationOptions},
     workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest},
 };
 use lsp_types::{
-    CompletionOptions, DeclarationCapability, DocumentLinkOptions, HoverProviderCapability,
-    ImplementationProviderCapability, InitializeParams, OneOf, RenameOptions, SaveOptions,
-    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability,
-    WorkDoneProgressOptions,
+    CompletionOptions, DeclarationCapability, DocumentLinkOptions, ExecuteCommandOptions,
+    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, OneOf,
+    RenameOptions, SaveOptions, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
 };
 use solar_interface::data_structures::map::FxHashSet;
 use std::{
@@ -257,6 +258,10 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
                 resolve_provider: Some(false),
                 work_done_progress_options: WorkDoneProgressOptions::default(),
             }),
+            execute_command_provider: Some(ExecuteCommandOptions {
+                commands: commands::ALL.into_iter().map(str::to_owned).collect(),
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+            }),
             document_symbol_provider: Some(OneOf::Left(true)),
             document_highlight_provider: Some(OneOf::Left(true)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
@@ -394,6 +399,19 @@ mod tests {
             panic!("expected save options");
         };
         assert_eq!(save_options.include_text, Some(false));
+    }
+
+    #[test]
+    fn negotiate_capabilities_advertises_cache_commands() {
+        let (capabilities, _) = negotiate_capabilities(InitializeParams::default());
+
+        assert_eq!(
+            capabilities.execute_command_provider,
+            Some(ExecuteCommandOptions {
+                commands: vec!["solar.clearCache".into(), "solar.reindex".into()],
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+            })
+        );
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -27,17 +27,31 @@ use solar_interface::{
 use solar_sema::Compiler;
 use std::{
     borrow::Cow,
+    mem,
     ops::ControlFlow,
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
     },
 };
 use tokio::{
     sync::{oneshot, watch},
     task::{JoinError, JoinHandle},
 };
+
+#[derive(Clone, Copy)]
+enum AnalysisMode {
+    Recompute,
+    Rediscover,
+    IfInvalidated,
+}
+
+/// State serialized with analysis and diagnostic publication.
+#[derive(Default)]
+struct AnalysisCommitState {
+    cache_invalidated: bool,
+}
 
 pub(crate) struct GlobalState {
     client: ClientSocket,
@@ -46,10 +60,7 @@ pub(crate) struct GlobalState {
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
     published_analysis_version: watch::Sender<usize>,
-    // Serializes generation changes with symbol and diagnostic publication.
-    analysis_commit: Arc<Mutex<()>>,
-    // Forces the next analysis trigger to rediscover all workspace inputs.
-    analysis_cache_invalidated: Arc<AtomicBool>,
+    analysis_commit: Arc<Mutex<AnalysisCommitState>>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     flycheck_cancels: FxHashMap<DiagnosticOwner, oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
@@ -66,7 +77,6 @@ impl GlobalState {
             analysis_version: Arc::new(AtomicUsize::new(0)),
             published_analysis_version,
             analysis_commit: Arc::new(Default::default()),
-            analysis_cache_invalidated: Arc::new(AtomicBool::new(false)),
             flycheck_versions: Arc::new(Default::default()),
             flycheck_cancels: FxHashMap::default(),
             symbol_tables: Arc::new(Default::default()),
@@ -129,7 +139,7 @@ impl GlobalState {
     }
 
     pub(crate) fn recompute_with_disk_files(&mut self, disk_paths: Vec<PathBuf>) {
-        self.request_analysis(false, false, disk_paths, Vec::new());
+        self.request_analysis(AnalysisMode::Recompute, disk_paths, Vec::new());
     }
 
     pub(crate) fn recompute_for_file_changes(
@@ -138,48 +148,52 @@ impl GlobalState {
         removed_paths: Vec<PathBuf>,
         force_rediscover: bool,
     ) {
-        self.request_analysis(force_rediscover, false, disk_paths, removed_paths);
+        let mode =
+            if force_rediscover { AnalysisMode::Rediscover } else { AnalysisMode::Recompute };
+        self.request_analysis(mode, disk_paths, removed_paths);
     }
 
     pub(crate) fn reindex(&mut self) {
-        self.request_analysis(true, false, Vec::new(), Vec::new());
+        self.request_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new());
     }
 
     pub(crate) fn reindex_if_invalidated(&mut self) {
-        self.request_analysis(false, true, Vec::new(), Vec::new());
+        self.request_analysis(AnalysisMode::IfInvalidated, Vec::new(), Vec::new());
     }
 
     pub(crate) fn clear_analysis_cache(&mut self) {
-        let analysis_commit = self.analysis_commit.clone();
-        let _commit = analysis_commit.lock();
-        let version = self.analysis_version.fetch_add(1, Ordering::AcqRel) + 1;
+        let old_symbol_tables = {
+            let analysis_commit = self.analysis_commit.clone();
+            let mut commit = analysis_commit.lock();
+            let version = self.analysis_version.fetch_add(1, Ordering::AcqRel) + 1;
 
-        *self.symbol_tables.write() = SymbolTables::default();
-        let batches = self
-            .diagnostics
-            .write()
-            .replace_and_publish_batches(DiagnosticOwner::Compiler, DiagnosticMap::default());
-        publish_diagnostic_batches(&mut self.client, batches);
+            let old_symbol_tables = mem::take(&mut *self.symbol_tables.write());
+            let batches = self
+                .diagnostics
+                .write()
+                .replace_and_publish_batches(DiagnosticOwner::Compiler, DiagnosticMap::default());
+            publish_diagnostic_batches(&mut self.client, batches);
 
-        self.analysis_cache_invalidated.store(true, Ordering::Release);
-        self.published_analysis_version.send_replace(version);
+            commit.cache_invalidated = true;
+            self.published_analysis_version.send_replace(version);
+            old_symbol_tables
+        };
+        drop(old_symbol_tables);
     }
 
+    #[cfg(test)]
     pub(crate) fn analysis_cache_invalidated(&self) -> bool {
-        self.analysis_cache_invalidated.load(Ordering::Acquire)
+        self.analysis_commit.lock().cache_invalidated
     }
 
     fn request_analysis(
         &mut self,
-        force_rediscover: bool,
-        only_if_invalidated: bool,
+        mode: AnalysisMode,
         disk_paths: Vec<PathBuf>,
         removed_paths: Vec<PathBuf>,
     ) {
         let removed_uris = self.prepare_removed_file_diagnostics(removed_paths);
-        let Some(version) =
-            self.begin_analysis(force_rediscover, only_if_invalidated, removed_uris)
-        else {
+        let Some(version) = self.begin_analysis(mode, removed_uris) else {
             return;
         };
         let task = self.spawn_with_snapshot(move |mut snapshot| {
@@ -220,28 +234,22 @@ impl GlobalState {
         self.monitor_analysis_task(version, task);
     }
 
-    fn begin_analysis(
-        &mut self,
-        force_rediscover: bool,
-        only_if_invalidated: bool,
-        removed_uris: Vec<Url>,
-    ) -> Option<usize> {
-        let invalidated;
-        let version;
-        {
+    fn begin_analysis(&mut self, mode: AnalysisMode, removed_uris: Vec<Url>) -> Option<usize> {
+        let (version, rediscover) = {
             let analysis_commit = self.analysis_commit.clone();
-            let _commit = analysis_commit.lock();
-            if only_if_invalidated && !self.analysis_cache_invalidated() {
+            let mut commit = analysis_commit.lock();
+            if matches!(mode, AnalysisMode::IfInvalidated) && !commit.cache_invalidated {
                 return None;
             }
 
-            invalidated = self.analysis_cache_invalidated.swap(false, Ordering::AcqRel);
-            version = self.analysis_version.fetch_add(1, Ordering::AcqRel) + 1;
+            let invalidated = mem::take(&mut commit.cache_invalidated);
+            let version = self.analysis_version.fetch_add(1, Ordering::AcqRel) + 1;
             let batches = self.diagnostics.write().clear_uris_and_publish_batches(removed_uris);
             publish_diagnostic_batches(&mut self.client, batches);
-        }
+            (version, matches!(mode, AnalysisMode::Rediscover) || invalidated)
+        };
 
-        if force_rediscover || invalidated {
+        if rediscover {
             self.rediscover_workspaces();
         }
         Some(version)
@@ -365,7 +373,6 @@ impl GlobalState {
             analysis_version: self.analysis_version.clone(),
             published_analysis_version: self.published_analysis_version.clone(),
             analysis_commit: self.analysis_commit.clone(),
-            analysis_cache_invalidated: self.analysis_cache_invalidated.clone(),
             flycheck_versions: self.flycheck_versions.clone(),
             symbol_tables: self.symbol_tables.clone(),
             diagnostics: self.diagnostics.clone(),
@@ -380,7 +387,7 @@ impl GlobalState {
         tokio::task::spawn_blocking(move || f(snapshot))
     }
 
-    fn monitor_analysis_task<T: Send + 'static>(&self, version: usize, task: JoinHandle<T>) {
+    fn monitor_analysis_task(&self, version: usize, task: JoinHandle<()>) {
         let mut snapshot = self.snapshot();
         tokio::spawn(async move {
             if let Err(error) = task.await {
@@ -429,8 +436,7 @@ pub(crate) struct GlobalStateSnapshot {
     config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
     published_analysis_version: watch::Sender<usize>,
-    analysis_commit: Arc<Mutex<()>>,
-    analysis_cache_invalidated: Arc<AtomicBool>,
+    analysis_commit: Arc<Mutex<AnalysisCommitState>>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     symbol_tables: Arc<RwLock<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
@@ -505,19 +511,24 @@ impl GlobalStateSnapshot {
     }
 
     fn publish_analysis(&mut self, version: usize, result: AnalysisResult) -> bool {
-        let analysis_commit = self.analysis_commit.clone();
-        let _commit = analysis_commit.lock();
-        if !self.is_current(version) {
-            return false;
-        }
+        let old_symbol_tables = {
+            let analysis_commit = self.analysis_commit.clone();
+            let _commit = analysis_commit.lock();
+            if !self.is_current(version) {
+                return false;
+            }
 
-        *self.symbol_tables.write() = result.symbol_tables;
-        let batches = self
-            .diagnostics
-            .write()
-            .replace_and_publish_batches(DiagnosticOwner::Compiler, result.diagnostics);
-        publish_diagnostic_batches(&mut self.client, batches);
-        self.published_analysis_version.send_replace(version);
+            let old_symbol_tables =
+                mem::replace(&mut *self.symbol_tables.write(), result.symbol_tables);
+            let batches = self
+                .diagnostics
+                .write()
+                .replace_and_publish_batches(DiagnosticOwner::Compiler, result.diagnostics);
+            publish_diagnostic_batches(&mut self.client, batches);
+            self.published_analysis_version.send_replace(version);
+            old_symbol_tables
+        };
+        drop(old_symbol_tables);
         true
     }
 
@@ -531,13 +542,13 @@ impl GlobalStateSnapshot {
 
     fn handle_analysis_failure(&mut self, version: usize, error: JoinError) {
         let analysis_commit = self.analysis_commit.clone();
-        let _commit = analysis_commit.lock();
+        let mut commit = analysis_commit.lock();
         if !self.is_current(version) {
             return;
         }
 
         tracing::warn!(%error, version, "analysis task failed");
-        self.analysis_cache_invalidated.store(true, Ordering::Release);
+        commit.cache_invalidated = true;
         self.published_analysis_version.send_replace(version);
     }
 

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -19,7 +19,7 @@ use solar_interface::{
     Session,
     data_structures::{
         map::{FxHashMap, FxHashSet},
-        sync::RwLock,
+        sync::{Mutex, RwLock},
     },
     diagnostics::{DiagCtxt, InMemoryEmitter},
     source_map::{FileName, SourceMap},
@@ -31,12 +31,12 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 use tokio::{
     sync::{oneshot, watch},
-    task::JoinHandle,
+    task::{JoinError, JoinHandle},
 };
 
 pub(crate) struct GlobalState {
@@ -46,6 +46,10 @@ pub(crate) struct GlobalState {
     pub(crate) config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
     published_analysis_version: watch::Sender<usize>,
+    // Serializes generation changes with symbol and diagnostic publication.
+    analysis_commit: Arc<Mutex<()>>,
+    // Forces the next analysis trigger to rediscover all workspace inputs.
+    analysis_cache_invalidated: Arc<AtomicBool>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     flycheck_cancels: FxHashMap<DiagnosticOwner, oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
@@ -61,6 +65,8 @@ impl GlobalState {
             vfs: Arc::new(Default::default()),
             analysis_version: Arc::new(AtomicUsize::new(0)),
             published_analysis_version,
+            analysis_commit: Arc::new(Default::default()),
+            analysis_cache_invalidated: Arc::new(AtomicBool::new(false)),
             flycheck_versions: Arc::new(Default::default()),
             flycheck_cancels: FxHashMap::default(),
             symbol_tables: Arc::new(Default::default()),
@@ -123,8 +129,60 @@ impl GlobalState {
     }
 
     pub(crate) fn recompute_with_disk_files(&mut self, disk_paths: Vec<PathBuf>) {
+        self.request_analysis(false, false, disk_paths, Vec::new());
+    }
+
+    pub(crate) fn recompute_for_file_changes(
+        &mut self,
+        disk_paths: Vec<PathBuf>,
+        removed_paths: Vec<PathBuf>,
+        force_rediscover: bool,
+    ) {
+        self.request_analysis(force_rediscover, false, disk_paths, removed_paths);
+    }
+
+    pub(crate) fn reindex(&mut self) {
+        self.request_analysis(true, false, Vec::new(), Vec::new());
+    }
+
+    pub(crate) fn reindex_if_invalidated(&mut self) {
+        self.request_analysis(false, true, Vec::new(), Vec::new());
+    }
+
+    pub(crate) fn clear_analysis_cache(&mut self) {
+        let analysis_commit = self.analysis_commit.clone();
+        let _commit = analysis_commit.lock();
         let version = self.analysis_version.fetch_add(1, Ordering::AcqRel) + 1;
-        self.spawn_with_snapshot(move |mut snapshot| {
+
+        *self.symbol_tables.write() = SymbolTables::default();
+        let batches = self
+            .diagnostics
+            .write()
+            .replace_and_publish_batches(DiagnosticOwner::Compiler, DiagnosticMap::default());
+        publish_diagnostic_batches(&mut self.client, batches);
+
+        self.analysis_cache_invalidated.store(true, Ordering::Release);
+        self.published_analysis_version.send_replace(version);
+    }
+
+    pub(crate) fn analysis_cache_invalidated(&self) -> bool {
+        self.analysis_cache_invalidated.load(Ordering::Acquire)
+    }
+
+    fn request_analysis(
+        &mut self,
+        force_rediscover: bool,
+        only_if_invalidated: bool,
+        disk_paths: Vec<PathBuf>,
+        removed_paths: Vec<PathBuf>,
+    ) {
+        let removed_uris = self.prepare_removed_file_diagnostics(removed_paths);
+        let Some(version) =
+            self.begin_analysis(force_rediscover, only_if_invalidated, removed_uris)
+        else {
+            return;
+        };
+        let task = self.spawn_with_snapshot(move |mut snapshot| {
             if !snapshot.is_current(version) {
                 return;
             }
@@ -157,10 +215,41 @@ impl GlobalState {
                 }
             }
 
-            if snapshot.publish_symbol_tables(version, symbol_tables) {
-                snapshot.publish_diagnostics(DiagnosticOwner::Compiler, diagnostics);
-            }
+            snapshot.publish_analysis(version, AnalysisResult { diagnostics, symbol_tables });
         });
+        self.monitor_analysis_task(version, task);
+    }
+
+    fn begin_analysis(
+        &mut self,
+        force_rediscover: bool,
+        only_if_invalidated: bool,
+        removed_uris: Vec<Url>,
+    ) -> Option<usize> {
+        let invalidated;
+        let version;
+        {
+            let analysis_commit = self.analysis_commit.clone();
+            let _commit = analysis_commit.lock();
+            if only_if_invalidated && !self.analysis_cache_invalidated() {
+                return None;
+            }
+
+            invalidated = self.analysis_cache_invalidated.swap(false, Ordering::AcqRel);
+            version = self.analysis_version.fetch_add(1, Ordering::AcqRel) + 1;
+            let batches = self.diagnostics.write().clear_uris_and_publish_batches(removed_uris);
+            publish_diagnostic_batches(&mut self.client, batches);
+        }
+
+        if force_rediscover || invalidated {
+            self.rediscover_workspaces();
+        }
+        Some(version)
+    }
+
+    fn rediscover_workspaces(&mut self) {
+        let removed_owners = Arc::make_mut(&mut self.config).rediscover_workspaces();
+        self.clear_removed_flycheck_diagnostics(removed_owners);
     }
 
     /// Waits for analysis results at least as new as the latest version requested before this call.
@@ -198,10 +287,16 @@ impl GlobalState {
                 }
 
                 match result {
-                    Ok(diagnostics) => snapshot.publish_diagnostics(task_owner, diagnostics),
+                    Ok(diagnostics) => {
+                        snapshot.publish_flycheck_diagnostics(task_owner, version, diagnostics)
+                    }
                     Err(error) => {
                         tracing::warn!(%id, %error, "flycheck failed");
-                        snapshot.publish_diagnostics(task_owner, DiagnosticMap::default());
+                        snapshot.publish_flycheck_diagnostics(
+                            task_owner,
+                            version,
+                            DiagnosticMap::default(),
+                        );
                     }
                 }
             });
@@ -224,15 +319,11 @@ impl GlobalState {
         }
     }
 
-    pub(crate) fn clear_removed_file_diagnostics(
-        &mut self,
-        paths: impl IntoIterator<Item = PathBuf>,
-    ) {
-        let paths = paths.into_iter().collect::<Vec<_>>();
+    fn prepare_removed_file_diagnostics(&mut self, paths: Vec<PathBuf>) -> Vec<Url> {
         let uris =
             paths.iter().filter_map(|path| Url::from_file_path(path).ok()).collect::<Vec<_>>();
         if uris.is_empty() {
-            return;
+            return uris;
         }
 
         let mut owners = FxHashSet::default();
@@ -244,17 +335,13 @@ impl GlobalState {
         for owner in owners {
             self.begin_flycheck_epoch(&owner);
         }
-
-        let batches = {
-            let mut store = self.diagnostics.write();
-            store.clear_uris_and_publish_batches(uris)
-        };
-
-        publish_diagnostic_batches(&mut self.client, batches);
+        uris
     }
 
     fn begin_flycheck_epoch(&mut self, owner: &DiagnosticOwner) -> usize {
         let version = {
+            let analysis_commit = self.analysis_commit.clone();
+            let _commit = analysis_commit.lock();
             let mut versions = self.flycheck_versions.write();
             let version = versions.get(owner).copied().unwrap_or_default() + 1;
             versions.insert(owner.clone(), version);
@@ -277,6 +364,8 @@ impl GlobalState {
             config: self.config.clone(),
             analysis_version: self.analysis_version.clone(),
             published_analysis_version: self.published_analysis_version.clone(),
+            analysis_commit: self.analysis_commit.clone(),
+            analysis_cache_invalidated: self.analysis_cache_invalidated.clone(),
             flycheck_versions: self.flycheck_versions.clone(),
             symbol_tables: self.symbol_tables.clone(),
             diagnostics: self.diagnostics.clone(),
@@ -289,6 +378,15 @@ impl GlobalState {
     ) -> JoinHandle<T> {
         let snapshot = self.snapshot();
         tokio::task::spawn_blocking(move || f(snapshot))
+    }
+
+    fn monitor_analysis_task<T: Send + 'static>(&self, version: usize, task: JoinHandle<T>) {
+        let mut snapshot = self.snapshot();
+        tokio::spawn(async move {
+            if let Err(error) = task.await {
+                snapshot.handle_analysis_failure(version, error);
+            }
+        });
     }
 }
 
@@ -331,6 +429,8 @@ pub(crate) struct GlobalStateSnapshot {
     config: Arc<Config>,
     analysis_version: Arc<AtomicUsize>,
     published_analysis_version: watch::Sender<usize>,
+    analysis_commit: Arc<Mutex<()>>,
+    analysis_cache_invalidated: Arc<AtomicBool>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     symbol_tables: Arc<RwLock<SymbolTables>>,
     diagnostics: Arc<RwLock<DiagnosticStore>>,
@@ -404,17 +504,41 @@ impl GlobalStateSnapshot {
         batches
     }
 
-    fn publish_symbol_tables(&mut self, version: usize, symbol_tables: SymbolTables) -> bool {
-        // Serialize the version check, table swap, and notification so stale tasks cannot publish
-        // last.
-        let mut current_tables = self.symbol_tables.write();
+    fn publish_analysis(&mut self, version: usize, result: AnalysisResult) -> bool {
+        let analysis_commit = self.analysis_commit.clone();
+        let _commit = analysis_commit.lock();
         if !self.is_current(version) {
             return false;
         }
 
-        *current_tables = symbol_tables;
+        *self.symbol_tables.write() = result.symbol_tables;
+        let batches = self
+            .diagnostics
+            .write()
+            .replace_and_publish_batches(DiagnosticOwner::Compiler, result.diagnostics);
+        publish_diagnostic_batches(&mut self.client, batches);
         self.published_analysis_version.send_replace(version);
         true
+    }
+
+    #[cfg(test)]
+    fn publish_symbol_tables(&mut self, version: usize, symbol_tables: SymbolTables) -> bool {
+        self.publish_analysis(
+            version,
+            AnalysisResult { diagnostics: DiagnosticMap::default(), symbol_tables },
+        )
+    }
+
+    fn handle_analysis_failure(&mut self, version: usize, error: JoinError) {
+        let analysis_commit = self.analysis_commit.clone();
+        let _commit = analysis_commit.lock();
+        if !self.is_current(version) {
+            return;
+        }
+
+        tracing::warn!(%error, version, "analysis task failed");
+        self.analysis_cache_invalidated.store(true, Ordering::Release);
+        self.published_analysis_version.send_replace(version);
     }
 
     fn analysis_workspaces(&self) -> Cow<'_, [crate::workspace::Workspace]> {
@@ -427,11 +551,32 @@ impl GlobalStateSnapshot {
     }
 
     fn publish_diagnostics(&mut self, owner: DiagnosticOwner, diagnostics: DiagnosticMap) {
+        let analysis_commit = self.analysis_commit.clone();
+        let _commit = analysis_commit.lock();
         let batches = {
             let mut store = self.diagnostics.write();
             store.replace_and_publish_batches(owner, diagnostics)
         };
 
+        publish_diagnostic_batches(&mut self.client, batches);
+    }
+
+    fn publish_flycheck_diagnostics(
+        &mut self,
+        owner: DiagnosticOwner,
+        version: usize,
+        diagnostics: DiagnosticMap,
+    ) {
+        let analysis_commit = self.analysis_commit.clone();
+        let _commit = analysis_commit.lock();
+        if !self.is_current_flycheck(&owner, version) {
+            return;
+        }
+
+        let batches = {
+            let mut store = self.diagnostics.write();
+            store.replace_and_publish_batches(owner, diagnostics)
+        };
         publish_diagnostic_batches(&mut self.client, batches);
     }
 }

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -25,9 +25,12 @@ pub(crate) fn did_open_text_document(
             Some(Rope::from(params.text_document.text)),
             Some(params.text_document.version),
         );
-        if vfs.mark_clean() {
-            drop(vfs);
+        let changed = vfs.mark_clean();
+        drop(vfs);
+        if changed {
             state.recompute();
+        } else {
+            state.reindex_if_invalidated();
         }
     }
 
@@ -57,6 +60,8 @@ pub(crate) fn did_change_text_document(
         );
         if changed {
             state.recompute();
+        } else {
+            state.reindex_if_invalidated();
         }
     }
 
@@ -84,6 +89,7 @@ pub(crate) fn did_save_text_document(
     state: &mut GlobalState,
     params: DidSaveTextDocumentParams,
 ) -> NotifyResult {
+    state.reindex_if_invalidated();
     if let Ok(path) = params.text_document.uri.to_file_path() {
         state.run_flychecks_on_save(path);
     }
@@ -97,8 +103,7 @@ pub(crate) fn did_change_configuration(
 ) -> NotifyResult {
     // As stated in https://github.com/microsoft/language-server-protocol/issues/676,
     // this notification's parameters should be ignored and the actual config queried separately.
-    rediscover_workspaces(state);
-    state.recompute();
+    state.reindex();
     ControlFlow::Continue(())
 }
 
@@ -132,12 +137,8 @@ pub(crate) fn did_change_watched_files(
         }
     }
 
-    if should_rediscover {
-        rediscover_workspaces(state);
-    }
-    state.clear_removed_file_diagnostics(removed_paths);
     if should_rediscover || !disk_paths.is_empty() {
-        state.recompute_with_disk_files(disk_paths);
+        state.recompute_for_file_changes(disk_paths, removed_paths, should_rediscover);
     }
 
     ControlFlow::Continue(())
@@ -159,13 +160,7 @@ pub(crate) fn did_change_workspace_folders(
     let added = params.event.added.into_iter().filter_map(|it| it.uri.to_file_path().ok());
     config.add_workspaces(added);
 
-    rediscover_workspaces(state);
-    state.recompute();
+    state.reindex();
 
     ControlFlow::Continue(())
-}
-
-fn rediscover_workspaces(state: &mut GlobalState) {
-    let removed_owners = Arc::make_mut(&mut state.config).rediscover_workspaces();
-    state.clear_removed_flycheck_diagnostics(removed_owners);
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -210,7 +210,7 @@ mod tests {
 
         let error = router.call(request).await.unwrap_err();
 
-        assert_eq!(error.code, async_lsp::ErrorCode::METHOD_NOT_FOUND);
+        assert_eq!(error.code, async_lsp::ErrorCode::INVALID_PARAMS);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -18,6 +18,7 @@ use solar_config::LspArgs;
 use std::ops::ControlFlow;
 use tower::ServiceBuilder;
 
+mod commands;
 mod config;
 mod diagnostics;
 mod document_links;
@@ -60,6 +61,7 @@ fn new_router(client: ClientSocket) -> Router<GlobalState> {
 
     // Requests
     router
+        .request::<req::ExecuteCommand, _>(commands::execute_command)
         .request::<req::DocumentSymbolRequest, _>(handlers::document_symbol)
         .request::<req::DocumentLinkRequest, _>(handlers::document_links)
         .request::<req::WorkspaceSymbolRequest, _>(handlers::workspace_symbol)
@@ -129,11 +131,11 @@ mod tests {
     use lsp_types::{
         DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
         DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlightParams,
-        DocumentLinkParams, FileChangeType, FileEvent, FormattingOptions, HoverParams,
-        InitializeParams, InitializedParams, PartialResultParams, Position, SignatureHelpParams,
-        TextDocumentIdentifier, TextDocumentPositionParams, WorkDoneProgressParams,
-        WorkspaceClientCapabilities, notification as notif, notification::Notification, request,
-        request::Request,
+        DocumentLinkParams, ExecuteCommandParams, FileChangeType, FileEvent, FormattingOptions,
+        HoverParams, InitializeParams, InitializedParams, PartialResultParams, Position,
+        SignatureHelpParams, TextDocumentIdentifier, TextDocumentPositionParams,
+        WorkDoneProgressParams, WorkspaceClientCapabilities, notification as notif,
+        notification::Notification, request, request::Request,
     };
     use std::ops::ControlFlow;
     use tokio::sync::oneshot;
@@ -174,6 +176,41 @@ mod tests {
         .unwrap();
 
         assert!(matches!(router.notify(notification), ControlFlow::Continue(())));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_cache_commands() {
+        let mut router = new_router(ClientSocket::new_closed());
+
+        for command in ["solar.clearCache", "solar.reindex"] {
+            let params = ExecuteCommandParams { command: command.into(), ..Default::default() };
+            let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
+                "id": 1,
+                "method": request::ExecuteCommand::METHOD,
+                "params": params,
+            }))
+            .unwrap();
+
+            let response = router.call(request).await.unwrap();
+
+            assert_eq!(response, serde_json::json!({ "success": true }));
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_rejects_unknown_cache_command() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let params = ExecuteCommandParams { command: "solar.unknown".into(), ..Default::default() };
+        let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
+            "id": 1,
+            "method": request::ExecuteCommand::METHOD,
+            "params": params,
+        }))
+        .unwrap();
+
+        let error = router.call(request).await.unwrap_err();
+
+        assert_eq!(error.code, async_lsp::ErrorCode::METHOD_NOT_FOUND);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -5,11 +5,16 @@ use crate::{
     config::negotiate_capabilities,
     test_support::{MarkedProject, TestProject},
 };
-use async_lsp::ClientSocket;
+use async_lsp::{ClientSocket, router::Router};
 use lsp_types::{
-    DocumentSymbol, SymbolKind, WatchKind, WorkspaceSymbol, notification::Notification,
+    Diagnostic, DidChangeTextDocumentParams, DidSaveTextDocumentParams, DocumentSymbol, Position,
+    Range, SymbolKind, TextDocumentContentChangeEvent, TextDocumentIdentifier,
+    VersionedTextDocumentIdentifier, WatchKind, WorkspaceSymbol, notification,
+    notification::Notification,
 };
 use std::{path::Path, time::Duration};
+use tokio::sync::mpsc;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 mod completion;
 mod document_highlight;
@@ -24,6 +29,8 @@ mod signature_help;
 mod support;
 mod type_definition;
 
+const ASYNC_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
 fn snapshot(project: &TestProject) -> GlobalStateSnapshot {
     snapshot_with_config(project.config(), project.vfs())
 }
@@ -36,10 +43,357 @@ fn snapshot_with_config(config: Config, vfs: Vfs) -> GlobalStateSnapshot {
         config: Arc::new(config),
         analysis_version: Arc::new(AtomicUsize::new(1)),
         published_analysis_version,
+        analysis_commit: Arc::new(Default::default()),
+        analysis_cache_invalidated: Arc::new(AtomicBool::new(false)),
         flycheck_versions: Arc::new(Default::default()),
         symbol_tables: Arc::new(Default::default()),
         diagnostics: Arc::new(Default::default()),
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn clearing_analysis_cache_publishes_an_empty_current_snapshot() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Cached.sol
+        contract Cached {}
+        "#,
+    );
+    let mut batches = snapshot(&project).analysis_batches(Vec::new());
+    let old_tables = analyze(batches.pop().unwrap()).symbol_tables;
+    assert!(!old_tables.workspace_symbols("").is_empty());
+
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    *state.symbol_tables.write() = old_tables;
+    let uri = Url::from_file_path(project.path("/Cached.sol")).unwrap();
+    let owner = flycheck_owner(project.root());
+    let compiler_diagnostic = diagnostic("compiler");
+    let flycheck_diagnostic = diagnostic("flycheck");
+    let mut state_snapshot = state.snapshot();
+    state_snapshot.publish_diagnostics(
+        DiagnosticOwner::Compiler,
+        DiagnosticMap::from_iter([(uri.clone(), vec![compiler_diagnostic])]),
+    );
+    state_snapshot.publish_diagnostics(
+        owner,
+        DiagnosticMap::from_iter([(uri.clone(), vec![flycheck_diagnostic])]),
+    );
+
+    state.clear_analysis_cache();
+
+    let tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("cleared analysis should be published")
+        .unwrap();
+    assert!(tables.read().workspace_symbols("").is_empty());
+    assert!(state.analysis_cache_invalidated());
+
+    let probe_owner =
+        DiagnosticOwner::Flycheck { id: "probe".into(), workspace: project.root().into() };
+    let batches = state.diagnostics.write().replace_and_publish_batches(
+        probe_owner,
+        DiagnosticMap::from_iter([(uri, vec![diagnostic("probe")])]),
+    );
+    assert_eq!(batches.len(), 1);
+    let mut messages =
+        batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>();
+    messages.sort_unstable();
+    assert_eq!(messages, ["flycheck", "probe"]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn clearing_analysis_cache_publishes_compiler_diagnostic_removals() {
+    let (server_main, client_socket) = async_lsp::MainLoop::new_server(|_| Router::new(()));
+    let (notifications_tx, mut notifications_rx) = mpsc::unbounded_channel();
+    let (client_main, _server_socket) = async_lsp::MainLoop::new_client(move |_| {
+        let mut router = Router::new(notifications_tx);
+        router.notification::<notification::PublishDiagnostics>(|notifications, params| {
+            notifications.send(params).unwrap();
+            ControlFlow::Continue(())
+        });
+        router
+    });
+
+    let (server_stream, client_stream) = tokio::io::duplex(64 << 10);
+    let (server_rx, server_tx) = tokio::io::split(server_stream);
+    let server_task =
+        tokio::spawn(server_main.run_buffered(server_rx.compat(), server_tx.compat_write()));
+    let (client_rx, client_tx) = tokio::io::split(client_stream);
+    let client_task =
+        tokio::spawn(client_main.run_buffered(client_rx.compat(), client_tx.compat_write()));
+
+    let mut state = GlobalState::new(client_socket);
+    let compiler_only = Url::parse("file:///workspace/CompilerOnly.sol").unwrap();
+    let shared = Url::parse("file:///workspace/Shared.sol").unwrap();
+    let owner = flycheck_owner("/workspace");
+    let mut snapshot = state.snapshot();
+    snapshot.publish_diagnostics(
+        DiagnosticOwner::Compiler,
+        DiagnosticMap::from_iter([
+            (compiler_only.clone(), vec![diagnostic("compiler only")]),
+            (shared.clone(), vec![diagnostic("compiler shared")]),
+        ]),
+    );
+    snapshot.publish_diagnostics(
+        owner,
+        DiagnosticMap::from_iter([(shared.clone(), vec![diagnostic("flycheck")])]),
+    );
+    for _ in 0..3 {
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, notifications_rx.recv())
+            .await
+            .expect("seed diagnostics should be published")
+            .expect("diagnostic channel should stay open");
+    }
+
+    state.clear_analysis_cache();
+
+    let mut cleared = Vec::new();
+    for _ in 0..2 {
+        cleared.push(
+            tokio::time::timeout(ASYNC_TEST_TIMEOUT, notifications_rx.recv())
+                .await
+                .expect("cleared diagnostics should be published")
+                .expect("diagnostic channel should stay open"),
+        );
+    }
+    cleared.sort_by(|lhs, rhs| lhs.uri.as_str().cmp(rhs.uri.as_str()));
+    assert_eq!(cleared[0].uri, compiler_only);
+    assert!(cleared[0].diagnostics.is_empty());
+    assert_eq!(cleared[1].uri, shared);
+    assert_eq!(
+        cleared[1]
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>(),
+        ["flycheck"]
+    );
+
+    server_task.abort();
+    client_task.abort();
+    let _ = server_task.await;
+    let _ = client_task.await;
+}
+
+#[test]
+fn clearing_analysis_cache_rejects_older_analysis_results() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Stale.sol
+        contract Stale {}
+        "#,
+    );
+    let mut batches = snapshot(&project).analysis_batches(Vec::new());
+    let mut stale_result = analyze(batches.pop().unwrap());
+    let uri = Url::from_file_path(project.path("/Stale.sol")).unwrap();
+    stale_result.diagnostics.insert(uri.clone(), vec![diagnostic("stale compiler")]);
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.mark_analysis_pending_for_test();
+    let mut stale_snapshot = state.snapshot();
+
+    state.clear_analysis_cache();
+
+    assert!(!stale_snapshot.publish_analysis(1, stale_result));
+    assert!(state.symbol_tables.read().workspace_symbols("").is_empty());
+    let probe_owner =
+        DiagnosticOwner::Flycheck { id: "probe".into(), workspace: project.root().into() };
+    let batches = state.diagnostics.write().replace_and_publish_batches(
+        probe_owner,
+        DiagnosticMap::from_iter([(uri, vec![diagnostic("probe")])]),
+    );
+    assert_eq!(
+        batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>(),
+        ["probe"]
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_current_analysis_unblocks_waiters_and_invalidates_cache() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Old.sol
+        contract Old {}
+        "#,
+    );
+    let mut batches = snapshot(&project).analysis_batches(Vec::new());
+    let old_tables = analyze(batches.pop().unwrap()).symbol_tables;
+    let uri = Url::from_file_path(project.path("/Old.sol")).unwrap();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    *state.symbol_tables.write() = old_tables;
+    state.snapshot().publish_diagnostics(
+        DiagnosticOwner::Compiler,
+        DiagnosticMap::from_iter([(uri.clone(), vec![diagnostic("old compiler")])]),
+    );
+
+    let version = state.begin_analysis(false, false, Vec::new()).unwrap();
+    let task = tokio::spawn(async { panic!("test analysis failure") });
+    state.monitor_analysis_task(version, task);
+
+    let tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("failed analysis should release waiters")
+        .unwrap();
+    assert!(tables.read().workspace_symbols("Old").iter().any(|symbol| symbol.name == "Old"));
+    assert!(state.analysis_cache_invalidated());
+
+    let probe_owner =
+        DiagnosticOwner::Flycheck { id: "probe".into(), workspace: project.root().into() };
+    let batches = state.diagnostics.write().replace_and_publish_batches(
+        probe_owner,
+        DiagnosticMap::from_iter([(uri, vec![diagnostic("probe")])]),
+    );
+    let mut messages =
+        batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>();
+    messages.sort_unstable();
+    assert_eq!(messages, ["old compiler", "probe"]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelled_current_analysis_unblocks_waiters_and_invalidates_cache() {
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+
+    let version = state.begin_analysis(false, false, Vec::new()).unwrap();
+    let task = tokio::spawn(std::future::pending::<()>());
+    task.abort();
+    state.monitor_analysis_task(version, task);
+
+    let tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("cancelled analysis should release waiters")
+        .unwrap();
+    assert!(tables.read().workspace_symbols("").is_empty());
+    assert!(state.analysis_cache_invalidated());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reindex_rediscovers_disk_files_without_preclearing_the_old_index() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /src/Old.sol
+        contract Old {}
+        "#,
+    );
+    let config = project.config();
+    let mut batches = snapshot_with_config(config.clone(), Vfs::default()).analysis_batches(vec![]);
+    let old_tables = analyze(batches.pop().unwrap()).symbol_tables;
+    project.remove_file("/src/Old.sol");
+    project.write_file("/src/New.sol", "contract New {}");
+
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(config);
+    *state.symbol_tables.write() = old_tables;
+    let tables = state.symbol_tables.clone();
+    {
+        let current_tables = tables.write();
+
+        state.reindex();
+
+        assert!(current_tables.workspace_symbols("Old").iter().any(|symbol| symbol.name == "Old"));
+        assert!(current_tables.workspace_symbols("New").is_empty());
+    }
+
+    let new_tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("reindex should finish")
+        .unwrap();
+    let new_tables = new_tables.read();
+    assert!(new_tables.workspace_symbols("Old").is_empty());
+    assert!(new_tables.workspace_symbols("New").iter().any(|symbol| symbol.name == "New"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn save_after_clear_rediscovers_disk_files_and_preserves_vfs_overlays() {
+    let mut project = TestProject::from_fixture(
+        r#"
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /src/Open.sol
+        contract DiskVersion {}
+        "#,
+    );
+    project.open_file("/src/Open.sol", "contract Unsaved {}");
+    let config = project.config();
+    project.write_file("/src/New.sol", "contract New {}");
+
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(config);
+    state.vfs = Arc::new(RwLock::new(project.vfs()));
+    state.clear_analysis_cache();
+
+    let result = crate::handlers::did_save_text_document(
+        &mut state,
+        DidSaveTextDocumentParams {
+            text_document: TextDocumentIdentifier::new(
+                Url::from_file_path(project.path("/src/Open.sol")).unwrap(),
+            ),
+            text: None,
+        },
+    );
+    assert!(matches!(result, ControlFlow::Continue(())));
+
+    let tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("save should rebuild an invalidated cache")
+        .unwrap();
+    let tables = tables.read();
+    assert!(tables.workspace_symbols("DiskVersion").is_empty());
+    assert!(tables.workspace_symbols("Unsaved").iter().any(|symbol| symbol.name == "Unsaved"));
+    assert!(tables.workspace_symbols("New").iter().any(|symbol| symbol.name == "New"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn no_op_change_after_clear_recovers_the_invalidated_cache() {
+    let mut project = TestProject::from_fixture(
+        r#"
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /src/Open.sol
+        contract DiskVersion {}
+        "#,
+    );
+    project.open_file("/src/Open.sol", "contract Unsaved {}");
+    let config = project.config();
+    project.write_file("/src/New.sol", "contract New {}");
+    let uri = Url::from_file_path(project.path("/src/Open.sol")).unwrap();
+
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(config);
+    state.vfs = Arc::new(RwLock::new(project.vfs()));
+    state.clear_analysis_cache();
+
+    let result = crate::handlers::did_change_text_document(
+        &mut state,
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier::new(uri, 1),
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: Some(Range::new(Position::new(0, 0), Position::new(0, 0))),
+                range_length: Some(0),
+                text: String::new(),
+            }],
+        },
+    );
+    assert!(matches!(result, ControlFlow::Continue(())));
+
+    let tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("no-op change should rebuild an invalidated cache")
+        .unwrap();
+    let tables = tables.read();
+    assert!(tables.workspace_symbols("DiskVersion").is_empty());
+    assert!(tables.workspace_symbols("Unsaved").iter().any(|symbol| symbol.name == "Unsaved"));
+    assert!(tables.workspace_symbols("New").iter().any(|symbol| symbol.name == "New"));
+}
+
+fn diagnostic(message: &str) -> Diagnostic {
+    Diagnostic::new_simple(Range::new(Position::new(0, 0), Position::new(0, 1)), message.into())
 }
 
 fn flycheck_owner(workspace: impl Into<PathBuf>) -> DiagnosticOwner {
@@ -102,8 +456,8 @@ fn clearing_removed_flychecks_stales_removed_owner_results() {
     assert!(!snapshot.is_current_flycheck(&owner, 0));
 }
 
-#[test]
-fn clearing_removed_file_diagnostics_stales_matching_flycheck_owner_only() {
+#[tokio::test(flavor = "current_thread")]
+async fn recomputing_for_removed_files_stales_matching_flycheck_owner_only() {
     let project = TestProject::from_fixture(
         r#"
         //- /first/foundry.toml
@@ -125,17 +479,42 @@ fn clearing_removed_file_diagnostics_stales_matching_flycheck_owner_only() {
     config.rediscover_workspaces();
     let mut state = GlobalState::new(ClientSocket::new_closed());
     state.config = Arc::new(config);
-    let snapshot = state.snapshot();
+    let mut snapshot = state.snapshot();
     let first_owner = flycheck_owner(project.path("/first"));
     let second_owner = flycheck_owner(project.path("/second"));
 
     assert!(snapshot.is_current_flycheck(&first_owner, 0));
     assert!(snapshot.is_current_flycheck(&second_owner, 0));
 
-    state.clear_removed_file_diagnostics([project.path("/first/src/Deleted.sol")]);
+    let deleted_path = project.path("/first/src/Deleted.sol");
+    state.recompute_for_file_changes(vec![deleted_path.clone()], vec![deleted_path.clone()], false);
 
     assert!(!snapshot.is_current_flycheck(&first_owner, 0));
     assert!(snapshot.is_current_flycheck(&second_owner, 0));
+
+    let uri = Url::from_file_path(deleted_path).unwrap();
+    snapshot.publish_flycheck_diagnostics(
+        first_owner,
+        0,
+        DiagnosticMap::from_iter([(uri.clone(), vec![diagnostic("stale")])]),
+    );
+    snapshot.publish_flycheck_diagnostics(
+        second_owner.clone(),
+        0,
+        DiagnosticMap::from_iter([(uri.clone(), vec![diagnostic("current")])]),
+    );
+    let batches = state.diagnostics.write().replace_and_publish_batches(
+        second_owner,
+        DiagnosticMap::from_iter([(uri, vec![diagnostic("current")])]),
+    );
+    assert_eq!(
+        batches[0].1.iter().map(|diagnostic| diagnostic.message.as_str()).collect::<Vec<_>>(),
+        ["current"]
+    );
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("file-change analysis should finish")
+        .unwrap();
 }
 
 #[test]

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -44,7 +44,6 @@ fn snapshot_with_config(config: Config, vfs: Vfs) -> GlobalStateSnapshot {
         analysis_version: Arc::new(AtomicUsize::new(1)),
         published_analysis_version,
         analysis_commit: Arc::new(Default::default()),
-        analysis_cache_invalidated: Arc::new(AtomicBool::new(false)),
         flycheck_versions: Arc::new(Default::default()),
         symbol_tables: Arc::new(Default::default()),
         diagnostics: Arc::new(Default::default()),
@@ -207,6 +206,17 @@ fn clearing_analysis_cache_rejects_older_analysis_results() {
     );
 }
 
+#[test]
+fn reindex_if_invalidated_is_a_no_op_for_a_current_cache() {
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    let version = state.analysis_version.load(Ordering::Acquire);
+
+    state.reindex_if_invalidated();
+
+    assert_eq!(state.analysis_version.load(Ordering::Acquire), version);
+    assert!(!state.analysis_cache_invalidated());
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn failed_current_analysis_unblocks_waiters_and_invalidates_cache() {
     let project = TestProject::from_fixture(
@@ -225,7 +235,7 @@ async fn failed_current_analysis_unblocks_waiters_and_invalidates_cache() {
         DiagnosticMap::from_iter([(uri.clone(), vec![diagnostic("old compiler")])]),
     );
 
-    let version = state.begin_analysis(false, false, Vec::new()).unwrap();
+    let version = state.begin_analysis(AnalysisMode::Recompute, Vec::new()).unwrap();
     let task = tokio::spawn(async { panic!("test analysis failure") });
     state.monitor_analysis_task(version, task);
 
@@ -252,7 +262,7 @@ async fn failed_current_analysis_unblocks_waiters_and_invalidates_cache() {
 async fn cancelled_current_analysis_unblocks_waiters_and_invalidates_cache() {
     let mut state = GlobalState::new(ClientSocket::new_closed());
 
-    let version = state.begin_analysis(false, false, Vec::new()).unwrap();
+    let version = state.begin_analysis(AnalysisMode::Recompute, Vec::new()).unwrap();
     let task = tokio::spawn(std::future::pending::<()>());
     task.abort();
     state.monitor_analysis_task(version, task);

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -136,6 +136,16 @@
         "command": "solarLsp.formatDocument",
         "title": "Format Document",
         "category": "Solar"
+      },
+      {
+        "command": "solar.clearCache",
+        "title": "Clear Analysis Cache",
+        "category": "Solar"
+      },
+      {
+        "command": "solar.reindex",
+        "title": "Reindex Workspace",
+        "category": "Solar"
       }
     ]
   },


### PR DESCRIPTION
Towards OSS-519 

This adds solar.clearCache and solar.reindex as LSP commands and exposes them through the VS Code command palette. 

Clearing the cache removes compiler-owned diagnostics and symbol tables while preserving independent flycheck results. Reindexing rediscovers workspace configuration and source files before rebuilding the analysis state.

