### PR TITLE
feat(codegen): print pass diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *.evmir linguist-language=Assembly
 /tests/ui/codegen/mir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
 /tests/ui/codegen/evm-ir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
+/tests/ui/codegen/evm-ir/none/**/*.stdout linguist-language=Assembly whitespace=-trailing-space
 /testdata/* linguist-vendored
 /testdata/**/* linguist-vendored
 /tests/foundry/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,9 @@
 *.mir linguist-language=Rust
 *.evmir linguist-language=Assembly
 /tests/ui/codegen/mir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
+/tests/ui/codegen/mir/pipeline/**/*.stdout linguist-language=Rust whitespace=trailing-space
+/tests/ui/codegen/mir/pipeline/pipeline.stdout linguist-language=Diff whitespace=-trailing-space
 /tests/ui/codegen/evm-ir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
-/tests/ui/codegen/evm-ir/none/**/*.stdout linguist-language=Assembly whitespace=-trailing-space
 /testdata/* linguist-vendored
 /testdata/**/* linguist-vendored
 /tests/foundry/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,15 @@
 * text=auto eol=lf
+
 *.sol linguist-language=Solidity
 *.yul linguist-language=Yul
 *.mir linguist-language=Rust
 *.evmir linguist-language=Assembly
+
 /tests/ui/codegen/mir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
 /tests/ui/codegen/mir/pipeline/**/*.stdout linguist-language=Rust whitespace=trailing-space
 /tests/ui/codegen/mir/pipeline/pipeline.stdout linguist-language=Diff whitespace=-trailing-space
 /tests/ui/codegen/evm-ir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
+
 /testdata/* linguist-vendored
 /testdata/**/* linguist-vendored
 /tests/foundry/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 * text=auto eol=lf
 *.sol linguist-language=Solidity
 *.yul linguist-language=Yul
+*.mir linguist-language=Rust
+*.evmir linguist-language=Assembly
+/tests/ui/codegen/mir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
+/tests/ui/codegen/evm-ir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
 /testdata/* linguist-vendored
 /testdata/**/* linguist-vendored
 /tests/foundry/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,8 +6,6 @@
 *.evmir linguist-language=Assembly
 
 /tests/ui/codegen/mir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
-/tests/ui/codegen/mir/pipeline/**/*.stdout linguist-language=Rust whitespace=trailing-space
-/tests/ui/codegen/mir/pipeline/pipeline.stdout linguist-language=Diff whitespace=-trailing-space
 /tests/ui/codegen/evm-ir/**/*.stdout linguist-language=Diff whitespace=-trailing-space
 
 /testdata/* linguist-vendored

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,15 +1,13 @@
 {
   "file_types": {
     "Rust": [
-      "mir",
-      "**/tests/ui/codegen/mir/pipeline/{check_elim_pipeline_*,fresh_array_bounds_pipeline,pipeline_*,pre_pingpong_pipeline}.stdout"
+      "mir"
     ],
     "Assembly": [
       "evmir"
     ],
     "Diff": [
-      "**/tests/ui/codegen/mir/{adce,cfg-simplify,check-elim,cse,dce,frame-slot-promotion,gvn,indvar-simplify,inline,inst-simplify,jump-threading,licm,load-pre,loop-canonicalize,lower-mapping-slots,lowering,memory-dse,none,outline-reverts,pre,pure-eval,sccp,storage-dse,storage-load-cse,storage-promotion,validation}/**/*.stdout",
-      "**/tests/ui/codegen/mir/pipeline/pipeline.stdout",
+      "**/tests/ui/codegen/mir/**/*.stdout",
       "**/tests/ui/codegen/evm-ir/**/*.stdout"
     ]
   },

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,18 @@
 {
+  "file_types": {
+    "Rust": [
+      "mir",
+      "**/tests/ui/codegen/mir/pipeline/{check_elim_pipeline_*,fresh_array_bounds_pipeline,pipeline_*,pre_pingpong_pipeline}.stdout"
+    ],
+    "Assembly": [
+      "evmir"
+    ],
+    "Diff": [
+      "**/tests/ui/codegen/mir/{adce,cfg-simplify,check-elim,cse,dce,frame-slot-promotion,gvn,indvar-simplify,inline,inst-simplify,jump-threading,licm,load-pre,loop-canonicalize,lower-mapping-slots,lowering,memory-dse,none,outline-reverts,pre,pure-eval,sccp,storage-dse,storage-load-cse,storage-promotion,validation}/**/*.stdout",
+      "**/tests/ui/codegen/mir/pipeline/pipeline.stdout",
+      "**/tests/ui/codegen/evm-ir/**/*.stdout"
+    ]
+  },
   "lsp": {
     "rust-analyzer": {
       "initialization_options": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3509,7 @@ name = "solar-data-structures"
 version = "0.2.0"
 dependencies = [
  "bumpalo",
+ "diff",
  "indexmap 2.14.0",
  "oxc_index",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ criterion = { package = "codspeed-criterion-compat", version = "4", default-feat
     "cargo_bench_support",
 ] }
 regex = "1.10"
+diff = "0.1"
 snapbox = { version = "1.2", features = ["json"] }
 tempfile = "3.9"
 

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -21,10 +21,9 @@ pub(crate) struct EvmOptArgs {
         visible_alias = "pass",
         value_name = "NAMES",
         value_delimiter = ',',
-        value_parser = parse_pass,
-        default_value = "none"
+        value_parser = parse_pass
     )]
-    passes: Vec<Option<&'static ir::PassInfo>>,
+    passes: Option<Vec<Option<&'static ir::PassInfo>>>,
     /// If true, print an EVM IR diff for every pass; otherwise only for the full pipeline.
     #[arg(long)]
     print_after_each: bool,
@@ -65,20 +64,33 @@ fn selected_pass_list_label(passes: &[Option<&ir::PassInfo>], separator: &str) -
     passes.iter().copied().map(pass_label).collect::<Vec<_>>().join(separator)
 }
 
+/// Prints a module with a header indicating which pass(es) produced it.
+fn print_module(module: &ir::Module, name: &str, after: &str) {
+    println!("// === {name} (after {after}) ===");
+    print!("{}", module.to_text());
+}
+
 fn run_pipeline(sess: &Session, module: &mut ir::Module, name: &str, args: &EvmOptArgs) {
     let dcx = &sess.dcx;
+    let Some(passes) = &args.passes else {
+        ir::validate(dcx, module);
+        if dcx.has_errors().is_ok() {
+            print_module(module, name, "none");
+        }
+        return;
+    };
     let options = ir::PassOptions {
         time_passes: sess.opts.unstable.time_passes,
         evm_version: sess.opts.evm_version,
         optimization: sess.opts.optimization,
     };
-    let pipeline_label = selected_pass_list_label(&args.passes, ",");
+    let pipeline_label = selected_pass_list_label(passes, ",");
     let mut before = module.to_text().to_string();
-    for (index, &pass) in args.passes.iter().enumerate() {
+    for (index, &pass) in passes.iter().enumerate() {
         if let Some(pass) = pass {
             ir::run_pass(module, pass, options);
         }
-        if args.print_after_each || index + 1 == args.passes.len() {
+        if args.print_after_each || index + 1 == passes.len() {
             ir::validate(dcx, module);
             if dcx.has_errors().is_err() {
                 break;

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -1,9 +1,11 @@
-//! The `solar evm-opt` subcommand — run EVM backend IR passes and print the
-//! resulting EVM IR.
+//! The `solar evm-opt` subcommand — run EVM backend IR passes and print a diff
+//! of the EVM IR before and after the passes.
 //!
 //! This is the backend-IR equivalent of `solar mir-opt`. It currently accepts
-//! EVM IR files (`.evmir`) and prints the canonical parser/printer output.
+//! EVM IR files (`.evmir`) and prints a line-oriented diff of the canonical
+//! parser/printer output.
 
+use super::print_pass_diff;
 use clap::ValueHint;
 use solar_codegen::backend::evm::ir;
 use solar_config::CompileOpts;
@@ -23,7 +25,7 @@ pub(crate) struct EvmOptArgs {
         default_value = "none"
     )]
     passes: Vec<Option<&'static ir::PassInfo>>,
-    /// If true, print EVM IR after every pass; otherwise only after the last.
+    /// If true, print an EVM IR diff for every pass; otherwise only for the full pipeline.
     #[arg(long)]
     print_after_each: bool,
     /// Path to input file. Extension determines whether it's .evmir.
@@ -63,12 +65,6 @@ fn selected_pass_list_label(passes: &[Option<&ir::PassInfo>], separator: &str) -
     passes.iter().copied().map(pass_label).collect::<Vec<_>>().join(separator)
 }
 
-/// Prints a module with a header indicating which pass(es) produced it.
-fn print_module(module: &ir::Module, name: &str, after: &str) {
-    println!("// === {name} (after {after}) ===");
-    print!("{}", module.to_text());
-}
-
 fn run_pipeline(sess: &Session, module: &mut ir::Module, name: &str, args: &EvmOptArgs) {
     let dcx = &sess.dcx;
     let options = ir::PassOptions {
@@ -77,6 +73,7 @@ fn run_pipeline(sess: &Session, module: &mut ir::Module, name: &str, args: &EvmO
         optimization: sess.opts.optimization,
     };
     let pipeline_label = selected_pass_list_label(&args.passes, ",");
+    let mut before = module.to_text().to_string();
     for (index, &pass) in args.passes.iter().enumerate() {
         if let Some(pass) = pass {
             ir::run_pass(module, pass, options);
@@ -86,9 +83,16 @@ fn run_pipeline(sess: &Session, module: &mut ir::Module, name: &str, args: &EvmO
             if dcx.has_errors().is_err() {
                 break;
             }
-            let label = if args.print_after_each { pass_label(pass) } else { &pipeline_label };
-            print_module(module, name, label);
+            if args.print_after_each {
+                let after = module.to_text().to_string();
+                print_pass_diff(name, pass_label(pass), &before, &after);
+                before = after;
+            }
         }
+    }
+    if !args.print_after_each && dcx.has_errors().is_ok() {
+        let after = module.to_text().to_string();
+        print_pass_diff(name, &pipeline_label, &before, &after);
     }
 }
 

--- a/crates/cli/src/commands/evm_opt.rs
+++ b/crates/cli/src/commands/evm_opt.rs
@@ -1,9 +1,10 @@
-//! The `solar evm-opt` subcommand — run EVM backend IR passes and print a diff
-//! of the EVM IR before and after the passes.
+//! The `solar evm-opt` subcommand — run EVM backend IR passes and print the
+//! resulting EVM IR.
 //!
 //! This is the backend-IR equivalent of `solar mir-opt`. It currently accepts
-//! EVM IR files (`.evmir`) and prints a line-oriented diff of the canonical
-//! parser/printer output.
+//! EVM IR files (`.evmir`) and prints the canonical parser/printer output. With
+//! `-Zpass-diff`, it instead prints a line-oriented before-and-after diff for
+//! each pass.
 
 use super::print_pass_diff;
 use clap::ValueHint;
@@ -21,10 +22,11 @@ pub(crate) struct EvmOptArgs {
         visible_alias = "pass",
         value_name = "NAMES",
         value_delimiter = ',',
-        value_parser = parse_pass
+        value_parser = parse_pass,
+        default_value = "none"
     )]
-    passes: Option<Vec<Option<&'static ir::PassInfo>>>,
-    /// If true, print an EVM IR diff for every pass; otherwise only for the full pipeline.
+    passes: Vec<Option<&'static ir::PassInfo>>,
+    /// If true, print EVM IR after every pass; otherwise only after the last.
     #[arg(long)]
     print_after_each: bool,
     /// Path to input file. Extension determines whether it's .evmir.
@@ -72,39 +74,30 @@ fn print_module(module: &ir::Module, name: &str, after: &str) {
 
 fn run_pipeline(sess: &Session, module: &mut ir::Module, name: &str, args: &EvmOptArgs) {
     let dcx = &sess.dcx;
-    let Some(passes) = &args.passes else {
-        ir::validate(dcx, module);
-        if dcx.has_errors().is_ok() {
-            print_module(module, name, "none");
-        }
-        return;
-    };
     let options = ir::PassOptions {
         time_passes: sess.opts.unstable.time_passes,
         evm_version: sess.opts.evm_version,
         optimization: sess.opts.optimization,
     };
-    let pipeline_label = selected_pass_list_label(passes, ",");
-    let mut before = module.to_text().to_string();
-    for (index, &pass) in passes.iter().enumerate() {
+    let pipeline_label = selected_pass_list_label(&args.passes, ",");
+    for (index, &pass) in args.passes.iter().enumerate() {
+        let before = sess.opts.unstable.pass_diff.then(|| module.to_text().to_string());
         if let Some(pass) = pass {
             ir::run_pass(module, pass, options);
         }
-        if args.print_after_each || index + 1 == passes.len() {
+        if before.is_some() || args.print_after_each || index + 1 == args.passes.len() {
             ir::validate(dcx, module);
             if dcx.has_errors().is_err() {
                 break;
             }
-            if args.print_after_each {
+            if let Some(before) = before {
                 let after = module.to_text().to_string();
                 print_pass_diff(name, pass_label(pass), &before, &after);
-                before = after;
+            } else {
+                let label = if args.print_after_each { pass_label(pass) } else { &pipeline_label };
+                print_module(module, name, label);
             }
         }
-    }
-    if !args.print_after_each && dcx.has_errors().is_ok() {
-        let after = module.to_text().to_string();
-        print_pass_diff(name, &pipeline_label, &before, &after);
     }
 }
 

--- a/crates/cli/src/commands/mir_opt.rs
+++ b/crates/cli/src/commands/mir_opt.rs
@@ -1,10 +1,11 @@
 //! The `solar mir-opt` subcommand — run one or more MIR transformation passes
-//! and print a diff of the MIR before and after the passes.
+//! and print the resulting MIR.
 //!
 //! This is the Solar equivalent of LLVM's `opt`. It accepts either a Solidity
 //! file (`.sol`) — which is parsed, lowered to MIR, and then transformed — or a
 //! textual MIR file (`.mir`) — which is parsed directly. After running the
-//! requested pass pipeline, it prints the line-oriented MIR diff.
+//! requested pass pipeline, it prints the resulting MIR. With `-Zpass-diff`,
+//! it instead prints a line-oriented before-and-after diff for each pass.
 //!
 //! It is an unstable, internal tool used by the `Mir` test mode; it is not part
 //! of the stable CLI surface.
@@ -79,7 +80,7 @@ pub(crate) struct MirOptArgs {
         conflicts_with = "pipeline_default"
     )]
     passes: Option<Vec<Option<&'static PassInfo>>>,
-    /// If true, print MIR output for every pass; otherwise only for the full pipeline.
+    /// If true, print MIR after every pass; otherwise only after the last.
     #[arg(long)]
     print_after_each: bool,
     /// Run the same pass pipeline as EvmCodegen::run_optimization_passes.
@@ -124,16 +125,20 @@ fn selected_pass_list_label(passes: &[Option<&PassInfo>], separator: &str) -> St
 
 /// Runs the pass pipeline on a single module and emits output.
 /// Used for both .sol contracts and .mir input.
-fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs, time_passes: bool) {
+fn run_pipeline(
+    module: &mut Module,
+    name: &str,
+    args: &MirOptArgs,
+    pass_diff: bool,
+    time_passes: bool,
+) {
     if args.pipeline_default {
-        let before = module.to_text().to_string();
         let mut options = PipelineOptions::default();
         options.print_after_each = args.print_after_each;
         options.time_passes = time_passes;
         run_default_pipeline(module, options);
         if !args.print_after_each {
-            let after = module.to_text().to_string();
-            print_pass_diff(name, "pipeline-default", &before, &after);
+            print_module(module, name, "pipeline-default");
         }
         return;
     }
@@ -142,21 +147,25 @@ fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs, time_passes:
     let mut options = PipelineOptions::default();
     options.time_passes = time_passes;
     let pipeline_label = args.pipeline_label(&passes);
-    let mut before = module.to_text().to_string();
-    for &pass in &passes {
+    for (index, &pass) in passes.iter().enumerate() {
+        let before = pass_diff.then(|| module.to_text().to_string());
         if let Some(pass) = pass {
             run_pass(module, pass, options);
         }
-        if args.print_after_each {
+        if let Some(before) = before {
             let after = module.to_text().to_string();
             print_pass_diff(name, pass_label(pass), &before, &after);
-            before = after;
+        } else if args.print_after_each || index + 1 == passes.len() {
+            let label = if args.print_after_each { pass_label(pass) } else { &pipeline_label };
+            print_module(module, name, label);
         }
     }
-    if !args.print_after_each {
-        let after = module.to_text().to_string();
-        print_pass_diff(name, &pipeline_label, &before, &after);
-    }
+}
+
+/// Prints a module with a header indicating which pass(es) produced it.
+fn print_module(module: &Module, name: &str, after: &str) {
+    println!("// === {name} (after {after}) ===");
+    print!("{}", module.to_text());
 }
 
 /// Process a `.mir` input: read file, parse, run passes, print.
@@ -170,7 +179,13 @@ fn process_mir(sess: &Session, args: &MirOptArgs) -> solar_interface::Result {
     // diagnostic instead of tripping the post-pass validator ICE.
     validate(&sess.dcx, &module);
     if sess.dcx.has_errors().is_ok() {
-        run_pipeline(&mut module, &args.input, args, sess.opts.unstable.time_passes);
+        run_pipeline(
+            &mut module,
+            &args.input,
+            args,
+            sess.opts.unstable.pass_diff,
+            sess.opts.unstable.time_passes,
+        );
     }
     Ok(())
 }
@@ -194,7 +209,13 @@ fn process_sol(compiler: &mut CompilerRef<'_>, args: &MirOptArgs) -> solar_inter
         }
         let mut module = lower::lower_contract(gcx, id);
         let name = gcx.contract_fully_qualified_name(id).to_string();
-        run_pipeline(&mut module, &name, args, gcx.sess.opts.unstable.time_passes);
+        run_pipeline(
+            &mut module,
+            &name,
+            args,
+            gcx.sess.opts.unstable.pass_diff,
+            gcx.sess.opts.unstable.time_passes,
+        );
     }
     Ok(())
 }

--- a/crates/cli/src/commands/mir_opt.rs
+++ b/crates/cli/src/commands/mir_opt.rs
@@ -1,14 +1,15 @@
 //! The `solar mir-opt` subcommand — run one or more MIR transformation passes
-//! and print the resulting MIR.
+//! and print a diff of the MIR before and after the passes.
 //!
 //! This is the Solar equivalent of LLVM's `opt`. It accepts either a Solidity
 //! file (`.sol`) — which is parsed, lowered to MIR, and then transformed — or a
 //! textual MIR file (`.mir`) — which is parsed directly. After running the
-//! requested pass pipeline, it prints the resulting MIR.
+//! requested pass pipeline, it prints the line-oriented MIR diff.
 //!
 //! It is an unstable, internal tool used by the `Mir` test mode; it is not part
 //! of the stable CLI surface.
 
+use super::print_pass_diff;
 use clap::ValueHint;
 use solar_codegen::{
     lower,
@@ -78,7 +79,7 @@ pub(crate) struct MirOptArgs {
         conflicts_with = "pipeline_default"
     )]
     passes: Option<Vec<Option<&'static PassInfo>>>,
-    /// If true, print MIR after every pass; otherwise only after the last.
+    /// If true, print a MIR diff for every pass; otherwise only for the full pipeline.
     #[arg(long)]
     print_after_each: bool,
     /// Run the same pass pipeline as EvmCodegen::run_optimization_passes.
@@ -121,22 +122,18 @@ fn selected_pass_list_label(passes: &[Option<&PassInfo>], separator: &str) -> St
     passes.iter().copied().map(pass_label).format(separator).to_string()
 }
 
-/// Prints a module with a header indicating which pass(es) produced it.
-fn print_module(module: &Module, name: &str, after: &str) {
-    println!("// === {name} (after {after}) ===");
-    print!("{}", module.to_text());
-}
-
 /// Runs the pass pipeline on a single module and emits output.
 /// Used for both .sol contracts and .mir input.
 fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs, time_passes: bool) {
     if args.pipeline_default {
+        let before = module.to_text().to_string();
         let mut options = PipelineOptions::default();
         options.print_after_each = args.print_after_each;
         options.time_passes = time_passes;
         run_default_pipeline(module, options);
         if !args.print_after_each {
-            print_module(module, name, "pipeline-default");
+            let after = module.to_text().to_string();
+            print_pass_diff(name, "pipeline-default", &before, &after);
         }
         return;
     }
@@ -145,14 +142,20 @@ fn run_pipeline(module: &mut Module, name: &str, args: &MirOptArgs, time_passes:
     let mut options = PipelineOptions::default();
     options.time_passes = time_passes;
     let pipeline_label = args.pipeline_label(&passes);
-    for (index, &pass) in passes.iter().enumerate() {
+    let mut before = module.to_text().to_string();
+    for &pass in &passes {
         if let Some(pass) = pass {
             run_pass(module, pass, options);
         }
-        if args.print_after_each || index + 1 == passes.len() {
-            let label = if args.print_after_each { pass_label(pass) } else { &pipeline_label };
-            print_module(module, name, label);
+        if args.print_after_each {
+            let after = module.to_text().to_string();
+            print_pass_diff(name, pass_label(pass), &before, &after);
+            before = after;
         }
+    }
+    if !args.print_after_each {
+        let after = module.to_text().to_string();
+        print_pass_diff(name, &pipeline_label, &before, &after);
     }
 }
 

--- a/crates/cli/src/commands/mir_opt.rs
+++ b/crates/cli/src/commands/mir_opt.rs
@@ -79,7 +79,7 @@ pub(crate) struct MirOptArgs {
         conflicts_with = "pipeline_default"
     )]
     passes: Option<Vec<Option<&'static PassInfo>>>,
-    /// If true, print a MIR diff for every pass; otherwise only for the full pipeline.
+    /// If true, print MIR output for every pass; otherwise only for the full pipeline.
     #[arg(long)]
     print_after_each: bool,
     /// Run the same pass pipeline as EvmCodegen::run_optimization_passes.

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command runners.
 
 use crate::args::{Args, Subcommands};
+use solar_data_structures::fmt::line_diff;
 use std::process::ExitCode;
 
 pub mod compile;
@@ -8,6 +9,12 @@ pub(crate) mod evm_opt;
 #[cfg(feature = "lsp")]
 mod lsp;
 pub(crate) mod mir_opt;
+
+fn print_pass_diff(name: &str, pass: &str, before: &str, after: &str) {
+    let before = format!("// === {name} (before {pass}) ===\n{before}");
+    let after = format!("// === {name} (after {pass}) ===\n{after}");
+    print!("{}", line_diff(&before, &after));
+}
 
 pub(crate) fn run(args: Args) -> ExitCode {
     let Args { commands, compile } = args;

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -65,7 +65,7 @@ pub struct EvmCodegenConfig {
     pub(crate) evm_version: EvmVersion,
     /// Optimization mode for MIR and EVM IR passes.
     pub(crate) optimization: OptimizationMode,
-    /// Print MIR after each pass before bytecode generation.
+    /// Print a MIR diff for each pass before bytecode generation.
     pub(crate) mir_print_after_each: bool,
     /// Print the time spent in each MIR and EVM IR pass.
     pub(crate) time_passes: bool,
@@ -645,7 +645,7 @@ pub struct EvmCodegen {
     emitting_dispatch_entry: bool,
     /// Optimization mode for MIR and EVM IR passes.
     optimization: OptimizationMode,
-    /// Print MIR after each pass before bytecode generation.
+    /// Print a MIR diff for each pass before bytecode generation.
     mir_print_after_each: bool,
     time_passes: bool,
     mir_dispatch: bool,

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -65,7 +65,7 @@ pub struct EvmCodegenConfig {
     pub(crate) evm_version: EvmVersion,
     /// Optimization mode for MIR and EVM IR passes.
     pub(crate) optimization: OptimizationMode,
-    /// Print a MIR diff for each pass before bytecode generation.
+    /// Print MIR after each pass before bytecode generation.
     pub(crate) mir_print_after_each: bool,
     /// Print the time spent in each MIR and EVM IR pass.
     pub(crate) time_passes: bool,
@@ -645,7 +645,7 @@ pub struct EvmCodegen {
     emitting_dispatch_entry: bool,
     /// Optimization mode for MIR and EVM IR passes.
     optimization: OptimizationMode,
-    /// Print a MIR diff for each pass before bytecode generation.
+    /// Print MIR after each pass before bytecode generation.
     mir_print_after_each: bool,
     time_passes: bool,
     mir_dispatch: bool,

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -288,7 +288,7 @@ const DEFAULT_CLEANUP_MAX_ROUNDS: usize = 3;
 /// Options for running a MIR pass pipeline.
 #[derive(Clone, Copy, Debug)]
 pub struct PipelineOptions {
-    /// Print a diff of the module before and after every pass in the pipeline.
+    /// Print the full module after every pass in the pipeline.
     pub print_after_each: bool,
     /// Print the time spent in each pass.
     pub time_passes: bool,
@@ -314,22 +314,9 @@ impl Default for PipelineOptions {
     fields(module = %module.name, pass = pass.name),
 )]
 pub fn run_pass(module: &mut Module, pass: &PassInfo, options: PipelineOptions) -> bool {
-    run_pass_with_label(module, pass, options, pass.name)
-}
-
-fn run_pass_with_label(
-    module: &mut Module,
-    pass: &PassInfo,
-    options: PipelineOptions,
-    label: &str,
-) -> bool {
-    let before = options.print_after_each.then(|| module.to_text().to_string());
     // Passes declare which phases they operate on; the manager enforces it so a
     // pipeline entry cannot silently corrupt a module in the wrong phase.
     if !pass.admits(module) {
-        if let Some(before) = before {
-            print_pass_diff(module, label, &before);
-        }
         return false;
     }
     if options.validate_after_each {
@@ -341,24 +328,18 @@ fn run_pass_with_label(
     if options.validate_after_each {
         validate_module_after_pass(module, pass.name);
     }
-    if let Some(before) = before {
-        print_pass_diff(module, label, &before);
-    }
     changed
-}
-
-fn print_pass_diff(module: &Module, pass: &str, before: &str) {
-    let after = module.to_text().to_string();
-    let before = format!("// === {} (before {pass}) ===\n{before}", module.name);
-    let after = format!("// === {} (after {pass}) ===\n{after}", module.name);
-    print!("{}", solar_data_structures::fmt::line_diff(&before, &after));
 }
 
 /// Runs a named MIR pass pipeline over a module.
 fn run_pipeline(module: &mut Module, passes: &[PassInfo], options: PipelineOptions) -> bool {
     let mut changed = false;
     for pass in passes {
-        changed |= run_pass_with_label(module, pass, options, pass.name);
+        changed |= run_pass(module, pass, options);
+        if options.print_after_each {
+            println!("// === {} (after {}) ===", module.name, pass.name);
+            print!("{}", module.to_text());
+        }
     }
     changed
 }
@@ -392,9 +373,12 @@ fn run_cleanup_pipeline_to_fixpoint(
     for round in 1..=DEFAULT_CLEANUP_MAX_ROUNDS {
         let mut round_changed = false;
         for pass in passes {
-            let pass_label = format!("{label}-{round}:{}", pass.name);
-            let pass_changed = run_pass_with_label(module, pass, options, &pass_label);
+            let pass_changed = run_pass(module, pass, options);
             round_changed |= pass_changed;
+            if options.print_after_each {
+                println!("// === {} (after {label}-{round}:{}) ===", module.name, pass.name);
+                print!("{}", module.to_text());
+            }
         }
         if !round_changed {
             break;

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -288,7 +288,7 @@ const DEFAULT_CLEANUP_MAX_ROUNDS: usize = 3;
 /// Options for running a MIR pass pipeline.
 #[derive(Clone, Copy, Debug)]
 pub struct PipelineOptions {
-    /// Print the full module after every pass in the pipeline.
+    /// Print a diff of the module before and after every pass in the pipeline.
     pub print_after_each: bool,
     /// Print the time spent in each pass.
     pub time_passes: bool,
@@ -314,9 +314,22 @@ impl Default for PipelineOptions {
     fields(module = %module.name, pass = pass.name),
 )]
 pub fn run_pass(module: &mut Module, pass: &PassInfo, options: PipelineOptions) -> bool {
+    run_pass_with_label(module, pass, options, pass.name)
+}
+
+fn run_pass_with_label(
+    module: &mut Module,
+    pass: &PassInfo,
+    options: PipelineOptions,
+    label: &str,
+) -> bool {
+    let before = options.print_after_each.then(|| module.to_text().to_string());
     // Passes declare which phases they operate on; the manager enforces it so a
     // pipeline entry cannot silently corrupt a module in the wrong phase.
     if !pass.admits(module) {
+        if let Some(before) = before {
+            print_pass_diff(module, label, &before);
+        }
         return false;
     }
     if options.validate_after_each {
@@ -328,18 +341,24 @@ pub fn run_pass(module: &mut Module, pass: &PassInfo, options: PipelineOptions) 
     if options.validate_after_each {
         validate_module_after_pass(module, pass.name);
     }
+    if let Some(before) = before {
+        print_pass_diff(module, label, &before);
+    }
     changed
+}
+
+fn print_pass_diff(module: &Module, pass: &str, before: &str) {
+    let after = module.to_text().to_string();
+    let before = format!("// === {} (before {pass}) ===\n{before}", module.name);
+    let after = format!("// === {} (after {pass}) ===\n{after}", module.name);
+    print!("{}", solar_data_structures::fmt::line_diff(&before, &after));
 }
 
 /// Runs a named MIR pass pipeline over a module.
 fn run_pipeline(module: &mut Module, passes: &[PassInfo], options: PipelineOptions) -> bool {
     let mut changed = false;
     for pass in passes {
-        changed |= run_pass(module, pass, options);
-        if options.print_after_each {
-            println!("// === {} (after {}) ===", module.name, pass.name);
-            print!("{}", module.to_text());
-        }
+        changed |= run_pass_with_label(module, pass, options, pass.name);
     }
     changed
 }
@@ -373,12 +392,9 @@ fn run_cleanup_pipeline_to_fixpoint(
     for round in 1..=DEFAULT_CLEANUP_MAX_ROUNDS {
         let mut round_changed = false;
         for pass in passes {
-            let pass_changed = run_pass(module, pass, options);
+            let pass_label = format!("{label}-{round}:{}", pass.name);
+            let pass_changed = run_pass_with_label(module, pass, options, &pass_label);
             round_changed |= pass_changed;
-            if options.print_after_each {
-                println!("// === {} (after {label}-{round}:{}) ===", module.name, pass.name);
-                print!("{}", module.to_text());
-            }
         }
         if !round_changed {
             break;

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -367,6 +367,10 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub mir_print_after_each: bool,
 
+    /// Print a before-and-after diff for each pass explicitly selected by `mir-opt` or `evm-opt`.
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub pass_diff: bool,
+
     /// Print the time spent in each MIR and EVM IR pass.
     #[cfg_attr(feature = "clap", arg(long))]
     pub time_passes: bool,

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -363,7 +363,7 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub print_natspec: bool,
 
-    /// Print a MIR diff for every MIR optimization pass during codegen.
+    /// Print MIR after every MIR optimization pass during codegen.
     #[cfg_attr(feature = "clap", arg(long))]
     pub mir_print_after_each: bool,
 

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -363,7 +363,7 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub print_natspec: bool,
 
-    /// Print MIR after every MIR optimization pass during codegen.
+    /// Print a MIR diff for every MIR optimization pass during codegen.
     #[cfg_attr(feature = "clap", arg(long))]
     pub mir_print_after_each: bool,
 

--- a/crates/data-structures/Cargo.toml
+++ b/crates/data-structures/Cargo.toml
@@ -25,6 +25,7 @@ workspace = true
 
 [dependencies]
 bumpalo.workspace = true
+diff.workspace = true
 oxc_index.workspace = true
 indexmap.workspace = true
 parking_lot.workspace = true

--- a/crates/data-structures/src/fmt.rs
+++ b/crates/data-structures/src/fmt.rs
@@ -5,6 +5,20 @@ use std::{
 
 pub use fmt::*;
 
+/// Formats a line-oriented diff with the same prefixes as rustc MIR tests.
+pub fn line_diff<'a>(before: &'a str, after: &'a str) -> impl fmt::Display + 'a {
+    from_fn(move |f| {
+        for result in diff::lines(before, after) {
+            match result {
+                diff::Result::Left(line) => writeln!(f, "- {line}")?,
+                diff::Result::Right(line) => writeln!(f, "+ {line}")?,
+                diff::Result::Both(line, _) => writeln!(f, "  {line}")?,
+            }
+        }
+        Ok(())
+    })
+}
+
 /// Creates a formatter from a function.
 pub fn from_fn<F>(f: F) -> FromFn<F>
 where
@@ -155,5 +169,10 @@ mod tests {
         let values = [1, 2, 3];
         let formatted = values.iter().format_with(" | ", |f, value| write!(f, "#{value}"));
         assert_eq!(formatted.to_string(), "#1 | #2 | #3");
+    }
+
+    #[test]
+    fn test_line_diff() {
+        assert_eq!(line_diff("a\nb\n", "a\nc\n").to_string(), "  a\n- b\n+ c\n  \n");
     }
 }

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -43,7 +43,7 @@ Options:
           Print resolved NatSpec docs as diagnostics for UI tests
 
       -Zmir-print-after-each
-          Print MIR after every MIR optimization pass during codegen
+          Print a MIR diff for every MIR optimization pass during codegen
 
       -Ztime-passes
           Print the time spent in each MIR and EVM IR pass

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -43,7 +43,7 @@ Options:
           Print resolved NatSpec docs as diagnostics for UI tests
 
       -Zmir-print-after-each
-          Print a MIR diff for every MIR optimization pass during codegen
+          Print MIR after every MIR optimization pass during codegen
 
       -Ztime-passes
           Print the time spent in each MIR and EVM IR pass

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -45,6 +45,9 @@ Options:
       -Zmir-print-after-each
           Print MIR after every MIR optimization pass during codegen
 
+      -Zpass-diff
+          Print a before-and-after diff for each pass explicitly selected by `mir-opt` or `evm-opt`
+
       -Ztime-passes
           Print the time spent in each MIR and EVM IR pass
 

--- a/tests/ui/codegen/evm-ir/block-layout/block_layout.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/block_layout.stdout
@@ -1,13 +1,17 @@
-// === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir (after block-layout) ===
-@module module
-bb0 (entry):
-  push 1
-  push bb1
-  jumpi
-  jump bb2
-bb2:
-  jump bb3
-bb3:
-  stop
-bb1:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir (before block-layout) ===
++ // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir (after block-layout) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push bb1
+    jumpi
+    jump bb2
+- bb1:
+-   stop
+  bb2:
+    jump bb3
+  bb3:
++   stop
++ bb1:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.stdout
@@ -1,10 +1,14 @@
-// === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir (after block-layout) ===
-@module module
-bb0 (entry):
-  jump bb2
-bb2:
-  stop
-bb1 [cold]:
-  push 0
-  push 0
-  revert
+- // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir (before block-layout) ===
++ // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir (after block-layout) ===
+  @module module
+  bb0 (entry):
+    jump bb2
++ bb2:
++   stop
+  bb1 [cold]:
+    push 0
+    push 0
+    revert
+- bb2:
+-   stop
+  

--- a/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.stdout
@@ -1,23 +1,27 @@
-// === ROOT/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir (after block-layout) ===
-@module module
-bb0 (entry):
-  push bb3
-  pop
-  push bb3
-  pop
-  push 1
-  jumpi bb2, bb1
-bb1:
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  push 0xffffffffffff
-  stop
-bb3:
-  invalid
-bb2:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir (before block-layout) ===
++ // === ROOT/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir (after block-layout) ===
+  @module module
+  bb0 (entry):
+    push bb3
+    pop
+    push bb3
+    pop
+    push 1
+    jumpi bb2, bb1
+  bb1:
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    push 0xffffffffffff
+    stop
+- bb2:
+-   stop
+  bb3:
+    invalid
++ bb2:
++   stop
+  

--- a/tests/ui/codegen/evm-ir/block-layout/time_passes.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/time_passes.stdout
@@ -1,10 +1,14 @@
-// === ROOT/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir (after block-layout) ===
-@module module
-bb0 (entry):
-  jump bb2
-bb2:
-  stop
-bb1 [cold]:
-  push 0
-  push 0
-  revert
+- // === ROOT/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir (before block-layout) ===
++ // === ROOT/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir (after block-layout) ===
+  @module module
+  bb0 (entry):
+    jump bb2
++ bb2:
++   stop
+  bb1 [cold]:
+    push 0
+    push 0
+    revert
+- bb2:
+-   stop
+  

--- a/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.stdout
+++ b/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.stdout
@@ -1,8 +1,17 @@
-// === ROOT/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir (after cfg-simplify) ===
-@module module
-bb0 (entry):
-  push bb3
-  push 1
-  stop
-bb3:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir (after cfg-simplify) ===
+  @module module
+  bb0 (entry):
+    push bb3
+-   jump bb1
+- bb1:
+-   jump bb2
+- bb2:
+    push 1
+-   jump bb4
+- bb3:
+    stop
+- bb4:
++ bb3:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.stdout
+++ b/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.stdout
@@ -1,10 +1,14 @@
-// === ROOT/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir (after compact-pushes) ===
-@module module
-bb0 (entry):
-  push 0
-  not
-  push 0
-  not
-  push 96
-  shr
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir (before compact-pushes) ===
++ // === ROOT/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir (after compact-pushes) ===
+  @module module
+  bb0 (entry):
+-   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-   push 0xffffffffffffffffffffffffffffffffffffffff
++   push 0
++   not
++   push 0
++   not
++   push 96
++   shr
+    stop
+  

--- a/tests/ui/codegen/evm-ir/none/branches.stdout
+++ b/tests/ui/codegen/evm-ir/none/branches.stdout
@@ -1,26 +1,28 @@
-// === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (after none) ===
-@module module
-bb0 (entry):
-  push 0
-  calldataload
-  dup1
-  push 1
-  eq
-  jumpi bb1, bb5
-bb1:
-  pop
-  jump bb4
-bb2:
-  pop
-  push 0xbeef
-  selfdestruct
-bb3 [cold]:
-  pop
-  invalid
-bb4:
-  stop
-bb5:
-  dup1
-  push 2
-  eq
-  jumpi bb2, bb3
+- // === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (before none) ===
++ // === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (after none) ===
+  @module module
+  bb0 (entry):
+    push 0
+    calldataload
+    dup1
+    push 1
+    eq
+    jumpi bb1, bb5
+  bb1:
+    pop
+    jump bb4
+  bb2:
+    pop
+    push 0xbeef
+    selfdestruct
+  bb3 [cold]:
+    pop
+    invalid
+  bb4:
+    stop
+  bb5:
+    dup1
+    push 2
+    eq
+    jumpi bb2, bb3
+  

--- a/tests/ui/codegen/evm-ir/none/branches.stdout
+++ b/tests/ui/codegen/evm-ir/none/branches.stdout
@@ -1,28 +1,26 @@
-- // === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (before none) ===
-+ // === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (after none) ===
-  @module module
-  bb0 (entry):
-    push 0
-    calldataload
-    dup1
-    push 1
-    eq
-    jumpi bb1, bb5
-  bb1:
-    pop
-    jump bb4
-  bb2:
-    pop
-    push 0xbeef
-    selfdestruct
-  bb3 [cold]:
-    pop
-    invalid
-  bb4:
-    stop
-  bb5:
-    dup1
-    push 2
-    eq
-    jumpi bb2, bb3
-  
+// === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (after none) ===
+@module module
+bb0 (entry):
+  push 0
+  calldataload
+  dup1
+  push 1
+  eq
+  jumpi bb1, bb5
+bb1:
+  pop
+  jump bb4
+bb2:
+  pop
+  push 0xbeef
+  selfdestruct
+bb3 [cold]:
+  pop
+  invalid
+bb4:
+  stop
+bb5:
+  dup1
+  push 2
+  eq
+  jumpi bb2, bb3

--- a/tests/ui/codegen/evm-ir/none/dispatch.stdout
+++ b/tests/ui/codegen/evm-ir/none/dispatch.stdout
@@ -1,20 +1,22 @@
-// === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (after none) ===
-@module module
-bb0 (entry):
-  push 0
-  calldataload
-  push 0x371303c0
-  eq
-  jumpi bb1, bb2
-bb1:
-  push 0
-  sload
-  jump bb3
-bb2 [cold]:
-  push 0
-  push 0
-  revert
-bb3:
-  push 32
-  push 0
-  return
+- // === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (before none) ===
++ // === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (after none) ===
+  @module module
+  bb0 (entry):
+    push 0
+    calldataload
+    push 0x371303c0
+    eq
+    jumpi bb1, bb2
+  bb1:
+    push 0
+    sload
+    jump bb3
+  bb2 [cold]:
+    push 0
+    push 0
+    revert
+  bb3:
+    push 32
+    push 0
+    return
+  

--- a/tests/ui/codegen/evm-ir/none/dispatch.stdout
+++ b/tests/ui/codegen/evm-ir/none/dispatch.stdout
@@ -1,22 +1,20 @@
-- // === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (before none) ===
-+ // === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (after none) ===
-  @module module
-  bb0 (entry):
-    push 0
-    calldataload
-    push 0x371303c0
-    eq
-    jumpi bb1, bb2
-  bb1:
-    push 0
-    sload
-    jump bb3
-  bb2 [cold]:
-    push 0
-    push 0
-    revert
-  bb3:
-    push 32
-    push 0
-    return
-  
+// === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (after none) ===
+@module module
+bb0 (entry):
+  push 0
+  calldataload
+  push 0x371303c0
+  eq
+  jumpi bb1, bb2
+bb1:
+  push 0
+  sload
+  jump bb3
+bb2 [cold]:
+  push 0
+  push 0
+  revert
+bb3:
+  push 32
+  push 0
+  return

--- a/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.stdout
+++ b/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.stdout
@@ -1,11 +1,9 @@
-- // === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (before none) ===
-+ // === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (after none) ===
-  @module module
-  bb0 (entry):
-    push 0
-    push 0
-    push 0
-    push 0
-    push 0
-    stop
-  
+// === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (after none) ===
+@module module
+bb0 (entry):
+  push 0
+  push 0
+  push 0
+  push 0
+  push 0
+  stop

--- a/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.stdout
+++ b/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.stdout
@@ -1,9 +1,11 @@
-// === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (after none) ===
-@module module
-bb0 (entry):
-  push 0
-  push 0
-  push 0
-  push 0
-  push 0
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (before none) ===
++ // === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (after none) ===
+  @module module
+  bb0 (entry):
+    push 0
+    push 0
+    push 0
+    push 0
+    push 0
+    stop
+  

--- a/tests/ui/codegen/evm-ir/none/push_family.stdout
+++ b/tests/ui/codegen/evm-ir/none/push_family.stdout
@@ -1,14 +1,16 @@
-// === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (after none) ===
-@module module
-bb0 (entry):
-  push 1
-  push_deferred 2
-  push_deferred 0xfffffff
-  push_immutable 3
-  push_immutable 0xfffffff
-  pop
-  pop
-  pop
-  pop
-  pop
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (before none) ===
++ // === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (after none) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push_deferred 2
+    push_deferred 0xfffffff
+    push_immutable 3
+    push_immutable 0xfffffff
+    pop
+    pop
+    pop
+    pop
+    pop
+    stop
+  

--- a/tests/ui/codegen/evm-ir/none/push_family.stdout
+++ b/tests/ui/codegen/evm-ir/none/push_family.stdout
@@ -1,16 +1,14 @@
-- // === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (before none) ===
-+ // === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (after none) ===
-  @module module
-  bb0 (entry):
-    push 1
-    push_deferred 2
-    push_deferred 0xfffffff
-    push_immutable 3
-    push_immutable 0xfffffff
-    pop
-    pop
-    pop
-    pop
-    pop
-    stop
-  
+// === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (after none) ===
+@module module
+bb0 (entry):
+  push 1
+  push_deferred 2
+  push_deferred 0xfffffff
+  push_immutable 3
+  push_immutable 0xfffffff
+  pop
+  pop
+  pop
+  pop
+  pop
+  stop

--- a/tests/ui/codegen/evm-ir/outline/outline_computation.stdout
+++ b/tests/ui/codegen/evm-ir/outline/outline_computation.stdout
@@ -1,38 +1,65 @@
-// === ROOT/tests/ui/codegen/evm-ir/outline/outline_computation.evmir (after outline) ===
-@module module
-bb0 (entry):
-  push bb3
-  jump bb2
-bb1:
-  push bb4
-  jump bb2
-bb2:
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  push 1
-  pop
-  jump
-bb3:
-  jump bb1
-bb4:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/outline/outline_computation.evmir (before outline) ===
++ // === ROOT/tests/ui/codegen/evm-ir/outline/outline_computation.evmir (after outline) ===
+  @module module
+  bb0 (entry):
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   push 1
+-   pop
+-   jump bb1
++   push bb3
++   jump bb2
+  bb1:
++   push bb4
++   jump bb2
++ bb2:
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
+    push 1
+    pop
++   jump
++ bb3:
++   jump bb1
++ bb4:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/outline/outline_order.stdout
+++ b/tests/ui/codegen/evm-ir/outline/outline_order.stdout
@@ -1,66 +1,95 @@
-// === ROOT/tests/ui/codegen/evm-ir/outline/outline_order.evmir (after outline) ===
-@module module
-bb0 (entry):
-  push bb4
-  jump bb3
-bb1:
-  push bb5
-  jump bb3
-bb2:
-  push 2
-  pop
-  push 3
-  pop
-  push 4
-  pop
-  push 5
-  pop
-  push 6
-  pop
-  push 7
-  pop
-  push 8
-  pop
-  push 9
-  pop
-  push 10
-  pop
-  push 11
-  pop
-  push 12
-  pop
-  push 13
-  pop
-  stop
-bb3:
-  push 1
-  pop
-  push 2
-  pop
-  push 3
-  pop
-  push 4
-  pop
-  push 5
-  pop
-  push 6
-  pop
-  push 7
-  pop
-  push 8
-  pop
-  push 9
-  pop
-  push 10
-  pop
-  push 11
-  pop
-  push 12
-  pop
-  jump
-bb4:
-  push 13
-  pop
-  stop
-bb5:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/outline/outline_order.evmir (before outline) ===
++ // === ROOT/tests/ui/codegen/evm-ir/outline/outline_order.evmir (after outline) ===
+  @module module
+  bb0 (entry):
+-   push 1
+-   pop
++   push bb4
++   jump bb3
++ bb1:
++   push bb5
++   jump bb3
++ bb2:
+    push 2
+    pop
+    push 3
+    pop
+    push 4
+    pop
+    push 5
+    pop
+    push 6
+    pop
+    push 7
+    pop
+    push 8
+    pop
+    push 9
+    pop
+    push 10
+    pop
+    push 11
+    pop
+    push 12
+    pop
+    push 13
+    pop
+    stop
+- bb1:
++ bb3:
+    push 1
+    pop
+    push 2
+    pop
+    push 3
+    pop
+    push 4
+    pop
+    push 5
+    pop
+    push 6
+    pop
+    push 7
+    pop
+    push 8
+    pop
+    push 9
+    pop
+    push 10
+    pop
+    push 11
+    pop
+    push 12
+    pop
+-   stop
+- bb2:
+-   push 2
+-   pop
+-   push 3
+-   pop
+-   push 4
+-   pop
+-   push 5
+-   pop
+-   push 6
+-   pop
+-   push 7
+-   pop
+-   push 8
+-   pop
+-   push 9
+-   pop
+-   push 10
+-   pop
+-   push 11
+-   pop
+-   push 12
+-   pop
++   jump
++ bb4:
+    push 13
+    pop
++   stop
++ bb5:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/outline/outline_push.stdout
+++ b/tests/ui/codegen/evm-ir/outline/outline_push.stdout
@@ -1,16 +1,20 @@
-// === ROOT/tests/ui/codegen/evm-ir/outline/outline_push.evmir (after outline) ===
-@module module
-bb0 (entry):
-  push bb3
-  jump bb1
-bb1:
-  push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  swap1
-  jump
-bb2:
-  pop
-  stop
-bb3:
-  pop
-  push bb2
-  jump bb1
+- // === ROOT/tests/ui/codegen/evm-ir/outline/outline_push.evmir (before outline) ===
++ // === ROOT/tests/ui/codegen/evm-ir/outline/outline_push.evmir (after outline) ===
+  @module module
+  bb0 (entry):
++   push bb3
++   jump bb1
++ bb1:
+    push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
++   swap1
++   jump
++ bb2:
+    pop
+-   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-   pop
+    stop
++ bb3:
++   pop
++   push bb2
++   jump bb1
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.stdout
@@ -1,63 +1,81 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  stop
-bb1:
-  push 1
-  stop
-bb2:
-  push 1
-  push 2
-  push 3
-  stop
-bb3:
-  push 1
-  push 2
-  stop
-bb4:
-  push 1
-  push 2
-  push 3
-  stop
-bb5:
-  push 1
-  iszero
-  stop
-bb6:
-  push 1
-  push 2
-  push 3
-  push 4
-  push 5
-  push 6
-  push 7
-  push 8
-  push 9
-  push 10
-  push 11
-  push 12
-  push 13
-  push 14
-  push 15
-  push 16
-  stop
-bb7:
-  push 1
-  push 2
-  push 3
-  push 4
-  push 5
-  push 6
-  push 7
-  push 8
-  push 9
-  push 10
-  push 11
-  push 12
-  push 13
-  push 14
-  push 15
-  push 16
-  push 17
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+-   not
+-   not
+    stop
+  bb1:
+    push 1
+-   dup1
+-   pop
+    stop
+  bb2:
+    push 1
+    push 2
+    push 3
+-   dup3
+-   pop
+    stop
+  bb3:
+    push 1
+    push 2
+-   swap1
+-   swap1
+    stop
+  bb4:
+    push 1
+    push 2
+    push 3
+-   swap2
+-   swap2
+    stop
+  bb5:
+    push 1
+    iszero
+-   iszero
+-   iszero
+    stop
+  bb6:
+    push 1
+    push 2
+    push 3
+    push 4
+    push 5
+    push 6
+    push 7
+    push 8
+    push 9
+    push 10
+    push 11
+    push 12
+    push 13
+    push 14
+    push 15
+    push 16
+-   dup16
+-   pop
+    stop
+  bb7:
+    push 1
+    push 2
+    push 3
+    push 4
+    push 5
+    push 6
+    push 7
+    push 8
+    push 9
+    push 10
+    push 11
+    push 12
+    push 13
+    push 14
+    push 15
+    push 16
+    push 17
+-   swap16
+-   swap16
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.stdout
@@ -1,52 +1,68 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  push 2
-  add
-  stop
-bb1:
-  push 1
-  push 2
-  mul
-  stop
-bb2:
-  push 1
-  push 2
-  and
-  stop
-bb3:
-  push 1
-  push 2
-  or
-  stop
-bb4:
-  push 1
-  push 2
-  xor
-  stop
-bb5:
-  push 1
-  push 2
-  eq
-  stop
-bb6:
-  push 1
-  push 2
-  gt
-  stop
-bb7:
-  push 1
-  push 2
-  lt
-  stop
-bb8:
-  push 1
-  push 2
-  sgt
-  stop
-bb9:
-  push 1
-  push 2
-  slt
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push 2
+-   swap1
+    add
+    stop
+  bb1:
+    push 1
+    push 2
+-   swap1
+    mul
+    stop
+  bb2:
+    push 1
+    push 2
+-   swap1
+    and
+    stop
+  bb3:
+    push 1
+    push 2
+-   swap1
+    or
+    stop
+  bb4:
+    push 1
+    push 2
+-   swap1
+    xor
+    stop
+  bb5:
+    push 1
+    push 2
+-   swap1
+    eq
+    stop
+  bb6:
+    push 1
+    push 2
+-   swap1
+-   lt
++   gt
+    stop
+  bb7:
+    push 1
+    push 2
+-   swap1
+-   gt
++   lt
+    stop
+  bb8:
+    push 1
+    push 2
+-   swap1
+-   slt
++   sgt
+    stop
+  bb9:
+    push 1
+    push 2
+-   swap1
+-   sgt
++   slt
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.stdout
@@ -1,26 +1,44 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 0
-  stop
-bb1:
-  push 0
-  stop
-bb2:
-  push 0
-  stop
-bb3:
-  push 0
-  stop
-bb4:
-  push 0
-  stop
-bb5:
-  push 0
-  stop
-bb6:
-  push 0
-  stop
-bb7:
-  push 1
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+-   push 2
+    push 0
+-   mul
+    stop
+  bb1:
+-   push 2
+    push 0
+-   div
+    stop
+  bb2:
+-   push 2
+    push 0
+-   sdiv
+    stop
+  bb3:
+-   push 2
+    push 0
+-   mod
+    stop
+  bb4:
+-   push 2
+    push 0
+-   smod
+    stop
+  bb5:
+-   push 2
+    push 0
+-   and
+    stop
+  bb6:
+-   push 2
+    push 0
+-   gt
+    stop
+  bb7:
+-   push 2
+    push 1
+-   exp
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.stdout
@@ -1,51 +1,85 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 2
-  stop
-bb1:
-  push 2
-  stop
-bb2:
-  push 2
-  stop
-bb3:
-  push 2
-  stop
-bb4:
-  push 2
-  stop
-bb5:
-  push 2
-  stop
-bb6:
-  push 2
-  iszero
-  stop
-bb7:
-  push 0
-  stop
-bb8:
-  push 0
-  stop
-bb9:
-  push 0
-  stop
-bb10:
-  push 0
-  stop
-bb11:
-  push 0
-  stop
-bb12:
-  push 0
-  stop
-bb13:
-  push 0
-  stop
-bb14:
-  push 2
-  stop
-bb15:
-  push 1
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 2
+-   push 0
+-   add
+    stop
+  bb1:
+    push 2
+-   push 0
+-   or
+    stop
+  bb2:
+    push 2
+-   push 0
+-   xor
+    stop
+  bb3:
+    push 2
+-   push 0
+-   shl
+    stop
+  bb4:
+    push 2
+-   push 0
+-   shr
+    stop
+  bb5:
+    push 2
+-   push 0
+-   sar
+    stop
+  bb6:
+    push 2
+-   push 0
+-   eq
++   iszero
+    stop
+  bb7:
+-   push 2
+    push 0
+-   mul
+    stop
+  bb8:
+-   push 2
+    push 0
+-   div
+    stop
+  bb9:
+-   push 2
+    push 0
+-   sdiv
+    stop
+  bb10:
+-   push 2
+    push 0
+-   mod
+    stop
+  bb11:
+-   push 2
+    push 0
+-   smod
+    stop
+  bb12:
+-   push 2
+    push 0
+-   and
+    stop
+  bb13:
+-   push 2
+    push 0
+-   gt
+    stop
+  bb14:
+    push 2
+-   push 1
+-   mul
+    stop
+  bb15:
+-   push 2
+    push 1
+-   exp
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.stdout
@@ -1,124 +1,196 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  push 2
-  add
-  stop
-bb1:
-  push 1
-  push 2
-  mul
-  stop
-bb2:
-  push 1
-  push 2
-  and
-  stop
-bb3:
-  push 1
-  push 2
-  or
-  stop
-bb4:
-  push 1
-  push 2
-  xor
-  stop
-bb5:
-  push 1
-  push 2
-  eq
-  stop
-bb6:
-  push 1
-  push 2
-  swap1
-  sub
-  stop
-bb7:
-  push 1
-  push 2
-  swap1
-  div
-  stop
-bb8:
-  push 1
-  push 2
-  swap1
-  sdiv
-  stop
-bb9:
-  push 1
-  push 2
-  swap1
-  mod
-  stop
-bb10:
-  push 1
-  push 2
-  swap1
-  smod
-  stop
-bb11:
-  push 1
-  push 2
-  swap1
-  exp
-  stop
-bb12:
-  push 1
-  push 2
-  swap1
-  signextend
-  stop
-bb13:
-  push 1
-  push 2
-  gt
-  stop
-bb14:
-  push 1
-  push 2
-  lt
-  stop
-bb15:
-  push 1
-  push 2
-  sgt
-  stop
-bb16:
-  push 1
-  push 2
-  slt
-  stop
-bb17:
-  push 1
-  push 2
-  swap1
-  byte
-  stop
-bb18:
-  push 1
-  push 2
-  swap1
-  shl
-  stop
-bb19:
-  push 1
-  push 2
-  swap1
-  shr
-  stop
-bb20:
-  push 1
-  push 2
-  swap1
-  sar
-  stop
-bb21:
-  push 1
-  push 2
-  swap1
-  keccak256
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push 2
+-   dup2
+    add
+-   swap1
+-   pop
+    stop
+  bb1:
+    push 1
+    push 2
+-   dup2
+    mul
+-   swap1
+-   pop
+    stop
+  bb2:
+    push 1
+    push 2
+-   dup2
+    and
+-   swap1
+-   pop
+    stop
+  bb3:
+    push 1
+    push 2
+-   dup2
+    or
+-   swap1
+-   pop
+    stop
+  bb4:
+    push 1
+    push 2
+-   dup2
+    xor
+-   swap1
+-   pop
+    stop
+  bb5:
+    push 1
+    push 2
+-   dup2
+    eq
+-   swap1
+-   pop
+    stop
+  bb6:
+    push 1
+    push 2
+-   dup2
+-   sub
+    swap1
+-   pop
++   sub
+    stop
+  bb7:
+    push 1
+    push 2
+-   dup2
+-   div
+    swap1
+-   pop
++   div
+    stop
+  bb8:
+    push 1
+    push 2
+-   dup2
+-   sdiv
+    swap1
+-   pop
++   sdiv
+    stop
+  bb9:
+    push 1
+    push 2
+-   dup2
+-   mod
+    swap1
+-   pop
++   mod
+    stop
+  bb10:
+    push 1
+    push 2
+-   dup2
+-   smod
+    swap1
+-   pop
++   smod
+    stop
+  bb11:
+    push 1
+    push 2
+-   dup2
+-   exp
+    swap1
+-   pop
++   exp
+    stop
+  bb12:
+    push 1
+    push 2
+-   dup2
+-   signextend
+    swap1
+-   pop
++   signextend
+    stop
+  bb13:
+    push 1
+    push 2
+-   dup2
+-   lt
+-   swap1
+-   pop
++   gt
+    stop
+  bb14:
+    push 1
+    push 2
+-   dup2
+-   gt
+-   swap1
+-   pop
++   lt
+    stop
+  bb15:
+    push 1
+    push 2
+-   dup2
+-   slt
+-   swap1
+-   pop
++   sgt
+    stop
+  bb16:
+    push 1
+    push 2
+-   dup2
+-   sgt
+-   swap1
+-   pop
++   slt
+    stop
+  bb17:
+    push 1
+    push 2
+-   dup2
+-   byte
+    swap1
+-   pop
++   byte
+    stop
+  bb18:
+    push 1
+    push 2
+-   dup2
+-   shl
+    swap1
+-   pop
++   shl
+    stop
+  bb19:
+    push 1
+    push 2
+-   dup2
+-   shr
+    swap1
+-   pop
++   shr
+    stop
+  bb20:
+    push 1
+    push 2
+-   dup2
+-   sar
+    swap1
+-   pop
++   sar
+    stop
+  bb21:
+    push 1
+    push 2
+-   dup2
+-   keccak256
+    swap1
+-   pop
++   keccak256
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.stdout
@@ -1,32 +1,44 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  push 2
-  swap1
-  mstore
-  stop
-bb1:
-  push 1
-  push 2
-  swap1
-  mstore8
-  stop
-bb2:
-  push 1
-  push 2
-  swap1
-  sstore
-  stop
-bb3:
-  push 1
-  push 2
-  swap1
-  tstore
-  stop
-bb4:
-  push 1
-  push 2
-  swap1
-  log0
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push 2
+-   dup2
++   swap1
+    mstore
+-   pop
+    stop
+  bb1:
+    push 1
+    push 2
+-   dup2
++   swap1
+    mstore8
+-   pop
+    stop
+  bb2:
+    push 1
+    push 2
+-   dup2
++   swap1
+    sstore
+-   pop
+    stop
+  bb3:
+    push 1
+    push 2
+-   dup2
++   swap1
+    tstore
+-   pop
+    stop
+  bb4:
+    push 1
+    push 2
+-   dup2
++   swap1
+    log0
+-   pop
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/jump.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/jump.stdout
@@ -1,16 +1,22 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  push bb2
-  jumpi
-  stop
-bb1:
-  push 1
-  push 2
-  sub
-  push bb2
-  jumpi
-  stop
-bb2:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+-   iszero
+-   iszero
+    push bb2
+    jumpi
+    stop
+  bb1:
+    push 1
+    push 2
+-   eq
+-   iszero
++   sub
+    push bb2
+    jumpi
+    stop
+  bb2:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/memory.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/memory.stdout
@@ -1,14 +1,22 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  dup1
-  push 32
-  mstore
-  stop
-bb1:
-  push 1
-  dup1
-  push 32
-  mstore
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+    dup1
+    push 32
+    mstore
+-   dup1
+-   push 32
+-   mstore
+    stop
+  bb1:
+    push 1
+    dup1
+    push 32
+    mstore
+-   pop
+-   push 32
+-   mload
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.stdout
@@ -1,56 +1,64 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  push 1
-  push 2
-  push 3
-  swap2
-  pop
-  pop
-  stop
-bb1:
-  push 1
-  push 2
-  push 3
-  push 4
-  swap3
-  pop
-  pop
-  pop
-  stop
-bb2:
-  push 1
-  push 2
-  push 3
-  push 4
-  push 5
-  push 6
-  push 7
-  push 8
-  push 9
-  push 10
-  push 11
-  push 12
-  push 13
-  push 14
-  push 15
-  push 16
-  push 17
-  swap16
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  pop
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push 2
+    push 3
+-   swap1
++   swap2
+    pop
+-   swap1
+    pop
+    stop
+  bb1:
+    push 1
+    push 2
+    push 3
+    push 4
+-   swap2
++   swap3
+    pop
+    pop
+-   swap1
+    pop
+    stop
+  bb2:
+    push 1
+    push 2
+    push 3
+    push 4
+    push 5
+    push 6
+    push 7
+    push 8
+    push 9
+    push 10
+    push 11
+    push 12
+    push 13
+    push 14
+    push 15
+    push 16
+    push 17
+-   swap15
++   swap16
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+    pop
+-   swap1
+    pop
+    stop
+  

--- a/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.stdout
@@ -1,8 +1,14 @@
-// === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir (after peephole) ===
-@module module
-bb0 (entry):
-  stop
-bb1:
-  stop
-bb2:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir (before peephole) ===
++ // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir (after peephole) ===
+  @module module
+  bb0 (entry):
+-   push 1
+-   pop
+    stop
+  bb1:
+-   push bb2
+-   pop
+    stop
+  bb2:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/share-reverts/share_reverts.stdout
+++ b/tests/ui/codegen/evm-ir/share-reverts/share_reverts.stdout
@@ -1,13 +1,18 @@
-// === ROOT/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir (after share-reverts) ===
-@module module
-bb0 (entry):
-  push 1
-  push bb1
-  jumpi
-  jump bb2
-bb1 [cold]:
-  push 0
-  dup1
-  revert
-bb2:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir (before share-reverts) ===
++ // === ROOT/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir (after share-reverts) ===
+  @module module
+  bb0 (entry):
+    push 1
+-   iszero
+-   push bb2
++   push bb1
+    jumpi
+-   jump bb1
++   jump bb2
+  bb1 [cold]:
+    push 0
+    dup1
+    revert
+  bb2:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/share-reverts/special_zero.stdout
+++ b/tests/ui/codegen/evm-ir/share-reverts/special_zero.stdout
@@ -1,24 +1,26 @@
-// === ROOT/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir (after share-reverts) ===
-@module module
-bb0 (entry):
-  push 1
-  iszero
-  push bb2
-  jumpi
-  jump bb1
-bb1 [cold]:
-  push_deferred 0
-  dup1
-  revert
-bb2:
-  push 1
-  iszero
-  push bb4
-  jumpi
-  jump bb3
-bb3 [cold]:
-  push_immutable 0
-  dup1
-  revert
-bb4:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir (before share-reverts) ===
++ // === ROOT/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir (after share-reverts) ===
+  @module module
+  bb0 (entry):
+    push 1
+    iszero
+    push bb2
+    jumpi
+    jump bb1
+  bb1 [cold]:
+    push_deferred 0
+    dup1
+    revert
+  bb2:
+    push 1
+    iszero
+    push bb4
+    jumpi
+    jump bb3
+  bb3 [cold]:
+    push_immutable 0
+    dup1
+    revert
+  bb4:
+    stop
+  

--- a/tests/ui/codegen/evm-ir/tail-merge/tail_merge.stdout
+++ b/tests/ui/codegen/evm-ir/tail-merge/tail_merge.stdout
@@ -1,37 +1,58 @@
-// === ROOT/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir (after tail-merge) ===
-@module module
-bb0 (entry):
-  push 1
-  push bb1
-  jumpi
-  jump bb2
-bb1 [cold]:
-  push 11
-  jump bb9
-bb2 [cold]:
-  push 99
-  jump bb9
-bb3:
-  push 77
-  push 66
-  jump bb8
-bb6 [cold]:
-  push 111
-  jump bb10
-bb7:
-  push 999
-  jump bb10
-bb8:
-  push 33
-  push 44
-  push 55
-  revert
-bb9 [cold]:
-  push 22
-  jump bb8
-bb10:
-  push 222
-  push 333
-  push 444
-  push 555
-  revert
+- // === ROOT/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir (before tail-merge) ===
++ // === ROOT/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir (after tail-merge) ===
+  @module module
+  bb0 (entry):
+    push 1
+    push bb1
+    jumpi
+    jump bb2
+  bb1 [cold]:
+    push 11
+-   push 22
+-   push 33
+-   push 44
+-   push 55
+-   revert
++   jump bb9
+  bb2 [cold]:
+    push 99
+-   push 22
+-   push 33
+-   push 44
+-   push 55
+-   revert
++   jump bb9
+  bb3:
+    push 77
+    push 66
+-   push 33
+-   push 44
+-   push 55
+-   revert
++   jump bb8
+  bb6 [cold]:
+    push 111
+-   push 222
+-   push 333
+-   push 444
+-   push 555
+-   revert
++   jump bb10
+  bb7:
+    push 999
++   jump bb10
++ bb8:
++   push 33
++   push 44
++   push 55
++   revert
++ bb9 [cold]:
++   push 22
++   jump bb8
++ bb10:
+    push 222
+    push 333
+    push 444
+    push 555
+    revert
+  

--- a/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.stdout
+++ b/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.stdout
@@ -1,14 +1,20 @@
-// === ROOT/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir (after terminal-dedup) ===
-@module module
-bb0 (entry):
-  push 1
-  jumpi bb1, bb2
-bb1 [cold]:
-  push 64
-  push 32
-  push 0
-  revert
-bb2 [cold]:
-  jump bb1
-bb3:
-  stop
+- // === ROOT/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir (before terminal-dedup) ===
++ // === ROOT/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir (after terminal-dedup) ===
+  @module module
+  bb0 (entry):
+    push 1
+    jumpi bb1, bb2
+  bb1 [cold]:
+    push 64
+    push 32
+    push 0
+    revert
+  bb2 [cold]:
+-   push 64
+-   push 32
+-   push 0
+-   revert
++   jump bb1
+  bb3:
+    stop
+  

--- a/tests/ui/codegen/mir/adce/adce.stdout
+++ b/tests/ui/codegen/mir/adce/adce.stdout
@@ -1,36 +1,43 @@
-// === ROOT/tests/ui/codegen/mir/adce/adce.mir (after adce) ===
-@module Adce
-fn @removes_dead_branch_region(arg0: bool) -> u256 {
-  bb0 (entry):
-    jump bb3
-  bb1:
-    invalid
-  bb2:
-    invalid
-  bb3:
-    ret 7
-}
-
-fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 0, 1
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    ret 7
-}
-
-fn @keeps_phi_target(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: 1], [bb2: 2]
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/adce/adce.mir (before adce) ===
++ // === ROOT/tests/ui/codegen/mir/adce/adce.mir (after adce) ===
+  @module Adce
+  fn @removes_dead_branch_region(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
+-   bb1:
+-     v0 = add 1, 2
+      jump bb3
++   bb1:
++     invalid
+    bb2:
+-     v1 = mul 3, 4
+-     jump bb3
++     invalid
+    bb3:
+      ret 7
+  }
+  
+  fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 0, 1
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      ret 7
+  }
+  
+  fn @keeps_phi_target(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: 1], [bb2: 2]
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
@@ -1,36 +1,43 @@
-// === ROOT/tests/ui/codegen/mir/adce/adce_branch_cycle.mir (after adce) ===
-@module AdceBranchCycle
-fn @keeps_branch_cycle(arg0: bool) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br arg0, bb2, bb3
-  bb2:
-    jump bb1
-  bb3:
-    ret 7
-}
-
-fn @keeps_branch_self_loop(arg0: bool) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br arg0, bb1, bb2
-  bb2:
-    ret 7
-}
-
-fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
-  bb0 (entry):
-    jump bb5
-  bb1:
-    invalid
-  bb2:
-    invalid
-  bb3:
-    invalid
-  bb4:
-    invalid
-  bb5:
-    ret 7
-}
+- // === ROOT/tests/ui/codegen/mir/adce/adce_branch_cycle.mir (before adce) ===
++ // === ROOT/tests/ui/codegen/mir/adce/adce_branch_cycle.mir (after adce) ===
+  @module AdceBranchCycle
+  fn @keeps_branch_cycle(arg0: bool) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br arg0, bb2, bb3
+    bb2:
+      jump bb1
+    bb3:
+      ret 7
+  }
+  
+  fn @keeps_branch_self_loop(arg0: bool) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br arg0, bb1, bb2
+    bb2:
+      ret 7
+  }
+  
+  fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
++     jump bb5
+    bb1:
+-     br arg1, bb3, bb4
++     invalid
+    bb2:
+-     jump bb5
++     invalid
+    bb3:
+-     jump bb5
++     invalid
+    bb4:
+-     jump bb5
++     invalid
+    bb5:
+      ret 7
+  }
+  

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
@@ -1,31 +1,41 @@
-// === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir (after cfg-simplify) ===
-@module CfgSimplify
-fn @sequential(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = add v0, 1
-    v2 = add v1, 1
-    ret v2
-  bb1:
-    invalid
-  bb2:
-    invalid
-}
-
-fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    ret 1
-  bb2:
-    ret 2
-  bb3:
-    invalid
-}
-
-fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
-  bb0 (entry):
-    ret 1
-  bb1:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir (after cfg-simplify) ===
+  @module CfgSimplify
+  fn @sequential(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     jump bb1
+-   bb1:
+      v1 = add v0, 1
+-     jump bb2
+-   bb2:
+      v2 = add v1, 1
+      ret v2
++   bb1:
++     invalid
++   bb2:
++     invalid
+  }
+  
+  fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      ret 1
+    bb2:
+-     jump bb3
+-   bb3:
+      ret 2
++   bb3:
++     invalid
+  }
+  
+  fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb1
+-   bb1:
+      ret 1
++   bb1:
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
@@ -1,80 +1,90 @@
-// === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir (after cfg-simplify) ===
-@module CfgDedupTerminalBlocks
-fn @dedup_identical_panics(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 17
-    revert 0, 36
-  bb2:
-    br arg1, bb1, bb4
-  bb3:
-    invalid
-  bb4:
-    stop
-}
-
-fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 17
-    revert 0, 36
-  bb2:
-    br arg1, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 18
-    revert 0, 36
-  bb4:
-    stop
-}
-
-fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 17
-    revert 0, 36
-  bb2:
-    br arg1, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 17
-    revert 0, 32
-  bb4:
-    stop
-}
-
-fn @dedup_local_computations(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = add arg0, 1
-    mstore 0, v0
-    revert 0, 32
-  bb2:
-    br arg1, bb1, bb4
-  bb3:
-    invalid
-  bb4:
-    stop
-}
-
-fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 0, arg0
-    revert 0, 32
-  bb2:
-    br arg1, bb3, bb4
-  bb3:
-    mstore 0, arg1
-    revert 0, 32
-  bb4:
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir (after cfg-simplify) ===
+  @module CfgDedupTerminalBlocks
+  fn @dedup_identical_panics(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 36
+    bb2:
+-     br arg1, bb3, bb4
++     br arg1, bb1, bb4
+    bb3:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+-     mstore 4, 17
+-     revert 0, 36
++     invalid
+    bb4:
+      stop
+  }
+  
+  fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 36
+    bb2:
+      br arg1, bb3, bb4
+    bb3:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 18
+      revert 0, 36
+    bb4:
+      stop
+  }
+  
+  fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 36
+    bb2:
+      br arg1, bb3, bb4
+    bb3:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 32
+    bb4:
+      stop
+  }
+  
+  fn @dedup_local_computations(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = add arg0, 1
+      mstore 0, v0
+      revert 0, 32
+    bb2:
+-     br arg1, bb3, bb4
++     br arg1, bb1, bb4
+    bb3:
+-     v1 = add arg0, 1
+-     mstore 0, v1
+-     revert 0, 32
++     invalid
+    bb4:
+      stop
+  }
+  
+  fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 0, arg0
+      revert 0, 32
+    bb2:
+      br arg1, bb3, bb4
+    bb3:
+      mstore 0, arg1
+      revert 0, 32
+    bb4:
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
@@ -1,25 +1,33 @@
-// === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir (after cfg-simplify) ===
-@module CfgSimplifyPhiForwarders
-fn @keep_conflicting_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb3, bb2
-  bb1:
-    invalid
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb0: 1], [bb2: 2]
-    ret v0
-}
-
-fn @fold_equal_value_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb3, bb2
-  bb1:
-    invalid
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb0: 7], [bb2: 7]
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir (after cfg-simplify) ===
+  @module CfgSimplifyPhiForwarders
+  fn @keep_conflicting_diamond(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
++     br arg0, bb3, bb2
+    bb1:
+-     jump bb3
++     invalid
+    bb2:
+      jump bb3
+    bb3:
+-     v0 = phi [bb1: 1], [bb2: 2]
++     v0 = phi [bb0: 1], [bb2: 2]
+      ret v0
+  }
+  
+  fn @fold_equal_value_diamond(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
++     br arg0, bb3, bb2
+    bb1:
+-     jump bb3
++     invalid
+    bb2:
+      jump bb3
+    bb3:
+-     v0 = phi [bb1: 7], [bb2: 7]
++     v0 = phi [bb0: 7], [bb2: 7]
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
@@ -1,26 +1,32 @@
-// === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after cfg-simplify,dce) ===
-@module CfgSimplifyTrivialPhi
-fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    log0 0, 0
-    jump bb3
-  bb2:
-    log0 0, 0
-    jump bb3
-  bb3:
-    ret arg0
-}
-
-fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br arg1, bb2, bb3
-  bb2:
-    log0 0, 0
-    jump bb1
-  bb3:
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (before cfg-simplify,dce) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after cfg-simplify,dce) ===
+  @module CfgSimplifyTrivialPhi
+  fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      log0 0, 0
+      jump bb3
+    bb2:
+      log0 0, 0
+      jump bb3
+    bb3:
+-     v0 = phi [bb1: arg0], [bb2: arg0]
+-     ret v0
++     ret arg0
+  }
+  
+  fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+-     v0 = phi [bb0: arg0], [bb2: v0]
+      br arg1, bb2, bb3
+    bb2:
+      log0 0, 0
+      jump bb1
+    bb3:
+-     ret v0
++     ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
@@ -1,5 +1,5 @@
-- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (before cfg-simplify,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after cfg-simplify,dce) ===
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after cfg-simplify) ===
   @module CfgSimplifyTrivialPhi
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
     bb0 (entry):
@@ -28,5 +28,33 @@
     bb3:
 -     ret v0
 +     ret arg0
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after dce) ===
+  @module CfgSimplifyTrivialPhi
+  fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      log0 0, 0
+      jump bb3
+    bb2:
+      log0 0, 0
+      jump bb3
+    bb3:
+      ret arg0
+  }
+  
+  fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br arg1, bb2, bb3
+    bb2:
+      log0 0, 0
+      jump bb1
+    bb3:
+      ret arg0
   }
   

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
@@ -1,15 +1,23 @@
-// === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir (after cfg-simplify) ===
-@module CfgSimplifyTrivialPhiChain
-fn @chained_trivial(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br arg0, bb2, bb4
-  bb2:
-    v2 = add arg0, 1
-    br v2, bb2, bb1
-  bb3:
-    invalid
-  bb4:
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir (after cfg-simplify) ===
+  @module CfgSimplifyTrivialPhiChain
+  fn @chained_trivial(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+-     v0 = phi [bb0: arg0], [bb3: v0]
+      br arg0, bb2, bb4
+    bb2:
+-     v1 = phi [bb1: v0], [bb2: v1]
+-     v2 = add v1, 1
+-     br v2, bb2, bb3
++     v2 = add arg0, 1
++     br v2, bb2, bb1
+    bb3:
+-     jump bb1
++     invalid
+    bb4:
+-     ret v0
++     ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
@@ -1,33 +1,36 @@
-// === ROOT/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir (after check-elim) ===
-@module CheckElimAddBounds
-fn @fold_exact_boundary(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-    br v0, bb1, bb2
-  bb1:
-    v1 = add arg0, 2
-    v2 = lt v1, arg0
-    jump bb4
-  bb2:
-    ret 0
-  bb3:
-    revert 0, 0
-  bb4:
-    ret v1
-}
-
-fn @keep_wrappable_boundary(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v0, bb1, bb2
-  bb1:
-    v1 = add arg0, 2
-    v2 = lt v1, arg0
-    br v2, bb3, bb4
-  bb2:
-    ret 0
-  bb3:
-    revert 0, 0
-  bb4:
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir (before check-elim) ===
++ // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir (after check-elim) ===
+  @module CheckElimAddBounds
+  fn @fold_exact_boundary(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
+      br v0, bb1, bb2
+    bb1:
+      v1 = add arg0, 2
+      v2 = lt v1, arg0
+-     br v2, bb3, bb4
++     jump bb4
+    bb2:
+      ret 0
+    bb3:
+      revert 0, 0
+    bb4:
+      ret v1
+  }
+  
+  fn @keep_wrappable_boundary(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      br v0, bb1, bb2
+    bb1:
+      v1 = add arg0, 2
+      v2 = lt v1, arg0
+      br v2, bb3, bb4
+    bb2:
+      ret 0
+    bb3:
+      revert 0, 0
+    bb4:
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
@@ -1,59 +1,63 @@
-// === ROOT/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir (after check-elim) ===
-@module CheckElimIndexGuard
-fn @fold_const_len_check(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, 3
-    br v0, bb1, bb4
-  bb1:
-    v1 = lt arg0, 3
-    jump bb3
-  bb2:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 50
-    revert 0, 36
-  bb3:
-    v2 = shl 5, arg0
-    v3 = mload v2
-    ret v3
-  bb4:
-    ret 0
-}
-
-fn @fold_dyn_len_check(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    v1 = lt arg0, v0
-    br v1, bb1, bb4
-  bb1:
-    v2 = lt arg0, v0
-    jump bb3
-  bb2:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 50
-    revert 0, 36
-  bb3:
-    v3 = add arg0, 100
-    v4 = sload v3
-    ret v4
-  bb4:
-    ret 0
-}
-
-fn @keep_weaker_guard(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, 5
-    br v0, bb1, bb4
-  bb1:
-    v1 = lt arg0, 3
-    br v1, bb3, bb2
-  bb2:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 50
-    revert 0, 36
-  bb3:
-    v2 = shl 5, arg0
-    v3 = mload v2
-    ret v3
-  bb4:
-    ret 0
-}
+- // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir (before check-elim) ===
++ // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir (after check-elim) ===
+  @module CheckElimIndexGuard
+  fn @fold_const_len_check(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, 3
+      br v0, bb1, bb4
+    bb1:
+      v1 = lt arg0, 3
+-     br v1, bb3, bb2
++     jump bb3
+    bb2:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 50
+      revert 0, 36
+    bb3:
+      v2 = shl 5, arg0
+      v3 = mload v2
+      ret v3
+    bb4:
+      ret 0
+  }
+  
+  fn @fold_dyn_len_check(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      v1 = lt arg0, v0
+      br v1, bb1, bb4
+    bb1:
+      v2 = lt arg0, v0
+-     br v2, bb3, bb2
++     jump bb3
+    bb2:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 50
+      revert 0, 36
+    bb3:
+      v3 = add arg0, 100
+      v4 = sload v3
+      ret v4
+    bb4:
+      ret 0
+  }
+  
+  fn @keep_weaker_guard(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, 5
+      br v0, bb1, bb4
+    bb1:
+      v1 = lt arg0, 3
+      br v1, bb3, bb2
+    bb2:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 50
+      revert 0, 36
+    bb3:
+      v2 = shl 5, arg0
+      v3 = mload v2
+      ret v3
+    bb4:
+      ret 0
+  }
+  

--- a/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
@@ -1,38 +1,41 @@
-// === ROOT/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir (after check-elim) ===
-@module CheckElimLoopIncrement
-fn @fold_increment_check(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb4: v2]
-    v1 = lt v0, arg0
-    br v1, bb2, bb5
-  bb2:
-    v2 = add v0, 1
-    v3 = lt v2, v0
-    jump bb4
-  bb3:
-    revert 0, 0
-  bb4:
-    jump bb1
-  bb5:
-    ret v0
-}
-
-fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    v0 = lt arg0, 100
-    br v0, bb3, bb2
-  bb2:
-    jump bb3
-  bb3:
-    v1 = add arg0, 1
-    v2 = lt v1, arg0
-    br v2, bb4, bb5
-  bb4:
-    revert 0, 0
-  bb5:
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir (before check-elim) ===
++ // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir (after check-elim) ===
+  @module CheckElimLoopIncrement
+  fn @fold_increment_check(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb4: v2]
+      v1 = lt v0, arg0
+      br v1, bb2, bb5
+    bb2:
+      v2 = add v0, 1
+      v3 = lt v2, v0
+-     br v3, bb3, bb4
++     jump bb4
+    bb3:
+      revert 0, 0
+    bb4:
+      jump bb1
+    bb5:
+      ret v0
+  }
+  
+  fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      v0 = lt arg0, 100
+      br v0, bb3, bb2
+    bb2:
+      jump bb3
+    bb3:
+      v1 = add arg0, 1
+      v2 = lt v1, arg0
+      br v2, bb4, bb5
+    bb4:
+      revert 0, 0
+    bb5:
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
@@ -1,32 +1,35 @@
-// === ROOT/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir (after check-elim) ===
-@module CheckElimMulDiv
-fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, 100
-    br v0, bb1, bb2
-  bb1:
-    v1 = mul arg0, 3
-    v2 = div v1, 3
-    v3 = eq v2, arg0
-    v4 = iszero v3
-    jump bb4
-  bb2:
-    ret 0
-  bb3:
-    revert 0, 0
-  bb4:
-    ret v1
-}
-
-fn @keep_mul_check_without_bound(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mul arg0, 3
-    v1 = div v0, 3
-    v2 = eq v1, arg0
-    v3 = iszero v2
-    br v3, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir (before check-elim) ===
++ // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir (after check-elim) ===
+  @module CheckElimMulDiv
+  fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, 100
+      br v0, bb1, bb2
+    bb1:
+      v1 = mul arg0, 3
+      v2 = div v1, 3
+      v3 = eq v2, arg0
+      v4 = iszero v3
+-     br v4, bb3, bb4
++     jump bb4
+    bb2:
+      ret 0
+    bb3:
+      revert 0, 0
+    bb4:
+      ret v1
+  }
+  
+  fn @keep_mul_check_without_bound(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mul arg0, 3
+      v1 = div v0, 3
+      v2 = eq v1, arg0
+      v3 = iszero v2
+      br v3, bb1, bb2
+    bb1:
+      revert 0, 0
+    bb2:
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
@@ -1,22 +1,24 @@
-// === ROOT/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir (after check-elim) ===
-@module CheckElimPhiKept
-fn @keep_check_on_loop_phi(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, 100
-    br v0, bb1, bb5
-  bb1:
-    jump bb2
-  bb2:
-    v1 = phi [bb1: arg0], [bb3: v2]
-    v2 = add v1, 1
-    v3 = lt v2, v1
-    br v3, bb4, bb3
-  bb3:
-    br arg1, bb2, bb6
-  bb4:
-    revert 0, 0
-  bb5:
-    ret 0
-  bb6:
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir (before check-elim) ===
++ // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir (after check-elim) ===
+  @module CheckElimPhiKept
+  fn @keep_check_on_loop_phi(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, 100
+      br v0, bb1, bb5
+    bb1:
+      jump bb2
+    bb2:
+      v1 = phi [bb1: arg0], [bb3: v2]
+      v2 = add v1, 1
+      v3 = lt v2, v1
+      br v3, bb4, bb3
+    bb3:
+      br arg1, bb2, bb6
+    bb4:
+      revert 0, 0
+    bb5:
+      ret 0
+    bb6:
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
@@ -1,47 +1,50 @@
-// === ROOT/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir (after check-elim) ===
-@module CheckElimSubGuard
-fn @fold_sub_after_ge_guard(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = gt arg1, arg0
-    v1 = iszero v0
-    v2 = iszero v1
-    br v2, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    v3 = sub arg0, arg1
-    v4 = lt arg0, arg1
-    jump bb4
-  bb3:
-    revert 0, 0
-  bb4:
-    ret v3
-}
-
-fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sub arg0, arg1
-    v1 = lt arg0, arg1
-    br v1, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    ret v0
-}
-
-fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = gt arg1, arg0
-    br v0, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    v1 = mload 0
-    v2 = sub v1, arg1
-    v3 = lt v1, arg1
-    br v3, bb3, bb4
-  bb3:
-    revert 0, 0
-  bb4:
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir (before check-elim) ===
++ // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir (after check-elim) ===
+  @module CheckElimSubGuard
+  fn @fold_sub_after_ge_guard(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = gt arg1, arg0
+      v1 = iszero v0
+      v2 = iszero v1
+      br v2, bb1, bb2
+    bb1:
+      revert 0, 0
+    bb2:
+      v3 = sub arg0, arg1
+      v4 = lt arg0, arg1
+-     br v4, bb3, bb4
++     jump bb4
+    bb3:
+      revert 0, 0
+    bb4:
+      ret v3
+  }
+  
+  fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sub arg0, arg1
+      v1 = lt arg0, arg1
+      br v1, bb1, bb2
+    bb1:
+      revert 0, 0
+    bb2:
+      ret v0
+  }
+  
+  fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = gt arg1, arg0
+      br v0, bb1, bb2
+    bb1:
+      revert 0, 0
+    bb2:
+      v1 = mload 0
+      v2 = sub v1, arg1
+      v3 = lt v1, arg1
+      br v3, bb3, bb4
+    bb3:
+      revert 0, 0
+    bb4:
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_basic.stdout
+++ b/tests/ui/codegen/mir/cse/cse_basic.stdout
@@ -1,8 +1,12 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_basic.mir (after cse) ===
-@module CseBasic
-fn @redundant_add(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, arg1
-    v2 = add v0, v0
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_basic.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_basic.mir (after cse) ===
+  @module CseBasic
+  fn @redundant_add(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, arg1
+-     v1 = add arg0, arg1
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_commutative.stdout
+++ b/tests/ui/codegen/mir/cse/cse_commutative.stdout
@@ -1,8 +1,12 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_commutative.mir (after cse) ===
-@module CseCommutative
-fn @commutative(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, arg1
-    v2 = add v0, v0
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_commutative.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_commutative.mir (after cse) ===
+  @module CseCommutative
+  fn @commutative(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, arg1
+-     v1 = add arg1, arg0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_environment.stdout
+++ b/tests/ui/codegen/mir/cse/cse_environment.stdout
@@ -1,63 +1,75 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_environment.mir (after cse) ===
-@module CseEnvironment
-fn @keep_cheap_nullary_environment_reads(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = caller
-    v1 = caller
-    v2 = callvalue
-    v3 = callvalue
-    v4 = calldatasize
-    v5 = calldatasize
-    v6 = chainid
-    v7 = chainid
-    v8 = add v0, v1
-    v9 = add v2, v3
-    v10 = add v4, v5
-    v11 = add v6, v7
-    v12 = add v8, v9
-    v13 = add v10, v11
-    v14 = add v12, v13
-    v15 = add v14, arg0
-    ret v15
-}
-
-fn @reuse_expensive_environment_reads(arg0: address, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = balance arg0
-    v2 = extcodesize arg0
-    v4 = extcodehash arg0
-    v6 = blockhash arg1
-    v8 = blobhash arg1
-    v10 = add v0, v0
-    v11 = add v2, v2
-    v12 = add v4, v4
-    v13 = add v6, v6
-    v14 = add v8, v8
-    v15 = add v10, v11
-    v16 = add v12, v13
-    v17 = add v15, v16
-    v18 = add v17, v14
-    ret v18
-}
-
-fn @invalidate_account_reads_after_call(arg0: address) -> u256 {
-  bb0 (entry):
-    v0 = balance arg0
-    v1 = extcodehash arg0
-    v2 = call 0x186a0, arg0, 0, 0, 0, 0, 0
-    v3 = balance arg0
-    v4 = extcodehash arg0
-    v5 = add v0, v3
-    v6 = add v1, v4
-    v7 = add v5, v6
-    v8 = add v7, v2
-    ret v8
-}
-
-fn @keep_gas_uncached() -> u256 {
-  bb0 (entry):
-    v0 = gas
-    v1 = gas
-    v2 = add v0, v1
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_environment.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_environment.mir (after cse) ===
+  @module CseEnvironment
+  fn @keep_cheap_nullary_environment_reads(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = caller
+      v1 = caller
+      v2 = callvalue
+      v3 = callvalue
+      v4 = calldatasize
+      v5 = calldatasize
+      v6 = chainid
+      v7 = chainid
+      v8 = add v0, v1
+      v9 = add v2, v3
+      v10 = add v4, v5
+      v11 = add v6, v7
+      v12 = add v8, v9
+      v13 = add v10, v11
+      v14 = add v12, v13
+      v15 = add v14, arg0
+      ret v15
+  }
+  
+  fn @reuse_expensive_environment_reads(arg0: address, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = balance arg0
+-     v1 = balance arg0
+      v2 = extcodesize arg0
+-     v3 = extcodesize arg0
+      v4 = extcodehash arg0
+-     v5 = extcodehash arg0
+      v6 = blockhash arg1
+-     v7 = blockhash arg1
+      v8 = blobhash arg1
+-     v9 = blobhash arg1
+-     v10 = add v0, v1
+-     v11 = add v2, v3
+-     v12 = add v4, v5
+-     v13 = add v6, v7
+-     v14 = add v8, v9
++     v10 = add v0, v0
++     v11 = add v2, v2
++     v12 = add v4, v4
++     v13 = add v6, v6
++     v14 = add v8, v8
+      v15 = add v10, v11
+      v16 = add v12, v13
+      v17 = add v15, v16
+      v18 = add v17, v14
+      ret v18
+  }
+  
+  fn @invalidate_account_reads_after_call(arg0: address) -> u256 {
+    bb0 (entry):
+      v0 = balance arg0
+      v1 = extcodehash arg0
+      v2 = call 0x186a0, arg0, 0, 0, 0, 0, 0
+      v3 = balance arg0
+      v4 = extcodehash arg0
+      v5 = add v0, v3
+      v6 = add v1, v4
+      v7 = add v5, v6
+      v8 = add v7, v2
+      ret v8
+  }
+  
+  fn @keep_gas_uncached() -> u256 {
+    bb0 (entry):
+      v0 = gas
+      v1 = gas
+      v2 = add v0, v1
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_extended_ops.stdout
+++ b/tests/ui/codegen/mir/cse/cse_extended_ops.stdout
@@ -1,18 +1,29 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_extended_ops.mir (after cse) ===
-@module CseExtendedOps
-fn @extended_pure_ops(arg0: u256, arg1: u256, arg2: bool) -> (u256, u256, u256, u256, u256, bool) {
-  bb0 (entry):
-    v0 = sdiv arg0, arg1
-    v2 = smod arg0, arg1
-    v4 = sar arg1, arg0
-    v6 = signextend arg1, arg0
-    v8 = addmod arg0, arg1, 97
-    v10 = select arg2, arg0, arg1
-    ret v0, v2, v4, v6, v8, v10
-}
-
-fn @calldata_reads(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = calldataload arg0
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_extended_ops.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_extended_ops.mir (after cse) ===
+  @module CseExtendedOps
+  fn @extended_pure_ops(arg0: u256, arg1: u256, arg2: bool) -> (u256, u256, u256, u256, u256, bool) {
+    bb0 (entry):
+      v0 = sdiv arg0, arg1
+-     v1 = sdiv arg0, arg1
+      v2 = smod arg0, arg1
+-     v3 = smod arg0, arg1
+      v4 = sar arg1, arg0
+-     v5 = sar arg1, arg0
+      v6 = signextend arg1, arg0
+-     v7 = signextend arg1, arg0
+      v8 = addmod arg0, arg1, 97
+-     v9 = addmod arg1, arg0, 97
+      v10 = select arg2, arg0, arg1
+-     v11 = select arg2, arg0, arg1
+-     ret v1, v3, v5, v7, v9, v11
++     ret v0, v2, v4, v6, v8, v10
+  }
+  
+  fn @calldata_reads(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = calldataload arg0
+-     v1 = calldataload arg0
+-     ret v1
++     ret v0
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_global.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global.stdout
@@ -1,16 +1,22 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_global.mir (after cse) ===
-@module CseGlobal
-fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, arg1
-    br arg2, bb1, bb2
-  bb1:
-    v2 = mul v0, 2
-    jump bb3
-  bb2:
-    v4 = mul v0, 3
-    jump bb3
-  bb3:
-    v5 = phi [bb1: v2], [bb2: v4]
-    ret v5
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_global.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_global.mir (after cse) ===
+  @module CseGlobal
+  fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, arg1
+      br arg2, bb1, bb2
+    bb1:
+-     v1 = add arg0, arg1
+-     v2 = mul v1, 2
++     v2 = mul v0, 2
+      jump bb3
+    bb2:
+-     v3 = add arg1, arg0
+-     v4 = mul v3, 3
++     v4 = mul v0, 3
+      jump bb3
+    bb3:
+      v5 = phi [bb1: v2], [bb2: v4]
+      ret v5
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
@@ -1,108 +1,117 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir (after cse) ===
-@module CseGlobalClobberPaths
-fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    br arg0, bb1, bb2
-  bb1:
-    sstore 0, 7
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v1 = sload 0
-    v2 = add v0, v1
-    ret v2
-}
-
-fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    br arg0, bb1, bb2
-  bb1:
-    sstore 1, 7
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @loop_sload_clobbered_body(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    jump bb1
-  bb1:
-    v1 = sload 0
-    v2 = lt v1, arg0
-    br v2, bb2, bb3
-  bb2:
-    sstore 0, 7
-    jump bb1
-  bb3:
-    v3 = add v0, v1
-    ret v3
-}
-
-fn @loop_sload_clean_body(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    jump bb1
-  bb1:
-    v2 = lt v0, arg0
-    br v2, bb2, bb3
-  bb2:
-    jump bb1
-  bb3:
-    v3 = add v0, v0
-    ret v3
-}
-
-fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
-  bb0 (entry):
-    mstore 0, 11
-    v0 = mload 0
-    br arg0, bb1, bb2
-  bb1:
-    mstore 0, 22
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v1 = mload 0
-    v2 = add v0, v1
-    ret v2
-}
-
-fn @diamond_call_clobbers_account_reads(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
-    v0 = balance arg1
-    v1 = extcodesize arg1
-    br arg0, bb1, bb2
-  bb1:
-    v2 = call 0x186a0, arg1, 0, 0, 0, 0, 0
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v3 = balance arg1
-    v4 = extcodesize arg1
-    v5 = add v0, v3
-    v6 = add v1, v4
-    v7 = add v5, v6
-    ret v7
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir (after cse) ===
+  @module CseGlobalClobberPaths
+  fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      br arg0, bb1, bb2
+    bb1:
+      sstore 0, 7
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v1 = sload 0
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+-     v1 = sload 0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      br arg0, bb1, bb2
+    bb1:
+      sstore 1, 7
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+-     v1 = sload 0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @loop_sload_clobbered_body(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      jump bb1
+    bb1:
+      v1 = sload 0
+      v2 = lt v1, arg0
+      br v2, bb2, bb3
+    bb2:
+      sstore 0, 7
+      jump bb1
+    bb3:
+      v3 = add v0, v1
+      ret v3
+  }
+  
+  fn @loop_sload_clean_body(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      jump bb1
+    bb1:
+-     v1 = sload 0
+-     v2 = lt v1, arg0
++     v2 = lt v0, arg0
+      br v2, bb2, bb3
+    bb2:
+      jump bb1
+    bb3:
+-     v3 = add v0, v1
++     v3 = add v0, v0
+      ret v3
+  }
+  
+  fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
+    bb0 (entry):
+      mstore 0, 11
+      v0 = mload 0
+      br arg0, bb1, bb2
+    bb1:
+      mstore 0, 22
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v1 = mload 0
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @diamond_call_clobbers_account_reads(arg0: bool, arg1: address) -> u256 {
+    bb0 (entry):
+      v0 = balance arg1
+      v1 = extcodesize arg1
+      br arg0, bb1, bb2
+    bb1:
+      v2 = call 0x186a0, arg1, 0, 0, 0, 0, 0
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v3 = balance arg1
+      v4 = extcodesize arg1
+      v5 = add v0, v3
+      v6 = add v1, v4
+      v7 = add v5, v6
+      ret v7
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_global_loads.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.stdout
@@ -1,26 +1,32 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_global_loads.mir (after cse) ===
-@module CseGlobalLoads
-fn @dominating_mload(arg0: bool) -> u256 {
-  bb0 (entry):
-    mstore 0, 11
-    v0 = mload 0
-    br arg0, bb1, bb2
-  bb1:
-    ret v0
-  bb2:
-    mstore 0, 22
-    v2 = mload 0
-    ret v2
-}
-
-fn @dominating_sload(arg0: bool) -> u256 {
-  bb0 (entry):
-    v0 = sload 0
-    br arg0, bb1, bb2
-  bb1:
-    ret v0
-  bb2:
-    sstore 0, 7
-    v2 = sload 0
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_global_loads.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_global_loads.mir (after cse) ===
+  @module CseGlobalLoads
+  fn @dominating_mload(arg0: bool) -> u256 {
+    bb0 (entry):
+      mstore 0, 11
+      v0 = mload 0
+      br arg0, bb1, bb2
+    bb1:
+-     v1 = mload 0
+-     ret v1
++     ret v0
+    bb2:
+      mstore 0, 22
+      v2 = mload 0
+      ret v2
+  }
+  
+  fn @dominating_sload(arg0: bool) -> u256 {
+    bb0 (entry):
+      v0 = sload 0
+      br arg0, bb1, bb2
+    bb1:
+-     v1 = sload 0
+-     ret v1
++     ret v0
+    bb2:
+      sstore 0, 7
+      v2 = sload 0
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_gvn.stdout
+++ b/tests/ui/codegen/mir/cse/cse_gvn.stdout
@@ -1,89 +1,104 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_gvn.mir (after cse) ===
-@module CseGvn
-fn @nested_offsets_across_dominator(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 16
-    v1 = add v0, 16
-    br arg1, bb1, bb2
-  bb1:
-    v3 = add v1, v1
-    ret v3
-  bb2:
-    ret v1
-}
-
-fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add 16, arg0
-    v1 = add 16, v0
-    br arg1, bb1, bb2
-  bb1:
-    ret v1
-  bb2:
-    ret v1
-}
-
-fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 16
-    v1 = add v0, 16
-    v2 = keccak256 v1, 32
-    br arg1, bb1, bb2
-  bb1:
-    ret v2
-  bb2:
-    ret v2
-}
-
-fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 16
-    v1 = add v0, 16
-    v2 = mload v1
-    br arg1, bb1, bb2
-  bb1:
-    mstore v1, 7
-    v4 = mload v1
-    ret v4
-  bb2:
-    ret v2
-}
-
-fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sub arg0, 1
-    v1 = mload v0
-    v2 = sub arg0, 2
-    v3 = mload v2
-    v4 = add v1, v3
-    ret v4
-}
-
-fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-  bb0 (entry):
-    br arg2, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v4 = add arg0, arg1
-    v3 = mul v4, 2
-    ret v3
-}
-
-fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    v0 = add arg0, 1
-    v1 = mul v0, 2
-    jump bb3
-  bb2:
-    v2 = add arg0, 1
-    v3 = mul v2, 2
-    jump bb3
-  bb3:
-    v4 = phi [bb1: v1], [bb2: v3]
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_gvn.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_gvn.mir (after cse) ===
+  @module CseGvn
+  fn @nested_offsets_across_dominator(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 16
+      v1 = add v0, 16
+      br arg1, bb1, bb2
+    bb1:
+-     v2 = add arg0, 32
+-     v3 = add v1, v2
++     v3 = add v1, v1
+      ret v3
+    bb2:
+      ret v1
+  }
+  
+  fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add 16, arg0
+      v1 = add 16, v0
+      br arg1, bb1, bb2
+    bb1:
+-     v2 = add arg0, 32
+-     ret v2
++     ret v1
+    bb2:
+      ret v1
+  }
+  
+  fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 16
+      v1 = add v0, 16
+      v2 = keccak256 v1, 32
+      br arg1, bb1, bb2
+    bb1:
+-     v3 = add arg0, 32
+-     v4 = keccak256 v3, 32
+-     ret v4
++     ret v2
+    bb2:
+      ret v2
+  }
+  
+  fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 16
+      v1 = add v0, 16
+      v2 = mload v1
+      br arg1, bb1, bb2
+    bb1:
+-     v3 = add arg0, 32
+-     mstore v3, 7
++     mstore v1, 7
+      v4 = mload v1
+      ret v4
+    bb2:
+      ret v2
+  }
+  
+  fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sub arg0, 1
+      v1 = mload v0
+      v2 = sub arg0, 2
+      v3 = mload v2
+      v4 = add v1, v3
+      ret v4
+  }
+  
+  fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
+    bb0 (entry):
+      br arg2, bb1, bb2
+    bb1:
+-     v0 = add arg0, arg1
+      jump bb3
+    bb2:
+-     v1 = add arg1, arg0
+      jump bb3
+    bb3:
+-     v2 = phi [bb1: v0], [bb2: v1]
+-     v3 = mul v2, 2
++     v4 = add arg0, arg1
++     v3 = mul v4, 2
+      ret v3
+  }
+  
+  fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      v0 = add arg0, 1
+      v1 = mul v0, 2
+      jump bb3
+    bb2:
+      v2 = add arg0, 1
+      v3 = mul v2, 2
+      jump bb3
+    bb3:
+      v4 = phi [bb1: v1], [bb2: v3]
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.stdout
+++ b/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.stdout
@@ -1,25 +1,29 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.mir (after cse) ===
-@module CseKeccakDynamicSize
-fn @keep_different_dynamic_sizes(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = keccak256 0, arg0
-    v1 = keccak256 0, arg1
-    v2 = add v0, v1
-    ret v2
-}
-
-fn @reuse_same_dynamic_size(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = keccak256 0, arg0
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @invalidate_after_dynamic_size_write(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = keccak256 0, arg0
-    calldatacopy 0, 0, arg1
-    v1 = keccak256 0, arg0
-    v2 = add v0, v1
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.mir (after cse) ===
+  @module CseKeccakDynamicSize
+  fn @keep_different_dynamic_sizes(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = keccak256 0, arg0
+      v1 = keccak256 0, arg1
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @reuse_same_dynamic_size(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = keccak256 0, arg0
+-     v1 = keccak256 0, arg0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @invalidate_after_dynamic_size_write(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = keccak256 0, arg0
+      calldatacopy 0, 0, arg1
+      v1 = keccak256 0, arg0
+      v2 = add v0, v1
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_memory_alias.stdout
+++ b/tests/ui/codegen/mir/cse/cse_memory_alias.stdout
@@ -1,44 +1,54 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_memory_alias.mir (after cse) ===
-@module CseMemoryAlias
-fn @reuse_same_memory_load(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mload arg0
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @reuse_after_disjoint_memory_store(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    mstore 96, arg0
-    v3 = add v0, v0
-    v4 = add v3, v0
-    ret v4
-}
-
-fn @keep_after_overlapping_memory_store(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    mstore 80, arg0
-    v1 = mload 64
-    v2 = add v0, v1
-    ret v2
-}
-
-fn @reuse_keccak_after_disjoint_memory_store(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = keccak256 128, 64
-    mstore 64, arg0
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @keep_mload_after_external_call(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    v1 = call 0x186a0, arg0, 0, 0, 0, 96, 32
-    v2 = mload 64
-    v3 = add v0, v2
-    v4 = add v3, v1
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_memory_alias.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_memory_alias.mir (after cse) ===
+  @module CseMemoryAlias
+  fn @reuse_same_memory_load(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mload arg0
+-     v1 = mload arg0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @reuse_after_disjoint_memory_store(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mload 64
+-     v1 = mload 64
+      mstore 96, arg0
+-     v2 = mload 64
+-     v3 = add v0, v1
+-     v4 = add v3, v2
++     v3 = add v0, v0
++     v4 = add v3, v0
+      ret v4
+  }
+  
+  fn @keep_after_overlapping_memory_store(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mload 64
+      mstore 80, arg0
+      v1 = mload 64
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @reuse_keccak_after_disjoint_memory_store(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = keccak256 128, 64
+      mstore 64, arg0
+-     v1 = keccak256 128, 64
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @keep_mload_after_external_call(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mload 64
+      v1 = call 0x186a0, arg0, 0, 0, 0, 96, 32
+      v2 = mload 64
+      v3 = add v0, v2
+      v4 = add v3, v1
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_non_commutative.stdout
+++ b/tests/ui/codegen/mir/cse/cse_non_commutative.stdout
@@ -1,9 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_non_commutative.mir (after cse) ===
-@module CseNonCommutative
-fn @non_commutative(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sub arg0, arg1
-    v1 = sub arg1, arg0
-    v2 = add v0, v1
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_non_commutative.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_non_commutative.mir (after cse) ===
+  @module CseNonCommutative
+  fn @non_commutative(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sub arg0, arg1
+      v1 = sub arg1, arg0
+      v2 = add v0, v1
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_sload.stdout
+++ b/tests/ui/codegen/mir/cse/cse_sload.stdout
@@ -1,17 +1,21 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_sload.mir (after cse) ===
-@module CseSload
-fn @sload_cse(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload arg0
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @sload_after_sstore(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload arg0
-    sstore arg0, arg1
-    v1 = sload arg0
-    v2 = add v0, v1
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_sload.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_sload.mir (after cse) ===
+  @module CseSload
+  fn @sload_cse(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload arg0
+-     v1 = sload arg0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @sload_after_sstore(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload arg0
+      sstore arg0, arg1
+      v1 = sload arg0
+      v2 = add v0, v1
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_staticcall_environment.stdout
+++ b/tests/ui/codegen/mir/cse/cse_staticcall_environment.stdout
@@ -1,39 +1,49 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_staticcall_environment.mir (after cse) ===
-@module CseStaticcallEnvironment
-fn @reuse_account_reads_across_staticcall(arg0: address) -> u256 {
-  bb0 (entry):
-    v0 = balance arg0
-    v1 = extcodesize arg0
-    v2 = extcodehash arg0
-    v3 = selfbalance
-    v4 = staticcall 0x186a0, arg0, 0, 0, 0, 0
-    v9 = add v0, v0
-    v10 = add v1, v1
-    v11 = add v2, v2
-    v12 = add v3, v3
-    v13 = add v9, v10
-    v14 = add v11, v12
-    v15 = add v13, v14
-    v16 = add v15, v4
-    ret v16
-}
-
-fn @keep_memory_reads_across_staticcall(arg0: address) -> u256 {
-  bb0 (entry):
-    v0 = mload 128
-    v1 = staticcall 0x186a0, arg0, 0, 0, 128, 32
-    v2 = mload 128
-    v3 = add v0, v2
-    v4 = add v3, v1
-    ret v4
-}
-
-fn @keep_account_reads_across_call(arg0: address) -> u256 {
-  bb0 (entry):
-    v0 = balance arg0
-    v1 = call 0x186a0, arg0, 0, 0, 0, 0, 0
-    v2 = balance arg0
-    v3 = add v0, v2
-    v4 = add v3, v1
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_staticcall_environment.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_staticcall_environment.mir (after cse) ===
+  @module CseStaticcallEnvironment
+  fn @reuse_account_reads_across_staticcall(arg0: address) -> u256 {
+    bb0 (entry):
+      v0 = balance arg0
+      v1 = extcodesize arg0
+      v2 = extcodehash arg0
+      v3 = selfbalance
+      v4 = staticcall 0x186a0, arg0, 0, 0, 0, 0
+-     v5 = balance arg0
+-     v6 = extcodesize arg0
+-     v7 = extcodehash arg0
+-     v8 = selfbalance
+-     v9 = add v0, v5
+-     v10 = add v1, v6
+-     v11 = add v2, v7
+-     v12 = add v3, v8
++     v9 = add v0, v0
++     v10 = add v1, v1
++     v11 = add v2, v2
++     v12 = add v3, v3
+      v13 = add v9, v10
+      v14 = add v11, v12
+      v15 = add v13, v14
+      v16 = add v15, v4
+      ret v16
+  }
+  
+  fn @keep_memory_reads_across_staticcall(arg0: address) -> u256 {
+    bb0 (entry):
+      v0 = mload 128
+      v1 = staticcall 0x186a0, arg0, 0, 0, 128, 32
+      v2 = mload 128
+      v3 = add v0, v2
+      v4 = add v3, v1
+      ret v4
+  }
+  
+  fn @keep_account_reads_across_call(arg0: address) -> u256 {
+    bb0 (entry):
+      v0 = balance arg0
+      v1 = call 0x186a0, arg0, 0, 0, 0, 0, 0
+      v2 = balance arg0
+      v3 = add v0, v2
+      v4 = add v3, v1
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_storage_alias.stdout
+++ b/tests/ui/codegen/mir/cse/cse_storage_alias.stdout
@@ -1,39 +1,45 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_storage_alias.mir (after cse) ===
-@module CseStorageAlias
-fn @reuse_sload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload arg0
-    v1 = add arg0, 1
-    sstore v1, arg1
-    v3 = add v0, v0
-    ret v3
-}
-
-fn @keep_sload_after_aliasing_store(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload arg0
-    v1 = add arg0, 0
-    sstore v1, arg1
-    v2 = sload arg0
-    v3 = add v0, v2
-    ret v3
-}
-
-fn @reuse_tload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = tload arg0
-    v1 = add arg0, 1
-    tstore v1, arg1
-    v3 = add v0, v0
-    ret v3
-}
-
-fn @keep_sload_after_external_call(arg0: u256, arg1: address) -> u256 {
-  bb0 (entry):
-    v0 = sload arg0
-    v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
-    v2 = sload arg0
-    v3 = add v0, v2
-    v4 = add v3, v1
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_storage_alias.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_storage_alias.mir (after cse) ===
+  @module CseStorageAlias
+  fn @reuse_sload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload arg0
+      v1 = add arg0, 1
+      sstore v1, arg1
+-     v2 = sload arg0
+-     v3 = add v0, v2
++     v3 = add v0, v0
+      ret v3
+  }
+  
+  fn @keep_sload_after_aliasing_store(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload arg0
+      v1 = add arg0, 0
+      sstore v1, arg1
+      v2 = sload arg0
+      v3 = add v0, v2
+      ret v3
+  }
+  
+  fn @reuse_tload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = tload arg0
+      v1 = add arg0, 1
+      tstore v1, arg1
+-     v2 = tload arg0
+-     v3 = add v0, v2
++     v3 = add v0, v0
+      ret v3
+  }
+  
+  fn @keep_sload_after_external_call(arg0: u256, arg1: address) -> u256 {
+    bb0 (entry):
+      v0 = sload arg0
+      v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
+      v2 = sload arg0
+      v3 = add v0, v2
+      v4 = add v3, v1
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_swapped_comparisons.stdout
+++ b/tests/ui/codegen/mir/cse/cse_swapped_comparisons.stdout
@@ -1,39 +1,49 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_swapped_comparisons.mir (after cse) ===
-@module CseSwappedComparisons
-fn @reuse_gt_after_lt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
-    v0 = lt arg0, arg1
-    ret v0, v0
-}
-
-fn @reuse_lt_after_gt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
-    v0 = gt arg1, arg0
-    ret v0, v0
-}
-
-fn @reuse_sgt_after_slt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
-    v0 = slt arg0, arg1
-    ret v0, v0
-}
-
-fn @reuse_slt_after_sgt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
-    v0 = sgt arg1, arg0
-    ret v0, v0
-}
-
-fn @keep_same_order_lt_gt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
-    v0 = lt arg0, arg1
-    v1 = gt arg0, arg1
-    ret v0, v1
-}
-
-fn @keep_unsigned_signed_distinct(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
-    v0 = lt arg0, arg1
-    v1 = sgt arg1, arg0
-    ret v0, v1
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_swapped_comparisons.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_swapped_comparisons.mir (after cse) ===
+  @module CseSwappedComparisons
+  fn @reuse_gt_after_lt(arg0: u256, arg1: u256) -> (bool, bool) {
+    bb0 (entry):
+      v0 = lt arg0, arg1
+-     v1 = gt arg1, arg0
+-     ret v0, v1
++     ret v0, v0
+  }
+  
+  fn @reuse_lt_after_gt(arg0: u256, arg1: u256) -> (bool, bool) {
+    bb0 (entry):
+      v0 = gt arg1, arg0
+-     v1 = lt arg0, arg1
+-     ret v0, v1
++     ret v0, v0
+  }
+  
+  fn @reuse_sgt_after_slt(arg0: u256, arg1: u256) -> (bool, bool) {
+    bb0 (entry):
+      v0 = slt arg0, arg1
+-     v1 = sgt arg1, arg0
+-     ret v0, v1
++     ret v0, v0
+  }
+  
+  fn @reuse_slt_after_sgt(arg0: u256, arg1: u256) -> (bool, bool) {
+    bb0 (entry):
+      v0 = sgt arg1, arg0
+-     v1 = slt arg0, arg1
+-     ret v0, v1
++     ret v0, v0
+  }
+  
+  fn @keep_same_order_lt_gt(arg0: u256, arg1: u256) -> (bool, bool) {
+    bb0 (entry):
+      v0 = lt arg0, arg1
+      v1 = gt arg0, arg1
+      ret v0, v1
+  }
+  
+  fn @keep_unsigned_signed_distinct(arg0: u256, arg1: u256) -> (bool, bool) {
+    bb0 (entry):
+      v0 = lt arg0, arg1
+      v1 = sgt arg1, arg0
+      ret v0, v1
+  }
+  

--- a/tests/ui/codegen/mir/cse/cse_unreachable_pred.stdout
+++ b/tests/ui/codegen/mir/cse/cse_unreachable_pred.stdout
@@ -1,14 +1,18 @@
-// === ROOT/tests/ui/codegen/mir/cse/cse_unreachable_pred.mir (after cse) ===
-@module CseUnreachablePred
-fn @no_dangling_use(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    jump bb2
-  bb2:
-    v0 = sload arg0
-    jump bb3
-  bb3:
-    v2 = add v0, v0
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/cse/cse_unreachable_pred.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/cse/cse_unreachable_pred.mir (after cse) ===
+  @module CseUnreachablePred
+  fn @no_dangling_use(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb2
+    bb1:
+      jump bb2
+    bb2:
+      v0 = sload arg0
+-     v1 = sload arg0
+      jump bb3
+    bb3:
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/dce/dce.stdout
+++ b/tests/ui/codegen/mir/dce/dce.stdout
@@ -1,7 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/dce/dce.mir (after dce) ===
-@module Dce
-fn @with_dead_code(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/dce/dce.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/dce/dce.mir (after dce) ===
+  @module Dce
+  fn @with_dead_code(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     v1 = mul arg0, arg0
+-     v2 = sub arg0, 1
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/dce/dce_chain.stdout
+++ b/tests/ui/codegen/mir/dce/dce_chain.stdout
@@ -1,6 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/dce/dce_chain.mir (after dce) ===
-@module DceChain
-fn @chain(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/dce/dce_chain.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/dce/dce_chain.mir (after dce) ===
+  @module DceChain
+  fn @chain(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = add arg0, 1
+-     v1 = mul v0, v0
+-     v2 = sub v1, arg0
+      ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/dce/dce_cross_block.stdout
+++ b/tests/ui/codegen/mir/dce/dce_cross_block.stdout
@@ -1,11 +1,14 @@
-// === ROOT/tests/ui/codegen/mir/dce/dce_cross_block.mir (after dce) ===
-@module DceCrossBlock
-fn @cross(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    br arg1, bb1, bb2
-  bb1:
-    jump bb2
-  bb2:
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/dce/dce_cross_block.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/dce/dce_cross_block.mir (after dce) ===
+  @module DceCrossBlock
+  fn @cross(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      br arg1, bb1, bb2
+    bb1:
+-     v1 = mul arg0, arg0
+      jump bb2
+    bb2:
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/dce/dce_side_effects.stdout
+++ b/tests/ui/codegen/mir/dce/dce_side_effects.stdout
@@ -1,8 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/dce/dce_side_effects.mir (after dce) ===
-@module DceSideEffects
-fn @effects(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    sstore arg0, arg1
-    log0 0, 32
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/dce/dce_side_effects.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/dce/dce_side_effects.mir (after dce) ===
+  @module DceSideEffects
+  fn @effects(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      sstore arg0, arg1
+      log0 0, 32
+-     v0 = add arg0, arg1
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/dce/dce_unreachable.stdout
+++ b/tests/ui/codegen/mir/dce/dce_unreachable.stdout
@@ -1,10 +1,15 @@
-// === ROOT/tests/ui/codegen/mir/dce/dce_unreachable.mir (after dce) ===
-@module DceUnreachable
-fn @skip(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    invalid
-  bb2:
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/dce/dce_unreachable.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/dce/dce_unreachable.mir (after dce) ===
+  @module DceUnreachable
+  fn @skip(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb2
+    bb1:
+-     v0 = add arg0, 1
+-     v1 = mul v0, v0
+-     ret v1
++     invalid
+    bb2:
+      ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/dce/dce_used_chain.stdout
+++ b/tests/ui/codegen/mir/dce/dce_used_chain.stdout
@@ -1,8 +1,10 @@
-// === ROOT/tests/ui/codegen/mir/dce/dce_used_chain.mir (after dce) ===
-@module DceUsedChain
-fn @used_chain(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = mul v0, 2
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/dce/dce_used_chain.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/dce/dce_used_chain.mir (after dce) ===
+  @module DceUsedChain
+  fn @used_chain(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      v1 = mul v0, 2
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
@@ -1,25 +1,34 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir (after frame-slot-promotion) ===
-@module FramePromotionDeadMerge
-fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = internal_frame_addr 128
-    jump bb4
-  bb4:
-    v8 = phi [bb3: 0], [bb5: v4]
-    v1 = internal_frame_addr 128
-    v3 = lt v8, arg0
-    br v3, bb5, bb6
-  bb5:
-    v4 = add v8, 1
-    v5 = internal_frame_addr 128
-    jump bb4
-  bb6:
-    v6 = internal_frame_addr 128
-    ret v8
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir (after frame-slot-promotion) ===
+  @module FramePromotionDeadMerge
+  fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = internal_frame_addr 128
+-     mstore v0, 0
+      jump bb4
+    bb4:
++     v8 = phi [bb3: 0], [bb5: v4]
+      v1 = internal_frame_addr 128
+-     v2 = mload v1
+-     v3 = lt v2, arg0
++     v3 = lt v8, arg0
+      br v3, bb5, bb6
+    bb5:
+-     v4 = add v2, 1
++     v4 = add v8, 1
+      v5 = internal_frame_addr 128
+-     mstore v5, v4
+      jump bb4
+    bb6:
+      v6 = internal_frame_addr 128
+-     v7 = mload v6
+-     ret v7
++     ret v8
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
@@ -1,59 +1,141 @@
-- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before frame-slot-promotion,cfg-simplify,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after frame-slot-promotion,cfg-simplify,dce) ===
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after frame-slot-promotion) ===
+  @module NestedCounter
+  fn @nested(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+-     mstore v0, 0
+      v1 = internal_frame_addr 160
+-     mstore v1, 0
+      jump bb1
+    bb1:
++     v23 = phi [bb0: 0], [bb5: v24]
++     v25 = phi [bb0: 0], [bb5: v19]
+      v2 = internal_frame_addr 160
+-     v3 = mload v2
+-     v4 = lt v3, arg0
++     v4 = lt v25, arg0
+      br v4, bb2, bb6
+    bb2:
+      v5 = internal_frame_addr 192
+-     mstore v5, 0
+      jump bb3
+    bb3:
++     v24 = phi [bb2: v23], [bb4: v11]
++     v26 = phi [bb2: 0], [bb4: v15]
+      v6 = internal_frame_addr 192
+-     v7 = mload v6
+-     v8 = lt v7, arg1
++     v8 = lt v26, arg1
+      br v8, bb4, bb5
+    bb4:
+      v9 = internal_frame_addr 128
+-     v10 = mload v9
+-     v11 = add v10, 1
++     v11 = add v24, 1
+      v12 = internal_frame_addr 128
+-     mstore v12, v11
+      v13 = internal_frame_addr 192
+-     v14 = mload v13
+-     v15 = add v14, 1
++     v15 = add v26, 1
+      v16 = internal_frame_addr 192
+-     mstore v16, v15
+      jump bb3
+    bb5:
+      v17 = internal_frame_addr 160
+-     v18 = mload v17
+-     v19 = add v18, 1
++     v19 = add v25, 1
+      v20 = internal_frame_addr 160
+-     mstore v20, v19
+      jump bb1
+    bb6:
+      v21 = internal_frame_addr 128
+-     v22 = mload v21
+-     ret v22
++     ret v23
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after cfg-simplify) ===
+  @module NestedCounter
+  fn @nested(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+      v1 = internal_frame_addr 160
+      jump bb1
+    bb1:
+      v23 = phi [bb0: 0], [bb5: v24]
+      v25 = phi [bb0: 0], [bb5: v19]
+      v2 = internal_frame_addr 160
+      v4 = lt v25, arg0
+      br v4, bb2, bb6
+    bb2:
+      v5 = internal_frame_addr 192
+      jump bb3
+    bb3:
+      v24 = phi [bb2: v23], [bb4: v11]
+      v26 = phi [bb2: 0], [bb4: v15]
+      v6 = internal_frame_addr 192
+      v8 = lt v26, arg1
+      br v8, bb4, bb5
+    bb4:
+      v9 = internal_frame_addr 128
+      v11 = add v24, 1
+      v12 = internal_frame_addr 128
+      v13 = internal_frame_addr 192
+      v15 = add v26, 1
+      v16 = internal_frame_addr 192
+      jump bb3
+    bb5:
+      v17 = internal_frame_addr 160
+      v19 = add v25, 1
+      v20 = internal_frame_addr 160
+      jump bb1
+    bb6:
+      v21 = internal_frame_addr 128
+      ret v23
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after dce) ===
   @module NestedCounter
   fn @nested(arg0: u256, arg1: u256) -> u256 {
     bb0 (entry):
 -     v0 = internal_frame_addr 128
--     mstore v0, 0
 -     v1 = internal_frame_addr 160
--     mstore v1, 0
       jump bb1
     bb1:
+      v23 = phi [bb0: 0], [bb5: v24]
+      v25 = phi [bb0: 0], [bb5: v19]
 -     v2 = internal_frame_addr 160
--     v3 = mload v2
--     v4 = lt v3, arg0
-+     v23 = phi [bb0: 0], [bb5: v24]
-+     v25 = phi [bb0: 0], [bb5: v19]
-+     v4 = lt v25, arg0
+      v4 = lt v25, arg0
       br v4, bb2, bb6
     bb2:
 -     v5 = internal_frame_addr 192
--     mstore v5, 0
       jump bb3
     bb3:
+      v24 = phi [bb2: v23], [bb4: v11]
+      v26 = phi [bb2: 0], [bb4: v15]
 -     v6 = internal_frame_addr 192
--     v7 = mload v6
--     v8 = lt v7, arg1
-+     v24 = phi [bb2: v23], [bb4: v11]
-+     v26 = phi [bb2: 0], [bb4: v15]
-+     v8 = lt v26, arg1
+      v8 = lt v26, arg1
       br v8, bb4, bb5
     bb4:
 -     v9 = internal_frame_addr 128
--     v10 = mload v9
--     v11 = add v10, 1
+      v11 = add v24, 1
 -     v12 = internal_frame_addr 128
--     mstore v12, v11
 -     v13 = internal_frame_addr 192
--     v14 = mload v13
--     v15 = add v14, 1
+      v15 = add v26, 1
 -     v16 = internal_frame_addr 192
--     mstore v16, v15
-+     v11 = add v24, 1
-+     v15 = add v26, 1
       jump bb3
     bb5:
 -     v17 = internal_frame_addr 160
--     v18 = mload v17
--     v19 = add v18, 1
+      v19 = add v25, 1
 -     v20 = internal_frame_addr 160
--     mstore v20, v19
-+     v19 = add v25, 1
       jump bb1
     bb6:
 -     v21 = internal_frame_addr 128
--     v22 = mload v21
--     ret v22
-+     ret v23
+      ret v23
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
@@ -1,27 +1,59 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after frame-slot-promotion,cfg-simplify,dce) ===
-@module NestedCounter
-fn @nested(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v23 = phi [bb0: 0], [bb5: v24]
-    v25 = phi [bb0: 0], [bb5: v19]
-    v4 = lt v25, arg0
-    br v4, bb2, bb6
-  bb2:
-    jump bb3
-  bb3:
-    v24 = phi [bb2: v23], [bb4: v11]
-    v26 = phi [bb2: 0], [bb4: v15]
-    v8 = lt v26, arg1
-    br v8, bb4, bb5
-  bb4:
-    v11 = add v24, 1
-    v15 = add v26, 1
-    jump bb3
-  bb5:
-    v19 = add v25, 1
-    jump bb1
-  bb6:
-    ret v23
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before frame-slot-promotion,cfg-simplify,dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after frame-slot-promotion,cfg-simplify,dce) ===
+  @module NestedCounter
+  fn @nested(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 0
+-     v1 = internal_frame_addr 160
+-     mstore v1, 0
+      jump bb1
+    bb1:
+-     v2 = internal_frame_addr 160
+-     v3 = mload v2
+-     v4 = lt v3, arg0
++     v23 = phi [bb0: 0], [bb5: v24]
++     v25 = phi [bb0: 0], [bb5: v19]
++     v4 = lt v25, arg0
+      br v4, bb2, bb6
+    bb2:
+-     v5 = internal_frame_addr 192
+-     mstore v5, 0
+      jump bb3
+    bb3:
+-     v6 = internal_frame_addr 192
+-     v7 = mload v6
+-     v8 = lt v7, arg1
++     v24 = phi [bb2: v23], [bb4: v11]
++     v26 = phi [bb2: 0], [bb4: v15]
++     v8 = lt v26, arg1
+      br v8, bb4, bb5
+    bb4:
+-     v9 = internal_frame_addr 128
+-     v10 = mload v9
+-     v11 = add v10, 1
+-     v12 = internal_frame_addr 128
+-     mstore v12, v11
+-     v13 = internal_frame_addr 192
+-     v14 = mload v13
+-     v15 = add v14, 1
+-     v16 = internal_frame_addr 192
+-     mstore v16, v15
++     v11 = add v24, 1
++     v15 = add v26, 1
+      jump bb3
+    bb5:
+-     v17 = internal_frame_addr 160
+-     v18 = mload v17
+-     v19 = add v18, 1
+-     v20 = internal_frame_addr 160
+-     mstore v20, v19
++     v19 = add v25, 1
+      jump bb1
+    bb6:
+-     v21 = internal_frame_addr 128
+-     v22 = mload v21
+-     ret v22
++     ret v23
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.stdout
@@ -1,9 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.mir (after frame-slot-promotion) ===
-@module FramePromotionLoadBeforeStore
-fn @load_before_store() -> u256 {
-  bb0 (entry):
-    v0 = internal_frame_addr 128
-    v1 = mload v0
-    mstore v0, 1
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.mir (after frame-slot-promotion) ===
+  @module FramePromotionLoadBeforeStore
+  fn @load_before_store() -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+      v1 = mload v0
+      mstore v0, 1
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.stdout
@@ -1,6 +1,15 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after frame-slot-promotion,dce) ===
-@module FramePromotionOffsetAddr
-fn @offset_addr() -> u256 {
-  bb0 (entry):
-    ret 99
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (before frame-slot-promotion,dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after frame-slot-promotion,dce) ===
+  @module FramePromotionOffsetAddr
+  fn @offset_addr() -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     v1 = add v0, 32
+-     mstore v1, 99
+-     v2 = internal_frame_addr 128
+-     v3 = add v2, 32
+-     v4 = mload v3
+-     ret v4
++     ret 99
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.stdout
@@ -1,15 +1,27 @@
-- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (before frame-slot-promotion,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after frame-slot-promotion,dce) ===
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after frame-slot-promotion) ===
+  @module FramePromotionOffsetAddr
+  fn @offset_addr() -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+      v1 = add v0, 32
+-     mstore v1, 99
+      v2 = internal_frame_addr 128
+      v3 = add v2, 32
+-     v4 = mload v3
+-     ret v4
++     ret 99
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after dce) ===
   @module FramePromotionOffsetAddr
   fn @offset_addr() -> u256 {
     bb0 (entry):
 -     v0 = internal_frame_addr 128
 -     v1 = add v0, 32
--     mstore v1, 99
 -     v2 = internal_frame_addr 128
 -     v3 = add v2, 32
--     v4 = mload v3
--     ret v4
-+     ret 99
+      ret 99
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.stdout
@@ -1,19 +1,32 @@
-- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (before frame-slot-promotion,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after frame-slot-promotion,dce) ===
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after frame-slot-promotion) ===
+  @module FramePromotionSameBlock
+  fn @same_block() -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+-     mstore v0, 7
+      v1 = internal_frame_addr 128
+-     v2 = mload v1
+-     v3 = add v2, 1
++     v3 = add 7, 1
+      v4 = internal_frame_addr 128
+-     mstore v4, v3
+      v5 = internal_frame_addr 128
+-     v6 = mload v5
+-     ret v6
++     ret v3
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after dce) ===
   @module FramePromotionSameBlock
   fn @same_block() -> u256 {
     bb0 (entry):
 -     v0 = internal_frame_addr 128
--     mstore v0, 7
 -     v1 = internal_frame_addr 128
--     v2 = mload v1
--     v3 = add v2, 1
+      v3 = add 7, 1
 -     v4 = internal_frame_addr 128
--     mstore v4, v3
 -     v5 = internal_frame_addr 128
--     v6 = mload v5
--     ret v6
-+     v3 = add 7, 1
-+     ret v3
+      ret v3
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.stdout
@@ -1,7 +1,19 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after frame-slot-promotion,dce) ===
-@module FramePromotionSameBlock
-fn @same_block() -> u256 {
-  bb0 (entry):
-    v3 = add 7, 1
-    ret v3
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (before frame-slot-promotion,dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after frame-slot-promotion,dce) ===
+  @module FramePromotionSameBlock
+  fn @same_block() -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 7
+-     v1 = internal_frame_addr 128
+-     v2 = mload v1
+-     v3 = add v2, 1
+-     v4 = internal_frame_addr 128
+-     mstore v4, v3
+-     v5 = internal_frame_addr 128
+-     v6 = mload v5
+-     ret v6
++     v3 = add 7, 1
++     ret v3
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
@@ -1,28 +1,65 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after frame-slot-promotion,cfg-simplify,dce) ===
-@module SequentialCounter
-fn @sequential(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v27 = phi [bb0: 0], [bb2: v7]
-    v29 = phi [bb0: 0], [bb2: v11]
-    v4 = lt v29, arg0
-    br v4, bb2, bb3
-  bb2:
-    v7 = add v27, 1
-    v11 = add v29, 1
-    jump bb1
-  bb3:
-    jump bb4
-  bb4:
-    v28 = phi [bb3: v27], [bb5: v19]
-    v30 = phi [bb3: 0], [bb5: v23]
-    v16 = lt v30, arg0
-    br v16, bb5, bb6
-  bb5:
-    v19 = add v28, 1
-    v23 = add v30, 1
-    jump bb4
-  bb6:
-    ret v28
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before frame-slot-promotion,cfg-simplify,dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after frame-slot-promotion,cfg-simplify,dce) ===
+  @module SequentialCounter
+  fn @sequential(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 0
+-     v1 = internal_frame_addr 160
+-     mstore v1, 0
+      jump bb1
+    bb1:
+-     v2 = internal_frame_addr 160
+-     v3 = mload v2
+-     v4 = lt v3, arg0
++     v27 = phi [bb0: 0], [bb2: v7]
++     v29 = phi [bb0: 0], [bb2: v11]
++     v4 = lt v29, arg0
+      br v4, bb2, bb3
+    bb2:
+-     v5 = internal_frame_addr 128
+-     v6 = mload v5
+-     v7 = add v6, 1
+-     v8 = internal_frame_addr 128
+-     mstore v8, v7
+-     v9 = internal_frame_addr 160
+-     v10 = mload v9
+-     v11 = add v10, 1
+-     v12 = internal_frame_addr 160
+-     mstore v12, v11
++     v7 = add v27, 1
++     v11 = add v29, 1
+      jump bb1
+    bb3:
+-     v13 = internal_frame_addr 192
+-     mstore v13, 0
+      jump bb4
+    bb4:
+-     v14 = internal_frame_addr 192
+-     v15 = mload v14
+-     v16 = lt v15, arg0
++     v28 = phi [bb3: v27], [bb5: v19]
++     v30 = phi [bb3: 0], [bb5: v23]
++     v16 = lt v30, arg0
+      br v16, bb5, bb6
+    bb5:
+-     v17 = internal_frame_addr 128
+-     v18 = mload v17
+-     v19 = add v18, 1
+-     v20 = internal_frame_addr 128
+-     mstore v20, v19
+-     v21 = internal_frame_addr 192
+-     v22 = mload v21
+-     v23 = add v22, 1
+-     v24 = internal_frame_addr 192
+-     mstore v24, v23
++     v19 = add v28, 1
++     v23 = add v30, 1
+      jump bb4
+    bb6:
+-     v25 = internal_frame_addr 128
+-     v26 = mload v25
+-     ret v26
++     ret v28
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
@@ -1,65 +1,153 @@
-- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before frame-slot-promotion,cfg-simplify,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after frame-slot-promotion,cfg-simplify,dce) ===
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after frame-slot-promotion) ===
+  @module SequentialCounter
+  fn @sequential(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+-     mstore v0, 0
+      v1 = internal_frame_addr 160
+-     mstore v1, 0
+      jump bb1
+    bb1:
++     v27 = phi [bb0: 0], [bb2: v7]
++     v29 = phi [bb0: 0], [bb2: v11]
+      v2 = internal_frame_addr 160
+-     v3 = mload v2
+-     v4 = lt v3, arg0
++     v4 = lt v29, arg0
+      br v4, bb2, bb3
+    bb2:
+      v5 = internal_frame_addr 128
+-     v6 = mload v5
+-     v7 = add v6, 1
++     v7 = add v27, 1
+      v8 = internal_frame_addr 128
+-     mstore v8, v7
+      v9 = internal_frame_addr 160
+-     v10 = mload v9
+-     v11 = add v10, 1
++     v11 = add v29, 1
+      v12 = internal_frame_addr 160
+-     mstore v12, v11
+      jump bb1
+    bb3:
+      v13 = internal_frame_addr 192
+-     mstore v13, 0
+      jump bb4
+    bb4:
++     v28 = phi [bb3: v27], [bb5: v19]
++     v30 = phi [bb3: 0], [bb5: v23]
+      v14 = internal_frame_addr 192
+-     v15 = mload v14
+-     v16 = lt v15, arg0
++     v16 = lt v30, arg0
+      br v16, bb5, bb6
+    bb5:
+      v17 = internal_frame_addr 128
+-     v18 = mload v17
+-     v19 = add v18, 1
++     v19 = add v28, 1
+      v20 = internal_frame_addr 128
+-     mstore v20, v19
+      v21 = internal_frame_addr 192
+-     v22 = mload v21
+-     v23 = add v22, 1
++     v23 = add v30, 1
+      v24 = internal_frame_addr 192
+-     mstore v24, v23
+      jump bb4
+    bb6:
+      v25 = internal_frame_addr 128
+-     v26 = mload v25
+-     ret v26
++     ret v28
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after cfg-simplify) ===
+  @module SequentialCounter
+  fn @sequential(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+      v1 = internal_frame_addr 160
+      jump bb1
+    bb1:
+      v27 = phi [bb0: 0], [bb2: v7]
+      v29 = phi [bb0: 0], [bb2: v11]
+      v2 = internal_frame_addr 160
+      v4 = lt v29, arg0
+      br v4, bb2, bb3
+    bb2:
+      v5 = internal_frame_addr 128
+      v7 = add v27, 1
+      v8 = internal_frame_addr 128
+      v9 = internal_frame_addr 160
+      v11 = add v29, 1
+      v12 = internal_frame_addr 160
+      jump bb1
+    bb3:
+      v13 = internal_frame_addr 192
+      jump bb4
+    bb4:
+      v28 = phi [bb3: v27], [bb5: v19]
+      v30 = phi [bb3: 0], [bb5: v23]
+      v14 = internal_frame_addr 192
+      v16 = lt v30, arg0
+      br v16, bb5, bb6
+    bb5:
+      v17 = internal_frame_addr 128
+      v19 = add v28, 1
+      v20 = internal_frame_addr 128
+      v21 = internal_frame_addr 192
+      v23 = add v30, 1
+      v24 = internal_frame_addr 192
+      jump bb4
+    bb6:
+      v25 = internal_frame_addr 128
+      ret v28
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after dce) ===
   @module SequentialCounter
   fn @sequential(arg0: u256) -> u256 {
     bb0 (entry):
 -     v0 = internal_frame_addr 128
--     mstore v0, 0
 -     v1 = internal_frame_addr 160
--     mstore v1, 0
       jump bb1
     bb1:
+      v27 = phi [bb0: 0], [bb2: v7]
+      v29 = phi [bb0: 0], [bb2: v11]
 -     v2 = internal_frame_addr 160
--     v3 = mload v2
--     v4 = lt v3, arg0
-+     v27 = phi [bb0: 0], [bb2: v7]
-+     v29 = phi [bb0: 0], [bb2: v11]
-+     v4 = lt v29, arg0
+      v4 = lt v29, arg0
       br v4, bb2, bb3
     bb2:
 -     v5 = internal_frame_addr 128
--     v6 = mload v5
--     v7 = add v6, 1
+      v7 = add v27, 1
 -     v8 = internal_frame_addr 128
--     mstore v8, v7
 -     v9 = internal_frame_addr 160
--     v10 = mload v9
--     v11 = add v10, 1
+      v11 = add v29, 1
 -     v12 = internal_frame_addr 160
--     mstore v12, v11
-+     v7 = add v27, 1
-+     v11 = add v29, 1
       jump bb1
     bb3:
 -     v13 = internal_frame_addr 192
--     mstore v13, 0
       jump bb4
     bb4:
+      v28 = phi [bb3: v27], [bb5: v19]
+      v30 = phi [bb3: 0], [bb5: v23]
 -     v14 = internal_frame_addr 192
--     v15 = mload v14
--     v16 = lt v15, arg0
-+     v28 = phi [bb3: v27], [bb5: v19]
-+     v30 = phi [bb3: 0], [bb5: v23]
-+     v16 = lt v30, arg0
+      v16 = lt v30, arg0
       br v16, bb5, bb6
     bb5:
 -     v17 = internal_frame_addr 128
--     v18 = mload v17
--     v19 = add v18, 1
+      v19 = add v28, 1
 -     v20 = internal_frame_addr 128
--     mstore v20, v19
 -     v21 = internal_frame_addr 192
--     v22 = mload v21
--     v23 = add v22, 1
+      v23 = add v30, 1
 -     v24 = internal_frame_addr 192
--     mstore v24, v23
-+     v19 = add v28, 1
-+     v23 = add v30, 1
       jump bb4
     bb6:
 -     v25 = internal_frame_addr 128
--     v26 = mload v25
--     ret v26
-+     ret v28
+      ret v28
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
@@ -1,30 +1,52 @@
-- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (before frame-slot-promotion,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after frame-slot-promotion,dce) ===
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after frame-slot-promotion) ===
+  @module LocalSlotPromotion
+  fn @promote_loop_carried_slot(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+-     mstore v0, 0
+      jump bb1
+    bb1:
++     v10 = phi [bb0: 0], [bb2: v6]
+      v1 = internal_frame_addr 128
+-     v2 = mload v1
+-     v3 = lt v2, arg0
++     v3 = lt v10, arg0
+      br v3, bb2, bb3
+    bb2:
+      v4 = internal_frame_addr 128
+-     v5 = mload v4
+-     v6 = add v5, 1
++     v6 = add v10, 1
+      v7 = internal_frame_addr 128
+-     mstore v7, v6
+      jump bb1
+    bb3:
+      v8 = internal_frame_addr 128
+-     v9 = mload v8
+-     ret v9
++     ret v10
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after dce) ===
   @module LocalSlotPromotion
   fn @promote_loop_carried_slot(arg0: u256) -> u256 {
     bb0 (entry):
 -     v0 = internal_frame_addr 128
--     mstore v0, 0
       jump bb1
     bb1:
+      v10 = phi [bb0: 0], [bb2: v6]
 -     v1 = internal_frame_addr 128
--     v2 = mload v1
--     v3 = lt v2, arg0
-+     v10 = phi [bb0: 0], [bb2: v6]
-+     v3 = lt v10, arg0
+      v3 = lt v10, arg0
       br v3, bb2, bb3
     bb2:
 -     v4 = internal_frame_addr 128
--     v5 = mload v4
--     v6 = add v5, 1
+      v6 = add v10, 1
 -     v7 = internal_frame_addr 128
--     mstore v7, v6
-+     v6 = add v10, 1
       jump bb1
     bb3:
 -     v8 = internal_frame_addr 128
--     v9 = mload v8
--     ret v9
-+     ret v10
+      ret v10
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
@@ -1,15 +1,30 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after frame-slot-promotion,dce) ===
-@module LocalSlotPromotion
-fn @promote_loop_carried_slot(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v10 = phi [bb0: 0], [bb2: v6]
-    v3 = lt v10, arg0
-    br v3, bb2, bb3
-  bb2:
-    v6 = add v10, 1
-    jump bb1
-  bb3:
-    ret v10
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (before frame-slot-promotion,dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after frame-slot-promotion,dce) ===
+  @module LocalSlotPromotion
+  fn @promote_loop_carried_slot(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 0
+      jump bb1
+    bb1:
+-     v1 = internal_frame_addr 128
+-     v2 = mload v1
+-     v3 = lt v2, arg0
++     v10 = phi [bb0: 0], [bb2: v6]
++     v3 = lt v10, arg0
+      br v3, bb2, bb3
+    bb2:
+-     v4 = internal_frame_addr 128
+-     v5 = mload v4
+-     v6 = add v5, 1
+-     v7 = internal_frame_addr 128
+-     mstore v7, v6
++     v6 = add v10, 1
+      jump bb1
+    bb3:
+-     v8 = internal_frame_addr 128
+-     v9 = mload v8
+-     ret v9
++     ret v10
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.stdout
@@ -1,29 +1,41 @@
-// === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after frame-slot-promotion,dce) ===
-@module LocalSlotPromotionCallBarrier
-fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
-  bb0 (entry):
-    v1 = staticcall 0x186a0, arg0, 0, 0, 0, 0
-    v4 = add 9, v1
-    ret v4
-}
-
-fn @keep_msize_observation() -> u256 {
-  bb0 (entry):
-    v0 = internal_frame_addr 128
-    mstore v0, 9
-    v1 = msize
-    v2 = internal_frame_addr 128
-    v3 = mload v2
-    v4 = add v3, v1
-    ret v4
-}
-
-fn @promote_slot_with_unrelated_frame_hash() -> u256 {
-  bb0 (entry):
-    v1 = internal_frame_addr 192
-    mstore v1, 1
-    v2 = internal_frame_addr 192
-    v3 = keccak256 v2, 32
-    v6 = add 9, v3
-    ret v6
-}
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (before frame-slot-promotion,dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after frame-slot-promotion,dce) ===
+  @module LocalSlotPromotionCallBarrier
+  fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 9
+      v1 = staticcall 0x186a0, arg0, 0, 0, 0, 0
+-     v2 = internal_frame_addr 128
+-     v3 = mload v2
+-     v4 = add v3, v1
++     v4 = add 9, v1
+      ret v4
+  }
+  
+  fn @keep_msize_observation() -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+      mstore v0, 9
+      v1 = msize
+      v2 = internal_frame_addr 128
+      v3 = mload v2
+      v4 = add v3, v1
+      ret v4
+  }
+  
+  fn @promote_slot_with_unrelated_frame_hash() -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 9
+      v1 = internal_frame_addr 192
+      mstore v1, 1
+      v2 = internal_frame_addr 192
+      v3 = keccak256 v2, 32
+-     v4 = internal_frame_addr 128
+-     v5 = mload v4
+-     v6 = add v5, v3
++     v6 = add 9, v3
+      ret v6
+  }
+  

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.stdout
@@ -1,12 +1,12 @@
-- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (before frame-slot-promotion,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after frame-slot-promotion,dce) ===
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (before frame-slot-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after frame-slot-promotion) ===
   @module LocalSlotPromotionCallBarrier
   fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
     bb0 (entry):
--     v0 = internal_frame_addr 128
+      v0 = internal_frame_addr 128
 -     mstore v0, 9
       v1 = staticcall 0x186a0, arg0, 0, 0, 0, 0
--     v2 = internal_frame_addr 128
+      v2 = internal_frame_addr 128
 -     v3 = mload v2
 -     v4 = add v3, v1
 +     v4 = add 9, v1
@@ -26,16 +26,51 @@
   
   fn @promote_slot_with_unrelated_frame_hash() -> u256 {
     bb0 (entry):
--     v0 = internal_frame_addr 128
+      v0 = internal_frame_addr 128
 -     mstore v0, 9
       v1 = internal_frame_addr 192
       mstore v1, 1
       v2 = internal_frame_addr 192
       v3 = keccak256 v2, 32
--     v4 = internal_frame_addr 128
+      v4 = internal_frame_addr 128
 -     v5 = mload v4
 -     v6 = add v5, v3
 +     v6 = add 9, v3
+      ret v6
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after dce) ===
+  @module LocalSlotPromotionCallBarrier
+  fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+      v1 = staticcall 0x186a0, arg0, 0, 0, 0, 0
+-     v2 = internal_frame_addr 128
+      v4 = add 9, v1
+      ret v4
+  }
+  
+  fn @keep_msize_observation() -> u256 {
+    bb0 (entry):
+      v0 = internal_frame_addr 128
+      mstore v0, 9
+      v1 = msize
+      v2 = internal_frame_addr 128
+      v3 = mload v2
+      v4 = add v3, v1
+      ret v4
+  }
+  
+  fn @promote_slot_with_unrelated_frame_hash() -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+      v1 = internal_frame_addr 192
+      mstore v1, 1
+      v2 = internal_frame_addr 192
+      v3 = keccak256 v2, 32
+-     v4 = internal_frame_addr 128
+      v6 = add 9, v3
       ret v6
   }
   

--- a/tests/ui/codegen/mir/gvn/gvn.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn.stdout
@@ -1,56 +1,66 @@
-// === ROOT/tests/ui/codegen/mir/gvn/gvn.mir (after gvn) ===
-@module Gvn
-fn @transitive_congruence(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, arg1
-    v2 = mul v0, 2
-    v4 = add v2, v2
-    ret v4
-}
-
-fn @equal_immediates_unify(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 16
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @swapped_comparison_feeds_arithmetic(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, arg1
-    v2 = select v0, arg0, arg1
-    v4 = add v2, v2
-    ret v4
-}
-
-fn @keep_state_dependent_reads(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload arg0
-    v1 = sload arg0
-    v2 = balance arg0
-    v3 = balance arg0
-    v4 = keccak256 0, 32
-    v5 = keccak256 0, 32
-    v6 = add v0, v1
-    v7 = add v2, v3
-    v8 = add v4, v5
-    v9 = add v6, v7
-    v10 = add v9, v8
-    ret v10
-}
-
-fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    v0 = add arg0, 1
-    v1 = mul v0, 3
-    jump bb3
-  bb2:
-    v2 = add arg0, 1
-    v3 = mul v2, 3
-    jump bb3
-  bb3:
-    v4 = phi [bb1: v1], [bb2: v3]
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/gvn/gvn.mir (before gvn) ===
++ // === ROOT/tests/ui/codegen/mir/gvn/gvn.mir (after gvn) ===
+  @module Gvn
+  fn @transitive_congruence(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, arg1
+-     v1 = add arg0, arg1
+      v2 = mul v0, 2
+-     v3 = mul v1, 2
+-     v4 = add v2, v3
++     v4 = add v2, v2
+      ret v4
+  }
+  
+  fn @equal_immediates_unify(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 16
+-     v1 = add 16, arg0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @swapped_comparison_feeds_arithmetic(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, arg1
+-     v1 = gt arg1, arg0
+      v2 = select v0, arg0, arg1
+-     v3 = select v1, arg0, arg1
+-     v4 = add v2, v3
++     v4 = add v2, v2
+      ret v4
+  }
+  
+  fn @keep_state_dependent_reads(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload arg0
+      v1 = sload arg0
+      v2 = balance arg0
+      v3 = balance arg0
+      v4 = keccak256 0, 32
+      v5 = keccak256 0, 32
+      v6 = add v0, v1
+      v7 = add v2, v3
+      v8 = add v4, v5
+      v9 = add v6, v7
+      v10 = add v9, v8
+      ret v10
+  }
+  
+  fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      v0 = add arg0, 1
+      v1 = mul v0, 3
+      jump bb3
+    bb2:
+      v2 = add arg0, 1
+      v3 = mul v2, 3
+      jump bb3
+    bb3:
+      v4 = phi [bb1: v1], [bb2: v3]
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/gvn/gvn_loadimmutable.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn_loadimmutable.stdout
@@ -1,16 +1,20 @@
-// === ROOT/tests/ui/codegen/mir/gvn/gvn_loadimmutable.mir (after gvn) ===
-@module GvnLoadImmutable
-fn @same_immutable_merges() -> u256 {
-  bb0 (entry):
-    v0 = loadimmutable 0
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @different_immutables_stay(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = loadimmutable 0
-    v1 = loadimmutable 32
-    v2 = add v0, v1
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/gvn/gvn_loadimmutable.mir (before gvn) ===
++ // === ROOT/tests/ui/codegen/mir/gvn/gvn_loadimmutable.mir (after gvn) ===
+  @module GvnLoadImmutable
+  fn @same_immutable_merges() -> u256 {
+    bb0 (entry):
+      v0 = loadimmutable 0
+-     v1 = loadimmutable 0
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @different_immutables_stay(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = loadimmutable 0
+      v1 = loadimmutable 32
+      v2 = add v0, v1
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/gvn/gvn_phi.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn_phi.stdout
@@ -1,67 +1,78 @@
-// === ROOT/tests/ui/codegen/mir/gvn/gvn_phi.mir (after gvn) ===
-@module GvnPhi
-fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-  bb0 (entry):
-    br arg2, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: arg0], [bb2: arg1]
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    br arg1, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v2 = mul v0, 2
-    ret v2
-}
-
-fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    br arg1, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    ret v0
-}
-
-fn @phi_of_equal_immediates(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    ret 7
-}
-
-fn @lockstep_loop_phis_stay(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v3]
-    v1 = phi [bb0: 0], [bb2: v4]
-    v2 = lt v0, arg0
-    br v2, bb2, bb3
-  bb2:
-    v3 = add v0, 1
-    v4 = add v1, 1
-    jump bb1
-  bb3:
-    v5 = add v0, v1
-    ret v5
-}
+- // === ROOT/tests/ui/codegen/mir/gvn/gvn_phi.mir (before gvn) ===
++ // === ROOT/tests/ui/codegen/mir/gvn/gvn_phi.mir (after gvn) ===
+  @module GvnPhi
+  fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
+    bb0 (entry):
+      br arg2, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: arg0], [bb2: arg1]
+-     v1 = phi [bb1: arg0], [bb2: arg1]
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      br arg1, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+-     v1 = phi [bb1: v0], [bb2: v0]
+-     v2 = mul v1, 2
++     v2 = mul v0, 2
+      ret v2
+  }
+  
+  fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      br arg1, bb1, bb2
+    bb1:
+-     v1 = add arg0, 1
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+-     v2 = phi [bb1: v1], [bb2: v0]
+-     ret v2
++     ret v0
+  }
+  
+  fn @phi_of_equal_immediates(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+-     v0 = phi [bb1: 7], [bb2: 7]
+-     ret v0
++     ret 7
+  }
+  
+  fn @lockstep_loop_phis_stay(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v3]
+      v1 = phi [bb0: 0], [bb2: v4]
+      v2 = lt v0, arg0
+      br v2, bb2, bb3
+    bb2:
+      v3 = add v0, 1
+      v4 = add v1, 1
+      jump bb1
+    bb3:
+      v5 = add v0, v1
+      ret v5
+  }
+  

--- a/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
+++ b/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
@@ -1,59 +1,64 @@
-// === ROOT/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir (after indvar-simplify) ===
-@module IndVarSimplify
-fn @strength_reduce_shifted_address(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v5 = phi [bb0: arg0], [bb2: v6]
-    v1 = lt v0, 4
-    br v1, bb2, bb3
-  bb2:
-    v2 = shl 5, v0
-    v3 = add arg0, v2
-    mstore v5, v0
-    v4 = add v0, 1
-    v6 = add v5, 32
-    jump bb1
-  bb3:
-    ret 0
-}
-
-fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
-  bb0 (entry):
-    v6 = add arg0, 4
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v5]
-    v7 = phi [bb0: v6], [bb2: v8]
-    v1 = lt v0, 4
-    br v1, bb2, bb3
-  bb2:
-    v2 = mul v0, 32
-    v3 = add arg0, v2
-    v4 = add v3, 4
-    mstore v7, v0
-    v5 = add v0, 1
-    v8 = add v7, 32
-    jump bb1
-  bb3:
-    ret 0
-}
-
-fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v3]
-    v4 = phi [bb0: arg0], [bb2: v5]
-    v1 = lt v0, 4
-    br v1, bb2, bb3
-  bb2:
-    v2 = add arg0, v0
-    mstore8 v4, v0
-    v3 = add v0, 1
-    v5 = add v4, 1
-    jump bb1
-  bb3:
-    ret 0
-}
+- // === ROOT/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir (before indvar-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir (after indvar-simplify) ===
+  @module IndVarSimplify
+  fn @strength_reduce_shifted_address(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
++     v5 = phi [bb0: arg0], [bb2: v6]
+      v1 = lt v0, 4
+      br v1, bb2, bb3
+    bb2:
+      v2 = shl 5, v0
+      v3 = add arg0, v2
+-     mstore v3, v0
++     mstore v5, v0
+      v4 = add v0, 1
++     v6 = add v5, 32
+      jump bb1
+    bb3:
+      ret 0
+  }
+  
+  fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
+    bb0 (entry):
++     v6 = add arg0, 4
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v5]
++     v7 = phi [bb0: v6], [bb2: v8]
+      v1 = lt v0, 4
+      br v1, bb2, bb3
+    bb2:
+      v2 = mul v0, 32
+      v3 = add arg0, v2
+      v4 = add v3, 4
+-     mstore v4, v0
++     mstore v7, v0
+      v5 = add v0, 1
++     v8 = add v7, 32
+      jump bb1
+    bb3:
+      ret 0
+  }
+  
+  fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v3]
++     v4 = phi [bb0: arg0], [bb2: v5]
+      v1 = lt v0, 4
+      br v1, bb2, bb3
+    bb2:
+      v2 = add arg0, v0
+-     mstore8 v2, v0
++     mstore8 v4, v0
+      v3 = add v0, 1
++     v5 = add v4, 1
+      jump bb1
+    bb3:
+      ret 0
+  }
+  

--- a/tests/ui/codegen/mir/inline/inline_internal_call.stdout
+++ b/tests/ui/codegen/mir/inline/inline_internal_call.stdout
@@ -1,18 +1,22 @@
-// === ROOT/tests/ui/codegen/mir/inline/inline_internal_call.mir (after inline) ===
-@module InlineInternalCall
-fn @caller(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    v2 = phi [bb2: v1]
-    ret v2
-  bb2:
-    v1 = add arg0, 1
-    jump bb1
-}
-
-fn @callee(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/inline/inline_internal_call.mir (before inline) ===
++ // === ROOT/tests/ui/codegen/mir/inline/inline_internal_call.mir (after inline) ===
+  @module InlineInternalCall
+  fn @caller(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_call @callee, 1, arg0
+-     ret v0
++     jump bb2
++   bb1:
++     v2 = phi [bb2: v1]
++     ret v2
++   bb2:
++     v1 = add arg0, 1
++     jump bb1
+  }
+  
+  fn @callee(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/inline/inline_v2_profitability.stdout
+++ b/tests/ui/codegen/mir/inline/inline_v2_profitability.stdout
@@ -1,109 +1,117 @@
-// === ROOT/tests/ui/codegen/mir/inline/inline_v2_profitability.mir (after inline) ===
-@module InlineV2Profitability
-fn @single_large_caller(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    v2 = phi [bb13: v1]
-    ret v2
-  bb2:
-    jump bb3
-  bb3:
-    jump bb4
-  bb4:
-    jump bb5
-  bb5:
-    jump bb6
-  bb6:
-    jump bb7
-  bb7:
-    jump bb8
-  bb8:
-    jump bb9
-  bb9:
-    jump bb10
-  bb10:
-    jump bb11
-  bb11:
-    jump bb12
-  bb12:
-    jump bb13
-  bb13:
-    v1 = add arg0, 1
-    jump bb1
-}
-
-fn @single_large_callee(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    jump bb2
-  bb2:
-    jump bb3
-  bb3:
-    jump bb4
-  bb4:
-    jump bb5
-  bb5:
-    jump bb6
-  bb6:
-    jump bb7
-  bb7:
-    jump bb8
-  bb8:
-    jump bb9
-  bb9:
-    jump bb10
-  bb10:
-    jump bb11
-  bb11:
-    v0 = add arg0, 1
-    ret v0
-}
-
-fn @multi_return_caller(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    v5 = phi [bb2: v3]
-    v6 = phi [bb2: v4]
-    v7 = mload 64
-    v8 = add v7, 32
-    mstore v8, v6
-    mstore 32, v7
-    v1 = mload 32
-    v2 = add v5, v1
-    ret v2
-  bb2:
-    v3 = add arg0, 1
-    v4 = add arg0, 2
-    jump bb1
-}
-
-fn @multi_return_callee(arg0: u256) -> (u256, u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = add arg0, 2
-    ret v0, v1
-}
-
-fn @tiny_stateful_caller(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    jump bb4
-  bb2:
-    sstore 0, arg0
-    jump bb1
-  bb3:
-    stop
-  bb4:
-    sstore 0, arg1
-    jump bb3
-}
-
-fn @tiny_stateful_callee(arg0: u256) {
-  bb0 (entry):
-    sstore 0, arg0
-    ret
-}
+- // === ROOT/tests/ui/codegen/mir/inline/inline_v2_profitability.mir (before inline) ===
++ // === ROOT/tests/ui/codegen/mir/inline/inline_v2_profitability.mir (after inline) ===
+  @module InlineV2Profitability
+  fn @single_large_caller(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_call @single_large_callee, 1, arg0
+-     ret v0
++     jump bb2
++   bb1:
++     v2 = phi [bb13: v1]
++     ret v2
++   bb2:
++     jump bb3
++   bb3:
++     jump bb4
++   bb4:
++     jump bb5
++   bb5:
++     jump bb6
++   bb6:
++     jump bb7
++   bb7:
++     jump bb8
++   bb8:
++     jump bb9
++   bb9:
++     jump bb10
++   bb10:
++     jump bb11
++   bb11:
++     jump bb12
++   bb12:
++     jump bb13
++   bb13:
++     v1 = add arg0, 1
++     jump bb1
+  }
+  
+  fn @single_large_callee(arg0: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      jump bb2
+    bb2:
+      jump bb3
+    bb3:
+      jump bb4
+    bb4:
+      jump bb5
+    bb5:
+      jump bb6
+    bb6:
+      jump bb7
+    bb7:
+      jump bb8
+    bb8:
+      jump bb9
+    bb9:
+      jump bb10
+    bb10:
+      jump bb11
+    bb11:
+      v0 = add arg0, 1
+      ret v0
+  }
+  
+  fn @multi_return_caller(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_call @multi_return_callee, 2, arg0
++     jump bb2
++   bb1:
++     v5 = phi [bb2: v3]
++     v6 = phi [bb2: v4]
++     v7 = mload 64
++     v8 = add v7, 32
++     mstore v8, v6
++     mstore 32, v7
+      v1 = mload 32
+-     v2 = add v0, v1
++     v2 = add v5, v1
+      ret v2
++   bb2:
++     v3 = add arg0, 1
++     v4 = add arg0, 2
++     jump bb1
+  }
+  
+  fn @multi_return_callee(arg0: u256) -> (u256, u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+      v1 = add arg0, 2
+      ret v0, v1
+  }
+  
+  fn @tiny_stateful_caller(arg0: u256, arg1: u256) {
+    bb0 (entry):
+-     internal_call @tiny_stateful_callee, 0, arg0
+-     internal_call @tiny_stateful_callee, 0, arg1
++     jump bb2
++   bb1:
++     jump bb4
++   bb2:
++     sstore 0, arg0
++     jump bb1
++   bb3:
+      stop
++   bb4:
++     sstore 0, arg1
++     jump bb3
+  }
+  
+  fn @tiny_stateful_callee(arg0: u256) {
+    bb0 (entry):
+      sstore 0, arg0
+      ret
+  }
+  

--- a/tests/ui/codegen/mir/inst-simplify/inst_simplify.stdout
+++ b/tests/ui/codegen/mir/inst-simplify/inst_simplify.stdout
@@ -1,79 +1,154 @@
-// === ROOT/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir (after inst-simplify) ===
-@module InstSimplify
-fn @strength_reduce_arithmetic(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = shl 5, arg0
-    v1 = shr 3, v0
-    v2 = and arg0, 15
-    v3 = mul arg0, arg0
-    v4 = add arg0, 4
-    v5 = add arg0, 32
-    v6 = and arg0, 255
-    v7 = and arg0, 15
-    v8 = add v1, v2
-    v9 = add v3, v5
-    v10 = add v8, v9
-    v11 = add v10, v7
-    ret v11
-}
-
-fn @simplify_booleans(arg0: bool, arg1: u256, arg2: u256) -> (bool, bool, u256, bool, bool) {
-  bb0 (entry):
-    v1 = iszero arg0
-    v4 = iszero arg0
-    ret arg0, v1, arg1, arg0, v4
-}
-
-fn @remove_zero_length_copies(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret arg0
-}
-
-fn @stop_zero_length_external_return(arg0: u256) {
-  bb0 (entry):
-    stop
-}
-
-fn @preserve_zero_length_internal_return(arg0: u256) {
-  bb0 (entry):
-    returndata arg0, 0
-}
-
-fn @fold_modular_helpers(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @complete_word_identities(arg0: u256, arg1: bool) -> (u256, u256, bool, bool, bool, u256, u256, u256, u256) {
-  bb0 (entry):
-    v1 = not arg0
-    v2 = iszero arg1
-    ret 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v1, arg1, arg1, arg1, 0, 0, 0, arg0
-}
-
-fn @complete_exact_identities(arg0: u256, arg1: bool) -> (u256, u256, u256, u256, bool, bool, bool, bool, u256, u256) {
-  bb0 (entry):
-    v0 = not arg0
-    ret v0, 0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1, 0, 1, 0, 0, 0
-}
-
-fn @fold_modular_mod_one(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @keep_exp_zero_base_with_unknown_exponent(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = exp 0, arg0
-    ret v0
-}
-
-fn @fold_wide_modular_constants() -> (u256, u256) {
-  bb0 (entry):
-    ret 2, 2
-}
-
-fn @fold_constant_ops() -> (u256, u256, u256, u256, u256, u256, u256, u256, u256, bool, bool, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256) {
-  bb0 (entry):
-    ret 12, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, 42, 8, 0, 2, 256, 2, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, 1, 1, 15, 17, 12, 256, 16, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc, 255, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 5
-}
+- // === ROOT/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir (before inst-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir (after inst-simplify) ===
+  @module InstSimplify
+  fn @strength_reduce_arithmetic(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = mul arg0, 32
+-     v1 = div v0, 8
+-     v2 = mod arg0, 16
+-     v3 = exp arg0, 2
++     v0 = shl 5, arg0
++     v1 = shr 3, v0
++     v2 = and arg0, 15
++     v3 = mul arg0, arg0
+      v4 = add arg0, 4
+-     v5 = add v4, 28
++     v5 = add arg0, 32
+      v6 = and arg0, 255
+-     v7 = and v6, 15
++     v7 = and arg0, 15
+      v8 = add v1, v2
+      v9 = add v3, v5
+      v10 = add v8, v9
+      v11 = add v10, v7
+      ret v11
+  }
+  
+  fn @simplify_booleans(arg0: bool, arg1: u256, arg2: u256) -> (bool, bool, u256, bool, bool) {
+    bb0 (entry):
+-     v0 = eq arg0, 1
+-     v1 = eq arg0, 0
+-     v2 = select 1, arg1, arg2
+-     v3 = select arg0, 1, 0
+-     v4 = select arg0, 0, 1
+-     ret v0, v1, v2, v3, v4
++     v1 = iszero arg0
++     v4 = iszero arg0
++     ret arg0, v1, arg1, arg0, v4
+  }
+  
+  fn @remove_zero_length_copies(arg0: u256) -> u256 {
+    bb0 (entry):
+-     mcopy 64, 96, 0
+-     calldatacopy 128, 0, 0
+-     codecopy 160, 0, 0
+-     returndatacopy 192, 0, 0
+      ret arg0
+  }
+  
+  fn @stop_zero_length_external_return(arg0: u256) {
+    bb0 (entry):
+-     v0 = xor arg0, arg0
+-     returndata arg0, v0
++     stop
+  }
+  
+  fn @preserve_zero_length_internal_return(arg0: u256) {
+    bb0 (entry):
+      returndata arg0, 0
+  }
+  
+  fn @fold_modular_helpers(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = addmod arg0, 0, 0
+-     v1 = mulmod arg0, 0, 97
+-     v2 = add v0, v1
+-     ret v2
++     ret 0
+  }
+  
+  fn @complete_word_identities(arg0: u256, arg1: bool) -> (u256, u256, bool, bool, bool, u256, u256, u256, u256) {
+    bb0 (entry):
+-     v0 = or arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     v1 = xor arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
++     v1 = not arg0
+      v2 = iszero arg1
+-     v3 = iszero v2
+-     v4 = lt 0, arg1
+-     v5 = gt arg1, 0
+-     v6 = shl 256, arg0
+-     v7 = shr 300, arg0
+-     v8 = byte 32, arg0
+-     v9 = signextend 32, arg0
+-     ret v0, v1, v3, v4, v5, v6, v7, v8, v9
++     ret 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v1, arg1, arg1, arg1, 0, 0, 0, arg0
+  }
+  
+  fn @complete_exact_identities(arg0: u256, arg1: bool) -> (u256, u256, u256, u256, bool, bool, bool, bool, u256, u256) {
+    bb0 (entry):
+      v0 = not arg0
+-     v1 = and arg0, v0
+-     v2 = or arg0, v0
+-     v3 = xor arg0, v0
+-     v4 = lt arg1, 2
+-     v5 = lt 1, arg1
+-     v6 = gt 2, arg1
+-     v7 = gt arg1, 1
+-     v8 = byte 0, 0
+-     v9 = signextend 3, 0
+-     ret v0, v1, v2, v3, v4, v5, v6, v7, v8, v9
++     ret v0, 0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1, 0, 1, 0, 0, 0
+  }
+  
+  fn @fold_modular_mod_one(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+-     v0 = addmod arg0, arg1, 1
+-     v1 = mulmod arg0, arg1, 1
+-     v2 = add v0, v1
+-     ret v2
++     ret 0
+  }
+  
+  fn @keep_exp_zero_base_with_unknown_exponent(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = exp 0, arg0
+      ret v0
+  }
+  
+  fn @fold_wide_modular_constants() -> (u256, u256) {
+    bb0 (entry):
+-     v0 = addmod 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3
+-     v1 = mulmod 0x100000000000000000000000000000000, 0x100000000000000000000000000000000, 7
+-     ret v0, v1
++     ret 2, 2
+  }
+  
+  fn @fold_constant_ops() -> (u256, u256, u256, u256, u256, u256, u256, u256, u256, bool, bool, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256) {
+    bb0 (entry):
+-     v0 = add 7, 5
+-     v1 = sub 7, 9
+-     v2 = mul 6, 7
+-     v3 = div 42, 5
+-     v4 = div 42, 0
+-     v5 = mod 42, 5
+-     v6 = exp 2, 8
+-     v7 = not 6
+-     v8 = not 2
+-     v9 = sdiv v7, v8
+-     v10 = smod v7, 5
+-     v11 = slt v7, 1
+-     v12 = sgt 1, v7
+-     v13 = and 255, 15
+-     v14 = or 16, 1
+-     v15 = xor 15, 3
+-     v16 = shl 8, 1
+-     v17 = shr 4, 256
+-     v18 = sar 1, v7
+-     v19 = byte 31, 255
+-     v20 = signextend 0, 255
+-     v21 = addmod 5, 7, 10
+-     v22 = mulmod 5, 7, 10
+-     ret v0, v1, v2, v3, v4, v5, v6, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22
++     ret 12, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, 42, 8, 0, 2, 256, 2, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, 1, 1, 15, 17, 12, 256, 16, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc, 255, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 5
+  }
+  

--- a/tests/ui/codegen/mir/jump-threading/jump_threading.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading.stdout
@@ -1,12 +1,16 @@
-// === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading.mir (after jump-threading) ===
-@module Threading
-fn @forwarder_chain(arg0: u256) -> u256 {
-  bb0 (entry):
-    jump bb3
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading.mir (before jump-threading) ===
++ // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading.mir (after jump-threading) ===
+  @module Threading
+  fn @forwarder_chain(arg0: u256) -> u256 {
+    bb0 (entry):
+-     jump bb1
++     jump bb3
+    bb1:
+-     jump bb2
++     jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
@@ -1,14 +1,17 @@
-// === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir (after jump-threading) ===
-@module ThreadingBranch
-fn @branch_forwarders(arg0: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb3, bb4
-  bb1:
-    jump bb3
-  bb2:
-    jump bb4
-  bb3:
-    ret arg0
-  bb4:
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir (before jump-threading) ===
++ // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir (after jump-threading) ===
+  @module ThreadingBranch
+  fn @branch_forwarders(arg0: u256) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
++     br arg0, bb3, bb4
+    bb1:
+      jump bb3
+    bb2:
+      jump bb4
+    bb3:
+      ret arg0
+    bb4:
+      ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
@@ -1,68 +1,78 @@
-// === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir (after jump-threading) ===
-@module JumpThreadingPhiConstants
-fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb5, bb4
-  bb1:
-    jump bb5
-  bb2:
-    jump bb4
-  bb3:
-    v0 = phi
-    br v0, bb4, bb5
-  bb4:
-    ret 11
-  bb5:
-    ret 22
-}
-
-fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb4, bb5
-  bb1:
-    jump bb4
-  bb2:
-    jump bb5
-  bb3:
-    v0 = phi
-    switch v0, default bb6, [1 => bb4, 2 => bb5]
-  bb4:
-    ret 11
-  bb5:
-    ret 22
-  bb6:
-    ret 33
-}
-
-fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: arg1], [bb2: arg2]
-    br v0, bb4, bb5
-  bb4:
-    ret 11
-  bb5:
-    ret 22
-}
-
-fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: 0], [bb2: 1]
-    br v0, bb4, bb5
-  bb4:
-    v1 = add v0, 1
-    ret v1
-  bb5:
-    ret 22
-}
+- // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir (before jump-threading) ===
++ // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir (after jump-threading) ===
+  @module JumpThreadingPhiConstants
+  fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
++     br arg0, bb5, bb4
+    bb1:
+-     jump bb3
++     jump bb5
+    bb2:
+-     jump bb3
++     jump bb4
+    bb3:
+-     v0 = phi [bb1: 0], [bb2: 1]
++     v0 = phi
+      br v0, bb4, bb5
+    bb4:
+      ret 11
+    bb5:
+      ret 22
+  }
+  
+  fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb2
++     br arg0, bb4, bb5
+    bb1:
+-     jump bb3
++     jump bb4
+    bb2:
+-     jump bb3
++     jump bb5
+    bb3:
+-     v0 = phi [bb1: 1], [bb2: 2]
++     v0 = phi
+      switch v0, default bb6, [1 => bb4, 2 => bb5]
+    bb4:
+      ret 11
+    bb5:
+      ret 22
+    bb6:
+      ret 33
+  }
+  
+  fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: arg1], [bb2: arg2]
+      br v0, bb4, bb5
+    bb4:
+      ret 11
+    bb5:
+      ret 22
+  }
+  
+  fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: 0], [bb2: 1]
+      br v0, bb4, bb5
+    bb4:
+      v1 = add v0, 1
+      ret v1
+    bb5:
+      ret 22
+  }
+  

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
@@ -1,16 +1,18 @@
-// === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir (after jump-threading) ===
-@module JumpThreadingPhiForwarder
-fn @keep_phi_only_block(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: 1], [bb2: 2]
-    jump bb4
-  bb4:
-    v1 = add v0, 1
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir (before jump-threading) ===
++ // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir (after jump-threading) ===
+  @module JumpThreadingPhiForwarder
+  fn @keep_phi_only_block(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: 1], [bb2: 2]
+      jump bb4
+    bb4:
+      v1 = add v0, 1
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
+++ b/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
@@ -1,35 +1,40 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_descending_iv.mir (after licm) ===
-@module LicmDescendingIv
-fn @keep_mload_descending_iv() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 64], [bb2: v3]
-    v1 = lt v0, 100
-    br v1, bb2, bb3
-  bb2:
-    v2 = mload 0
-    sstore v0, v2 !metadata(storage=symbolic(v0))
-    mstore v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    v3 = sub v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
-
-fn @hoist_mload_ascending_iv() -> u256 {
-  bb0 (entry):
-    v2 = mload 0
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 64], [bb2: v3]
-    v1 = lt v0, 100
-    br v1, bb2, bb3
-  bb2:
-    sstore v0, v2 !metadata(storage=symbolic(v0))
-    mstore v0, 7
-    v3 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_descending_iv.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_descending_iv.mir (after licm) ===
+  @module LicmDescendingIv
+  fn @keep_mload_descending_iv() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 64], [bb2: v3]
+      v1 = lt v0, 100
+      br v1, bb2, bb3
+    bb2:
+      v2 = mload 0
+-     sstore v0, v2
++     sstore v0, v2 !metadata(storage=symbolic(v0))
+      mstore v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      v3 = sub v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  
+  fn @hoist_mload_ascending_iv() -> u256 {
+    bb0 (entry):
++     v2 = mload 0
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 64], [bb2: v3]
+      v1 = lt v0, 100
+      br v1, bb2, bb3
+    bb2:
+-     v2 = mload 0
+-     sstore v0, v2
++     sstore v0, v2 !metadata(storage=symbolic(v0))
+      mstore v0, 7
+      v3 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_env_reads.stdout
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.stdout
@@ -1,69 +1,73 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_env_reads.mir (after licm) ===
-@module LicmEnvReads
-fn @keep_balance_with_call() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    v0 = balance 0xbeef
-    v1 = mul v0, 3
-    v2 = call 0x3e8, 0xbeef, 1, 0, 0, 0, 0
-    jump bb1
-  bb3:
-    ret v1
-}
-
-fn @hoist_balance_without_calls() -> u256 {
-  bb0 (entry):
-    v0 = balance 0xbeef
-    v1 = mul v0, 3
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    jump bb1
-  bb3:
-    ret v1
-}
-
-fn @keep_extcodesize_with_create() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    v0 = extcodesize 0xbeef
-    v1 = mul v0, 3
-    v2 = create 0, 0, 32
-    jump bb1
-  bb3:
-    ret v1
-}
-
-fn @keep_returndatasize_with_staticcall() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    v0 = returndatasize
-    v1 = mul v0, 3
-    v2 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
-    jump bb1
-  bb3:
-    ret v1
-}
-
-fn @keep_msize() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    v0 = msize
-    v1 = mul v0, 3
-    jump bb1
-  bb3:
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_env_reads.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_env_reads.mir (after licm) ===
+  @module LicmEnvReads
+  fn @keep_balance_with_call() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+      v0 = balance 0xbeef
+      v1 = mul v0, 3
+      v2 = call 0x3e8, 0xbeef, 1, 0, 0, 0, 0
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
+  fn @hoist_balance_without_calls() -> u256 {
+    bb0 (entry):
++     v0 = balance 0xbeef
++     v1 = mul v0, 3
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+-     v0 = balance 0xbeef
+-     v1 = mul v0, 3
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
+  fn @keep_extcodesize_with_create() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+      v0 = extcodesize 0xbeef
+      v1 = mul v0, 3
+      v2 = create 0, 0, 32
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
+  fn @keep_returndatasize_with_staticcall() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+      v0 = returndatasize
+      v1 = mul v0, 3
+      v2 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
+  fn @keep_msize() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+      v0 = msize
+      v1 = mul v0, 3
+      jump bb1
+    bb3:
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
+++ b/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
@@ -1,45 +1,47 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_loop_bound.mir (after licm) ===
-@module LicmLoopBound
-fn @keep_mload_non_exiting_bound() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb4: v5]
-    v1 = eq v0, 100
-    br v1, bb5, bb2
-  bb2:
-    v2 = mload 64
-    v3 = mul v0, 32
-    mstore v3, 1
-    v4 = lt v0, 2
-    br v4, bb3, bb4
-  bb3:
-    jump bb4
-  bb4:
-    v5 = add v0, 1
-    jump bb1
-  bb5:
-    ret v2
-}
-
-fn @keep_mload_inner_branch_bound() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb4: v5]
-    v1 = lt v0, 100
-    br v1, bb2, bb5
-  bb2:
-    v2 = mload 64
-    v3 = mul v0, 32
-    mstore v3, 1
-    v4 = lt v0, 2
-    br v4, bb3, bb4
-  bb3:
-    jump bb4
-  bb4:
-    v5 = add v0, 1
-    jump bb1
-  bb5:
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_loop_bound.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_loop_bound.mir (after licm) ===
+  @module LicmLoopBound
+  fn @keep_mload_non_exiting_bound() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb4: v5]
+      v1 = eq v0, 100
+      br v1, bb5, bb2
+    bb2:
+      v2 = mload 64
+      v3 = mul v0, 32
+      mstore v3, 1
+      v4 = lt v0, 2
+      br v4, bb3, bb4
+    bb3:
+      jump bb4
+    bb4:
+      v5 = add v0, 1
+      jump bb1
+    bb5:
+      ret v2
+  }
+  
+  fn @keep_mload_inner_branch_bound() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb4: v5]
+      v1 = lt v0, 100
+      br v1, bb2, bb5
+    bb2:
+      v2 = mload 64
+      v3 = mul v0, 32
+      mstore v3, 1
+      v4 = lt v0, 2
+      br v4, bb3, bb4
+    bb3:
+      jump bb4
+    bb4:
+      v5 = add v0, 1
+      jump bb1
+    bb5:
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
@@ -1,53 +1,57 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_memory_alias.mir (after licm) ===
-@module LicmMemoryAlias
-fn @hoist_non_aliasing_mload() -> u256 {
-  bb0 (entry):
-    v0 = mload 0
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    mstore 64, 1
-    jump bb1
-  bb3:
-    ret v0
-}
-
-fn @keep_aliasing_mload() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    v0 = mload 0
-    mstore 16, 1
-    jump bb1
-  bb3:
-    ret v0
-}
-
-fn @hoist_non_aliasing_keccak() -> bytes32 {
-  bb0 (entry):
-    v0 = keccak256 0, 32
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    mstore 64, 1
-    jump bb1
-  bb3:
-    ret v0
-}
-
-fn @keep_aliasing_keccak() -> bytes32 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    br 1, bb2, bb3
-  bb2:
-    v0 = keccak256 0, 32
-    mstore 16, 1
-    jump bb1
-  bb3:
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_memory_alias.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_memory_alias.mir (after licm) ===
+  @module LicmMemoryAlias
+  fn @hoist_non_aliasing_mload() -> u256 {
+    bb0 (entry):
++     v0 = mload 0
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+-     v0 = mload 0
+      mstore 64, 1
+      jump bb1
+    bb3:
+      ret v0
+  }
+  
+  fn @keep_aliasing_mload() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+      v0 = mload 0
+      mstore 16, 1
+      jump bb1
+    bb3:
+      ret v0
+  }
+  
+  fn @hoist_non_aliasing_keccak() -> bytes32 {
+    bb0 (entry):
++     v0 = keccak256 0, 32
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+-     v0 = keccak256 0, 32
+      mstore 64, 1
+      jump bb1
+    bb3:
+      ret v0
+  }
+  
+  fn @keep_aliasing_keccak() -> bytes32 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      br 1, bb2, bb3
+    bb2:
+      v0 = keccak256 0, 32
+      mstore 16, 1
+      jump bb1
+    bb3:
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
+++ b/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
@@ -1,46 +1,51 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_multi_latch.mir (after licm) ===
-@module LicmMultiLatch
-fn @multi_latch_mixed_step() -> u256 {
-  bb0 (entry):
-    v4 = calldataload 0
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb3: v5], [bb4: v6]
-    v1 = lt v0, 10
-    br v1, bb2, bb5
-  bb2:
-    v2 = mul v0, 32
-    mstore v2, 1
-    v3 = mload 288
-    br v4, bb3, bb4
-  bb3:
-    v5 = add v0, 1
-    jump bb1
-  bb4:
-    v6 = add v0, 7
-    jump bb1
-  bb5:
-    ret v3
-}
-
-fn @multi_latch_same_value() -> u256 {
-  bb0 (entry):
-    v3 = mload 320
-    v5 = calldataload 0
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb3: v4], [bb4: v4]
-    v1 = lt v0, 10
-    br v1, bb2, bb5
-  bb2:
-    v2 = mul v0, 32
-    mstore v2, 1
-    v4 = add v0, 1
-    br v5, bb3, bb4
-  bb3:
-    jump bb1
-  bb4:
-    jump bb1
-  bb5:
-    ret v3
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_multi_latch.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_multi_latch.mir (after licm) ===
+  @module LicmMultiLatch
+  fn @multi_latch_mixed_step() -> u256 {
+    bb0 (entry):
++     v4 = calldataload 0
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb3: v5], [bb4: v6]
+      v1 = lt v0, 10
+      br v1, bb2, bb5
+    bb2:
+      v2 = mul v0, 32
+      mstore v2, 1
+      v3 = mload 288
+-     v4 = calldataload 0
+      br v4, bb3, bb4
+    bb3:
+      v5 = add v0, 1
+      jump bb1
+    bb4:
+      v6 = add v0, 7
+      jump bb1
+    bb5:
+      ret v3
+  }
+  
+  fn @multi_latch_same_value() -> u256 {
+    bb0 (entry):
++     v3 = mload 320
++     v5 = calldataload 0
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb3: v4], [bb4: v4]
+      v1 = lt v0, 10
+      br v1, bb2, bb5
+    bb2:
+      v2 = mul v0, 32
+      mstore v2, 1
+-     v3 = mload 320
+      v4 = add v0, 1
+-     v5 = calldataload 0
+      br v5, bb3, bb4
+    bb3:
+      jump bb1
+    bb4:
+      jump bb1
+    bb5:
+      ret v3
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
+++ b/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
@@ -1,67 +1,71 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_rotated_guard.mir (after licm) ===
-@module LicmRotatedGuard
-fn @rotated_guard_overlap() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v1 = mul v0, 32
-    mstore v1, 1
-    v2 = mload 320
-    v3 = lt v0, 10
-    br v3, bb2, bb3
-  bb2:
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
-
-fn @dowhile_latch_guard_overlap() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb1: v3]
-    v1 = mul v0, 32
-    mstore v1, 1
-    v2 = mload 320
-    v3 = add v0, 1
-    v4 = lt v0, 10
-    br v4, bb1, bb2
-  bb2:
-    ret v2
-}
-
-fn @top_tested_control() -> u256 {
-  bb0 (entry):
-    v3 = mload 320
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v1 = lt v0, 10
-    br v1, bb2, bb3
-  bb2:
-    v2 = mul v0, 32
-    mstore v2, 1
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @disjoint_past_widened_range() -> u256 {
-  bb0 (entry):
-    v2 = mload 384
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v1 = mul v0, 32
-    mstore v1, 1
-    v3 = lt v0, 10
-    br v3, bb2, bb3
-  bb2:
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_rotated_guard.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_rotated_guard.mir (after licm) ===
+  @module LicmRotatedGuard
+  fn @rotated_guard_overlap() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      v1 = mul v0, 32
+      mstore v1, 1
+      v2 = mload 320
+      v3 = lt v0, 10
+      br v3, bb2, bb3
+    bb2:
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  
+  fn @dowhile_latch_guard_overlap() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb1: v3]
+      v1 = mul v0, 32
+      mstore v1, 1
+      v2 = mload 320
+      v3 = add v0, 1
+      v4 = lt v0, 10
+      br v4, bb1, bb2
+    bb2:
+      ret v2
+  }
+  
+  fn @top_tested_control() -> u256 {
+    bb0 (entry):
++     v3 = mload 320
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      v1 = lt v0, 10
+      br v1, bb2, bb3
+    bb2:
+      v2 = mul v0, 32
+      mstore v2, 1
+-     v3 = mload 320
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      ret v3
+  }
+  
+  fn @disjoint_past_widened_range() -> u256 {
+    bb0 (entry):
++     v2 = mload 384
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      v1 = mul v0, 32
+      mstore v1, 1
+-     v2 = mload 384
+      v3 = lt v0, 10
+      br v3, bb2, bb3
+    bb2:
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
+++ b/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
@@ -1,49 +1,54 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir (after licm) ===
-@module LicmStaticcallStorage
-fn @hoist_sload_with_staticcall() -> u256 {
-  bb0 (entry):
-    v2 = sload 5 !metadata(storage=slot(5))
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v1 = lt v0, 10
-    br v1, bb2, bb3
-  bb2:
-    v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
-
-fn @hoist_tload_with_staticcall() -> u256 {
-  bb0 (entry):
-    v2 = tload 5 !metadata(storage=slot(5))
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v1 = lt v0, 10
-    br v1, bb2, bb3
-  bb2:
-    v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
-
-fn @keep_sload_with_call() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    v1 = lt v0, 10
-    br v1, bb2, bb3
-  bb2:
-    v2 = sload 5 !metadata(storage=slot(5))
-    v3 = call 0x3e8, 0xbeef, 0, 0, 0, 0, 0
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir (after licm) ===
+  @module LicmStaticcallStorage
+  fn @hoist_sload_with_staticcall() -> u256 {
+    bb0 (entry):
++     v2 = sload 5 !metadata(storage=slot(5))
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      v1 = lt v0, 10
+      br v1, bb2, bb3
+    bb2:
+-     v2 = sload 5
+      v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  
+  fn @hoist_tload_with_staticcall() -> u256 {
+    bb0 (entry):
++     v2 = tload 5 !metadata(storage=slot(5))
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      v1 = lt v0, 10
+      br v1, bb2, bb3
+    bb2:
+-     v2 = tload 5
+      v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  
+  fn @keep_sload_with_call() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      v1 = lt v0, 10
+      br v1, bb2, bb3
+    bb2:
+-     v2 = sload 5
++     v2 = sload 5 !metadata(storage=slot(5))
+      v3 = call 0x3e8, 0xbeef, 0, 0, 0, 0, 0
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_v2.stdout
+++ b/tests/ui/codegen/mir/licm/licm_v2.stdout
@@ -1,88 +1,104 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_v2.mir (after licm) ===
-@module LicmV2
-fn @hoist_symbolic_offset_sload(arg0: u256) -> u256 {
-  bb0 (entry):
-    v2 = add arg0, 1
-    v3 = sload v2 !metadata(storage=offset(arg0, 1))
-    v4 = add arg0, 2
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v5]
-    v1 = lt v0, 4
-    br v1, bb2, bb3
-  bb2:
-    sstore v4, 9 !metadata(storage=offset(arg0, 2))
-    v5 = add v0, 1
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
-  bb0 (entry):
-    v2 = add arg0, 1
-    v4 = add arg0, 1
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v5]
-    v1 = lt v0, 4
-    br v1, bb2, bb3
-  bb2:
-    v3 = sload v2 !metadata(storage=offset(arg0, 1))
-    sstore v4, 9 !metadata(storage=offset(arg0, 1))
-    v5 = add v0, 1
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v2 = add arg0, 2
-    jump bb1
-  bb1:
-    br arg1, bb2, bb3
-  bb2:
-    v1 = sload v0 !metadata(storage=offset(arg0, 1))
-    sstore v2, 9 !metadata(storage=offset(arg0, 2))
-    jump bb1
-  bb3:
-    ret v1
-}
-
-fn @hoist_affine_memory_base(arg0: u256) -> u256 {
-  bb0 (entry):
-    v2 = add arg0, 32
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v5]
-    v1 = lt v0, 4
-    br v1, bb2, bb3
-  bb2:
-    v3 = mul v0, 32
-    v4 = add v2, v3
-    mstore v4, v0
-    v5 = add v0, 1
-    jump bb1
-  bb3:
-    ret 0
-}
-
-fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v2 = add arg0, 32
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v5]
-    v1 = lt v0, arg1
-    br v1, bb2, bb3
-  bb2:
-    v3 = mul v0, 32
-    v4 = add v2, v3
-    mstore v4, v0
-    v5 = add v0, 1
-    jump bb1
-  bb3:
-    ret 0
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_v2.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_v2.mir (after licm) ===
+  @module LicmV2
+  fn @hoist_symbolic_offset_sload(arg0: u256) -> u256 {
+    bb0 (entry):
++     v2 = add arg0, 1
++     v3 = sload v2 !metadata(storage=offset(arg0, 1))
++     v4 = add arg0, 2
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v5]
+      v1 = lt v0, 4
+      br v1, bb2, bb3
+    bb2:
+-     v2 = add arg0, 1
+-     v3 = sload v2
+-     v4 = add arg0, 2
+-     sstore v4, 9
++     sstore v4, 9 !metadata(storage=offset(arg0, 2))
+      v5 = add v0, 1
+      jump bb1
+    bb3:
+      ret v3
+  }
+  
+  fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
+    bb0 (entry):
++     v2 = add arg0, 1
++     v4 = add arg0, 1
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v5]
+      v1 = lt v0, 4
+      br v1, bb2, bb3
+    bb2:
+-     v2 = add arg0, 1
+-     v3 = sload v2
+-     v4 = add arg0, 1
+-     sstore v4, 9
++     v3 = sload v2 !metadata(storage=offset(arg0, 1))
++     sstore v4, 9 !metadata(storage=offset(arg0, 1))
+      v5 = add v0, 1
+      jump bb1
+    bb3:
+      ret v3
+  }
+  
+  fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
++     v0 = add arg0, 1
++     v2 = add arg0, 2
+      jump bb1
+    bb1:
+      br arg1, bb2, bb3
+    bb2:
+-     v0 = add arg0, 1
+-     v1 = sload v0
+-     v2 = add arg0, 2
+-     sstore v2, 9
++     v1 = sload v0 !metadata(storage=offset(arg0, 1))
++     sstore v2, 9 !metadata(storage=offset(arg0, 2))
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
+  fn @hoist_affine_memory_base(arg0: u256) -> u256 {
+    bb0 (entry):
++     v2 = add arg0, 32
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v5]
+      v1 = lt v0, 4
+      br v1, bb2, bb3
+    bb2:
+-     v2 = add arg0, 32
+      v3 = mul v0, 32
+      v4 = add v2, v3
+      mstore v4, v0
+      v5 = add v0, 1
+      jump bb1
+    bb3:
+      ret 0
+  }
+  
+  fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
++     v2 = add arg0, 32
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v5]
+      v1 = lt v0, arg1
+      br v1, bb2, bb3
+    bb2:
+-     v2 = add arg0, 32
+      v3 = mul v0, 32
+      v4 = add v2, v3
+      mstore v4, v0
+      v5 = add v0, 1
+      jump bb1
+    bb3:
+      ret 0
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
+++ b/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
@@ -1,18 +1,20 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir (after licm) ===
-@module LicmWrapAddDescending
-fn @wrap_add_descending() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 64], [bb2: v4]
-    v1 = lt v0, 100
-    br v1, bb2, bb3
-  bb2:
-    v2 = mul v0, 32
-    mstore v2, 1
-    v3 = mload 0
-    v4 = add v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    jump bb1
-  bb3:
-    ret v3
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir (after licm) ===
+  @module LicmWrapAddDescending
+  fn @wrap_add_descending() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 64], [bb2: v4]
+      v1 = lt v0, 100
+      br v1, bb2, bb3
+    bb2:
+      v2 = mul v0, 32
+      mstore v2, 1
+      v3 = mload 0
+      v4 = add v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+      jump bb1
+    bb3:
+      ret v3
+  }
+  

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
@@ -1,77 +1,83 @@
-// === ROOT/tests/ui/codegen/mir/licm/licm_zero_trip.mir (after licm) ===
-@module LicmZeroTrip
-fn @keep_sload_zero_trip() -> u256 {
-  bb0 (entry):
-    v0 = calldatasize
-    jump bb1
-  bb1:
-    v1 = phi [bb0: 0], [bb2: v4]
-    v2 = lt v1, v0
-    br v2, bb2, bb3
-  bb2:
-    v3 = sload 5 !metadata(storage=slot(5))
-    v4 = add v1, 1
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @keep_mload_zero_trip() -> u256 {
-  bb0 (entry):
-    v0 = calldatasize
-    jump bb1
-  bb1:
-    v1 = phi [bb0: 0], [bb2: v4]
-    v2 = lt v1, v0
-    br v2, bb2, bb3
-  bb2:
-    v3 = mload 0x1000000
-    v4 = add v1, 1
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @hoist_sload_known_trip() -> u256 {
-  bb0 (entry):
-    v2 = sload 5 !metadata(storage=slot(5))
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v3]
-    v1 = lt v0, 10
-    br v1, bb2, bb3
-  bb2:
-    v3 = add v0, 1
-    jump bb1
-  bb3:
-    ret v2
-}
-
-fn @hoist_mload_dominates_exits() -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    v1 = calldataload 0
-    jump bb1
-  bb1:
-    v2 = lt v0, v1
-    br v2, bb1, bb2
-  bb2:
-    ret v0
-}
-
-fn @keep_mload_msize_in_function() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v3]
-    v1 = lt v0, 10
-    br v1, bb2, bb3
-  bb2:
-    v2 = mload 64
-    v3 = add v0, 1
-    jump bb1
-  bb3:
-    v4 = msize
-    v5 = add v2, v4
-    ret v5
-}
+- // === ROOT/tests/ui/codegen/mir/licm/licm_zero_trip.mir (before licm) ===
++ // === ROOT/tests/ui/codegen/mir/licm/licm_zero_trip.mir (after licm) ===
+  @module LicmZeroTrip
+  fn @keep_sload_zero_trip() -> u256 {
+    bb0 (entry):
+      v0 = calldatasize
+      jump bb1
+    bb1:
+      v1 = phi [bb0: 0], [bb2: v4]
+      v2 = lt v1, v0
+      br v2, bb2, bb3
+    bb2:
+-     v3 = sload 5
++     v3 = sload 5 !metadata(storage=slot(5))
+      v4 = add v1, 1
+      jump bb1
+    bb3:
+      ret v3
+  }
+  
+  fn @keep_mload_zero_trip() -> u256 {
+    bb0 (entry):
+      v0 = calldatasize
+      jump bb1
+    bb1:
+      v1 = phi [bb0: 0], [bb2: v4]
+      v2 = lt v1, v0
+      br v2, bb2, bb3
+    bb2:
+      v3 = mload 0x1000000
+      v4 = add v1, 1
+      jump bb1
+    bb3:
+      ret v3
+  }
+  
+  fn @hoist_sload_known_trip() -> u256 {
+    bb0 (entry):
++     v2 = sload 5 !metadata(storage=slot(5))
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v3]
+      v1 = lt v0, 10
+      br v1, bb2, bb3
+    bb2:
+-     v2 = sload 5
+      v3 = add v0, 1
+      jump bb1
+    bb3:
+      ret v2
+  }
+  
+  fn @hoist_mload_dominates_exits() -> u256 {
+    bb0 (entry):
+-     jump bb1
+-   bb1:
+      v0 = mload 64
+      v1 = calldataload 0
++     jump bb1
++   bb1:
+      v2 = lt v0, v1
+      br v2, bb1, bb2
+    bb2:
+      ret v0
+  }
+  
+  fn @keep_mload_msize_in_function() -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v3]
+      v1 = lt v0, 10
+      br v1, bb2, bb3
+    bb2:
+      v2 = mload 64
+      v3 = add v0, 1
+      jump bb1
+    bb3:
+      v4 = msize
+      v5 = add v2, v4
+      ret v5
+  }
+  

--- a/tests/ui/codegen/mir/load-pre/load_pre.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre.stdout
@@ -1,57 +1,67 @@
-// === ROOT/tests/ui/codegen/mir/load-pre/load_pre.mir (after load-pre) ===
-@module LoadPre
-fn @full_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = sload 5
-    jump bb3
-  bb2:
-    v1 = sload 5
-    jump bb3
-  bb3:
-    v3 = phi [bb1: v0], [bb2: v1]
-    ret v3
-}
-
-fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    sstore 5, arg1
-    jump bb3
-  bb2:
-    v0 = sload 5
-    jump bb3
-  bb3:
-    v2 = phi [bb1: arg1], [bb2: v0]
-    ret v2
-}
-
-fn @partial_insert_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = sload 5
-    jump bb3
-  bb2:
-    v2 = sload 5
-    jump bb3
-  bb3:
-    v3 = phi [bb1: v0], [bb2: v2]
-    ret v3
-}
-
-fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    tstore 5, arg1
-    jump bb3
-  bb2:
-    v0 = tload 5
-    jump bb3
-  bb3:
-    v2 = phi [bb1: arg1], [bb2: v0]
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/load-pre/load_pre.mir (before load-pre) ===
++ // === ROOT/tests/ui/codegen/mir/load-pre/load_pre.mir (after load-pre) ===
+  @module LoadPre
+  fn @full_diamond(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = sload 5
+      jump bb3
+    bb2:
+      v1 = sload 5
+      jump bb3
+    bb3:
+-     v2 = sload 5
+-     ret v2
++     v3 = phi [bb1: v0], [bb2: v1]
++     ret v3
+  }
+  
+  fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      sstore 5, arg1
+      jump bb3
+    bb2:
+      v0 = sload 5
+      jump bb3
+    bb3:
+-     v1 = sload 5
+-     ret v1
++     v2 = phi [bb1: arg1], [bb2: v0]
++     ret v2
+  }
+  
+  fn @partial_insert_diamond(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = sload 5
+      jump bb3
+    bb2:
++     v2 = sload 5
+      jump bb3
+    bb3:
+-     v1 = sload 5
+-     ret v1
++     v3 = phi [bb1: v0], [bb2: v2]
++     ret v3
+  }
+  
+  fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      tstore 5, arg1
+      jump bb3
+    bb2:
+      v0 = tload 5
+      jump bb3
+    bb3:
+-     v1 = tload 5
+-     ret v1
++     v2 = phi [bb1: arg1], [bb2: v0]
++     ret v2
+  }
+  

--- a/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
@@ -1,80 +1,86 @@
-// === ROOT/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir (after load-pre) ===
-@module LoadPreClobbers
-fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 5
-    br arg0, bb1, bb2
-  bb1:
-    sstore arg1, 7
-    br arg0, bb3, bb4
-  bb2:
-    jump bb3
-  bb3:
-    v1 = sload 5
-    ret v1
-  bb4:
-    ret v0
-}
-
-fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
-    v0 = sload 5
-    br arg0, bb1, bb2
-  bb1:
-    v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
-    br arg0, bb3, bb4
-  bb2:
-    jump bb3
-  bb3:
-    v2 = sload 5
-    ret v2
-  bb4:
-    ret v0
-}
-
-fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
-    v0 = sload 5
-    br arg0, bb1, bb2
-  bb1:
-    v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
-    br arg0, bb3, bb4
-  bb2:
-    jump bb3
-  bb3:
-    ret v0
-  bb4:
-    ret v0
-}
-
-fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = sload 5
-    sstore arg1, 7
-    v3 = sload 5
-    jump bb3
-  bb2:
-    v1 = sload 5
-    jump bb3
-  bb3:
-    v4 = phi [bb1: v3], [bb2: v1]
-    ret v4
-}
-
-fn @gas_blocks_rewrite(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = sload 5
-    jump bb3
-  bb2:
-    v1 = sload 5
-    jump bb3
-  bb3:
-    v2 = gas
-    v3 = sload 5
-    v4 = add v2, v3
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir (before load-pre) ===
++ // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir (after load-pre) ===
+  @module LoadPreClobbers
+  fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 5
+      br arg0, bb1, bb2
+    bb1:
+      sstore arg1, 7
+      br arg0, bb3, bb4
+    bb2:
+      jump bb3
+    bb3:
+      v1 = sload 5
+      ret v1
+    bb4:
+      ret v0
+  }
+  
+  fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
+    bb0 (entry):
+      v0 = sload 5
+      br arg0, bb1, bb2
+    bb1:
+      v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
+      br arg0, bb3, bb4
+    bb2:
+      jump bb3
+    bb3:
+      v2 = sload 5
+      ret v2
+    bb4:
+      ret v0
+  }
+  
+  fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
+    bb0 (entry):
+      v0 = sload 5
+      br arg0, bb1, bb2
+    bb1:
+      v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
+      br arg0, bb3, bb4
+    bb2:
+      jump bb3
+    bb3:
+-     v2 = sload 5
+-     ret v2
++     ret v0
+    bb4:
+      ret v0
+  }
+  
+  fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = sload 5
+      sstore arg1, 7
++     v3 = sload 5
+      jump bb3
+    bb2:
+      v1 = sload 5
+      jump bb3
+    bb3:
+-     v2 = sload 5
+-     ret v2
++     v4 = phi [bb1: v3], [bb2: v1]
++     ret v4
+  }
+  
+  fn @gas_blocks_rewrite(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = sload 5
+      jump bb3
+    bb2:
+      v1 = sload 5
+      jump bb3
+    bb3:
+      v2 = gas
+      v3 = sload 5
+      v4 = add v2, v3
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
@@ -1,29 +1,33 @@
-// === ROOT/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir (after load-pre) ===
-@module LoadPreKeccak
-fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = keccak256 0, arg1
-    jump bb3
-  bb2:
-    v1 = keccak256 0, arg1
-    jump bb3
-  bb3:
-    v3 = phi [bb1: v0], [bb2: v1]
-    ret v3
-}
-
-fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = keccak256 0, arg1
-    jump bb3
-  bb2:
-    v1 = keccak256 0, arg1
-    jump bb3
-  bb3:
-    v2 = keccak256 0, arg2
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir (before load-pre) ===
++ // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir (after load-pre) ===
+  @module LoadPreKeccak
+  fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = keccak256 0, arg1
+      jump bb3
+    bb2:
+      v1 = keccak256 0, arg1
+      jump bb3
+    bb3:
+-     v2 = keccak256 0, arg1
+-     ret v2
++     v3 = phi [bb1: v0], [bb2: v1]
++     ret v3
+  }
+  
+  fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = keccak256 0, arg1
+      jump bb3
+    bb2:
+      v1 = keccak256 0, arg1
+      jump bb3
+    bb3:
+      v2 = keccak256 0, arg2
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
@@ -1,45 +1,50 @@
-// === ROOT/tests/ui/codegen/mir/load-pre/load_pre_loop.mir (after load-pre) ===
-@module LoadPreLoop
-fn @loop_header_reload(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 5
-    jump bb1
-  bb1:
-    v3 = phi [bb0: v0], [bb2: v3]
-    v2 = lt v3, arg0
-    br v2, bb2, bb3
-  bb2:
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 5
-    jump bb1
-  bb1:
-    v1 = sload 5
-    v2 = lt v1, arg0
-    br v2, bb2, bb3
-  bb2:
-    sstore arg1, 9
-    jump bb1
-  bb3:
-    ret v1
-}
-
-fn @loop_clobbered_no_insert(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 5
-    jump bb1
-  bb1:
-    v1 = sload 5
-    v2 = lt v1, arg0
-    br v2, bb2, bb3
-  bb2:
-    sstore arg1, 9
-    br v2, bb1, bb3
-  bb3:
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_loop.mir (before load-pre) ===
++ // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_loop.mir (after load-pre) ===
+  @module LoadPreLoop
+  fn @loop_header_reload(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 5
+      jump bb1
+    bb1:
+-     v1 = sload 5
+-     v2 = lt v1, arg0
++     v3 = phi [bb0: v0], [bb2: v3]
++     v2 = lt v3, arg0
+      br v2, bb2, bb3
+    bb2:
+      jump bb1
+    bb3:
+-     ret v1
++     ret v3
+  }
+  
+  fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 5
+      jump bb1
+    bb1:
+      v1 = sload 5
+      v2 = lt v1, arg0
+      br v2, bb2, bb3
+    bb2:
+      sstore arg1, 9
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
+  fn @loop_clobbered_no_insert(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 5
+      jump bb1
+    bb1:
+      v1 = sload 5
+      v2 = lt v1, arg0
+      br v2, bb2, bb3
+    bb2:
+      sstore arg1, 9
+      br v2, bb1, bb3
+    bb3:
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
@@ -1,135 +1,143 @@
-// === ROOT/tests/ui/codegen/mir/load-pre/load_pre_memory.mir (after load-pre) ===
-@module LoadPreMemory
-fn @mload_full_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = mload 128
-    jump bb3
-  bb2:
-    v1 = mload 128
-    jump bb3
-  bb3:
-    v2 = mload 128
-    ret v2
-}
-
-fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 128, arg1
-    jump bb3
-  bb2:
-    v0 = mload 128
-    jump bb3
-  bb3:
-    v1 = mload 128
-    ret v1
-}
-
-fn @mstore8_overlap_kills(arg0: bool) -> u256 {
-  bb0 (entry):
-    v0 = mload 128
-    br arg0, bb1, bb2
-  bb1:
-    mstore8 159, 7
-    br arg0, bb3, bb4
-  bb2:
-    jump bb3
-  bb3:
-    v1 = mload 128
-    ret v1
-  bb4:
-    ret v0
-}
-
-fn @mload_partial_rejected(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = mload 128
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v1 = mload 128
-    ret v1
-}
-
-fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = mload 128
-    jump bb3
-  bb2:
-    v4 = mload 128
-    jump bb3
-  bb3:
-    v5 = phi [bb1: v0], [bb2: v4]
-    v3 = add v5, v5
-    ret v3
-}
-
-fn @mload_partial_two_available(arg0: u256) -> u256 {
-  bb0 (entry):
-    switch arg0, default bb3, [1 => bb1, 2 => bb2]
-  bb1:
-    v0 = mload 128
-    jump bb4
-  bb2:
-    v1 = mload 128
-    jump bb4
-  bb3:
-    jump bb4
-  bb4:
-    v2 = mload 128
-    ret v2
-}
-
-fn @mload_loop_header(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mload 128
-    jump bb1
-  bb1:
-    v3 = phi [bb0: v0], [bb2: v3]
-    v2 = lt v3, arg0
-    br v2, bb2, bb3
-  bb2:
-    jump bb1
-  bb3:
-    ret v3
-}
-
-fn @staticcall_kills_memory(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
-    v0 = mload 128
-    br arg0, bb1, bb2
-  bb1:
-    v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
-    br arg0, bb3, bb4
-  bb2:
-    jump bb3
-  bb3:
-    v2 = mload 128
-    ret v2
-  bb4:
-    ret v0
-}
-
-fn @msize_blocks_memory(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    v0 = mload 128
-    jump bb3
-  bb2:
-    v1 = mload 128
-    jump bb3
-  bb3:
-    v2 = msize
-    v3 = mload 128
-    v4 = add v2, v3
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_memory.mir (before load-pre) ===
++ // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_memory.mir (after load-pre) ===
+  @module LoadPreMemory
+  fn @mload_full_diamond(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = mload 128
+      jump bb3
+    bb2:
+      v1 = mload 128
+      jump bb3
+    bb3:
+      v2 = mload 128
+      ret v2
+  }
+  
+  fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 128, arg1
+      jump bb3
+    bb2:
+      v0 = mload 128
+      jump bb3
+    bb3:
+      v1 = mload 128
+      ret v1
+  }
+  
+  fn @mstore8_overlap_kills(arg0: bool) -> u256 {
+    bb0 (entry):
+      v0 = mload 128
+      br arg0, bb1, bb2
+    bb1:
+      mstore8 159, 7
+      br arg0, bb3, bb4
+    bb2:
+      jump bb3
+    bb3:
+      v1 = mload 128
+      ret v1
+    bb4:
+      ret v0
+  }
+  
+  fn @mload_partial_rejected(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = mload 128
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v1 = mload 128
+      ret v1
+  }
+  
+  fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = mload 128
+      jump bb3
+    bb2:
++     v4 = mload 128
+      jump bb3
+    bb3:
+-     v1 = mload 128
+-     v2 = mload 128
+-     v3 = add v1, v2
++     v5 = phi [bb1: v0], [bb2: v4]
++     v3 = add v5, v5
+      ret v3
+  }
+  
+  fn @mload_partial_two_available(arg0: u256) -> u256 {
+    bb0 (entry):
+      switch arg0, default bb3, [1 => bb1, 2 => bb2]
+    bb1:
+      v0 = mload 128
+      jump bb4
+    bb2:
+      v1 = mload 128
+      jump bb4
+    bb3:
+      jump bb4
+    bb4:
+      v2 = mload 128
+      ret v2
+  }
+  
+  fn @mload_loop_header(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mload 128
+      jump bb1
+    bb1:
+-     v1 = mload 128
+-     v2 = lt v1, arg0
++     v3 = phi [bb0: v0], [bb2: v3]
++     v2 = lt v3, arg0
+      br v2, bb2, bb3
+    bb2:
+      jump bb1
+    bb3:
+-     ret v1
++     ret v3
+  }
+  
+  fn @staticcall_kills_memory(arg0: bool, arg1: address) -> u256 {
+    bb0 (entry):
+      v0 = mload 128
+      br arg0, bb1, bb2
+    bb1:
+      v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
+      br arg0, bb3, bb4
+    bb2:
+      jump bb3
+    bb3:
+      v2 = mload 128
+      ret v2
+    bb4:
+      ret v0
+  }
+  
+  fn @msize_blocks_memory(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      v0 = mload 128
+      jump bb3
+    bb2:
+      v1 = mload 128
+      jump bb3
+    bb3:
+      v2 = msize
+      v3 = mload 128
+      v4 = add v2, v3
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
@@ -1,34 +1,41 @@
-// === ROOT/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir (after loop-canonicalize) ===
-@module LoopCanonicalize
-fn @insert_preheader(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb6
-  bb2:
-    jump bb6
-  bb3:
-    v0 = phi [bb4: 30], [bb6: v1]
-    br 1, bb4, bb5
-  bb4:
-    jump bb3
-  bb5:
-    ret v0
-  bb6:
-    v1 = phi [bb1: 10], [bb2: 20]
-    jump bb3
-}
-
-fn @split_conditional_predecessor(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb4, bb3
-  bb1:
-    v0 = phi [bb2: 1], [bb4: 0]
-    br 1, bb2, bb3
-  bb2:
-    jump bb1
-  bb3:
-    ret 0
-  bb4:
-    jump bb1
-}
+- // === ROOT/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir (before loop-canonicalize) ===
++ // === ROOT/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir (after loop-canonicalize) ===
+  @module LoopCanonicalize
+  fn @insert_preheader(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+-     jump bb3
++     jump bb6
+    bb2:
+-     jump bb3
++     jump bb6
+    bb3:
+-     v0 = phi [bb1: 10], [bb2: 20], [bb4: 30]
++     v0 = phi [bb4: 30], [bb6: v1]
+      br 1, bb4, bb5
+    bb4:
+      jump bb3
+    bb5:
+      ret v0
++   bb6:
++     v1 = phi [bb1: 10], [bb2: 20]
++     jump bb3
+  }
+  
+  fn @split_conditional_predecessor(arg0: bool) -> u256 {
+    bb0 (entry):
+-     br arg0, bb1, bb3
++     br arg0, bb4, bb3
+    bb1:
+-     v0 = phi [bb0: 0], [bb2: 1]
++     v0 = phi [bb2: 1], [bb4: 0]
+      br 1, bb2, bb3
+    bb2:
+      jump bb1
+    bb3:
+      ret 0
++   bb4:
++     jump bb1
+  }
+  

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
@@ -1,11 +1,54 @@
-- // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (before cse,lower-mapping-slots) ===
-+ // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after cse,lower-mapping-slots) ===
+- // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (before cse) ===
++ // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after cse) ===
+  @module MappingSlotBuiltin
+  fn @word(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mapping_slot arg0, 7
+-     v1 = mapping_slot arg0, 7
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      v0 = mapping_slot arg0, 7
+      br arg1, bb1, bb2
+    bb1:
+      mstore 0, 1
+      revert 0, 0
+    bb2:
+-     v1 = mapping_slot arg0, 7
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @memory(arg0: memptr) -> u256 {
+    bb0 (entry):
+      v0 = mapping_slot_memory arg0, 9
+      mstore arg0, 1
+      v1 = mapping_slot_memory arg0, 9
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @calldata(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mapping_slot_calldata arg0, 11
+-     v1 = mapping_slot_calldata arg0, 11
+-     v2 = add v0, v1
++     v2 = add v0, v0
+      ret v2
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (before lower-mapping-slots) ===
++ // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after lower-mapping-slots) ===
   @module MappingSlotBuiltin
   fn @word(arg0: u256) -> u256 {
     bb0 (entry):
 -     v0 = mapping_slot arg0, 7
--     v1 = mapping_slot arg0, 7
--     v2 = add v0, v1
+-     v2 = add v0, v0
 +     mstore 0, arg0 !metadata(memory=scratch)
 +     mstore 32, 7 !metadata(memory=scratch)
 +     v3 = keccak256 0, 64 !metadata(memory=scratch)
@@ -24,8 +67,7 @@
       mstore 0, 1
       revert 0, 0
     bb2:
--     v1 = mapping_slot arg0, 7
--     v2 = add v0, v1
+-     v2 = add v0, v0
 +     v2 = add v3, v3
       ret v2
   }
@@ -59,8 +101,7 @@
   fn @calldata(arg0: u256) -> u256 {
     bb0 (entry):
 -     v0 = mapping_slot_calldata arg0, 11
--     v1 = mapping_slot_calldata arg0, 11
--     v2 = add v0, v1
+-     v2 = add v0, v0
 +     v3 = add arg0, 4
 +     v4 = calldataload v3
 +     v5 = add v3, 32

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
@@ -1,62 +1,76 @@
-// === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after cse,lower-mapping-slots) ===
-@module MappingSlotBuiltin
-fn @word(arg0: u256) -> u256 {
-  bb0 (entry):
-    mstore 0, arg0 !metadata(memory=scratch)
-    mstore 32, 7 !metadata(memory=scratch)
-    v3 = keccak256 0, 64 !metadata(memory=scratch)
-    v2 = add v3, v3
-    ret v2
-}
-
-fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    mstore 0, arg0 !metadata(memory=scratch)
-    mstore 32, 7 !metadata(memory=scratch)
-    v3 = keccak256 0, 64 !metadata(memory=scratch)
-    br arg1, bb1, bb2
-  bb1:
-    mstore 0, 1
-    revert 0, 0
-  bb2:
-    v2 = add v3, v3
-    ret v2
-}
-
-fn @memory(arg0: memptr) -> u256 {
-  bb0 (entry):
-    v3 = mload arg0
-    v4 = add arg0, 32
-    v5 = mload 64 !metadata(memory=scratch)
-    mcopy v5, v4, v3
-    v6 = add v5, v3
-    mstore v6, 9
-    v7 = add v3, 32
-    v8 = keccak256 v5, v7
-    mstore arg0, 1
-    v9 = mload arg0
-    v10 = add arg0, 32
-    v11 = mload 64 !metadata(memory=scratch)
-    mcopy v11, v10, v9
-    v12 = add v11, v9
-    mstore v12, 9
-    v13 = add v9, 32
-    v14 = keccak256 v11, v13
-    v2 = add v8, v14
-    ret v2
-}
-
-fn @calldata(arg0: u256) -> u256 {
-  bb0 (entry):
-    v3 = add arg0, 4
-    v4 = calldataload v3
-    v5 = add v3, 32
-    v6 = mload 64 !metadata(memory=scratch)
-    calldatacopy v6, v5, v4
-    v7 = add v6, v4
-    mstore v7, 11
-    v8 = add v4, 32
-    v9 = keccak256 v6, v8
-    v2 = add v9, v9
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (before cse,lower-mapping-slots) ===
++ // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after cse,lower-mapping-slots) ===
+  @module MappingSlotBuiltin
+  fn @word(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = mapping_slot arg0, 7
+-     v1 = mapping_slot arg0, 7
+-     v2 = add v0, v1
++     mstore 0, arg0 !metadata(memory=scratch)
++     mstore 32, 7 !metadata(memory=scratch)
++     v3 = keccak256 0, 64 !metadata(memory=scratch)
++     v2 = add v3, v3
+      ret v2
+  }
+  
+  fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+-     v0 = mapping_slot arg0, 7
++     mstore 0, arg0 !metadata(memory=scratch)
++     mstore 32, 7 !metadata(memory=scratch)
++     v3 = keccak256 0, 64 !metadata(memory=scratch)
+      br arg1, bb1, bb2
+    bb1:
+      mstore 0, 1
+      revert 0, 0
+    bb2:
+-     v1 = mapping_slot arg0, 7
+-     v2 = add v0, v1
++     v2 = add v3, v3
+      ret v2
+  }
+  
+  fn @memory(arg0: memptr) -> u256 {
+    bb0 (entry):
+-     v0 = mapping_slot_memory arg0, 9
++     v3 = mload arg0
++     v4 = add arg0, 32
++     v5 = mload 64 !metadata(memory=scratch)
++     mcopy v5, v4, v3
++     v6 = add v5, v3
++     mstore v6, 9
++     v7 = add v3, 32
++     v8 = keccak256 v5, v7
+      mstore arg0, 1
+-     v1 = mapping_slot_memory arg0, 9
+-     v2 = add v0, v1
++     v9 = mload arg0
++     v10 = add arg0, 32
++     v11 = mload 64 !metadata(memory=scratch)
++     mcopy v11, v10, v9
++     v12 = add v11, v9
++     mstore v12, 9
++     v13 = add v9, 32
++     v14 = keccak256 v11, v13
++     v2 = add v8, v14
+      ret v2
+  }
+  
+  fn @calldata(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = mapping_slot_calldata arg0, 11
+-     v1 = mapping_slot_calldata arg0, 11
+-     v2 = add v0, v1
++     v3 = add arg0, 4
++     v4 = calldataload v3
++     v5 = add v3, 32
++     v6 = mload 64 !metadata(memory=scratch)
++     calldatacopy v6, v5, v4
++     v7 = add v6, v4
++     mstore v7, 11
++     v8 = add v4, 32
++     v9 = keccak256 v6, v8
++     v2 = add v9, v9
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi.stdout
@@ -1,15 +1,19 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_abi.mir (after lower-abi) ===
-@module LowerAbi
-@phase abi
-fn @add() {
-  bb0 (entry):
-    v0 = add arg0, arg1
-    mstore 128, v0
-    returndata 128, 32
-}
-
-fn @flag() {
-  bb0 (entry):
-    mstore 128, arg0
-    returndata 128, 32
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi.mir (after lower-abi) ===
+  @module LowerAbi
+- fn @add(arg0: u256, arg1: u256) {
++ @phase abi
++ fn @add() {
+    bb0 (entry):
+      v0 = add arg0, arg1
+      mstore 128, v0
+      returndata 128, 32
+  }
+  
+- fn @flag(arg0: bool) {
++ fn @flag() {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.stdout
@@ -1,10 +1,13 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.mir (after lower-abi) ===
-@module LowerAbiDynamicParams
-@phase abi
-fn @takesBytes() {
-  bb0 (entry):
-    v0 = mload arg0
-    v1 = add v0, arg1
-    mstore 128, v1
-    returndata 128, 32
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.mir (after lower-abi) ===
+  @module LowerAbiDynamicParams
+- fn @takesBytes(arg0: memptr, arg1: u256) {
++ @phase abi
++ fn @takesBytes() {
+    bb0 (entry):
+      v0 = mload arg0
+      v1 = add v0, arg1
+      mstore 128, v1
+      returndata 128, 32
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi_multi_return.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_multi_return.stdout
@@ -1,7 +1,9 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_abi_multi_return.mir (after lower-abi) ===
-@module LowerAbiMultiReturn
-fn @pair(arg0: u256) -> (u256, u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    ret arg0, v0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_multi_return.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_multi_return.mir (after lower-abi) ===
+  @module LowerAbiMultiReturn
+  fn @pair(arg0: u256) -> (u256, u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+      ret arg0, v0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.stdout
@@ -1,23 +1,28 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir (after lower-abi) ===
-@module LowerAbiRetargets
-@phase abi
-fn @pub() {
-  bb0 (entry):
-    v0 = add arg0, 1
-    mstore 128, v0
-    returndata 128, 32
-}
-
-fn @caller() {
-  bb0 (entry):
-    v0 = internal_call @pub.body, 1, arg0
-    mstore 128, v0
-    returndata 128, 32
-}
-
-fn @pub.body(arg0: u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    mstore 128, v0
-    returndata 128, 32
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir (after lower-abi) ===
+  @module LowerAbiRetargets
+- fn @pub(arg0: u256) {
++ @phase abi
++ fn @pub() {
+    bb0 (entry):
+      v0 = add arg0, 1
+      mstore 128, v0
+      returndata 128, 32
+  }
+  
+- fn @caller(arg0: u256) {
++ fn @caller() {
+    bb0 (entry):
+-     v0 = internal_call @pub, 1, arg0
++     v0 = internal_call @pub.body, 1, arg0
++     mstore 128, v0
++     returndata 128, 32
++ }
++ 
++ fn @pub.body(arg0: u256) {
++   bb0 (entry):
++     v0 = add arg0, 1
+      mstore 128, v0
+      returndata 128, 32
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.stdout
@@ -1,6 +1,8 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.mir (after lower-abi) ===
-@module LowerAbiSkipsDynamic
-fn @givesBytes(arg0: u256) -> memptr {
-  bb0 (entry):
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.mir (after lower-abi) ===
+  @module LowerAbiSkipsDynamic
+  fn @givesBytes(arg0: u256) -> memptr {
+    bb0 (entry):
+      ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
@@ -1,25 +1,28 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (after lower-abi,lower-dispatch) ===
-@module LowerAbiThenDispatch
-@phase dispatch
-fn @get() {
-  bb0 (entry):
-    mstore 128, arg0
-    returndata 128, 32
-}
-
-fn @entry() {
-  bb0 (entry):
-    v0 = callvalue
-    br v0, bb4, bb1
-  bb1:
-    v1 = calldatasize
-    br v1, bb2, bb4
-  bb2:
-    v2 = calldataload 0
-    v3 = shr 224, v2
-    switch v3, default bb4, [0x9507d39a => bb3]
-  bb3:
-    tail_call @get
-  bb4:
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (before lower-abi,lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (after lower-abi,lower-dispatch) ===
+  @module LowerAbiThenDispatch
+- fn @get(arg0: u256) {
++ @phase dispatch
++ fn @get() {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
++ }
++ 
++ fn @entry() {
++   bb0 (entry):
++     v0 = callvalue
++     br v0, bb4, bb1
++   bb1:
++     v1 = calldatasize
++     br v1, bb2, bb4
++   bb2:
++     v2 = calldataload 0
++     v3 = shr 224, v2
++     switch v3, default bb4, [0x9507d39a => bb3]
++   bb3:
++     tail_call @get
++   bb4:
++     revert 0, 0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
@@ -1,9 +1,20 @@
-- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (before lower-abi,lower-dispatch) ===
-+ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (after lower-abi,lower-dispatch) ===
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (after lower-abi) ===
   @module LowerAbiThenDispatch
 - fn @get(arg0: u256) {
-+ @phase dispatch
++ @phase abi
 + fn @get() {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir (after lower-dispatch) ===
+  @module LowerAbiThenDispatch
+- @phase abi
++ @phase dispatch
+  fn @get() {
     bb0 (entry):
       mstore 128, arg0
       returndata 128, 32

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
@@ -1,31 +1,34 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch.mir (after lower-dispatch) ===
-@module LowerDispatch
-@phase dispatch
-fn @ping() {
-  bb0 (entry):
-    stop
-}
-
-fn @pong() {
-  bb0 (entry):
-    stop
-}
-
-fn @entry() {
-  bb0 (entry):
-    v0 = callvalue
-    br v0, bb5, bb1
-  bb1:
-    v1 = calldatasize
-    br v1, bb2, bb5
-  bb2:
-    v2 = calldataload 0
-    v3 = shr 224, v2
-    switch v3, default bb5, [0x5c36b186 => bb3, 0x8d3a3e57 => bb4]
-  bb3:
-    tail_call @ping
-  bb4:
-    tail_call @pong
-  bb5:
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch.mir (after lower-dispatch) ===
+  @module LowerDispatch
+- @phase abi
++ @phase dispatch
+  fn @ping() {
+    bb0 (entry):
+      stop
+  }
+  
+  fn @pong() {
+    bb0 (entry):
+      stop
++ }
++ 
++ fn @entry() {
++   bb0 (entry):
++     v0 = callvalue
++     br v0, bb5, bb1
++   bb1:
++     v1 = calldatasize
++     br v1, bb2, bb5
++   bb2:
++     v2 = calldataload 0
++     v3 = shr 224, v2
++     switch v3, default bb5, [0x5c36b186 => bb3, 0x8d3a3e57 => bb4]
++   bb3:
++     tail_call @ping
++   bb4:
++     tail_call @pong
++   bb5:
++     revert 0, 0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
@@ -1,31 +1,34 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir (after lower-dispatch) ===
-@module DispatchHoisted
-@phase dispatch
-fn @a() {
-  bb0 (entry):
-    stop
-}
-
-fn @b() {
-  bb0 (entry):
-    stop
-}
-
-fn @entry() {
-  bb0 (entry):
-    v0 = callvalue
-    br v0, bb5, bb1
-  bb1:
-    v1 = calldatasize
-    br v1, bb2, bb5
-  bb2:
-    v2 = calldataload 0
-    v3 = shr 224, v2
-    switch v3, default bb5, [1 => bb3, 2 => bb4]
-  bb3:
-    tail_call @a
-  bb4:
-    tail_call @b
-  bb5:
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir (after lower-dispatch) ===
+  @module DispatchHoisted
+- @phase abi
++ @phase dispatch
+  fn @a() {
+    bb0 (entry):
+      stop
+  }
+  
+  fn @b() {
+    bb0 (entry):
+      stop
++ }
++ 
++ fn @entry() {
++   bb0 (entry):
++     v0 = callvalue
++     br v0, bb5, bb1
++   bb1:
++     v1 = calldatasize
++     br v1, bb2, bb5
++   bb2:
++     v2 = calldataload 0
++     v3 = shr 224, v2
++     switch v3, default bb5, [1 => bb3, 2 => bb4]
++   bb3:
++     tail_call @a
++   bb4:
++     tail_call @b
++   bb5:
++     revert 0, 0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
@@ -1,44 +1,47 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir (after lower-dispatch) ===
-@module DispatchParity
-@phase dispatch
-fn @pay() {
-  bb0 (entry):
-    stop
-}
-
-fn @nopay() {
-  bb0 (entry):
-    stop
-}
-
-fn @recv() {
-  bb0 (entry):
-    stop
-}
-
-fn @fb() {
-  bb0 (entry):
-    stop
-}
-
-fn @entry() {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = calldatasize
-    br v0, bb3, bb2
-  bb2:
-    tail_call @recv
-  bb3:
-    v1 = calldataload 0
-    v2 = shr 224, v1
-    switch v2, default bb6, [1 => bb4, 2 => bb5]
-  bb4:
-    tail_call @pay
-  bb5:
-    tail_call @nopay
-  bb6:
-    tail_call @fb
-  bb7:
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir (after lower-dispatch) ===
+  @module DispatchParity
+- @phase abi
++ @phase dispatch
+  fn @pay() {
+    bb0 (entry):
+      stop
+  }
+  
+  fn @nopay() {
+    bb0 (entry):
+      stop
+  }
+  
+  fn @recv() {
+    bb0 (entry):
+      stop
+  }
+  
+  fn @fb() {
+    bb0 (entry):
+      stop
++ }
++ 
++ fn @entry() {
++   bb0 (entry):
++     jump bb1
++   bb1:
++     v0 = calldatasize
++     br v0, bb3, bb2
++   bb2:
++     tail_call @recv
++   bb3:
++     v1 = calldataload 0
++     v2 = shr 224, v1
++     switch v2, default bb6, [1 => bb4, 2 => bb5]
++   bb4:
++     tail_call @pay
++   bb5:
++     tail_call @nopay
++   bb6:
++     tail_call @fb
++   bb7:
++     revert 0, 0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.stdout
@@ -1,6 +1,8 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.mir (after lower-dispatch) ===
-@module LowerDispatchRequiresAbi
-fn @takesArg(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.mir (after lower-dispatch) ===
+  @module LowerDispatchRequiresAbi
+  fn @takesArg(arg0: u256) -> u256 {
+    bb0 (entry):
+      ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/lower_evm_shaped.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_evm_shaped.stdout
@@ -1,31 +1,36 @@
-// === ROOT/tests/ui/codegen/mir/lowering/lower_evm_shaped.mir (after lower-evm-shaped) ===
-@module LowerEvmShaped
-@phase evm-shaped
-fn @entry() {
-  bb0 (entry):
-    v0 = calldataload 0
-    v1 = shr 224, v0
-    switch v1, default bb2, [7 => bb1]
-  bb1:
-    tail_call @caller
-  bb2:
-    revert 0, 0
-}
-
-fn @caller() {
-  bb0 (entry):
-    v0 = calldataload 4
-    tail_call @fused, v0
-}
-
-fn @fused(arg0: u256) {
-  bb0 (entry):
-    mstore 128, arg0
-    returndata 128, 32
-}
-
-fn @spin(arg0: u256) {
-  bb0 (entry):
-    internal_call @spin, 0, arg0
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/lower_evm_shaped.mir (before lower-evm-shaped) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/lower_evm_shaped.mir (after lower-evm-shaped) ===
+  @module LowerEvmShaped
+- @phase dispatch
++ @phase evm-shaped
+  fn @entry() {
+    bb0 (entry):
+      v0 = calldataload 0
+      v1 = shr 224, v0
+      switch v1, default bb2, [7 => bb1]
+    bb1:
+      tail_call @caller
+    bb2:
+      revert 0, 0
+  }
+  
+  fn @caller() {
+    bb0 (entry):
+      v0 = calldataload 4
+-     internal_call @fused, 0, v0
+-     stop
++     tail_call @fused, v0
+  }
+  
+  fn @fused(arg0: u256) {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  
+  fn @spin(arg0: u256) {
+    bb0 (entry):
+      internal_call @spin, 0, arg0
+      revert 0, 0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/phase_explicit_built.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_explicit_built.stdout
@@ -1,6 +1,8 @@
-// === ROOT/tests/ui/codegen/mir/lowering/phase_explicit_built.mir (after dce) ===
-@module PhaseExplicitBuilt
-fn @f() {
-  bb0 (entry):
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_explicit_built.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_explicit_built.mir (after dce) ===
+  @module PhaseExplicitBuilt
+  fn @f() {
+    bb0 (entry):
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/lowering/phase_header_preserved.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_header_preserved.stdout
@@ -1,7 +1,9 @@
-// === ROOT/tests/ui/codegen/mir/lowering/phase_header_preserved.mir (after dce) ===
-@module PhaseHeaderPreserved
-@phase optimized
-fn @f() {
-  bb0 (entry):
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_header_preserved.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_header_preserved.mir (after dce) ===
+  @module PhaseHeaderPreserved
+  @phase optimized
+  fn @f() {
+    bb0 (entry):
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir
+++ b/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir
@@ -1,8 +1,8 @@
 //@compile-flags: --pass lower-dispatch,lower-abi,lower-dispatch,dce
 //@filecheck: --match-full-lines
 // CHECK: @module PhasePassBounds
-// CHECK-NEXT: @phase dispatch
-// CHECK: fn @entry() {
+// CHECK: + @phase dispatch
+// CHECK: + fn @entry() {
 // Passes declare the phases they operate on and the pass manager enforces the
 // range: the first lower-dispatch is skipped on a `built` module (it requires
 // `abi`), lower-abi then advances the phase, the second lower-dispatch runs,

--- a/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
@@ -1,25 +1,28 @@
-// === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-dispatch,lower-abi,lower-dispatch,dce) ===
-@module PhasePassBounds
-@phase dispatch
-fn @get() {
-  bb0 (entry):
-    mstore 128, arg0
-    returndata 128, 32
-}
-
-fn @entry() {
-  bb0 (entry):
-    v0 = callvalue
-    br v0, bb4, bb1
-  bb1:
-    v1 = calldatasize
-    br v1, bb2, bb4
-  bb2:
-    v2 = calldataload 0
-    v3 = shr 224, v2
-    switch v3, default bb4, [0x9507d39a => bb3]
-  bb3:
-    tail_call @get
-  bb4:
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (before lower-dispatch,lower-abi,lower-dispatch,dce) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-dispatch,lower-abi,lower-dispatch,dce) ===
+  @module PhasePassBounds
+- fn @get(arg0: u256) {
++ @phase dispatch
++ fn @get() {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
++ }
++ 
++ fn @entry() {
++   bb0 (entry):
++     v0 = callvalue
++     br v0, bb4, bb1
++   bb1:
++     v1 = calldatasize
++     br v1, bb2, bb4
++   bb2:
++     v2 = calldataload 0
++     v3 = shr 224, v2
++     switch v3, default bb4, [0x9507d39a => bb3]
++   bb3:
++     tail_call @get
++   bb4:
++     revert 0, 0
+  }
+  

--- a/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
@@ -1,9 +1,29 @@
-- // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (before lower-dispatch,lower-abi,lower-dispatch,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-dispatch,lower-abi,lower-dispatch,dce) ===
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-dispatch) ===
+  @module PhasePassBounds
+  fn @get(arg0: u256) {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (before lower-abi) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-abi) ===
   @module PhasePassBounds
 - fn @get(arg0: u256) {
-+ @phase dispatch
++ @phase abi
 + fn @get() {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (before lower-dispatch) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-dispatch) ===
+  @module PhasePassBounds
+- @phase abi
++ @phase dispatch
+  fn @get() {
     bb0 (entry):
       mstore 128, arg0
       returndata 128, 32
@@ -24,5 +44,32 @@
 +     tail_call @get
 +   bb4:
 +     revert 0, 0
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after dce) ===
+  @module PhasePassBounds
+  @phase dispatch
+  fn @get() {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  
+  fn @entry() {
+    bb0 (entry):
+      v0 = callvalue
+      br v0, bb4, bb1
+    bb1:
+      v1 = calldatasize
+      br v1, bb2, bb4
+    bb2:
+      v2 = calldataload 0
+      v3 = shr 224, v2
+      switch v3, default bb4, [0x9507d39a => bb3]
+    bb3:
+      tail_call @get
+    bb4:
+      revert 0, 0
   }
   

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pipeline-default
 //@filecheck: --match-full-lines
 // CHECK: @module PhasePipelineTransition
-// CHECK-NEXT: @phase optimized
+// CHECK-NEXT: + @phase optimized
 // The canonical pipeline is a phase transition: the module comes out in
 // `optimized` and the header says so.
 @module PhasePipelineTransition

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pipeline-default
 //@filecheck: --match-full-lines
 // CHECK: @module PhasePipelineTransition
-// CHECK-NEXT: + @phase optimized
+// CHECK-NEXT: @phase optimized
 // The canonical pipeline is a phase transition: the module comes out in
 // `optimized` and the header says so.
 @module PhasePipelineTransition

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_transition.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_transition.stdout
@@ -1,11 +1,9 @@
-- // === ROOT/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir (after pipeline-default) ===
-  @module PhasePipelineTransition
-+ @phase optimized
-  fn @f(arg0: u256) {
-    bb0 (entry):
-      v0 = add arg0, 1
-      mstore 128, v0
-      returndata 128, 32
-  }
-  
+// === ROOT/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir (after pipeline-default) ===
+@module PhasePipelineTransition
+@phase optimized
+fn @f(arg0: u256) {
+  bb0 (entry):
+    v0 = add arg0, 1
+    mstore 128, v0
+    returndata 128, 32
+}

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_transition.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_transition.stdout
@@ -1,9 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir (after pipeline-default) ===
-@module PhasePipelineTransition
-@phase optimized
-fn @f(arg0: u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    mstore 128, v0
-    returndata 128, 32
-}
+- // === ROOT/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir (after pipeline-default) ===
+  @module PhasePipelineTransition
++ @phase optimized
+  fn @f(arg0: u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+      mstore 128, v0
+      returndata 128, 32
+  }
+  

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_alias.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_alias.stdout
@@ -1,45 +1,54 @@
-// === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_alias.mir (after memory-dse) ===
-@module MemoryDseAlias
-fn @keep_symbolic_store_read_by_const_load(arg0: u256) -> u256 {
-  bb0 (entry):
-    mstore arg0, 1
-    v0 = mload 128
-    mstore arg0, 2
-    ret v0
-}
-
-fn @keep_const_store_forwarding_to_symbolic_load(arg0: u256) -> u256 {
-  bb0 (entry):
-    mstore arg0, 1
-    mstore 128, 2
-    v0 = mload arg0
-    ret v0
-}
-
-fn @keep_store_read_by_distinct_symbolic_base(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    mstore arg0, 1
-    v0 = mload arg1
-    mstore arg0, 2
-    ret v0
-}
-
-fn @remove_dead_const_overwrite() -> u256 {
-  bb0 (entry):
-    mstore 128, 2
-    ret 2
-}
-
-fn @remove_dead_symbolic_overwrite(arg0: u256) -> u256 {
-  bb0 (entry):
-    mstore arg0, 2
-    ret 2
-}
-
-fn @remove_overwrite_past_same_base_disjoint_load(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 32
-    v1 = mload v0
-    mstore arg0, 2
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_alias.mir (before memory-dse) ===
++ // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_alias.mir (after memory-dse) ===
+  @module MemoryDseAlias
+  fn @keep_symbolic_store_read_by_const_load(arg0: u256) -> u256 {
+    bb0 (entry):
+      mstore arg0, 1
+      v0 = mload 128
+      mstore arg0, 2
+      ret v0
+  }
+  
+  fn @keep_const_store_forwarding_to_symbolic_load(arg0: u256) -> u256 {
+    bb0 (entry):
+      mstore arg0, 1
+      mstore 128, 2
+      v0 = mload arg0
+      ret v0
+  }
+  
+  fn @keep_store_read_by_distinct_symbolic_base(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      mstore arg0, 1
+      v0 = mload arg1
+      mstore arg0, 2
+      ret v0
+  }
+  
+  fn @remove_dead_const_overwrite() -> u256 {
+    bb0 (entry):
+-     mstore 128, 1
+      mstore 128, 2
+-     v0 = mload 128
+-     ret v0
++     ret 2
+  }
+  
+  fn @remove_dead_symbolic_overwrite(arg0: u256) -> u256 {
+    bb0 (entry):
+-     mstore arg0, 1
+      mstore arg0, 2
+-     v0 = mload arg0
+-     ret v0
++     ret 2
+  }
+  
+  fn @remove_overwrite_past_same_base_disjoint_load(arg0: u256) -> u256 {
+    bb0 (entry):
+-     mstore arg0, 1
+      v0 = add arg0, 32
+      v1 = mload v0
+      mstore arg0, 2
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.stdout
@@ -1,25 +1,32 @@
-// === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.mir (after memory-dse) ===
-@module MemoryDseCopyRanges
-fn @remove_store_overwritten_by_codecopy() -> u256 {
-  bb0 (entry):
-    codecopy 0, 0, 64
-    ret 0
-}
-
-fn @keep_store_after_partial_copy() -> u256 {
-  bb0 (entry):
-    mstore 32, 1
-    codecopy 0, 0, 32
-    ret 1
-}
-
-fn @forward_fresh_array_length() -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    mstore v0, 3
-    v1 = add v0, 128
-    mstore 64, v1
-    v2 = add v0, 32
-    calldatacopy v2, 0, 96
-    ret 3
-}
+- // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.mir (before memory-dse) ===
++ // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.mir (after memory-dse) ===
+  @module MemoryDseCopyRanges
+  fn @remove_store_overwritten_by_codecopy() -> u256 {
+    bb0 (entry):
+-     mstore 0, 1
+      codecopy 0, 0, 64
+      ret 0
+  }
+  
+  fn @keep_store_after_partial_copy() -> u256 {
+    bb0 (entry):
+      mstore 32, 1
+      codecopy 0, 0, 32
+-     v0 = mload 32
+-     ret v0
++     ret 1
+  }
+  
+  fn @forward_fresh_array_length() -> u256 {
+    bb0 (entry):
+      v0 = mload 64
+      mstore v0, 3
+      v1 = add v0, 128
+      mstore 64, v1
+      v2 = add v0, 32
+      calldatacopy v2, 0, 96
+-     v3 = mload v0
+-     ret v3
++     ret 3
+  }
+  

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
@@ -1,32 +1,39 @@
-// === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir (after memory-dse) ===
-@module MemoryDseCrossBlock
-fn @remove_store_overwritten_on_unique_edge() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    mstore 128, 2
-    ret 2
-}
-
-fn @keep_store_read_before_successor_overwrite() -> u256 {
-  bb0 (entry):
-    mstore 128, 1
-    jump bb1
-  bb1:
-    v0 = mload 128
-    mstore 128, 2
-    ret v0
-}
-
-fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    mstore 128, 1
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    mstore 128, 2
-    ret 2
-}
+- // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir (before memory-dse) ===
++ // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir (after memory-dse) ===
+  @module MemoryDseCrossBlock
+  fn @remove_store_overwritten_on_unique_edge() -> u256 {
+    bb0 (entry):
+-     mstore 128, 1
+      jump bb1
+    bb1:
+      mstore 128, 2
+-     v0 = mload 128
+-     ret v0
++     ret 2
+  }
+  
+  fn @keep_store_read_before_successor_overwrite() -> u256 {
+    bb0 (entry):
+      mstore 128, 1
+      jump bb1
+    bb1:
+      v0 = mload 128
+      mstore 128, 2
+      ret v0
+  }
+  
+  fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      mstore 128, 1
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      mstore 128, 2
+-     v0 = mload 128
+-     ret v0
++     ret 2
+  }
+  

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.stdout
@@ -1,15 +1,21 @@
-// === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.mir (after memory-dse) ===
-@module MemoryDseEqualStore
-fn @remove_equal_store_after_keccak(arg0: u256) -> u256 {
-  bb0 (entry):
-    mstore 128, arg0
-    v0 = keccak256 128, 32
-    ret v0
-}
-
-fn @keep_equal_store_after_copy(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    calldatacopy 128, arg1, 32
-    mstore 128, arg0
-    ret arg0
-}
+- // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.mir (before memory-dse) ===
++ // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.mir (after memory-dse) ===
+  @module MemoryDseEqualStore
+  fn @remove_equal_store_after_keccak(arg0: u256) -> u256 {
+    bb0 (entry):
+      mstore 128, arg0
+      v0 = keccak256 128, 32
+-     mstore 128, arg0
+      ret v0
+  }
+  
+  fn @keep_equal_store_after_copy(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+-     mstore 128, arg0
+      calldatacopy 128, arg1, 32
+      mstore 128, arg0
+-     v0 = mload 128
+-     ret v0
++     ret arg0
+  }
+  

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.stdout
@@ -1,24 +1,29 @@
-// === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.mir (after memory-dse) ===
-@module MemoryDseKeccakFold
-fn @fold_constant_scratch_keccak() -> bytes32 {
-  bb0 (entry):
-    mstore 0, 7
-    mstore 32, 5
-    ret 0xeddb6698d7c569ff62ff64f1f1492bf14a54594835ba0faac91f84b4f5d81460
-}
-
-fn @keep_dynamic_word(arg0: u256) -> bytes32 {
-  bb0 (entry):
-    mstore 0, arg0
-    mstore 32, 5
-    v0 = keccak256 0, 64
-    ret v0
-}
-
-fn @keep_after_memory_clobber() -> bytes32 {
-  bb0 (entry):
-    mstore 32, 5
-    calldatacopy 0, 0, 32
-    v0 = keccak256 0, 64
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.mir (before memory-dse) ===
++ // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.mir (after memory-dse) ===
+  @module MemoryDseKeccakFold
+  fn @fold_constant_scratch_keccak() -> bytes32 {
+    bb0 (entry):
+      mstore 0, 7
+      mstore 32, 5
+-     v0 = keccak256 0, 64
+-     ret v0
++     ret 0xeddb6698d7c569ff62ff64f1f1492bf14a54594835ba0faac91f84b4f5d81460
+  }
+  
+  fn @keep_dynamic_word(arg0: u256) -> bytes32 {
+    bb0 (entry):
+      mstore 0, arg0
+      mstore 32, 5
+      v0 = keccak256 0, 64
+      ret v0
+  }
+  
+  fn @keep_after_memory_clobber() -> bytes32 {
+    bb0 (entry):
+-     mstore 0, 7
+      mstore 32, 5
+      calldatacopy 0, 0, 32
+      v0 = keccak256 0, 64
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/none/identity.stdout
+++ b/tests/ui/codegen/mir/none/identity.stdout
@@ -1,13 +1,15 @@
-// === ROOT/tests/ui/codegen/mir/none/identity.mir (after none) ===
-@module Identity
-fn @add(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, arg1
-    ret v0
-}
-
-fn @double(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, arg0
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/none/identity.mir (before none) ===
++ // === ROOT/tests/ui/codegen/mir/none/identity.mir (after none) ===
+  @module Identity
+  fn @add(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, arg1
+      ret v0
+  }
+  
+  fn @double(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, arg0
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/none/metadata.stdout
+++ b/tests/ui/codegen/mir/none/metadata.stdout
@@ -1,9 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/none/metadata.mir (after none) ===
-@module Metadata
-fn @metadata(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 7 !metadata(storage=slot(7), hir=42, span=1..5, loop_depth=2)
-    v1 = mload 64 !metadata(memory=scratch, unchecked)
-    v2 = add v0, v1
-    ret v2
-}
+- // === ROOT/tests/ui/codegen/mir/none/metadata.mir (before none) ===
++ // === ROOT/tests/ui/codegen/mir/none/metadata.mir (after none) ===
+  @module Metadata
+  fn @metadata(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = sload 7 !metadata(storage=slot(7), hir=42, span=1..5, loop_depth=2)
+      v1 = mload 64 !metadata(memory=scratch, unchecked)
+      v2 = add v0, v1
+      ret v2
+  }
+  

--- a/tests/ui/codegen/mir/none/phi.stdout
+++ b/tests/ui/codegen/mir/none/phi.stdout
@@ -1,13 +1,15 @@
-// === ROOT/tests/ui/codegen/mir/none/phi.mir (after none) ===
-@module PhiTest
-fn @diamond(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: 10], [bb2: 20]
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/none/phi.mir (before none) ===
++ // === ROOT/tests/ui/codegen/mir/none/phi.mir (after none) ===
+  @module PhiTest
+  fn @diamond(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: 10], [bb2: 20]
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/none/switch.stdout
+++ b/tests/ui/codegen/mir/none/switch.stdout
@@ -1,14 +1,16 @@
-// === ROOT/tests/ui/codegen/mir/none/switch.mir (after none) ===
-@module SwitchTest
-fn @dispatch(arg0: u256) -> u256 {
-  bb0 (entry):
-    switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
-  bb1:
-    ret arg0
-  bb2:
-    ret 0
-  bb3:
-    ret 1
-  bb4:
-    ret 2
-}
+- // === ROOT/tests/ui/codegen/mir/none/switch.mir (before none) ===
++ // === ROOT/tests/ui/codegen/mir/none/switch.mir (after none) ===
+  @module SwitchTest
+  fn @dispatch(arg0: u256) -> u256 {
+    bb0 (entry):
+      switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
+    bb1:
+      ret arg0
+    bb2:
+      ret 0
+    bb3:
+      ret 1
+    bb4:
+      ret 2
+  }
+  

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
@@ -46,6 +46,6 @@ fn @third(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK:     tail_call @__revert_stub0
-// CHECK:     tail_call @__revert_stub0
-// CHECK: fn @__revert_stub0() {
+// CHECK: +     tail_call @__revert_stub0
+// CHECK: +     tail_call @__revert_stub0
+// CHECK: + fn @__revert_stub0() {

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
@@ -1,46 +1,54 @@
-// === ROOT/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir (after outline-reverts) ===
-@module OutlineReverts
-fn @first(arg0: u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = lt v0, arg0
-    br v1, bb1, bb2
-  bb1:
-    tail_call @__revert_stub0
-  bb2:
-    mstore 128, v0
-    returndata 128, 32
-}
-
-fn @second(arg0: u256) {
-  bb0 (entry):
-    v0 = mul arg0, 2
-    v1 = lt v0, arg0
-    br v1, bb1, bb2
-  bb1:
-    tail_call @__revert_stub0
-  bb2:
-    mstore 128, v0
-    returndata 128, 32
-}
-
-fn @third(arg0: u256) {
-  bb0 (entry):
-    v0 = sub arg0, 1
-    v1 = gt v0, arg0
-    br v1, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-    mstore 4, 18
-    revert 0, 36
-  bb2:
-    mstore 128, v0
-    returndata 128, 32
-}
-
-fn @__revert_stub0() {
-  bb0 (entry):
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-}
+- // === ROOT/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir (before outline-reverts) ===
++ // === ROOT/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir (after outline-reverts) ===
+  @module OutlineReverts
+  fn @first(arg0: u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+      v1 = lt v0, arg0
+      br v1, bb1, bb2
+    bb1:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+-     mstore 4, 17
+-     revert 0, 36
++     tail_call @__revert_stub0
+    bb2:
+      mstore 128, v0
+      returndata 128, 32
+  }
+  
+  fn @second(arg0: u256) {
+    bb0 (entry):
+      v0 = mul arg0, 2
+      v1 = lt v0, arg0
+      br v1, bb1, bb2
+    bb1:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+-     mstore 4, 17
+-     revert 0, 36
++     tail_call @__revert_stub0
+    bb2:
+      mstore 128, v0
+      returndata 128, 32
+  }
+  
+  fn @third(arg0: u256) {
+    bb0 (entry):
+      v0 = sub arg0, 1
+      v1 = gt v0, arg0
+      br v1, bb1, bb2
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 18
+      revert 0, 36
+    bb2:
+      mstore 128, v0
+      returndata 128, 32
++ }
++ 
++ fn @__revert_stub0() {
++   bb0 (entry):
++     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
++     mstore 4, 17 !metadata(memory=scratch)
++     revert 0, 36
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
@@ -1,50 +1,37 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir (after pipeline-default) ===
-  @module CheckElimPipelineLoop
-+ @phase optimized
-  fn @sum(arg0: u256) {
-    bb0 (entry):
-      mstore 128, 0
-      jump bb1
-    bb1:
--     v0 = phi [bb0: 0], [bb9: v3]
-+     v0 = phi [bb0: 0], [bb7: v3]
-      v1 = lt v0, arg0
--     br v1, bb4, bb5
-+     br v1, bb4, bb2
-    bb2:
-      v2 = mload 128
-      mstore 128, v2
-      returndata 128, 32
-    bb3:
--     v3 = add v0, 1
--     v4 = lt v3, v0
--     br v4, bb8, bb9
-+     invalid
-    bb4:
-      v5 = mload 128
-      v6 = add v5, v0
-      v7 = lt v6, v5
-      br v7, bb6, bb7
-    bb5:
--     jump bb2
-+     invalid
-    bb6:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-      mstore 4, 17 !metadata(memory=scratch)
-      revert 0, 36
-    bb7:
-      mstore 128, v6
--     jump bb3
-+     v3 = add v0, 1
-+     jump bb1
-    bb8:
--     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
--     mstore 4, 17 !metadata(memory=scratch)
--     revert 0, 36
-+     invalid
-    bb9:
--     jump bb1
-+     invalid
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir (after pipeline-default) ===
+@module CheckElimPipelineLoop
+@phase optimized
+fn @sum(arg0: u256) {
+  bb0 (entry):
+    mstore 128, 0
+    jump bb1
+  bb1:
+    v0 = phi [bb0: 0], [bb7: v3]
+    v1 = lt v0, arg0
+    br v1, bb4, bb2
+  bb2:
+    v2 = mload 128
+    mstore 128, v2
+    returndata 128, 32
+  bb3:
+    invalid
+  bb4:
+    v5 = mload 128
+    v6 = add v5, v0
+    v7 = lt v6, v5
+    br v7, bb6, bb7
+  bb5:
+    invalid
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 128, v6
+    v3 = add v0, 1
+    jump bb1
+  bb8:
+    invalid
+  bb9:
+    invalid
+}

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
@@ -1,37 +1,50 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir (after pipeline-default) ===
-@module CheckElimPipelineLoop
-@phase optimized
-fn @sum(arg0: u256) {
-  bb0 (entry):
-    mstore 128, 0
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb7: v3]
-    v1 = lt v0, arg0
-    br v1, bb4, bb2
-  bb2:
-    v2 = mload 128
-    mstore 128, v2
-    returndata 128, 32
-  bb3:
-    invalid
-  bb4:
-    v5 = mload 128
-    v6 = add v5, v0
-    v7 = lt v6, v5
-    br v7, bb6, bb7
-  bb5:
-    invalid
-  bb6:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb7:
-    mstore 128, v6
-    v3 = add v0, 1
-    jump bb1
-  bb8:
-    invalid
-  bb9:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir (after pipeline-default) ===
+  @module CheckElimPipelineLoop
++ @phase optimized
+  fn @sum(arg0: u256) {
+    bb0 (entry):
+      mstore 128, 0
+      jump bb1
+    bb1:
+-     v0 = phi [bb0: 0], [bb9: v3]
++     v0 = phi [bb0: 0], [bb7: v3]
+      v1 = lt v0, arg0
+-     br v1, bb4, bb5
++     br v1, bb4, bb2
+    bb2:
+      v2 = mload 128
+      mstore 128, v2
+      returndata 128, 32
+    bb3:
+-     v3 = add v0, 1
+-     v4 = lt v3, v0
+-     br v4, bb8, bb9
++     invalid
+    bb4:
+      v5 = mload 128
+      v6 = add v5, v0
+      v7 = lt v6, v5
+      br v7, bb6, bb7
+    bb5:
+-     jump bb2
++     invalid
+    bb6:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+      mstore 4, 17 !metadata(memory=scratch)
+      revert 0, 36
+    bb7:
+      mstore 128, v6
+-     jump bb3
++     v3 = add v0, 1
++     jump bb1
+    bb8:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+-     mstore 4, 17 !metadata(memory=scratch)
+-     revert 0, 36
++     invalid
+    bb9:
+-     jump bb1
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
@@ -1,32 +1,46 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir (after pipeline-default) ===
-@module CheckElimPipelineRequireSub
-@phase optimized
-fn @guarded(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    v0 = gt arg1, arg0
-    br v0, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    v3 = sub arg0, arg1
-    mstore 128, v3
-    returndata 128, 32
-  bb3:
-    invalid
-  bb4:
-    invalid
-}
-
-fn @unguarded(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    v0 = sub arg0, arg1
-    v1 = lt arg0, arg1
-    br v1, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb2:
-    mstore 128, v0
-    returndata 128, 32
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir (after pipeline-default) ===
+  @module CheckElimPipelineRequireSub
++ @phase optimized
+  fn @guarded(arg0: u256, arg1: u256) {
+    bb0 (entry):
+-     mstore 128, 0
+      v0 = gt arg1, arg0
+-     v1 = iszero v0
+-     v2 = iszero v1
+-     br v2, bb1, bb2
++     br v0, bb1, bb2
+    bb1:
+      revert 0, 0
+    bb2:
+      v3 = sub arg0, arg1
+-     v4 = lt arg0, arg1
+-     br v4, bb3, bb4
+-   bb3:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+-     mstore 4, 17 !metadata(memory=scratch)
+-     revert 0, 36
+-   bb4:
+      mstore 128, v3
+      returndata 128, 32
++   bb3:
++     invalid
++   bb4:
++     invalid
+  }
+  
+  fn @unguarded(arg0: u256, arg1: u256) {
+    bb0 (entry):
+-     mstore 128, 0
+      v0 = sub arg0, arg1
+      v1 = lt arg0, arg1
+      br v1, bb1, bb2
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+      mstore 4, 17 !metadata(memory=scratch)
+      revert 0, 36
+    bb2:
+      mstore 128, v0
+      returndata 128, 32
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
@@ -1,46 +1,32 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir (after pipeline-default) ===
-  @module CheckElimPipelineRequireSub
-+ @phase optimized
-  fn @guarded(arg0: u256, arg1: u256) {
-    bb0 (entry):
--     mstore 128, 0
-      v0 = gt arg1, arg0
--     v1 = iszero v0
--     v2 = iszero v1
--     br v2, bb1, bb2
-+     br v0, bb1, bb2
-    bb1:
-      revert 0, 0
-    bb2:
-      v3 = sub arg0, arg1
--     v4 = lt arg0, arg1
--     br v4, bb3, bb4
--   bb3:
--     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
--     mstore 4, 17 !metadata(memory=scratch)
--     revert 0, 36
--   bb4:
-      mstore 128, v3
-      returndata 128, 32
-+   bb3:
-+     invalid
-+   bb4:
-+     invalid
-  }
-  
-  fn @unguarded(arg0: u256, arg1: u256) {
-    bb0 (entry):
--     mstore 128, 0
-      v0 = sub arg0, arg1
-      v1 = lt arg0, arg1
-      br v1, bb1, bb2
-    bb1:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-      mstore 4, 17 !metadata(memory=scratch)
-      revert 0, 36
-    bb2:
-      mstore 128, v0
-      returndata 128, 32
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir (after pipeline-default) ===
+@module CheckElimPipelineRequireSub
+@phase optimized
+fn @guarded(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    v0 = gt arg1, arg0
+    br v0, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = sub arg0, arg1
+    mstore 128, v3
+    returndata 128, 32
+  bb3:
+    invalid
+  bb4:
+    invalid
+}
+
+fn @unguarded(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    v0 = sub arg0, arg1
+    v1 = lt arg0, arg1
+    br v1, bb1, bb2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb2:
+    mstore 128, v0
+    returndata 128, 32
+}

--- a/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
@@ -1,36 +1,43 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir (after pipeline-default) ===
-@module FreshArrayBoundsPipeline
-@phase optimized
-fn @constant_index() -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    mstore v0, 3
-    v1 = add v0, 128
-    mstore 64, v1
-    v2 = add v0, 32
-    calldatacopy v2, 0, 96
-    ret 7
-  bb1:
-    invalid
-  bb2:
-    invalid
-}
-
-fn @runtime_index(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = mload 64
-    mstore v0, arg0
-    v1 = shl 5, arg0
-    v2 = add v1, 32
-    v3 = add v0, v2
-    mstore 64, v3
-    v4 = add v0, 32
-    calldatacopy v4, 0, v1
-    v5 = mload v0
-    v6 = lt 1, v5
-    br v6, bb2, bb1
-  bb1:
-    revert 0, 36
-  bb2:
-    ret 7
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir (after pipeline-default) ===
+  @module FreshArrayBoundsPipeline
++ @phase optimized
+  fn @constant_index() -> u256 {
+    bb0 (entry):
+      v0 = mload 64
+      mstore v0, 3
+      v1 = add v0, 128
+      mstore 64, v1
+      v2 = add v0, 32
+      calldatacopy v2, 0, 96
+-     v3 = mload v0
+-     v4 = lt 1, v3
+-     br v4, bb2, bb1
++     ret 7
+    bb1:
+-     revert 0, 36
++     invalid
+    bb2:
+-     ret 7
++     invalid
+  }
+  
+  fn @runtime_index(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = mload 64
+      mstore v0, arg0
+      v1 = shl 5, arg0
+      v2 = add v1, 32
+      v3 = add v0, v2
+      mstore 64, v3
+      v4 = add v0, 32
+      calldatacopy v4, 0, v1
+      v5 = mload v0
+      v6 = lt 1, v5
+      br v6, bb2, bb1
+    bb1:
+      revert 0, 36
+    bb2:
+      ret 7
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
@@ -1,43 +1,36 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir (after pipeline-default) ===
-  @module FreshArrayBoundsPipeline
-+ @phase optimized
-  fn @constant_index() -> u256 {
-    bb0 (entry):
-      v0 = mload 64
-      mstore v0, 3
-      v1 = add v0, 128
-      mstore 64, v1
-      v2 = add v0, 32
-      calldatacopy v2, 0, 96
--     v3 = mload v0
--     v4 = lt 1, v3
--     br v4, bb2, bb1
-+     ret 7
-    bb1:
--     revert 0, 36
-+     invalid
-    bb2:
--     ret 7
-+     invalid
-  }
-  
-  fn @runtime_index(arg0: u256) -> u256 {
-    bb0 (entry):
-      v0 = mload 64
-      mstore v0, arg0
-      v1 = shl 5, arg0
-      v2 = add v1, 32
-      v3 = add v0, v2
-      mstore 64, v3
-      v4 = add v0, 32
-      calldatacopy v4, 0, v1
-      v5 = mload v0
-      v6 = lt 1, v5
-      br v6, bb2, bb1
-    bb1:
-      revert 0, 36
-    bb2:
-      ret 7
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir (after pipeline-default) ===
+@module FreshArrayBoundsPipeline
+@phase optimized
+fn @constant_index() -> u256 {
+  bb0 (entry):
+    v0 = mload 64
+    mstore v0, 3
+    v1 = add v0, 128
+    mstore 64, v1
+    v2 = add v0, 32
+    calldatacopy v2, 0, 96
+    ret 7
+  bb1:
+    invalid
+  bb2:
+    invalid
+}
+
+fn @runtime_index(arg0: u256) -> u256 {
+  bb0 (entry):
+    v0 = mload 64
+    mstore v0, arg0
+    v1 = shl 5, arg0
+    v2 = add v1, 32
+    v3 = add v0, v2
+    mstore 64, v3
+    v4 = add v0, 32
+    calldatacopy v4, 0, v1
+    v5 = mload v0
+    v6 = lt 1, v5
+    br v6, bb2, bb1
+  bb1:
+    revert 0, 36
+  bb2:
+    ret 7
+}

--- a/tests/ui/codegen/mir/pipeline/pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline.stdout
@@ -1,11 +1,17 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after jump-threading,cfg-simplify,dce) ===
-@module Pipeline
-fn @noisy(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    ret v0
-  bb1:
-    invalid
-  bb2:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before jump-threading,cfg-simplify,dce) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after jump-threading,cfg-simplify,dce) ===
+  @module Pipeline
+  fn @noisy(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     v1 = mul arg0, arg0
+-     jump bb1
++     ret v0
+    bb1:
+-     jump bb2
++     invalid
+    bb2:
+-     ret v0
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline.stdout
@@ -1,11 +1,26 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before jump-threading,cfg-simplify,dce) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after jump-threading,cfg-simplify,dce) ===
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before jump-threading) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after jump-threading) ===
   @module Pipeline
   fn @noisy(arg0: u256) -> u256 {
     bb0 (entry):
       v0 = add arg0, 1
--     v1 = mul arg0, arg0
+      v1 = mul arg0, arg0
 -     jump bb1
++     jump bb2
+    bb1:
+      jump bb2
+    bb2:
+      ret v0
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after cfg-simplify) ===
+  @module Pipeline
+  fn @noisy(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      v1 = mul arg0, arg0
+-     jump bb2
 +     ret v0
     bb1:
 -     jump bb2
@@ -13,5 +28,19 @@
     bb2:
 -     ret v0
 +     invalid
+  }
+  
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after dce) ===
+  @module Pipeline
+  fn @noisy(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     v1 = mul arg0, arg0
+      ret v0
+    bb1:
+      invalid
+    bb2:
+      invalid
   }
   

--- a/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.stdout
@@ -1,13 +1,27 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir (after pipeline-default) ===
-@module PipelineCleanupFixpoint
-@phase optimized
-fn @fold_phi_after_promotion(arg0: bool) -> u256 {
-  bb0 (entry):
-    ret 1
-  bb1:
-    invalid
-  bb2:
-    invalid
-  bb3:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir (after pipeline-default) ===
+  @module PipelineCleanupFixpoint
++ @phase optimized
+  fn @fold_phi_after_promotion(arg0: bool) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 1
+-     br arg0, bb1, bb2
++     ret 1
+    bb1:
+-     v1 = internal_frame_addr 128
+-     mstore v1, 1
+-     jump bb3
++     invalid
+    bb2:
+-     v2 = internal_frame_addr 128
+-     mstore v2, 1
+-     jump bb3
++     invalid
+    bb3:
+-     v3 = internal_frame_addr 128
+-     v4 = mload v3
+-     ret v4
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.stdout
@@ -1,27 +1,13 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir (after pipeline-default) ===
-  @module PipelineCleanupFixpoint
-+ @phase optimized
-  fn @fold_phi_after_promotion(arg0: bool) -> u256 {
-    bb0 (entry):
--     v0 = internal_frame_addr 128
--     mstore v0, 1
--     br arg0, bb1, bb2
-+     ret 1
-    bb1:
--     v1 = internal_frame_addr 128
--     mstore v1, 1
--     jump bb3
-+     invalid
-    bb2:
--     v2 = internal_frame_addr 128
--     mstore v2, 1
--     jump bb3
-+     invalid
-    bb3:
--     v3 = internal_frame_addr 128
--     v4 = mload v3
--     ret v4
-+     invalid
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir (after pipeline-default) ===
+@module PipelineCleanupFixpoint
+@phase optimized
+fn @fold_phi_after_promotion(arg0: bool) -> u256 {
+  bb0 (entry):
+    ret 1
+  bb1:
+    invalid
+  bb2:
+    invalid
+  bb3:
+    invalid
+}

--- a/tests/ui/codegen/mir/pipeline/pipeline_default.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_default.stdout
@@ -1,18 +1,12 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_default.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_default.mir (after pipeline-default) ===
-  @module PipelineDefault
-+ @phase optimized
-  fn @noisy(arg0: u256) -> u256 {
-    bb0 (entry):
-      v0 = add arg0, 1
--     v1 = mul arg0, arg0
--     jump bb1
-+     ret v0
-    bb1:
--     jump bb2
-+     invalid
-    bb2:
--     ret v0
-+     invalid
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/pipeline_default.mir (after pipeline-default) ===
+@module PipelineDefault
+@phase optimized
+fn @noisy(arg0: u256) -> u256 {
+  bb0 (entry):
+    v0 = add arg0, 1
+    ret v0
+  bb1:
+    invalid
+  bb2:
+    invalid
+}

--- a/tests/ui/codegen/mir/pipeline/pipeline_default.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_default.stdout
@@ -1,12 +1,18 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/pipeline_default.mir (after pipeline-default) ===
-@module PipelineDefault
-@phase optimized
-fn @noisy(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    ret v0
-  bb1:
-    invalid
-  bb2:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_default.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_default.mir (after pipeline-default) ===
+  @module PipelineDefault
++ @phase optimized
+  fn @noisy(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     v1 = mul arg0, arg0
+-     jump bb1
++     ret v0
+    bb1:
+-     jump bb2
++     invalid
+    bb2:
+-     ret v0
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
@@ -1,32 +1,19 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir (after pipeline-default) ===
-  @module PipelineFrameIndVar
-+ @phase optimized
-  fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
--     v0 = internal_frame_addr 128
--     mstore v0, 0
-      jump bb1
-    bb1:
--     v1 = internal_frame_addr 128
--     v2 = mload v1
--     v3 = lt v2, arg0
-+     v8 = phi [bb0: 0], [bb2: v6]
-+     v9 = phi [bb0: arg1], [bb2: v10]
-+     v3 = lt v8, arg0
-      br v3, bb2, bb3
-    bb2:
--     v4 = mul v2, 32
--     v5 = add arg1, v4
--     mstore v5, v2
--     v6 = add v2, 1
--     v7 = internal_frame_addr 128
--     mstore v7, v6
-+     mstore v9, v8
-+     v6 = add v8, 1
-+     v10 = add v9, 32
-      jump bb1
-    bb3:
-      ret 0
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir (after pipeline-default) ===
+@module PipelineFrameIndVar
+@phase optimized
+fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
+  bb0 (entry):
+    jump bb1
+  bb1:
+    v8 = phi [bb0: 0], [bb2: v6]
+    v9 = phi [bb0: arg1], [bb2: v10]
+    v3 = lt v8, arg0
+    br v3, bb2, bb3
+  bb2:
+    mstore v9, v8
+    v6 = add v8, 1
+    v10 = add v9, 32
+    jump bb1
+  bb3:
+    ret 0
+}

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
@@ -1,19 +1,32 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir (after pipeline-default) ===
-@module PipelineFrameIndVar
-@phase optimized
-fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v8 = phi [bb0: 0], [bb2: v6]
-    v9 = phi [bb0: arg1], [bb2: v10]
-    v3 = lt v8, arg0
-    br v3, bb2, bb3
-  bb2:
-    mstore v9, v8
-    v6 = add v8, 1
-    v10 = add v9, 32
-    jump bb1
-  bb3:
-    ret 0
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir (after pipeline-default) ===
+  @module PipelineFrameIndVar
++ @phase optimized
+  fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+-     v0 = internal_frame_addr 128
+-     mstore v0, 0
+      jump bb1
+    bb1:
+-     v1 = internal_frame_addr 128
+-     v2 = mload v1
+-     v3 = lt v2, arg0
++     v8 = phi [bb0: 0], [bb2: v6]
++     v9 = phi [bb0: arg1], [bb2: v10]
++     v3 = lt v8, arg0
+      br v3, bb2, bb3
+    bb2:
+-     v4 = mul v2, 32
+-     v5 = add arg1, v4
+-     mstore v5, v2
+-     v6 = add v2, 1
+-     v7 = internal_frame_addr 128
+-     mstore v7, v6
++     mstore v9, v8
++     v6 = add v8, 1
++     v10 = add v9, 32
+      jump bb1
+    bb3:
+      ret 0
+  }
+  

--- a/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.stdout
@@ -1,33 +1,19 @@
-- // === ROOT/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir (before pipeline-default) ===
-+ // === ROOT/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir (after pipeline-default) ===
-  @module PingPongPipeline
-+ @phase optimized
-  fn @pingpong(arg0: u256, arg1: u256) {
-    bb0 (entry):
--     switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
-+     jump bb6
-    bb1:
--     v0 = add arg0, 7
--     jump bb5
-+     invalid
-    bb2:
--     v1 = add arg0, 7
--     jump bb5
-+     invalid
-    bb3:
--     v2 = add arg0, 7
--     jump bb6
-+     invalid
-    bb4:
--     v3 = add arg0, 7
--     jump bb6
-+     invalid
-    bb5:
--     v4 = add arg0, 7
--     jump bb6
-+     invalid
-    bb6:
--     jump bb5
-+     jump bb6
-  }
-  
+// === ROOT/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir (after pipeline-default) ===
+@module PingPongPipeline
+@phase optimized
+fn @pingpong(arg0: u256, arg1: u256) {
+  bb0 (entry):
+    jump bb6
+  bb1:
+    invalid
+  bb2:
+    invalid
+  bb3:
+    invalid
+  bb4:
+    invalid
+  bb5:
+    invalid
+  bb6:
+    jump bb6
+}

--- a/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.stdout
@@ -1,19 +1,33 @@
-// === ROOT/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir (after pipeline-default) ===
-@module PingPongPipeline
-@phase optimized
-fn @pingpong(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    jump bb6
-  bb1:
-    invalid
-  bb2:
-    invalid
-  bb3:
-    invalid
-  bb4:
-    invalid
-  bb5:
-    invalid
-  bb6:
-    jump bb6
-}
+- // === ROOT/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir (before pipeline-default) ===
++ // === ROOT/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir (after pipeline-default) ===
+  @module PingPongPipeline
++ @phase optimized
+  fn @pingpong(arg0: u256, arg1: u256) {
+    bb0 (entry):
+-     switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
++     jump bb6
+    bb1:
+-     v0 = add arg0, 7
+-     jump bb5
++     invalid
+    bb2:
+-     v1 = add arg0, 7
+-     jump bb5
++     invalid
+    bb3:
+-     v2 = add arg0, 7
+-     jump bb6
++     invalid
+    bb4:
+-     v3 = add arg0, 7
+-     jump bb6
++     invalid
+    bb5:
+-     v4 = add arg0, 7
+-     jump bb6
++     invalid
+    bb6:
+-     jump bb5
++     jump bb6
+  }
+  

--- a/tests/ui/codegen/mir/pre/pre.stdout
+++ b/tests/ui/codegen/mir/pre/pre.stdout
@@ -1,68 +1,79 @@
-// === ROOT/tests/ui/codegen/mir/pre/pre.mir (after pre) ===
-@module Pre
-fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    switch arg1, default bb3, [1 => bb1, 2 => bb2]
-  bb1:
-    v0 = add arg0, 7
-    jump bb4
-  bb2:
-    v1 = add 7, arg0
-    jump bb4
-  bb3:
-    v3 = add arg0, 7
-    jump bb4
-  bb4:
-    v4 = phi [bb1: v0], [bb2: v1], [bb3: v3]
-    ret v4
-}
-
-fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
-  bb0 (entry):
-    switch arg3, default bb3, [1 => bb1, 2 => bb2]
-  bb1:
-    v0 = add arg0, 1
-    jump bb4
-  bb2:
-    v1 = add arg1, 1
-    jump bb4
-  bb3:
-    v4 = add arg2, 1
-    jump bb4
-  bb4:
-    v2 = phi [bb1: arg0], [bb2: arg1], [bb3: arg2]
-    v5 = phi [bb1: v0], [bb2: v1], [bb3: v4]
-    ret v5
-}
-
-fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    v0 = add arg0, 1
-    jump bb3
-  bb2:
-    v2 = add arg0, 1
-    jump bb3
-  bb3:
-    v3 = phi [bb1: v0], [bb2: v2]
-    ret v3
-}
-
-fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    v0 = add arg0, 1
-    jump bb3
-  bb2:
-    br arg1, bb5, bb4
-  bb3:
-    v3 = phi [bb1: v0], [bb5: v2]
-    ret v3
-  bb4:
-    ret arg0
-  bb5:
-    v2 = add arg0, 1
-    jump bb3
-}
+- // === ROOT/tests/ui/codegen/mir/pre/pre.mir (before pre) ===
++ // === ROOT/tests/ui/codegen/mir/pre/pre.mir (after pre) ===
+  @module Pre
+  fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      switch arg1, default bb3, [1 => bb1, 2 => bb2]
+    bb1:
+      v0 = add arg0, 7
+      jump bb4
+    bb2:
+      v1 = add 7, arg0
+      jump bb4
+    bb3:
++     v3 = add arg0, 7
+      jump bb4
+    bb4:
+-     v2 = add arg0, 7
+-     ret v2
++     v4 = phi [bb1: v0], [bb2: v1], [bb3: v3]
++     ret v4
+  }
+  
+  fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
+    bb0 (entry):
+      switch arg3, default bb3, [1 => bb1, 2 => bb2]
+    bb1:
+      v0 = add arg0, 1
+      jump bb4
+    bb2:
+      v1 = add arg1, 1
+      jump bb4
+    bb3:
++     v4 = add arg2, 1
+      jump bb4
+    bb4:
+      v2 = phi [bb1: arg0], [bb2: arg1], [bb3: arg2]
+-     v3 = add v2, 1
+-     ret v3
++     v5 = phi [bb1: v0], [bb2: v1], [bb3: v4]
++     ret v5
+  }
+  
+  fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      v0 = add arg0, 1
+      jump bb3
+    bb2:
++     v2 = add arg0, 1
+      jump bb3
+    bb3:
+-     v1 = add arg0, 1
+-     ret v1
++     v3 = phi [bb1: v0], [bb2: v2]
++     ret v3
+  }
+  
+  fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      v0 = add arg0, 1
+      jump bb3
+    bb2:
+-     br arg1, bb3, bb4
++     br arg1, bb5, bb4
+    bb3:
+-     v1 = add arg0, 1
+-     ret v1
++     v3 = phi [bb1: v0], [bb5: v2]
++     ret v3
+    bb4:
+      ret arg0
++   bb5:
++     v2 = add arg0, 1
++     jump bb3
+  }
+  

--- a/tests/ui/codegen/mir/pre/pre_dominator_availability.stdout
+++ b/tests/ui/codegen/mir/pre/pre_dominator_availability.stdout
@@ -1,32 +1,38 @@
-// === ROOT/tests/ui/codegen/mir/pre/pre_dominator_availability.mir (after pre) ===
-@module DomAvail
-fn @reuse_dominating_def(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    switch arg1, default bb1, [1 => bb2, 2 => bb3]
-  bb1:
-    v0 = add arg0, 7
-    jump bb5
-  bb2:
-    v1 = add arg0, 7
-    jump bb5
-  bb3:
-    v2 = add arg0, 7
-    jump bb4
-  bb4:
-    jump bb5
-  bb5:
-    v4 = phi [bb1: v0], [bb2: v1], [bb4: v2]
-    ret v4
-}
-
-fn @collapse_to_shared_def(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 7
-    switch arg1, default bb1, [1 => bb2]
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/pre/pre_dominator_availability.mir (before pre) ===
++ // === ROOT/tests/ui/codegen/mir/pre/pre_dominator_availability.mir (after pre) ===
+  @module DomAvail
+  fn @reuse_dominating_def(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      switch arg1, default bb1, [1 => bb2, 2 => bb3]
+    bb1:
+      v0 = add arg0, 7
+      jump bb5
+    bb2:
+      v1 = add arg0, 7
+      jump bb5
+    bb3:
+      v2 = add arg0, 7
+      jump bb4
+    bb4:
+      jump bb5
+    bb5:
+-     v3 = add arg0, 7
+-     ret v3
++     v4 = phi [bb1: v0], [bb2: v1], [bb4: v2]
++     ret v4
+  }
+  
+  fn @collapse_to_shared_def(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 7
+      switch arg1, default bb1, [1 => bb2]
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+-     v1 = add arg0, 7
+-     ret v1
++     ret v0
+  }
+  

--- a/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
+++ b/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
@@ -1,64 +1,74 @@
-// === ROOT/tests/ui/codegen/mir/pre/pre_join_shapes.mir (after pre) ===
-@module JoinShapes
-fn @duplicate_pred_edges(arg0: u256, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
-    switch arg1, default bb1, [1 => bb2, 2 => bb3]
-  bb1:
-    v0 = add arg0, 7
-    jump bb4
-  bb2:
-    v1 = add arg0, 7
-    switch arg2, default bb4, [1 => bb4]
-  bb3:
-    v3 = add arg0, 7
-    jump bb4
-  bb4:
-    v4 = phi [bb1: v0], [bb2: v1], [bb3: v3]
-    ret v4
-}
-
-fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    switch arg1, default bb3, [1 => bb1, 2 => bb2]
-  bb1:
-    v0 = add arg0, 7
-    jump bb4
-  bb2:
-    v1 = add arg0, 7
-    jump bb4
-  bb3:
-    v4 = add arg0, 7
-    jump bb4
-  bb4:
-    v5 = phi [bb1: v0], [bb2: v1], [bb3: v4], [bb4: v5]
-    v3 = eq arg1, v5
-    br v3, bb4, bb5
-  bb5:
-    ret v5
-}
-
-fn @outer_phi_operand(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: arg0], [bb6: v5]
-    switch arg1, default bb2, [1 => bb3, 2 => bb4]
-  bb2:
-    v1 = add v0, 7
-    jump bb5
-  bb3:
-    v2 = add 7, v0
-    jump bb5
-  bb4:
-    v6 = add v0, 7
-    jump bb5
-  bb5:
-    v7 = phi [bb2: v1], [bb3: v2], [bb4: v6]
-    v4 = lt v7, arg1
-    br v4, bb6, bb7
-  bb6:
-    v5 = add v0, 1
-    jump bb1
-  bb7:
-    ret v7
-}
+- // === ROOT/tests/ui/codegen/mir/pre/pre_join_shapes.mir (before pre) ===
++ // === ROOT/tests/ui/codegen/mir/pre/pre_join_shapes.mir (after pre) ===
+  @module JoinShapes
+  fn @duplicate_pred_edges(arg0: u256, arg1: u256, arg2: u256) -> u256 {
+    bb0 (entry):
+      switch arg1, default bb1, [1 => bb2, 2 => bb3]
+    bb1:
+      v0 = add arg0, 7
+      jump bb4
+    bb2:
+      v1 = add arg0, 7
+      switch arg2, default bb4, [1 => bb4]
+    bb3:
++     v3 = add arg0, 7
+      jump bb4
+    bb4:
+-     v2 = add arg0, 7
+-     ret v2
++     v4 = phi [bb1: v0], [bb2: v1], [bb3: v3]
++     ret v4
+  }
+  
+  fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      switch arg1, default bb3, [1 => bb1, 2 => bb2]
+    bb1:
+      v0 = add arg0, 7
+      jump bb4
+    bb2:
+      v1 = add arg0, 7
+      jump bb4
+    bb3:
++     v4 = add arg0, 7
+      jump bb4
+    bb4:
+-     v2 = add arg0, 7
+-     v3 = eq arg1, v2
++     v5 = phi [bb1: v0], [bb2: v1], [bb3: v4], [bb4: v5]
++     v3 = eq arg1, v5
+      br v3, bb4, bb5
+    bb5:
+-     ret v2
++     ret v5
+  }
+  
+  fn @outer_phi_operand(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: arg0], [bb6: v5]
+      switch arg1, default bb2, [1 => bb3, 2 => bb4]
+    bb2:
+      v1 = add v0, 7
+      jump bb5
+    bb3:
+      v2 = add 7, v0
+      jump bb5
+    bb4:
++     v6 = add v0, 7
+      jump bb5
+    bb5:
+-     v3 = add v0, 7
+-     v4 = lt v3, arg1
++     v7 = phi [bb2: v1], [bb3: v2], [bb4: v6]
++     v4 = lt v7, arg1
+      br v4, bb6, bb7
+    bb6:
+      v5 = add v0, 1
+      jump bb1
+    bb7:
+-     ret v3
++     ret v7
+  }
+  

--- a/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
+++ b/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
@@ -1,41 +1,49 @@
-// === ROOT/tests/ui/codegen/mir/pre/pre_loop_invariant.mir (after pre) ===
-@module LoopInvariant
-fn @hoist_header_expr(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v5 = add arg0, 7
-    jump bb1
-  bb1:
-    v0 = phi [bb0: arg0], [bb2: v3]
-    v6 = phi [bb0: v5], [bb2: v4]
-    v2 = lt v6, arg1
-    br v2, bb2, bb3
-  bb2:
-    v3 = add v0, 1
-    v4 = add v3, 7
-    jump bb1
-  bb3:
-    ret v6
-}
-
-fn @hoist_header_expr_two_latches(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v7 = add arg0, 7
-    jump bb1
-  bb1:
-    v0 = phi [bb0: arg0], [bb3: v3], [bb4: v5]
-    v8 = phi [bb0: v7], [bb3: v4], [bb4: v6]
-    v2 = lt v8, arg1
-    br v2, bb2, bb5
-  bb2:
-    switch arg1, default bb3, [1 => bb4]
-  bb3:
-    v3 = add v0, 1
-    v4 = add v3, 7
-    jump bb1
-  bb4:
-    v5 = add v0, 2
-    v6 = add v5, 7
-    jump bb1
-  bb5:
-    ret v8
-}
+- // === ROOT/tests/ui/codegen/mir/pre/pre_loop_invariant.mir (before pre) ===
++ // === ROOT/tests/ui/codegen/mir/pre/pre_loop_invariant.mir (after pre) ===
+  @module LoopInvariant
+  fn @hoist_header_expr(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
++     v5 = add arg0, 7
+      jump bb1
+    bb1:
+      v0 = phi [bb0: arg0], [bb2: v3]
+-     v1 = add v0, 7
+-     v2 = lt v1, arg1
++     v6 = phi [bb0: v5], [bb2: v4]
++     v2 = lt v6, arg1
+      br v2, bb2, bb3
+    bb2:
+      v3 = add v0, 1
+      v4 = add v3, 7
+      jump bb1
+    bb3:
+-     ret v1
++     ret v6
+  }
+  
+  fn @hoist_header_expr_two_latches(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
++     v7 = add arg0, 7
+      jump bb1
+    bb1:
+      v0 = phi [bb0: arg0], [bb3: v3], [bb4: v5]
+-     v1 = add v0, 7
+-     v2 = lt v1, arg1
++     v8 = phi [bb0: v7], [bb3: v4], [bb4: v6]
++     v2 = lt v8, arg1
+      br v2, bb2, bb5
+    bb2:
+      switch arg1, default bb3, [1 => bb4]
+    bb3:
+      v3 = add v0, 1
+      v4 = add v3, 7
+      jump bb1
+    bb4:
+      v5 = add v0, 2
+      v6 = add v5, 7
+      jump bb1
+    bb5:
+-     ret v1
++     ret v8
+  }
+  

--- a/tests/ui/codegen/mir/pre/pre_pingpong.stdout
+++ b/tests/ui/codegen/mir/pre/pre_pingpong.stdout
@@ -1,24 +1,27 @@
-// === ROOT/tests/ui/codegen/mir/pre/pre_pingpong.mir (after pre) ===
-@module PingPong
-fn @pingpong(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
-  bb1:
-    v0 = add arg0, 7
-    jump bb5
-  bb2:
-    v1 = add arg0, 7
-    jump bb5
-  bb3:
-    v2 = add arg0, 7
-    jump bb6
-  bb4:
-    v3 = add arg0, 7
-    jump bb6
-  bb5:
-    v6 = phi [bb1: v0], [bb2: v1], [bb6: v5]
-    jump bb6
-  bb6:
-    v5 = add arg0, 7
-    jump bb5
-}
+- // === ROOT/tests/ui/codegen/mir/pre/pre_pingpong.mir (before pre) ===
++ // === ROOT/tests/ui/codegen/mir/pre/pre_pingpong.mir (after pre) ===
+  @module PingPong
+  fn @pingpong(arg0: u256, arg1: u256) {
+    bb0 (entry):
+      switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
+    bb1:
+      v0 = add arg0, 7
+      jump bb5
+    bb2:
+      v1 = add arg0, 7
+      jump bb5
+    bb3:
+      v2 = add arg0, 7
+      jump bb6
+    bb4:
+      v3 = add arg0, 7
+      jump bb6
+    bb5:
+-     v4 = add arg0, 7
++     v6 = phi [bb1: v0], [bb2: v1], [bb6: v5]
+      jump bb6
+    bb6:
++     v5 = add arg0, 7
+      jump bb5
+  }
+  

--- a/tests/ui/codegen/mir/pre/pre_split_edges.stdout
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.stdout
@@ -1,76 +1,93 @@
-// === ROOT/tests/ui/codegen/mir/pre/pre_split_edges.mir (after pre) ===
-@module SplitEdges
-fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    switch arg1, default bb1, [1 => bb2]
-  bb1:
-    v0 = add arg0, 7
-    jump bb3
-  bb2:
-    switch arg1, default bb4, [2 => bb5, 3 => bb5]
-  bb3:
-    v3 = phi [bb1: v0], [bb5: v2]
-    ret v3
-  bb4:
-    ret arg0
-  bb5:
-    v2 = add arg0, 7
-    jump bb3
-}
-
-fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
-    br arg1, bb1, bb2
-  bb1:
-    v0 = add arg0, 7
-    jump bb3
-  bb2:
-    br arg1, bb4, bb4
-  bb3:
-    v3 = phi [bb1: v0], [bb4: v2]
-    ret v3
-  bb4:
-    v2 = add arg0, 7
-    jump bb3
-}
-
-fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = add arg0, 7
-    jump bb2
-  bb2:
-    v1 = phi [bb1: arg0], [bb4: v2]
-    v6 = phi [bb1: v0], [bb4: v5]
-    v2 = add v1, 1
-    v4 = lt v2, arg1
-    br v4, bb4, bb3
-  bb3:
-    ret v6
-  bb4:
-    v5 = add v2, 7
-    jump bb2
-}
-
-fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
-    v0 = lt arg0, arg1
-    br v0, bb5, bb4
-  bb1:
-    v1 = phi [bb5: arg0], [bb2: v4]
-    v7 = phi [bb2: v5], [bb5: v6]
-    v3 = lt v7, arg1
-    br v3, bb2, bb3
-  bb2:
-    v4 = add v1, 1
-    v5 = add v4, 7
-    jump bb1
-  bb3:
-    ret v7
-  bb4:
-    ret arg0
-  bb5:
-    v6 = add arg0, 7
-    jump bb1
-}
+- // === ROOT/tests/ui/codegen/mir/pre/pre_split_edges.mir (before pre) ===
++ // === ROOT/tests/ui/codegen/mir/pre/pre_split_edges.mir (after pre) ===
+  @module SplitEdges
+  fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      switch arg1, default bb1, [1 => bb2]
+    bb1:
+      v0 = add arg0, 7
+      jump bb3
+    bb2:
+-     switch arg1, default bb4, [2 => bb3, 3 => bb3]
++     switch arg1, default bb4, [2 => bb5, 3 => bb5]
+    bb3:
+-     v1 = add arg0, 7
+-     ret v1
++     v3 = phi [bb1: v0], [bb5: v2]
++     ret v3
+    bb4:
+      ret arg0
++   bb5:
++     v2 = add arg0, 7
++     jump bb3
+  }
+  
+  fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
+    bb0 (entry):
+      br arg1, bb1, bb2
+    bb1:
+      v0 = add arg0, 7
+      jump bb3
+    bb2:
+-     br arg1, bb3, bb3
++     br arg1, bb4, bb4
+    bb3:
+-     v1 = add arg0, 7
+-     ret v1
++     v3 = phi [bb1: v0], [bb4: v2]
++     ret v3
++   bb4:
++     v2 = add arg0, 7
++     jump bb3
+  }
+  
+  fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = add arg0, 7
+      jump bb2
+    bb2:
+-     v1 = phi [bb1: arg0], [bb2: v2]
++     v1 = phi [bb1: arg0], [bb4: v2]
++     v6 = phi [bb1: v0], [bb4: v5]
+      v2 = add v1, 1
+-     v3 = add v1, 7
+      v4 = lt v2, arg1
+-     br v4, bb2, bb3
++     br v4, bb4, bb3
+    bb3:
+-     ret v3
++     ret v6
++   bb4:
++     v5 = add v2, 7
++     jump bb2
+  }
+  
+  fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
+    bb0 (entry):
+      v0 = lt arg0, arg1
+-     br v0, bb1, bb4
++     br v0, bb5, bb4
+    bb1:
+-     v1 = phi [bb0: arg0], [bb2: v4]
+-     v2 = add v1, 7
+-     v3 = lt v2, arg1
++     v1 = phi [bb5: arg0], [bb2: v4]
++     v7 = phi [bb2: v5], [bb5: v6]
++     v3 = lt v7, arg1
+      br v3, bb2, bb3
+    bb2:
+      v4 = add v1, 1
+      v5 = add v4, 7
+      jump bb1
+    bb3:
+-     ret v2
++     ret v7
+    bb4:
+      ret arg0
++   bb5:
++     v6 = add arg0, 7
++     jump bb1
+  }
+  

--- a/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
+++ b/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
@@ -1,18 +1,26 @@
-// === ROOT/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir (after pure-eval) ===
-@module PureEvalLoop
-fn @bounded_loop() -> u256 {
-  bb0 (entry):
-    ret 3
-  bb1:
-    invalid
-  bb2:
-    invalid
-  bb3:
-    invalid
-}
-
-fn @with_arg(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    ret v0
-}
+- // === ROOT/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir (before pure-eval) ===
++ // === ROOT/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir (after pure-eval) ===
+  @module PureEvalLoop
+  fn @bounded_loop() -> u256 {
+    bb0 (entry):
+-     jump bb1
++     ret 3
+    bb1:
+-     v0 = phi [bb0: 0], [bb2: 3]
+-     v1 = lt v0, 3
+-     br v1, bb2, bb3
++     invalid
+    bb2:
+-     jump bb1
++     invalid
+    bb3:
+-     ret v0
++     invalid
+  }
+  
+  fn @with_arg(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      ret v0
+  }
+  

--- a/tests/ui/codegen/mir/sccp/sccp_branch.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_branch.stdout
@@ -1,10 +1,15 @@
-// === ROOT/tests/ui/codegen/mir/sccp/sccp_branch.mir (after sccp) ===
-@module SccpBranch
-fn @const_branch() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    ret 1
-  bb2:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/sccp/sccp_branch.mir (before sccp) ===
++ // === ROOT/tests/ui/codegen/mir/sccp/sccp_branch.mir (after sccp) ===
+  @module SccpBranch
+  fn @const_branch() -> u256 {
+    bb0 (entry):
+-     v0 = lt 5, 10
+-     br v0, bb1, bb2
++     jump bb1
+    bb1:
+      ret 1
+    bb2:
+-     ret 0
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/sccp/sccp_edge.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_edge.stdout
@@ -1,37 +1,48 @@
-// === ROOT/tests/ui/codegen/mir/sccp/sccp_edge.mir (after sccp) ===
-@module SccpEdge
-fn @phi_ignores_unreachable_predecessor() -> u256 {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    jump bb3
-  bb2:
-    invalid
-  bb3:
-    ret 11
-}
-
-fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
-  bb0 (entry):
-    br arg0, bb1, bb2
-  bb1:
-    jump bb3
-  bb2:
-    jump bb3
-  bb3:
-    v0 = phi [bb1: 11], [bb2: 22]
-    ret v0
-}
-
-fn @constant_switch_selects_one_case() -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    invalid
-  bb2:
-    ret 22
-  bb3:
-    invalid
-  bb4:
-    invalid
-}
+- // === ROOT/tests/ui/codegen/mir/sccp/sccp_edge.mir (before sccp) ===
++ // === ROOT/tests/ui/codegen/mir/sccp/sccp_edge.mir (after sccp) ===
+  @module SccpEdge
+  fn @phi_ignores_unreachable_predecessor() -> u256 {
+    bb0 (entry):
+-     v0 = eq 1, 1
+-     br v0, bb1, bb2
++     jump bb1
+    bb1:
+      jump bb3
+    bb2:
+-     jump bb3
++     invalid
+    bb3:
+-     v1 = phi [bb1: 11], [bb2: 22]
+-     ret v1
++     ret 11
+  }
+  
+  fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
+    bb0 (entry):
+      br arg0, bb1, bb2
+    bb1:
+      jump bb3
+    bb2:
+      jump bb3
+    bb3:
+      v0 = phi [bb1: 11], [bb2: 22]
+      ret v0
+  }
+  
+  fn @constant_switch_selects_one_case() -> u256 {
+    bb0 (entry):
+-     switch 2, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
++     jump bb2
+    bb1:
+-     ret 11
++     invalid
+    bb2:
+      ret 22
+    bb3:
+-     ret 33
++     invalid
+    bb4:
+-     ret 44
++     invalid
+  }
+  

--- a/tests/ui/codegen/mir/sccp/sccp_fold.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_fold.stdout
@@ -1,6 +1,11 @@
-// === ROOT/tests/ui/codegen/mir/sccp/sccp_fold.mir (after sccp) ===
-@module SccpFold
-fn @const_chain() -> u256 {
-  bb0 (entry):
-    ret 60
-}
+- // === ROOT/tests/ui/codegen/mir/sccp/sccp_fold.mir (before sccp) ===
++ // === ROOT/tests/ui/codegen/mir/sccp/sccp_fold.mir (after sccp) ===
+  @module SccpFold
+  fn @const_chain() -> u256 {
+    bb0 (entry):
+-     v0 = add 10, 20
+-     v1 = mul v0, 2
+-     ret v1
++     ret 60
+  }
+  

--- a/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.stdout
@@ -1,126 +1,186 @@
-// === ROOT/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.mir (after sccp) ===
-@module SccpFoldEvmOps
-fn @sdiv_min_by_neg_one() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @sdiv_truncates_toward_zero() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @div_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @mod_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @sdiv_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @smod_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @smod_negative_dividend() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @smod_positive_dividend() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @slt_negative() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @sgt_negative() -> bool {
-  bb0 (entry):
-    ret 0
-}
-
-fn @sar_saturates_negative() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @sar_saturates_positive() -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @sar_fills_sign_bits() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @byte_index_out_of_range() -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @byte_extracts_big_endian() -> u256 {
-  bb0 (entry):
-    ret 18
-}
-
-fn @signextend_identity_at_31() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @signextend_byte_zero() -> bool {
-  bb0 (entry):
-    ret 1
-}
-
-fn @addmod_zero_modulus() -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @addmod_unknown_operands_zero_modulus(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @mulmod_zero_modulus() -> u256 {
-  bb0 (entry):
-    ret 0
-}
-
-fn @addmod_wide_intermediate() -> u256 {
-  bb0 (entry):
-    ret 2
-}
-
-fn @mulmod_wide_intermediate() -> u256 {
-  bb0 (entry):
-    ret 2
-}
-
-fn @select_true_condition() -> u256 {
-  bb0 (entry):
-    ret 11
-}
-
-fn @select_false_condition() -> u256 {
-  bb0 (entry):
-    ret 22
-}
-
-fn @select_equal_arms(arg0: u256) -> u256 {
-  bb0 (entry):
-    ret 7
-}
+- // === ROOT/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.mir (before sccp) ===
++ // === ROOT/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.mir (after sccp) ===
+  @module SccpFoldEvmOps
+  fn @sdiv_min_by_neg_one() -> bool {
+    bb0 (entry):
+-     v0 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
+-     ret v1
++     ret 1
+  }
+  
+  fn @sdiv_truncates_toward_zero() -> bool {
+    bb0 (entry):
+-     v0 = sdiv 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 2
+-     v1 = eq v0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
+-     ret v1
++     ret 1
+  }
+  
+  fn @div_by_known_zero(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = div arg0, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @mod_by_known_zero(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = mod arg0, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @sdiv_by_known_zero(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = sdiv arg0, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @smod_by_known_zero(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = smod arg0, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @smod_negative_dividend() -> bool {
+    bb0 (entry):
+-     v0 = smod 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 3
+-     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     ret v1
++     ret 1
+  }
+  
+  fn @smod_positive_dividend() -> bool {
+    bb0 (entry):
+-     v0 = smod 7, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
+-     v1 = eq v0, 1
+-     ret v1
++     ret 1
+  }
+  
+  fn @slt_negative() -> bool {
+    bb0 (entry):
+-     v0 = slt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0
+-     ret v0
++     ret 1
+  }
+  
+  fn @sgt_negative() -> bool {
+    bb0 (entry):
+-     v0 = sgt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @sar_saturates_negative() -> bool {
+    bb0 (entry):
+-     v0 = sar 256, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
+-     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     ret v1
++     ret 1
+  }
+  
+  fn @sar_saturates_positive() -> u256 {
+    bb0 (entry):
+-     v0 = sar 300, 7
+-     ret v0
++     ret 0
+  }
+  
+  fn @sar_fills_sign_bits() -> bool {
+    bb0 (entry):
+-     v0 = sar 1, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9
+-     v1 = eq v0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc
+-     ret v1
++     ret 1
+  }
+  
+  fn @byte_index_out_of_range() -> u256 {
+    bb0 (entry):
+-     v0 = byte 32, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     ret v0
++     ret 0
+  }
+  
+  fn @byte_extracts_big_endian() -> u256 {
+    bb0 (entry):
+-     v0 = byte 30, 0x1234
+-     ret v0
++     ret 18
+  }
+  
+  fn @signextend_identity_at_31() -> bool {
+    bb0 (entry):
+-     v0 = signextend 31, 0x8000000000000000000000000000000000000000000000000000000000000000
+-     v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
+-     ret v1
++     ret 1
+  }
+  
+  fn @signextend_byte_zero() -> bool {
+    bb0 (entry):
+-     v0 = signextend 0, 255
+-     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     ret v1
++     ret 1
+  }
+  
+  fn @addmod_zero_modulus() -> u256 {
+    bb0 (entry):
+-     v0 = addmod 1, 2, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @addmod_unknown_operands_zero_modulus(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = addmod arg0, arg0, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @mulmod_zero_modulus() -> u256 {
+    bb0 (entry):
+-     v0 = mulmod 5, 5, 0
+-     ret v0
++     ret 0
+  }
+  
+  fn @addmod_wide_intermediate() -> u256 {
+    bb0 (entry):
+-     v0 = addmod 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3
+-     ret v0
++     ret 2
+  }
+  
+  fn @mulmod_wide_intermediate() -> u256 {
+    bb0 (entry):
+-     v0 = mulmod 0x100000000000000000000000000000000, 0x100000000000000000000000000000000, 7
+-     ret v0
++     ret 2
+  }
+  
+  fn @select_true_condition() -> u256 {
+    bb0 (entry):
+-     v0 = select 1, 11, 22
+-     ret v0
++     ret 11
+  }
+  
+  fn @select_false_condition() -> u256 {
+    bb0 (entry):
+-     v0 = select 0, 11, 22
+-     ret v0
++     ret 22
+  }
+  
+  fn @select_equal_arms(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = select arg0, 7, 7
+-     ret v0
++     ret 7
+  }
+  

--- a/tests/ui/codegen/mir/sccp/sccp_no_fold.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_no_fold.stdout
@@ -1,8 +1,10 @@
-// === ROOT/tests/ui/codegen/mir/sccp/sccp_no_fold.mir (after sccp) ===
-@module SccpNoFold
-fn @with_arg(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = mul v0, 2
-    ret v1
-}
+- // === ROOT/tests/ui/codegen/mir/sccp/sccp_no_fold.mir (before sccp) ===
++ // === ROOT/tests/ui/codegen/mir/sccp/sccp_no_fold.mir (after sccp) ===
+  @module SccpNoFold
+  fn @with_arg(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+      v1 = mul v0, 2
+      ret v1
+  }
+  

--- a/tests/ui/codegen/mir/sccp/sccp_switch_order.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_switch_order.stdout
@@ -1,34 +1,41 @@
-// === ROOT/tests/ui/codegen/mir/sccp/sccp_switch_order.mir (after sccp) ===
-@module SccpSwitchOrder
-fn @earlier_unknown_case_blocks_fold(arg0: u256) -> u256 {
-  bb0 (entry):
-    switch 5, default bb3, [arg0 => bb1, 5 => bb2]
-  bb1:
-    ret 1
-  bb2:
-    ret 2
-  bb3:
-    invalid
-}
-
-fn @constant_cases_fold() -> u256 {
-  bb0 (entry):
-    jump bb2
-  bb1:
-    invalid
-  bb2:
-    ret 2
-  bb3:
-    invalid
-}
-
-fn @unknown_case_keeps_default(arg0: u256) -> u256 {
-  bb0 (entry):
-    switch 5, default bb3, [arg0 => bb1, 4 => bb2]
-  bb1:
-    ret 1
-  bb2:
-    invalid
-  bb3:
-    ret 3
-}
+- // === ROOT/tests/ui/codegen/mir/sccp/sccp_switch_order.mir (before sccp) ===
++ // === ROOT/tests/ui/codegen/mir/sccp/sccp_switch_order.mir (after sccp) ===
+  @module SccpSwitchOrder
+  fn @earlier_unknown_case_blocks_fold(arg0: u256) -> u256 {
+    bb0 (entry):
+      switch 5, default bb3, [arg0 => bb1, 5 => bb2]
+    bb1:
+      ret 1
+    bb2:
+      ret 2
+    bb3:
+-     ret 3
++     invalid
+  }
+  
+  fn @constant_cases_fold() -> u256 {
+    bb0 (entry):
+-     switch 5, default bb3, [1 => bb1, 5 => bb2]
++     jump bb2
+    bb1:
+-     ret 1
++     invalid
+    bb2:
+      ret 2
+    bb3:
+-     ret 3
++     invalid
+  }
+  
+  fn @unknown_case_keeps_default(arg0: u256) -> u256 {
+    bb0 (entry):
+      switch 5, default bb3, [arg0 => bb1, 4 => bb2]
+    bb1:
+      ret 1
+    bb2:
+-     ret 2
++     invalid
+    bb3:
+      ret 3
+  }
+  

--- a/tests/ui/codegen/mir/storage-dse/storage_dse.stdout
+++ b/tests/ui/codegen/mir/storage-dse/storage_dse.stdout
@@ -1,47 +1,64 @@
-// === ROOT/tests/ui/codegen/mir/storage-dse/storage_dse.mir (after storage-dse) ===
-@module StorageDse
-fn @remove_overwritten_store(arg0: u256) {
-  bb0 (entry):
-    sstore 0, 7 !metadata(storage=slot(0))
-    stop
-}
-
-fn @keep_store_observed_by_load(arg0: u256) -> u256 {
-  bb0 (entry):
-    sstore 0, arg0 !metadata(storage=slot(0))
-    v0 = sload 0 !metadata(storage=slot(0))
-    sstore 0, 7 !metadata(storage=slot(0))
-    ret v0
-}
-
-fn @remove_equal_store_after_load(arg0: u256) -> u256 {
-  bb0 (entry):
-    sstore 0, arg0 !metadata(storage=slot(0))
-    v0 = sload 0 !metadata(storage=slot(0))
-    ret v0
-}
-
-fn @keep_may_alias_symbolic_store(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    sstore arg0, 1 !metadata(storage=symbolic(arg0))
-    sstore arg1, 2 !metadata(storage=symbolic(arg1))
-    stop
-}
-
-fn @remove_disjoint_offset_overwrite(arg0: u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = add arg0, 2
-    sstore v1, 2 !metadata(storage=offset(arg0, 2))
-    v2 = add arg0, 1
-    sstore v2, 3 !metadata(storage=offset(arg0, 1))
-    stop
-}
-
-fn @keep_across_call(arg0: u256, arg1: address) {
-  bb0 (entry):
-    sstore 0, arg0 !metadata(storage=slot(0))
-    v0 = call 0x186a0, arg1, 0, 0, 0, 0, 0
-    sstore 0, 7 !metadata(storage=slot(0))
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/storage-dse/storage_dse.mir (before storage-dse) ===
++ // === ROOT/tests/ui/codegen/mir/storage-dse/storage_dse.mir (after storage-dse) ===
+  @module StorageDse
+  fn @remove_overwritten_store(arg0: u256) {
+    bb0 (entry):
+-     sstore 0, arg0
+-     sstore 0, 7
++     sstore 0, 7 !metadata(storage=slot(0))
+      stop
+  }
+  
+  fn @keep_store_observed_by_load(arg0: u256) -> u256 {
+    bb0 (entry):
+-     sstore 0, arg0
+-     v0 = sload 0
+-     sstore 0, 7
++     sstore 0, arg0 !metadata(storage=slot(0))
++     v0 = sload 0 !metadata(storage=slot(0))
++     sstore 0, 7 !metadata(storage=slot(0))
+      ret v0
+  }
+  
+  fn @remove_equal_store_after_load(arg0: u256) -> u256 {
+    bb0 (entry):
+-     sstore 0, arg0
+-     v0 = sload 0
+-     sstore 0, arg0
++     sstore 0, arg0 !metadata(storage=slot(0))
++     v0 = sload 0 !metadata(storage=slot(0))
+      ret v0
+  }
+  
+  fn @keep_may_alias_symbolic_store(arg0: u256, arg1: u256) {
+    bb0 (entry):
+-     sstore arg0, 1
+-     sstore arg1, 2
++     sstore arg0, 1 !metadata(storage=symbolic(arg0))
++     sstore arg1, 2 !metadata(storage=symbolic(arg1))
+      stop
+  }
+  
+  fn @remove_disjoint_offset_overwrite(arg0: u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     sstore v0, 1
+      v1 = add arg0, 2
+-     sstore v1, 2
++     sstore v1, 2 !metadata(storage=offset(arg0, 2))
+      v2 = add arg0, 1
+-     sstore v2, 3
++     sstore v2, 3 !metadata(storage=offset(arg0, 1))
+      stop
+  }
+  
+  fn @keep_across_call(arg0: u256, arg1: address) {
+    bb0 (entry):
+-     sstore 0, arg0
++     sstore 0, arg0 !metadata(storage=slot(0))
+      v0 = call 0x186a0, arg1, 0, 0, 0, 0, 0
+-     sstore 0, 7
++     sstore 0, 7 !metadata(storage=slot(0))
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.stdout
+++ b/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.stdout
@@ -1,57 +1,80 @@
-// === ROOT/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.mir (after storage-load-cse) ===
-@module StorageLoadCse
-fn @reuse_across_disjoint_constant_store() -> u256 {
-  bb0 (entry):
-    v0 = sload 0 !metadata(storage=slot(0))
-    sstore 1, 9 !metadata(storage=slot(1))
-    v2 = add v0, v0
-    ret v2
-}
-
-fn @keep_after_same_slot_store() -> u256 {
-  bb0 (entry):
-    v0 = sload 0 !metadata(storage=slot(0))
-    sstore 0, 9 !metadata(storage=slot(0))
-    v1 = sload 0 !metadata(storage=slot(0))
-    v2 = add v0, v1
-    ret v2
-}
-
-fn @keep_after_symbolic_store(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = sload 0 !metadata(storage=slot(0))
-    sstore arg0, 9 !metadata(storage=symbolic(arg0))
-    v1 = sload 0 !metadata(storage=slot(0))
-    v2 = add v0, v1
-    ret v2
-}
-
-fn @reuse_across_disjoint_offset_store(arg0: u256) -> u256 {
-  bb0 (entry):
-    v0 = add arg0, 1
-    v1 = sload v0 !metadata(storage=offset(arg0, 1))
-    v2 = add arg0, 2
-    sstore v2, 9 !metadata(storage=offset(arg0, 2))
-    v3 = add arg0, 1
-    v5 = add v1, v1
-    ret v5
-}
-
-fn @keep_when_reuse_extends_live_range() -> u256 {
-  bb0 (entry):
-    v0 = sload 0 !metadata(storage=slot(0))
-    sstore 1, 9 !metadata(storage=slot(1))
-    v1 = sload 0 !metadata(storage=slot(0))
-    ret v1
-}
-
-fn @replace_uses_after_second_load() -> u256 {
-  bb0 (entry):
-    v0 = sload 0 !metadata(storage=slot(0))
-    v2 = add v0, v0
-    jump bb1
-  bb1:
-    v3 = phi [bb0: v0]
-    v4 = add v2, v3
-    ret v4
-}
+- // === ROOT/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.mir (before storage-load-cse) ===
++ // === ROOT/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.mir (after storage-load-cse) ===
+  @module StorageLoadCse
+  fn @reuse_across_disjoint_constant_store() -> u256 {
+    bb0 (entry):
+-     v0 = sload 0
+-     sstore 1, 9
+-     v1 = sload 0
+-     v2 = add v0, v1
++     v0 = sload 0 !metadata(storage=slot(0))
++     sstore 1, 9 !metadata(storage=slot(1))
++     v2 = add v0, v0
+      ret v2
+  }
+  
+  fn @keep_after_same_slot_store() -> u256 {
+    bb0 (entry):
+-     v0 = sload 0
+-     sstore 0, 9
+-     v1 = sload 0
++     v0 = sload 0 !metadata(storage=slot(0))
++     sstore 0, 9 !metadata(storage=slot(0))
++     v1 = sload 0 !metadata(storage=slot(0))
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @keep_after_symbolic_store(arg0: u256) -> u256 {
+    bb0 (entry):
+-     v0 = sload 0
+-     sstore arg0, 9
+-     v1 = sload 0
++     v0 = sload 0 !metadata(storage=slot(0))
++     sstore arg0, 9 !metadata(storage=symbolic(arg0))
++     v1 = sload 0 !metadata(storage=slot(0))
+      v2 = add v0, v1
+      ret v2
+  }
+  
+  fn @reuse_across_disjoint_offset_store(arg0: u256) -> u256 {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     v1 = sload v0
++     v1 = sload v0 !metadata(storage=offset(arg0, 1))
+      v2 = add arg0, 2
+-     sstore v2, 9
++     sstore v2, 9 !metadata(storage=offset(arg0, 2))
+      v3 = add arg0, 1
+-     v4 = sload v3
+-     v5 = add v1, v4
++     v5 = add v1, v1
+      ret v5
+  }
+  
+  fn @keep_when_reuse_extends_live_range() -> u256 {
+    bb0 (entry):
+-     v0 = sload 0
+-     sstore 1, 9
+-     v1 = sload 0
++     v0 = sload 0 !metadata(storage=slot(0))
++     sstore 1, 9 !metadata(storage=slot(1))
++     v1 = sload 0 !metadata(storage=slot(0))
+      ret v1
+  }
+  
+  fn @replace_uses_after_second_load() -> u256 {
+    bb0 (entry):
+-     v0 = sload 0
+-     v1 = sload 0
+-     v2 = add v0, v1
++     v0 = sload 0 !metadata(storage=slot(0))
++     v2 = add v0, v0
+      jump bb1
+    bb1:
+-     v3 = phi [bb0: v1]
++     v3 = phi [bb0: v0]
+      v4 = add v2, v3
+      ret v4
+  }
+  

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
@@ -1,120 +1,138 @@
-// === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir (after storage-promotion) ===
-@module StoragePromotion
-fn @promote_recomputed_offset_slot(arg0: u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    mstore 128, 1
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v1 = add arg0, 1
-    v2 = mload 128
-    v3 = mul v2, 2
-    v4 = add arg0, 1
-    mstore 128, v3
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v5 = mload 128
-    sstore v0, v5
-    stop
-}
-
-fn @reject_loop_variant_offset_slot(arg0: u256) {
-  bb0 (entry):
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb2: v4]
-    br 1, bb2, bb3
-  bb2:
-    v1 = add arg0, v0
-    v2 = sload v1 !metadata(storage=symbolic(v1))
-    v3 = add v2, 2
-    sstore v1, v3 !metadata(storage=symbolic(v1))
-    v4 = add v0, 1
-    jump bb1
-  bb3:
-    stop
-}
-
-fn @promote_store_only_without_initial_load() {
-  bb0 (entry):
-    mstore 160, 0
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    mstore 128, 7
-    mstore 160, 1
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v0 = mload 160
-    br v0, bb6, bb5
-  bb5:
-    stop
-  bb6:
-    v1 = mload 128
-    sstore 0, v1
-    jump bb5
-}
-
-fn @promote_two_initialized_slots() {
-  bb0 (entry):
-    mstore 128, 1
-    mstore 160, 2
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v0 = mload 128
-    v1 = mul v0, 2
-    mstore 128, v1
-    v2 = mload 160
-    v3 = add v2, 3
-    mstore 160, v3
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v5 = mload 160
-    sstore 1, v5
-    v4 = mload 128
-    sstore 0, v4
-    stop
-}
-
-fn @promote_without_init_rewrites_successor_phi() -> u256 {
-  bb0 (entry):
-    v3 = sload 0
-    mstore 128, v3
-    mstore 160, 0
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v0 = mload 128
-    v1 = add v0, 2
-    mstore 128, v1
-    mstore 160, 1
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v4 = mload 160
-    br v4, bb8, bb7
-  bb5:
-    v2 = phi [bb7: 7], [bb6: 9]
-    ret v2
-  bb6:
-    jump bb5
-  bb7:
-    jump bb5
-  bb8:
-    v5 = mload 128
-    sstore 0, v5
-    jump bb7
-}
+- // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir (before storage-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir (after storage-promotion) ===
+  @module StoragePromotion
+  fn @promote_recomputed_offset_slot(arg0: u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     sstore v0, 1
++     mstore 128, 1
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+      v1 = add arg0, 1
+-     v2 = sload v1
++     v2 = mload 128
+      v3 = mul v2, 2
+      v4 = add arg0, 1
+-     sstore v4, v3
++     mstore 128, v3
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
++     v5 = mload 128
++     sstore v0, v5
+      stop
+  }
+  
+  fn @reject_loop_variant_offset_slot(arg0: u256) {
+    bb0 (entry):
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb2: v4]
+      br 1, bb2, bb3
+    bb2:
+      v1 = add arg0, v0
+-     v2 = sload v1
++     v2 = sload v1 !metadata(storage=symbolic(v1))
+      v3 = add v2, 2
+-     sstore v1, v3
++     sstore v1, v3 !metadata(storage=symbolic(v1))
+      v4 = add v0, 1
+      jump bb1
+    bb3:
+      stop
+  }
+  
+  fn @promote_store_only_without_initial_load() {
+    bb0 (entry):
++     mstore 160, 0
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     sstore 0, 7
++     mstore 128, 7
++     mstore 160, 1
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
++     v0 = mload 160
++     br v0, bb6, bb5
++   bb5:
+      stop
++   bb6:
++     v1 = mload 128
++     sstore 0, v1
++     jump bb5
+  }
+  
+  fn @promote_two_initialized_slots() {
+    bb0 (entry):
+-     sstore 0, 1
+-     sstore 1, 2
++     mstore 128, 1
++     mstore 160, 2
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     v0 = sload 0
++     v0 = mload 128
+      v1 = mul v0, 2
+-     sstore 0, v1
+-     v2 = sload 1
++     mstore 128, v1
++     v2 = mload 160
+      v3 = add v2, 3
+-     sstore 1, v3
++     mstore 160, v3
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
++     v5 = mload 160
++     sstore 1, v5
++     v4 = mload 128
++     sstore 0, v4
+      stop
+  }
+  
+  fn @promote_without_init_rewrites_successor_phi() -> u256 {
+    bb0 (entry):
++     v3 = sload 0
++     mstore 128, v3
++     mstore 160, 0
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     v0 = sload 0
++     v0 = mload 128
+      v1 = add v0, 2
+-     sstore 0, v1
++     mstore 128, v1
++     mstore 160, 1
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
+-     jump bb5
++     v4 = mload 160
++     br v4, bb8, bb7
+    bb5:
+-     v2 = phi [bb4: 7], [bb6: 9]
++     v2 = phi [bb7: 7], [bb6: 9]
+      ret v2
+    bb6:
+      jump bb5
++   bb7:
++     jump bb5
++   bb8:
++     v5 = mload 128
++     sstore 0, v5
++     jump bb7
+  }
+  

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
@@ -1,99 +1,125 @@
-// === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir (after storage-promotion) ===
-@module StoragePromotionAlias
-fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) {
-  bb0 (entry):
-    sstore arg0, 1 !metadata(storage=symbolic(arg0))
-    sstore arg1, 2 !metadata(storage=symbolic(arg1))
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v0 = sload arg0 !metadata(storage=symbolic(arg0))
-    v1 = mul v0, 2
-    sstore arg0, v1 !metadata(storage=symbolic(arg0))
-    v2 = sload arg1 !metadata(storage=symbolic(arg1))
-    v3 = add v2, 3
-    sstore arg1, v3 !metadata(storage=symbolic(arg1))
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    stop
-}
-
-fn @reject_symbolic_and_constant_slots(arg0: u256) {
-  bb0 (entry):
-    sstore arg0, 1 !metadata(storage=symbolic(arg0))
-    sstore 7, 2 !metadata(storage=slot(7))
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v0 = sload arg0 !metadata(storage=symbolic(arg0))
-    v1 = mul v0, 2
-    sstore arg0, v1 !metadata(storage=symbolic(arg0))
-    v2 = sload 7 !metadata(storage=slot(7))
-    v3 = add v2, 3
-    sstore 7, v3 !metadata(storage=slot(7))
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    stop
-}
-
-fn @promote_two_constant_slots() {
-  bb0 (entry):
-    mstore 128, 1
-    mstore 160, 2
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v0 = mload 128
-    v1 = mul v0, 2
-    mstore 128, v1
-    v2 = mload 160
-    v3 = add v2, 3
-    mstore 160, v3
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v5 = mload 160
-    sstore 1, v5
-    v4 = mload 128
-    sstore 0, v4
-    stop
-}
-
-fn @promote_same_base_distinct_offsets(arg0: u256) {
-  bb0 (entry):
-    v0 = add arg0, 1
-    mstore 128, 1
-    v1 = add arg0, 2
-    mstore 160, 2
-    jump bb1
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    v2 = add arg0, 1
-    v3 = mload 128
-    v4 = mul v3, 2
-    v5 = add arg0, 1
-    mstore 128, v4
-    v6 = add arg0, 2
-    v7 = mload 160
-    v8 = add v7, 3
-    v9 = add arg0, 2
-    mstore 160, v8
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v11 = mload 160
-    sstore v1, v11
-    v10 = mload 128
-    sstore v0, v10
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir (before storage-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir (after storage-promotion) ===
+  @module StoragePromotionAlias
+  fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) {
+    bb0 (entry):
+-     sstore arg0, 1
+-     sstore arg1, 2
++     sstore arg0, 1 !metadata(storage=symbolic(arg0))
++     sstore arg1, 2 !metadata(storage=symbolic(arg1))
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     v0 = sload arg0
++     v0 = sload arg0 !metadata(storage=symbolic(arg0))
+      v1 = mul v0, 2
+-     sstore arg0, v1
+-     v2 = sload arg1
++     sstore arg0, v1 !metadata(storage=symbolic(arg0))
++     v2 = sload arg1 !metadata(storage=symbolic(arg1))
+      v3 = add v2, 3
+-     sstore arg1, v3
++     sstore arg1, v3 !metadata(storage=symbolic(arg1))
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
+      stop
+  }
+  
+  fn @reject_symbolic_and_constant_slots(arg0: u256) {
+    bb0 (entry):
+-     sstore arg0, 1
+-     sstore 7, 2
++     sstore arg0, 1 !metadata(storage=symbolic(arg0))
++     sstore 7, 2 !metadata(storage=slot(7))
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     v0 = sload arg0
++     v0 = sload arg0 !metadata(storage=symbolic(arg0))
+      v1 = mul v0, 2
+-     sstore arg0, v1
+-     v2 = sload 7
++     sstore arg0, v1 !metadata(storage=symbolic(arg0))
++     v2 = sload 7 !metadata(storage=slot(7))
+      v3 = add v2, 3
+-     sstore 7, v3
++     sstore 7, v3 !metadata(storage=slot(7))
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
+      stop
+  }
+  
+  fn @promote_two_constant_slots() {
+    bb0 (entry):
+-     sstore 0, 1
+-     sstore 1, 2
++     mstore 128, 1
++     mstore 160, 2
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     v0 = sload 0
++     v0 = mload 128
+      v1 = mul v0, 2
+-     sstore 0, v1
+-     v2 = sload 1
++     mstore 128, v1
++     v2 = mload 160
+      v3 = add v2, 3
+-     sstore 1, v3
++     mstore 160, v3
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
++     v5 = mload 160
++     sstore 1, v5
++     v4 = mload 128
++     sstore 0, v4
+      stop
+  }
+  
+  fn @promote_same_base_distinct_offsets(arg0: u256) {
+    bb0 (entry):
+      v0 = add arg0, 1
+-     sstore v0, 1
++     mstore 128, 1
+      v1 = add arg0, 2
+-     sstore v1, 2
++     mstore 160, 2
+      jump bb1
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+      v2 = add arg0, 1
+-     v3 = sload v2
++     v3 = mload 128
+      v4 = mul v3, 2
+      v5 = add arg0, 1
+-     sstore v5, v4
++     mstore 128, v4
+      v6 = add arg0, 2
+-     v7 = sload v6
++     v7 = mload 160
+      v8 = add v7, 3
+      v9 = add arg0, 2
+-     sstore v9, v8
++     mstore 160, v8
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
++     v11 = mload 160
++     sstore v1, v11
++     v10 = mload 128
++     sstore v0, v10
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
@@ -1,81 +1,91 @@
-// === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir (after storage-promotion) ===
-@module StoragePromotionNested
-fn @promote_outer_after_inner_flush_split() {
-  bb0 (entry):
-    v4 = sload 0
-    mstore 192, v4
-    mstore 224, 0
-    jump bb6
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    mstore 128, 7
-    mstore 160, 1
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v2 = mload 160
-    br v2, bb10, bb9
-  bb5:
-    v0 = mload 192
-    v1 = add v0, 1
-    mstore 192, v1
-    mstore 224, 1
-    jump bb6
-  bb6:
-    br 1, bb7, bb8
-  bb7:
-    mstore 160, 0
-    jump bb1
-  bb8:
-    v5 = mload 224
-    br v5, bb12, bb11
-  bb9:
-    jump bb5
-  bb10:
-    v3 = mload 128
-    mstore 192, v3
-    mstore 224, 1
-    jump bb9
-  bb11:
-    stop
-  bb12:
-    v6 = mload 192
-    sstore 0, v6
-    jump bb11
-}
-
-fn @reject_outer_when_inner_flush_may_alias(arg0: u256) {
-  bb0 (entry):
-    jump bb6
-  bb1:
-    br 1, bb2, bb4
-  bb2:
-    mstore 128, 7
-    mstore 160, 1
-    jump bb3
-  bb3:
-    jump bb1
-  bb4:
-    v2 = mload 160
-    br v2, bb10, bb9
-  bb5:
-    v0 = sload 0 !metadata(storage=slot(0))
-    v1 = add v0, 1
-    sstore 0, v1 !metadata(storage=slot(0))
-    jump bb6
-  bb6:
-    br 1, bb7, bb8
-  bb7:
-    mstore 160, 0
-    jump bb1
-  bb8:
-    stop
-  bb9:
-    jump bb5
-  bb10:
-    v3 = mload 128
-    sstore arg0, v3
-    jump bb9
-}
+- // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir (before storage-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir (after storage-promotion) ===
+  @module StoragePromotionNested
+  fn @promote_outer_after_inner_flush_split() {
+    bb0 (entry):
++     v4 = sload 0
++     mstore 192, v4
++     mstore 224, 0
+      jump bb6
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     sstore 0, 7
++     mstore 128, 7
++     mstore 160, 1
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
+-     jump bb5
++     v2 = mload 160
++     br v2, bb10, bb9
+    bb5:
+-     v0 = sload 0
++     v0 = mload 192
+      v1 = add v0, 1
+-     sstore 0, v1
++     mstore 192, v1
++     mstore 224, 1
+      jump bb6
+    bb6:
+      br 1, bb7, bb8
+    bb7:
++     mstore 160, 0
+      jump bb1
+    bb8:
++     v5 = mload 224
++     br v5, bb12, bb11
++   bb9:
++     jump bb5
++   bb10:
++     v3 = mload 128
++     mstore 192, v3
++     mstore 224, 1
++     jump bb9
++   bb11:
+      stop
++   bb12:
++     v6 = mload 192
++     sstore 0, v6
++     jump bb11
+  }
+  
+  fn @reject_outer_when_inner_flush_may_alias(arg0: u256) {
+    bb0 (entry):
+      jump bb6
+    bb1:
+      br 1, bb2, bb4
+    bb2:
+-     sstore arg0, 7
++     mstore 128, 7
++     mstore 160, 1
+      jump bb3
+    bb3:
+      jump bb1
+    bb4:
+-     jump bb5
++     v2 = mload 160
++     br v2, bb10, bb9
+    bb5:
+-     v0 = sload 0
++     v0 = sload 0 !metadata(storage=slot(0))
+      v1 = add v0, 1
+-     sstore 0, v1
++     sstore 0, v1 !metadata(storage=slot(0))
+      jump bb6
+    bb6:
+      br 1, bb7, bb8
+    bb7:
++     mstore 160, 0
+      jump bb1
+    bb8:
+      stop
++   bb9:
++     jump bb5
++   bb10:
++     v3 = mload 128
++     sstore arg0, v3
++     jump bb9
+  }
+  

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
@@ -1,81 +1,92 @@
-// === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir (after storage-promotion) ===
-@module StoragePromotionRevertExit
-fn @promote_checked_sum_loop(arg0: u256) {
-  bb0 (entry):
-    v6 = sload 0
-    mstore 128, v6
-    mstore 160, 0
-    jump bb1
-  bb1:
-    v0 = phi [bb0: 0], [bb5: v5]
-    v1 = lt v0, arg0
-    br v1, bb2, bb6
-  bb2:
-    v2 = mload 128
-    v3 = add v2, v0
-    v4 = lt v3, v2
-    br v4, bb3, bb4
-  bb3:
-    revert 0, 0
-  bb4:
-    mstore 128, v3
-    mstore 160, 1
-    jump bb5
-  bb5:
-    v5 = add v0, 1
-    jump bb1
-  bb6:
-    v7 = mload 160
-    br v7, bb8, bb7
-  bb7:
-    stop
-  bb8:
-    v8 = mload 128
-    sstore 0, v8
-    jump bb7
-}
-
-fn @promote_revert_exit_reads_slot(arg0: u256) {
-  bb0 (entry):
-    mstore 128, 1
-    jump bb1
-  bb1:
-    br 1, bb2, bb5
-  bb2:
-    v0 = mload 128
-    v1 = mul v0, 2
-    mstore 128, v1
-    v2 = lt v1, arg0
-    br v2, bb4, bb3
-  bb3:
-    v3 = mload 128
-    mstore 0, v3
-    revert 0, 32
-  bb4:
-    jump bb1
-  bb5:
-    v4 = mload 128
-    sstore 0, v4
-    stop
-}
-
-fn @reject_revert_exit_with_call(arg0: u256) {
-  bb0 (entry):
-    sstore 0, 1 !metadata(storage=slot(0))
-    jump bb1
-  bb1:
-    br 1, bb2, bb5
-  bb2:
-    v0 = sload 0 !metadata(storage=slot(0))
-    v1 = mul v0, 2
-    sstore 0, v1 !metadata(storage=slot(0))
-    v2 = lt v1, arg0
-    br v2, bb4, bb3
-  bb3:
-    v3 = call 100, arg0, 0, 0, 0, 0, 32
-    revert 0, 32
-  bb4:
-    jump bb1
-  bb5:
-    stop
-}
+- // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir (before storage-promotion) ===
++ // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir (after storage-promotion) ===
+  @module StoragePromotionRevertExit
+  fn @promote_checked_sum_loop(arg0: u256) {
+    bb0 (entry):
++     v6 = sload 0
++     mstore 128, v6
++     mstore 160, 0
+      jump bb1
+    bb1:
+      v0 = phi [bb0: 0], [bb5: v5]
+      v1 = lt v0, arg0
+      br v1, bb2, bb6
+    bb2:
+-     v2 = sload 0
++     v2 = mload 128
+      v3 = add v2, v0
+      v4 = lt v3, v2
+      br v4, bb3, bb4
+    bb3:
+      revert 0, 0
+    bb4:
+-     sstore 0, v3
++     mstore 128, v3
++     mstore 160, 1
+      jump bb5
+    bb5:
+      v5 = add v0, 1
+      jump bb1
+    bb6:
++     v7 = mload 160
++     br v7, bb8, bb7
++   bb7:
+      stop
++   bb8:
++     v8 = mload 128
++     sstore 0, v8
++     jump bb7
+  }
+  
+  fn @promote_revert_exit_reads_slot(arg0: u256) {
+    bb0 (entry):
+-     sstore 0, 1
++     mstore 128, 1
+      jump bb1
+    bb1:
+      br 1, bb2, bb5
+    bb2:
+-     v0 = sload 0
++     v0 = mload 128
+      v1 = mul v0, 2
+-     sstore 0, v1
++     mstore 128, v1
+      v2 = lt v1, arg0
+      br v2, bb4, bb3
+    bb3:
+-     v3 = sload 0
++     v3 = mload 128
+      mstore 0, v3
+      revert 0, 32
+    bb4:
+      jump bb1
+    bb5:
++     v4 = mload 128
++     sstore 0, v4
+      stop
+  }
+  
+  fn @reject_revert_exit_with_call(arg0: u256) {
+    bb0 (entry):
+-     sstore 0, 1
++     sstore 0, 1 !metadata(storage=slot(0))
+      jump bb1
+    bb1:
+      br 1, bb2, bb5
+    bb2:
+-     v0 = sload 0
++     v0 = sload 0 !metadata(storage=slot(0))
+      v1 = mul v0, 2
+-     sstore 0, v1
++     sstore 0, v1 !metadata(storage=slot(0))
+      v2 = lt v1, arg0
+      br v2, bb4, bb3
+    bb3:
+      v3 = call 100, arg0, 0, 0, 0, 0, 32
+      revert 0, 32
+    bb4:
+      jump bb1
+    bb5:
+      stop
+  }
+  

--- a/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
+++ b/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
@@ -1,21 +1,23 @@
-// === ROOT/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir (after dce) ===
-@module TailCallRoundtrip
-@phase dispatch
-fn @wrapper(arg0: u256) {
-  bb0 (entry):
-    mstore 128, arg0
-    returndata 128, 32
-}
-
-fn @entry() {
-  bb0 (entry):
-    v0 = calldataload 0
-    v1 = shr 224, v0
-    v2 = eq v1, 0x9507d39a
-    br v2, bb1, bb2
-  bb1:
-    v3 = calldataload 4
-    tail_call @wrapper, v3
-  bb2:
-    revert 0, 0
-}
+- // === ROOT/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir (before dce) ===
++ // === ROOT/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir (after dce) ===
+  @module TailCallRoundtrip
+  @phase dispatch
+  fn @wrapper(arg0: u256) {
+    bb0 (entry):
+      mstore 128, arg0
+      returndata 128, 32
+  }
+  
+  fn @entry() {
+    bb0 (entry):
+      v0 = calldataload 0
+      v1 = shr 224, v0
+      v2 = eq v1, 0x9507d39a
+      br v2, bb1, bb2
+    bb1:
+      v3 = calldataload 4
+      tail_call @wrapper, v3
+    bb2:
+      revert 0, 0
+  }
+  

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -125,17 +125,21 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             program: cmd.into(),
             args: {
                 let mut args: Vec<OsString> =
-                    ["-j1", "--error-format=rustc-json", "-Zui-testing", "-Zparse-yul"]
-                        .into_iter()
-                        .map(Into::into)
-                        .collect();
+                    ["-j1", "--error-format=rustc-json"].into_iter().map(Into::into).collect();
                 match mode {
-                    Mode::Mir => args.push("mir-opt".into()),
-                    Mode::EvmIr => args.push("evm-opt".into()),
+                    Mode::Mir => args.extend(
+                        ["mir-opt", "-Zui-testing", "-Zparse-yul", "-Zpass-diff"].map(Into::into),
+                    ),
+                    Mode::EvmIr => args.extend(
+                        ["evm-opt", "-Zui-testing", "-Zparse-yul", "-Zpass-diff"].map(Into::into),
+                    ),
                     Mode::StandardJson => {
-                        args.extend(["--standard-json".into(), "--pretty-json".into()]);
+                        args.extend(
+                            ["-Zui-testing", "-Zparse-yul", "--standard-json", "--pretty-json"]
+                                .map(Into::into),
+                        );
                     }
-                    _ => {}
+                    _ => args.extend(["-Zui-testing", "-Zparse-yul"].map(Into::into)),
                 }
                 if mode.is_solc() {
                     args.push("--stop-after=parsing".into());


### PR DESCRIPTION
Pass test snapshots currently show only the resulting IR, which hides what each transformation changed. The MIR and EVM IR test modes now opt into `-Zpass-diff`, which prints a rustc-style whole-file before/after diff for every explicitly selected pass, including the changed header line. A pass list produces a separate diff for each pass against the output of the preceding pass.

Direct `mir-opt` and `evm-opt` invocations retain their clean final-module output unless `-Zpass-diff` is requested, and `--pipeline-default` remains a clean pipeline snapshot. The current `ui_test` integration keeps its stdout normalization hooks private, so the expectations remain `.stdout`; Linguist attributes and Zed project settings render pass snapshots as Diff and give `.mir` and `.evmir` files approximate Rust and Assembly highlighting.
