### PR TITLE
refactor: use typed index vectors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,10 @@ Default format (conventional commits): `type: description` (feat, fix, perf, cho
 
 ## Notes
 
+- **Typed index collections**: Use `IndexVec<I, T>` for every collection indexed by an `I` index
+  type, including local variables. For `Vec<Option<T>>`, consider `FxHashMap<I, T>` when the
+  collection is expected to be sparse (mostly `None`); otherwise use `IndexVec<I, Option<T>>` when
+  it is indexed by `I`.
 - **Index sets**: Never use `Vec<bool>`; a bitset is always the more compact representation. Prefer
   fixed dense or mixed bitsets for compact, stable domains and growable bitsets when new indices
   may be allocated while the set is live. Use hash sets for sparse sets, especially when there are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,8 @@ Default format (conventional commits): `type: description` (feat, fix, perf, cho
 ## Notes
 
 - **Typed index collections**: Use `IndexVec<I, T>` for every collection indexed by an `I` index
-  type, including local variables.
+  type, including local variables; if code repeatedly indexes a collection with `x.index()`, it is
+  probably using the wrong collection type.
 - **Index sets**: Never use `Vec<bool>`; a bitset is always the more compact representation. Prefer
   fixed dense or mixed bitsets for compact, stable domains and growable bitsets when new indices
   may be allocated while the set is live. Use hash sets for sparse sets, especially when there are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,9 +295,7 @@ Default format (conventional commits): `type: description` (feat, fix, perf, cho
 ## Notes
 
 - **Typed index collections**: Use `IndexVec<I, T>` for every collection indexed by an `I` index
-  type, including local variables. For `Vec<Option<T>>`, consider `FxHashMap<I, T>` when the
-  collection is expected to be sparse (mostly `None`); otherwise use `IndexVec<I, Option<T>>` when
-  it is indexed by `I`.
+  type, including local variables.
 - **Index sets**: Never use `Vec<bool>`; a bitset is always the more compact representation. Prefer
   fixed dense or mixed bitsets for compact, stable domains and growable bitsets when new indices
   may be allocated while the set is live. Use hash sets for sparse sets, especially when there are

--- a/crates/codegen/src/analysis/cfg.rs
+++ b/crates/codegen/src/analysis/cfg.rs
@@ -31,7 +31,7 @@ impl CfgInfo {
     /// Snapshots the control-flow graph for `func`.
     #[must_use]
     pub(crate) fn new(func: &Function) -> Self {
-        let successors: IndexVec<BlockId, _> = func
+        let successors = func
             .blocks
             .iter()
             .map(|block| {

--- a/crates/codegen/src/analysis/cfg.rs
+++ b/crates/codegen/src/analysis/cfg.rs
@@ -10,13 +10,17 @@ use std::cell::OnceCell;
 
 use crate::mir::{BlockId, Function};
 use smallvec::SmallVec;
-use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
+use solar_data_structures::{
+    bit_set::DenseBitSet,
+    index::{IndexVec, index_vec},
+    map::FxHashMap,
+};
 
 /// Control-flow facts for one MIR function.
 #[derive(Clone, Debug)]
 pub(crate) struct CfgInfo {
     entry_block: BlockId,
-    successors: Vec<SmallVec<[BlockId; 2]>>,
+    successors: IndexVec<BlockId, SmallVec<[BlockId; 2]>>,
     reachable: OnceCell<DenseBitSet<BlockId>>,
     rpo: OnceCell<Vec<BlockId>>,
     dominators: OnceCell<DominatorTree>,
@@ -27,7 +31,7 @@ impl CfgInfo {
     /// Snapshots the control-flow graph for `func`.
     #[must_use]
     pub(crate) fn new(func: &Function) -> Self {
-        let successors = func
+        let successors: IndexVec<BlockId, _> = func
             .blocks
             .iter()
             .map(|block| {
@@ -47,7 +51,7 @@ impl CfgInfo {
     /// Returns successor blocks for `block`.
     #[must_use]
     pub(crate) fn successors(&self, block: BlockId) -> &[BlockId] {
-        &self.successors[block.index()]
+        &self.successors[block]
     }
 
     /// Returns the blocks reachable from the entry.
@@ -59,7 +63,7 @@ impl CfgInfo {
             stack.push(self.entry_block);
             while let Some(block) = stack.pop() {
                 if reachable.insert(block) {
-                    stack.extend(self.successors[block.index()].iter().copied());
+                    stack.extend(self.successors[block].iter().copied());
                 }
             }
             reachable
@@ -81,7 +85,7 @@ impl CfgInfo {
             let mut stack = vec![(self.entry_block, 0usize)];
             reachable.insert(self.entry_block);
             while let Some((block, next)) = stack.last_mut() {
-                if let Some(&succ) = self.successors[block.index()].get(*next) {
+                if let Some(&succ) = self.successors[*block].get(*next) {
                     *next += 1;
                     if reachable.insert(succ) {
                         stack.push((succ, 0));
@@ -112,14 +116,13 @@ impl CfgInfo {
         self.reachability.get_or_init(|| {
             let mut reachability = FxHashMap::default();
             let mut stack = Vec::new();
-            for block_index in 0..self.successors.len() {
-                let block_id = BlockId::from_usize(block_index);
+            for block_id in self.successors.indices() {
                 let mut reachable = DenseBitSet::new_empty(self.successors.len());
                 stack.clear();
-                stack.extend(self.successors[block_id.index()].iter().copied());
+                stack.extend(self.successors[block_id].iter().copied());
                 while let Some(block) = stack.pop() {
                     if reachable.insert(block) {
-                        stack.extend(self.successors[block.index()].iter().copied());
+                        stack.extend(self.successors[block].iter().copied());
                     }
                 }
                 reachability.insert(block_id, reachable);
@@ -132,31 +135,30 @@ impl CfgInfo {
 /// Immediate-dominator tree for one MIR function.
 #[derive(Clone, Debug)]
 pub(crate) struct DominatorTree {
-    idoms: Vec<Option<BlockId>>,
-    children: Vec<Vec<BlockId>>,
+    idoms: IndexVec<BlockId, Option<BlockId>>,
+    children: IndexVec<BlockId, Vec<BlockId>>,
 }
 
 impl DominatorTree {
     fn compute(
         entry_block: BlockId,
-        successors: &[SmallVec<[BlockId; 2]>],
+        successors: &IndexVec<BlockId, SmallVec<[BlockId; 2]>>,
         rpo: &[BlockId],
     ) -> Self {
         let block_count = successors.len();
-        let mut predecessors = vec![Vec::new(); block_count];
-        for (block_index, block_successors) in successors.iter().enumerate() {
-            let block = BlockId::from_usize(block_index);
+        let mut predecessors = index_vec![Vec::new(); block_count];
+        for (block, block_successors) in successors.iter_enumerated() {
             for &successor in block_successors {
-                predecessors[successor.index()].push(block);
+                predecessors[successor].push(block);
             }
         }
-        let mut rpo_numbers = vec![usize::MAX; block_count];
+        let mut rpo_numbers = index_vec![usize::MAX; block_count];
         for (number, &block) in rpo.iter().enumerate() {
-            rpo_numbers[block.index()] = number;
+            rpo_numbers[block] = number;
         }
 
-        let mut idoms = vec![None; block_count];
-        idoms[entry_block.index()] = Some(entry_block);
+        let mut idoms = index_vec![None; block_count];
+        idoms[entry_block] = Some(entry_block);
         let mut changed = true;
         while changed {
             changed = false;
@@ -165,8 +167,8 @@ impl DominatorTree {
                     continue;
                 }
                 let mut new_idom: Option<BlockId> = None;
-                for &pred in &predecessors[block.index()] {
-                    if idoms[pred.index()].is_none() {
+                for &pred in &predecessors[block] {
+                    if idoms[pred].is_none() {
                         continue;
                     }
                     new_idom = Some(match new_idom {
@@ -175,22 +177,21 @@ impl DominatorTree {
                     });
                 }
                 if let Some(new_idom) = new_idom
-                    && idoms[block.index()] != Some(new_idom)
+                    && idoms[block] != Some(new_idom)
                 {
-                    idoms[block.index()] = Some(new_idom);
+                    idoms[block] = Some(new_idom);
                     changed = true;
                 }
             }
         }
 
-        let mut children = vec![Vec::new(); block_count];
-        for (block_index, idom) in idoms.iter().copied().enumerate() {
-            let block = BlockId::from_usize(block_index);
+        let mut children = index_vec![Vec::new(); block_count];
+        for (block, idom) in idoms.iter_enumerated() {
             if block == entry_block {
                 continue;
             }
-            if let Some(idom) = idom {
-                children[idom.index()].push(block);
+            if let Some(idom) = *idom {
+                children[idom].push(block);
             }
         }
         for children in &mut children {
@@ -201,18 +202,18 @@ impl DominatorTree {
     }
 
     fn intersect(
-        idoms: &[Option<BlockId>],
-        rpo_numbers: &[usize],
+        idoms: &IndexVec<BlockId, Option<BlockId>>,
+        rpo_numbers: &IndexVec<BlockId, usize>,
         a: BlockId,
         b: BlockId,
     ) -> BlockId {
         let (mut a, mut b) = (a, b);
         while a != b {
-            while rpo_numbers[a.index()] > rpo_numbers[b.index()] {
-                a = idoms[a.index()].expect("processed block has an immediate dominator");
+            while rpo_numbers[a] > rpo_numbers[b] {
+                a = idoms[a].expect("processed block has an immediate dominator");
             }
-            while rpo_numbers[b.index()] > rpo_numbers[a.index()] {
-                b = idoms[b.index()].expect("processed block has an immediate dominator");
+            while rpo_numbers[b] > rpo_numbers[a] {
+                b = idoms[b].expect("processed block has an immediate dominator");
             }
         }
         a
@@ -221,7 +222,7 @@ impl DominatorTree {
     /// Returns the immediate dominator of `block`, if reachable.
     #[must_use]
     pub(crate) fn idom(&self, block: BlockId) -> Option<BlockId> {
-        self.idoms.get(block.index()).copied().flatten()
+        self.idoms.get(block).copied().flatten()
     }
 
     /// Returns true if `dominator` dominates `block`.
@@ -242,7 +243,7 @@ impl DominatorTree {
     /// Returns dominator-tree children of `block`.
     #[must_use]
     pub(crate) fn children(&self, block: BlockId) -> &[BlockId] {
-        self.children.get(block.index()).map_or(&[], Vec::as_slice)
+        self.children.get(block).map_or(&[], Vec::as_slice)
     }
 
     /// Returns `block`, then its immediate dominators up to the entry.

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -14,6 +14,7 @@ use crate::mir::{BlockId, Function, InstId, Terminator, Value, ValueId};
 use smallvec::SmallVec;
 use solar_data_structures::{
     bit_set::{DenseBitSet, GrowableBitSet},
+    index::{IndexVec, index_vec},
     map::FxHashMap,
 };
 use std::collections::VecDeque;
@@ -41,7 +42,7 @@ struct BlockLiveness {
 #[derive(Debug)]
 pub(crate) struct Liveness {
     /// Per-block liveness information (indexed by block index).
-    block_liveness: Vec<BlockLiveness>,
+    block_liveness: IndexVec<BlockId, BlockLiveness>,
     /// The last use location of each value within each block: (block, instruction index).
     /// The key is (ValueId, BlockId), and value is the instruction index (None = terminator).
     /// This tracks the last use of a value *within* each block where it's used.
@@ -68,7 +69,7 @@ impl Liveness {
         }
 
         // Initialize per-block liveness
-        let mut block_liveness: Vec<BlockLiveness> = (0..num_blocks)
+        let mut block_liveness: IndexVec<BlockId, BlockLiveness> = (0..num_blocks)
             .map(|_| BlockLiveness {
                 live_in: LiveSet::with_capacity(num_values),
                 live_out: LiveSet::with_capacity(num_values),
@@ -76,15 +77,14 @@ impl Liveness {
             .collect();
 
         // Compute local def/use sets for each block
-        let mut block_defs: Vec<LiveSet> =
+        let mut block_defs: IndexVec<BlockId, LiveSet> =
             (0..num_blocks).map(|_| LiveSet::with_capacity(num_values)).collect();
-        let mut block_uses: Vec<LiveSet> =
+        let mut block_uses: IndexVec<BlockId, LiveSet> =
             (0..num_blocks).map(|_| LiveSet::with_capacity(num_values)).collect();
 
         let mut operand_buf = SmallVec::<[ValueId; 8]>::new();
 
         for (block_id, block) in func.blocks.iter_enumerated() {
-            let bidx = block_id.index();
             // Process instructions in forward order to compute upward-exposed uses and defs
             for &inst_id in &block.instructions {
                 let inst = func.instruction(inst_id);
@@ -93,14 +93,14 @@ impl Liveness {
                 operand_buf.clear();
                 inst.kind.collect_operands(&mut operand_buf);
                 for &operand in &operand_buf {
-                    if !block_defs[bidx].contains(operand) {
-                        block_uses[bidx].insert(operand);
+                    if !block_defs[block_id].contains(operand) {
+                        block_uses[block_id].insert(operand);
                     }
                 }
 
                 // Record definition using precomputed map (O(1) instead of O(n)).
                 if let Some(&val_id) = inst_to_value.get(&inst_id) {
-                    block_defs[bidx].insert(val_id);
+                    block_defs[block_id].insert(val_id);
                 }
             }
 
@@ -109,8 +109,8 @@ impl Liveness {
                 operand_buf.clear();
                 collect_terminator_uses(term, &mut operand_buf);
                 for &operand in &operand_buf {
-                    if !block_defs[bidx].contains(operand) {
-                        block_uses[bidx].insert(operand);
+                    if !block_defs[block_id].contains(operand) {
+                        block_uses[block_id].insert(operand);
                     }
                 }
             }
@@ -127,26 +127,25 @@ impl Liveness {
 
         while let Some(block_id) = worklist.pop_front() {
             queued.remove(block_id);
-            let bidx = block_id.index();
             let block = &func.blocks[block_id];
 
             new_live_out.clear();
             let successors =
                 block.terminator.as_ref().map(Terminator::successors).unwrap_or_default();
             for succ in successors {
-                new_live_out.union(&block_liveness[succ.index()].live_in);
+                new_live_out.union(&block_liveness[succ].live_in);
             }
 
             // live_in = use ∪ (live_out - def)
             new_live_in.clone_from(&new_live_out);
-            new_live_in.subtract(&block_defs[bidx]);
-            new_live_in.union(&block_uses[bidx]);
+            new_live_in.subtract(&block_defs[block_id]);
+            new_live_in.union(&block_uses[block_id]);
 
-            if new_live_out != block_liveness[bidx].live_out
-                || new_live_in != block_liveness[bidx].live_in
+            if new_live_out != block_liveness[block_id].live_out
+                || new_live_in != block_liveness[block_id].live_in
             {
-                std::mem::swap(&mut block_liveness[bidx].live_out, &mut new_live_out);
-                std::mem::swap(&mut block_liveness[bidx].live_in, &mut new_live_in);
+                std::mem::swap(&mut block_liveness[block_id].live_out, &mut new_live_out);
+                std::mem::swap(&mut block_liveness[block_id].live_in, &mut new_live_in);
 
                 // Add predecessors to worklist
                 for &pred in &block.predecessors {
@@ -204,15 +203,15 @@ impl Liveness {
             }
         }
 
-        let mut defining_blocks = vec![None; func.instructions.len()];
+        let mut defining_blocks = index_vec![None; func.instructions.len()];
         for (block_id, block) in func.blocks.iter_enumerated() {
             for &inst_id in &block.instructions {
-                defining_blocks[inst_id.index()] = Some(block_id);
+                defining_blocks[inst_id] = Some(block_id);
             }
         }
 
         let is_local = |value, block_id| match func.value(value) {
-            Value::Inst(inst_id) => defining_blocks[inst_id.index()] == Some(block_id),
+            Value::Inst(inst_id) => defining_blocks[*inst_id] == Some(block_id),
             Value::Arg { .. } => false,
             Value::Immediate(_) | Value::Undef(_) | Value::Error(_) => true,
         };
@@ -234,7 +233,7 @@ impl Liveness {
             }
         }
 
-        let block_liveness = (0..func.blocks.len())
+        let block_liveness: IndexVec<BlockId, _> = (0..func.blocks.len())
             .map(|_| BlockLiveness {
                 live_in: LiveSet::new_empty(),
                 live_out: LiveSet::new_empty(),
@@ -264,20 +263,20 @@ impl Liveness {
     /// Returns the values live at the entry of a block.
     #[must_use]
     pub(crate) fn live_in(&self, block: BlockId) -> &LiveSet {
-        &self.block_liveness[block.index()].live_in
+        &self.block_liveness[block].live_in
     }
 
     /// Returns the values live at the exit of a block.
     #[must_use]
     pub(crate) fn live_out(&self, block: BlockId) -> &LiveSet {
-        &self.block_liveness[block.index()].live_out
+        &self.block_liveness[block].live_out
     }
 
     #[cfg(test)]
     fn live_at_inst(&self, func: &Function, block_id: BlockId, inst_idx: usize) -> LivenessInfo {
         let block = &func.blocks[block_id];
         let inst_to_value = func.inst_results();
-        let mut live = self.block_liveness[block_id.index()].live_out.clone();
+        let mut live = self.block_liveness[block_id].live_out.clone();
 
         if let Some(term) = &block.terminator {
             let mut term_uses = SmallVec::<[ValueId; 8]>::new();
@@ -319,7 +318,7 @@ impl Liveness {
         block: BlockId,
         inst_idx: usize,
     ) -> bool {
-        if self.block_liveness[block.index()].live_out.contains(val) {
+        if self.block_liveness[block].live_out.contains(val) {
             return true;
         }
 
@@ -338,7 +337,7 @@ impl Liveness {
     #[must_use]
     pub(crate) fn is_dead_after(&self, val: ValueId, block: BlockId, inst_idx: usize) -> bool {
         // If the value is in live_out, it's used by successor blocks, so it's not dead
-        if self.block_liveness[block.index()].live_out.contains(val) {
+        if self.block_liveness[block].live_out.contains(val) {
             return false;
         }
 

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -69,17 +69,20 @@ impl Liveness {
         }
 
         // Initialize per-block liveness
-        let mut block_liveness = index_vec![
-            BlockLiveness {
+        let mut block_liveness = (0..num_blocks)
+            .map(|_| BlockLiveness {
                 live_in: LiveSet::with_capacity(num_values),
                 live_out: LiveSet::with_capacity(num_values),
-            };
-            num_blocks
-        ];
+            })
+            .collect::<IndexVec<BlockId, _>>();
 
         // Compute local def/use sets for each block
-        let mut block_defs = index_vec![LiveSet::with_capacity(num_values); num_blocks];
-        let mut block_uses = index_vec![LiveSet::with_capacity(num_values); num_blocks];
+        let mut block_defs = (0..num_blocks)
+            .map(|_| LiveSet::with_capacity(num_values))
+            .collect::<IndexVec<BlockId, _>>();
+        let mut block_uses = (0..num_blocks)
+            .map(|_| LiveSet::with_capacity(num_values))
+            .collect::<IndexVec<BlockId, _>>();
 
         let mut operand_buf = SmallVec::<[ValueId; 8]>::new();
 

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -69,18 +69,17 @@ impl Liveness {
         }
 
         // Initialize per-block liveness
-        let mut block_liveness: IndexVec<BlockId, BlockLiveness> = (0..num_blocks)
-            .map(|_| BlockLiveness {
+        let mut block_liveness = index_vec![
+            BlockLiveness {
                 live_in: LiveSet::with_capacity(num_values),
                 live_out: LiveSet::with_capacity(num_values),
-            })
-            .collect();
+            };
+            num_blocks
+        ];
 
         // Compute local def/use sets for each block
-        let mut block_defs: IndexVec<BlockId, LiveSet> =
-            (0..num_blocks).map(|_| LiveSet::with_capacity(num_values)).collect();
-        let mut block_uses: IndexVec<BlockId, LiveSet> =
-            (0..num_blocks).map(|_| LiveSet::with_capacity(num_values)).collect();
+        let mut block_defs = index_vec![LiveSet::with_capacity(num_values); num_blocks];
+        let mut block_uses = index_vec![LiveSet::with_capacity(num_values); num_blocks];
 
         let mut operand_buf = SmallVec::<[ValueId; 8]>::new();
 
@@ -233,12 +232,13 @@ impl Liveness {
             }
         }
 
-        let block_liveness: IndexVec<BlockId, _> = (0..func.blocks.len())
-            .map(|_| BlockLiveness {
+        let block_liveness = index_vec![
+            BlockLiveness {
                 live_in: LiveSet::new_empty(),
                 live_out: LiveSet::new_empty(),
-            })
-            .collect();
+            };
+            func.blocks.len()
+        ];
         let mut last_use_in_block = FxHashMap::default();
         for (block_id, block) in func.blocks.iter_enumerated() {
             if let Some(term) = &block.terminator {

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -26,6 +26,7 @@ use alloy_primitives::U256;
 use solar_config::OptimizationMode;
 use solar_data_structures::{
     bit_set::{DenseBitSet, GrowableBitSet},
+    index::IndexVec,
     map::FxHashMap,
 };
 use solar_interface::sym;
@@ -1164,10 +1165,12 @@ impl<'gcx> EvmCodegen<'gcx> {
     fn generate_dispatcher(&mut self, module: &Module) {
         // Find executable receive and fallback functions. Interface/abstract declarations can
         // have ABI entries but no MIR body, so they must not participate in runtime dispatch.
-        let receive_idx =
-            module.functions.iter().position(|f| f.attributes.is_receive && Self::has_body(f));
-        let fallback_idx =
-            module.functions.iter().position(|f| f.attributes.is_fallback && Self::has_body(f));
+        let receive_idx = module.functions.iter_enumerated().find_map(|(func_id, func)| {
+            (func.attributes.is_receive && Self::has_body(func)).then_some(func_id)
+        });
+        let fallback_idx = module.functions.iter_enumerated().find_map(|(func_id, func)| {
+            (func.attributes.is_fallback && Self::has_body(func)).then_some(func_id)
+        });
 
         let call_graph = CallGraphInfo::new(module);
         let internal_targets = call_graph.reachable_bodies_from(
@@ -1193,7 +1196,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.compute_stack_arg_masks(module);
 
         // Create labels for externally reachable runtime entry points and internal-call targets.
-        let mut func_labels: Vec<Option<Label>> = Vec::new();
+        let mut func_labels = IndexVec::<FunctionId, Option<Label>>::new();
         for (func_id, func) in module.functions.iter_enumerated() {
             let external = Self::is_external_entry(func);
             let needs_body =
@@ -1258,16 +1261,15 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         let mut selectors: Vec<_> = module
             .functions
-            .iter()
-            .enumerate()
-            .filter_map(|(i, func)| {
+            .iter_enumerated()
+            .filter_map(|(func_id, func)| {
                 if !Self::is_external_entry(func) {
                     return None;
                 }
                 let selector = func.selector?;
                 Some(SelectorDispatchEntry {
                     selector: u32::from_be_bytes(selector),
-                    label: func_labels[i].expect("selector label missing"),
+                    label: func_labels[func_id].expect("selector label missing"),
                 })
             })
             .collect();
@@ -1282,7 +1284,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             if !Self::is_external_entry(func) {
                 continue;
             }
-            let Some(label) = func_labels[func_id.index()] else { continue };
+            let Some(label) = func_labels[func_id] else { continue };
             self.asm.define_label(label);
 
             // The dispatcher's shr'd selector is still on the physical stack
@@ -1310,7 +1312,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             if Self::is_external_entry(func) || !Self::has_body(func) {
                 continue;
             }
-            let Some(label) = func_labels[func_id.index()] else { continue };
+            let Some(label) = func_labels[func_id] else { continue };
             self.asm.define_label(label);
             self.emit_stack_arg_prologue(func_id, func);
             self.in_internal_function = true;

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -1196,7 +1196,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.compute_stack_arg_masks(module);
 
         // Create labels for externally reachable runtime entry points and internal-call targets.
-        let mut func_labels = IndexVec::<FunctionId, Option<Label>>::new();
+        let mut func_labels = IndexVec::new();
         for (func_id, func) in module.functions.iter_enumerated() {
             let external = Self::is_external_entry(func);
             let needs_body =

--- a/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
@@ -14,7 +14,7 @@ use crate::backend::evm::{
     op,
 };
 use alloy_primitives::U256;
-use solar_data_structures::bit_set::DenseBitSet;
+use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec};
 use solar_sema::Gcx;
 
 pub(super) fn run(gcx: Gcx<'_>, module: &mut Module) -> bool {
@@ -27,7 +27,7 @@ pub(super) fn run(gcx: Gcx<'_>, module: &mut Module) -> bool {
         if let Some(target) = layout_successor(block)
             && target.index() < state.predecessor_counts.len()
         {
-            state.predecessor_counts[target.index()] += 1;
+            state.predecessor_counts[target] += 1;
         }
     }
 
@@ -36,7 +36,7 @@ pub(super) fn run(gcx: Gcx<'_>, module: &mut Module) -> bool {
     }
     for cold in [false, true] {
         for block in module.blocks.indices() {
-            if state.predecessor_counts[block.index()] == 0
+            if state.predecessor_counts[block] == 0
                 && is_cold_terminal_block(&module.blocks[block]) == cold
             {
                 append_layout_trace(module, block, &mut state.placed, &mut state.order);
@@ -61,10 +61,10 @@ pub(super) fn run(gcx: Gcx<'_>, module: &mut Module) -> bool {
 }
 
 struct RunState {
-    predecessor_counts: Vec<usize>,
+    predecessor_counts: IndexVec<BlockId, usize>,
     order: Vec<BlockId>,
     placed: DenseBitSet<BlockId>,
-    references: Vec<usize>,
+    references: IndexVec<BlockId, usize>,
     candidates: Vec<Candidate>,
     picked: DenseBitSet<BlockId>,
     picked_order: Vec<BlockId>,
@@ -73,10 +73,10 @@ struct RunState {
 impl Default for RunState {
     fn default() -> Self {
         Self {
-            predecessor_counts: Vec::new(),
+            predecessor_counts: IndexVec::new(),
             order: Vec::new(),
             placed: DenseBitSet::new_empty(0),
-            references: Vec::new(),
+            references: IndexVec::new(),
             candidates: Vec::new(),
             picked: DenseBitSet::new_empty(0),
             picked_order: Vec::new(),
@@ -129,7 +129,7 @@ fn pack_hot_terminal_blocks(gcx: Gcx<'_>, module: &Module, state: &mut RunState)
                 gcx,
                 &module.blocks[block],
                 state.order.get(index + 1).copied(),
-                state.references[block.index()] != 0,
+                state.references[block] != 0,
             )
         })
         .sum();
@@ -152,9 +152,9 @@ fn pack_hot_terminal_blocks(gcx: Gcx<'_>, module: &Module, state: &mut RunState)
             gcx,
             &module.blocks[block],
             state.order.get(position + 1).copied(),
-            state.references[block.index()] != 0,
+            state.references[block] != 0,
         );
-        let count = state.references[block.index()];
+        let count = state.references[block];
         if size <= 32 && count >= 2 {
             state.candidates.push(Candidate { block, position, size, references: count });
         }
@@ -180,17 +180,21 @@ fn pack_hot_terminal_blocks(gcx: Gcx<'_>, module: &Module, state: &mut RunState)
     state.order.splice(insert_at..insert_at, state.picked_order.drain(..));
 }
 
-fn block_reference_counts(module: &Module, order: &[BlockId], references: &mut [usize]) {
+fn block_reference_counts(
+    module: &Module,
+    order: &[BlockId],
+    references: &mut IndexVec<BlockId, usize>,
+) {
     for (position, &block_id) in order.iter().enumerate() {
         let block = &module.blocks[block_id];
         for inst in &block.instructions {
             if let Some(PushValue::Block(block)) = &inst.value {
-                references[block.index()] += 1;
+                references[*block] += 1;
             }
         }
         if let Some(term) = &block.terminator {
             term.kind.visit_label_targets(order.get(position + 1).copied(), |target| {
-                references[target.index()] += 1;
+                references[target] += 1;
             });
         }
     }

--- a/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
@@ -5,10 +5,7 @@ use crate::backend::evm::{
     ir::{BlockId, Module, PushValue, Terminator, TerminatorKind},
     op,
 };
-use solar_data_structures::{
-    bit_set::DenseBitSet,
-    index::{Idx, IndexVec},
-};
+use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec};
 use solar_sema::Gcx;
 
 pub(super) fn run(_gcx: Gcx<'_>, module: &mut Module) -> bool {
@@ -57,21 +54,15 @@ impl Default for RunState {
 
 impl RunState {
     fn reserve(&mut self, blocks: usize) {
-        reserve_index_vec_to(&mut self.thunks, blocks);
+        reserve_to(self.thunks.as_mut_vec(), blocks);
         reserve_to(&mut self.pending, blocks);
-        reserve_index_vec_to(&mut self.references, blocks);
+        reserve_to(self.references.as_mut_vec(), blocks);
         reserve_to(&mut self.order, blocks);
     }
 }
 
 fn reserve_to<T>(values: &mut Vec<T>, capacity: usize) {
     if values.capacity() < capacity {
-        values.reserve(capacity - values.len());
-    }
-}
-
-fn reserve_index_vec_to<I: Idx, T>(values: &mut IndexVec<I, T>, capacity: usize) {
-    if values.as_vec().capacity() < capacity {
         values.reserve(capacity - values.len());
     }
 }

--- a/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
@@ -5,7 +5,10 @@ use crate::backend::evm::{
     ir::{BlockId, Module, PushValue, Terminator, TerminatorKind},
     op,
 };
-use solar_data_structures::bit_set::DenseBitSet;
+use solar_data_structures::{
+    bit_set::DenseBitSet,
+    index::{Idx, IndexVec},
+};
 use solar_sema::Gcx;
 
 pub(super) fn run(_gcx: Gcx<'_>, module: &mut Module) -> bool {
@@ -31,10 +34,10 @@ pub(super) fn run(_gcx: Gcx<'_>, module: &mut Module) -> bool {
 }
 
 struct RunState {
-    thunks: Vec<Option<BlockId>>,
+    thunks: IndexVec<BlockId, Option<BlockId>>,
     reachable: DenseBitSet<BlockId>,
     pending: Vec<BlockId>,
-    references: Vec<usize>,
+    references: IndexVec<BlockId, usize>,
     retained: DenseBitSet<BlockId>,
     order: Vec<BlockId>,
 }
@@ -42,10 +45,10 @@ struct RunState {
 impl Default for RunState {
     fn default() -> Self {
         Self {
-            thunks: Vec::new(),
+            thunks: IndexVec::new(),
             reachable: DenseBitSet::new_empty(0),
             pending: Vec::new(),
-            references: Vec::new(),
+            references: IndexVec::new(),
             retained: DenseBitSet::new_empty(0),
             order: Vec::new(),
         }
@@ -54,15 +57,21 @@ impl Default for RunState {
 
 impl RunState {
     fn reserve(&mut self, blocks: usize) {
-        reserve_to(&mut self.thunks, blocks);
+        reserve_index_vec_to(&mut self.thunks, blocks);
         reserve_to(&mut self.pending, blocks);
-        reserve_to(&mut self.references, blocks);
+        reserve_index_vec_to(&mut self.references, blocks);
         reserve_to(&mut self.order, blocks);
     }
 }
 
 fn reserve_to<T>(values: &mut Vec<T>, capacity: usize) {
     if values.capacity() < capacity {
+        values.reserve(capacity - values.len());
+    }
+}
+
+fn reserve_index_vec_to<I: Idx, T>(values: &mut IndexVec<I, T>, capacity: usize) {
+    if values.as_vec().capacity() < capacity {
         values.reserve(capacity - values.len());
     }
 }
@@ -82,7 +91,10 @@ fn truncate_after_terminal(module: &mut Module) -> bool {
     changed
 }
 
-fn redirect_jump_thunks(module: &mut Module, thunks: &mut Vec<Option<BlockId>>) -> bool {
+fn redirect_jump_thunks(
+    module: &mut Module,
+    thunks: &mut IndexVec<BlockId, Option<BlockId>>,
+) -> bool {
     thunks.clear();
     thunks.extend(module.blocks.iter().map(|block| {
         if block.instructions.is_empty() {
@@ -101,7 +113,7 @@ fn redirect_jump_thunks(module: &mut Module, thunks: &mut Vec<Option<BlockId>>) 
     let resolve = |start: BlockId| {
         let mut target = start;
         for _ in 0..thunks.len() {
-            let Some(next) = thunks[target.index()] else { break };
+            let Some(next) = thunks[target] else { break };
             if next == start {
                 return start;
             }
@@ -174,7 +186,7 @@ fn remove_unreachable_blocks(
 
 fn coalesce_blocks(
     module: &mut Module,
-    references: &mut Vec<usize>,
+    references: &mut IndexVec<BlockId, usize>,
     retained: &mut DenseBitSet<BlockId>,
     order: &mut Vec<BlockId>,
 ) -> bool {
@@ -183,11 +195,11 @@ fn coalesce_blocks(
     for block in &module.blocks {
         for inst in &block.instructions {
             if let Some(PushValue::Block(target)) = &inst.value {
-                references[target.index()] += 1;
+                references[*target] += 1;
             }
         }
         if let Some(term) = &block.terminator {
-            term.kind.visit_targets(|target| references[target.index()] += 1);
+            term.kind.visit_targets(|target| references[target] += 1);
         }
     }
 
@@ -206,7 +218,7 @@ fn coalesce_blocks(
             let target = *target;
             if target == predecessor
                 || Some(target) == module.entry_block
-                || references[target.index()] != 1
+                || references[target] != 1
                 || !retained.contains(target)
             {
                 break;

--- a/crates/codegen/src/backend/evm/ir/passes/outline.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/outline.rs
@@ -6,7 +6,11 @@ use crate::backend::evm::{
 };
 use alloy_primitives::U256;
 use smallvec::SmallVec;
-use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec, map::FxHashMap};
+use solar_data_structures::{
+    bit_set::DenseBitSet,
+    index::{IndexVec, index_vec},
+    map::FxHashMap,
+};
 use solar_sema::Gcx;
 use std::hash::{Hash, Hasher};
 
@@ -52,11 +56,11 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
         let first = sites[0];
         (std::cmp::Reverse(key.0.len()), first.block.index(), first.start)
     });
-    let mut claimed: IndexVec<BlockId, _> = module
+    let mut claimed = module
         .blocks
         .iter()
         .map(|block| DenseBitSet::new_empty(block.instructions.len()))
-        .collect();
+        .collect::<IndexVec<BlockId, _>>();
     let mut chosen = Vec::new();
     for (_, sites) in groups {
         let mut free = SmallVec::<[Site; 2]>::new();
@@ -97,7 +101,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
         stubs.push(module.add_block(stub));
     }
     let original_blocks = claimed.len();
-    let mut edits = IndexVec::from_vec(vec![BlockEdits::new(); original_blocks]);
+    let mut edits = index_vec![BlockEdits::new(); original_blocks];
     for (group, stub) in chosen.into_iter().zip(stubs) {
         for site in group.sites {
             edits[site.block].push((site.start, site.len, stub));
@@ -138,7 +142,7 @@ fn outline_repeated_pushes(gcx: Gcx<'_>, module: &mut Module, state: &mut RunSta
     values.sort_unstable();
 
     let original_blocks = module.blocks.len();
-    let mut edits = IndexVec::from_vec(vec![BlockEdits::new(); original_blocks]);
+    let mut edits = index_vec![BlockEdits::new(); original_blocks];
     for value in values {
         let mut stub = Block::new(state.next_label(module));
         stub.instructions.push(Instruction::push_value(value));

--- a/crates/codegen/src/backend/evm/ir/passes/outline.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/outline.rs
@@ -6,11 +6,14 @@ use crate::backend::evm::{
 };
 use alloy_primitives::U256;
 use smallvec::SmallVec;
-use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
+use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec, map::FxHashMap};
 use solar_sema::Gcx;
 use std::hash::{Hash, Hasher};
 
 const MIN_CLOSED_RUN: usize = 4;
+
+type BlockEdits = SmallVec<[(usize, usize, BlockId); 1]>;
+type OutlineEdits = IndexVec<BlockId, BlockEdits>;
 
 pub(super) fn run(gcx: Gcx<'_>, module: &mut Module) -> bool {
     let mut state = RunState::default();
@@ -49,7 +52,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
         let first = sites[0];
         (std::cmp::Reverse(key.0.len()), first.block.index(), first.start)
     });
-    let mut claimed: Vec<_> = module
+    let mut claimed: IndexVec<BlockId, _> = module
         .blocks
         .iter()
         .map(|block| DenseBitSet::new_empty(block.instructions.len()))
@@ -58,7 +61,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
     for (_, sites) in groups {
         let mut free = SmallVec::<[Site; 2]>::new();
         for site in sites {
-            if !claimed[site.block.index()].contains_any(site.start..site.start + site.len) {
+            if !claimed[site.block].contains_any(site.start..site.start + site.len) {
                 free.push(site);
             }
         }
@@ -75,7 +78,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
             continue;
         }
         for site in &free {
-            claimed[site.block.index()].insert_range(site.start..site.start + site.len);
+            claimed[site.block].insert_range(site.start..site.start + site.len);
         }
         chosen.push(ChosenGroup { body, sites: free, height: first.height });
     }
@@ -94,10 +97,10 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
         stubs.push(module.add_block(stub));
     }
     let original_blocks = claimed.len();
-    let mut edits = vec![SmallVec::<[_; 1]>::new(); original_blocks];
+    let mut edits = IndexVec::from_vec(vec![BlockEdits::new(); original_blocks]);
     for (group, stub) in chosen.into_iter().zip(stubs) {
         for site in group.sites {
-            edits[site.block.index()].push((site.start, site.len, stub));
+            edits[site.block].push((site.start, site.len, stub));
         }
     }
     apply_outline_edits(module, edits, state);
@@ -135,7 +138,7 @@ fn outline_repeated_pushes(gcx: Gcx<'_>, module: &mut Module, state: &mut RunSta
     values.sort_unstable();
 
     let original_blocks = module.blocks.len();
-    let mut edits = vec![SmallVec::<[_; 1]>::new(); original_blocks];
+    let mut edits = IndexVec::from_vec(vec![BlockEdits::new(); original_blocks]);
     for value in values {
         let mut stub = Block::new(state.next_label(module));
         stub.instructions.push(Instruction::push_value(value));
@@ -143,21 +146,17 @@ fn outline_repeated_pushes(gcx: Gcx<'_>, module: &mut Module, state: &mut RunSta
         stub.terminator = Some(Terminator::new(TerminatorKind::Op(op::JUMP)));
         let stub = module.add_block(stub);
         for &(block, index) in &sites[&value] {
-            edits[block.index()].push((index, 1, stub));
+            edits[block].push((index, 1, stub));
         }
     }
     apply_outline_edits(module, edits, state);
     true
 }
 
-fn apply_outline_edits(
-    module: &mut Module,
-    mut edits: Vec<SmallVec<[(usize, usize, BlockId); 1]>>,
-    state: &mut RunState,
-) {
-    for (block, edits) in edits.iter_mut().enumerate() {
+fn apply_outline_edits(module: &mut Module, mut edits: OutlineEdits, state: &mut RunState) {
+    for block in edits.indices() {
+        let edits = &mut edits[block];
         edits.sort_unstable_by_key(|(start, _, _)| std::cmp::Reverse(*start));
-        let block = BlockId::from_usize(block);
         for &(start, len, stub) in edits.iter() {
             split_outline_site(module, block, start, len, stub, state);
         }

--- a/crates/codegen/src/backend/evm/ir/passes/utils.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/utils.rs
@@ -5,10 +5,10 @@
 //! entry, push, and terminator reference together.
 
 use crate::backend::evm::{
-    ir::{Block, BlockId, Module, PushValue, TerminatorKind},
+    ir::{BlockId, Module, PushValue, TerminatorKind},
     op,
 };
-use solar_data_structures::index::IndexVec;
+use solar_data_structures::index::{IndexVec, index_vec};
 
 pub(super) fn is_evm_terminal(kind: &TerminatorKind) -> bool {
     matches!(kind, TerminatorKind::Op(opcode) if op::is_terminal(*opcode))
@@ -25,9 +25,9 @@ pub(super) fn retain_blocks(module: &mut Module, order: &[BlockId]) {
 }
 
 fn remap_blocks(module: &mut Module, order: &[BlockId]) {
-    let mut remap = IndexVec::from_vec(vec![None; module.blocks.len()]);
-    let mut old_blocks: IndexVec<BlockId, Option<Block>> =
-        std::mem::take(&mut module.blocks).into_iter().map(Some).collect();
+    let mut remap = index_vec![None; module.blocks.len()];
+    let mut old_blocks =
+        std::mem::take(&mut module.blocks).into_iter().map(Some).collect::<IndexVec<BlockId, _>>();
     let mut blocks = IndexVec::with_capacity(order.len());
     for &old_block in order {
         let block =

--- a/crates/codegen/src/backend/evm/ir/passes/utils.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/utils.rs
@@ -25,24 +25,23 @@ pub(super) fn retain_blocks(module: &mut Module, order: &[BlockId]) {
 }
 
 fn remap_blocks(module: &mut Module, order: &[BlockId]) {
-    let mut remap = vec![None; module.blocks.len()];
-    let mut old_blocks: Vec<Option<Block>> =
+    let mut remap = IndexVec::from_vec(vec![None; module.blocks.len()]);
+    let mut old_blocks: IndexVec<BlockId, Option<Block>> =
         std::mem::take(&mut module.blocks).into_iter().map(Some).collect();
     let mut blocks = IndexVec::with_capacity(order.len());
     for &old_block in order {
-        let block = old_blocks[old_block.index()]
-            .take()
-            .expect("block order must contain each block exactly once");
+        let block =
+            old_blocks[old_block].take().expect("block order must contain each block exactly once");
         let new_block = blocks.push(block);
-        remap[old_block.index()] = Some(new_block);
+        remap[old_block] = Some(new_block);
     }
     module.blocks = blocks;
     module.entry_block =
-        module.entry_block.map(|block| remap[block.index()].expect("entry block must be retained"));
+        module.entry_block.map(|block| remap[block].expect("entry block must be retained"));
     for block in &mut module.blocks {
         for inst in &mut block.instructions {
             if let Some(PushValue::Block(block)) = &mut inst.value {
-                *block = remap[block.index()].expect("referenced block must be retained");
+                *block = remap[*block].expect("referenced block must be retained");
             }
         }
         if let Some(term) = &mut block.terminator {
@@ -51,8 +50,8 @@ fn remap_blocks(module: &mut Module, order: &[BlockId]) {
     }
 }
 
-fn remap_terminator_blocks(kind: &mut TerminatorKind, remap: &[Option<BlockId>]) {
+fn remap_terminator_blocks(kind: &mut TerminatorKind, remap: &IndexVec<BlockId, Option<BlockId>>) {
     kind.visit_targets_mut(|target| {
-        *target = remap[target.index()].expect("terminator target must be retained");
+        *target = remap[*target].expect("terminator target must be retained");
     });
 }

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -348,7 +348,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         };
         for reference in &mut self.function_refs {
             if let FunctionRefTarget::Terminator(block) = &mut reference.target {
-                *block = block_remap[block.index()];
+                *block = block_remap[*block];
             }
         }
 

--- a/crates/codegen/src/mir/utils.rs
+++ b/crates/codegen/src/mir/utils.rs
@@ -5,23 +5,26 @@ use alloy_primitives::U256;
 use smallvec::smallvec;
 use solar_data_structures::{index::IndexVec, map::FxHashMap};
 
-pub(crate) fn remap_block_order(func: &mut Function, order: &[BlockId]) -> Vec<BlockId> {
+pub(crate) fn remap_block_order(
+    func: &mut Function,
+    order: &[BlockId],
+) -> IndexVec<BlockId, BlockId> {
     debug_assert_eq!(order.len(), func.blocks.len());
-    let mut remap = vec![BlockId::from_usize(0); order.len()];
-    let mut old_blocks: Vec<Option<BasicBlock>> =
+    let mut remap = IndexVec::from_vec(vec![BlockId::from_usize(0); order.len()]);
+    let mut old_blocks: IndexVec<BlockId, Option<BasicBlock>> =
         std::mem::take(&mut func.blocks).into_iter().map(Some).collect();
     let mut blocks = IndexVec::with_capacity(old_blocks.len());
     for &old_block in order {
-        let block = old_blocks[old_block.index()].take().expect("duplicate block in order");
-        remap[old_block.index()] = blocks.push(block);
+        let block = old_blocks[old_block].take().expect("duplicate block in order");
+        remap[old_block] = blocks.push(block);
     }
     debug_assert!(old_blocks.into_iter().all(|block| block.is_none()));
     func.blocks = blocks;
-    func.entry_block = remap[func.entry_block.index()];
+    func.entry_block = remap[func.entry_block];
 
     for block in &mut func.blocks {
         for predecessor in &mut block.predecessors {
-            *predecessor = remap[predecessor.index()];
+            *predecessor = remap[*predecessor];
         }
         if let Some(terminator) = &mut block.terminator {
             remap_terminator_blocks(terminator, &remap);
@@ -30,15 +33,15 @@ pub(crate) fn remap_block_order(func: &mut Function, order: &[BlockId]) -> Vec<B
     for inst in &mut func.instructions {
         if let InstKind::Phi(incoming) = &mut inst.kind {
             for (block, _) in incoming {
-                *block = remap[block.index()];
+                *block = remap[*block];
             }
         }
     }
     remap
 }
 
-fn remap_terminator_blocks(terminator: &mut Terminator, remap: &[BlockId]) {
-    let remap_block = |block: &mut BlockId| *block = remap[block.index()];
+fn remap_terminator_blocks(terminator: &mut Terminator, remap: &IndexVec<BlockId, BlockId>) {
+    let remap_block = |block: &mut BlockId| *block = remap[*block];
     match terminator {
         Terminator::Jump(target) => remap_block(target),
         Terminator::Branch { then_block, else_block, .. } => {

--- a/crates/codegen/src/mir/utils.rs
+++ b/crates/codegen/src/mir/utils.rs
@@ -3,16 +3,19 @@
 use crate::mir::{BasicBlock, BlockId, Function, InstKind, Terminator, ValueId};
 use alloy_primitives::U256;
 use smallvec::smallvec;
-use solar_data_structures::{index::IndexVec, map::FxHashMap};
+use solar_data_structures::{
+    index::{IndexVec, index_vec},
+    map::FxHashMap,
+};
 
 pub(crate) fn remap_block_order(
     func: &mut Function,
     order: &[BlockId],
 ) -> IndexVec<BlockId, BlockId> {
     debug_assert_eq!(order.len(), func.blocks.len());
-    let mut remap = IndexVec::from_vec(vec![BlockId::from_usize(0); order.len()]);
-    let mut old_blocks: IndexVec<BlockId, Option<BasicBlock>> =
-        std::mem::take(&mut func.blocks).into_iter().map(Some).collect();
+    let mut remap = index_vec![BlockId::from_usize(0); order.len()];
+    let mut old_blocks =
+        std::mem::take(&mut func.blocks).into_iter().map(Some).collect::<IndexVec<BlockId, _>>();
     let mut blocks = IndexVec::with_capacity(old_blocks.len());
     for &old_block in order {
         let block = old_blocks[old_block].take().expect("duplicate block in order");

--- a/crates/codegen/src/transform/check_elim.rs
+++ b/crates/codegen/src/transform/check_elim.rs
@@ -31,7 +31,10 @@ use crate::{
     pass::FunctionPass,
 };
 use alloy_primitives::U256;
-use solar_data_structures::map::{FxHashMap, FxHashSet};
+use solar_data_structures::{
+    index::{IndexVec, index_vec},
+    map::{FxHashMap, FxHashSet},
+};
 
 /// Maximum recursion depth when evaluating value ranges and conditions.
 const MAX_DEPTH: usize = 12;
@@ -133,10 +136,10 @@ impl CheckEliminator {
 
         // Predecessors recomputed from reachable terminators: facts must only
         // come from edges that can actually execute.
-        let mut preds: Vec<Vec<BlockId>> = vec![Vec::new(); func.blocks.len()];
+        let mut preds = index_vec![Vec::new(); func.blocks.len()];
         for &block in cfg.rpo() {
             for &succ in cfg.successors(block) {
-                preds[succ.index()].push(block);
+                preds[succ].push(block);
             }
         }
 
@@ -163,7 +166,7 @@ impl CheckEliminator {
         &mut self,
         func: &Function,
         cfg: &CfgInfo,
-        preds: &[Vec<BlockId>],
+        preds: &IndexVec<BlockId, Vec<BlockId>>,
     ) -> Vec<(BlockId, BlockId)> {
         enum Walk {
             Enter(BlockId),
@@ -596,7 +599,7 @@ impl CheckEliminator {
 /// the branch condition of its sole predecessor and whether it is true.
 fn dominating_edge_fact(
     func: &Function,
-    preds: &[Vec<BlockId>],
+    preds: &IndexVec<BlockId, Vec<BlockId>>,
     block: BlockId,
 ) -> Option<(ValueId, bool)> {
     // The entry executes before any branch, so no edge fact holds on it even
@@ -604,7 +607,7 @@ fn dominating_edge_fact(
     if block == func.entry_block {
         return None;
     }
-    let preds = &preds[block.index()];
+    let preds = &preds[block];
     let (&first, rest) = preds.split_first()?;
     if rest.iter().any(|&pred| pred != first) {
         return None;

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use solar_data_structures::{
     bit_set::{DenseBitSet, GrowableBitSet},
+    index::{IndexVec, index_vec},
     map::FxHashMap,
 };
 
@@ -735,7 +736,7 @@ impl<'a> SlotSsaBuilder<'a> {
         let mut worklist = sorted_blocks(&self.info.def_blocks);
 
         while let Some(block) = worklist.pop() {
-            let Some(frontier) = frontiers.get(block.index()) else { continue };
+            let Some(frontier) = frontiers.get(block) else { continue };
             for &frontier_block in frontier {
                 if !live_in.contains(frontier_block) || !phi_blocks.insert(frontier_block) {
                     continue;
@@ -747,8 +748,8 @@ impl<'a> SlotSsaBuilder<'a> {
         phi_blocks
     }
 
-    fn compute_dominance_frontiers(&self, func: &Function) -> Vec<Vec<BlockId>> {
-        let mut frontiers = vec![Vec::new(); func.blocks.len()];
+    fn compute_dominance_frontiers(&self, func: &Function) -> IndexVec<BlockId, Vec<BlockId>> {
+        let mut frontiers = index_vec![Vec::new(); func.blocks.len()];
         for block in func.blocks.indices() {
             if !self.cfg.is_reachable(block) {
                 continue;
@@ -767,8 +768,8 @@ impl<'a> SlotSsaBuilder<'a> {
             let Some(idom) = self.cfg.dominators().idom(block) else { continue };
             for mut runner in preds {
                 while runner != idom {
-                    if !frontiers[runner.index()].contains(&block) {
-                        frontiers[runner.index()].push(block);
+                    if !frontiers[runner].contains(&block) {
+                        frontiers[runner].push(block);
                     }
 
                     let Some(next) = self.cfg.dominators().idom(runner) else { break };

--- a/crates/codegen/src/transform/gvn.rs
+++ b/crates/codegen/src/transform/gvn.rs
@@ -194,7 +194,7 @@ impl GlobalValueNumberer {
         rpo: &[BlockId],
         inst_results: &FxHashMap<InstId, ValueId>,
     ) -> Option<IndexVec<ValueId, ClassId>> {
-        let mut vn: IndexVec<ValueId, ClassId> = func.values.indices().collect();
+        let mut vn = func.values.indices().collect::<IndexVec<ValueId, _>>();
         let mut immediate_reps: FxHashMap<Immediate, ValueId> = FxHashMap::default();
         let mut arg_reps: FxHashMap<u32, ValueId> = FxHashMap::default();
         for (value_id, value) in func.values.iter_enumerated() {

--- a/crates/codegen/src/transform/gvn.rs
+++ b/crates/codegen/src/transform/gvn.rs
@@ -50,7 +50,7 @@ use crate::{
     },
     pass::FunctionPass,
 };
-use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
+use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec, map::FxHashMap};
 
 /// Hard cap on value-numbering sweeps per round.
 const MAX_VN_SWEEPS: usize = 10;
@@ -122,7 +122,7 @@ enum ExprKind {
 }
 
 struct ReplaceCtx<'a> {
-    vn: &'a [ClassId],
+    vn: &'a IndexVec<ValueId, ClassId>,
     cfg: &'a CfgInfo,
     inst_results: &'a FxHashMap<InstId, ValueId>,
     replacements: &'a mut FxHashMap<ValueId, ValueId>,
@@ -159,7 +159,7 @@ impl GlobalValueNumberer {
         // classes start with a leader. This folds phi-of-same over constants.
         let mut leaders: FxHashMap<ClassId, ValueId> = FxHashMap::default();
         for (value_id, value) in func.values.iter_enumerated() {
-            if !matches!(value, Value::Inst(_)) && vn[value_id.index()] == value_id {
+            if !matches!(value, Value::Inst(_)) && vn[value_id] == value_id {
                 leaders.insert(value_id, value_id);
             }
         }
@@ -193,17 +193,17 @@ impl GlobalValueNumberer {
         func: &Function,
         rpo: &[BlockId],
         inst_results: &FxHashMap<InstId, ValueId>,
-    ) -> Option<Vec<ClassId>> {
-        let mut vn: Vec<ClassId> = func.values.indices().collect();
+    ) -> Option<IndexVec<ValueId, ClassId>> {
+        let mut vn: IndexVec<ValueId, ClassId> = func.values.indices().collect();
         let mut immediate_reps: FxHashMap<Immediate, ValueId> = FxHashMap::default();
         let mut arg_reps: FxHashMap<u32, ValueId> = FxHashMap::default();
         for (value_id, value) in func.values.iter_enumerated() {
             match value {
                 Value::Immediate(imm) => {
-                    vn[value_id.index()] = *immediate_reps.entry(imm.clone()).or_insert(value_id);
+                    vn[value_id] = *immediate_reps.entry(imm.clone()).or_insert(value_id);
                 }
                 Value::Arg { index, .. } => {
-                    vn[value_id.index()] = *arg_reps.entry(*index).or_insert(value_id);
+                    vn[value_id] = *arg_reps.entry(*index).or_insert(value_id);
                 }
                 Value::Inst(_) | Value::Undef(_) | Value::Error(_) => {}
             }
@@ -222,8 +222,8 @@ impl GlobalValueNumberer {
                     else {
                         continue;
                     };
-                    if vn[result.index()] != class {
-                        vn[result.index()] = class;
+                    if vn[result] != class {
+                        vn[result] = class;
                         changed = true;
                     }
                 }
@@ -246,14 +246,14 @@ impl GlobalValueNumberer {
         kind: &InstKind,
         ty: MirType,
         result: ValueId,
-        vn: &[ClassId],
+        vn: &IndexVec<ValueId, ClassId>,
         table: &mut FxHashMap<ExprKey, ClassId>,
     ) -> Option<ClassId> {
         if let InstKind::Phi(incoming) = kind {
             let Some((&(_, first), rest)) = incoming.split_first() else { return Some(result) };
             // Phi-of-same: a phi over one class is that class.
-            if rest.iter().all(|&(_, value)| vn[value.index()] == vn[first.index()]) {
-                return Some(vn[first.index()]);
+            if rest.iter().all(|&(_, value)| vn[value] == vn[first]) {
+                return Some(vn[first]);
             }
             let Some(incoming) = Self::phi_key_incoming(incoming, vn) else { return Some(result) };
             let key = ExprKey { kind: ExprKind::Phi(block_id, incoming), ty };
@@ -267,10 +267,10 @@ impl GlobalValueNumberer {
     /// sorted by predecessor with exact duplicates removed.
     fn phi_key_incoming(
         incoming: &[(BlockId, ValueId)],
-        vn: &[ClassId],
+        vn: &IndexVec<ValueId, ClassId>,
     ) -> Option<Vec<(BlockId, ClassId)>> {
         let mut entries: Vec<(BlockId, ClassId)> =
-            incoming.iter().map(|&(pred, value)| (pred, vn[value.index()])).collect();
+            incoming.iter().map(|&(pred, value)| (pred, vn[value])).collect();
         entries.sort_by_key(|&(pred, class)| (pred.index(), class.index()));
         entries.dedup();
         // A predecessor listed with two distinct classes has no well-defined
@@ -283,8 +283,8 @@ impl GlobalValueNumberer {
 
     /// Builds the expression shape over operand classes for pure word ops.
     /// Returns `None` for every other instruction.
-    fn expr_kind(kind: &InstKind, vn: &[ClassId]) -> Option<ExprKind> {
-        let class = |value: ValueId| vn[value.index()];
+    fn expr_kind(kind: &InstKind, vn: &IndexVec<ValueId, ClassId>) -> Option<ExprKind> {
+        let class = |value: ValueId| vn[value];
         let sorted = |a: ValueId, b: ValueId| {
             let (a, b) = (class(a), class(b));
             if b.index() < a.index() { (b, a) } else { (a, b) }
@@ -371,7 +371,7 @@ impl GlobalValueNumberer {
             if !matches!(kind, InstKind::Phi(_)) && Self::expr_kind(kind, ctx.vn).is_none() {
                 continue;
             }
-            let class = ctx.vn[result.index()];
+            let class = ctx.vn[result];
             if let Some(&leader) = leaders.get(&class) {
                 if leader != result {
                     ctx.replacements.insert(result, leader);

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -25,6 +25,7 @@ use crate::{
 use alloy_primitives::U256;
 use solar_data_structures::{
     bit_set::DenseBitSet,
+    index::IndexVec,
     map::{FxHashMap, FxHashSet},
 };
 use std::collections::VecDeque;
@@ -112,20 +113,20 @@ impl SccpPass {
             .collect();
 
         // Initialize lattice: all values start as Top.
-        let mut lattice: Vec<LatticeValue> = vec![LatticeValue::Top; num_values];
+        let mut lattice = IndexVec::<ValueId, _>::from_vec(vec![LatticeValue::Top; num_values]);
 
         // Arguments are overdefined (we don't know their runtime values).
         for (vid, val) in func.values.iter_enumerated() {
             match val {
-                Value::Arg { .. } => lattice[vid.index()] = LatticeValue::Bottom,
+                Value::Arg { .. } => lattice[vid] = LatticeValue::Bottom,
                 Value::Immediate(imm) => {
                     if let Some(v) = imm.as_u256() {
-                        lattice[vid.index()] = LatticeValue::Constant(v);
+                        lattice[vid] = LatticeValue::Constant(v);
                     } else {
-                        lattice[vid.index()] = LatticeValue::Bottom;
+                        lattice[vid] = LatticeValue::Bottom;
                     }
                 }
-                Value::Undef(_) | Value::Error(_) => lattice[vid.index()] = LatticeValue::Bottom,
+                Value::Undef(_) | Value::Error(_) => lattice[vid] = LatticeValue::Bottom,
                 Value::Inst(_) => {} // stays Top
             }
         }
@@ -231,7 +232,7 @@ impl SccpPass {
         func: &Function,
         block_id: BlockId,
         inst_to_value: &FxHashMap<InstId, ValueId>,
-        lattice: &mut [LatticeValue],
+        lattice: &mut IndexVec<ValueId, LatticeValue>,
         _executable_blocks: &DenseBitSet<BlockId>,
         _executable_edges: &FxHashSet<(BlockId, BlockId)>,
         cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
@@ -264,7 +265,7 @@ impl SccpPass {
         func: &Function,
         block_id: BlockId,
         inst_to_value: &FxHashMap<InstId, ValueId>,
-        lattice: &mut [LatticeValue],
+        lattice: &mut IndexVec<ValueId, LatticeValue>,
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
     ) {
@@ -278,7 +279,7 @@ impl SccpPass {
                 let mut result = LatticeValue::Top;
                 for &(pred, operand) in incoming {
                     if executable_edges.contains(&(pred, block_id)) {
-                        result = result.meet(&lattice[operand.index()]);
+                        result = result.meet(&lattice[operand]);
                     }
                 }
                 if self.update_lattice(lattice, vid, result) {
@@ -293,11 +294,11 @@ impl SccpPass {
         &self,
         _func: &Function,
         kind: &InstKind,
-        lattice: &[LatticeValue],
+        lattice: &IndexVec<ValueId, LatticeValue>,
     ) -> LatticeValue {
         // Helper: get the constant value of a ValueId, or None if not constant.
         let get_const = |v: ValueId| -> Option<U256> {
-            match &lattice[v.index()] {
+            match &lattice[v] {
                 LatticeValue::Constant(c) => Some(*c),
                 _ => None,
             }
@@ -434,15 +435,13 @@ impl SccpPass {
             },
 
             InstKind::Select(condition, then_value, else_value) => {
-                match &lattice[condition.index()] {
+                match &lattice[*condition] {
                     LatticeValue::Constant(c) => {
                         let chosen = if c.is_zero() { *else_value } else { *then_value };
-                        lattice[chosen.index()].clone()
+                        lattice[chosen].clone()
                     }
                     // Unknown condition: the result is whatever both arms agree on.
-                    LatticeValue::Bottom => {
-                        lattice[then_value.index()].meet(&lattice[else_value.index()])
-                    }
+                    LatticeValue::Bottom => lattice[*then_value].meet(&lattice[*else_value]),
                     LatticeValue::Top => match (get_const(*then_value), get_const(*else_value)) {
                         (Some(t), Some(e)) if t == e => LatticeValue::Constant(t),
                         _ => LatticeValue::Top,
@@ -457,9 +456,13 @@ impl SccpPass {
     }
 
     /// Helper: if any operand is Bottom, return Bottom; otherwise Top (still waiting).
-    fn check_any_bottom(&self, operands: &[ValueId], lattice: &[LatticeValue]) -> LatticeValue {
+    fn check_any_bottom(
+        &self,
+        operands: &[ValueId],
+        lattice: &IndexVec<ValueId, LatticeValue>,
+    ) -> LatticeValue {
         for &op in operands {
-            if matches!(lattice[op.index()], LatticeValue::Bottom) {
+            if matches!(lattice[op], LatticeValue::Bottom) {
                 return LatticeValue::Bottom;
             }
         }
@@ -471,7 +474,7 @@ impl SccpPass {
         &self,
         term: &Terminator,
         block_id: BlockId,
-        lattice: &[LatticeValue],
+        lattice: &IndexVec<ValueId, LatticeValue>,
         cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
     ) {
         match term {
@@ -479,7 +482,7 @@ impl SccpPass {
                 cfg_worklist.push_back((block_id, *target));
             }
             Terminator::Branch { condition, then_block, else_block } => {
-                match &lattice[condition.index()] {
+                match &lattice[*condition] {
                     LatticeValue::Constant(v) => {
                         if !v.is_zero() {
                             cfg_worklist.push_back((block_id, *then_block));
@@ -496,7 +499,7 @@ impl SccpPass {
                 }
             }
             Terminator::Switch { value, default, cases } => {
-                match &lattice[value.index()] {
+                match &lattice[*value] {
                     LatticeValue::Constant(v) => {
                         // Cases are tested in order at runtime, so a constant
                         // case match is definitive only if every earlier case
@@ -504,7 +507,7 @@ impl SccpPass {
                         // Overdefined earlier cases stay feasible; an
                         // unresolved case defers the remaining edges.
                         for &(case_val, target) in cases {
-                            match &lattice[case_val.index()] {
+                            match &lattice[case_val] {
                                 LatticeValue::Constant(cv) if cv == v => {
                                     cfg_worklist.push_back((block_id, target));
                                     return;
@@ -544,14 +547,14 @@ impl SccpPass {
     /// Lattice values can only move downward: Top → Constant → Bottom.
     fn update_lattice(
         &self,
-        lattice: &mut [LatticeValue],
+        lattice: &mut IndexVec<ValueId, LatticeValue>,
         vid: ValueId,
         new_val: LatticeValue,
     ) -> bool {
-        let old = &lattice[vid.index()];
+        let old = &lattice[vid];
         let merged = old.meet(&new_val);
         if merged != *old {
-            lattice[vid.index()] = merged;
+            lattice[vid] = merged;
             true
         } else {
             false
@@ -565,7 +568,7 @@ impl SccpPass {
         func: &Function,
         vid: ValueId,
         inst_to_value: &FxHashMap<InstId, ValueId>,
-        lattice: &mut [LatticeValue],
+        lattice: &mut IndexVec<ValueId, LatticeValue>,
         executable_blocks: &DenseBitSet<BlockId>,
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
         cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
@@ -616,7 +619,7 @@ impl SccpPass {
     fn rewrite(
         &mut self,
         func: &mut Function,
-        lattice: &[LatticeValue],
+        lattice: &IndexVec<ValueId, LatticeValue>,
         inst_to_value: &FxHashMap<InstId, ValueId>,
         executable_blocks: &DenseBitSet<BlockId>,
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
@@ -627,7 +630,7 @@ impl SccpPass {
         let mut dead_insts = DenseBitSet::new_empty(func.instructions.len());
 
         for (&inst_id, &vid) in inst_to_value {
-            if let LatticeValue::Constant(c) = &lattice[vid.index()] {
+            if let LatticeValue::Constant(c) = &lattice[vid] {
                 // Don't fold side-effecting instructions.
                 if func.instructions[inst_id].kind.has_side_effects() {
                     continue;

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -25,7 +25,7 @@ use crate::{
 use alloy_primitives::U256;
 use solar_data_structures::{
     bit_set::DenseBitSet,
-    index::IndexVec,
+    index::{IndexVec, index_vec},
     map::{FxHashMap, FxHashSet},
 };
 use std::collections::VecDeque;
@@ -113,7 +113,7 @@ impl SccpPass {
             .collect();
 
         // Initialize lattice: all values start as Top.
-        let mut lattice = IndexVec::<ValueId, _>::from_vec(vec![LatticeValue::Top; num_values]);
+        let mut lattice = index_vec![LatticeValue::Top; num_values];
 
         // Arguments are overdefined (we don't know their runtime values).
         for (vid, val) in func.values.iter_enumerated() {

--- a/crates/data-structures/src/bit_set/mod.rs
+++ b/crates/data-structures/src/bit_set/mod.rs
@@ -5,6 +5,7 @@
     clippy::use_self
 )]
 
+use crate::map::FxHashMap;
 use smallvec::SmallVec;
 use std::{
     fmt, iter,
@@ -1647,10 +1648,7 @@ impl<R: BitSetIndex, C: BitSetIndex> fmt::Debug for BitMatrix<R, C> {
 /// sparse representation.
 ///
 /// Initially, every row has no explicit representation. If any bit within a row
-/// is set, the entire row is instantiated as `Some(<DenseBitSet>)`.
-/// Furthermore, any previously uninstantiated rows prior to it will be
-/// instantiated as `None`. Those prior rows may themselves become fully
-/// instantiated later on if any of their bits are set.
+/// is set, the entire row is instantiated as a `DenseBitSet` in a hash map.
 ///
 /// `R` and `C` are index types used to identify rows and columns respectively;
 /// typically newtyped `usize` wrappers, but they can also just be `usize`.
@@ -1661,24 +1659,20 @@ where
     C: BitSetIndex,
 {
     num_columns: usize,
-    rows: Vec<Option<DenseBitSet<C>>>,
-    marker: PhantomData<R>,
+    num_rows: usize,
+    rows: FxHashMap<R, DenseBitSet<C>>,
 }
 
 impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     /// Creates a new empty sparse bit matrix with no rows or columns.
     pub fn new(num_columns: usize) -> Self {
-        Self { num_columns, rows: Vec::new(), marker: PhantomData }
+        Self { num_columns, num_rows: 0, rows: FxHashMap::default() }
     }
 
     fn ensure_row(&mut self, row: R) -> &mut DenseBitSet<C> {
-        // Instantiate any missing rows up to and including row `row` with an empty `DenseBitSet`.
-        // Then replace row `row` with a full `DenseBitSet` if necessary.
-        let row = row.index();
-        if self.rows.len() <= row {
-            self.rows.resize_with(row + 1, || None);
-        }
-        self.rows[row].get_or_insert_with(|| DenseBitSet::new_empty(self.num_columns))
+        self.num_rows = self.num_rows.max(row.index() + 1);
+        let num_columns = self.num_columns;
+        self.rows.entry(row).or_insert_with(|| DenseBitSet::new_empty(num_columns))
     }
 
     /// Sets the cell at `(row, column)` to true. Put another way, insert
@@ -1695,16 +1689,13 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     ///
     /// Returns `true` if this changed the matrix.
     pub fn remove(&mut self, row: R, column: C) -> bool {
-        match self.rows.get_mut(row.index()) {
-            Some(Some(row)) => row.remove(column),
-            _ => false,
-        }
+        self.rows.get_mut(&row).is_some_and(|row| row.remove(column))
     }
 
     /// Sets all columns at `row` to false. Has no effect if `row` does
     /// not exist.
     pub fn clear(&mut self, row: R) {
-        if let Some(Some(row)) = self.rows.get_mut(row.index()) {
+        if let Some(row) = self.rows.get_mut(&row) {
             row.clear();
         }
     }
@@ -1729,15 +1720,11 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
             return false;
         }
 
-        self.ensure_row(write);
-        let Some((read_row, write_row)) = pick2_mut(&mut self.rows, read.index(), write.index())
-        else {
-            unreachable!()
-        };
-        let (Some(read_row), Some(write_row)) = (read_row.as_ref(), write_row.as_mut()) else {
-            unreachable!()
-        };
-        write_row.union(read_row)
+        let _ = self.ensure_row(write);
+        let mut write_row = self.rows.remove(&write).expect("write row was just instantiated");
+        let changed = write_row.union(self.rows.get(&read).expect("read row was checked above"));
+        self.rows.insert(write, write_row);
+        changed
     }
 
     /// Insert all bits in the given row.
@@ -1746,7 +1733,7 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     }
 
     pub fn rows(&self) -> impl Iterator<Item = R> {
-        (0..self.rows.len()).map(R::from_usize)
+        (0..self.num_rows).map(R::from_usize)
     }
 
     /// Iterates through all the columns set to true in a given row of
@@ -1756,7 +1743,7 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     }
 
     pub fn row(&self, row: R) -> Option<&DenseBitSet<C>> {
-        self.rows.get(row.index())?.as_ref()
+        self.rows.get(&row)
     }
 
     /// Intersects `row` with `set`. `set` can be either `DenseBitSet` or
@@ -1767,10 +1754,7 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     where
         DenseBitSet<C>: BitRelations<Set>,
     {
-        match self.rows.get_mut(row.index()) {
-            Some(Some(row)) => row.intersect(set),
-            _ => false,
-        }
+        self.rows.get_mut(&row).is_some_and(|row| row.intersect(set))
     }
 
     /// Subtracts `set` from `row`. `set` can be either `DenseBitSet` or
@@ -1781,10 +1765,7 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     where
         DenseBitSet<C>: BitRelations<Set>,
     {
-        match self.rows.get_mut(row.index()) {
-            Some(Some(row)) => row.subtract(set),
-            _ => false,
-        }
+        self.rows.get_mut(&row).is_some_and(|row| row.subtract(set))
     }
 
     /// Unions `row` with `set`. `set` can be either `DenseBitSet` or
@@ -1825,20 +1806,6 @@ fn chunk_index<T: BitSetIndex>(elem: T) -> usize {
 fn chunk_word_index_and_mask<T: BitSetIndex>(elem: T) -> (usize, Word) {
     let chunk_elem = elem.index() % CHUNK_BITS;
     word_index_and_mask_usize(chunk_elem)
-}
-
-fn pick2_mut<T>(slice: &mut [T], idx_1: usize, idx_2: usize) -> Option<(&mut T, &mut T)> {
-    if idx_1 == idx_2 || idx_1 >= slice.len() || idx_2 >= slice.len() {
-        return None;
-    }
-
-    if idx_1 < idx_2 {
-        let (left, right) = slice.split_at_mut(idx_2);
-        Some((&mut left[idx_1], &mut right[0]))
-    } else {
-        let (left, right) = slice.split_at_mut(idx_1);
-        Some((&mut right[0], &mut left[idx_2]))
-    }
 }
 
 fn clear_excess_bits_in_final_word(domain_size: usize, words: &mut [Word]) {

--- a/crates/data-structures/src/bit_set/mod.rs
+++ b/crates/data-structures/src/bit_set/mod.rs
@@ -5,7 +5,6 @@
     clippy::use_self
 )]
 
-use crate::map::FxHashMap;
 use smallvec::SmallVec;
 use std::{
     fmt, iter,
@@ -1648,7 +1647,10 @@ impl<R: BitSetIndex, C: BitSetIndex> fmt::Debug for BitMatrix<R, C> {
 /// sparse representation.
 ///
 /// Initially, every row has no explicit representation. If any bit within a row
-/// is set, the entire row is instantiated as a `DenseBitSet` in a hash map.
+/// is set, the entire row is instantiated as `Some(<DenseBitSet>)`.
+/// Furthermore, any previously uninstantiated rows prior to it will be
+/// instantiated as `None`. Those prior rows may themselves become fully
+/// instantiated later on if any of their bits are set.
 ///
 /// `R` and `C` are index types used to identify rows and columns respectively;
 /// typically newtyped `usize` wrappers, but they can also just be `usize`.
@@ -1659,20 +1661,24 @@ where
     C: BitSetIndex,
 {
     num_columns: usize,
-    num_rows: usize,
-    rows: FxHashMap<R, DenseBitSet<C>>,
+    rows: Vec<Option<DenseBitSet<C>>>,
+    marker: PhantomData<R>,
 }
 
 impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     /// Creates a new empty sparse bit matrix with no rows or columns.
     pub fn new(num_columns: usize) -> Self {
-        Self { num_columns, num_rows: 0, rows: FxHashMap::default() }
+        Self { num_columns, rows: Vec::new(), marker: PhantomData }
     }
 
     fn ensure_row(&mut self, row: R) -> &mut DenseBitSet<C> {
-        self.num_rows = self.num_rows.max(row.index() + 1);
-        let num_columns = self.num_columns;
-        self.rows.entry(row).or_insert_with(|| DenseBitSet::new_empty(num_columns))
+        // Instantiate any missing rows up to and including row `row` with an empty `DenseBitSet`.
+        // Then replace row `row` with a full `DenseBitSet` if necessary.
+        let row = row.index();
+        if self.rows.len() <= row {
+            self.rows.resize_with(row + 1, || None);
+        }
+        self.rows[row].get_or_insert_with(|| DenseBitSet::new_empty(self.num_columns))
     }
 
     /// Sets the cell at `(row, column)` to true. Put another way, insert
@@ -1689,13 +1695,16 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     ///
     /// Returns `true` if this changed the matrix.
     pub fn remove(&mut self, row: R, column: C) -> bool {
-        self.rows.get_mut(&row).is_some_and(|row| row.remove(column))
+        match self.rows.get_mut(row.index()) {
+            Some(Some(row)) => row.remove(column),
+            _ => false,
+        }
     }
 
     /// Sets all columns at `row` to false. Has no effect if `row` does
     /// not exist.
     pub fn clear(&mut self, row: R) {
-        if let Some(row) = self.rows.get_mut(&row) {
+        if let Some(Some(row)) = self.rows.get_mut(row.index()) {
             row.clear();
         }
     }
@@ -1720,11 +1729,15 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
             return false;
         }
 
-        let _ = self.ensure_row(write);
-        let mut write_row = self.rows.remove(&write).expect("write row was just instantiated");
-        let changed = write_row.union(self.rows.get(&read).expect("read row was checked above"));
-        self.rows.insert(write, write_row);
-        changed
+        self.ensure_row(write);
+        let Some((read_row, write_row)) = pick2_mut(&mut self.rows, read.index(), write.index())
+        else {
+            unreachable!()
+        };
+        let (Some(read_row), Some(write_row)) = (read_row.as_ref(), write_row.as_mut()) else {
+            unreachable!()
+        };
+        write_row.union(read_row)
     }
 
     /// Insert all bits in the given row.
@@ -1733,7 +1746,7 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     }
 
     pub fn rows(&self) -> impl Iterator<Item = R> {
-        (0..self.num_rows).map(R::from_usize)
+        (0..self.rows.len()).map(R::from_usize)
     }
 
     /// Iterates through all the columns set to true in a given row of
@@ -1743,7 +1756,7 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     }
 
     pub fn row(&self, row: R) -> Option<&DenseBitSet<C>> {
-        self.rows.get(&row)
+        self.rows.get(row.index())?.as_ref()
     }
 
     /// Intersects `row` with `set`. `set` can be either `DenseBitSet` or
@@ -1754,7 +1767,10 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     where
         DenseBitSet<C>: BitRelations<Set>,
     {
-        self.rows.get_mut(&row).is_some_and(|row| row.intersect(set))
+        match self.rows.get_mut(row.index()) {
+            Some(Some(row)) => row.intersect(set),
+            _ => false,
+        }
     }
 
     /// Subtracts `set` from `row`. `set` can be either `DenseBitSet` or
@@ -1765,7 +1781,10 @@ impl<R: BitSetIndex, C: BitSetIndex> SparseBitMatrix<R, C> {
     where
         DenseBitSet<C>: BitRelations<Set>,
     {
-        self.rows.get_mut(&row).is_some_and(|row| row.subtract(set))
+        match self.rows.get_mut(row.index()) {
+            Some(Some(row)) => row.subtract(set),
+            _ => false,
+        }
     }
 
     /// Unions `row` with `set`. `set` can be either `DenseBitSet` or
@@ -1806,6 +1825,20 @@ fn chunk_index<T: BitSetIndex>(elem: T) -> usize {
 fn chunk_word_index_and_mask<T: BitSetIndex>(elem: T) -> (usize, Word) {
     let chunk_elem = elem.index() % CHUNK_BITS;
     word_index_and_mask_usize(chunk_elem)
+}
+
+fn pick2_mut<T>(slice: &mut [T], idx_1: usize, idx_2: usize) -> Option<(&mut T, &mut T)> {
+    if idx_1 == idx_2 || idx_1 >= slice.len() || idx_2 >= slice.len() {
+        return None;
+    }
+
+    if idx_1 < idx_2 {
+        let (left, right) = slice.split_at_mut(idx_2);
+        Some((&mut left[idx_1], &mut right[0]))
+    } else {
+        let (left, right) = slice.split_at_mut(idx_1);
+        Some((&mut right[0], &mut left[idx_2]))
+    }
 }
 
 fn clear_excess_bits_in_final_word(domain_size: usize, words: &mut [Word]) {


### PR DESCRIPTION
Several compiler analyses and EVM transforms stored dense tables in `Vec` while indexing them with MIR or EVM index newtypes. This switches those tables to `IndexVec`, including local tables and helper signatures, so indexing remains type-checked end to end.

The repository guidance now requires `IndexVec` whenever a collection is keyed by a typed index, including local variables.
