### PR TITLE
refactor(codegen): simplify IR entry blocks

### DIFF
--- a/crates/codegen/src/analysis/call_graph.rs
+++ b/crates/codegen/src/analysis/call_graph.rs
@@ -10,7 +10,6 @@ pub(crate) struct CallGraphInfo {
     callees: FxHashMap<FunctionId, DenseBitSet<FunctionId>>,
     reachable_from_entries: DenseBitSet<FunctionId>,
     recursive_functions: DenseBitSet<FunctionId>,
-    has_body: DenseBitSet<FunctionId>,
 }
 
 impl CallGraphInfo {
@@ -20,14 +19,10 @@ impl CallGraphInfo {
         let function_count = module.functions.len();
         let mut callees = FxHashMap::default();
         let mut entry_functions = DenseBitSet::new_empty(function_count);
-        let mut has_body = DenseBitSet::new_empty(function_count);
 
         for (func_id, func) in module.functions.iter_enumerated() {
             if Self::is_entry_function(func) {
                 entry_functions.insert(func_id);
-            }
-            if Self::has_body(func) {
-                has_body.insert(func_id);
             }
 
             let direct_callees = Self::collect_internal_callees(func, function_count);
@@ -40,7 +35,7 @@ impl CallGraphInfo {
             Self::reachable_from_roots_in_graph(&callees, &entry_functions);
         let recursive_functions = Self::recursive_functions_in_graph(&callees, function_count);
 
-        Self { callees, reachable_from_entries, recursive_functions, has_body }
+        Self { callees, reachable_from_entries, recursive_functions }
     }
 
     /// Returns all functions reachable from entry functions.
@@ -55,19 +50,19 @@ impl CallGraphInfo {
         self.recursive_functions.contains(func)
     }
 
-    /// Returns functions reachable from `roots` that have MIR bodies.
+    /// Returns functions reachable from `roots` through MIR call edges.
     #[must_use]
-    pub(crate) fn reachable_bodies_from(
+    pub(crate) fn reachable_callees_from(
         &self,
         roots: impl IntoIterator<Item = FunctionId>,
     ) -> DenseBitSet<FunctionId> {
-        let mut reachable = DenseBitSet::new_empty(self.has_body.domain_size());
+        let mut reachable = DenseBitSet::new_empty(self.reachable_from_entries.domain_size());
         let mut worklist: VecDeque<_> = roots.into_iter().collect();
 
         while let Some(func) = worklist.pop_front() {
             let Some(callees) = self.callees.get(&func) else { continue };
             for callee in callees {
-                if self.has_body.contains(callee) && reachable.insert(callee) {
+                if reachable.insert(callee) {
                     worklist.push_back(callee);
                 }
             }
@@ -98,10 +93,6 @@ impl CallGraphInfo {
             || func.attributes.is_constructor
             || func.attributes.is_fallback
             || func.attributes.is_receive
-    }
-
-    fn has_body(func: &Function) -> bool {
-        !func.blocks.is_empty()
     }
 
     fn reachable_from_roots_in_graph(

--- a/crates/codegen/src/analysis/cfg.rs
+++ b/crates/codegen/src/analysis/cfg.rs
@@ -15,7 +15,6 @@ use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
 /// Control-flow facts for one MIR function.
 #[derive(Clone, Debug)]
 pub(crate) struct CfgInfo {
-    entry_block: BlockId,
     successors: Vec<SmallVec<[BlockId; 2]>>,
     reachable: OnceCell<DenseBitSet<BlockId>>,
     rpo: OnceCell<Vec<BlockId>>,
@@ -35,7 +34,6 @@ impl CfgInfo {
             })
             .collect();
         Self {
-            entry_block: func.entry_block,
             successors,
             reachable: OnceCell::new(),
             rpo: OnceCell::new(),
@@ -56,7 +54,7 @@ impl CfgInfo {
         self.reachable.get_or_init(|| {
             let mut reachable = DenseBitSet::new_empty(self.successors.len());
             let mut stack = Vec::new();
-            stack.push(self.entry_block);
+            stack.push(BlockId::ENTRY);
             while let Some(block) = stack.pop() {
                 if reachable.insert(block) {
                     stack.extend(self.successors[block.index()].iter().copied());
@@ -78,8 +76,8 @@ impl CfgInfo {
         self.rpo.get_or_init(|| {
             let mut reachable = DenseBitSet::new_empty(self.successors.len());
             let mut rpo = Vec::with_capacity(self.successors.len());
-            let mut stack = vec![(self.entry_block, 0usize)];
-            reachable.insert(self.entry_block);
+            let mut stack = vec![(BlockId::ENTRY, 0usize)];
+            reachable.insert(BlockId::ENTRY);
             while let Some((block, next)) = stack.last_mut() {
                 if let Some(&succ) = self.successors[block.index()].get(*next) {
                     *next += 1;
@@ -100,8 +98,7 @@ impl CfgInfo {
     /// Returns immediate-dominator information.
     #[must_use]
     pub(crate) fn dominators(&self) -> &DominatorTree {
-        self.dominators
-            .get_or_init(|| DominatorTree::compute(self.entry_block, &self.successors, self.rpo()))
+        self.dominators.get_or_init(|| DominatorTree::compute(&self.successors, self.rpo()))
     }
 
     /// Returns block-to-block reachability through at least one CFG edge.
@@ -137,11 +134,7 @@ pub(crate) struct DominatorTree {
 }
 
 impl DominatorTree {
-    fn compute(
-        entry_block: BlockId,
-        successors: &[SmallVec<[BlockId; 2]>],
-        rpo: &[BlockId],
-    ) -> Self {
+    fn compute(successors: &[SmallVec<[BlockId; 2]>], rpo: &[BlockId]) -> Self {
         let block_count = successors.len();
         let mut predecessors = vec![Vec::new(); block_count];
         for (block_index, block_successors) in successors.iter().enumerate() {
@@ -156,16 +149,17 @@ impl DominatorTree {
         }
 
         let mut idoms = vec![None; block_count];
-        idoms[entry_block.index()] = Some(entry_block);
+        idoms[BlockId::ENTRY.index()] = Some(BlockId::ENTRY);
         let mut changed = true;
         while changed {
             changed = false;
             for &block in rpo {
-                if block == entry_block {
+                let block_predecessors = &predecessors[block.index()];
+                if block_predecessors.is_empty() {
                     continue;
                 }
                 let mut new_idom: Option<BlockId> = None;
-                for &pred in &predecessors[block.index()] {
+                for &pred in block_predecessors {
                     if idoms[pred.index()].is_none() {
                         continue;
                     }
@@ -186,10 +180,9 @@ impl DominatorTree {
         let mut children = vec![Vec::new(); block_count];
         for (block_index, idom) in idoms.iter().copied().enumerate() {
             let block = BlockId::from_usize(block_index);
-            if block == entry_block {
-                continue;
-            }
-            if let Some(idom) = idom {
+            if let Some(idom) = idom
+                && idom != block
+            {
                 children[idom.index()].push(block);
             }
         }

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -462,7 +462,7 @@ mod tests {
         b.ret([sum]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         // x and one are used by add, so live-in to entry.
         assert!(liveness.live_in(entry).contains(x));
@@ -510,7 +510,7 @@ mod tests {
         assert!(liveness.live_in(then_bb).contains(x));
         assert!(liveness.live_in(else_bb).contains(x));
         // x must be live-out of entry (flows to successors).
-        assert!(liveness.live_out(func.entry_block).contains(x));
+        assert!(liveness.live_out(BlockId::ENTRY).contains(x));
         // v_then must be live-out of then_bb (used in merge's ret).
         assert!(liveness.live_out(then_bb).contains(v_then));
         // v_else should NOT be live-out of else_bb (merge returns v_then, not v_else).
@@ -571,7 +571,7 @@ mod tests {
         b.ret([x]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         assert!(liveness.live_in(entry).contains(x));
         // dead instruction result must not be live-out.
@@ -589,7 +589,7 @@ mod tests {
         b.ret([y]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         assert!(!liveness.live_in(entry).contains(_x), "unused param not live");
         assert!(liveness.live_in(entry).contains(y), "used param is live");
@@ -620,7 +620,7 @@ mod tests {
 
         assert!(liveness.live_in(left).contains(x));
         assert!(liveness.live_in(right).contains(x));
-        assert!(liveness.live_out(func.entry_block).contains(x));
+        assert!(liveness.live_out(BlockId::ENTRY).contains(x));
     }
 
     #[test]
@@ -630,8 +630,8 @@ mod tests {
         b.stop();
 
         let liveness = Liveness::compute(&func);
-        assert_eq!(liveness.live_in(func.entry_block).count(), 0);
-        assert_eq!(liveness.live_out(func.entry_block).count(), 0);
+        assert_eq!(liveness.live_in(BlockId::ENTRY).count(), 0);
+        assert_eq!(liveness.live_out(BlockId::ENTRY).count(), 0);
     }
 
     #[test]
@@ -646,7 +646,7 @@ mod tests {
         b.ret([loaded]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         // Before sstore (inst 0): slot and val must be live.
         let info_0 = liveness.live_at_inst(&func, entry, 0);
@@ -671,7 +671,7 @@ mod tests {
         b.ret([v3]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         // Before add (inst 0): v0 and v1 are live.
         let info_0 = liveness.live_at_inst(&func, entry, 0);
@@ -707,7 +707,7 @@ mod tests {
         b.ret([v2]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         // v0 and v1 are dead after the add (inst 0) — their last use is at inst 0.
         assert!(liveness.is_dead_after(v0, entry, 0), "v0 dead after add");
@@ -728,7 +728,7 @@ mod tests {
         b.ret([v3]);
 
         let liveness = Liveness::compute(&func);
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
 
         // v0 last used at inst 1 (mul).
         assert_eq!(liveness.last_use_in_block(v0, entry), Some(Some(1)));

--- a/crates/codegen/src/analysis/loop_analysis.rs
+++ b/crates/codegen/src/analysis/loop_analysis.rs
@@ -464,7 +464,7 @@ mod tests {
     fn test_simple_loop_detection() {
         let mut func = make_test_func();
 
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let header = func.alloc_block();
         let body = func.alloc_block();
         let exit = func.alloc_block();

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -99,6 +99,7 @@ impl<'a> Validator<'a> {
         let num_insts = func.instructions.len();
 
         if num_blocks == 0 {
+            self.emit("function has no entry block");
             return;
         }
 
@@ -311,9 +312,9 @@ impl<'a> Validator<'a> {
             }
         }
 
-        // ----- Entry block must have no predecessors -----
-        if !func.blocks[func.entry_block].predecessors.is_empty() {
-            self.emit_at_block("entry block must have no predecessors", func.entry_block);
+        // ----- Entry block invariants -----
+        if !func.blocks[BlockId::ENTRY].predecessors.is_empty() {
+            self.emit_at_block("entry block must have no predecessors", BlockId::ENTRY);
         }
 
         // ----- Use reachability -----
@@ -492,9 +493,9 @@ impl<'a> Validator<'a> {
     /// the phase is a real contract rather than a label.
     fn validate_module_phase(&mut self, module: &Module) {
         // From the `dispatch` phase on, routing is materialized: a module with
-        // bodied selector functions must contain the synthesized `entry`.
+        // selector functions must contain the synthesized `entry`.
         if module.phase >= crate::mir::MirPhase::Dispatch
-            && module.functions.iter().any(|f| f.selector.is_some() && !f.blocks.is_empty())
+            && module.functions.iter().any(|f| f.selector.is_some())
             && !module.functions.iter().any(|f| f.name.name == sym::entry)
         {
             self.emit(format_args!(
@@ -509,7 +510,6 @@ impl<'a> Validator<'a> {
         // function is an argument-free self-decoding wrapper.
         if module.phase >= crate::mir::MirPhase::Abi
             && func.selector.is_some()
-            && !func.blocks.is_empty()
             && !func.params.is_empty()
         {
             self.emit(format_args!(
@@ -599,7 +599,7 @@ error: [bb0] block has no terminator
             }
             // Manually corrupt: replace the terminator with a Jump to a nonexistent block.
             let bad_block = BlockId::from_usize(99);
-            func.blocks[func.entry_block].terminator = Some(Terminator::Jump(bad_block));
+            func.blocks[BlockId::ENTRY].terminator = Some(Terminator::Jump(bad_block));
             Validator::new(&sess.dcx).validate_standalone_function(&func);
             assert!(sess.dcx.has_errors().is_err());
             assert_data_eq!(
@@ -653,7 +653,7 @@ error: [bb0] successor bb1 does not list bb0 as a predecessor
                 b.stop();
             }
             // Add the invalid predecessor to the entry block.
-            func.blocks[func.entry_block].predecessors.push(func.entry_block);
+            func.blocks[BlockId::ENTRY].predecessors.push(BlockId::ENTRY);
             Validator::new(&sess.dcx).validate_standalone_function(&func);
             assert!(sess.dcx.has_errors().is_err());
             assert_data_eq!(
@@ -670,7 +670,25 @@ error: [bb0] entry block must have no predecessors
     }
 
     #[test]
-    fn empty_function_with_just_terminator_is_valid() {
+    fn function_without_entry_block_is_caught() {
+        with_session(|sess| {
+            let mut func = make_func();
+            func.blocks.clear();
+            Validator::new(&sess.dcx).validate_standalone_function(&func);
+            assert!(sess.dcx.has_errors().is_err());
+            assert_data_eq!(
+                sess.emitted_diagnostics().unwrap().to_string(),
+                str![[r#"
+error: function has no entry block
+
+
+"#]]
+            );
+        });
+    }
+
+    #[test]
+    fn entry_with_just_terminator_is_valid() {
         with_session(|sess| {
             let mut func = make_func();
             {

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -159,8 +159,7 @@ impl GlobalStackPlan {
         }
 
         for block_id in func.blocks.indices() {
-            if block_id == func.entry_block
-                || !cfg.is_reachable(block_id)
+            if !cfg.is_reachable(block_id)
                 || func.blocks[block_id].predecessors.is_empty()
                 || stack_phi_plan.entries.contains_key(&block_id)
                 || Self::is_terminal_block(func, block_id)
@@ -722,6 +721,9 @@ impl<'gcx> EvmCodegen<'gcx> {
         if module.is_interface {
             return EvmArtifact::default();
         }
+        if let Some(func) = module.functions.iter().find(|func| func.blocks.is_empty()) {
+            panic!("cannot codegen MIR function `{}` without an entry block", func.name);
+        }
         self.run_optimization_passes(module);
         // First generate the runtime code
         let mut runtime_code = self.generate_runtime_code(module);
@@ -888,7 +890,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             }
 
             let call_graph = CallGraphInfo::new(module);
-            let internal_targets = call_graph.reachable_bodies_from(std::iter::once(ctor_id));
+            let internal_targets = call_graph.reachable_callees_from(std::iter::once(ctor_id));
             for func_id in &internal_targets {
                 let label = self.new_function_label(func_id);
                 self.function_labels.insert(func_id, label);
@@ -1069,7 +1071,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         };
 
         let call_graph = CallGraphInfo::new(module);
-        let internal_targets = call_graph.reachable_bodies_from(
+        let internal_targets = call_graph.reachable_callees_from(
             module.functions.iter_enumerated().filter_map(|(func_id, func)| {
                 (func_id == entry_id || Self::is_external_entry(func)).then_some(func_id)
             }),
@@ -1083,7 +1085,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             // Non-recursive internal functions get compile-time-fixed frames.
             if func_id != entry_id
                 && !Self::is_external_entry(func)
-                && Self::has_body(func)
+                && Self::is_runtime_function(func)
                 && !call_graph.is_recursive(func_id)
             {
                 self.static_frame_functions.insert(func_id);
@@ -1097,7 +1099,7 @@ impl<'gcx> EvmCodegen<'gcx> {
                 continue;
             }
             let needs_body = Self::is_external_entry(func)
-                || (Self::has_body(func) && internal_targets.contains(func_id));
+                || (Self::is_runtime_function(func) && internal_targets.contains(func_id));
             if needs_body {
                 let label = self.new_function_label(func_id);
                 self.function_labels.insert(func_id, label);
@@ -1130,7 +1132,10 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         // Internal-call targets, exactly as in the backend dispatcher path.
         for (func_id, func) in module.functions.iter_enumerated() {
-            if func_id == entry_id || Self::is_external_entry(func) || !Self::has_body(func) {
+            if func_id == entry_id
+                || Self::is_external_entry(func)
+                || !Self::is_runtime_function(func)
+            {
                 continue;
             }
             let Some(&label) = self.function_labels.get(&func_id) else { continue };
@@ -1162,15 +1167,11 @@ impl<'gcx> EvmCodegen<'gcx> {
     ///     else: revert
     /// ```
     fn generate_dispatcher(&mut self, module: &Module) {
-        // Find executable receive and fallback functions. Interface/abstract declarations can
-        // have ABI entries but no MIR body, so they must not participate in runtime dispatch.
-        let receive_idx =
-            module.functions.iter().position(|f| f.attributes.is_receive && Self::has_body(f));
-        let fallback_idx =
-            module.functions.iter().position(|f| f.attributes.is_fallback && Self::has_body(f));
+        let receive_idx = module.functions.iter().position(|f| f.attributes.is_receive);
+        let fallback_idx = module.functions.iter().position(|f| f.attributes.is_fallback);
 
         let call_graph = CallGraphInfo::new(module);
-        let internal_targets = call_graph.reachable_bodies_from(
+        let internal_targets = call_graph.reachable_callees_from(
             module
                 .functions
                 .iter_enumerated()
@@ -1184,7 +1185,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             }
             // Non-recursive internal functions get compile-time-fixed frames.
             if !Self::is_external_entry(func)
-                && Self::has_body(func)
+                && Self::is_runtime_function(func)
                 && !call_graph.is_recursive(func_id)
             {
                 self.static_frame_functions.insert(func_id);
@@ -1197,7 +1198,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         for (func_id, func) in module.functions.iter_enumerated() {
             let external = Self::is_external_entry(func);
             let needs_body =
-                external || (Self::has_body(func) && internal_targets.contains(func_id));
+                external || (Self::is_runtime_function(func) && internal_targets.contains(func_id));
             let label = needs_body.then(|| self.new_function_label(func_id));
             if let Some(label) = label {
                 self.function_labels.insert(func_id, label);
@@ -1307,7 +1308,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         // Define internal-call targets once. Calls jump here and return
         // through the stack-passed return address.
         for (func_id, func) in module.functions.iter_enumerated() {
-            if Self::is_external_entry(func) || !Self::has_body(func) {
+            if Self::is_external_entry(func) || !Self::is_runtime_function(func) {
                 continue;
             }
             let Some(label) = func_labels[func_id.index()] else { continue };
@@ -1354,14 +1355,14 @@ impl<'gcx> EvmCodegen<'gcx> {
     }
 
     fn is_external_entry(func: &Function) -> bool {
-        Self::has_body(func)
+        Self::is_runtime_function(func)
             && (func.selector.is_some()
                 || func.attributes.is_receive
                 || func.attributes.is_fallback)
     }
 
-    fn has_body(func: &Function) -> bool {
-        !func.attributes.is_constructor && !func.blocks.is_empty()
+    fn is_runtime_function(func: &Function) -> bool {
+        !func.attributes.is_constructor
     }
 
     fn emit_selector_dispatch(
@@ -1526,9 +1527,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             preserved_fallthrough = None;
 
             let label = self.block_labels[&block_id];
-            if !entered_by_preserved_fallthrough
-                && (block_id != func.entry_block || !block.predecessors.is_empty())
-            {
+            if !entered_by_preserved_fallthrough && !block.predecessors.is_empty() {
                 self.asm.define_label(label);
             }
 
@@ -1759,11 +1758,11 @@ impl<'gcx> EvmCodegen<'gcx> {
         loop {
             let mut changed = false;
             for (function_id, func) in module.functions.iter_enumerated() {
-                if cold.contains(function_id) || func.blocks.is_empty() {
+                if cold.contains(function_id) {
                     continue;
                 }
                 worklist.clear();
-                worklist.push(func.entry_block);
+                worklist.push(BlockId::ENTRY);
                 visited.clear();
                 let mut saw_exit = false;
                 let mut all_exits_cold = true;
@@ -1888,7 +1887,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         let mut order = Vec::with_capacity(func.blocks.len());
         let mut placed = DenseBitSet::new_empty(func.blocks.len());
 
-        self.append_layout_chain(func, func.entry_block, reachable, &mut placed, &mut order);
+        self.append_layout_chain(func, BlockId::ENTRY, reachable, &mut placed, &mut order);
         for block_id in func.blocks.indices() {
             if reachable.contains(block_id) {
                 self.append_layout_chain(func, block_id, reachable, &mut placed, &mut order);
@@ -5086,7 +5085,7 @@ REVERT
                 let cold_wrapper = module.add_function(cold_wrapper);
 
                 let mut caller = Function::new(Ident::with_dummy_span(sym::Test));
-                let entry = caller.entry_block;
+                let entry = BlockId::ENTRY;
                 let (cold_forwarder, cold_block, hot_block);
                 {
                     let mut builder = FunctionBuilder::new(&mut caller);

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -12,23 +12,18 @@ impl Module {
             write!(
                 f,
                 "{}",
-                self.blocks.iter_enumerated().format_with("", |f, (block_id, block)| {
-                    write!(f, "{}", display_block(self, block_id, block))
-                })
+                self.blocks
+                    .iter()
+                    .format_with("", |f, block| { write!(f, "{}", display_block(self, block)) })
             )
         })
     }
 }
 
-fn display_block<'a>(
-    module: &'a Module,
-    block_id: BlockId,
-    block: &'a Block,
-) -> impl fmt::Display + 'a {
+fn display_block<'a>(module: &'a Module, block: &'a Block) -> impl fmt::Display + 'a {
     fmt::from_fn(move |f| {
-        let entry = if module.entry_block == Some(block_id) { " (entry)" } else { "" };
         let cold = if block.metadata.hotness.is_cold() { " [cold]" } else { "" };
-        writeln!(f, "bb{}{}{}:", block.label, entry, cold)?;
+        writeln!(f, "bb{}{}:", block.label, cold)?;
         for inst in &block.instructions {
             writeln!(f, "  {}", display_instruction(module, inst))?;
         }

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -36,6 +36,11 @@ newtype_index! {
     pub(crate) struct BlockId;
 }
 
+impl BlockId {
+    /// The first block in every non-empty module.
+    pub(crate) const ENTRY: Self = Self::new(0);
+}
+
 /// An EVM IR module.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Module {
@@ -43,8 +48,6 @@ pub struct Module {
     pub(crate) name: String,
     /// Basic blocks in layout order.
     pub(crate) blocks: IndexVec<BlockId, Block>,
-    /// The entry block, if one has been created.
-    pub(crate) entry_block: Option<BlockId>,
 }
 
 impl Module {
@@ -61,7 +64,7 @@ impl Module {
     pub(crate) fn new(name: impl Into<String>) -> Self {
         let name = name.into();
         assert!(is_ident(&name), "invalid EVM IR program name `{name}`");
-        Self { name, blocks: IndexVec::new(), entry_block: None }
+        Self { name, blocks: IndexVec::new() }
     }
 
     /// Changes the program name.
@@ -79,11 +82,7 @@ impl Module {
 
     /// Adds a block to the program.
     pub(crate) fn add_block(&mut self, block: Block) -> BlockId {
-        let id = self.blocks.push(block);
-        if self.entry_block.is_none() {
-            self.entry_block = Some(id);
-        }
-        id
+        self.blocks.push(block)
     }
 }
 

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -19,7 +19,6 @@ pub(super) fn parse(sess: &Session, source: &SourceFile) -> Result<Module> {
 #[derive(Clone, Debug)]
 struct ParsedBlockHeader {
     label: Symbol,
-    entry: bool,
     hotness: Hotness,
 }
 
@@ -60,9 +59,6 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         while !self.parser.is_eof() {
             if let Some(header) = self.try_parse_block_header()? {
                 let block_id = self.define_block(module, header.label)?;
-                if header.entry {
-                    module.entry_block = Some(block_id);
-                }
                 module.blocks[block_id].metadata.hotness = header.hotness;
                 current_block = Some(block_id);
                 continue;
@@ -85,13 +81,6 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
     fn try_parse_block_header(&mut self) -> PResult<'sess, Option<ParsedBlockHeader>> {
         let Some(label) = self.current_block_label()? else { return Ok(None) };
         self.parser.bump();
-        let entry = self.parser.check(TokenKind::OpenDelim(Delimiter::Parenthesis))
-            && self.parser.look_ahead(1).is_keyword(sym::entry);
-        if entry {
-            self.parser.bump();
-            self.parser.bump();
-            self.parser.expect(TokenKind::CloseDelim(Delimiter::Parenthesis))?;
-        }
         let mut hotness = Hotness::Hot;
         if self.parser.eat(TokenKind::OpenDelim(Delimiter::Bracket)) {
             self.parser.expect_keyword(sym::cold)?;
@@ -101,7 +90,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
         self.parser.expect(TokenKind::Colon)?;
 
-        Ok(Some(ParsedBlockHeader { label, entry, hotness }))
+        Ok(Some(ParsedBlockHeader { label, hotness }))
     }
 
     fn current_block_label(&self) -> PResult<'sess, Option<Symbol>> {
@@ -350,8 +339,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         Ok(self.current_block_label()?.is_some()
             && !matches!(
                 self.parser.look_ahead(1).kind,
-                TokenKind::Colon
-                    | TokenKind::OpenDelim(Delimiter::Parenthesis | Delimiter::Bracket)
+                TokenKind::Colon | TokenKind::OpenDelim(Delimiter::Bracket)
             ))
     }
 }
@@ -364,12 +352,8 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     fn parse_module(sess: &Session, input: &str) -> Result<Module> {
-        let id =
-            input.bytes().fold(0u64, |hash, byte| hash.wrapping_mul(31).wrapping_add(byte.into()));
-        let source = sess
-            .source_map()
-            .new_source_file(FileName::Custom(format!("evmir-test-{id}")), input)
-            .unwrap();
+        let name = format!("test{}.evmir", sess.source_map().files().len());
+        let source = sess.source_map().new_source_file(FileName::Custom(name), input).unwrap();
         Module::parse(sess, &source)
     }
 
@@ -421,14 +405,14 @@ mod tests {
     #[test]
     fn parser_does_not_treat_newlines_as_syntax() {
         let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
-        let input = "@module m bb0 (entry): push 1 push 2 add jump bb1 bb1 [cold]: jump";
+        let input = "@module m bb0: push 1 push 2 add jump bb1 bb1 [cold]: jump";
         sess.enter(|| {
             let module = parse_module(&sess, input).unwrap();
             assert_data_eq!(
                 module.to_text().to_string(),
                 str![[r#"
 @module m
-bb0 (entry):
+bb0:
   push 1
   push 2
   add
@@ -448,7 +432,7 @@ bb1 [cold]:
         let input = "\
 @module m
 
-bb0 (entry):
+bb0:
   stop
   invalid
 ";
@@ -457,7 +441,7 @@ bb0 (entry):
             sess.emitted_diagnostics().unwrap().to_string(),
             str![[r#"
 error: instruction after terminator in block `bb0`
-  ╭▸ <evmir-test-10709633122247444245>:5:3
+  ╭▸ <test0.evmir>:5:3
   │
 5 │   invalid
   ╰╴  ━━━━━━━
@@ -475,7 +459,7 @@ error: instruction after terminator in block `bb0`
 /// module docs
 @module m
 
-bb0 (entry):
+bb0:
   push 1
   add !meta(foo= )
 ";
@@ -510,7 +494,7 @@ error: expected metadata value
         ];
         sess.enter(|| {
             for (name, instruction) in cases {
-                let input = format!("@module m\n\nbb0 (entry):\n  {instruction}\n  stop\n");
+                let input = format!("@module m\n\nbb0:\n  {instruction}\n  stop\n");
                 let source = sess
                     .source_map()
                     .new_source_file(FileName::Custom(name.into()), input)
@@ -554,7 +538,7 @@ error: immutable ID exceeds the assembler limit
     fn unresolved_block_reports_reference_span() {
         let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
         sess.dcx.set_flags(|flags| flags.track_diagnostics = false);
-        let input = "@module m\n\nbb0 (entry):\n  jump bb9\n";
+        let input = "@module m\n\nbb0:\n  jump bb9\n";
         let source = sess
             .source_map()
             .new_source_file(FileName::Custom("unknown-block.evmir".into()), input)
@@ -578,7 +562,7 @@ error: unknown block `bb9`
     fn parser_rejects_hotness_block_metadata() {
         let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
         sess.dcx.set_flags(|flags| flags.track_diagnostics = false);
-        let input = "@module m\n\nbb0 (entry) [hotness=cold]:\n  stop\n";
+        let input = "@module m\n\nbb0 [hotness=cold]:\n  stop\n";
         let source = sess
             .source_map()
             .new_source_file(FileName::Custom("hotness.evmir".into()), input)
@@ -588,10 +572,10 @@ error: unknown block `bb9`
             sess.emitted_diagnostics().unwrap().to_string(),
             str![[r#"
 error: expected `cold`
-  ╭▸ <hotness.evmir>:3:14
+  ╭▸ <hotness.evmir>:3:6
   │
-3 │ bb0 (entry) [hotness=cold]:
-  ╰╴             ━━━━━━━
+3 │ bb0 [hotness=cold]:
+  ╰╴     ━━━━━━━
 
 
 "#]]

--- a/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
@@ -31,9 +31,7 @@ pub(super) fn run(gcx: Gcx<'_>, module: &mut Module) -> bool {
         }
     }
 
-    if let Some(entry) = module.entry_block {
-        append_layout_trace(module, entry, &mut state.placed, &mut state.order);
-    }
+    append_layout_trace(module, BlockId::ENTRY, &mut state.placed, &mut state.order);
     for cold in [false, true] {
         for block in module.blocks.indices() {
             if state.predecessor_counts[block.index()] == 0

--- a/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
@@ -1,6 +1,6 @@
 //! Machine-level EVM control-flow simplification.
 
-use super::utils::retain_blocks;
+use super::utils::{remap_block_order, retain_blocks};
 use crate::backend::evm::{
     ir::{BlockId, Module, PushValue, Terminator, TerminatorKind},
     op,
@@ -14,7 +14,7 @@ pub(super) fn run(_gcx: Gcx<'_>, module: &mut Module) -> bool {
     let mut changed = false;
     loop {
         let truncated = truncate_after_terminal(module);
-        let redirected = redirect_jump_thunks(module, &mut state.thunks);
+        let redirected = redirect_jump_thunks(module, &mut state.thunks, &mut state.order);
         let swept = remove_unreachable_blocks(
             module,
             &mut state.reachable,
@@ -82,7 +82,11 @@ fn truncate_after_terminal(module: &mut Module) -> bool {
     changed
 }
 
-fn redirect_jump_thunks(module: &mut Module, thunks: &mut Vec<Option<BlockId>>) -> bool {
+fn redirect_jump_thunks(
+    module: &mut Module,
+    thunks: &mut Vec<Option<BlockId>>,
+    order: &mut Vec<BlockId>,
+) -> bool {
     thunks.clear();
     thunks.extend(module.blocks.iter().map(|block| {
         if block.instructions.is_empty() {
@@ -111,11 +115,6 @@ fn redirect_jump_thunks(module: &mut Module, thunks: &mut Vec<Option<BlockId>>) 
     };
 
     let mut changed = false;
-    if let Some(entry) = &mut module.entry_block {
-        let target = resolve(*entry);
-        changed |= target != *entry;
-        *entry = target;
-    }
     for block in &mut module.blocks {
         for inst in &mut block.instructions {
             if let Some(PushValue::Block(block)) = &mut inst.value {
@@ -132,6 +131,14 @@ fn redirect_jump_thunks(module: &mut Module, thunks: &mut Vec<Option<BlockId>>) 
             });
         }
     }
+    let entry = resolve(BlockId::ENTRY);
+    if entry != BlockId::ENTRY {
+        order.clear();
+        order.push(entry);
+        order.extend(module.blocks.indices().filter(|&block| block != entry));
+        remap_block_order(module, order);
+        changed = true;
+    }
     changed
 }
 
@@ -141,14 +148,16 @@ fn remove_unreachable_blocks(
     pending: &mut Vec<BlockId>,
     order: &mut Vec<BlockId>,
 ) -> bool {
-    let Some(entry) = module.entry_block else { return false };
+    if module.blocks.is_empty() {
+        return false;
+    }
     if reachable.domain_size() != module.blocks.len() {
         *reachable = DenseBitSet::new_empty(module.blocks.len());
     } else {
         reachable.clear();
     }
     pending.clear();
-    pending.push(entry);
+    pending.push(BlockId::ENTRY);
     while let Some(block_id) = pending.pop() {
         if !reachable.insert(block_id) {
             continue;
@@ -180,6 +189,10 @@ fn coalesce_blocks(
 ) -> bool {
     references.clear();
     references.resize(module.blocks.len(), 0);
+    // Count the implicit program-entry edge.
+    if let Some(entry_references) = references.first_mut() {
+        *entry_references = 1;
+    }
     for block in &module.blocks {
         for inst in &block.instructions {
             if let Some(PushValue::Block(target)) = &inst.value {
@@ -205,7 +218,6 @@ fn coalesce_blocks(
         {
             let target = *target;
             if target == predecessor
-                || Some(target) == module.entry_block
                 || references[target.index()] != 1
                 || !retained.contains(target)
             {

--- a/crates/codegen/src/backend/evm/ir/passes/utils.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/utils.rs
@@ -37,8 +37,6 @@ fn remap_blocks(module: &mut Module, order: &[BlockId]) {
         remap[old_block.index()] = Some(new_block);
     }
     module.blocks = blocks;
-    module.entry_block =
-        module.entry_block.map(|block| remap[block.index()].expect("entry block must be retained"));
     for block in &mut module.blocks {
         for inst in &mut block.instructions {
             if let Some(PushValue::Block(block)) = &mut inst.value {

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -34,15 +34,6 @@ impl<'a> Verifier<'a> {
             self.error("program has no blocks");
             return;
         }
-        match module.entry_block {
-            Some(entry) if self.block_exists(module, entry) => {}
-            Some(entry) => {
-                self.error(format_args!("entry block `{}` is out of range", entry.index()));
-            }
-            None => {
-                self.error("program has no entry block");
-            }
-        }
 
         let mut labels = FxHashSet::default();
         for (block_id, block) in module.blocks.iter_enumerated() {
@@ -203,10 +194,9 @@ impl<'a> Verifier<'a> {
 
     /// Checks physical stack operations along generated direct control-flow edges.
     fn verify_stack_ops(&self, module: &Module) {
-        let Some(entry) = module.entry_block else { return };
         let mut entry_depths = IndexVec::<BlockId, _>::from_vec(vec![None; module.blocks.len()]);
-        entry_depths[entry] = Some(0);
-        let mut pending = vec![entry];
+        entry_depths[BlockId::ENTRY] = Some(0);
+        let mut pending = vec![BlockId::ENTRY];
         while let Some(block_id) = pending.pop() {
             let block = &module.blocks[block_id];
             let term =

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -18,8 +18,7 @@ pub(crate) struct FunctionBuilder<'a> {
 impl<'a> FunctionBuilder<'a> {
     /// Creates a new function builder.
     pub(crate) fn new(func: &'a mut Function) -> Self {
-        let entry = func.entry_block;
-        Self { func, current_block: entry }
+        Self { func, current_block: BlockId::ENTRY }
     }
 
     /// Returns the current block.

--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -22,12 +22,10 @@ pub(crate) fn display_function_dot<'a>(
     ) -> impl fmt::Display + 'a {
         fmt::from_fn(move |f| {
             let block_idx = block_id.index();
-            let is_entry = block_id == func.entry_block;
-            let color = if is_entry { ", fillcolor=\"#e0ffe0\", style=filled" } else { "" };
 
             write!(f, "    bb{block_idx} [label=\"")?;
             write_dot_block_label(f, func, funcs, block_id)?;
-            writeln!(f, "\"{color}];")
+            writeln!(f, "\"];")
         })
     }
 
@@ -39,8 +37,7 @@ pub(crate) fn display_function_dot<'a>(
     ) -> fmt::Result {
         let block = &func.blocks[block_id];
         let block_idx = block_id.index();
-        let entry_marker = if block_id == func.entry_block { " (entry)" } else { "" };
-        write!(f, "bb{block_idx}{entry_marker}:\\l")?;
+        write!(f, "bb{block_idx}:\\l")?;
 
         write!(
             f,
@@ -199,8 +196,7 @@ pub(crate) fn display_function_text<'a>(
         block: &'a BasicBlock,
     ) -> impl fmt::Display + 'a {
         fmt::from_fn(move |f| {
-            let entry_marker = if block_id == func.entry_block { " (entry)" } else { "" };
-            writeln!(f, "  bb{}{}:", block_id.index(), entry_marker)?;
+            writeln!(f, "  bb{}:", block_id.index())?;
 
             write!(
                 f,
@@ -545,7 +541,7 @@ mod tests {
                 text,
                 str![[r#"
 fn @display_test(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = add arg0, 1
     ret v0
 }
@@ -560,7 +556,7 @@ digraph "display_test" {
     node [shape=box, fontname="Courier", fontsize=10];
     edge [fontname="Courier", fontsize=9];
 
-    bb0 [label="bb0 (entry):\l  v0 = add arg0, 1\l  ret v0\l", fillcolor="#e0ffe0", style=filled];
+    bb0 [label="bb0:\l  v0 = add arg0, 1\l  ret v0\l"];
 
 }
 
@@ -591,7 +587,7 @@ digraph "display_test" {
                 text,
                 str![[r#"
 fn @display_test(arg0: u256, arg1: bool) {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     ret arg0
@@ -609,7 +605,7 @@ digraph "display_test" {
     node [shape=box, fontname="Courier", fontsize=10];
     edge [fontname="Courier", fontsize=9];
 
-    bb0 [label="bb0 (entry):\l  br arg1, bb1, bb2\l", fillcolor="#e0ffe0", style=filled];
+    bb0 [label="bb0:\l  br arg1, bb1, bb2\l"];
     bb1 [label="bb1:\l  ret arg0\l"];
     bb2 [label="bb2:\l  ret arg0\l"];
 
@@ -640,7 +636,7 @@ digraph "display_test" {
                 text,
                 str![[r#"
 fn @display_test(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     sstore arg0, arg1 !metadata(storage=symbolic(arg0))
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     ret v0
@@ -656,7 +652,7 @@ digraph "display_test" {
     node [shape=box, fontname="Courier", fontsize=10];
     edge [fontname="Courier", fontsize=9];
 
-    bb0 [label="bb0 (entry):\l  sstore arg0, arg1\l  v0 = sload arg0\l  ret v0\l", fillcolor="#e0ffe0", style=filled];
+    bb0 [label="bb0:\l  sstore arg0, arg1\l  v0 = sload arg0\l  ret v0\l"];
 
 }
 

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -38,10 +38,8 @@ pub(crate) struct Function {
     pub(crate) values: IndexVec<ValueId, Value>,
     /// All instructions in this function.
     pub(crate) instructions: IndexVec<InstId, Instruction>,
-    /// All basic blocks in this function.
+    /// All basic blocks in this function. This is never empty; block zero is the entry.
     pub(crate) blocks: IndexVec<BlockId, BasicBlock>,
-    /// The entry block.
-    pub(crate) entry_block: BlockId,
 }
 
 impl Function {
@@ -49,7 +47,8 @@ impl Function {
     #[must_use]
     pub(crate) fn new(name: Ident) -> Self {
         let mut blocks = IndexVec::new();
-        let entry_block = blocks.push(BasicBlock::new());
+        let entry = blocks.push(BasicBlock::new());
+        debug_assert_eq!(entry, BlockId::ENTRY);
 
         Self {
             name,
@@ -62,7 +61,6 @@ impl Function {
             values: IndexVec::new(),
             instructions: IndexVec::new(),
             blocks,
-            entry_block,
         }
     }
 

--- a/crates/codegen/src/mir/inst.rs
+++ b/crates/codegen/src/mir/inst.rs
@@ -1201,7 +1201,7 @@ mod tests {
     #[test]
     fn phi_operands_include_incoming_values() {
         let mut func = Function::new(Ident::DUMMY);
-        let pred_a = func.entry_block;
+        let pred_a = BlockId::ENTRY;
         let pred_b = func.alloc_block();
         let a = func.alloc_value(Value::Immediate(Immediate::uint256(U256::from(1))));
         let b = func.alloc_value(Value::Immediate(Immediate::uint256(U256::from(2))));

--- a/crates/codegen/src/mir/mod.rs
+++ b/crates/codegen/src/mir/mod.rs
@@ -53,6 +53,11 @@ newtype_index! {
     pub(crate) struct FunctionId;
 }
 
+impl BlockId {
+    /// The first block in every function.
+    pub(crate) const ENTRY: Self = Self::new(0);
+}
+
 /// Property tests verifying that the MIR printer/parser pair is self-consistent.
 ///
 /// For each fixture under `tests/ui/codegen/`:

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -5,7 +5,7 @@
 //! ```text
 //! @module Counter
 //! fn @increment() {
-//!   bb0 (entry):
+//!   bb0:
 //!     v0 = sload 0
 //!     v1 = add v0, 1
 //!     sstore 0, v1
@@ -58,26 +58,20 @@ pub(super) fn parse(sess: &Session, source: &SourceFile) -> Result<Module> {
 
 #[cfg(test)]
 pub(super) fn parse_module(sess: &Session, input: &str) -> Result<Module> {
-    let id = input.bytes().fold(0u64, |hash, byte| hash.wrapping_mul(31).wrapping_add(byte.into()));
+    let name = format!("test{}.mir", sess.source_map().files().len());
     let file = sess
         .source_map()
-        .new_source_file(
-            solar_interface::source_map::FileName::Custom(format!("mir-test-{id}")),
-            input,
-        )
+        .new_source_file(solar_interface::source_map::FileName::Custom(name), input)
         .unwrap();
     Module::parse(sess, &file)
 }
 
 #[cfg(test)]
 fn parse_function(sess: &Session, input: &str) -> Result<Function> {
-    let id = input.bytes().fold(0u64, |hash, byte| hash.wrapping_mul(31).wrapping_add(byte.into()));
+    let name = format!("test{}.mir", sess.source_map().files().len());
     let source = sess
         .source_map()
-        .new_source_file(
-            solar_interface::source_map::FileName::Custom(format!("mir-function-test-{id}")),
-            input,
-        )
+        .new_source_file(solar_interface::source_map::FileName::Custom(name), input)
         .unwrap();
     let arena = Arena::new();
     let mut p = Parser::new(sess, &arena, &source);
@@ -342,6 +336,9 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 self.parse_instruction_or_terminator(&mut builder)?;
             }
 
+            if self.block_order.is_empty() {
+                return Err(self.parser.error("function must contain at least one block"));
+            }
             self.reject_unresolved_block_labels()?;
             self.reject_unresolved_value_labels(builder.func())?;
             crate::mir::utils::remap_block_order(builder.func_mut(), &self.block_order)
@@ -363,17 +360,10 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let Ok(index) = index.parse() else {
             return Ok(None);
         };
-        if !matches!(
-            self.parser.look_ahead(1).kind,
-            TokenKind::Colon | TokenKind::OpenDelim(Delimiter::Parenthesis)
-        ) {
+        if !matches!(self.parser.look_ahead(1).kind, TokenKind::Colon) {
             return Ok(None);
         }
         self.parser.bump();
-        if self.parser.eat(TokenKind::OpenDelim(Delimiter::Parenthesis)) {
-            self.parser.expect_keyword(sym::entry)?;
-            self.parser.expect(TokenKind::CloseDelim(Delimiter::Parenthesis))?;
-        }
         self.parser.expect(TokenKind::Colon)?;
         Ok(Some(index))
     }
@@ -391,11 +381,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             self.block_order.push(label.id);
             return Ok(label.id);
         }
-        let id = if self.block_labels.is_empty() {
-            builder.func().entry_block
-        } else {
-            builder.create_block()
-        };
+        let id = if self.block_labels.is_empty() { BlockId::ENTRY } else { builder.create_block() };
         self.block_labels.insert(index, BlockLabel { id, defined: true, reference_span: None });
         self.block_order.push(id);
         Ok(id)
@@ -587,11 +573,8 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         if let Some(label) = self.block_labels.get(&idx) {
             return Ok(label.id);
         }
-        let block = if self.block_labels.is_empty() {
-            builder.func().entry_block
-        } else {
-            builder.create_block()
-        };
+        let block =
+            if self.block_labels.is_empty() { BlockId::ENTRY } else { builder.create_block() };
         self.block_labels
             .insert(idx, BlockLabel { id: block, defined: false, reference_span: Some(span) });
         Ok(block)
@@ -1134,7 +1117,7 @@ mod tests {
     #[test]
     fn parse_module_phase_header() {
         with_session(|sess| {
-            let src = "/// module docs\n@module Phased\n@phase optimized\nfn @f() {\n  bb0 (entry):\n    stop\n}\n";
+            let src = "/// module docs\n@module Phased\n@phase optimized\nfn @f() {\n  bb0:\n    stop\n}\n";
             let module = parse_module(sess, src).unwrap();
             assert_eq!(module.phase, crate::mir::MirPhase::Optimized);
             // Round-trips through the printer.
@@ -1145,7 +1128,7 @@ mod tests {
 @module Phased
 @phase optimized
 fn @f() {
-  bb0 (entry):
+  bb0:
     stop
 }
 
@@ -1155,7 +1138,7 @@ fn @f() {
             assert_eq!(reparsed.phase, crate::mir::MirPhase::Optimized);
 
             // The default phase is not printed, and parses back as built.
-            let src = "@module Fresh\nfn @f() {\n  bb0 (entry):\n    stop\n}\n";
+            let src = "@module Fresh\nfn @f() {\n  bb0:\n    stop\n}\n";
             let module = parse_module(sess, src).unwrap();
             assert_eq!(module.phase, crate::mir::MirPhase::Built);
             assert_data_eq!(
@@ -1163,7 +1146,7 @@ fn @f() {
                 str![[r#"
 @module Fresh
 fn @f() {
-  bb0 (entry):
+  bb0:
     stop
 }
 
@@ -1179,7 +1162,7 @@ fn @f() {
                 crate::mir::MirPhase::EvmShaped,
             ] {
                 let src = format!(
-                    "@module P\n@phase {}\nfn @f() {{\n  bb0 (entry):\n    stop\n}}\n",
+                    "@module P\n@phase {}\nfn @f() {{\n  bb0:\n    stop\n}}\n",
                     phase.name()
                 );
                 let module = parse_module(sess, &src).unwrap();
@@ -1189,13 +1172,13 @@ fn @f() {
             }
 
             // Unknown phase names are rejected.
-            let src = "@module Bogus\n@phase shiny\nfn @f() {\n  bb0 (entry):\n    stop\n}\n";
+            let src = "@module Bogus\n@phase shiny\nfn @f() {\n  bb0:\n    stop\n}\n";
             assert!(parse_module(sess, src).is_err());
             assert_data_eq!(
                 sess.emitted_diagnostics().unwrap().to_string(),
                 str![[r#"
 error: unknown MIR phase `shiny`
-  ╭▸ <mir-test-15579854765591958512>:2:8
+  ╭▸ <test13.mir>:2:8
   │
 2 │ @phase shiny
   ╰╴       ━━━━━
@@ -1209,14 +1192,14 @@ error: unknown MIR phase `shiny`
     #[test]
     fn parser_does_not_treat_newlines_as_syntax() {
         with_session(|sess| {
-            let src = "@module m fn @f() -> u256 { bb0 (entry): v0 = add 1, 2 ret v0 }";
+            let src = "@module m fn @f() -> u256 { bb0: v0 = add 1, 2 ret v0 }";
             let module = parse_module(sess, src).unwrap();
             assert_data_eq!(
                 module.to_text().to_string(),
                 str![[r#"
 @module m
 fn @f() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = add 1, 2
     ret v0
 }
@@ -1231,7 +1214,7 @@ fn @f() -> u256 {
         with_session(|sess| {
             let src = "\
 fn @add(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, arg1
     ret v2
 }
@@ -1251,7 +1234,7 @@ fn @add(arg0: u256, arg1: u256) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @increment() {
-  bb0 (entry):
+  bb0:
     v0 = sload 0
     v1 = add v0, 1
     sstore 0, v1
@@ -1274,7 +1257,7 @@ fn @increment() {
         with_session(|sess| {
             let src = "\
 fn @max(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = gt arg0, arg1
     br v2, bb1, bb2
   bb1:
@@ -1286,7 +1269,7 @@ fn @max(arg0: u256, arg1: u256) -> u256 {
             let func = parse_function(sess, src).unwrap();
             assert_eq!(func.blocks.len(), 3);
             // bb0 should have 2 successors.
-            assert_eq!(func.blocks[func.entry_block].terminator().unwrap().successors().len(), 2);
+            assert_eq!(func.blocks[BlockId::ENTRY].terminator().unwrap().successors().len(), 2);
         });
     }
 
@@ -1295,7 +1278,7 @@ fn @max(arg0: u256, arg1: u256) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @count_down(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = lt 0, arg0
@@ -1316,7 +1299,7 @@ fn @count_down(arg0: u256) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @do_call(arg0: address, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = call 100, arg0, arg1, 0, 0, 0, 0
     ret v2
 }
@@ -1331,7 +1314,7 @@ fn @do_call(arg0: address, arg1: u256) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @hash() -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 0, 1
     mstore 32, 2
     v1 = keccak256 0, 64
@@ -1349,12 +1332,12 @@ fn @hash() -> u256 {
             let src = "\
 @module Counter
 fn @count() {
-  bb0 (entry):
+  bb0:
     tail_call @set, 1
 }
 
 fn @set(arg0: u256) {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0
     stop
 }
@@ -1380,7 +1363,7 @@ fn @set(arg0: u256) {
         with_session(|sess| {
             let src = "\
 fn @bad() {
-  bb0 (entry):
+  bb0:
     v1 = bogus arg0
     stop
 }
@@ -1390,10 +1373,29 @@ fn @bad() {
                 sess.emitted_diagnostics().unwrap().to_string(),
                 str![[r#"
 error: unknown instruction `bogus`
-  ╭▸ <mir-function-test-13016118735129543399>:3:10
+  ╭▸ <test0.mir>:3:10
   │
 3 │     v1 = bogus arg0
   ╰╴         ━━━━━
+
+
+"#]]
+            );
+        });
+    }
+
+    #[test]
+    fn parse_function_without_blocks_errors() {
+        with_session(|sess| {
+            assert!(parse_function(sess, "fn @bad() {}\n").is_err());
+            assert_data_eq!(
+                sess.emitted_diagnostics().unwrap().to_string(),
+                str![[r#"
+error: function must contain at least one block
+  ╭▸ <test0.mir>:1:12
+  │
+1 │ fn @bad() {}
+  ╰╴           ━
 
 
 "#]]
@@ -1425,7 +1427,7 @@ error: expected identifier
         });
 
         with_session(|sess| {
-            let input = "@module m\nfn @f() {\n  bb0 (entry):\n    %bad\n}\n";
+            let input = "@module m\nfn @f() {\n  bb0:\n    %bad\n}\n";
             let source = sess
                 .source_map()
                 .new_source_file(FileName::Custom("malformed-result.mir".into()), input)
@@ -1446,7 +1448,7 @@ error: expected identifier
         });
 
         with_session(|sess| {
-            let input = "@module m\nfn @f() {\n  bb0 (entry):\n    jump bb9\n}\n";
+            let input = "@module m\nfn @f() {\n  bb0:\n    jump bb9\n}\n";
             let source = sess
                 .source_map()
                 .new_source_file(FileName::Custom("unknown-block.mir".into()), input)
@@ -1471,13 +1473,13 @@ error: unknown block `bb9`
     fn error_snippet_format_is_clang_like() {
         // Verify the precise format users will see, end-to-end.
         with_session(|sess| {
-            let src = "fn @x() -> notatype {\n  bb0 (entry):\n    stop\n}\n";
+            let src = "fn @x() -> notatype {\n  bb0:\n    stop\n}\n";
             assert!(parse_function(sess, src).is_err());
             assert_data_eq!(
                 sess.emitted_diagnostics().unwrap().to_string(),
                 str![[r#"
 error: unknown type `notatype`
-  ╭▸ <mir-function-test-2067061233293511805>:1:21
+  ╭▸ <test0.mir>:1:21
   │
 1 │ fn @x() -> notatype {
   ╰╴                    ━
@@ -1493,7 +1495,7 @@ error: unknown type `notatype`
         with_session(|sess| {
             for span in ["1..5", "1 .. 5"] {
                 let src = format!(
-                    "@module m\nfn @f() {{\n  bb0 (entry):\n    v0 = sload 0 !metadata(span={span})\n    stop\n}}\n"
+                    "@module m\nfn @f() {{\n  bb0:\n    v0 = sload 0 !metadata(span={span})\n    stop\n}}\n"
                 );
                 let module = parse_module(sess, &src).unwrap();
                 assert_data_eq!(
@@ -1501,7 +1503,7 @@ error: unknown type `notatype`
                     str![[r#"
 @module m
 fn @f() {
-  bb0 (entry):
+  bb0:
     v0 = sload 0 !metadata(span=1..5)
     stop
 }
@@ -1517,13 +1519,13 @@ fn @f() {
         with_session(|sess| {
             let src = "\
 fn @oops() {
-  bb0 (entry):
+  bb0:
     revert 0, 0
 }
 ";
             let func = parse_function(sess, src).unwrap();
             assert!(matches!(
-                func.blocks[func.entry_block].terminator,
+                func.blocks[BlockId::ENTRY].terminator,
                 Some(Terminator::Revert { .. })
             ));
         });
@@ -1534,7 +1536,7 @@ fn @oops() {
         with_session(|sess| {
             let src = "\
 fn @env() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = caller
     v1 = callvalue
     v2 = gas
@@ -1552,7 +1554,7 @@ fn @env() -> u256 {
         with_session(|sess| {
             let src = "\
 fn @sel(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v3 = select arg0, arg1, arg2
     log1 0, 32, v3
     ret v3
@@ -1568,7 +1570,7 @@ fn @sel(arg0: bool, arg1: u256, arg2: u256) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -1597,7 +1599,7 @@ fn @diamond(arg0: bool) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @dispatch(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
   bb1:
     ret arg0
@@ -1611,7 +1613,7 @@ fn @dispatch(arg0: u256) -> u256 {
 ";
             let func = parse_function(sess, src).unwrap();
             assert_eq!(func.blocks.len(), 5);
-            let term = func.blocks[func.entry_block].terminator.as_ref().unwrap();
+            let term = func.blocks[BlockId::ENTRY].terminator.as_ref().unwrap();
             if let Terminator::Switch { cases, .. } = term {
                 assert_eq!(cases.len(), 3);
             } else {
@@ -1627,7 +1629,7 @@ fn @dispatch(arg0: u256) -> u256 {
         with_session(|sess| {
             let src = "\
 fn @diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -1644,7 +1646,7 @@ fn @diamond(arg0: bool) -> u256 {
                 &printed,
                 str![[r#"
 fn @diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/crates/codegen/src/mir/utils.rs
+++ b/crates/codegen/src/mir/utils.rs
@@ -17,7 +17,6 @@ pub(crate) fn remap_block_order(func: &mut Function, order: &[BlockId]) -> Vec<B
     }
     debug_assert!(old_blocks.into_iter().all(|block| block.is_none()));
     func.blocks = blocks;
-    func.entry_block = remap[func.entry_block.index()];
 
     for block in &mut func.blocks {
         for predecessor in &mut block.predecessors {
@@ -82,11 +81,7 @@ pub(crate) enum StorageAliasScope {
 ///
 /// Self-loops (`pred == succ`) are supported: the new block takes over the
 /// backedge and `succ`'s phis are rekeyed from `pred` to the new block.
-///
-/// `succ` cannot be the entry block, which has no predecessors by definition.
 pub(crate) fn split_edge(func: &mut Function, pred: BlockId, succ: BlockId) -> BlockId {
-    debug_assert_ne!(succ, func.entry_block, "the entry block has no predecessor edges to split");
-
     let new_block = func.blocks.push(BasicBlock {
         instructions: Vec::new(),
         terminator: Some(Terminator::Jump(succ)),

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -410,7 +410,7 @@ pub(crate) trait FunctionPass {
 impl<T: FunctionPass> ModulePass for T {
     fn run(&mut self, _gcx: Gcx<'_>, module: &mut Module) -> bool {
         let mut changed = false;
-        for func in module.functions.iter_mut().filter(|func| !func.blocks.is_empty()) {
+        for func in &mut module.functions {
             changed |= self.run_on_function(func);
         }
         changed

--- a/crates/codegen/src/transform/cfg_simplify.rs
+++ b/crates/codegen/src/transform/cfg_simplify.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     pass::{FunctionPass, ModulePass},
 };
-use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
+use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec, map::FxHashMap};
 
 /// Alpha-equivalence key for a terminal block used by
 /// [`CfgSimplifier::deduplicate_terminal_blocks`].
@@ -155,7 +155,7 @@ impl CfgSimplifier {
         let mut kept: Vec<(BlockId, CanonBlock)> = Vec::new();
         let mut merges: Vec<(BlockId, BlockId)> = Vec::new();
         for block_id in func.blocks.indices() {
-            if block_id == func.entry_block || func.blocks[block_id].predecessors.is_empty() {
+            if func.blocks[block_id].predecessors.is_empty() {
                 continue;
             }
             let Some(canon) = Self::canonicalize_terminal_block(func, block_id, &inst_results)
@@ -388,10 +388,6 @@ impl CfgSimplifier {
             return None;
         }
 
-        if *target == func.entry_block {
-            return None;
-        }
-
         let target_block = &func.blocks[*target];
         if target_block.predecessors.len() != 1 {
             return None;
@@ -477,9 +473,10 @@ impl CfgSimplifier {
         while eliminated {
             eliminated = false;
 
+            let cfg = CfgInfo::new(func);
             let block_ids: Vec<_> = func.blocks.indices().collect();
             for block_id in block_ids {
-                if block_id == func.entry_block {
+                if func.blocks[block_id].predecessors.is_empty() && cfg.is_reachable(block_id) {
                     continue;
                 }
 
@@ -682,16 +679,36 @@ impl DeadFunctionEliminator {
             return 0;
         }
 
-        let dead_functions: Vec<FunctionId> =
-            module.functions.indices().filter(|&id| !reachable.contains(id)).collect();
+        self.stats.dead_functions_eliminated = module.functions.len() - reachable.count();
+        if self.stats.dead_functions_eliminated == 0 {
+            return 0;
+        }
 
-        self.stats.dead_functions_eliminated = dead_functions.len();
+        let mut remap = vec![None; module.functions.len()];
+        let mut old_functions: Vec<_> =
+            std::mem::take(&mut module.functions).into_iter().map(Some).collect();
+        let mut functions = IndexVec::with_capacity(reachable.count());
+        for old_id in reachable {
+            let function =
+                old_functions[old_id.index()].take().expect("reachable function must exist");
+            let new_id = functions.push(function);
+            remap[old_id.index()] = Some(new_id);
+        }
+        module.functions = functions;
 
-        for func_id in &dead_functions {
-            let func = &mut module.functions[*func_id];
-            func.blocks.clear();
-            func.instructions.clear();
-            func.values.clear();
+        for func in &mut module.functions {
+            for inst in &mut func.instructions {
+                if let InstKind::InternalCall { function, .. } = &mut inst.kind {
+                    *function = remap[function.index()]
+                        .expect("reachable function cannot call an eliminated function");
+                }
+            }
+            for block in &mut func.blocks {
+                if let Some(Terminator::TailCall { function, .. }) = &mut block.terminator {
+                    *function = remap[function.index()]
+                        .expect("reachable function cannot tail-call an eliminated function");
+                }
+            }
         }
 
         self.stats.dead_functions_eliminated
@@ -709,8 +726,8 @@ mod tests {
     fn dead_function_elimination_keeps_internal_call_targets() {
         let mut module = Module::new(Ident::DUMMY);
 
-        let live_helper = module.add_function(Function::new(Ident::DUMMY));
         let dead_helper = module.add_function(Function::new(Ident::DUMMY));
+        let live_helper = module.add_function(Function::new(Ident::DUMMY));
 
         let mut entry = Function::new(Ident::DUMMY);
         entry.selector = Some([0, 0, 0, 1]);
@@ -720,7 +737,13 @@ mod tests {
             let value = builder.internal_call(live_helper, Vec::new(), MirType::uint256(), 1);
             builder.ret([value]);
         }
-        let entry = module.add_function(entry);
+        module.add_function(entry);
+
+        let mut tail_entry = Function::new(Ident::DUMMY);
+        tail_entry.selector = Some([0, 0, 0, 2]);
+        tail_entry.attributes.visibility = Visibility::Public;
+        FunctionBuilder::new(&mut tail_entry).tail_call(live_helper, Vec::new());
+        module.add_function(tail_entry);
 
         {
             let mut builder = FunctionBuilder::new(module.function_mut(live_helper));
@@ -736,11 +759,24 @@ mod tests {
         let mut dfe = DeadFunctionEliminator::new();
         assert_eq!(dfe.run(&mut module), 1);
 
-        assert!(!module.function(entry).blocks.is_empty());
-        assert!(!module.function(live_helper).blocks.is_empty());
-        assert!(module.function(dead_helper).blocks.is_empty());
-        assert!(module.function(dead_helper).instructions.is_empty());
-        assert!(module.function(dead_helper).values.is_empty());
+        assert_eq!(module.functions.len(), 3);
+        assert!(module.functions.iter().all(|func| !func.blocks.is_empty()));
+        let live_helper = FunctionId::from_usize(0);
+        let entry = module.function(FunctionId::from_usize(1));
+        let InstKind::InternalCall { function, .. } =
+            &entry.instructions.iter().next().expect("entry call").kind
+        else {
+            panic!("expected internal call");
+        };
+        assert_eq!(*function, live_helper);
+
+        let tail_entry = module.function(FunctionId::from_usize(2));
+        let Some(Terminator::TailCall { function, .. }) =
+            &tail_entry.blocks[BlockId::ENTRY].terminator
+        else {
+            panic!("expected tail call");
+        };
+        assert_eq!(*function, live_helper);
     }
 
     #[test]
@@ -787,7 +823,7 @@ mod tests {
         let InstKind::Phi(incoming) = &func.instructions[phi_inst].kind else {
             panic!("expected phi");
         };
-        assert_eq!(incoming.as_slice(), &[(func.entry_block, value), (direct, other)]);
+        assert_eq!(incoming.as_slice(), &[(BlockId::ENTRY, value), (direct, other)]);
     }
 
     #[test]

--- a/crates/codegen/src/transform/check_elim.rs
+++ b/crates/codegen/src/transform/check_elim.rs
@@ -125,10 +125,6 @@ impl CheckEliminator {
     /// branches.
     pub(crate) fn run(&mut self, func: &mut Function) -> usize {
         self.stats = CheckElimStats::default();
-        if func.blocks.is_empty() {
-            return 0;
-        }
-
         let cfg = CfgInfo::new(func);
 
         // Predecessors recomputed from reachable terminators: facts must only
@@ -171,7 +167,7 @@ impl CheckEliminator {
         }
 
         let mut folds = Vec::new();
-        let mut stack = vec![Walk::Enter(func.entry_block)];
+        let mut stack = vec![Walk::Enter(BlockId::ENTRY)];
         while let Some(item) = stack.pop() {
             match item {
                 Walk::Exit { range_mark, relation_mark } => {
@@ -599,11 +595,6 @@ fn dominating_edge_fact(
     preds: &[Vec<BlockId>],
     block: BlockId,
 ) -> Option<(ValueId, bool)> {
-    // The entry executes before any branch, so no edge fact holds on it even
-    // if malformed input gives it a predecessor.
-    if block == func.entry_block {
-        return None;
-    }
     let preds = &preds[block.index()];
     let (&first, rest) = preds.split_first()?;
     if rest.iter().any(|&pred| pred != first) {

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -385,7 +385,7 @@ impl CommonSubexprEliminator {
     }
 
     fn process_global_blocks(&mut self, func: &Function, ctx: &mut GlobalCseContext<'_>) {
-        let mut worklist = vec![(func.entry_block, FxHashMap::default())];
+        let mut worklist = vec![(BlockId::ENTRY, FxHashMap::default())];
         while let Some((block_id, mut cache)) = worklist.pop() {
             for &inst_id in &func.blocks[block_id].instructions {
                 let kind = func.instructions[inst_id].kind.clone();

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -799,7 +799,7 @@ impl<'a> SlotSsaBuilder<'a> {
         for block in sorted_blocks(&self.phi_blocks) {
             self.create_phi(func, block);
         }
-        self.rename_block(func, func.entry_block, None);
+        self.rename_block(func, BlockId::ENTRY, None);
         !self.failed
     }
 

--- a/crates/codegen/src/transform/gvn.rs
+++ b/crates/codegen/src/transform/gvn.rs
@@ -173,7 +173,7 @@ impl GlobalValueNumberer {
             replacements: &mut replacements,
             dead: &mut dead,
         };
-        self.replace_in_block(func, func.entry_block, &mut leaders, &mut ctx);
+        self.replace_in_block(func, BlockId::ENTRY, &mut leaders, &mut ctx);
 
         if replacements.is_empty() {
             return false;

--- a/crates/codegen/src/transform/inline.rs
+++ b/crates/codegen/src/transform/inline.rs
@@ -739,7 +739,7 @@ impl<'a> InlineCloner<'a> {
             self.caller.blocks[caller_block].terminator = Some(term);
         }
 
-        Some(self.block_map[&self.callee.entry_block])
+        Some(self.block_map[&BlockId::ENTRY])
     }
 
     fn clone_value(&mut self, value: ValueId) -> Option<ValueId> {

--- a/crates/codegen/src/transform/inst_simplify.rs
+++ b/crates/codegen/src/transform/inst_simplify.rs
@@ -975,7 +975,7 @@ impl InstSimplifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mir::{FunctionBuilder, MirType};
+    use crate::mir::{BlockId, FunctionBuilder, MirType};
     use solar_interface::Ident;
 
     fn test_func() -> Function {
@@ -994,7 +994,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1014,7 +1014,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
@@ -1032,7 +1032,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1056,7 +1056,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 3);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1080,7 +1080,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
@@ -1098,7 +1098,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1121,7 +1121,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 1);
         let eq_inst = func.instructions[block.instructions[0]].kind.clone();
         assert!(matches!(eq_inst, InstKind::IsZero(value) if value == arg));
@@ -1139,7 +1139,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
@@ -1158,7 +1158,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 1);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1177,7 +1177,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 2);
         let balance_inst = func.instructions[*block.instructions.last().unwrap()].kind.clone();
         assert!(matches!(balance_inst, InstKind::SelfBalance));
@@ -1198,7 +1198,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 2);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         let Some(Terminator::Branch { condition, then_block: new_then, else_block: new_else }) =
             block.terminator
         else {
@@ -1222,7 +1222,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 2);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 2);
         let balance_inst = func.instructions[*block.instructions.last().unwrap()].kind.clone();
         assert!(matches!(balance_inst, InstKind::SelfBalance));

--- a/crates/codegen/src/transform/jump_threading.rs
+++ b/crates/codegen/src/transform/jump_threading.rs
@@ -118,8 +118,7 @@ impl JumpThreader {
         let mut forwarders = FxHashMap::default();
 
         for (block_id, block) in func.blocks.iter_enumerated() {
-            // Skip the entry block
-            if block_id == func.entry_block {
+            if block.predecessors.is_empty() {
                 continue;
             }
 

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -395,7 +395,7 @@ impl LoadRedundancyEliminator {
         let mut outs: FxHashMap<BlockId, KeySet> = rpo
             .iter()
             .map(|&block| {
-                let out = if block == func.entry_block {
+                let out = if func.blocks[block].predecessors.is_empty() {
                     gens[&block].clone()
                 } else {
                     KeySet::new_filled(key_count)
@@ -406,23 +406,19 @@ impl LoadRedundancyEliminator {
         loop {
             let mut changed = false;
             for &block in rpo {
-                let in_set = if block == func.entry_block {
-                    KeySet::new_empty(key_count)
-                } else {
-                    let mut acc: Option<KeySet> = None;
-                    for &pred in &func.blocks[block].predecessors {
-                        // Unreachable predecessors never execute and cannot
-                        // contribute a path.
-                        let Some(out) = outs.get(&pred) else { continue };
-                        match &mut acc {
-                            Some(acc) => {
-                                acc.intersect(out);
-                            }
-                            None => acc = Some(out.clone()),
+                let mut acc: Option<KeySet> = None;
+                for &pred in &func.blocks[block].predecessors {
+                    // Unreachable predecessors never execute and cannot
+                    // contribute a path.
+                    let Some(out) = outs.get(&pred) else { continue };
+                    match &mut acc {
+                        Some(acc) => {
+                            acc.intersect(out);
                         }
+                        None => acc = Some(out.clone()),
                     }
-                    acc.unwrap_or_else(|| KeySet::new_empty(key_count))
-                };
+                }
+                let in_set = acc.unwrap_or_else(|| KeySet::new_empty(key_count));
                 let mut out = in_set.clone();
                 if let Some(kill) = kills.get(&block) {
                     out.subtract(kill);

--- a/crates/codegen/src/transform/lower_abi.rs
+++ b/crates/codegen/src/transform/lower_abi.rs
@@ -39,7 +39,7 @@
 //! and is dispatched by the backend instead.
 
 use crate::{
-    mir::{Function, FunctionBuilder, FunctionId, InstKind, MirPhase, Module, Terminator},
+    mir::{BlockId, Function, FunctionBuilder, FunctionId, InstKind, MirPhase, Module, Terminator},
     pass::ModulePass,
 };
 use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
@@ -200,7 +200,7 @@ impl LowerAbiPass {
     /// per-wrapper payable-check shape. Injected after the `.body` copy is
     /// taken: internal callers never pay the check.
     fn inject_callvalue_check(func: &mut Function) {
-        let old_entry = func.entry_block;
+        let old_entry = BlockId::ENTRY;
         let mut builder = FunctionBuilder::new(func);
         let guard = builder.create_block();
         let revert = builder.create_block();
@@ -210,7 +210,11 @@ impl LowerAbiPass {
         builder.switch_to_block(revert);
         let zero = builder.imm_u64(0);
         builder.revert(zero, zero);
-        func.entry_block = guard;
+
+        let order = std::iter::once(guard)
+            .chain(func.blocks.indices().filter(|&block| block != guard))
+            .collect::<Vec<_>>();
+        crate::mir::utils::remap_block_order(func, &order);
     }
 }
 
@@ -223,7 +227,7 @@ impl ModulePass for LowerAbiPass {
 /// An external entry with a body and a selector — the shape a wrapper is built
 /// for. Receive/fallback entries have no selector and are left to the backend.
 fn is_wrappable_external(func: &Function) -> bool {
-    func.selector.is_some() && !func.attributes.is_constructor && !func.blocks.is_empty()
+    func.selector.is_some() && !func.attributes.is_constructor
 }
 
 /// Absorption relies on the fused encode: the body must produce its own

--- a/crates/codegen/src/transform/lower_dispatch.rs
+++ b/crates/codegen/src/transform/lower_dispatch.rs
@@ -54,8 +54,8 @@ impl LowerDispatchPass {
             return false;
         }
 
-        // Collect the routable external wrappers: a selector plus a body. After
-        // the ABI phase every such wrapper is argument-free; assert that rather
+        // Collect the routable external wrappers. After the ABI phase every
+        // such wrapper is argument-free; assert that rather
         // than silently skipping, since a leftover argument-taking selector
         // function would mean the ABI invariant was violated.
         let mut routes: Vec<(u32, FunctionId)> = Vec::new();
@@ -64,15 +64,13 @@ impl LowerDispatchPass {
         let mut callvalue = super::DispatchCallvalue::default();
         for (id, func) in module.functions.iter_enumerated() {
             callvalue.observe(func);
-            if func.attributes.is_receive && !func.blocks.is_empty() && receive.is_none() {
+            if func.attributes.is_receive && receive.is_none() {
                 receive = Some(id);
             }
-            if func.attributes.is_fallback && !func.blocks.is_empty() && fallback.is_none() {
+            if func.attributes.is_fallback && fallback.is_none() {
                 fallback = Some(id);
             }
-            if let Some(selector) = func.selector
-                && !func.blocks.is_empty()
-            {
+            if let Some(selector) = func.selector {
                 debug_assert!(
                     func.params.is_empty(),
                     "dispatch after abi phase: selector function `{}` still takes arguments",
@@ -83,10 +81,8 @@ impl LowerDispatchPass {
         }
         routes.sort_by_key(|(selector, _)| *selector);
 
-        // Receive/fallback entries, mirroring the backend dispatcher: only
-        // bodied declarations participate in runtime dispatch. A fallback with
-        // the `fallback(bytes) returns (bytes)` shape takes an argument this
-        // switch cannot supply; bail all-or-nothing rather than half-routing.
+        // A fallback with the `fallback(bytes) returns (bytes)` shape takes an
+        // argument this switch cannot supply; bail all-or-nothing rather than half-routing.
         for id in [receive, fallback].into_iter().flatten() {
             if !module.function(id).params.is_empty() {
                 return false;

--- a/crates/codegen/src/transform/lower_evm_shaped.rs
+++ b/crates/codegen/src/transform/lower_evm_shaped.rs
@@ -115,8 +115,8 @@ impl ModulePass for LowerEvmShapedPass {
 /// Whether a function can never return to an internal caller: it has no `ret`
 /// and no `stop` terminator (`stop` is the internal return of a void function).
 fn function_cannot_return(func: &Function) -> bool {
-    !func.blocks.is_empty()
-        && !func.blocks.iter().any(|block| {
-            matches!(block.terminator, Some(Terminator::Return { .. } | Terminator::Stop))
-        })
+    !func
+        .blocks
+        .iter()
+        .any(|block| matches!(block.terminator, Some(Terminator::Return { .. } | Terminator::Stop)))
 }

--- a/crates/codegen/src/transform/memory_dse.rs
+++ b/crates/codegen/src/transform/memory_dse.rs
@@ -1431,7 +1431,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 1);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 1);
     }
 
     #[test]
@@ -1449,7 +1449,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 2);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 1);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1475,7 +1475,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
         // The keccak and the surviving store remain.
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 2);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 2);
     }
 
     #[test]
@@ -1496,7 +1496,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 3);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
     }
 
     #[test]
@@ -1527,7 +1527,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
-        let entry_stores = func.blocks[func.entry_block]
+        let entry_stores = func.blocks[BlockId::ENTRY]
             .instructions
             .iter()
             .filter(|&&id| matches!(func.instructions[id].kind, InstKind::MStore(_, _)))
@@ -1562,7 +1562,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 0);
-        let entry_stores = func.blocks[func.entry_block]
+        let entry_stores = func.blocks[BlockId::ENTRY]
             .instructions
             .iter()
             .filter(|&&id| matches!(func.instructions[id].kind, InstKind::MStore(_, _)))
@@ -1585,7 +1585,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 0);
-        let stores = func.blocks[func.entry_block]
+        let stores = func.blocks[BlockId::ENTRY]
             .instructions
             .iter()
             .filter(|&&id| matches!(func.instructions[id].kind, InstKind::MStore(_, _)))
@@ -1607,7 +1607,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 3);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
     }
 
     #[test]
@@ -1624,7 +1624,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 1);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 1);
     }
 
     #[test]
@@ -1643,7 +1643,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 3);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1667,7 +1667,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 3);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
     }
 
     #[test]
@@ -1681,7 +1681,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 1);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 1);
     }
 
     #[test]
@@ -1752,7 +1752,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 4);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 4);
     }
 
     #[test]
@@ -1768,7 +1768,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 1);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1791,7 +1791,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 2);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1814,7 +1814,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 3);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
     }
 
     #[test]
@@ -1830,7 +1830,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[func.entry_block].instructions.len(), 3);
+        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
     }
 
     #[test]
@@ -1849,7 +1849,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 2);
 
-        let block = &func.blocks[func.entry_block];
+        let block = &func.blocks[BlockId::ENTRY];
         assert_eq!(block.instructions.len(), 2);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");

--- a/crates/codegen/src/transform/pure_eval.rs
+++ b/crates/codegen/src/transform/pure_eval.rs
@@ -6,7 +6,7 @@
 //! normal encoder path.
 
 use crate::{
-    mir::{Function, Immediate, InstKind, Terminator, Value, ValueId},
+    mir::{BlockId, Function, Immediate, InstKind, Terminator, Value, ValueId},
     pass::FunctionPass,
     utils::evm_word,
 };
@@ -75,7 +75,7 @@ impl PureEvaluator {
     /// [`Self::rewrite_to_return`] would produce, so rewriting again would
     /// report a change (and allocate fresh immediates) without progress.
     fn is_already_folded(&self, func: &Function, values: &[U256]) -> bool {
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         for (block_id, block) in func.blocks.iter_enumerated() {
             if !block.instructions.is_empty() {
                 return false;
@@ -117,7 +117,7 @@ impl PureEvaluator {
             }
         }
 
-        let mut current = func.entry_block;
+        let mut current = BlockId::ENTRY;
         let mut predecessor = None;
         let mut fuel = self.fuel;
         while fuel != 0 {
@@ -235,7 +235,7 @@ impl PureEvaluator {
     }
 
     fn rewrite_to_return(&self, func: &mut Function, values: &[U256]) {
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let block_ids: Vec<_> = func.blocks.indices().collect();
         for block_id in block_ids {
             let block = &mut func.blocks[block_id];

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -140,10 +140,10 @@ impl SccpPass {
         let mut ssa_worklist: VecDeque<ValueId> = VecDeque::new();
 
         // Seed: entry block is executable.
-        executable_blocks.insert(func.entry_block);
+        executable_blocks.insert(BlockId::ENTRY);
         self.evaluate_phis_in_block(
             func,
-            func.entry_block,
+            BlockId::ENTRY,
             &inst_to_value,
             &mut lattice,
             &executable_edges,
@@ -152,7 +152,7 @@ impl SccpPass {
         // Evaluate all instructions in the entry block.
         self.evaluate_block(
             func,
-            func.entry_block,
+            BlockId::ENTRY,
             &inst_to_value,
             &mut lattice,
             &executable_blocks,

--- a/crates/codegen/src/transform/static_alloc.rs
+++ b/crates/codegen/src/transform/static_alloc.rs
@@ -62,7 +62,6 @@ impl ModulePass for StaticAllocPass {
 
 fn is_entry(func: &Function) -> bool {
     !func.attributes.is_constructor
-        && !func.blocks.is_empty()
         && (func.selector.is_some() || func.attributes.is_receive || func.attributes.is_fallback)
 }
 

--- a/crates/codegen/src/transform/storage_promotion.rs
+++ b/crates/codegen/src/transform/storage_promotion.rs
@@ -945,7 +945,7 @@ mod tests {
             func.selector = Some([0, 0, 0, 1]);
         }
 
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let header = func.alloc_block();
         let body = func.alloc_block();
         let update = func.alloc_block();
@@ -998,7 +998,7 @@ mod tests {
         let mut func = Function::new(Ident::DUMMY);
         func.selector = Some([0, 0, 0, 1]);
 
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let header = func.alloc_block();
         let body = func.alloc_block();
         let update = func.alloc_block();
@@ -1048,7 +1048,7 @@ mod tests {
         let mut func = Function::new(Ident::DUMMY);
         func.selector = Some([0, 0, 0, 1]);
 
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let header = func.alloc_block();
         let body = func.alloc_block();
         let update = func.alloc_block();
@@ -1083,7 +1083,7 @@ mod tests {
         func.selector = Some([0, 0, 0, 1]);
         func.params.push(MirType::uint256());
 
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let header = func.alloc_block();
         let body = func.alloc_block();
         let update = func.alloc_block();
@@ -1124,7 +1124,7 @@ mod tests {
         func.selector = Some([0, 0, 0, 1]);
         func.params.push(MirType::uint256());
 
-        let entry = func.entry_block;
+        let entry = BlockId::ENTRY;
         let header = func.alloc_block();
         let body = func.alloc_block();
         let update = func.alloc_block();
@@ -1213,7 +1213,7 @@ mod tests {
     #[test]
     fn promotes_storage_update_loop_without_preheader_store() {
         let mut test = make_storage_loop_without_init();
-        let entry = test.func.entry_block;
+        let entry = BlockId::ENTRY;
         let mut pass = StorageScalarPromoter::new();
         let stats = pass.run(&mut test.func);
 
@@ -1273,7 +1273,7 @@ mod tests {
     #[test]
     fn promotes_store_only_loop_without_preheader_store() {
         let mut test = make_store_only_loop_without_init();
-        let entry = test.func.entry_block;
+        let entry = BlockId::ENTRY;
         let mut pass = StorageScalarPromoter::new();
         let stats = pass.run(&mut test.func);
 

--- a/crates/codegen/src/transform/utils.rs
+++ b/crates/codegen/src/transform/utils.rs
@@ -13,8 +13,7 @@ pub(crate) fn rejects_callvalue(func: &Function) -> bool {
 }
 
 /// Incremental form of the shared dispatch callvalue-hoisting predicate:
-/// every bodied external entry (selector-bearing, receive, or fallback)
-/// rejects value.
+/// every external entry (selector-bearing, receive, or fallback) rejects value.
 ///
 /// `LowerAbiPass` and `LowerDispatchPass` both use this while performing their
 /// existing module scans, so they must observe every function and agree.
@@ -33,7 +32,7 @@ impl DispatchCallvalue {
     pub(crate) fn observe(&mut self, func: &Function) {
         let external =
             func.selector.is_some() || func.attributes.is_receive || func.attributes.is_fallback;
-        if !external || func.blocks.is_empty() || func.attributes.is_constructor {
+        if !external || func.attributes.is_constructor {
             return;
         }
         self.any = true;

--- a/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir
+++ b/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass block-layout
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push bb1
   jumpi

--- a/tests/ui/codegen/evm-ir/block-layout/block_layout.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/block_layout.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir (before block-layout) ===
 + // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout.evmir (after block-layout) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push bb1
     jumpi

--- a/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir
+++ b/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass block-layout
 @module module
 
-bb0 (entry):
+bb0:
   jump bb2
 bb1 [cold]:
   push 0

--- a/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir (before block-layout) ===
 + // === ROOT/tests/ui/codegen/evm-ir/block-layout/block_layout_cold.evmir (after block-layout) ===
   @module module
-  bb0 (entry):
+  bb0:
     jump bb2
 + bb2:
 +   stop

--- a/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir
+++ b/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass block-layout
 @module module
 
-bb0 (entry):
+bb0:
   push bb3
   pop
   push bb3

--- a/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir (before block-layout) ===
 + // === ROOT/tests/ui/codegen/evm-ir/block-layout/structural_jumpi_fallthrough.evmir (after block-layout) ===
   @module module
-  bb0 (entry):
+  bb0:
     push bb3
     pop
     push bb3

--- a/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir
+++ b/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir
@@ -3,7 +3,7 @@
 @module module
 
 
-bb0 (entry):
+bb0:
   jump bb2
 bb1 [cold]:
   push 0

--- a/tests/ui/codegen/evm-ir/block-layout/time_passes.stdout
+++ b/tests/ui/codegen/evm-ir/block-layout/time_passes.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir (before block-layout) ===
 + // === ROOT/tests/ui/codegen/evm-ir/block-layout/time_passes.evmir (after block-layout) ===
   @module module
-  bb0 (entry):
+  bb0:
     jump bb2
 + bb2:
 +   stop

--- a/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir
+++ b/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cfg-simplify
 @module module
 
-bb0 (entry):
+bb0:
   push bb3
   jump bb1
 bb1:
@@ -10,6 +10,7 @@ bb2:
   push 1
   jump bb4
 bb3:
-  stop
+  push 2
+  jump bb0
 bb4:
   stop

--- a/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.stdout
+++ b/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir (before cfg-simplify) ===
 + // === ROOT/tests/ui/codegen/evm-ir/cfg-simplify/cfg_simplify.evmir (after cfg-simplify) ===
   @module module
-  bb0 (entry):
+  bb0:
     push bb3
 -   jump bb1
 - bb1:
@@ -9,9 +9,10 @@
 - bb2:
     push 1
 -   jump bb4
-- bb3:
-    stop
++   stop
+  bb3:
+    push 2
+    jump bb0
 - bb4:
-+ bb3:
-    stop
+-   stop
   

--- a/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir
+++ b/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass compact-pushes
 @module module
 
-bb0 (entry):
+bb0:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   push 0xffffffffffffffffffffffffffffffffffffffff
   stop

--- a/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.stdout
+++ b/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir (before compact-pushes) ===
 + // === ROOT/tests/ui/codegen/evm-ir/compact-pushes/compact_pushes.evmir (after compact-pushes) ===
   @module module
-  bb0 (entry):
+  bb0:
 -   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -   push 0xffffffffffffffffffffffffffffffffffffffff
 +   push 0

--- a/tests/ui/codegen/evm-ir/none/branches.evmir
+++ b/tests/ui/codegen/evm-ir/none/branches.evmir
@@ -1,6 +1,6 @@
 @module module
 
-bb0 (entry):
+bb0:
   push 0
   calldataload
   dup1

--- a/tests/ui/codegen/evm-ir/none/branches.stdout
+++ b/tests/ui/codegen/evm-ir/none/branches.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (before none) ===
 + // === ROOT/tests/ui/codegen/evm-ir/none/branches.evmir (after none) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 0
     calldataload
     dup1

--- a/tests/ui/codegen/evm-ir/none/dispatch.evmir
+++ b/tests/ui/codegen/evm-ir/none/dispatch.evmir
@@ -1,6 +1,6 @@
 @module module
 
-bb0 (entry):
+bb0:
   push 0
   calldataload !meta(source=dispatch)
   push 0x371303c0

--- a/tests/ui/codegen/evm-ir/none/dispatch.stdout
+++ b/tests/ui/codegen/evm-ir/none/dispatch.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (before none) ===
 + // === ROOT/tests/ui/codegen/evm-ir/none/dispatch.evmir (after none) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 0
     calldataload
     push 0x371303c0

--- a/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir
+++ b/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir
@@ -1,6 +1,6 @@
 @module module
 
-bb0 (entry):
+bb0:
   push 0 !meta(type=u256)
   push 0 !meta(ty=u256)
   push 0 !meta(result_ty=u256)

--- a/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.stdout
+++ b/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (before none) ===
 + // === ROOT/tests/ui/codegen/evm-ir/none/drop_unknown_metadata.evmir (after none) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 0
     push 0
     push 0

--- a/tests/ui/codegen/evm-ir/none/push_family.evmir
+++ b/tests/ui/codegen/evm-ir/none/push_family.evmir
@@ -1,6 +1,6 @@
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push_deferred 2
   push_deferred 0xfffffff

--- a/tests/ui/codegen/evm-ir/none/push_family.stdout
+++ b/tests/ui/codegen/evm-ir/none/push_family.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (before none) ===
 + // === ROOT/tests/ui/codegen/evm-ir/none/push_family.evmir (after none) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push_deferred 2
     push_deferred 0xfffffff

--- a/tests/ui/codegen/evm-ir/outline/outline_computation.evmir
+++ b/tests/ui/codegen/evm-ir/outline/outline_computation.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass outline
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   pop
   push 1

--- a/tests/ui/codegen/evm-ir/outline/outline_computation.stdout
+++ b/tests/ui/codegen/evm-ir/outline/outline_computation.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/outline/outline_computation.evmir (before outline) ===
 + // === ROOT/tests/ui/codegen/evm-ir/outline/outline_computation.evmir (after outline) ===
   @module module
-  bb0 (entry):
+  bb0:
 -   push 1
 -   pop
 -   push 1

--- a/tests/ui/codegen/evm-ir/outline/outline_order.evmir
+++ b/tests/ui/codegen/evm-ir/outline/outline_order.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass outline
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   pop
   push 2

--- a/tests/ui/codegen/evm-ir/outline/outline_order.stdout
+++ b/tests/ui/codegen/evm-ir/outline/outline_order.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/outline/outline_order.evmir (before outline) ===
 + // === ROOT/tests/ui/codegen/evm-ir/outline/outline_order.evmir (after outline) ===
   @module module
-  bb0 (entry):
+  bb0:
 -   push 1
 -   pop
 +   push bb4

--- a/tests/ui/codegen/evm-ir/outline/outline_push.evmir
+++ b/tests/ui/codegen/evm-ir/outline/outline_push.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass outline
 @module module
 
-bb0 (entry):
+bb0:
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   pop
   push 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/tests/ui/codegen/evm-ir/outline/outline_push.stdout
+++ b/tests/ui/codegen/evm-ir/outline/outline_push.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/outline/outline_push.evmir (before outline) ===
 + // === ROOT/tests/ui/codegen/evm-ir/outline/outline_push.evmir (after outline) ===
   @module module
-  bb0 (entry):
+  bb0:
 +   push bb3
 +   jump bb1
 + bb1:

--- a/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   not
   not

--- a/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
 -   not
 -   not

--- a/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push 2
   swap1

--- a/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/commutative_swap.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push 2
 -   swap1

--- a/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 2
   push 0
   mul

--- a/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_dead_lhs.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
 -   push 2
     push 0
 -   mul

--- a/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 2
   push 0
   add

--- a/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/constant_rhs.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 2
 -   push 0
 -   add

--- a/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push 2
   dup2

--- a/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_binop_pop.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push 2
 -   dup2

--- a/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push 2
   dup2

--- a/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/dup2_sink_pop.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push 2
 -   dup2

--- a/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   iszero
   iszero

--- a/tests/ui/codegen/evm-ir/peephole/patterns/jump.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/jump.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/jump.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
 -   iszero
 -   iszero

--- a/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   dup1
   push 32

--- a/tests/ui/codegen/evm-ir/peephole/patterns/memory.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/memory.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/memory.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     dup1
     push 32

--- a/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push 2
   push 3

--- a/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/merge_swap_pop.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push 2
     push 3

--- a/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass peephole
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   pop
   stop

--- a/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir (before peephole) ===
 + // === ROOT/tests/ui/codegen/evm-ir/peephole/patterns/push_pop.evmir (after peephole) ===
   @module module
-  bb0 (entry):
+  bb0:
 -   push 1
 -   pop
     stop

--- a/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir
+++ b/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass share-reverts
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   iszero
   push bb2

--- a/tests/ui/codegen/evm-ir/share-reverts/share_reverts.stdout
+++ b/tests/ui/codegen/evm-ir/share-reverts/share_reverts.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir (before share-reverts) ===
 + // === ROOT/tests/ui/codegen/evm-ir/share-reverts/share_reverts.evmir (after share-reverts) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
 -   iszero
 -   push bb2

--- a/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir
+++ b/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass share-reverts
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   iszero
   push bb2

--- a/tests/ui/codegen/evm-ir/share-reverts/special_zero.stdout
+++ b/tests/ui/codegen/evm-ir/share-reverts/special_zero.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir (before share-reverts) ===
 + // === ROOT/tests/ui/codegen/evm-ir/share-reverts/special_zero.evmir (after share-reverts) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     iszero
     push bb2

--- a/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir
+++ b/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass tail-merge
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push bb1
   jumpi

--- a/tests/ui/codegen/evm-ir/tail-merge/tail_merge.stdout
+++ b/tests/ui/codegen/evm-ir/tail-merge/tail_merge.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir (before tail-merge) ===
 + // === ROOT/tests/ui/codegen/evm-ir/tail-merge/tail_merge.evmir (after tail-merge) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     push bb1
     jumpi

--- a/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir
+++ b/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass terminal-dedup
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   jumpi bb1, bb2
 bb1 [cold]:

--- a/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.stdout
+++ b/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.stdout
@@ -1,7 +1,7 @@
 - // === ROOT/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir (before terminal-dedup) ===
 + // === ROOT/tests/ui/codegen/evm-ir/terminal-dedup/terminal_dedup.evmir (after terminal-dedup) ===
   @module module
-  bb0 (entry):
+  bb0:
     push 1
     jumpi bb1, bb2
   bb1 [cold]:

--- a/tests/ui/codegen/evm-ir/validation/direct_edge_stack_underflow.evmir
+++ b/tests/ui/codegen/evm-ir/validation/direct_edge_stack_underflow.evmir
@@ -1,7 +1,7 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   jump bb1
 bb1:
   pop

--- a/tests/ui/codegen/evm-ir/validation/missing_stack_effect.evmir
+++ b/tests/ui/codegen/evm-ir/validation/missing_stack_effect.evmir
@@ -1,6 +1,6 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   op_0c
   stop

--- a/tests/ui/codegen/evm-ir/validation/physical_jumpi_stack_underflow.evmir
+++ b/tests/ui/codegen/evm-ir/validation/physical_jumpi_stack_underflow.evmir
@@ -1,7 +1,7 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push bb1
   jumpi

--- a/tests/ui/codegen/evm-ir/validation/raw_push.evmir
+++ b/tests/ui/codegen/evm-ir/validation/raw_push.evmir
@@ -1,6 +1,6 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   push1
   stop

--- a/tests/ui/codegen/evm-ir/validation/stack_effect_mismatch.evmir
+++ b/tests/ui/codegen/evm-ir/validation/stack_effect_mismatch.evmir
@@ -1,6 +1,6 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   push 1 !meta(stack=0->0)
   stop

--- a/tests/ui/codegen/evm-ir/validation/stack_underflow.evmir
+++ b/tests/ui/codegen/evm-ir/validation/stack_underflow.evmir
@@ -1,7 +1,7 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   dup2
   stop

--- a/tests/ui/codegen/evm-ir/validation/swap_out_of_range.evmir
+++ b/tests/ui/codegen/evm-ir/validation/swap_out_of_range.evmir
@@ -1,7 +1,7 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   push 1
   push 2
   swap2

--- a/tests/ui/codegen/evm-ir/validation/terminator_stack_effect_mismatch.evmir
+++ b/tests/ui/codegen/evm-ir/validation/terminator_stack_effect_mismatch.evmir
@@ -1,5 +1,5 @@
 //@ failure-status: 1
 @module module
 
-bb0 (entry):
+bb0:
   return !meta(stack=0->0)

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.sol:AbiDecodeDynamicTuple ===
 @module AbiDecodeDynamicTuple
 fn @decode(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -212,7 +212,7 @@ fn @decode(arg0: memptr) {
 }
 
 fn @roundtrip(arg0: u256, arg1: memptr, arg2: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -485,7 +485,7 @@ fn @roundtrip(arg0: u256, arg1: memptr, arg2: memptr) {
 }
 
 fn @decodeBytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -577,7 +577,7 @@ fn @decodeBytes(arg0: memptr) {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0

--- a/tests/ui/codegen/lowering/abi_decode_static_tuple.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_static_tuple.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_decode_static_tuple.sol:AbiDecodeStaticTuple ===
 @module AbiDecodeStaticTuple
 fn @decode(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/abi_dynamic_return.stdout
+++ b/tests/ui/codegen/lowering/abi_dynamic_return.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_dynamic_return.sol:AbiDynamicReturn ===
 @module AbiDynamicReturn
 fn @bytesLiteral() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
@@ -15,7 +15,7 @@ fn @bytesLiteral() {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -35,7 +35,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @stringLiteral() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64

--- a/tests/ui/codegen/lowering/abi_encode_bytes.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_bytes.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_encode_bytes.sol:AbiEncodeBytes ===
 @module AbiEncodeBytes
 fn @hash3(arg0: u256, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -22,7 +22,7 @@ fn @hash3(arg0: u256, arg1: u256, arg2: u256) {
 }
 
 fn @encode3(arg0: u256, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -47,7 +47,7 @@ fn @encode3(arg0: u256, arg1: u256, arg2: u256) {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -67,7 +67,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @encodeDynamic(arg0: u256, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -123,7 +123,7 @@ fn @encodeDynamic(arg0: u256, arg1: memptr) {
 }
 
 fn @hashDynamic(arg0: u256, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -175,7 +175,7 @@ fn @hashDynamic(arg0: u256, arg1: memptr) {
 }
 
 fn @roundtrip(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.sol:AbiEncodePackedCalldataSlice (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 384
   push 64
   mstore

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol:AbiEncodePackedMixed ===
 @module AbiEncodePackedMixed
 fn @fixedBytesArg(arg0: u256, arg1: address, arg2: bytes2) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -37,7 +37,7 @@ fn @fixedBytesArg(arg0: u256, arg1: address, arg2: bytes2) {
 }
 
 fn @dynamicArg(arg0: bytes32, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -73,7 +73,7 @@ fn @dynamicArg(arg0: bytes32, arg1: memptr) {
 }
 
 fn @materialized(arg0: u16, arg1: memptr, arg2: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -135,7 +135,7 @@ fn @materialized(arg0: u16, arg1: memptr, arg2: bool) {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0

--- a/tests/ui/codegen/lowering/abi_encode_packed_static_hash.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_static_hash.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_encode_packed_static_hash.sol:AbiEncodePackedStaticHash ===
 @module AbiEncodePackedStaticHash
 fn @hash(arg0: u64, arg1: u64, arg2: bytes32) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96

--- a/tests/ui/codegen/lowering/abi_nested_return.stdout
+++ b/tests/ui/codegen/lowering/abi_nested_return.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/abi_nested_return.sol:AbiNestedReturn ===
 @module AbiNestedReturn
 fn @structArray(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -134,7 +134,7 @@ fn @structArray(arg0: u256) {
 }
 
 fn @nestedArray(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/abi_packed_calldata_bytes.stdout
+++ b/tests/ui/codegen/lowering/abi_packed_calldata_bytes.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/abi_packed_calldata_bytes.sol:P (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 352
   push 64
   mstore

--- a/tests/ui/codegen/lowering/array_bounds_panic.stdout
+++ b/tests/ui/codegen/lowering/array_bounds_panic.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/array_bounds_panic.sol:ArrayBoundsPanic ===
 @module ArrayBoundsPanic
 fn @memFix(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -36,7 +36,7 @@ fn @memFix(arg0: u256) {
 }
 
 fn @memFixConst() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 96
@@ -57,7 +57,7 @@ fn @memFixConst() {
 }
 
 fn @memFixConstOob() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 96
@@ -81,7 +81,7 @@ fn @memFixConstOob() {
 }
 
 fn @memDyn(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -145,7 +145,7 @@ fn @memDyn(arg0: u256, arg1: u256) {
 }
 
 fn @stDyn(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -171,7 +171,7 @@ fn @stDyn(arg0: u256) {
 }
 
 fn @stDynWrite(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -195,7 +195,7 @@ fn @stDynWrite(arg0: u256, arg1: u256) {
 }
 
 fn @stFix(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -218,7 +218,7 @@ fn @stFix(arg0: u256) {
 }
 
 fn @cdDyn(arg0: memptr, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -245,7 +245,7 @@ fn @cdDyn(arg0: memptr, arg1: u256) {
 }
 
 fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 128
@@ -277,7 +277,7 @@ fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) {
 }
 
 fn @cdBytes(arg0: memptr, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/assembler_block_dedup.stdout
+++ b/tests/ui/codegen/lowering/assembler_block_dedup.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/assembler_block_dedup.sol:AssemblerBlockDedup (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 192
   push 64
   mstore

--- a/tests/ui/codegen/lowering/base_constructor.stdout
+++ b/tests/ui/codegen/lowering/base_constructor.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/base_constructor.sol:Base ===
 @module Base
 fn @value() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @value() {
 }
 
 fn @_anonymous(arg0: u256) {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0 !metadata(storage=slot(0))
     stop
 }
@@ -17,13 +17,13 @@ fn @_anonymous(arg0: u256) {
 // === ROOT/tests/ui/codegen/lowering/base_constructor.sol:Derived ===
 @module Derived
 fn @_anonymous(arg0: u256) {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0 !metadata(storage=slot(0))
     stop
 }
 
 fn @value() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0

--- a/tests/ui/codegen/lowering/branch.stdout
+++ b/tests/ui/codegen/lowering/branch.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/branch.sol:Branch ===
 @module Branch
 fn @max(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -21,7 +21,7 @@ fn @max(arg0: u256, arg1: u256) {
 }
 
 fn @abs_diff(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol:AddmodMulmod ===
 @module AddmodMulmod
 fn @am(arg0: u256, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -16,7 +16,7 @@ fn @am(arg0: u256, arg1: u256, arg2: u256) {
 }
 
 fn @mm(arg0: u256, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96

--- a/tests/ui/codegen/lowering/bytes_memory_elements.stdout
+++ b/tests/ui/codegen/lowering/bytes_memory_elements.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/bytes_memory_elements.sol:BytesMemoryElements ===
 @module BytesMemoryElements
 fn @alloc() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 96
@@ -72,7 +72,7 @@ fn @alloc() {
 }
 
 fn @literal() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
@@ -100,7 +100,7 @@ fn @literal() {
 }
 
 fn @allocDynamic(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -154,7 +154,7 @@ fn @allocDynamic(arg0: u256) {
 }
 
 fn @readWrite(arg0: memptr, arg1: u256, arg2: bytes1) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96

--- a/tests/ui/codegen/lowering/calldata_array_to_memory.stdout
+++ b/tests/ui/codegen/lowering/calldata_array_to_memory.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/calldata_array_to_memory.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 672
   push 64
   mstore

--- a/tests/ui/codegen/lowering/calldata_slice_rebind.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_rebind.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/calldata_slice_rebind.sol:CalldataSliceRebind ===
 @module CalldataSliceRebind
 fn @forward(arg0: memptr, arg1: u256, arg2: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96

--- a/tests/ui/codegen/lowering/calldata_validation.stdout
+++ b/tests/ui/codegen/lowering/calldata_validation.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/calldata_validation.sol:CalldataValidation ===
 @module CalldataValidation
 fn @vUint8(arg0: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -22,7 +22,7 @@ fn @vUint8(arg0: u8) {
 }
 
 fn @vInt16(arg0: i16) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -43,7 +43,7 @@ fn @vInt16(arg0: i16) {
 }
 
 fn @vBool(arg0: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -65,7 +65,7 @@ fn @vBool(arg0: bool) {
 }
 
 fn @vAddress(arg0: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -86,7 +86,7 @@ fn @vAddress(arg0: address) {
 }
 
 fn @vBytes4(arg0: bytes4) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -107,7 +107,7 @@ fn @vBytes4(arg0: bytes4) {
 }
 
 fn @vEnum(arg0: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -127,7 +127,7 @@ fn @vEnum(arg0: u8) {
 }
 
 fn @vMulti(arg0: u32, arg1: i8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -167,7 +167,7 @@ fn @vMulti(arg0: u32, arg1: i8) {
 }
 
 fn @vFull(arg0: u256, arg1: bytes32, arg2: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96

--- a/tests/ui/codegen/lowering/checked_arithmetic_panic.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_panic.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/checked_arithmetic_panic.sol:CheckedArithmeticPanic ===
 @module CheckedArithmeticPanic
 fn @add(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -23,7 +23,7 @@ fn @add(arg0: u256, arg1: u256) {
 }
 
 fn @sub(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -45,7 +45,7 @@ fn @sub(arg0: u256, arg1: u256) {
 }
 
 fn @mul(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -71,7 +71,7 @@ fn @mul(arg0: u256, arg1: u256) {
 }
 
 fn @div_zero(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -92,7 +92,7 @@ fn @div_zero(arg0: u256, arg1: u256) {
 }
 
 fn @pow(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -175,7 +175,7 @@ fn @pow(arg0: u256, arg1: u256) {
 }
 
 fn @signed_add(arg0: i256, arg1: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -199,7 +199,7 @@ fn @signed_add(arg0: i256, arg1: i256) {
 }
 
 fn @signed_neg(arg0: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -221,7 +221,7 @@ fn @signed_neg(arg0: i256) {
 }
 
 fn @narrow_add(arg0: u8, arg1: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -257,7 +257,7 @@ fn @narrow_add(arg0: u8, arg1: u8) {
 }
 
 fn @unchecked_add(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -272,7 +272,7 @@ fn @unchecked_add(arg0: u256, arg1: u256) {
 }
 
 fn @unchecked_neg(arg0: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -287,7 +287,7 @@ fn @unchecked_neg(arg0: i256) {
 }
 
 fn @unchecked_pow(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -302,7 +302,7 @@ fn @unchecked_pow(arg0: u256, arg1: u256) {
 }
 
 fn @unchecked_call(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -324,7 +324,7 @@ fn @unchecked_call(arg0: u256, arg1: u256) {
 }
 
 fn @checked_inner(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 160
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = add arg0, arg1

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol:CheckedArithmeticShapes ===
 @module CheckedArithmeticShapes
 fn @sadd(arg0: i256, arg1: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -25,7 +25,7 @@ fn @sadd(arg0: i256, arg1: i256) {
 }
 
 fn @ssub(arg0: i256, arg1: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -49,7 +49,7 @@ fn @ssub(arg0: i256, arg1: i256) {
 }
 
 fn @smul(arg0: i256, arg1: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -79,7 +79,7 @@ fn @smul(arg0: i256, arg1: i256) {
 }
 
 fn @sdiv(arg0: i256, arg1: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -109,7 +109,7 @@ fn @sdiv(arg0: i256, arg1: i256) {
 }
 
 fn @smod(arg0: i256, arg1: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -130,7 +130,7 @@ fn @smod(arg0: i256, arg1: i256) {
 }
 
 fn @neg(arg0: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -152,7 +152,7 @@ fn @neg(arg0: i256) {
 }
 
 fn @inc(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -174,7 +174,7 @@ fn @inc(arg0: u256) {
 }
 
 fn @dec(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -196,7 +196,7 @@ fn @dec(arg0: u256) {
 }
 
 fn @uadd128(arg0: u128, arg1: u128) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -232,7 +232,7 @@ fn @uadd128(arg0: u128, arg1: u128) {
 }
 
 fn @umul128(arg0: u128, arg1: u128) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -268,7 +268,7 @@ fn @umul128(arg0: u128, arg1: u128) {
 }
 
 fn @smul128(arg0: i128, arg1: i128) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -306,7 +306,7 @@ fn @smul128(arg0: i128, arg1: i128) {
 }
 
 fn @umul192(arg0: u192, arg1: u192) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/checked_pow_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/checked_pow_shapes.sol:CheckedPowShapes ===
 @module CheckedPowShapes
 fn @upow(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -84,7 +84,7 @@ fn @upow(arg0: u256, arg1: u256) {
 }
 
 fn @spow(arg0: i256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -210,7 +210,7 @@ fn @spow(arg0: i256, arg1: u256) {
 }
 
 fn @upow8(arg0: u8, arg1: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -321,7 +321,7 @@ fn @upow8(arg0: u8, arg1: u8) {
 }
 
 fn @spow8(arg0: i8, arg1: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -461,7 +461,7 @@ fn @spow8(arg0: i8, arg1: u8) {
 }
 
 fn @const2(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -483,7 +483,7 @@ fn @const2(arg0: u256) {
 }
 
 fn @const10(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -505,7 +505,7 @@ fn @const10(arg0: u256) {
 }
 
 fn @const_neg2(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -639,7 +639,7 @@ fn @const_neg2(arg0: u256) {
 }
 
 fn @unchecked_pow8(arg0: u8, arg1: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/cold_call_hot_fallthrough.stdout
+++ b/tests/ui/codegen/lowering/cold_call_hot_fallthrough.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/cold_call_hot_fallthrough.sol:ColdCallHotFallthrough (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 448
   push 64
   mstore

--- a/tests/ui/codegen/lowering/comparison.stdout
+++ b/tests/ui/codegen/lowering/comparison.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/comparison.sol:Comparison ===
 @module Comparison
 fn @eq(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -16,7 +16,7 @@ fn @eq(arg0: u256, arg1: u256) {
 }
 
 fn @lt(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -31,7 +31,7 @@ fn @lt(arg0: u256, arg1: u256) {
 }
 
 fn @is_zero(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/compound_assign.stdout
+++ b/tests/ui/codegen/lowering/compound_assign.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/compound_assign.sol:CompoundAssign ===
 @module CompoundAssign
 fn @value() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @value() {
 }
 
 fn @add_to_value(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -31,7 +31,7 @@ fn @add_to_value(arg0: u256) {
 }
 
 fn @sub_from_value(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -53,7 +53,7 @@ fn @sub_from_value(arg0: u256) {
 }
 
 fn @mul_value(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -79,7 +79,7 @@ fn @mul_value(arg0: u256) {
 }
 
 fn @bump_post() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = add v0, 1
@@ -96,7 +96,7 @@ fn @bump_post() {
 }
 
 fn @bump_pre() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = add v0, 1

--- a/tests/ui/codegen/lowering/constructor_abi_validation.stdout
+++ b/tests/ui/codegen/lowering/constructor_abi_validation.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/constructor_abi_validation.sol:ConstructorAbiValidation ===
 @module ConstructorAbiValidation
 fn @flag() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = and v0, 255
@@ -10,7 +10,7 @@ fn @flag() {
 }
 
 fn @second() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = shr 8, v0
@@ -20,7 +20,7 @@ fn @second() {
 }
 
 fn @_anonymous(arg0: bool, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = mload 128
     v1 = iszero v0
     v2 = iszero v1

--- a/tests/ui/codegen/lowering/constructor_internal_call.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_call.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/constructor_internal_call.sol:ConstructorInternalCall ===
 @module ConstructorInternalCall
 fn @value() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @value() {
 }
 
 fn @_anonymous(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = and arg0, 7
     v1 = internal_call @helper, 1, v0
     sstore 0, v1 !metadata(storage=slot(0))
@@ -17,7 +17,7 @@ fn @_anonymous(arg0: u256) {
 }
 
 fn @helper(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0

--- a/tests/ui/codegen/lowering/constructor_internal_call_bin.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_call_bin.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/constructor_internal_call_bin.sol:ConstructorInternalCallBin (creation) ===
 // === deployment ===
 @module deployment
-bb0 (entry):
+bb0:
   push 0x4000
   push 64
   mstore
@@ -246,7 +246,7 @@ bb9:
 
 // === runtime ===
 @module runtime
-bb0 (entry):
+bb0:
   push 160
   push 64
   mstore

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/constructor_internal_library_call.sol:ConstructorLibrary ===
 @module ConstructorLibrary
 fn @helper(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
@@ -44,7 +44,7 @@ fn @helper(arg0: u256) -> u256 {
 // === ROOT/tests/ui/codegen/lowering/constructor_internal_library_call.sol:ConstructorInternalLibraryCall ===
 @module ConstructorInternalLibraryCall
 fn @value() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0
@@ -52,7 +52,7 @@ fn @value() {
 }
 
 fn @_anonymous(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = and arg0, 7
     v1 = internal_call @helper, 1, v0
     sstore 0, v1 !metadata(storage=slot(0))
@@ -60,7 +60,7 @@ fn @_anonymous(arg0: u256) {
 }
 
 fn @helper(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0

--- a/tests/ui/codegen/lowering/custom_error_payloads.stdout
+++ b/tests/ui/codegen/lowering/custom_error_payloads.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/custom_error_payloads.sol:CustomErrorPayloads ===
 @module CustomErrorPayloads
 fn @revert_empty() {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 4
     mstore 64, v1 !metadata(memory=scratch)
@@ -12,7 +12,7 @@ fn @revert_empty() {
 }
 
 fn @revert_args() {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
     mstore 64, v1 !metadata(memory=scratch)
@@ -53,7 +53,7 @@ fn @revert_args() {
 }
 
 fn @require_empty(arg0: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -84,7 +84,7 @@ fn @require_empty(arg0: bool) {
 }
 
 fn @require_named(arg0: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/emit_abi_bin.evmir.stdout
+++ b/tests/ui/codegen/lowering/emit_abi_bin.evmir.stdout
@@ -34,7 +34,7 @@
 // === ROOT/tests/ui/codegen/lowering/emit_abi_bin.sol:C (creation) ===
 // === deployment ===
 @module deployment
-bb0 (entry):
+bb0:
   push 0x4000
   push 64
   mstore
@@ -58,7 +58,7 @@ bb0 (entry):
 
 // === runtime ===
 @module runtime
-bb0 (entry):
+bb0:
   push 160
   push 64
   mstore
@@ -91,7 +91,7 @@ bb4 [cold]:
   revert
 // === ROOT/tests/ui/codegen/lowering/emit_abi_bin.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 160
   push 64
   mstore

--- a/tests/ui/codegen/lowering/enum_conversion_qualified.stdout
+++ b/tests/ui/codegen/lowering/enum_conversion_qualified.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/enum_conversion_qualified.sol:DataTypes (runtime) ===
 // === ROOT/tests/ui/codegen/lowering/enum_conversion_qualified.sol:E (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 160
   push 64
   mstore

--- a/tests/ui/codegen/lowering/event_dynamic_data.stdout
+++ b/tests/ui/codegen/lowering/event_dynamic_data.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/event_dynamic_data.sol:EventDynamicData ===
 @module EventDynamicData
 fn @text(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -56,7 +56,7 @@ fn @text(arg0: memptr) {
 }
 
 fn @literal() {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
     mstore 64, v1 !metadata(memory=scratch)
@@ -98,7 +98,7 @@ fn @literal() {
 }
 
 fn @blob(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/event_overloads.stdout
+++ b/tests/ui/codegen/lowering/event_overloads.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/event_overloads.sol:EventOverloads ===
 @module EventOverloads
 fn @emitBoth(arg0: address, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/fixed_bytes_canonical.stdout
+++ b/tests/ui/codegen/lowering/fixed_bytes_canonical.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/fixed_bytes_canonical.sol:FixedBytesCanonical ===
 @module FixedBytesCanonical
 fn @fromUint(arg0: u8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -24,14 +24,14 @@ fn @fromUint(arg0: u8) {
 }
 
 fn @fromHex() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     mstore 128, 0x100000000000000000000000000000000000000000000000000000000000000
     returndata 128, 32
 }
 
 fn @compareElement(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -74,7 +74,7 @@ fn @compareElement(arg0: memptr) {
 }
 
 fn @narrow(arg0: bytes4) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/function_call.stdout
+++ b/tests/ui/codegen/lowering/function_call.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/function_call.sol:FunctionCall ===
 @module FunctionCall
 fn @double(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = add arg0, arg0
@@ -16,7 +16,7 @@ fn @double(arg0: u256) -> u256 {
 }
 
 fn @quadruple(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -46,7 +46,7 @@ fn @quadruple(arg0: u256) {
 }
 
 fn @sum_then_double(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/global_stack_calldata_alias.stdout
+++ b/tests/ui/codegen/lowering/global_stack_calldata_alias.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/global_stack_calldata_alias.sol:Test (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 320
   push 64
   mstore

--- a/tests/ui/codegen/lowering/immutable_getter.stdout
+++ b/tests/ui/codegen/lowering/immutable_getter.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/immutable_getter.sol:C ===
 @module C
 fn @owner() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = loadimmutable 0
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @owner() {
 }
 
 fn @_anonymous(arg0: address) {
-  bb0 (entry):
+  bb0:
     v0 = mload 128
     v1 = and v0, 0xffffffffffffffffffffffffffffffffffffffff
     v2 = eq v0, v1

--- a/tests/ui/codegen/lowering/immutable_keccak_literal.stdout
+++ b/tests/ui/codegen/lowering/immutable_keccak_literal.stdout
@@ -1,13 +1,13 @@
 // === ROOT/tests/ui/codegen/lowering/immutable_keccak_literal.sol:ImmutableKeccakLiteral ===
 @module ImmutableKeccakLiteral
 fn @constructor() {
-  bb0 (entry):
+  bb0:
     mstore 0x2000, 0x31e1c5bf9da84811147b2cab01421da1659d9baff618fb99b976b2c0901cba01
     stop
 }
 
 fn @get() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = loadimmutable 0
     mstore 128, v0

--- a/tests/ui/codegen/lowering/immutable_reads.stdout
+++ b/tests/ui/codegen/lowering/immutable_reads.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/immutable_reads.sol:C ===
 @module C
 fn @start() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = loadimmutable 0
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @start() {
 }
 
 fn @duration() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = loadimmutable 32
     mstore 128, v0
@@ -17,7 +17,7 @@ fn @duration() {
 }
 
 fn @_anonymous(arg0: u256) {
-  bb0 (entry):
+  bb0:
     mstore 0x2000, arg0
     v0 = mload 0x2000
     v1 = add v0, 1
@@ -33,7 +33,7 @@ fn @_anonymous(arg0: u256) {
 }
 
 fn @end() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = loadimmutable 0
     v1 = loadimmutable 32

--- a/tests/ui/codegen/lowering/internal_call_fallbacks.stdout
+++ b/tests/ui/codegen/lowering/internal_call_fallbacks.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/internal_call_fallbacks.sol:InternalCallFallbacks ===
 @module InternalCallFallbacks
 fn @recurse(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -16,7 +16,7 @@ fn @recurse(arg0: u256) {
 }
 
 fn @a(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
@@ -42,7 +42,7 @@ fn @a(arg0: u256) -> u256 {
 }
 
 fn @b(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
@@ -68,7 +68,7 @@ fn @b(arg0: u256) -> u256 {
 }
 
 fn @multi(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -89,7 +89,7 @@ fn @multi(arg0: u256) {
 }
 
 fn @pair(arg0: u256) -> (u256, u256) {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 160
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = internal_frame_addr 192

--- a/tests/ui/codegen/lowering/internal_call_frame_dealloc.stdout
+++ b/tests/ui/codegen/lowering/internal_call_frame_dealloc.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/internal_call_frame_dealloc.sol:InternalCallFrameDealloc (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 352
   push 64
   mstore

--- a/tests/ui/codegen/lowering/internal_loop_call.stdout
+++ b/tests/ui/codegen/lowering/internal_loop_call.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/internal_loop_call.sol:C ===
 @module C
 fn @sumTo(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = internal_frame_addr 160
@@ -51,7 +51,7 @@ fn @sumTo(arg0: u256) -> u256 {
 }
 
 fn @run(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/internal_void_call.stdout
+++ b/tests/ui/codegen/lowering/internal_void_call.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/internal_void_call.sol:InternalVoidCall ===
 @module InternalVoidCall
 fn @value() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @value() {
 }
 
 fn @set(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -28,7 +28,7 @@ fn @set(arg0: u256) {
 }
 
 fn @setUnlessZero(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -46,7 +46,7 @@ fn @setUnlessZero(arg0: u256) {
 }
 
 fn @writeIfNonZero(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = eq arg0, 0
     v1 = iszero v0
     br v1, bb1, bb2

--- a/tests/ui/codegen/lowering/library_mapping_storage_param.stdout
+++ b/tests/ui/codegen/lowering/library_mapping_storage_param.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/library_mapping_storage_param.sol:L (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 0
   push 64
   mstore
@@ -21,7 +21,7 @@ bb2 [cold]:
   revert
 // === ROOT/tests/ui/codegen/lowering/library_mapping_storage_param.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 704
   push 64
   mstore

--- a/tests/ui/codegen/lowering/library_wrapper_storage_param.stdout
+++ b/tests/ui/codegen/lowering/library_wrapper_storage_param.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/library_wrapper_storage_param.sol:DataTypes (runtime) ===
 // === ROOT/tests/ui/codegen/lowering/library_wrapper_storage_param.sol:L (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 416
   push 64
   mstore

--- a/tests/ui/codegen/lowering/linear.stdout
+++ b/tests/ui/codegen/lowering/linear.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/linear.sol:Linear ===
 @module Linear
 fn @add(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -23,7 +23,7 @@ fn @add(arg0: u256, arg1: u256) {
 }
 
 fn @sub(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -45,7 +45,7 @@ fn @sub(arg0: u256, arg1: u256) {
 }
 
 fn @add_one(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/linked_library_call.stdout
+++ b/tests/ui/codegen/lowering/linked_library_call.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/linked_library_call.sol:Lib (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 256
   push 64
   mstore
@@ -115,7 +115,7 @@ bb10 [cold]:
   revert
 // === ROOT/tests/ui/codegen/lowering/linked_library_call.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 224
   push 64
   mstore

--- a/tests/ui/codegen/lowering/linked_library_chain.stdout
+++ b/tests/ui/codegen/lowering/linked_library_chain.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/linked_library_chain.sol:DataTypes (runtime) ===
 // === ROOT/tests/ui/codegen/lowering/linked_library_chain.sol:Inner (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 224
   push 64
   mstore
@@ -90,7 +90,7 @@ bb9 [cold]:
   revert
 // === ROOT/tests/ui/codegen/lowering/linked_library_chain.sol:Outer (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 224
   push 64
   mstore
@@ -197,7 +197,7 @@ bb11 [cold]:
   revert
 // === ROOT/tests/ui/codegen/lowering/linked_library_chain.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 224
   push 64
   mstore

--- a/tests/ui/codegen/lowering/linked_library_dynamic_fields.stdout
+++ b/tests/ui/codegen/lowering/linked_library_dynamic_fields.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/linked_library_dynamic_fields.sol:L (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 896
   push 64
   mstore
@@ -504,7 +504,7 @@ bb19 [cold]:
   jump bb21
 // === ROOT/tests/ui/codegen/lowering/linked_library_dynamic_fields.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 544
   push 64
   mstore

--- a/tests/ui/codegen/lowering/log_topic_reuse.stdout
+++ b/tests/ui/codegen/lowering/log_topic_reuse.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/log_topic_reuse.sol:LogTopicReuse (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 160
   push 64
   mstore

--- a/tests/ui/codegen/lowering/loop_simple.stdout
+++ b/tests/ui/codegen/lowering/loop_simple.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/loop_simple.sol:LoopSimple ===
 @module LoopSimple
 fn @sum_to(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/low_level_call_calldata_bytes.stdout
+++ b/tests/ui/codegen/lowering/low_level_call_calldata_bytes.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/low_level_call_calldata_bytes.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 352
   push 64
   mstore

--- a/tests/ui/codegen/lowering/low_level_call_returndata.stdout
+++ b/tests/ui/codegen/lowering/low_level_call_returndata.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/low_level_call_returndata.sol:LowLevelCallReturndata ===
 @module LowLevelCallReturndata
 fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -91,7 +91,7 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
 }
 
 fn @__revert_error(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     mstore 0, 0x8c379a000000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 32 !metadata(memory=scratch)
     mstore 36, arg0 !metadata(memory=scratch)
@@ -100,7 +100,7 @@ fn @__revert_error(arg0: u256, arg1: u256) {
 }
 
 fn @balanceOf(arg0: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -163,7 +163,7 @@ fn @balanceOf(arg0: address) {
 }
 
 fn @forward(arg0: address, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -221,7 +221,7 @@ fn @forward(arg0: address, arg1: memptr) {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0

--- a/tests/ui/codegen/lowering/mapping.stdout
+++ b/tests/ui/codegen/lowering/mapping.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/mapping.sol:Mapping ===
 @module Mapping
 fn @balances(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -17,7 +17,7 @@ fn @balances(arg0: u256) {
 }
 
 fn @allowances(arg0: address, arg1: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -48,7 +48,7 @@ fn @allowances(arg0: address, arg1: address) {
 }
 
 fn @set_balance(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -62,7 +62,7 @@ fn @set_balance(arg0: u256, arg1: u256) {
 }
 
 fn @add_balance(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -86,7 +86,7 @@ fn @add_balance(arg0: u256, arg1: u256) {
 }
 
 fn @approve(arg0: address, arg1: address, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -115,7 +115,7 @@ fn @approve(arg0: address, arg1: address, arg2: u256) {
 }
 
 fn @get_allowance(arg0: address, arg1: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/mapping_bytes_values.stdout
+++ b/tests/ui/codegen/lowering/mapping_bytes_values.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/mapping_bytes_values.sol:MappingBytesValues ===
 @module MappingBytesValues
 fn @set(arg0: u256, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -97,7 +97,7 @@ fn @set(arg0: u256, arg1: memptr) {
 }
 
 fn @setNested(arg0: u256, arg1: u256, arg2: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -194,7 +194,7 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memptr) {
 }
 
 fn @get(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -210,7 +210,7 @@ fn @get(arg0: u256) {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -260,7 +260,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -280,7 +280,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @getNested(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/mapping_dynamic_key.stdout
+++ b/tests/ui/codegen/lowering/mapping_dynamic_key.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/mapping_dynamic_key.sol:MappingDynamicKey ===
 @module MappingDynamicKey
 fn @lookup(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -17,7 +17,7 @@ fn @lookup(arg0: memptr) {
 }
 
 fn @set(arg0: memptr, arg1: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -51,7 +51,7 @@ fn @set(arg0: memptr, arg1: address) {
 }
 
 fn @get(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -82,7 +82,7 @@ fn @get(arg0: memptr) {
 // === ROOT/tests/ui/codegen/lowering/mapping_dynamic_key.sol:MappingDynamicKeyPaths ===
 @module MappingDynamicKeyPaths
 fn @flat(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -98,7 +98,7 @@ fn @flat(arg0: memptr) {
 }
 
 fn @nestedFirst(arg0: memptr, arg1: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -122,7 +122,7 @@ fn @nestedFirst(arg0: memptr, arg1: address) {
 }
 
 fn @nestedSecond(arg0: address, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -146,7 +146,7 @@ fn @nestedSecond(arg0: address, arg1: memptr) {
 }
 
 fn @skey() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 3
     internal_call @__ret_bytes, 0, v0
@@ -154,7 +154,7 @@ fn @skey() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -204,7 +204,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -224,7 +224,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @setLit(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -244,7 +244,7 @@ fn @setLit(arg0: u256) {
 }
 
 fn @setLitLong(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -266,7 +266,7 @@ fn @setLitLong(arg0: u256) {
 }
 
 fn @setNestedFirst(arg0: memptr, arg1: address, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -301,7 +301,7 @@ fn @setNestedFirst(arg0: memptr, arg1: address, arg2: u256) {
 }
 
 fn @getNestedFirst(arg0: memptr, arg1: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -338,7 +338,7 @@ fn @getNestedFirst(arg0: memptr, arg1: address) {
 }
 
 fn @setNestedSecond(arg0: address, arg1: memptr, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -373,7 +373,7 @@ fn @setNestedSecond(arg0: address, arg1: memptr, arg2: u256) {
 }
 
 fn @setSkey(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -468,7 +468,7 @@ fn @setSkey(arg0: memptr) {
 }
 
 fn @setViaStorageKey(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -483,7 +483,7 @@ fn @setViaStorageKey(arg0: u256) {
 }
 
 fn @setThenAlloc(arg0: memptr, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/mapping_nested_struct_copy.stdout
+++ b/tests/ui/codegen/lowering/mapping_nested_struct_copy.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/mapping_nested_struct_copy.sol:MappingNestedStructCopy ===
 @module MappingNestedStructCopy
 fn @set(arg0: u256, arg1: u256, arg2: u256, arg3: u256, arg4: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 160
@@ -43,7 +43,7 @@ fn @set(arg0: u256, arg1: u256, arg2: u256, arg3: u256, arg4: u256) {
 }
 
 fn @get(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -98,7 +98,7 @@ fn @get(arg0: u256) {
 }
 
 fn @clear(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/mapping_struct_getter.stdout
+++ b/tests/ui/codegen/lowering/mapping_struct_getter.stdout
@@ -1,13 +1,13 @@
 // === ROOT/tests/ui/codegen/lowering/mapping_struct_getter.sol:C ===
 @module C
 fn @constructor() {
-  bb0 (entry):
+  bb0:
     sstore 0, 1 !metadata(storage=slot(0))
     stop
 }
 
 fn @items(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/memory_allocation_panic.stdout
+++ b/tests/ui/codegen/lowering/memory_allocation_panic.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/memory_allocation_panic.sol:MemoryAllocationPanic ===
 @module MemoryAllocationPanic
 fn @makeBytes(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -55,7 +55,7 @@ fn @makeBytes(arg0: u256) {
 }
 
 fn @makeArray(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/memory_fixed_array_alloc.stdout
+++ b/tests/ui/codegen/lowering/memory_fixed_array_alloc.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol:MemoryFixedArrayAlloc ===
 @module MemoryFixedArrayAlloc
 fn @guardedFix(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -33,7 +33,7 @@ fn @guardedFix(arg0: u256) {
 }
 
 fn @structArr(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -70,7 +70,7 @@ fn @structArr(arg0: u256) {
 }
 
 fn @nested(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -136,7 +136,7 @@ fn @nested(arg0: u256, arg1: u256) {
 }
 
 fn @fmpIntegrity() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     mstore 160, 0
     v0 = mload 64 !metadata(memory=scratch)
@@ -222,7 +222,7 @@ fn @fmpIntegrity() {
 }
 
 fn @literal() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 96
@@ -243,7 +243,7 @@ fn @literal() {
 // === ROOT/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol:NamedReturnAndDelete ===
 @module NamedReturnAndDelete
 fn @namedReturn() {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 96
     mstore 64, v1 !metadata(memory=scratch)
@@ -346,7 +346,7 @@ fn @namedReturn() {
 }
 
 fn @deleteInPlace() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     mstore 160, 0
     v0 = mload 64 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/multi_return.stdout
+++ b/tests/ui/codegen/lowering/multi_return.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/multi_return.sol:MultiReturn ===
 @module MultiReturn
 fn @div_mod(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -32,7 +32,7 @@ fn @div_mod(arg0: u256, arg1: u256) {
 }
 
 fn @min_max(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -57,7 +57,7 @@ fn @min_max(arg0: u256, arg1: u256) {
 }
 
 fn @triple(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/multi_return_call.stdout
+++ b/tests/ui/codegen/lowering/multi_return_call.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/multi_return_call.sol:Math ===
 @module Math
 fn @tryAdd(arg0: u256, arg1: u256) -> (bool, u256) {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 192
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = internal_frame_addr 224
@@ -25,7 +25,7 @@ fn @tryAdd(arg0: u256, arg1: u256) -> (bool, u256) {
 // === ROOT/tests/ui/codegen/lowering/multi_return_call.sol:C ===
 @module C
 fn @sat(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -53,7 +53,7 @@ fn @sat(arg0: u256, arg1: u256) {
 }
 
 fn @tryAdd(arg0: u256, arg1: u256) -> (bool, u256) {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 192
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = internal_frame_addr 224
@@ -75,7 +75,7 @@ fn @tryAdd(arg0: u256, arg1: u256) -> (bool, u256) {
 }
 
 fn @tryA(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/multi_return_named_init.stdout
+++ b/tests/ui/codegen/lowering/multi_return_named_init.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/multi_return_named_init.sol:MultiReturnNamedInit ===
 @module MultiReturnNamedInit
 fn @readU64(arg0: memptr, arg1: u256) -> (u64, u256) {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 192
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = internal_frame_addr 224
@@ -82,7 +82,7 @@ fn @readU64(arg0: memptr, arg1: u256) -> (u64, u256) {
 }
 
 fn @readTwice(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/multi_return_scratch.stdout
+++ b/tests/ui/codegen/lowering/multi_return_scratch.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/multi_return_scratch.sol:MultiReturnScratch ===
 @module MultiReturnScratch
 fn @stored(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -17,7 +17,7 @@ fn @stored(arg0: u256) {
 }
 
 fn @triple(arg0: u256) -> (u256, u256, u256) {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 192
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = internal_frame_addr 224
@@ -49,7 +49,7 @@ fn @triple(arg0: u256) -> (u256, u256, u256) {
 }
 
 fn @assign(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/nested_loops.stdout
+++ b/tests/ui/codegen/lowering/nested_loops.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/nested_loops.sol:NestedLoops ===
 @module NestedLoops
 fn @sum_grid(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -87,7 +87,7 @@ fn @sum_grid(arg0: u256, arg1: u256) {
 }
 
 fn @find_first(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/public_library_call.stdout
+++ b/tests/ui/codegen/lowering/public_library_call.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/public_library_call.sol:Lib (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 352
   push 64
   mstore
@@ -147,7 +147,7 @@ bb5:
   return
 // === ROOT/tests/ui/codegen/lowering/public_library_call.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 672
   push 64
   mstore

--- a/tests/ui/codegen/lowering/recursive.stdout
+++ b/tests/ui/codegen/lowering/recursive.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/recursive.sol:Recursive ===
 @module Recursive
 fn @fact(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -43,7 +43,7 @@ fn @fact(arg0: u256) {
 }
 
 fn @fact(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = gt arg0, 1
@@ -77,7 +77,7 @@ fn @fact(arg0: u256) -> u256 {
 }
 
 fn @fib(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -124,7 +124,7 @@ fn @fib(arg0: u256) {
 }
 
 fn @fib(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = gt arg0, 1
@@ -163,7 +163,7 @@ fn @fib(arg0: u256) -> u256 {
 }
 
 fn @isEven(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -192,7 +192,7 @@ fn @isEven(arg0: u256) {
 }
 
 fn @isOdd(arg0: u256) -> bool {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
@@ -213,7 +213,7 @@ fn @isOdd(arg0: u256) -> bool {
 }
 
 fn @isEven(arg0: u256) -> bool {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
@@ -234,7 +234,7 @@ fn @isEven(arg0: u256) -> bool {
 }
 
 fn @isOdd(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/recursive_memory_return.stdout
+++ b/tests/ui/codegen/lowering/recursive_memory_return.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/recursive_memory_return.sol:C ===
 @module C
 fn @build(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -76,7 +76,7 @@ fn @build(arg0: u256) {
 }
 
 fn @build(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     v1 = mload 64 !metadata(memory=scratch)
     v2 = add v1, 64
@@ -131,7 +131,7 @@ fn @build(arg0: u256) -> memptr {
 }
 
 fn @mkArr(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -245,7 +245,7 @@ fn @mkArr(arg0: u256) {
 }
 
 fn @fillImpl(arg0: memptr, arg1: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 160
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = mload arg0
@@ -291,7 +291,7 @@ fn @fillImpl(arg0: memptr, arg1: u256) -> memptr {
 }
 
 fn @squares(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/revert_error_helper.stdout
+++ b/tests/ui/codegen/lowering/revert_error_helper.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/revert_error_helper.sol:Errors (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 320
   push 64
   mstore
@@ -94,7 +94,7 @@ bb7:
   jump bb9
 // === ROOT/tests/ui/codegen/lowering/revert_error_helper.sol:R (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 352
   push 64
   mstore

--- a/tests/ui/codegen/lowering/revert_payloads.stdout
+++ b/tests/ui/codegen/lowering/revert_payloads.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/revert_payloads.sol:RevertPayloads ===
 @module RevertPayloads
 fn @assert_panic(arg0: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -28,7 +28,7 @@ fn @assert_panic(arg0: bool) {
 }
 
 fn @require_message(arg0: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -54,7 +54,7 @@ fn @require_message(arg0: bool) {
 }
 
 fn @__revert_error(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     mstore 0, 0x8c379a000000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 32 !metadata(memory=scratch)
     mstore 36, arg0 !metadata(memory=scratch)
@@ -63,7 +63,7 @@ fn @__revert_error(arg0: u256, arg1: u256) {
 }
 
 fn @revert_message() {
-  bb0 (entry):
+  bb0:
     internal_call @__revert_error, 0, 3, 0x6261640000000000000000000000000000000000000000000000000000000000
     invalid
 }

--- a/tests/ui/codegen/lowering/signed_constant_ops.stdout
+++ b/tests/ui/codegen/lowering/signed_constant_ops.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/signed_constant_ops.sol:SignedConstantOps ===
 @module SignedConstantOps
 fn @lt() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = eq 1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     br v0, bb1, bb2
@@ -17,7 +17,7 @@ fn @lt() {
 }
 
 fn @div() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = eq 7, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
     br v0, bb1, bb2
@@ -48,7 +48,7 @@ fn @div() {
 }
 
 fn @shr() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = eq 8, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
     br v0, bb1, bb2

--- a/tests/ui/codegen/lowering/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/call_args.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/stack-too-deep/call_args.sol:StackTooDeepCall (creation) ===
 // === deployment ===
 @module deployment
-bb0 (entry):
+bb0:
   push 0x3f6
   dup1
   push 10
@@ -12,7 +12,7 @@ bb0 (entry):
 
 // === runtime ===
 @module runtime
-bb0 (entry):
+bb0:
   push 0x560
   push 64
   mstore

--- a/tests/ui/codegen/lowering/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/locals.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/stack-too-deep/locals.sol:StackTooDeepLocals (creation) ===
 // === deployment ===
 @module deployment
-bb0 (entry):
+bb0:
   push 0x45a
   dup1
   push 10
@@ -12,7 +12,7 @@ bb0 (entry):
 
 // === runtime ===
 @module runtime
-bb0 (entry):
+bb0:
   push 0x5e0
   push 64
   mstore

--- a/tests/ui/codegen/lowering/stack-too-deep/params.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/params.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/stack-too-deep/params.sol:StackTooDeepParams (creation) ===
 // === deployment ===
 @module deployment
-bb0 (entry):
+bb0:
   push 571
   dup1
   push 10
@@ -12,7 +12,7 @@ bb0 (entry):
 
 // === runtime ===
 @module runtime
-bb0 (entry):
+bb0:
   push 768
   push 64
   mstore

--- a/tests/ui/codegen/lowering/stack_phi_loop.stdout
+++ b/tests/ui/codegen/lowering/stack_phi_loop.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/stack_phi_loop.sol:StackPhiLoop (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 576
   push 64
   mstore

--- a/tests/ui/codegen/lowering/static_frames.stdout
+++ b/tests/ui/codegen/lowering/static_frames.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/static_frames.sol:SF (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 0x680
   push 64
   mstore

--- a/tests/ui/codegen/lowering/storage.stdout
+++ b/tests/ui/codegen/lowering/storage.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage.sol:Storage ===
 @module Storage
 fn @count() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0
@@ -9,7 +9,7 @@ fn @count() {
 }
 
 fn @increment() {
-  bb0 (entry):
+  bb0:
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = add v0, 1
     v2 = lt v1, v0
@@ -24,7 +24,7 @@ fn @increment() {
 }
 
 fn @set(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -37,7 +37,7 @@ fn @set(arg0: u256) {
 }
 
 fn @get() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     mstore 128, v0

--- a/tests/ui/codegen/lowering/storage_bytes_elements.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageBytesElements ===
 @module StorageBytesElements
 fn @b() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -9,7 +9,7 @@ fn @b() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -59,7 +59,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -79,7 +79,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @init(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -174,7 +174,7 @@ fn @init(arg0: memptr) {
 }
 
 fn @poke() {
-  bb0 (entry):
+  bb0:
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -221,7 +221,7 @@ fn @poke() {
 }
 
 fn @hashB() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = mload v0
@@ -234,7 +234,7 @@ fn @hashB() {
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringConstructor ===
 @module StorageStringConstructor
 fn @name() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -242,7 +242,7 @@ fn @name() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -292,7 +292,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -312,7 +312,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @symbol() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0
@@ -320,7 +320,7 @@ fn @symbol() {
 }
 
 fn @_anonymous(arg0: memptr, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = add 128, arg0
     v1 = mload v0
     v2 = add v1, 31
@@ -493,7 +493,7 @@ fn @_anonymous(arg0: memptr, arg1: memptr) {
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringBase ===
 @module StorageStringBase
 fn @name() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -501,7 +501,7 @@ fn @name() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -551,7 +551,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -571,7 +571,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @symbol() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0
@@ -579,7 +579,7 @@ fn @symbol() {
 }
 
 fn @_anonymous(arg0: memptr, arg1: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = add 128, arg0
     v1 = mload v0
     v2 = add v1, 31
@@ -752,7 +752,7 @@ fn @_anonymous(arg0: memptr, arg1: memptr) {
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringDerived ===
 @module StorageStringDerived
 fn @_anonymous() {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
     mstore 64, v1 !metadata(memory=scratch)
@@ -911,7 +911,7 @@ fn @_anonymous() {
 }
 
 fn @name() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -919,7 +919,7 @@ fn @name() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -969,7 +969,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -989,7 +989,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @symbol() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0
@@ -999,7 +999,7 @@ fn @symbol() {
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringImplicitDerived ===
 @module StorageStringImplicitDerived
 fn @constructor() {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
     mstore 64, v1 !metadata(memory=scratch)
@@ -1158,7 +1158,7 @@ fn @constructor() {
 }
 
 fn @name() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -1166,7 +1166,7 @@ fn @name() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -1216,7 +1216,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -1236,7 +1236,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @symbol() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0

--- a/tests/ui/codegen/lowering/storage_bytes_from_calldata.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_from_calldata.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_from_calldata.sol:StorageBytesFromCalldata ===
 @module StorageBytesFromCalldata
 fn @setText(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -115,7 +115,7 @@ fn @setText(arg0: memptr) {
 }
 
 fn @setBlob(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -229,7 +229,7 @@ fn @setBlob(arg0: memptr) {
 }
 
 fn @getText() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -237,7 +237,7 @@ fn @getText() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -287,7 +287,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -307,7 +307,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @getBlob() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0

--- a/tests/ui/codegen/lowering/storage_bytes_member.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_member.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_member.sol:StorageBytesMember (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 0x620
   push 64
   mstore

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_push_pop.sol:StorageBytesPushPop ===
 @module StorageBytesPushPop
 fn @_anonymous() {
-  bb0 (entry):
+  bb0:
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = mload v0
     v2 = add v1, 1
@@ -204,7 +204,7 @@ fn @_anonymous() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -254,7 +254,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @pushValue(arg0: bytes1) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -373,7 +373,7 @@ fn @pushValue(arg0: bytes1) {
 }
 
 fn @pushZero() {
-  bb0 (entry):
+  bb0:
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = mload v0
     v2 = add v1, 1
@@ -477,7 +477,7 @@ fn @pushZero() {
 }
 
 fn @popValue() {
-  bb0 (entry):
+  bb0:
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = mload v0
     br v1, bb2, bb1
@@ -577,7 +577,7 @@ fn @popValue() {
 }
 
 fn @get() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -585,7 +585,7 @@ fn @get() {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0

--- a/tests/ui/codegen/lowering/storage_checked_arithmetic.stdout
+++ b/tests/ui/codegen/lowering/storage_checked_arithmetic.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_checked_arithmetic.sol:StorageCheckedArithmetic ===
 @module StorageCheckedArithmetic
 fn @storage_sub(arg0: address, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -32,7 +32,7 @@ fn @storage_sub(arg0: address, arg1: u256) {
 }
 
 fn @storage_binary_sub(arg0: address, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -63,7 +63,7 @@ fn @storage_binary_sub(arg0: address, arg1: u256) {
 }
 
 fn @storage_struct_add(arg0: address, arg1: u128) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -101,7 +101,7 @@ fn @storage_struct_add(arg0: address, arg1: u128) {
 }
 
 fn @storage_struct_signed_sub(arg0: address, arg1: i8) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_long_bytes_return.sol:StorageLongBytesReturn ===
 @module StorageLongBytesReturn
 fn @s() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -9,7 +9,7 @@ fn @s() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1
@@ -59,7 +59,7 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
 }
 
 fn @__ret_bytes(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = mload 64 !metadata(memory=scratch)
     mstore v0, 32
     v1 = mload arg0
@@ -79,7 +79,7 @@ fn @__ret_bytes(arg0: memptr) {
 }
 
 fn @b() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0
@@ -87,7 +87,7 @@ fn @b() {
 }
 
 fn @_anonymous() {
-  bb0 (entry):
+  bb0:
     sstore 0, 65 !metadata(storage=slot(0))
     mstore 0, 0 !metadata(memory=scratch)
     v0 = keccak256 0, 32 !metadata(memory=scratch)
@@ -102,7 +102,7 @@ fn @_anonymous() {
 }
 
 fn @getS() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     internal_call @__ret_bytes, 0, v0
@@ -110,7 +110,7 @@ fn @getS() {
 }
 
 fn @getB() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 1
     internal_call @__ret_bytes, 0, v0

--- a/tests/ui/codegen/lowering/storage_packed_bool.stdout
+++ b/tests/ui/codegen/lowering/storage_packed_bool.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_packed_bool.sol:PackedBool ===
 @module PackedBool
 fn @a() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = and v0, 255
@@ -10,7 +10,7 @@ fn @a() {
 }
 
 fn @b() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = shr 8, v0
@@ -20,7 +20,7 @@ fn @b() {
 }
 
 fn @set(arg0: bool, arg1: bool) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -59,7 +59,7 @@ fn @set(arg0: bool, arg1: bool) {
 }
 
 fn @both() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = and v0, 255

--- a/tests/ui/codegen/lowering/storage_reference.stdout
+++ b/tests/ui/codegen/lowering/storage_reference.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_reference.sol:C ===
 @module C
 fn @setDirect(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -15,7 +15,7 @@ fn @setDirect(arg0: u256, arg1: u256) {
 }
 
 fn @getViaRef(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -31,7 +31,7 @@ fn @getViaRef(arg0: u256) {
 }
 
 fn @bump(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/storage_struct_array.stdout
+++ b/tests/ui/codegen/lowering/storage_struct_array.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/storage_struct_array.sol:StorageStructArray ===
 @module StorageStructArray
 fn @setS(arg0: u256, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -34,7 +34,7 @@ fn @setS(arg0: u256, arg1: u256, arg2: u256) {
 }
 
 fn @getS(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/ternary.stdout
+++ b/tests/ui/codegen/lowering/ternary.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/ternary.sol:Ternary ===
 @module Ternary
 fn @max(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
@@ -25,7 +25,7 @@ fn @max(arg0: u256, arg1: u256) {
 }
 
 fn @clamp(arg0: u256, arg1: u256, arg2: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
@@ -59,7 +59,7 @@ fn @clamp(arg0: u256, arg1: u256, arg2: u256) {
 }
 
 fn @abs_diff(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/lowering/tuple_assign_branch_leak.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol:TupleAssignBranchLeak (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 0x460
   push 64
   mstore

--- a/tests/ui/codegen/lowering/tuple_assignment.stdout
+++ b/tests/ui/codegen/lowering/tuple_assignment.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/tuple_assignment.sol:C (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 512
   push 64
   mstore

--- a/tests/ui/codegen/lowering/type_conversion.stdout
+++ b/tests/ui/codegen/lowering/type_conversion.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/type_conversion.sol:TypeConversion ===
 @module TypeConversion
 fn @narrowAddress(arg0: address) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -24,7 +24,7 @@ fn @narrowAddress(arg0: address) {
 }
 
 fn @narrowUint(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -39,7 +39,7 @@ fn @narrowUint(arg0: u256) {
 }
 
 fn @narrowSigned(arg0: i256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/udvt_selector.stdout
+++ b/tests/ui/codegen/lowering/udvt_selector.stdout
@@ -10,7 +10,7 @@
 }
 // === ROOT/tests/ui/codegen/lowering/udvt_selector.sol:UdvtSelector (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 192
   push 64
   mstore

--- a/tests/ui/codegen/lowering/using_for_struct.stdout
+++ b/tests/ui/codegen/lowering/using_for_struct.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/using_for_struct.sol:L ===
 @module L
 fn @hashLib(arg0: memptr) -> bytes32 {
-  bb0 (entry):
+  bb0:
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = mload arg0
@@ -29,7 +29,7 @@ fn @hashLib(arg0: memptr) -> bytes32 {
 // === ROOT/tests/ui/codegen/lowering/using_for_struct.sol:C ===
 @module C
 fn @viaMethod(arg0: bytes32, arg1: bytes32) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/while_empty_body.stdout
+++ b/tests/ui/codegen/lowering/while_empty_body.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/while_empty_body.sol:WhileEmptyBody (creation) ===
 // === deployment ===
 @module deployment
-bb0 (entry):
+bb0:
   push 52
   dup1
   push 9
@@ -12,7 +12,7 @@ bb0 (entry):
 
 // === runtime ===
 @module runtime
-bb0 (entry):
+bb0:
   push 128
   push 64
   mstore

--- a/tests/ui/codegen/lowering/while_loop.stdout
+++ b/tests/ui/codegen/lowering/while_loop.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/while_loop.sol:WhileLoop ===
 @module WhileLoop
 fn @count_down(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -39,7 +39,7 @@ fn @count_down(arg0: u256) {
 }
 
 fn @do_at_least_once(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -77,7 +77,7 @@ fn @do_at_least_once(arg0: u256) {
 }
 
 fn @break_when_found(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/yul_calldata_array.stdout
+++ b/tests/ui/codegen/lowering/yul_calldata_array.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/yul_calldata_array.sol:C ===
 @module C
 fn @probe(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/yul_local_phi.stdout
+++ b/tests/ui/codegen/lowering/yul_local_phi.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/yul_local_phi.sol:YulLocalPhi ===
 @module YulLocalPhi
 fn @branchLocal(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/yul_low_level_builtins.sol:YulLowLevelBuiltins ===
 @module YulLowLevelBuiltins
 fn @safeCall(arg0: address, arg1: bytes4) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64

--- a/tests/ui/codegen/lowering/yul_return.stdout
+++ b/tests/ui/codegen/lowering/yul_return.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/yul_return.sol:R (runtime) ===
 @module runtime
-bb0 (entry):
+bb0:
   push 160
   push 64
   mstore

--- a/tests/ui/codegen/mir/adce/adce.mir
+++ b/tests/ui/codegen/mir/adce/adce.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass adce
 @module Adce
 fn @removes_dead_branch_region(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = add 1, 2
@@ -14,7 +14,7 @@ fn @removes_dead_branch_region(arg0: bool) -> u256 {
 }
 
 fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 0, 1
@@ -26,7 +26,7 @@ fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
 }
 
 fn @keeps_phi_target(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/adce/adce.stdout
+++ b/tests/ui/codegen/mir/adce/adce.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/adce/adce.mir (after adce) ===
   @module Adce
   fn @removes_dead_branch_region(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 -   bb1:
 -     v0 = add 1, 2
@@ -18,7 +18,7 @@
   }
   
   fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 0, 1
@@ -30,7 +30,7 @@
   }
   
   fn @keeps_phi_target(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass adce
 @module AdceBranchCycle
 fn @keeps_branch_cycle(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br arg0, bb2, bb3
@@ -12,7 +12,7 @@ fn @keeps_branch_cycle(arg0: bool) -> u256 {
 }
 
 fn @keeps_branch_self_loop(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br arg0, bb1, bb2
@@ -21,7 +21,7 @@ fn @keeps_branch_self_loop(arg0: bool) -> u256 {
 }
 
 fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     br arg1, bb3, bb4

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/adce/adce_branch_cycle.mir (after adce) ===
   @module AdceBranchCycle
   fn @keeps_branch_cycle(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br arg0, bb2, bb3
@@ -13,7 +13,7 @@
   }
   
   fn @keeps_branch_self_loop(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br arg0, bb1, bb2
@@ -22,7 +22,7 @@
   }
   
   fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 +     jump bb5
     bb1:

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cfg-simplify
 @module CfgSimplify
 fn @sequential(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     jump bb1
   bb1:
@@ -13,7 +13,7 @@ fn @sequential(arg0: u256) -> u256 {
 }
 
 fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     ret 1
@@ -24,7 +24,7 @@ fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
 }
 
 fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb1
   bb1:
     ret 1

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir (after cfg-simplify) ===
   @module CfgSimplify
   fn @sequential(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     jump bb1
 -   bb1:
@@ -18,7 +18,7 @@
   }
   
   fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       ret 1
@@ -31,7 +31,7 @@
   }
   
   fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb1
 -   bb1:
       ret 1

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir
@@ -3,7 +3,7 @@
 
 // Two structurally identical panic blocks collapse into one shared block.
 fn @dedup_identical_panics(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -21,7 +21,7 @@ fn @dedup_identical_panics(arg0: u256, arg1: u256) {
 
 // Panic blocks with different panic codes must NOT merge.
 fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -39,7 +39,7 @@ fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
 
 // Identical instructions but different terminator operands must NOT merge.
 fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -58,7 +58,7 @@ fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
 // Block-local values compare by definition position, so alpha-equivalent
 // computations merge.
 fn @dedup_local_computations(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v10 = add arg0, 1
@@ -76,7 +76,7 @@ fn @dedup_local_computations(arg0: u256, arg1: u256) {
 
 // Blocks reading different outside values must NOT merge.
 fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 0, arg0

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir (after cfg-simplify) ===
   @module CfgDedupTerminalBlocks
   fn @dedup_identical_panics(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -21,7 +21,7 @@
   }
   
   fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -38,7 +38,7 @@
   }
   
   fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -55,7 +55,7 @@
   }
   
   fn @dedup_local_computations(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = add arg0, 1
@@ -74,7 +74,7 @@
   }
   
   fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 0, arg0

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir
@@ -4,7 +4,7 @@
 // conflicting values, so at most one forwarder may be folded away.
 @module CfgSimplifyPhiForwarders
 fn @keep_conflicting_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -18,7 +18,7 @@ fn @keep_conflicting_diamond(arg0: bool) -> u256 {
 // With equal incoming values the forwarders can both collapse; the phi
 // keeps a single entry per predecessor.
 fn @fold_equal_value_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir (after cfg-simplify) ===
   @module CfgSimplifyPhiForwarders
   fn @keep_conflicting_diamond(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 +     br arg0, bb3, bb2
     bb1:
@@ -17,7 +17,7 @@
   }
   
   fn @fold_equal_value_diamond(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 +     br arg0, bb3, bb2
     bb1:

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes cfg-simplify,dce
 @module CfgSimplifyTrivialPhi
 fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     log0 0, 0
@@ -15,7 +15,7 @@ fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v2 = phi [bb0: arg0], [bb2: v2]

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after cfg-simplify) ===
   @module CfgSimplifyTrivialPhi
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       log0 0, 0
@@ -17,7 +17,7 @@
   }
   
   fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
 -     v0 = phi [bb0: arg0], [bb2: v0]
@@ -34,7 +34,7 @@
 + // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (after dce) ===
   @module CfgSimplifyTrivialPhi
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       log0 0, 0
@@ -47,7 +47,7 @@
   }
   
   fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br arg1, bb2, bb3

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
@@ -4,7 +4,7 @@
 // through the chain to arg0, not to the deleted intermediate.
 @module CfgSimplifyTrivialPhiChain
 fn @chained_trivial(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: arg0], [bb3: v1]

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir (after cfg-simplify) ===
   @module CfgSimplifyTrivialPhiChain
   fn @chained_trivial(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
 -     v0 = phi [bb0: arg0], [bb3: v0]

--- a/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir
@@ -4,7 +4,7 @@
 // `arg0 < 2^256 - 2` bounds `arg0` at `2^256 - 3`, so `arg0 + 2` tops out at
 // exactly `2^256 - 1` and cannot wrap: the check folds.
 fn @fold_exact_boundary(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
     br v1, bb1, bb2
   bb1:
@@ -22,7 +22,7 @@ fn @fold_exact_boundary(arg0: u256) -> u256 {
 // `arg0 < 2^256 - 1` only bounds `arg0` at `2^256 - 2`, so `arg0 + 2` can
 // still wrap: the check must stay.
 fn @keep_wrappable_boundary(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     br v1, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir (after check-elim) ===
   @module CheckElimAddBounds
   fn @fold_exact_boundary(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
       br v0, bb1, bb2
     bb1:
@@ -19,7 +19,7 @@
   }
   
   fn @keep_wrappable_boundary(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       br v0, bb1, bb2
     bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir
@@ -5,7 +5,7 @@
 // (the shape emitted for `if (i < 3) { x[i] }` on a fixed-size array), so
 // the check folds to the continue edge and the Panic(0x32) block dies.
 fn @fold_const_len_check(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = lt arg0, 3
     br v1, bb1, bb4
   bb1:
@@ -27,7 +27,7 @@ fn @fold_const_len_check(arg0: u256) -> u256 {
 // bounds check for a dynamic array (`if (i < x.length) { x[i] }` once load
 // CSE merges the two length loads), so the check folds.
 fn @fold_dyn_len_check(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     v2 = lt arg0, v1
     br v2, bb1, bb4
@@ -49,7 +49,7 @@ fn @fold_dyn_len_check(arg0: u256) -> u256 {
 // The guard checks a different bound (`i < 2` does prove `i < 3`, but
 // `i < 5` does not), so the bounds check must stay.
 fn @keep_weaker_guard(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = lt arg0, 5
     br v1, bb1, bb4
   bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir (after check-elim) ===
   @module CheckElimIndexGuard
   fn @fold_const_len_check(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, 3
       br v0, bb1, bb4
     bb1:
@@ -22,7 +22,7 @@
   }
   
   fn @fold_dyn_len_check(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       v1 = lt arg0, v0
       br v1, bb1, bb4
@@ -43,7 +43,7 @@
   }
   
   fn @keep_weaker_guard(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, 5
       br v0, bb1, bb4
     bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir
@@ -4,7 +4,7 @@
 // The loop-header guard `v1 < arg0` dominates the increment, so `v1 + 1`
 // cannot wrap and its overflow check folds to the continue edge.
 fn @fold_increment_check(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb4: v3]
@@ -25,7 +25,7 @@ fn @fold_increment_check(arg0: u256) -> u256 {
 // The guard sits on one arm of a diamond and does not dominate the join,
 // so the overflow check must stay.
 fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     v1 = lt arg0, 100

--- a/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir (after check-elim) ===
   @module CheckElimLoopIncrement
   fn @fold_increment_check(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb4: v2]
@@ -22,7 +22,7 @@
   }
   
   fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       v0 = lt arg0, 100

--- a/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir
@@ -5,7 +5,7 @@
 // product is at most 297 and cannot wrap, so the roundtrip holds and the
 // panic branch folds.
 fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = lt arg0, 100
     br v1, bb1, bb2
   bb1:
@@ -24,7 +24,7 @@ fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
 
 // Without a bound on `arg0` the product can wrap: the check must stay.
 fn @keep_mul_check_without_bound(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mul arg0, 3
     v2 = div v1, 3
     v3 = eq v2, arg0

--- a/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir (after check-elim) ===
   @module CheckElimMulDiv
   fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, 100
       br v0, bb1, bb2
     bb1:
@@ -21,7 +21,7 @@
   }
   
   fn @keep_mul_check_without_bound(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mul arg0, 3
       v1 = div v0, 3
       v2 = eq v1, arg0

--- a/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir
@@ -4,7 +4,7 @@
 // The guard bounds the initial value `arg0`, but the loop-carried phi is a
 // different SSA value with an unbounded range: its overflow check stays.
 fn @keep_check_on_loop_phi(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = lt arg0, 100
     br v1, bb1, bb5
   bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir (after check-elim) ===
   @module CheckElimPhiKept
   fn @keep_check_on_loop_phi(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, 100
       br v0, bb1, bb5
     bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir
@@ -5,7 +5,7 @@
 // iszero chain. On the surviving edge `a >= b` holds, so the checked
 // subtraction's underflow test `lt a, b` is constant false.
 fn @fold_sub_after_ge_guard(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = gt arg1, arg0
     v2 = iszero v1
     v3 = iszero v2
@@ -24,7 +24,7 @@ fn @fold_sub_after_ge_guard(arg0: u256, arg1: u256) -> u256 {
 
 // Without a dominating guard the underflow check must stay.
 fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sub arg0, arg1
     v2 = lt arg0, arg1
     br v2, bb1, bb2
@@ -37,7 +37,7 @@ fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
 // The guarded values are arg0/arg1, but the checked subtraction uses a new
 // SSA value derived from a fresh load: no fact transfers, the check stays.
 fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = gt arg1, arg0
     br v1, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir (after check-elim) ===
   @module CheckElimSubGuard
   fn @fold_sub_after_ge_guard(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = gt arg1, arg0
       v1 = iszero v0
       v2 = iszero v1
@@ -21,7 +21,7 @@
   }
   
   fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sub arg0, arg1
       v1 = lt arg0, arg1
       br v1, bb1, bb2
@@ -32,7 +32,7 @@
   }
   
   fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = gt arg1, arg0
       br v0, bb1, bb2
     bb1:

--- a/tests/ui/codegen/mir/cse/cse_basic.mir
+++ b/tests/ui/codegen/mir/cse/cse_basic.mir
@@ -3,7 +3,7 @@
 // CSE should eliminate v3 and replace its uses with v2.
 @module CseBasic
 fn @redundant_add(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, arg1
     v3 = add arg0, arg1
     v4 = add v2, v3

--- a/tests/ui/codegen/mir/cse/cse_basic.stdout
+++ b/tests/ui/codegen/mir/cse/cse_basic.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_basic.mir (after cse) ===
   @module CseBasic
   fn @redundant_add(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg1
 -     v1 = add arg0, arg1
 -     v2 = add v0, v1

--- a/tests/ui/codegen/mir/cse/cse_commutative.mir
+++ b/tests/ui/codegen/mir/cse/cse_commutative.mir
@@ -3,7 +3,7 @@
 // CSE should recognize this and eliminate the second computation.
 @module CseCommutative
 fn @commutative(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, arg1
     v3 = add arg1, arg0
     v4 = add v2, v3

--- a/tests/ui/codegen/mir/cse/cse_commutative.stdout
+++ b/tests/ui/codegen/mir/cse/cse_commutative.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_commutative.mir (after cse) ===
   @module CseCommutative
   fn @commutative(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg1
 -     v1 = add arg1, arg0
 -     v2 = add v0, v1

--- a/tests/ui/codegen/mir/cse/cse_environment.mir
+++ b/tests/ui/codegen/mir/cse/cse_environment.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseEnvironment
 fn @keep_cheap_nullary_environment_reads(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = caller
     v2 = caller
     v3 = callvalue
@@ -22,7 +22,7 @@ fn @keep_cheap_nullary_environment_reads(arg0: u256) -> u256 {
 }
 
 fn @reuse_expensive_environment_reads(arg0: address, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = balance arg0
     v2 = balance arg0
     v3 = extcodesize arg0
@@ -46,7 +46,7 @@ fn @reuse_expensive_environment_reads(arg0: address, arg1: u256) -> u256 {
 }
 
 fn @invalidate_account_reads_after_call(arg0: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = balance arg0
     v2 = extcodehash arg0
     v3 = call 100000, arg0, 0, 0, 0, 0, 0
@@ -60,7 +60,7 @@ fn @invalidate_account_reads_after_call(arg0: address) -> u256 {
 }
 
 fn @keep_gas_uncached() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = gas
     v2 = gas
     v3 = add v1, v2

--- a/tests/ui/codegen/mir/cse/cse_environment.stdout
+++ b/tests/ui/codegen/mir/cse/cse_environment.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_environment.mir (after cse) ===
   @module CseEnvironment
   fn @keep_cheap_nullary_environment_reads(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = caller
       v1 = caller
       v2 = callvalue
@@ -23,7 +23,7 @@
   }
   
   fn @reuse_expensive_environment_reads(arg0: address, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = balance arg0
 -     v1 = balance arg0
       v2 = extcodesize arg0
@@ -52,7 +52,7 @@
   }
   
   fn @invalidate_account_reads_after_call(arg0: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = balance arg0
       v1 = extcodehash arg0
       v2 = call 0x186a0, arg0, 0, 0, 0, 0, 0
@@ -66,7 +66,7 @@
   }
   
   fn @keep_gas_uncached() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = gas
       v1 = gas
       v2 = add v0, v1

--- a/tests/ui/codegen/mir/cse/cse_extended_ops.mir
+++ b/tests/ui/codegen/mir/cse/cse_extended_ops.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseExtendedOps
 fn @extended_pure_ops(arg0: u256, arg1: u256, arg2: bool) -> (u256, u256, u256, u256, u256, bool) {
-  bb0 (entry):
+  bb0:
     v3 = sdiv arg0, arg1
     v4 = sdiv arg0, arg1
     v5 = smod arg0, arg1
@@ -18,7 +18,7 @@ fn @extended_pure_ops(arg0: u256, arg1: u256, arg2: bool) -> (u256, u256, u256, 
 }
 
 fn @calldata_reads(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = calldataload arg0
     v2 = calldataload arg0
     ret v2

--- a/tests/ui/codegen/mir/cse/cse_extended_ops.stdout
+++ b/tests/ui/codegen/mir/cse/cse_extended_ops.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_extended_ops.mir (after cse) ===
   @module CseExtendedOps
   fn @extended_pure_ops(arg0: u256, arg1: u256, arg2: bool) -> (u256, u256, u256, u256, u256, bool) {
-    bb0 (entry):
+    bb0:
       v0 = sdiv arg0, arg1
 -     v1 = sdiv arg0, arg1
       v2 = smod arg0, arg1
@@ -20,7 +20,7 @@
   }
   
   fn @calldata_reads(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = calldataload arg0
 -     v1 = calldataload arg0
 -     ret v1

--- a/tests/ui/codegen/mir/cse/cse_global.mir
+++ b/tests/ui/codegen/mir/cse/cse_global.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseGlobal
 fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v3 = add arg0, arg1
     br arg2, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/cse/cse_global.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_global.mir (after cse) ===
   @module CseGlobal
   fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg1
       br arg2, bb1, bb2
     bb1:

--- a/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseGlobalClobberPaths
 fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     br arg0, bb1, bb2
   bb1:
@@ -16,7 +16,7 @@ fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
 }
 
 fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     br arg0, bb1, bb2
   bb1:
@@ -30,7 +30,7 @@ fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
 }
 
 fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     br arg0, bb1, bb2
   bb1:
@@ -45,7 +45,7 @@ fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
 }
 
 fn @loop_sload_clobbered_body(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     jump bb1
   bb1:
@@ -61,7 +61,7 @@ fn @loop_sload_clobbered_body(arg0: u256) -> u256 {
 }
 
 fn @loop_sload_clean_body(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     jump bb1
   bb1:
@@ -76,7 +76,7 @@ fn @loop_sload_clean_body(arg0: u256) -> u256 {
 }
 
 fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 0, 11
     v1 = mload 0
     br arg0, bb1, bb2
@@ -92,7 +92,7 @@ fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
 }
 
 fn @diamond_call_clobbers_account_reads(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = balance arg1
     v2 = extcodesize arg1
     br arg0, bb1, bb2

--- a/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir (after cse) ===
   @module CseGlobalClobberPaths
   fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       br arg0, bb1, bb2
     bb1:
@@ -17,7 +17,7 @@
   }
   
   fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       br arg0, bb1, bb2
     bb1:
@@ -32,7 +32,7 @@
   }
   
   fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       br arg0, bb1, bb2
     bb1:
@@ -48,7 +48,7 @@
   }
   
   fn @loop_sload_clobbered_body(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       jump bb1
     bb1:
@@ -64,7 +64,7 @@
   }
   
   fn @loop_sload_clean_body(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       jump bb1
     bb1:
@@ -81,7 +81,7 @@
   }
   
   fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       mstore 0, 11
       v0 = mload 0
       br arg0, bb1, bb2
@@ -97,7 +97,7 @@
   }
   
   fn @diamond_call_clobbers_account_reads(arg0: bool, arg1: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = balance arg1
       v1 = extcodesize arg1
       br arg0, bb1, bb2

--- a/tests/ui/codegen/mir/cse/cse_global_loads.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseGlobalLoads
 fn @dominating_mload(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 0, 11
     v1 = mload 0
     br arg0, bb1, bb2
@@ -15,7 +15,7 @@ fn @dominating_mload(arg0: bool) -> u256 {
 }
 
 fn @dominating_sload(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     br arg0, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/cse/cse_global_loads.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_global_loads.mir (after cse) ===
   @module CseGlobalLoads
   fn @dominating_mload(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       mstore 0, 11
       v0 = mload 0
       br arg0, bb1, bb2
@@ -17,7 +17,7 @@
   }
   
   fn @dominating_sload(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 0
       br arg0, bb1, bb2
     bb1:

--- a/tests/ui/codegen/mir/cse/cse_gvn.mir
+++ b/tests/ui/codegen/mir/cse/cse_gvn.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseGvn
 fn @nested_offsets_across_dominator(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 16
     v3 = add v2, 16
     br arg1, bb1, bb2
@@ -14,7 +14,7 @@ fn @nested_offsets_across_dominator(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add 16, arg0
     v3 = add 16, v2
     br arg1, bb1, bb2
@@ -26,7 +26,7 @@ fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 16
     v3 = add v2, 16
     v4 = keccak256 v3, 32
@@ -40,7 +40,7 @@ fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 16
     v3 = add v2, 16
     v4 = mload v3
@@ -55,7 +55,7 @@ fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256
 }
 
 fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sub arg0, 1
     v2 = mload v1
     v3 = sub arg0, 2
@@ -65,7 +65,7 @@ fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
 }
 
 fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg2, bb1, bb2
   bb1:
     v3 = add arg0, arg1
@@ -80,7 +80,7 @@ fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
 }
 
 fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1

--- a/tests/ui/codegen/mir/cse/cse_gvn.stdout
+++ b/tests/ui/codegen/mir/cse/cse_gvn.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_gvn.mir (after cse) ===
   @module CseGvn
   fn @nested_offsets_across_dominator(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 16
       v1 = add v0, 16
       br arg1, bb1, bb2
@@ -16,7 +16,7 @@
   }
   
   fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add 16, arg0
       v1 = add 16, v0
       br arg1, bb1, bb2
@@ -29,7 +29,7 @@
   }
   
   fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 16
       v1 = add v0, 16
       v2 = keccak256 v1, 32
@@ -44,7 +44,7 @@
   }
   
   fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 16
       v1 = add v0, 16
       v2 = mload v1
@@ -60,7 +60,7 @@
   }
   
   fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sub arg0, 1
       v1 = mload v0
       v2 = sub arg0, 2
@@ -70,7 +70,7 @@
   }
   
   fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg2, bb1, bb2
     bb1:
 -     v0 = add arg0, arg1
@@ -87,7 +87,7 @@
   }
   
   fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1

--- a/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.mir
+++ b/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.mir
@@ -4,7 +4,7 @@
 // memory write with a dynamic size still invalidates them conservatively.
 @module CseKeccakDynamicSize
 fn @keep_different_dynamic_sizes(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = keccak256 0, arg0
     v3 = keccak256 0, arg1
     v4 = add v2, v3
@@ -12,7 +12,7 @@ fn @keep_different_dynamic_sizes(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @reuse_same_dynamic_size(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = keccak256 0, arg0
     v2 = keccak256 0, arg0
     v3 = add v1, v2
@@ -20,7 +20,7 @@ fn @reuse_same_dynamic_size(arg0: u256) -> u256 {
 }
 
 fn @invalidate_after_dynamic_size_write(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = keccak256 0, arg0
     calldatacopy 0, 0, arg1
     v4 = keccak256 0, arg0

--- a/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.stdout
+++ b/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_keccak_dynamic_size.mir (after cse) ===
   @module CseKeccakDynamicSize
   fn @keep_different_dynamic_sizes(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = keccak256 0, arg0
       v1 = keccak256 0, arg1
       v2 = add v0, v1
@@ -10,7 +10,7 @@
   }
   
   fn @reuse_same_dynamic_size(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = keccak256 0, arg0
 -     v1 = keccak256 0, arg0
 -     v2 = add v0, v1
@@ -19,7 +19,7 @@
   }
   
   fn @invalidate_after_dynamic_size_write(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = keccak256 0, arg0
       calldatacopy 0, 0, arg1
       v1 = keccak256 0, arg0

--- a/tests/ui/codegen/mir/cse/cse_memory_alias.mir
+++ b/tests/ui/codegen/mir/cse/cse_memory_alias.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseMemoryAlias
 fn @reuse_same_memory_load(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload arg0
     v2 = mload arg0
     v3 = add v1, v2
@@ -9,7 +9,7 @@ fn @reuse_same_memory_load(arg0: u256) -> u256 {
 }
 
 fn @reuse_after_disjoint_memory_store(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 64
     v2 = mload 64
     mstore 96, arg0
@@ -20,7 +20,7 @@ fn @reuse_after_disjoint_memory_store(arg0: u256) -> u256 {
 }
 
 fn @keep_after_overlapping_memory_store(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 64
     mstore 80, arg0
     v3 = mload 64
@@ -29,7 +29,7 @@ fn @keep_after_overlapping_memory_store(arg0: u256) -> u256 {
 }
 
 fn @reuse_keccak_after_disjoint_memory_store(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = keccak256 128, 64
     mstore 64, arg0
     v3 = keccak256 128, 64
@@ -38,7 +38,7 @@ fn @reuse_keccak_after_disjoint_memory_store(arg0: u256) -> u256 {
 }
 
 fn @keep_mload_after_external_call(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 64
     v2 = call 100000, arg0, 0, 0, 0, 96, 32
     v3 = mload 64

--- a/tests/ui/codegen/mir/cse/cse_memory_alias.stdout
+++ b/tests/ui/codegen/mir/cse/cse_memory_alias.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_memory_alias.mir (after cse) ===
   @module CseMemoryAlias
   fn @reuse_same_memory_load(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload arg0
 -     v1 = mload arg0
 -     v2 = add v0, v1
@@ -11,7 +11,7 @@
   }
   
   fn @reuse_after_disjoint_memory_store(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 64
 -     v1 = mload 64
       mstore 96, arg0
@@ -24,7 +24,7 @@
   }
   
   fn @keep_after_overlapping_memory_store(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 64
       mstore 80, arg0
       v1 = mload 64
@@ -33,7 +33,7 @@
   }
   
   fn @reuse_keccak_after_disjoint_memory_store(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = keccak256 128, 64
       mstore 64, arg0
 -     v1 = keccak256 128, 64
@@ -43,7 +43,7 @@
   }
   
   fn @keep_mload_after_external_call(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 64
       v1 = call 0x186a0, arg0, 0, 0, 0, 96, 32
       v2 = mload 64

--- a/tests/ui/codegen/mir/cse/cse_non_commutative.mir
+++ b/tests/ui/codegen/mir/cse/cse_non_commutative.mir
@@ -3,7 +3,7 @@
 // CSE must NOT merge them.
 @module CseNonCommutative
 fn @non_commutative(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = sub arg0, arg1
     v3 = sub arg1, arg0
     v4 = add v2, v3

--- a/tests/ui/codegen/mir/cse/cse_non_commutative.stdout
+++ b/tests/ui/codegen/mir/cse/cse_non_commutative.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_non_commutative.mir (after cse) ===
   @module CseNonCommutative
   fn @non_commutative(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sub arg0, arg1
       v1 = sub arg1, arg0
       v2 = add v0, v1

--- a/tests/ui/codegen/mir/cse/cse_sload.mir
+++ b/tests/ui/codegen/mir/cse/cse_sload.mir
@@ -3,7 +3,7 @@
 // should be CSE'd. But after an SSTORE, the cache is invalidated.
 @module CseSload
 fn @sload_cse(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload arg0
     v2 = sload arg0
     v3 = add v1, v2
@@ -11,7 +11,7 @@ fn @sload_cse(arg0: u256) -> u256 {
 }
 
 fn @sload_after_sstore(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = sload arg0
     sstore arg0, arg1
     v4 = sload arg0

--- a/tests/ui/codegen/mir/cse/cse_sload.stdout
+++ b/tests/ui/codegen/mir/cse/cse_sload.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_sload.mir (after cse) ===
   @module CseSload
   fn @sload_cse(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload arg0
 -     v1 = sload arg0
 -     v2 = add v0, v1
@@ -11,7 +11,7 @@
   }
   
   fn @sload_after_sstore(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload arg0
       sstore arg0, arg1
       v1 = sload arg0

--- a/tests/ui/codegen/mir/cse/cse_staticcall_environment.mir
+++ b/tests/ui/codegen/mir/cse/cse_staticcall_environment.mir
@@ -5,7 +5,7 @@
 // CALL invalidates account-environment reads as before.
 @module CseStaticcallEnvironment
 fn @reuse_account_reads_across_staticcall(arg0: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = balance arg0
     v2 = extcodesize arg0
     v3 = extcodehash arg0
@@ -27,7 +27,7 @@ fn @reuse_account_reads_across_staticcall(arg0: address) -> u256 {
 }
 
 fn @keep_memory_reads_across_staticcall(arg0: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 128
     v2 = staticcall 100000, arg0, 0, 0, 128, 32
     v3 = mload 128
@@ -37,7 +37,7 @@ fn @keep_memory_reads_across_staticcall(arg0: address) -> u256 {
 }
 
 fn @keep_account_reads_across_call(arg0: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = balance arg0
     v2 = call 100000, arg0, 0, 0, 0, 0, 0
     v3 = balance arg0

--- a/tests/ui/codegen/mir/cse/cse_staticcall_environment.stdout
+++ b/tests/ui/codegen/mir/cse/cse_staticcall_environment.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_staticcall_environment.mir (after cse) ===
   @module CseStaticcallEnvironment
   fn @reuse_account_reads_across_staticcall(arg0: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = balance arg0
       v1 = extcodesize arg0
       v2 = extcodehash arg0
@@ -28,7 +28,7 @@
   }
   
   fn @keep_memory_reads_across_staticcall(arg0: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 128
       v1 = staticcall 0x186a0, arg0, 0, 0, 128, 32
       v2 = mload 128
@@ -38,7 +38,7 @@
   }
   
   fn @keep_account_reads_across_call(arg0: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = balance arg0
       v1 = call 0x186a0, arg0, 0, 0, 0, 0, 0
       v2 = balance arg0

--- a/tests/ui/codegen/mir/cse/cse_storage_alias.mir
+++ b/tests/ui/codegen/mir/cse/cse_storage_alias.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass cse
 @module CseStorageAlias
 fn @reuse_sload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = sload arg0
     v3 = add arg0, 1
     sstore v3, arg1
@@ -11,7 +11,7 @@ fn @reuse_sload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @keep_sload_after_aliasing_store(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = sload arg0
     v3 = add arg0, 0
     sstore v3, arg1
@@ -21,7 +21,7 @@ fn @keep_sload_after_aliasing_store(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @reuse_tload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = tload arg0
     v3 = add arg0, 1
     tstore v3, arg1
@@ -31,7 +31,7 @@ fn @reuse_tload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @keep_sload_after_external_call(arg0: u256, arg1: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = sload arg0
     v3 = call 100000, arg1, 0, 0, 0, 0, 0
     v4 = sload arg0

--- a/tests/ui/codegen/mir/cse/cse_storage_alias.stdout
+++ b/tests/ui/codegen/mir/cse/cse_storage_alias.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_storage_alias.mir (after cse) ===
   @module CseStorageAlias
   fn @reuse_sload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload arg0
       v1 = add arg0, 1
       sstore v1, arg1
@@ -13,7 +13,7 @@
   }
   
   fn @keep_sload_after_aliasing_store(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload arg0
       v1 = add arg0, 0
       sstore v1, arg1
@@ -23,7 +23,7 @@
   }
   
   fn @reuse_tload_after_disjoint_store(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = tload arg0
       v1 = add arg0, 1
       tstore v1, arg1
@@ -34,7 +34,7 @@
   }
   
   fn @keep_sload_after_external_call(arg0: u256, arg1: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload arg0
       v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
       v2 = sload arg0

--- a/tests/ui/codegen/mir/cse/cse_swapped_comparisons.mir
+++ b/tests/ui/codegen/mir/cse/cse_swapped_comparisons.mir
@@ -4,42 +4,42 @@
 // retains its own opcode. Same-order lt/gt must not unify.
 @module CseSwappedComparisons
 fn @reuse_gt_after_lt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
+  bb0:
     v2 = lt arg0, arg1
     v3 = gt arg1, arg0
     ret v2, v3
 }
 
 fn @reuse_lt_after_gt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
+  bb0:
     v2 = gt arg1, arg0
     v3 = lt arg0, arg1
     ret v2, v3
 }
 
 fn @reuse_sgt_after_slt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
+  bb0:
     v2 = slt arg0, arg1
     v3 = sgt arg1, arg0
     ret v2, v3
 }
 
 fn @reuse_slt_after_sgt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
+  bb0:
     v2 = sgt arg1, arg0
     v3 = slt arg0, arg1
     ret v2, v3
 }
 
 fn @keep_same_order_lt_gt(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
+  bb0:
     v2 = lt arg0, arg1
     v3 = gt arg0, arg1
     ret v2, v3
 }
 
 fn @keep_unsigned_signed_distinct(arg0: u256, arg1: u256) -> (bool, bool) {
-  bb0 (entry):
+  bb0:
     v2 = lt arg0, arg1
     v3 = sgt arg1, arg0
     ret v2, v3

--- a/tests/ui/codegen/mir/cse/cse_swapped_comparisons.stdout
+++ b/tests/ui/codegen/mir/cse/cse_swapped_comparisons.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_swapped_comparisons.mir (after cse) ===
   @module CseSwappedComparisons
   fn @reuse_gt_after_lt(arg0: u256, arg1: u256) -> (bool, bool) {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, arg1
 -     v1 = gt arg1, arg0
 -     ret v0, v1
@@ -10,7 +10,7 @@
   }
   
   fn @reuse_lt_after_gt(arg0: u256, arg1: u256) -> (bool, bool) {
-    bb0 (entry):
+    bb0:
       v0 = gt arg1, arg0
 -     v1 = lt arg0, arg1
 -     ret v0, v1
@@ -18,7 +18,7 @@
   }
   
   fn @reuse_sgt_after_slt(arg0: u256, arg1: u256) -> (bool, bool) {
-    bb0 (entry):
+    bb0:
       v0 = slt arg0, arg1
 -     v1 = sgt arg1, arg0
 -     ret v0, v1
@@ -26,7 +26,7 @@
   }
   
   fn @reuse_slt_after_sgt(arg0: u256, arg1: u256) -> (bool, bool) {
-    bb0 (entry):
+    bb0:
       v0 = sgt arg1, arg0
 -     v1 = slt arg0, arg1
 -     ret v0, v1
@@ -34,14 +34,14 @@
   }
   
   fn @keep_same_order_lt_gt(arg0: u256, arg1: u256) -> (bool, bool) {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, arg1
       v1 = gt arg0, arg1
       ret v0, v1
   }
   
   fn @keep_unsigned_signed_distinct(arg0: u256, arg1: u256) -> (bool, bool) {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, arg1
       v1 = sgt arg1, arg0
       ret v0, v1

--- a/tests/ui/codegen/mir/cse/cse_unreachable_pred.mir
+++ b/tests/ui/codegen/mir/cse/cse_unreachable_pred.mir
@@ -5,7 +5,7 @@
 // instead of dangling on the deleted result.
 @module CseUnreachablePred
 fn @no_dangling_use(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb2
   bb1:
     jump bb2

--- a/tests/ui/codegen/mir/cse/cse_unreachable_pred.stdout
+++ b/tests/ui/codegen/mir/cse/cse_unreachable_pred.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/cse/cse_unreachable_pred.mir (after cse) ===
   @module CseUnreachablePred
   fn @no_dangling_use(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb2
     bb1:
       jump bb2

--- a/tests/ui/codegen/mir/dce/dce.mir
+++ b/tests/ui/codegen/mir/dce/dce.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass dce
 @module Dce
 fn @with_dead_code(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = mul arg0, arg0
     v3 = sub arg0, 1

--- a/tests/ui/codegen/mir/dce/dce.stdout
+++ b/tests/ui/codegen/mir/dce/dce.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/dce/dce.mir (after dce) ===
   @module Dce
   fn @with_dead_code(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     v1 = mul arg0, arg0
 -     v2 = sub arg0, 1

--- a/tests/ui/codegen/mir/dce/dce_chain.mir
+++ b/tests/ui/codegen/mir/dce/dce_chain.mir
@@ -3,7 +3,7 @@
 // run_to_fixpoint should eliminate all three.
 @module DceChain
 fn @chain(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = mul v1, v1
     v3 = sub v2, arg0

--- a/tests/ui/codegen/mir/dce/dce_chain.stdout
+++ b/tests/ui/codegen/mir/dce/dce_chain.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/dce/dce_chain.mir (after dce) ===
   @module DceChain
   fn @chain(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = add arg0, 1
 -     v1 = mul v0, v0
 -     v2 = sub v1, arg0

--- a/tests/ui/codegen/mir/dce/dce_cross_block.mir
+++ b/tests/ui/codegen/mir/dce/dce_cross_block.mir
@@ -3,7 +3,7 @@
 // v2 is computed in bb1 but never used anywhere. It should be eliminated.
 @module DceCrossBlock
 fn @cross(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 1
     br arg1, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/dce/dce_cross_block.stdout
+++ b/tests/ui/codegen/mir/dce/dce_cross_block.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/dce/dce_cross_block.mir (after dce) ===
   @module DceCrossBlock
   fn @cross(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       br arg1, bb1, bb2
     bb1:

--- a/tests/ui/codegen/mir/dce/dce_side_effects.mir
+++ b/tests/ui/codegen/mir/dce/dce_side_effects.mir
@@ -3,7 +3,7 @@
 // sstore, log0, call all have side effects.
 @module DceSideEffects
 fn @effects(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     sstore arg0, arg1
     log0 0, 32
     v1 = add arg0, arg1

--- a/tests/ui/codegen/mir/dce/dce_side_effects.stdout
+++ b/tests/ui/codegen/mir/dce/dce_side_effects.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/dce/dce_side_effects.mir (after dce) ===
   @module DceSideEffects
   fn @effects(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       sstore arg0, arg1
       log0 0, 32
 -     v0 = add arg0, arg1

--- a/tests/ui/codegen/mir/dce/dce_unreachable.mir
+++ b/tests/ui/codegen/mir/dce/dce_unreachable.mir
@@ -3,7 +3,7 @@
 // DCE should clear bb1's instructions and mark it invalid.
 @module DceUnreachable
 fn @skip(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb2
   bb1:
     v1 = add arg0, 1

--- a/tests/ui/codegen/mir/dce/dce_unreachable.stdout
+++ b/tests/ui/codegen/mir/dce/dce_unreachable.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/dce/dce_unreachable.mir (after dce) ===
   @module DceUnreachable
   fn @skip(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb2
     bb1:
 -     v0 = add arg0, 1

--- a/tests/ui/codegen/mir/dce/dce_used_chain.mir
+++ b/tests/ui/codegen/mir/dce/dce_used_chain.mir
@@ -3,7 +3,7 @@
 // DCE must not eliminate anything.
 @module DceUsedChain
 fn @used_chain(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = mul v1, 2
     ret v2

--- a/tests/ui/codegen/mir/dce/dce_used_chain.stdout
+++ b/tests/ui/codegen/mir/dce/dce_used_chain.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/dce/dce_used_chain.mir (after dce) ===
   @module DceUsedChain
   fn @used_chain(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       v1 = mul v0, 2
       ret v1

--- a/tests/ui/codegen/mir/dump_cfg.sol
+++ b/tests/ui/codegen/mir/dump_cfg.sol
@@ -6,7 +6,7 @@ contract DumpCfg {
         // DOT: // === ROOT/tests/ui/codegen/mir/dump_cfg.sol:DumpCfg ===
         // DOT: digraph "f" {
         // DOT: node [shape=box
-        // DOT: bb0 [label="bb0 (entry):\l
+        // DOT: bb0 [label="bb0:\l
         // DOT: bb0 -> bb
         if (x == 0) {
             return 1;

--- a/tests/ui/codegen/mir/dump_cfg.stdout
+++ b/tests/ui/codegen/mir/dump_cfg.stdout
@@ -3,7 +3,7 @@ digraph "f" {
     node [shape=box, fontname="Courier", fontsize=10];
     edge [fontname="Courier", fontsize=9];
 
-    bb0 [label="bb0 (entry):\l  v0 = calldatasize\l  v1 = sub v0, 4\l  v2 = slt v1, 32\l  br v2, bb1, bb2\l", fillcolor="#e0ffe0", style=filled];
+    bb0 [label="bb0:\l  v0 = calldatasize\l  v1 = sub v0, 4\l  v2 = slt v1, 32\l  br v2, bb1, bb2\l"];
     bb1 [label="bb1:\l  revert 0, 0\l"];
     bb2 [label="bb2:\l  mstore 128, 0\l  v3 = eq arg0, 0\l  br v3, bb3, bb4\l"];
     bb3 [label="bb3:\l  mstore 128, 1\l  returndata 128, 32\l"];

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion
 @module FramePromotionDeadMerge
 fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir (after frame-slot-promotion) ===
   @module FramePromotionDeadMerge
   fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       jump bb3

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion,cfg-simplify,dce
 @module NestedCounter
 fn @nested(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 0
     v2 = internal_frame_addr 160

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after frame-slot-promotion) ===
   @module NestedCounter
   fn @nested(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
 -     mstore v0, 0
       v1 = internal_frame_addr 160
@@ -61,7 +61,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after cfg-simplify) ===
   @module NestedCounter
   fn @nested(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
       v1 = internal_frame_addr 160
       jump bb1
@@ -102,7 +102,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (after dce) ===
   @module NestedCounter
   fn @nested(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
 -     v1 = internal_frame_addr 160
       jump bb1

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion
 @module FramePromotionLoadBeforeStore
 fn @load_before_store() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     v2 = mload v1
     mstore v1, 1

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_load_before_store.mir (after frame-slot-promotion) ===
   @module FramePromotionLoadBeforeStore
   fn @load_before_store() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
       v1 = mload v0
       mstore v0, 1

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion,dce
 @module FramePromotionOffsetAddr
 fn @offset_addr() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     v2 = add v1, 32
     mstore v2, 99

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after frame-slot-promotion) ===
   @module FramePromotionOffsetAddr
   fn @offset_addr() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
       v1 = add v0, 32
 -     mstore v1, 99
@@ -17,7 +17,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_offset_addr.mir (after dce) ===
   @module FramePromotionOffsetAddr
   fn @offset_addr() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
 -     v1 = add v0, 32
 -     v2 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion,dce
 @module FramePromotionSameBlock
 fn @same_block() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 7
     v2 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after frame-slot-promotion) ===
   @module FramePromotionSameBlock
   fn @same_block() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
 -     mstore v0, 7
       v1 = internal_frame_addr 128
@@ -21,7 +21,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_same_block.mir (after dce) ===
   @module FramePromotionSameBlock
   fn @same_block() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
 -     v1 = internal_frame_addr 128
       v3 = add 7, 1

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion,cfg-simplify,dce
 @module SequentialCounter
 fn @sequential(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 0
     v2 = internal_frame_addr 160

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after frame-slot-promotion) ===
   @module SequentialCounter
   fn @sequential(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
 -     mstore v0, 0
       v1 = internal_frame_addr 160
@@ -67,7 +67,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after cfg-simplify) ===
   @module SequentialCounter
   fn @sequential(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
       v1 = internal_frame_addr 160
       jump bb1
@@ -111,7 +111,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (after dce) ===
   @module SequentialCounter
   fn @sequential(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
 -     v1 = internal_frame_addr 160
       jump bb1

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion,dce
 @module LocalSlotPromotion
 fn @promote_loop_carried_slot(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 0
     jump bb1

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after frame-slot-promotion) ===
   @module LocalSlotPromotion
   fn @promote_loop_carried_slot(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
 -     mstore v0, 0
       jump bb1
@@ -32,7 +32,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (after dce) ===
   @module LocalSlotPromotion
   fn @promote_loop_carried_slot(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
       jump bb1
     bb1:

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes frame-slot-promotion,dce
 @module LocalSlotPromotionCallBarrier
 fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 9
     v2 = staticcall 100000, arg0, 0, 0, 0, 0
@@ -12,7 +12,7 @@ fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
 }
 
 fn @keep_msize_observation() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 9
     v2 = msize
@@ -23,7 +23,7 @@ fn @keep_msize_observation() -> u256 {
 }
 
 fn @promote_slot_with_unrelated_frame_hash() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 9
     v2 = internal_frame_addr 192

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after frame-slot-promotion) ===
   @module LocalSlotPromotionCallBarrier
   fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
 -     mstore v0, 9
       v1 = staticcall 0x186a0, arg0, 0, 0, 0, 0
@@ -14,7 +14,7 @@
   }
   
   fn @keep_msize_observation() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
       mstore v0, 9
       v1 = msize
@@ -25,7 +25,7 @@
   }
   
   fn @promote_slot_with_unrelated_frame_hash() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
 -     mstore v0, 9
       v1 = internal_frame_addr 192
@@ -43,7 +43,7 @@
 + // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion_call_barrier.mir (after dce) ===
   @module LocalSlotPromotionCallBarrier
   fn @promote_across_unrelated_staticcall(arg0: address) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
       v1 = staticcall 0x186a0, arg0, 0, 0, 0, 0
 -     v2 = internal_frame_addr 128
@@ -52,7 +52,7 @@
   }
   
   fn @keep_msize_observation() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = internal_frame_addr 128
       mstore v0, 9
       v1 = msize
@@ -63,7 +63,7 @@
   }
   
   fn @promote_slot_with_unrelated_frame_hash() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_frame_addr 128
       v1 = internal_frame_addr 192
       mstore v1, 1

--- a/tests/ui/codegen/mir/gvn/gvn.mir
+++ b/tests/ui/codegen/mir/gvn/gvn.mir
@@ -4,7 +4,7 @@
 // Transitive congruence: v3 joins v2's class, so v5 and v4 key identically
 // over classes and v5 folds onto v4 in the same run.
 fn @transitive_congruence(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, arg1
     v3 = add arg0, arg1
     v4 = mul v2, 2
@@ -16,7 +16,7 @@ fn @transitive_congruence(arg0: u256, arg1: u256) -> u256 {
 // The two `16` literals are distinct value-table entries; equal immediates
 // share a class, and commutative operands sort by class.
 fn @equal_immediates_unify(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 16
     v2 = add 16, arg0
     v3 = add v1, v2
@@ -26,7 +26,7 @@ fn @equal_immediates_unify(arg0: u256) -> u256 {
 // `gt arg1, arg0` keys as `lt arg0, arg1`, so the selects over the two
 // comparisons become congruent as well.
 fn @swapped_comparison_feeds_arithmetic(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = lt arg0, arg1
     v3 = gt arg1, arg0
     v4 = select v2, arg0, arg1
@@ -38,7 +38,7 @@ fn @swapped_comparison_feeds_arithmetic(arg0: u256, arg1: u256) -> u256 {
 // Negative: storage, balance, and keccak reads never merge here even with
 // identical operands; only CSE may unify those under its clobber tracking.
 fn @keep_state_dependent_reads(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload arg0
     v2 = sload arg0
     v3 = balance arg0
@@ -56,7 +56,7 @@ fn @keep_state_dependent_reads(arg0: u256) -> u256 {
 // Diamond: the sibling adds and muls share classes, and the phi-of-same joins
 // the mul class, but no member dominates bb3 so nothing is replaced.
 fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1

--- a/tests/ui/codegen/mir/gvn/gvn.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/gvn/gvn.mir (after gvn) ===
   @module Gvn
   fn @transitive_congruence(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg1
 -     v1 = add arg0, arg1
       v2 = mul v0, 2
@@ -13,7 +13,7 @@
   }
   
   fn @equal_immediates_unify(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 16
 -     v1 = add 16, arg0
 -     v2 = add v0, v1
@@ -22,7 +22,7 @@
   }
   
   fn @swapped_comparison_feeds_arithmetic(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, arg1
 -     v1 = gt arg1, arg0
       v2 = select v0, arg0, arg1
@@ -33,7 +33,7 @@
   }
   
   fn @keep_state_dependent_reads(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload arg0
       v1 = sload arg0
       v2 = balance arg0
@@ -49,7 +49,7 @@
   }
   
   fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1

--- a/tests/ui/codegen/mir/gvn/gvn_loadimmutable.mir
+++ b/tests/ui/codegen/mir/gvn/gvn_loadimmutable.mir
@@ -3,7 +3,7 @@
 
 // Repeated reads of the same immutable are congruent and merge.
 fn @same_immutable_merges() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = loadimmutable 0
     v1 = loadimmutable 0
     v2 = add v0, v1
@@ -12,7 +12,7 @@ fn @same_immutable_merges() -> u256 {
 
 // Reads of different immutables stay distinct.
 fn @different_immutables_stay(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = loadimmutable 0
     v1 = loadimmutable 32
     v2 = add v0, v1

--- a/tests/ui/codegen/mir/gvn/gvn_loadimmutable.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn_loadimmutable.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/gvn/gvn_loadimmutable.mir (after gvn) ===
   @module GvnLoadImmutable
   fn @same_immutable_merges() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = loadimmutable 0
 -     v1 = loadimmutable 0
 -     v2 = add v0, v1
@@ -11,7 +11,7 @@
   }
   
   fn @different_immutables_stay(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = loadimmutable 0
       v1 = loadimmutable 32
       v2 = add v0, v1

--- a/tests/ui/codegen/mir/gvn/gvn_phi.mir
+++ b/tests/ui/codegen/mir/gvn/gvn_phi.mir
@@ -3,7 +3,7 @@
 
 // Two phis in one block with pairwise-congruent incoming collapse to one.
 fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg2, bb1, bb2
   bb1:
     jump bb3
@@ -18,7 +18,7 @@ fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
 
 // Phi-of-same folds onto the operand because its def dominates the join.
 fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 1
     br arg1, bb1, bb2
   bb1:
@@ -34,7 +34,7 @@ fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
 // The incoming values are distinct defs in one class: v3 folds onto v2, and
 // the phi-of-same then folds onto the class leader v2 as well.
 fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 1
     br arg1, bb1, bb2
   bb1:
@@ -49,7 +49,7 @@ fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
 
 // Phi-of-same over equal immediates folds onto the constant.
 fn @phi_of_equal_immediates(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -64,7 +64,7 @@ fn @phi_of_equal_immediates(arg0: bool) -> u256 {
 // iteration starts them in distinct classes and nothing ever merges them -
 // unifying lockstep loop phis needs optimistic NewGVN-style assumptions.
 fn @lockstep_loop_phis_stay(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v4]

--- a/tests/ui/codegen/mir/gvn/gvn_phi.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn_phi.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/gvn/gvn_phi.mir (after gvn) ===
   @module GvnPhi
   fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg2, bb1, bb2
     bb1:
       jump bb3
@@ -17,7 +17,7 @@
   }
   
   fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       br arg1, bb1, bb2
     bb1:
@@ -32,7 +32,7 @@
   }
   
   fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       br arg1, bb1, bb2
     bb1:
@@ -47,7 +47,7 @@
   }
   
   fn @phi_of_equal_immediates(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3
@@ -60,7 +60,7 @@
   }
   
   fn @lockstep_loop_phis_stay(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v3]

--- a/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir
+++ b/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass indvar-simplify
 @module IndVarSimplify
 fn @strength_reduce_shifted_address(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v6]
@@ -18,7 +18,7 @@ fn @strength_reduce_shifted_address(arg0: u256) -> u256 {
 }
 
 fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
@@ -36,7 +36,7 @@ fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
 }
 
 fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v5]

--- a/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
+++ b/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir (after indvar-simplify) ===
   @module IndVarSimplify
   fn @strength_reduce_shifted_address(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
@@ -22,7 +22,7 @@
   }
   
   fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v6 = add arg0, 4
       jump bb1
     bb1:
@@ -44,7 +44,7 @@
   }
   
   fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v3]

--- a/tests/ui/codegen/mir/inline/inline_internal_call.mir
+++ b/tests/ui/codegen/mir/inline/inline_internal_call.mir
@@ -1,13 +1,13 @@
 //@compile-flags: --pass inline
 @module InlineInternalCall
 fn @caller(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_call fn1, 1, arg0
     ret v1
 }
 
 fn @callee(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     ret v1
 }

--- a/tests/ui/codegen/mir/inline/inline_internal_call.stdout
+++ b/tests/ui/codegen/mir/inline/inline_internal_call.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/inline/inline_internal_call.mir (after inline) ===
   @module InlineInternalCall
   fn @caller(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_call @callee, 1, arg0
 -     ret v0
 +     jump bb2
@@ -15,7 +15,7 @@
   }
   
   fn @callee(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       ret v0
   }

--- a/tests/ui/codegen/mir/inline/inline_v2_profitability.mir
+++ b/tests/ui/codegen/mir/inline/inline_v2_profitability.mir
@@ -2,7 +2,7 @@
 @module InlineV2Profitability
 
 fn @single_large_caller(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_call fn1, 1, arg0
     ret v1
 }
@@ -10,7 +10,7 @@ fn @single_large_caller(arg0: u256) -> u256 {
 // More than the normal 10-block cap, but it has exactly one call site and the
 // original callee body disappears after function-dce.
 fn @single_large_callee(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     jump bb2
@@ -38,7 +38,7 @@ fn @single_large_callee(arg0: u256) -> u256 {
 }
 
 fn @multi_return_caller(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_call fn3, 2, arg0
     v2 = mload 32
     v3 = add v1, v2
@@ -46,21 +46,21 @@ fn @multi_return_caller(arg0: u256) -> u256 {
 }
 
 fn @multi_return_callee(arg0: u256) -> (u256, u256) {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = add arg0, 2
     ret v1, v2
 }
 
 fn @tiny_stateful_caller(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     internal_call fn5, 0, arg0
     internal_call fn5, 0, arg1
     stop
 }
 
 fn @tiny_stateful_callee(arg0: u256) {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0
     ret
 }

--- a/tests/ui/codegen/mir/inline/inline_v2_profitability.stdout
+++ b/tests/ui/codegen/mir/inline/inline_v2_profitability.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/inline/inline_v2_profitability.mir (after inline) ===
   @module InlineV2Profitability
   fn @single_large_caller(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_call @single_large_callee, 1, arg0
 -     ret v0
 +     jump bb2
@@ -37,7 +37,7 @@
   }
   
   fn @single_large_callee(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       jump bb2
@@ -65,7 +65,7 @@
   }
   
   fn @multi_return_caller(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_call @multi_return_callee, 2, arg0
 +     jump bb2
 +   bb1:
@@ -86,14 +86,14 @@
   }
   
   fn @multi_return_callee(arg0: u256) -> (u256, u256) {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       v1 = add arg0, 2
       ret v0, v1
   }
   
   fn @tiny_stateful_caller(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
 -     internal_call @tiny_stateful_callee, 0, arg0
 -     internal_call @tiny_stateful_callee, 0, arg1
 +     jump bb2
@@ -110,7 +110,7 @@
   }
   
   fn @tiny_stateful_callee(arg0: u256) {
-    bb0 (entry):
+    bb0:
       sstore 0, arg0
       ret
   }

--- a/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir
+++ b/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass inst-simplify
 @module InstSimplify
 fn @strength_reduce_arithmetic(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mul arg0, 32
     v2 = div v1, 8
     v3 = mod arg0, 16
@@ -18,7 +18,7 @@ fn @strength_reduce_arithmetic(arg0: u256) -> u256 {
 }
 
 fn @simplify_booleans(arg0: bool, arg1: u256, arg2: u256) -> (bool, bool, u256, bool, bool) {
-  bb0 (entry):
+  bb0:
     v3 = eq arg0, true
     v4 = eq arg0, false
     v5 = select true, arg1, arg2
@@ -28,7 +28,7 @@ fn @simplify_booleans(arg0: bool, arg1: u256, arg2: u256) -> (bool, bool, u256, 
 }
 
 fn @remove_zero_length_copies(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mcopy 64, 96, 0
     calldatacopy 128, 0, 0
     codecopy 160, 0, 0
@@ -37,18 +37,18 @@ fn @remove_zero_length_copies(arg0: u256) -> u256 {
 }
 
 fn @stop_zero_length_external_return(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     v1 = xor arg0, arg0
     returndata arg0, v1
 }
 
 fn @preserve_zero_length_internal_return(arg0: u256) {
-  bb0 (entry):
+  bb0:
     returndata arg0, 0
 }
 
 fn @fold_modular_helpers(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = addmod arg0, 0, 0
     v2 = mulmod arg0, 0, 97
     v3 = add v1, v2
@@ -56,7 +56,7 @@ fn @fold_modular_helpers(arg0: u256) -> u256 {
 }
 
 fn @complete_word_identities(arg0: u256, arg1: bool) -> (u256, u256, bool, bool, bool, u256, u256, u256, u256) {
-  bb0 (entry):
+  bb0:
     v2 = or arg0, 115792089237316195423570985008687907853269984665640564039457584007913129639935
     v3 = xor arg0, 115792089237316195423570985008687907853269984665640564039457584007913129639935
     v4 = iszero arg1
@@ -71,7 +71,7 @@ fn @complete_word_identities(arg0: u256, arg1: bool) -> (u256, u256, bool, bool,
 }
 
 fn @complete_exact_identities(arg0: u256, arg1: bool) -> (u256, u256, u256, u256, bool, bool, bool, bool, u256, u256) {
-  bb0 (entry):
+  bb0:
     v2 = not arg0
     v3 = and arg0, v2
     v4 = or arg0, v2
@@ -86,7 +86,7 @@ fn @complete_exact_identities(arg0: u256, arg1: bool) -> (u256, u256, u256, u256
 }
 
 fn @fold_modular_mod_one(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = addmod arg0, arg1, 1
     v3 = mulmod arg0, arg1, 1
     v4 = add v2, v3
@@ -94,20 +94,20 @@ fn @fold_modular_mod_one(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @keep_exp_zero_base_with_unknown_exponent(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = exp 0, arg0
     ret v1
 }
 
 fn @fold_wide_modular_constants() -> (u256, u256) {
-  bb0 (entry):
+  bb0:
     v0 = addmod 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3
     v1 = mulmod 0x100000000000000000000000000000000, 0x100000000000000000000000000000000, 7
     ret v0, v1
 }
 
 fn @fold_constant_ops() -> (u256, u256, u256, u256, u256, u256, u256, u256, u256, bool, bool, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256) {
-  bb0 (entry):
+  bb0:
     v1 = add 7, 5
     v2 = sub 7, 9
     v3 = mul 6, 7

--- a/tests/ui/codegen/mir/inst-simplify/inst_simplify.stdout
+++ b/tests/ui/codegen/mir/inst-simplify/inst_simplify.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir (after inst-simplify) ===
   @module InstSimplify
   fn @strength_reduce_arithmetic(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mul arg0, 32
 -     v1 = div v0, 8
 -     v2 = mod arg0, 16
@@ -25,7 +25,7 @@
   }
   
   fn @simplify_booleans(arg0: bool, arg1: u256, arg2: u256) -> (bool, bool, u256, bool, bool) {
-    bb0 (entry):
+    bb0:
 -     v0 = eq arg0, 1
 -     v1 = eq arg0, 0
 -     v2 = select 1, arg1, arg2
@@ -38,7 +38,7 @@
   }
   
   fn @remove_zero_length_copies(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     mcopy 64, 96, 0
 -     calldatacopy 128, 0, 0
 -     codecopy 160, 0, 0
@@ -47,19 +47,19 @@
   }
   
   fn @stop_zero_length_external_return(arg0: u256) {
-    bb0 (entry):
+    bb0:
 -     v0 = xor arg0, arg0
 -     returndata arg0, v0
 +     stop
   }
   
   fn @preserve_zero_length_internal_return(arg0: u256) {
-    bb0 (entry):
+    bb0:
       returndata arg0, 0
   }
   
   fn @fold_modular_helpers(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = addmod arg0, 0, 0
 -     v1 = mulmod arg0, 0, 97
 -     v2 = add v0, v1
@@ -68,7 +68,7 @@
   }
   
   fn @complete_word_identities(arg0: u256, arg1: bool) -> (u256, u256, bool, bool, bool, u256, u256, u256, u256) {
-    bb0 (entry):
+    bb0:
 -     v0 = or arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -     v1 = xor arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 +     v1 = not arg0
@@ -85,7 +85,7 @@
   }
   
   fn @complete_exact_identities(arg0: u256, arg1: bool) -> (u256, u256, u256, u256, bool, bool, bool, bool, u256, u256) {
-    bb0 (entry):
+    bb0:
       v0 = not arg0
 -     v1 = and arg0, v0
 -     v2 = or arg0, v0
@@ -101,7 +101,7 @@
   }
   
   fn @fold_modular_mod_one(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = addmod arg0, arg1, 1
 -     v1 = mulmod arg0, arg1, 1
 -     v2 = add v0, v1
@@ -110,13 +110,13 @@
   }
   
   fn @keep_exp_zero_base_with_unknown_exponent(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = exp 0, arg0
       ret v0
   }
   
   fn @fold_wide_modular_constants() -> (u256, u256) {
-    bb0 (entry):
+    bb0:
 -     v0 = addmod 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3
 -     v1 = mulmod 0x100000000000000000000000000000000, 0x100000000000000000000000000000000, 7
 -     ret v0, v1
@@ -124,7 +124,7 @@
   }
   
   fn @fold_constant_ops() -> (u256, u256, u256, u256, u256, u256, u256, u256, u256, bool, bool, u256, u256, u256, u256, u256, u256, u256, u256, u256, u256) {
-    bb0 (entry):
+    bb0:
 -     v0 = add 7, 5
 -     v1 = sub 7, 9
 -     v2 = mul 6, 7

--- a/tests/ui/codegen/mir/jump-threading/jump_threading.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass jump-threading
 @module Threading
 fn @forwarder_chain(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     jump bb2

--- a/tests/ui/codegen/mir/jump-threading/jump_threading.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading.mir (after jump-threading) ===
   @module Threading
   fn @forwarder_chain(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     jump bb1
 +     jump bb3
     bb1:

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir
@@ -3,7 +3,7 @@
 // Jump threading should rewrite the branch to point past the forwarders.
 @module ThreadingBranch
 fn @branch_forwarders(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir (after jump-threading) ===
   @module ThreadingBranch
   fn @branch_forwarders(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 +     br arg0, bb3, bb4
     bb1:

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass jump-threading
 @module JumpThreadingPhiConstants
 fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -17,7 +17,7 @@ fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
 }
 
 fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -35,7 +35,7 @@ fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
 }
 
 fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -51,7 +51,7 @@ fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
 }
 
 fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir (after jump-threading) ===
   @module JumpThreadingPhiConstants
   fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 +     br arg0, bb5, bb4
     bb1:
@@ -22,7 +22,7 @@
   }
   
   fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb2
 +     br arg0, bb4, bb5
     bb1:
@@ -44,7 +44,7 @@
   }
   
   fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3
@@ -60,7 +60,7 @@
   }
   
   fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir
@@ -3,7 +3,7 @@
 // its predecessors past it would sever the phi's incoming edges.
 @module JumpThreadingPhiForwarder
 fn @keep_phi_only_block(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir (after jump-threading) ===
   @module JumpThreadingPhiForwarder
   fn @keep_phi_only_block(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3

--- a/tests/ui/codegen/mir/licm/licm_descending_iv.mir
+++ b/tests/ui/codegen/mir/licm/licm_descending_iv.mir
@@ -6,7 +6,7 @@
 // exits. mstore(i, ...) therefore writes bytes [0, 96), overlapping mload 0's
 // The range [0, 32) overlaps, so the mload must not be hoisted.
 fn @keep_mload_descending_iv() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 64], [bb2: v9]
@@ -25,7 +25,7 @@ fn @keep_mload_descending_iv() -> u256 {
 // Ascending control: i = 64..99, the mstore range [64, 131) really is disjoint
 // from mload 0's [0, 32); hoisting here is correct.
 fn @hoist_mload_ascending_iv() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 64], [bb2: v9]

--- a/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
+++ b/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_descending_iv.mir (after licm) ===
   @module LicmDescendingIv
   fn @keep_mload_descending_iv() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 64], [bb2: v3]
@@ -20,7 +20,7 @@
   }
   
   fn @hoist_mload_ascending_iv() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = mload 0
       jump bb1
     bb1:

--- a/tests/ui/codegen/mir/licm/licm_env_reads.mir
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.mir
@@ -4,7 +4,7 @@
 // The value-transferring call can change the queried balance between iterations,
 // so neither the balance nor the mul depending on it may be hoisted.
 fn @keep_balance_with_call() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -19,7 +19,7 @@ fn @keep_balance_with_call() -> u256 {
 
 // Without any call or create in the loop the balance is loop-invariant for real.
 fn @hoist_balance_without_calls() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -33,7 +33,7 @@ fn @hoist_balance_without_calls() -> u256 {
 
 // The created contract's constructor can run arbitrary code.
 fn @keep_extcodesize_with_create() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -48,7 +48,7 @@ fn @keep_extcodesize_with_create() -> u256 {
 
 // Every external call, including staticcall, rewrites the return-data buffer.
 fn @keep_returndatasize_with_staticcall() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -63,7 +63,7 @@ fn @keep_returndatasize_with_staticcall() -> u256 {
 
 // msize observes memory expansion and must never move.
 fn @keep_msize() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3

--- a/tests/ui/codegen/mir/licm/licm_env_reads.stdout
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_env_reads.mir (after licm) ===
   @module LicmEnvReads
   fn @keep_balance_with_call() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br 1, bb2, bb3
@@ -16,7 +16,7 @@
   }
   
   fn @hoist_balance_without_calls() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v0 = balance 0xbeef
 +     v1 = mul v0, 3
       jump bb1
@@ -31,7 +31,7 @@
   }
   
   fn @keep_extcodesize_with_create() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br 1, bb2, bb3
@@ -45,7 +45,7 @@
   }
   
   fn @keep_returndatasize_with_staticcall() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br 1, bb2, bb3
@@ -59,7 +59,7 @@
   }
   
   fn @keep_msize() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br 1, bb2, bb3

--- a/tests/ui/codegen/mir/licm/licm_loop_bound.mir
+++ b/tests/ui/codegen/mir/licm/licm_loop_bound.mir
@@ -5,7 +5,7 @@
 // in-body `lt v1, 2` has both successors inside the loop and must not be used
 // as a trip count. The mstore really covers [0, 3200) and overlaps mload 64.
 fn @keep_mload_non_exiting_bound() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb4: v9]
@@ -30,7 +30,7 @@ fn @keep_mload_non_exiting_bound() -> u256 {
 // exiting guard may provide the bound (previously hash-order dependent).
 // With bound 100 the mstore range overlaps mload 64, so nothing is hoisted.
 fn @keep_mload_inner_branch_bound() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb4: v9]

--- a/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
+++ b/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_loop_bound.mir (after licm) ===
   @module LicmLoopBound
   fn @keep_mload_non_exiting_bound() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb4: v5]
@@ -24,7 +24,7 @@
   }
   
   fn @keep_mload_inner_branch_bound() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb4: v5]

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.mir
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass licm
 @module LicmMemoryAlias
 fn @hoist_non_aliasing_mload() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -14,7 +14,7 @@ fn @hoist_non_aliasing_mload() -> u256 {
 }
 
 fn @keep_aliasing_mload() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -27,7 +27,7 @@ fn @keep_aliasing_mload() -> u256 {
 }
 
 fn @hoist_non_aliasing_keccak() -> bytes32 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3
@@ -40,7 +40,7 @@ fn @hoist_non_aliasing_keccak() -> bytes32 {
 }
 
 fn @keep_aliasing_keccak() -> bytes32 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb3

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_memory_alias.mir (after licm) ===
   @module LicmMemoryAlias
   fn @hoist_non_aliasing_mload() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v0 = mload 0
       jump bb1
     bb1:
@@ -16,7 +16,7 @@
   }
   
   fn @keep_aliasing_mload() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br 1, bb2, bb3
@@ -29,7 +29,7 @@
   }
   
   fn @hoist_non_aliasing_keccak() -> bytes32 {
-    bb0 (entry):
+    bb0:
 +     v0 = keccak256 0, 32
       jump bb1
     bb1:
@@ -43,7 +43,7 @@
   }
   
   fn @keep_aliasing_keccak() -> bytes32 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       br 1, bb2, bb3

--- a/tests/ui/codegen/mir/licm/licm_multi_latch.mir
+++ b/tests/ui/codegen/mir/licm/licm_multi_latch.mir
@@ -6,7 +6,7 @@
 // recorded and the mload must stay in the loop.
 @module LicmMultiLatch
 fn @multi_latch_mixed_step() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v8], [bb3: v9]
@@ -31,7 +31,7 @@ fn @multi_latch_mixed_step() -> u256 {
 // Two latches passing the SAME update value keep the stride uniform; the
 // store range is exactly [0, 320) and the mload at 320 may be hoisted.
 fn @multi_latch_same_value() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v8], [bb3: v8]

--- a/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
+++ b/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_multi_latch.mir (after licm) ===
   @module LicmMultiLatch
   fn @multi_latch_mixed_step() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v4 = calldataload 0
       jump bb1
     bb1:
@@ -26,7 +26,7 @@
   }
   
   fn @multi_latch_same_value() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v3 = mload 320
 +     v5 = calldataload 0
       jump bb1

--- a/tests/ui/codegen/mir/licm/licm_rotated_guard.mir
+++ b/tests/ui/codegen/mir/licm/licm_rotated_guard.mir
@@ -6,7 +6,7 @@
 // stay in the loop.
 @module LicmRotatedGuard
 fn @rotated_guard_overlap() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
@@ -25,7 +25,7 @@ fn @rotated_guard_overlap() -> u256 {
 // Self-loop do-while variant of the same off-by-one: guard on the pre-increment
 // phi at the bottom of the single-block loop. The body runs with v1 = 0..10.
 fn @dowhile_latch_guard_overlap() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb1: v9]
@@ -43,7 +43,7 @@ fn @dowhile_latch_guard_overlap() -> u256 {
 // only executes after the bound check passed and the store range is exactly
 // The range is [0, 320), so the mload at 320 is genuinely disjoint and is hoisted.
 fn @top_tested_control() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
@@ -63,7 +63,7 @@ fn @top_tested_control() -> u256 {
 // iteration, so their range is widened one stride to [0, 352); a load one
 // stride further is still provably disjoint and may be hoisted.
 fn @disjoint_past_widened_range() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]

--- a/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
+++ b/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_rotated_guard.mir (after licm) ===
   @module LicmRotatedGuard
   fn @rotated_guard_overlap() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
@@ -19,7 +19,7 @@
   }
   
   fn @dowhile_latch_guard_overlap() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb1: v3]
@@ -34,7 +34,7 @@
   }
   
   fn @top_tested_control() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v3 = mload 320
       jump bb1
     bb1:
@@ -52,7 +52,7 @@
   }
   
   fn @disjoint_past_widened_range() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = mload 384
       jump bb1
     bb1:

--- a/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir
+++ b/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir
@@ -4,7 +4,7 @@
 // STATICCALL cannot write storage, even reentrantly: the sload stays invariant
 // and is hoisted out of this view-heavy loop.
 fn @hoist_sload_with_staticcall() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
@@ -21,7 +21,7 @@ fn @hoist_sload_with_staticcall() -> u256 {
 
 // Transient storage is equally unwritable from a static context.
 fn @hoist_tload_with_staticcall() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
@@ -38,7 +38,7 @@ fn @hoist_tload_with_staticcall() -> u256 {
 
 // A plain call may write any slot; the sload must stay in the loop.
 fn @keep_sload_with_call() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]

--- a/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
+++ b/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir (after licm) ===
   @module LicmStaticcallStorage
   fn @hoist_sload_with_staticcall() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = sload 5 !metadata(storage=slot(5))
       jump bb1
     bb1:
@@ -19,7 +19,7 @@
   }
   
   fn @hoist_tload_with_staticcall() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = tload 5 !metadata(storage=slot(5))
       jump bb1
     bb1:
@@ -36,7 +36,7 @@
   }
   
   fn @keep_sload_with_call() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]

--- a/tests/ui/codegen/mir/licm/licm_v2.mir
+++ b/tests/ui/codegen/mir/licm/licm_v2.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass licm
 @module LicmV2
 fn @hoist_symbolic_offset_sload(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
@@ -19,7 +19,7 @@ fn @hoist_symbolic_offset_sload(arg0: u256) -> u256 {
 }
 
 fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
@@ -37,7 +37,7 @@ fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
 }
 
 fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br arg1, bb2, bb3
@@ -52,7 +52,7 @@ fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @hoist_affine_memory_base(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
@@ -70,7 +70,7 @@ fn @hoist_affine_memory_base(arg0: u256) -> u256 {
 }
 
 fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]

--- a/tests/ui/codegen/mir/licm/licm_v2.stdout
+++ b/tests/ui/codegen/mir/licm/licm_v2.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_v2.mir (after licm) ===
   @module LicmV2
   fn @hoist_symbolic_offset_sload(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = add arg0, 1
 +     v3 = sload v2 !metadata(storage=offset(arg0, 1))
 +     v4 = add arg0, 2
@@ -24,7 +24,7 @@
   }
   
   fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = add arg0, 1
 +     v4 = add arg0, 1
       jump bb1
@@ -46,7 +46,7 @@
   }
   
   fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v0 = add arg0, 1
 +     v2 = add arg0, 2
       jump bb1
@@ -65,7 +65,7 @@
   }
   
   fn @hoist_affine_memory_base(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = add arg0, 32
       jump bb1
     bb1:
@@ -84,7 +84,7 @@
   }
   
   fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = add arg0, 32
       jump bb1
     bb1:

--- a/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir
+++ b/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir
@@ -4,7 +4,7 @@
 // trip count, so range reasoning must not prove the mload disjoint.
 @module LicmWrapAddDescending
 fn @wrap_add_descending() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 64], [bb2: v9]

--- a/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
+++ b/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir (after licm) ===
   @module LicmWrapAddDescending
   fn @wrap_add_descending() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 64], [bb2: v4]

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.mir
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.mir
@@ -4,7 +4,7 @@
 // The bound is unknown, so the loop may run zero times: speculating the sload
 // into the always-executed preheader is a pure gas pessimization.
 fn @keep_sload_zero_trip() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     jump bb1
   bb1:
@@ -22,7 +22,7 @@ fn @keep_sload_zero_trip() -> u256 {
 // Hoisting the mload would unconditionally expand memory to 0x1000000 even
 // when the loop runs zero times (out-of-gas risk).
 fn @keep_mload_zero_trip() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     jump bb1
   bb1:
@@ -40,7 +40,7 @@ fn @keep_mload_zero_trip() -> u256 {
 // A verified trip count of 10 guarantees the body executes, so the sload is
 // still hoisted.
 fn @hoist_sload_known_trip() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
@@ -57,7 +57,7 @@ fn @hoist_sload_known_trip() -> u256 {
 // Do-while shape: the mload's block dominates the loop exit, so it executes
 // whenever the loop is entered and may be hoisted despite the unknown bound.
 fn @hoist_mload_dominates_exits() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v0 = mload 64
@@ -71,7 +71,7 @@ fn @hoist_mload_dominates_exits() -> u256 {
 // The msize after the loop makes any early memory expansion observable;
 // keep the mload in place even though the trip count is known.
 fn @keep_mload_msize_in_function() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/licm/licm_zero_trip.mir (after licm) ===
   @module LicmZeroTrip
   fn @keep_sload_zero_trip() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = calldatasize
       jump bb1
     bb1:
@@ -19,7 +19,7 @@
   }
   
   fn @keep_mload_zero_trip() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = calldatasize
       jump bb1
     bb1:
@@ -35,7 +35,7 @@
   }
   
   fn @hoist_sload_known_trip() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v2 = sload 5 !metadata(storage=slot(5))
       jump bb1
     bb1:
@@ -51,7 +51,7 @@
   }
   
   fn @hoist_mload_dominates_exits() -> u256 {
-    bb0 (entry):
+    bb0:
 -     jump bb1
 -   bb1:
       v0 = mload 64
@@ -65,7 +65,7 @@
   }
   
   fn @keep_mload_msize_in_function() -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v3]

--- a/tests/ui/codegen/mir/load-pre/load_pre.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre.mir
@@ -6,7 +6,7 @@
 // loop-carried-only policy (load_pre_memory.mir).
 @module LoadPre
 fn @full_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = sload 5
@@ -20,7 +20,7 @@ fn @full_diamond(arg0: bool) -> u256 {
 }
 
 fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     sstore 5, arg1
@@ -34,7 +34,7 @@ fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
 }
 
 fn @partial_insert_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = sload 5
@@ -47,7 +47,7 @@ fn @partial_insert_diamond(arg0: bool) -> u256 {
 }
 
 fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     tstore 5, arg1

--- a/tests/ui/codegen/mir/load-pre/load_pre.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/load-pre/load_pre.mir (after load-pre) ===
   @module LoadPre
   fn @full_diamond(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = sload 5
@@ -18,7 +18,7 @@
   }
   
   fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       sstore 5, arg1
@@ -34,7 +34,7 @@
   }
   
   fn @partial_insert_diamond(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = sload 5
@@ -50,7 +50,7 @@
   }
   
   fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       tstore 5, arg1

--- a/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir
@@ -6,7 +6,7 @@
 // blocks the rewrite in all spaces.
 @module LoadPreClobbers
 fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 5
     br arg0, bb1, bb2
   bb1:
@@ -22,7 +22,7 @@ fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
 }
 
 fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 5
     br arg0, bb1, bb2
   bb1:
@@ -38,7 +38,7 @@ fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
 }
 
 fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 5
     br arg0, bb1, bb2
   bb1:
@@ -54,7 +54,7 @@ fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
 }
 
 fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = sload 5
@@ -69,7 +69,7 @@ fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
 }
 
 fn @gas_blocks_rewrite(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = sload 5

--- a/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir (after load-pre) ===
   @module LoadPreClobbers
   fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 5
       br arg0, bb1, bb2
     bb1:
@@ -18,7 +18,7 @@
   }
   
   fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 5
       br arg0, bb1, bb2
     bb1:
@@ -34,7 +34,7 @@
   }
   
   fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 5
       br arg0, bb1, bb2
     bb1:
@@ -51,7 +51,7 @@
   }
   
   fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = sload 5
@@ -69,7 +69,7 @@
   }
   
   fn @gas_blocks_rewrite(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = sload 5

--- a/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir
@@ -4,7 +4,7 @@
 // different dynamic size share no key and are left alone.
 @module LoadPreKeccak
 fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = keccak256 0, arg1
@@ -18,7 +18,7 @@ fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
 }
 
 fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = keccak256 0, arg1

--- a/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir (after load-pre) ===
   @module LoadPreKeccak
   fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = keccak256 0, arg1
@@ -18,7 +18,7 @@
   }
   
   fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = keccak256 0, arg1

--- a/tests/ui/codegen/mir/load-pre/load_pre_loop.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_loop.mir
@@ -7,7 +7,7 @@
 // loss.
 @module LoadPreLoop
 fn @loop_header_reload(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 5
     jump bb1
   bb1:
@@ -21,7 +21,7 @@ fn @loop_header_reload(arg0: u256) -> u256 {
 }
 
 fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 5
     jump bb1
   bb1:
@@ -36,7 +36,7 @@ fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @loop_clobbered_no_insert(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 5
     jump bb1
   bb1:

--- a/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_loop.mir (after load-pre) ===
   @module LoadPreLoop
   fn @loop_header_reload(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 5
       jump bb1
     bb1:
@@ -19,7 +19,7 @@
   }
   
   fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 5
       jump bb1
     bb1:
@@ -34,7 +34,7 @@
   }
   
   fn @loop_clobbered_no_insert(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 5
       jump bb1
     bb1:

--- a/tests/ui/codegen/mir/load-pre/load_pre_memory.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_memory.mir
@@ -5,7 +5,7 @@
 // stay stack-resident in the EVM backend.
 @module LoadPreMemory
 fn @mload_full_diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = mload 128
@@ -19,7 +19,7 @@ fn @mload_full_diamond(arg0: bool) -> u256 {
 }
 
 fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 128, arg1
@@ -33,7 +33,7 @@ fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
 }
 
 fn @mstore8_overlap_kills(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 128
     br arg0, bb1, bb2
   bb1:
@@ -49,7 +49,7 @@ fn @mstore8_overlap_kills(arg0: bool) -> u256 {
 }
 
 fn @mload_partial_rejected(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = mload 128
@@ -62,7 +62,7 @@ fn @mload_partial_rejected(arg0: bool) -> u256 {
 }
 
 fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = mload 128
@@ -77,7 +77,7 @@ fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
 }
 
 fn @mload_partial_two_available(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg0, default bb3, [1 => bb1, 2 => bb2]
   bb1:
     v1 = mload 128
@@ -93,7 +93,7 @@ fn @mload_partial_two_available(arg0: u256) -> u256 {
 }
 
 fn @mload_loop_header(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 128
     jump bb1
   bb1:
@@ -107,7 +107,7 @@ fn @mload_loop_header(arg0: u256) -> u256 {
 }
 
 fn @staticcall_kills_memory(arg0: bool, arg1: address) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mload 128
     br arg0, bb1, bb2
   bb1:
@@ -123,7 +123,7 @@ fn @staticcall_kills_memory(arg0: bool, arg1: address) -> u256 {
 }
 
 fn @msize_blocks_memory(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     v1 = mload 128

--- a/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/load-pre/load_pre_memory.mir (after load-pre) ===
   @module LoadPreMemory
   fn @mload_full_diamond(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = mload 128
@@ -16,7 +16,7 @@
   }
   
   fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 128, arg1
@@ -30,7 +30,7 @@
   }
   
   fn @mstore8_overlap_kills(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 128
       br arg0, bb1, bb2
     bb1:
@@ -46,7 +46,7 @@
   }
   
   fn @mload_partial_rejected(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = mload 128
@@ -59,7 +59,7 @@
   }
   
   fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = mload 128
@@ -77,7 +77,7 @@
   }
   
   fn @mload_partial_two_available(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg0, default bb3, [1 => bb1, 2 => bb2]
     bb1:
       v0 = mload 128
@@ -93,7 +93,7 @@
   }
   
   fn @mload_loop_header(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 128
       jump bb1
     bb1:
@@ -110,7 +110,7 @@
   }
   
   fn @staticcall_kills_memory(arg0: bool, arg1: address) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 128
       br arg0, bb1, bb2
     bb1:
@@ -126,7 +126,7 @@
   }
   
   fn @msize_blocks_memory(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       v0 = mload 128

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass loop-canonicalize
 @module LoopCanonicalize
 fn @insert_preheader(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -17,7 +17,7 @@ fn @insert_preheader(arg0: bool) -> u256 {
 }
 
 fn @split_conditional_predecessor(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb3
   bb1:
     v1 = phi [bb0: 0], [bb2: 1]

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir (after loop-canonicalize) ===
   @module LoopCanonicalize
   fn @insert_preheader(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
 -     jump bb3
@@ -24,7 +24,7 @@
   }
   
   fn @split_conditional_predecessor(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     br arg0, bb1, bb3
 +     br arg0, bb4, bb3
     bb1:

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes cse,lower-mapping-slots
 @module MappingSlotBuiltin
 fn @word(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mapping_slot arg0, 7
     v2 = mapping_slot arg0, 7
     v3 = add v1, v2
@@ -9,7 +9,7 @@ fn @word(arg0: u256) -> u256 {
 }
 
 fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = mapping_slot arg0, 7
     br arg1, bb1, bb2
   bb1:
@@ -22,7 +22,7 @@ fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @memory(arg0: memptr) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mapping_slot_memory arg0, 9
     mstore arg0, 1
     v2 = mapping_slot_memory arg0, 9
@@ -31,7 +31,7 @@ fn @memory(arg0: memptr) -> u256 {
 }
 
 fn @calldata(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = mapping_slot_calldata arg0, 11
     v2 = mapping_slot_calldata arg0, 11
     v3 = add v1, v2

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after cse) ===
   @module MappingSlotBuiltin
   fn @word(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mapping_slot arg0, 7
 -     v1 = mapping_slot arg0, 7
 -     v2 = add v0, v1
@@ -11,7 +11,7 @@
   }
   
   fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mapping_slot arg0, 7
       br arg1, bb1, bb2
     bb1:
@@ -25,7 +25,7 @@
   }
   
   fn @memory(arg0: memptr) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mapping_slot_memory arg0, 9
       mstore arg0, 1
       v1 = mapping_slot_memory arg0, 9
@@ -34,7 +34,7 @@
   }
   
   fn @calldata(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mapping_slot_calldata arg0, 11
 -     v1 = mapping_slot_calldata arg0, 11
 -     v2 = add v0, v1
@@ -46,7 +46,7 @@
 + // === ROOT/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir (after lower-mapping-slots) ===
   @module MappingSlotBuiltin
   fn @word(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mapping_slot arg0, 7
 -     v2 = add v0, v0
 +     mstore 0, arg0 !metadata(memory=scratch)
@@ -57,7 +57,7 @@
   }
   
   fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mapping_slot arg0, 7
 +     mstore 0, arg0 !metadata(memory=scratch)
 +     mstore 32, 7 !metadata(memory=scratch)
@@ -73,7 +73,7 @@
   }
   
   fn @memory(arg0: memptr) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mapping_slot_memory arg0, 9
 +     v3 = mload arg0
 +     v4 = add arg0, 32
@@ -99,7 +99,7 @@
   }
   
   fn @calldata(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mapping_slot_calldata arg0, 11
 -     v2 = add v0, v0
 +     v3 = add arg0, 4

--- a/tests/ui/codegen/mir/lowering/lower_abi.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi.mir
@@ -7,13 +7,13 @@
 // phase.
 @module LowerAbi
 fn @add(arg0: u256, arg1: u256) [selector=0x771602f7] {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, arg1
     mstore 128, v2
     returndata 128, 32
 }
 fn @flag(arg0: bool) [selector=0x0d2020dd] {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     returndata 128, 32
 }

--- a/tests/ui/codegen/mir/lowering/lower_abi.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi.stdout
@@ -4,7 +4,7 @@
 - fn @add(arg0: u256, arg1: u256) {
 + @phase abi
 + fn @add() {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg1
       mstore 128, v0
       returndata 128, 32
@@ -12,7 +12,7 @@
   
 - fn @flag(arg0: bool) {
 + fn @flag() {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }

--- a/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.mir
@@ -4,7 +4,7 @@
 // memory-pointer parameter does not block the `abi` phase.
 @module LowerAbiDynamicParams
 fn @takesBytes(arg0: memptr, arg1: u256) [selector=0x0dead002] {
-  bb0 (entry):
+  bb0:
     v1 = mload arg0
     v2 = add v1, arg1
     mstore 128, v2

--- a/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_dynamic_params.stdout
@@ -4,7 +4,7 @@
 - fn @takesBytes(arg0: memptr, arg1: u256) {
 + @phase abi
 + fn @takesBytes() {
-    bb0 (entry):
+    bb0:
       v0 = mload arg0
       v1 = add v0, arg1
       mstore 128, v1

--- a/tests/ui/codegen/mir/lowering/lower_abi_multi_return.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi_multi_return.mir
@@ -3,7 +3,7 @@
 // first call result.
 @module LowerAbiMultiReturn
 fn @pair(arg0: u256) -> (u256, u256) [selector=0x1f6a26ff] {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     ret arg0, v1
 }

--- a/tests/ui/codegen/mir/lowering/lower_abi_multi_return.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_multi_return.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_multi_return.mir (after lower-abi) ===
   @module LowerAbiMultiReturn
   fn @pair(arg0: u256) -> (u256, u256) {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       ret arg0, v0
   }

--- a/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.mir
@@ -5,13 +5,13 @@
 // has no internal callers.
 @module LowerAbiRetargets
 fn @pub(arg0: u256) [selector=0x0a0a0a01] {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     mstore 128, v1
     returndata 128, 32
 }
 fn @caller(arg0: u256) [selector=0x0a0a0a02] {
-  bb0 (entry):
+  bb0:
     v1 = internal_call fn0, 1, arg0
     mstore 128, v1
     returndata 128, 32

--- a/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_retargets_calls.stdout
@@ -4,7 +4,7 @@
 - fn @pub(arg0: u256) {
 + @phase abi
 + fn @pub() {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       mstore 128, v0
       returndata 128, 32
@@ -12,7 +12,7 @@
   
 - fn @caller(arg0: u256) {
 + fn @caller() {
-    bb0 (entry):
+    bb0:
 -     v0 = internal_call @pub, 1, arg0
 +     v0 = internal_call @pub.body, 1, arg0
 +     mstore 128, v0
@@ -20,7 +20,7 @@
 + }
 + 
 + fn @pub.body(arg0: u256) {
-+   bb0 (entry):
++   bb0:
 +     v0 = add arg0, 1
       mstore 128, v0
       returndata 128, 32

--- a/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.mir
@@ -4,6 +4,6 @@
 // phase transition is all-or-nothing and the module does not advance to `abi`.
 @module LowerAbiSkipsDynamic
 fn @givesBytes(arg0: u256) -> memptr [selector=0x0dead001] {
-  bb0 (entry):
+  bb0:
     ret arg0
 }

--- a/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/lowering/lower_abi_skips_dynamic.mir (after lower-abi) ===
   @module LowerAbiSkipsDynamic
   fn @givesBytes(arg0: u256) -> memptr {
-    bb0 (entry):
+    bb0:
       ret arg0
   }
   

--- a/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir
+++ b/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.mir
@@ -4,7 +4,7 @@
 // wrappers. The module ends in the `dispatch` phase.
 @module LowerAbiThenDispatch
 fn @get(arg0: u256) [selector=0x9507d39a] {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     returndata 128, 32
 }

--- a/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
@@ -4,7 +4,7 @@
 - fn @get(arg0: u256) {
 + @phase abi
 + fn @get() {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }
@@ -15,13 +15,13 @@
 - @phase abi
 + @phase dispatch
   fn @get() {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
 + }
 + 
 + fn @entry() {
-+   bb0 (entry):
++   bb0:
 +     v0 = callvalue
 +     br v0, bb4, bb1
 +   bb1:

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.mir
@@ -6,10 +6,10 @@
 @module LowerDispatch
 @phase abi
 fn @ping() [selector=0x5c36b186] {
-  bb0 (entry):
+  bb0:
     stop
 }
 fn @pong() [selector=0x8d3a3e57] {
-  bb0 (entry):
+  bb0:
     stop
 }

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
@@ -4,17 +4,17 @@
 - @phase abi
 + @phase dispatch
   fn @ping() {
-    bb0 (entry):
+    bb0:
       stop
   }
   
   fn @pong() {
-    bb0 (entry):
+    bb0:
       stop
 + }
 + 
 + fn @entry() {
-+   bb0 (entry):
++   bb0:
 +     v0 = callvalue
 +     br v0, bb5, bb1
 +   bb1:

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir
@@ -6,10 +6,10 @@
 @module DispatchHoisted
 @phase abi
 fn @a() [selector=0x00000001] {
-  bb0 (entry):
+  bb0:
     stop
 }
 fn @b() [selector=0x00000002] {
-  bb0 (entry):
+  bb0:
     stop
 }

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
@@ -4,17 +4,17 @@
 - @phase abi
 + @phase dispatch
   fn @a() {
-    bb0 (entry):
+    bb0:
       stop
   }
   
   fn @b() {
-    bb0 (entry):
+    bb0:
       stop
 + }
 + 
 + fn @entry() {
-+   bb0 (entry):
++   bb0:
 +     v0 = callvalue
 +     br v0, bb5, bb1
 +   bb1:

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir
@@ -6,18 +6,18 @@
 @module DispatchParity
 @phase abi
 fn @pay() [selector=0x00000001, payable] {
-  bb0 (entry):
+  bb0:
     stop
 }
 fn @nopay() [selector=0x00000002] {
-  bb0 (entry):
+  bb0:
     stop
 }
 fn @recv() [receive, payable] {
-  bb0 (entry):
+  bb0:
     stop
 }
 fn @fb() [fallback, payable] {
-  bb0 (entry):
+  bb0:
     stop
 }

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
@@ -4,27 +4,27 @@
 - @phase abi
 + @phase dispatch
   fn @pay() {
-    bb0 (entry):
+    bb0:
       stop
   }
   
   fn @nopay() {
-    bb0 (entry):
+    bb0:
       stop
   }
   
   fn @recv() {
-    bb0 (entry):
+    bb0:
       stop
   }
   
   fn @fb() {
-    bb0 (entry):
+    bb0:
       stop
 + }
 + 
 + fn @entry() {
-+   bb0 (entry):
++   bb0:
 +     jump bb1
 +   bb1:
 +     v0 = calldatasize

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.mir
@@ -3,6 +3,6 @@
 // has typed external arguments, so the pass must leave it untouched.
 @module LowerDispatchRequiresAbi
 fn @takesArg(arg0: u256) -> u256 [selector=0x9a2dbe3f] {
-  bb0 (entry):
+  bb0:
     ret arg0
 }

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/lowering/lower_dispatch_requires_abi.mir (after lower-dispatch) ===
   @module LowerDispatchRequiresAbi
   fn @takesArg(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       ret arg0
   }
   

--- a/tests/ui/codegen/mir/lowering/lower_evm_shaped.mir
+++ b/tests/ui/codegen/mir/lowering/lower_evm_shaped.mir
@@ -9,7 +9,7 @@
 @module LowerEvmShaped
 @phase dispatch
 fn @entry() {
-  bb0 (entry):
+  bb0:
     v0 = calldataload 0
     v2 = shr 224, v0
     switch v2, default bb2, [7 => bb1]
@@ -19,18 +19,18 @@ fn @entry() {
     revert 0, 0
 }
 fn @caller() [selector=0x00000007] {
-  bb0 (entry):
+  bb0:
     v0 = calldataload 4
     internal_call fn2, 0, v0
     stop
 }
 fn @fused(arg0: u256) {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     returndata 128, 32
 }
 fn @spin(arg0: u256) {
-  bb0 (entry):
+  bb0:
     internal_call fn3, 0, arg0
     revert 0, 0
 }

--- a/tests/ui/codegen/mir/lowering/lower_evm_shaped.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_evm_shaped.stdout
@@ -4,7 +4,7 @@
 - @phase dispatch
 + @phase evm-shaped
   fn @entry() {
-    bb0 (entry):
+    bb0:
       v0 = calldataload 0
       v1 = shr 224, v0
       switch v1, default bb2, [7 => bb1]
@@ -15,7 +15,7 @@
   }
   
   fn @caller() {
-    bb0 (entry):
+    bb0:
       v0 = calldataload 4
 -     internal_call @fused, 0, v0
 -     stop
@@ -23,13 +23,13 @@
   }
   
   fn @fused(arg0: u256) {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }
   
   fn @spin(arg0: u256) {
-    bb0 (entry):
+    bb0:
       internal_call @spin, 0, arg0
       revert 0, 0
   }

--- a/tests/ui/codegen/mir/lowering/phase_explicit_built.mir
+++ b/tests/ui/codegen/mir/lowering/phase_explicit_built.mir
@@ -6,6 +6,6 @@
 @module PhaseExplicitBuilt
 @phase built
 fn @f() {
-  bb0 (entry):
+  bb0:
     stop
 }

--- a/tests/ui/codegen/mir/lowering/phase_explicit_built.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_explicit_built.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/lowering/phase_explicit_built.mir (after dce) ===
   @module PhaseExplicitBuilt
   fn @f() {
-    bb0 (entry):
+    bb0:
       stop
   }
   

--- a/tests/ui/codegen/mir/lowering/phase_header_preserved.mir
+++ b/tests/ui/codegen/mir/lowering/phase_header_preserved.mir
@@ -7,6 +7,6 @@
 @module PhaseHeaderPreserved
 @phase optimized
 fn @f() {
-  bb0 (entry):
+  bb0:
     stop
 }

--- a/tests/ui/codegen/mir/lowering/phase_header_preserved.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_header_preserved.stdout
@@ -3,7 +3,7 @@
   @module PhaseHeaderPreserved
   @phase optimized
   fn @f() {
-    bb0 (entry):
+    bb0:
       stop
   }
   

--- a/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir
+++ b/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir
@@ -9,7 +9,7 @@
 // and dce demonstrates ordinary optimization still works after dispatch.
 @module PhasePassBounds
 fn @get(arg0: u256) [selector=0x9507d39a] {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     returndata 128, 32
 }

--- a/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/lowering/phase_pass_bounds.mir (after lower-dispatch) ===
   @module PhasePassBounds
   fn @get(arg0: u256) {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }
@@ -13,7 +13,7 @@
 - fn @get(arg0: u256) {
 + @phase abi
 + fn @get() {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }
@@ -24,13 +24,13 @@
 - @phase abi
 + @phase dispatch
   fn @get() {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
 + }
 + 
 + fn @entry() {
-+   bb0 (entry):
++   bb0:
 +     v0 = callvalue
 +     br v0, bb4, bb1
 +   bb1:
@@ -51,13 +51,13 @@
   @module PhasePassBounds
   @phase dispatch
   fn @get() {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }
   
   fn @entry() {
-    bb0 (entry):
+    bb0:
       v0 = callvalue
       br v0, bb4, bb1
     bb1:

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_transition.mir
@@ -6,7 +6,7 @@
 // `optimized` and the header says so.
 @module PhasePipelineTransition
 fn @f(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     mstore 128, v1
     returndata 128, 32

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_transition.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_transition.stdout
@@ -2,7 +2,7 @@
 @module PhasePipelineTransition
 @phase optimized
 fn @f(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v0 = add arg0, 1
     mstore 128, v0
     returndata 128, 32

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_alias.mir
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_alias.mir
@@ -4,7 +4,7 @@
 // A symbolic address can equal any constant address at runtime, so the load
 // from 128 may observe the first store and it must be kept.
 fn @keep_symbolic_store_read_by_const_load(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore arg0, 1
     v2 = mload 128
     mstore arg0, 2
@@ -14,7 +14,7 @@ fn @keep_symbolic_store_read_by_const_load(arg0: u256) -> u256 {
 // The constant store may overwrite the symbolic store, so the load must not be
 // forwarded from the first store.
 fn @keep_const_store_forwarding_to_symbolic_load(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore arg0, 1
     mstore 128, 2
     v3 = mload arg0
@@ -23,7 +23,7 @@ fn @keep_const_store_forwarding_to_symbolic_load(arg0: u256) -> u256 {
 
 // Two distinct symbolic bases may hold equal addresses at runtime.
 fn @keep_store_read_by_distinct_symbolic_base(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore arg0, 1
     v2 = mload arg1
     mstore arg0, 2
@@ -31,7 +31,7 @@ fn @keep_store_read_by_distinct_symbolic_base(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @remove_dead_const_overwrite() -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 128, 1
     mstore 128, 2
     v3 = mload 128
@@ -39,7 +39,7 @@ fn @remove_dead_const_overwrite() -> u256 {
 }
 
 fn @remove_dead_symbolic_overwrite(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore arg0, 1
     mstore arg0, 2
     v3 = mload arg0
@@ -49,7 +49,7 @@ fn @remove_dead_symbolic_overwrite(arg0: u256) -> u256 {
 // Same canonical base with disjoint constant offsets is provably no-alias, so
 // the intervening load does not keep the overwritten store alive.
 fn @remove_overwrite_past_same_base_disjoint_load(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore arg0, 1
     v2 = add arg0, 32
     v3 = mload v2

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_alias.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_alias.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_alias.mir (after memory-dse) ===
   @module MemoryDseAlias
   fn @keep_symbolic_store_read_by_const_load(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       mstore arg0, 1
       v0 = mload 128
       mstore arg0, 2
@@ -10,7 +10,7 @@
   }
   
   fn @keep_const_store_forwarding_to_symbolic_load(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       mstore arg0, 1
       mstore 128, 2
       v0 = mload arg0
@@ -18,7 +18,7 @@
   }
   
   fn @keep_store_read_by_distinct_symbolic_base(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       mstore arg0, 1
       v0 = mload arg1
       mstore arg0, 2
@@ -26,7 +26,7 @@
   }
   
   fn @remove_dead_const_overwrite() -> u256 {
-    bb0 (entry):
+    bb0:
 -     mstore 128, 1
       mstore 128, 2
 -     v0 = mload 128
@@ -35,7 +35,7 @@
   }
   
   fn @remove_dead_symbolic_overwrite(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     mstore arg0, 1
       mstore arg0, 2
 -     v0 = mload arg0
@@ -44,7 +44,7 @@
   }
   
   fn @remove_overwrite_past_same_base_disjoint_load(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     mstore arg0, 1
       v0 = add arg0, 32
       v1 = mload v0

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.mir
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.mir
@@ -3,7 +3,7 @@
 
 // A full-word copy write to the same range makes the prior store dead.
 fn @remove_store_overwritten_by_codecopy() -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 0, 1
     codecopy 0, 0, 64
     ret 0
@@ -11,7 +11,7 @@ fn @remove_store_overwritten_by_codecopy() -> u256 {
 
 // A partial disjoint copy range must not kill the store read from the next word.
 fn @keep_store_after_partial_copy() -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 32, 1
     codecopy 0, 0, 32
     v2 = mload 32
@@ -21,7 +21,7 @@ fn @keep_store_after_partial_copy() -> u256 {
 // Updating the free-memory pointer at 0x40 and zeroing the data area do not
 // clobber the fresh allocation length word at the old FMP.
 fn @forward_fresh_array_length() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mload 64
     mstore v0, 3
     v1 = add v0, 128

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.stdout
@@ -2,14 +2,14 @@
 + // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_copy_ranges.mir (after memory-dse) ===
   @module MemoryDseCopyRanges
   fn @remove_store_overwritten_by_codecopy() -> u256 {
-    bb0 (entry):
+    bb0:
 -     mstore 0, 1
       codecopy 0, 0, 64
       ret 0
   }
   
   fn @keep_store_after_partial_copy() -> u256 {
-    bb0 (entry):
+    bb0:
       mstore 32, 1
       codecopy 0, 0, 32
 -     v0 = mload 32
@@ -18,7 +18,7 @@
   }
   
   fn @forward_fresh_array_length() -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = mload 64
       mstore v0, 3
       v1 = add v0, 128

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir
@@ -2,7 +2,7 @@
 @module MemoryDseCrossBlock
 
 fn @remove_store_overwritten_on_unique_edge() -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 128, 1
     jump bb1
   bb1:
@@ -12,7 +12,7 @@ fn @remove_store_overwritten_on_unique_edge() -> u256 {
 }
 
 fn @keep_store_read_before_successor_overwrite() -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 128, 1
     jump bb1
   bb1:
@@ -22,7 +22,7 @@ fn @keep_store_read_before_successor_overwrite() -> u256 {
 }
 
 fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     mstore 128, 1

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir (after memory-dse) ===
   @module MemoryDseCrossBlock
   fn @remove_store_overwritten_on_unique_edge() -> u256 {
-    bb0 (entry):
+    bb0:
 -     mstore 128, 1
       jump bb1
     bb1:
@@ -13,7 +13,7 @@
   }
   
   fn @keep_store_read_before_successor_overwrite() -> u256 {
-    bb0 (entry):
+    bb0:
       mstore 128, 1
       jump bb1
     bb1:
@@ -23,7 +23,7 @@
   }
   
   fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       mstore 128, 1

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.mir
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.mir
@@ -4,7 +4,7 @@
 // A memory observer can read the first store but does not mutate memory, so the
 // second equal store is redundant.
 fn @remove_equal_store_after_keccak(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     v2 = keccak256 128, 32
     mstore 128, arg0
@@ -14,7 +14,7 @@ fn @remove_equal_store_after_keccak(arg0: u256) -> u256 {
 // A memory mutator can change the address, so the equal-looking store after it
 // must be kept.
 fn @keep_equal_store_after_copy(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     calldatacopy 128, arg1, 32
     mstore 128, arg0

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_equal_store.mir (after memory-dse) ===
   @module MemoryDseEqualStore
   fn @remove_equal_store_after_keccak(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       v0 = keccak256 128, 32
 -     mstore 128, arg0
@@ -10,7 +10,7 @@
   }
   
   fn @keep_equal_store_after_copy(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     mstore 128, arg0
       calldatacopy 128, arg1, 32
       mstore 128, arg0

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.mir
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass memory-dse
 @module MemoryDseKeccakFold
 fn @fold_constant_scratch_keccak() -> bytes32 {
-  bb0 (entry):
+  bb0:
     mstore 0, 7
     mstore 32, 5
     v2 = keccak256 0, 64
@@ -9,7 +9,7 @@ fn @fold_constant_scratch_keccak() -> bytes32 {
 }
 
 fn @keep_dynamic_word(arg0: u256) -> bytes32 {
-  bb0 (entry):
+  bb0:
     mstore 0, arg0
     mstore 32, 5
     v2 = keccak256 0, 64
@@ -17,7 +17,7 @@ fn @keep_dynamic_word(arg0: u256) -> bytes32 {
 }
 
 fn @keep_after_memory_clobber() -> bytes32 {
-  bb0 (entry):
+  bb0:
     mstore 0, 7
     mstore 32, 5
     calldatacopy 0, 0, 32

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/memory-dse/memory_dse_keccak_fold.mir (after memory-dse) ===
   @module MemoryDseKeccakFold
   fn @fold_constant_scratch_keccak() -> bytes32 {
-    bb0 (entry):
+    bb0:
       mstore 0, 7
       mstore 32, 5
 -     v0 = keccak256 0, 64
@@ -11,7 +11,7 @@
   }
   
   fn @keep_dynamic_word(arg0: u256) -> bytes32 {
-    bb0 (entry):
+    bb0:
       mstore 0, arg0
       mstore 32, 5
       v0 = keccak256 0, 64
@@ -19,7 +19,7 @@
   }
   
   fn @keep_after_memory_clobber() -> bytes32 {
-    bb0 (entry):
+    bb0:
 -     mstore 0, 7
       mstore 32, 5
       calldatacopy 0, 0, 32

--- a/tests/ui/codegen/mir/none/identity.mir
+++ b/tests/ui/codegen/mir/none/identity.mir
@@ -1,13 +1,13 @@
 //@compile-flags: --pass none
 @module Identity
 fn @add(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, arg1
     ret v2
 }
 
 fn @double(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, arg0
     ret v1
 }

--- a/tests/ui/codegen/mir/none/identity.stdout
+++ b/tests/ui/codegen/mir/none/identity.stdout
@@ -2,13 +2,13 @@
 + // === ROOT/tests/ui/codegen/mir/none/identity.mir (after none) ===
   @module Identity
   fn @add(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg1
       ret v0
   }
   
   fn @double(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, arg0
       ret v0
   }

--- a/tests/ui/codegen/mir/none/metadata.mir
+++ b/tests/ui/codegen/mir/none/metadata.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes none
 @module Metadata
 fn @metadata(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 7 !metadata(storage=slot(7), loop_depth=2, hir=42, span=1..5)
     v2 = mload 64 !metadata(memory=scratch, unchecked)
     v3 = add v1, v2

--- a/tests/ui/codegen/mir/none/metadata.stdout
+++ b/tests/ui/codegen/mir/none/metadata.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/none/metadata.mir (after none) ===
   @module Metadata
   fn @metadata(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = sload 7 !metadata(storage=slot(7), hir=42, span=1..5, loop_depth=2)
       v1 = mload 64 !metadata(memory=scratch, unchecked)
       v2 = add v0, v1

--- a/tests/ui/codegen/mir/none/phi.mir
+++ b/tests/ui/codegen/mir/none/phi.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass none
 @module PhiTest
 fn @diamond(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3

--- a/tests/ui/codegen/mir/none/phi.stdout
+++ b/tests/ui/codegen/mir/none/phi.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/none/phi.mir (after none) ===
   @module PhiTest
   fn @diamond(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3

--- a/tests/ui/codegen/mir/none/switch.mir
+++ b/tests/ui/codegen/mir/none/switch.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass none
 @module SwitchTest
 fn @dispatch(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
   bb1:
     ret arg0

--- a/tests/ui/codegen/mir/none/switch.stdout
+++ b/tests/ui/codegen/mir/none/switch.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/none/switch.mir (after none) ===
   @module SwitchTest
   fn @dispatch(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
     bb1:
       ret arg0

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
@@ -7,7 +7,7 @@
 
 @module OutlineReverts
 fn @first(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = lt v1, arg0
     br v2, bb1, bb2
@@ -20,7 +20,7 @@ fn @first(arg0: u256) {
     returndata 128, 32
 }
 fn @second(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v1 = mul arg0, 2
     v2 = lt v1, arg0
     br v2, bb1, bb2
@@ -33,7 +33,7 @@ fn @second(arg0: u256) {
     returndata 128, 32
 }
 fn @third(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v1 = sub arg0, 1
     v2 = gt v1, arg0
     br v2, bb1, bb2

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir (after outline-reverts) ===
   @module OutlineReverts
   fn @first(arg0: u256) {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       v1 = lt v0, arg0
       br v1, bb1, bb2
@@ -17,7 +17,7 @@
   }
   
   fn @second(arg0: u256) {
-    bb0 (entry):
+    bb0:
       v0 = mul arg0, 2
       v1 = lt v0, arg0
       br v1, bb1, bb2
@@ -32,7 +32,7 @@
   }
   
   fn @third(arg0: u256) {
-    bb0 (entry):
+    bb0:
       v0 = sub arg0, 1
       v1 = gt v0, arg0
       br v1, bb1, bb2
@@ -46,7 +46,7 @@
 + }
 + 
 + fn @__revert_stub0() {
-+   bb0 (entry):
++   bb0:
 +     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
 +     mstore 4, 17 !metadata(memory=scratch)
 +     revert 0, 36

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
@@ -7,7 +7,7 @@
 // Panic(0x11) check — no `lt` after `add v, 1` and only one panic block —
 // while the unguarded accumulator check on `s += i` must survive.
 fn @sum(arg0: u256) {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     jump bb1
   bb1:

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
@@ -2,7 +2,7 @@
 @module CheckElimPipelineLoop
 @phase optimized
 fn @sum(arg0: u256) {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     jump bb1
   bb1:

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir
@@ -5,7 +5,7 @@
 // default pipeline the require guard must fold the subtraction's
 // Panic(0x11) underflow branch.
 fn @guarded(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v5 = gt arg1, arg0
     v6 = iszero v5
@@ -29,7 +29,7 @@ fn @guarded(arg0: u256, arg1: u256) {
 // Negative control: without the require, the underflow check must survive
 // the full pipeline.
 fn @unguarded(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v5 = sub arg0, arg1
     v6 = lt arg0, arg1

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
@@ -2,7 +2,7 @@
 @module CheckElimPipelineRequireSub
 @phase optimized
 fn @guarded(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = gt arg1, arg0
     br v0, bb1, bb2
   bb1:
@@ -18,7 +18,7 @@ fn @guarded(arg0: u256, arg1: u256) {
 }
 
 fn @unguarded(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     v0 = sub arg0, arg1
     v1 = lt arg0, arg1
     br v1, bb1, bb2

--- a/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir
+++ b/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir
@@ -6,7 +6,7 @@
 // zeroing calldatacopy over the data area. The default pipeline should forward
 // the stored length, fold `1 < 3`, and delete the panic branch.
 fn @constant_index() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mload 64
     mstore v0, 3
     v1 = add v0, 128
@@ -24,7 +24,7 @@ fn @constant_index() -> u256 {
 
 // Runtime lengths still need the bounds branch.
 fn @runtime_index(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mload 64
     mstore v0, arg0
     v1 = shl 5, arg0

--- a/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
@@ -2,7 +2,7 @@
 @module FreshArrayBoundsPipeline
 @phase optimized
 fn @constant_index() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mload 64
     mstore v0, 3
     v1 = add v0, 128
@@ -17,7 +17,7 @@ fn @constant_index() -> u256 {
 }
 
 fn @runtime_index(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mload 64
     mstore v0, arg0
     v1 = shl 5, arg0

--- a/tests/ui/codegen/mir/pipeline/pipeline.mir
+++ b/tests/ui/codegen/mir/pipeline/pipeline.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --passes jump-threading,cfg-simplify,dce
 @module Pipeline
 fn @noisy(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = mul arg0, arg0
     jump bb1

--- a/tests/ui/codegen/mir/pipeline/pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after jump-threading) ===
   @module Pipeline
   fn @noisy(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       v1 = mul arg0, arg0
 -     jump bb1
@@ -17,7 +17,7 @@
 + // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after cfg-simplify) ===
   @module Pipeline
   fn @noisy(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       v1 = mul arg0, arg0
 -     jump bb2
@@ -34,7 +34,7 @@
 + // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (after dce) ===
   @module Pipeline
   fn @noisy(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     v1 = mul arg0, arg0
       ret v0

--- a/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir
+++ b/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pipeline-default
 @module PipelineCleanupFixpoint
 fn @fold_phi_after_promotion(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 1
     br arg0, bb1, bb2

--- a/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_cleanup_fixpoint.stdout
@@ -2,7 +2,7 @@
 @module PipelineCleanupFixpoint
 @phase optimized
 fn @fold_phi_after_promotion(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     ret 1
   bb1:
     invalid

--- a/tests/ui/codegen/mir/pipeline/pipeline_default.mir
+++ b/tests/ui/codegen/mir/pipeline/pipeline_default.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pipeline-default
 @module PipelineDefault
 fn @noisy(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = mul arg0, arg0
     jump bb1

--- a/tests/ui/codegen/mir/pipeline/pipeline_default.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_default.stdout
@@ -2,7 +2,7 @@
 @module PipelineDefault
 @phase optimized
 fn @noisy(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = add arg0, 1
     ret v0
   bb1:

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pipeline-default
 @module PipelineFrameIndVar
 fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = internal_frame_addr 128
     mstore v1, 0
     jump bb1

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
@@ -2,7 +2,7 @@
 @module PipelineFrameIndVar
 @phase optimized
 fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v8 = phi [bb0: 0], [bb2: v6]

--- a/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir
+++ b/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.mir
@@ -3,7 +3,7 @@
 // joins that are mutual predecessors.
 @module PingPongPipeline
 fn @pingpong(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
   bb1:
     v2 = add arg0, 7

--- a/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/pre_pingpong_pipeline.stdout
@@ -2,7 +2,7 @@
 @module PingPongPipeline
 @phase optimized
 fn @pingpong(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     jump bb6
   bb1:
     invalid

--- a/tests/ui/codegen/mir/pre/pre.mir
+++ b/tests/ui/codegen/mir/pre/pre.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass pre
 @module Pre
 fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb3, [1 => bb1, 2 => bb2]
   bb1:
     v2 = add arg0, 7
@@ -17,7 +17,7 @@ fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg3, default bb3, [1 => bb1, 2 => bb2]
   bb1:
     v4 = add arg0, 1
@@ -34,7 +34,7 @@ fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
 }
 
 fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1
@@ -47,7 +47,7 @@ fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
 }
 
 fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1

--- a/tests/ui/codegen/mir/pre/pre.stdout
+++ b/tests/ui/codegen/mir/pre/pre.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pre/pre.mir (after pre) ===
   @module Pre
   fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg1, default bb3, [1 => bb1, 2 => bb2]
     bb1:
       v0 = add arg0, 7
@@ -21,7 +21,7 @@
   }
   
   fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg3, default bb3, [1 => bb1, 2 => bb2]
     bb1:
       v0 = add arg0, 1
@@ -41,7 +41,7 @@
   }
   
   fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1
@@ -57,7 +57,7 @@
   }
   
   fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1

--- a/tests/ui/codegen/mir/pre/pre_dominator_availability.mir
+++ b/tests/ui/codegen/mir/pre/pre_dominator_availability.mir
@@ -4,7 +4,7 @@
 // duplicate computation into bb4.
 @module DomAvail
 fn @reuse_dominating_def(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb1, [1 => bb2, 2 => bb3]
   bb1:
     v3 = add arg0, 7
@@ -25,7 +25,7 @@ fn @reuse_dominating_def(arg0: u256, arg1: u256) -> u256 {
 // Every predecessor reuses the same def from the shared dominator bb0: the
 // join expression collapses to that value directly, with no phi.
 fn @collapse_to_shared_def(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = add arg0, 7
     switch arg1, default bb1, [1 => bb2]
   bb1:

--- a/tests/ui/codegen/mir/pre/pre_dominator_availability.stdout
+++ b/tests/ui/codegen/mir/pre/pre_dominator_availability.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pre/pre_dominator_availability.mir (after pre) ===
   @module DomAvail
   fn @reuse_dominating_def(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3]
     bb1:
       v0 = add arg0, 7
@@ -23,7 +23,7 @@
   }
   
   fn @collapse_to_shared_def(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 7
       switch arg1, default bb1, [1 => bb2]
     bb1:

--- a/tests/ui/codegen/mir/pre/pre_join_shapes.mir
+++ b/tests/ui/codegen/mir/pre/pre_join_shapes.mir
@@ -4,7 +4,7 @@
 // bb2 reaches the join through two switch edges: the phi must keep one
 // incoming entry per unique predecessor.
 fn @duplicate_pred_edges(arg0: u256, arg1: u256, arg2: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb1, [1 => bb2, 2 => bb3]
   bb1:
     v3 = add arg0, 7
@@ -22,7 +22,7 @@ fn @duplicate_pred_edges(arg0: u256, arg1: u256, arg2: u256) -> u256 {
 // The join is its own predecessor: the backedge incoming becomes the phi
 // itself, which is correct because the expression is loop-invariant.
 fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb3, [1 => bb1, 2 => bb2]
   bb1:
     v2 = add arg0, 7
@@ -43,7 +43,7 @@ fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
 // The join expression's operand is a phi defined in an enclosing header
 // block, not in the join itself: it must not be translated per predecessor.
 fn @outer_phi_operand(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v2 = phi [bb0: arg0], [bb6: v20]

--- a/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
+++ b/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pre/pre_join_shapes.mir (after pre) ===
   @module JoinShapes
   fn @duplicate_pred_edges(arg0: u256, arg1: u256, arg2: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3]
     bb1:
       v0 = add arg0, 7
@@ -21,7 +21,7 @@
   }
   
   fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg1, default bb3, [1 => bb1, 2 => bb2]
     bb1:
       v0 = add arg0, 7
@@ -44,7 +44,7 @@
   }
   
   fn @outer_phi_operand(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: arg0], [bb6: v5]

--- a/tests/ui/codegen/mir/pre/pre_loop_invariant.mir
+++ b/tests/ui/codegen/mir/pre/pre_loop_invariant.mir
@@ -4,7 +4,7 @@
 // hoisted out of the loop and the header gets a phi.
 @module LoopInvariant
 fn @hoist_header_expr(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v2 = phi [bb0: arg0], [bb2: v5]
@@ -20,7 +20,7 @@ fn @hoist_header_expr(arg0: u256, arg1: u256) -> u256 {
 }
 
 fn @hoist_header_expr_two_latches(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v2 = phi [bb0: arg0], [bb3: v5], [bb4: v8]

--- a/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
+++ b/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pre/pre_loop_invariant.mir (after pre) ===
   @module LoopInvariant
   fn @hoist_header_expr(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v5 = add arg0, 7
       jump bb1
     bb1:
@@ -22,7 +22,7 @@
   }
   
   fn @hoist_header_expr_two_latches(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 +     v7 = add arg0, 7
       jump bb1
     bb1:

--- a/tests/ui/codegen/mir/pre/pre_pingpong.mir
+++ b/tests/ui/codegen/mir/pre/pre_pingpong.mir
@@ -4,7 +4,7 @@
 // The pass must terminate after the single profitable rewrite in bb5.
 @module PingPong
 fn @pingpong(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
   bb1:
     v2 = add arg0, 7

--- a/tests/ui/codegen/mir/pre/pre_pingpong.stdout
+++ b/tests/ui/codegen/mir/pre/pre_pingpong.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pre/pre_pingpong.mir (after pre) ===
   @module PingPong
   fn @pingpong(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
     bb1:
       v0 = add arg0, 7

--- a/tests/ui/codegen/mir/pre/pre_split_edges.mir
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.mir
@@ -6,7 +6,7 @@
 // bb2 reaches the join through two switch cases: both retarget to the same
 // split block, so the join phi gets exactly one new incoming entry.
 fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch arg1, default bb1, [1 => bb2]
   bb1:
     v2 = add arg0, 7
@@ -23,7 +23,7 @@ fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
 // bb2 branches to the join on both arms: one logical edge, one split block,
 // one phi entry.
 fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg1, bb1, bb2
   bb1:
     v2 = add arg0, 7
@@ -39,7 +39,7 @@ fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
 // translation of the expression is not available: the backedge is split and
 // the new block carries the per-iteration recomputation.
 fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v2 = add arg0, 7
@@ -57,7 +57,7 @@ fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
 // Loop-invariant PRE through a branch-terminated preheader: the entry edge
 // into the header is split and the hoisted computation lands on it.
 fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v2 = lt arg0, arg1
     br v2, bb1, bb4
   bb1:

--- a/tests/ui/codegen/mir/pre/pre_split_edges.stdout
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pre/pre_split_edges.mir (after pre) ===
   @module SplitEdges
   fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch arg1, default bb1, [1 => bb2]
     bb1:
       v0 = add arg0, 7
@@ -23,7 +23,7 @@
   }
   
   fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg1, bb1, bb2
     bb1:
       v0 = add arg0, 7
@@ -42,7 +42,7 @@
   }
   
   fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = add arg0, 7
@@ -65,7 +65,7 @@
   }
   
   fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = lt arg0, arg1
 -     br v0, bb1, bb4
 +     br v0, bb5, bb4

--- a/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir
+++ b/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass pure-eval
 @module PureEvalLoop
 fn @bounded_loop() -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v0 = phi [bb0: 0], [bb2: 3]
@@ -14,7 +14,7 @@ fn @bounded_loop() -> u256 {
 }
 
 fn @with_arg(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = add arg0, 1
     ret v0
 }

--- a/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
+++ b/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir (after pure-eval) ===
   @module PureEvalLoop
   fn @bounded_loop() -> u256 {
-    bb0 (entry):
+    bb0:
 -     jump bb1
 +     ret 3
     bb1:
@@ -19,7 +19,7 @@
   }
   
   fn @with_arg(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       ret v0
   }

--- a/tests/ui/codegen/mir/sccp/sccp_branch.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_branch.mir
@@ -3,7 +3,7 @@
 // SCCP should fold the comparison and the branch, making bb2 unreachable.
 @module SccpBranch
 fn @const_branch() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = lt 5, 10
     br v0, bb1, bb2
   bb1:

--- a/tests/ui/codegen/mir/sccp/sccp_branch.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_branch.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/sccp/sccp_branch.mir (after sccp) ===
   @module SccpBranch
   fn @const_branch() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = lt 5, 10
 -     br v0, bb1, bb2
 +     jump bb1

--- a/tests/ui/codegen/mir/sccp/sccp_edge.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_edge.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass sccp
 @module SccpEdge
 fn @phi_ignores_unreachable_predecessor() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = eq 1, 1
     br v0, bb1, bb2
   bb1:
@@ -14,7 +14,7 @@ fn @phi_ignores_unreachable_predecessor() -> u256 {
 }
 
 fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     br arg0, bb1, bb2
   bb1:
     jump bb3
@@ -26,7 +26,7 @@ fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
 }
 
 fn @constant_switch_selects_one_case() -> u256 {
-  bb0 (entry):
+  bb0:
     switch 2, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
   bb1:
     ret 11

--- a/tests/ui/codegen/mir/sccp/sccp_edge.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_edge.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/sccp/sccp_edge.mir (after sccp) ===
   @module SccpEdge
   fn @phi_ignores_unreachable_predecessor() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = eq 1, 1
 -     br v0, bb1, bb2
 +     jump bb1
@@ -18,7 +18,7 @@
   }
   
   fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
-    bb0 (entry):
+    bb0:
       br arg0, bb1, bb2
     bb1:
       jump bb3
@@ -30,7 +30,7 @@
   }
   
   fn @constant_switch_selects_one_case() -> u256 {
-    bb0 (entry):
+    bb0:
 -     switch 2, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
 +     jump bb2
     bb1:

--- a/tests/ui/codegen/mir/sccp/sccp_fold.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_fold.mir
@@ -3,7 +3,7 @@
 // SCCP should propagate through the chain and fold everything.
 @module SccpFold
 fn @const_chain() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = add 10, 20
     v1 = mul v0, 2
     ret v1

--- a/tests/ui/codegen/mir/sccp/sccp_fold.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_fold.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/sccp/sccp_fold.mir (after sccp) ===
   @module SccpFold
   fn @const_chain() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = add 10, 20
 -     v1 = mul v0, 2
 -     ret v1

--- a/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.mir
@@ -6,7 +6,7 @@
 
 // MIN sdiv -1 wraps back to MIN.
 fn @sdiv_min_by_neg_one() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
     ret v1
@@ -14,7 +14,7 @@ fn @sdiv_min_by_neg_one() -> bool {
 
 // -7 sdiv 2 truncates toward zero: -3.
 fn @sdiv_truncates_toward_zero() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = sdiv 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 2
     v1 = eq v0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
     ret v1
@@ -22,32 +22,32 @@ fn @sdiv_truncates_toward_zero() -> bool {
 
 // A known-zero divisor folds to 0 even when the dividend is unknown.
 fn @div_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = div arg0, 0
     ret v0
 }
 
 fn @mod_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mod arg0, 0
     ret v0
 }
 
 fn @sdiv_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = sdiv arg0, 0
     ret v0
 }
 
 fn @smod_by_known_zero(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = smod arg0, 0
     ret v0
 }
 
 // The smod result takes the dividend's sign: -7 smod 3 == -1.
 fn @smod_negative_dividend() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = smod 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 3
     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     ret v1
@@ -55,7 +55,7 @@ fn @smod_negative_dividend() -> bool {
 
 // 7 smod -3 == 1.
 fn @smod_positive_dividend() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = smod 7, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
     v1 = eq v0, 1
     ret v1
@@ -63,34 +63,34 @@ fn @smod_positive_dividend() -> bool {
 
 // Signed comparisons: -1 < 0 and not -1 > 0.
 fn @slt_negative() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = slt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0
     ret v0
 }
 
 fn @sgt_negative() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = sgt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0
     ret v0
 }
 
 // sar by 256 or more saturates: all ones for negative values, 0 otherwise.
 fn @sar_saturates_negative() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = sar 256, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     ret v1
 }
 
 fn @sar_saturates_positive() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = sar 300, 7
     ret v0
 }
 
 // -7 sar 1 == -4 (sign-filling shift).
 fn @sar_fills_sign_bits() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = sar 1, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9
     v1 = eq v0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc
     ret v1
@@ -98,20 +98,20 @@ fn @sar_fills_sign_bits() -> bool {
 
 // byte indices of 32 or more produce 0; smaller indices are big-endian.
 fn @byte_index_out_of_range() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = byte 32, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     ret v0
 }
 
 fn @byte_extracts_big_endian() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = byte 30, 0x1234
     ret v0
 }
 
 // signextend with byte size 31 or more is the identity.
 fn @signextend_identity_at_31() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = signextend 31, 0x8000000000000000000000000000000000000000000000000000000000000000
     v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
     ret v1
@@ -119,7 +119,7 @@ fn @signextend_identity_at_31() -> bool {
 
 // signextend 0 of 0xff is -1.
 fn @signextend_byte_zero() -> bool {
-  bb0 (entry):
+  bb0:
     v0 = signextend 0, 0xff
     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     ret v1
@@ -127,19 +127,19 @@ fn @signextend_byte_zero() -> bool {
 
 // addmod/mulmod with a zero modulus produce 0, even with unknown operands.
 fn @addmod_zero_modulus() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = addmod 1, 2, 0
     ret v0
 }
 
 fn @addmod_unknown_operands_zero_modulus(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = addmod arg0, arg0, 0
     ret v0
 }
 
 fn @mulmod_zero_modulus() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mulmod 5, 5, 0
     ret v0
 }
@@ -147,14 +147,14 @@ fn @mulmod_zero_modulus() -> u256 {
 // addmod/mulmod use a 512-bit intermediate: (2^256 - 1 + 2) % 3 == 2, not
 // (wrapped 1) % 3 == 1.
 fn @addmod_wide_intermediate() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = addmod 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3
     ret v0
 }
 
 // (2^128 * 2^128) % 7 == 2, not (wrapped 0) % 7 == 0.
 fn @mulmod_wide_intermediate() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = mulmod 0x100000000000000000000000000000000, 0x100000000000000000000000000000000, 7
     ret v0
 }
@@ -162,19 +162,19 @@ fn @mulmod_wide_intermediate() -> u256 {
 // select folds on a constant condition, and on equal arms regardless of the
 // condition.
 fn @select_true_condition() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = select 1, 11, 22
     ret v0
 }
 
 fn @select_false_condition() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = select 0, 11, 22
     ret v0
 }
 
 fn @select_equal_arms(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = select arg0, 7, 7
     ret v0
 }

--- a/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/sccp/sccp_fold_evm_ops.mir (after sccp) ===
   @module SccpFoldEvmOps
   fn @sdiv_min_by_neg_one() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -     v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
 -     ret v1
@@ -10,7 +10,7 @@
   }
   
   fn @sdiv_truncates_toward_zero() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = sdiv 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 2
 -     v1 = eq v0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
 -     ret v1
@@ -18,35 +18,35 @@
   }
   
   fn @div_by_known_zero(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = div arg0, 0
 -     ret v0
 +     ret 0
   }
   
   fn @mod_by_known_zero(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mod arg0, 0
 -     ret v0
 +     ret 0
   }
   
   fn @sdiv_by_known_zero(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sdiv arg0, 0
 -     ret v0
 +     ret 0
   }
   
   fn @smod_by_known_zero(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = smod arg0, 0
 -     ret v0
 +     ret 0
   }
   
   fn @smod_negative_dividend() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = smod 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 3
 -     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -     ret v1
@@ -54,7 +54,7 @@
   }
   
   fn @smod_positive_dividend() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = smod 7, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
 -     v1 = eq v0, 1
 -     ret v1
@@ -62,21 +62,21 @@
   }
   
   fn @slt_negative() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = slt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0
 -     ret v0
 +     ret 1
   }
   
   fn @sgt_negative() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = sgt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0
 -     ret v0
 +     ret 0
   }
   
   fn @sar_saturates_negative() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = sar 256, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
 -     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -     ret v1
@@ -84,14 +84,14 @@
   }
   
   fn @sar_saturates_positive() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sar 300, 7
 -     ret v0
 +     ret 0
   }
   
   fn @sar_fills_sign_bits() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = sar 1, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9
 -     v1 = eq v0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc
 -     ret v1
@@ -99,21 +99,21 @@
   }
   
   fn @byte_index_out_of_range() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = byte 32, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -     ret v0
 +     ret 0
   }
   
   fn @byte_extracts_big_endian() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = byte 30, 0x1234
 -     ret v0
 +     ret 18
   }
   
   fn @signextend_identity_at_31() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = signextend 31, 0x8000000000000000000000000000000000000000000000000000000000000000
 -     v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
 -     ret v1
@@ -121,7 +121,7 @@
   }
   
   fn @signextend_byte_zero() -> bool {
-    bb0 (entry):
+    bb0:
 -     v0 = signextend 0, 255
 -     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 -     ret v1
@@ -129,56 +129,56 @@
   }
   
   fn @addmod_zero_modulus() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = addmod 1, 2, 0
 -     ret v0
 +     ret 0
   }
   
   fn @addmod_unknown_operands_zero_modulus(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = addmod arg0, arg0, 0
 -     ret v0
 +     ret 0
   }
   
   fn @mulmod_zero_modulus() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mulmod 5, 5, 0
 -     ret v0
 +     ret 0
   }
   
   fn @addmod_wide_intermediate() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = addmod 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3
 -     ret v0
 +     ret 2
   }
   
   fn @mulmod_wide_intermediate() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = mulmod 0x100000000000000000000000000000000, 0x100000000000000000000000000000000, 7
 -     ret v0
 +     ret 2
   }
   
   fn @select_true_condition() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = select 1, 11, 22
 -     ret v0
 +     ret 11
   }
   
   fn @select_false_condition() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = select 0, 11, 22
 -     ret v0
 +     ret 22
   }
   
   fn @select_equal_arms(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = select arg0, 7, 7
 -     ret v0
 +     ret 7

--- a/tests/ui/codegen/mir/sccp/sccp_no_fold.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_no_fold.mir
@@ -3,7 +3,7 @@
 // SCCP should leave these instructions as-is.
 @module SccpNoFold
 fn @with_arg(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = mul v1, 2
     ret v2

--- a/tests/ui/codegen/mir/sccp/sccp_no_fold.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_no_fold.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/sccp/sccp_no_fold.mir (after sccp) ===
   @module SccpNoFold
   fn @with_arg(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
       v1 = mul v0, 2
       ret v1

--- a/tests/ui/codegen/mir/sccp/sccp_switch_order.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_switch_order.mir
@@ -7,7 +7,7 @@
 // arg0 may equal 5 at runtime, so the switch must not fold to bb2. The default
 // edge is still infeasible: case 5 matches whenever arg0 does not.
 fn @earlier_unknown_case_blocks_fold(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch 5, default bb3, [arg0 => bb1, 5 => bb2]
   bb1:
     ret 1
@@ -20,7 +20,7 @@ fn @earlier_unknown_case_blocks_fold(arg0: u256) -> u256 {
 // Every earlier case is a constant that differs from the scrutinee, so the
 // match on 5 is definitive and the switch folds.
 fn @constant_cases_fold() -> u256 {
-  bb0 (entry):
+  bb0:
     switch 5, default bb3, [1 => bb1, 5 => bb2]
   bb1:
     ret 1
@@ -33,7 +33,7 @@ fn @constant_cases_fold() -> u256 {
 // No constant case matches: the unknown case and the default stay feasible,
 // but the constant case that differs from the scrutinee is unreachable.
 fn @unknown_case_keeps_default(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     switch 5, default bb3, [arg0 => bb1, 4 => bb2]
   bb1:
     ret 1

--- a/tests/ui/codegen/mir/sccp/sccp_switch_order.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_switch_order.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/sccp/sccp_switch_order.mir (after sccp) ===
   @module SccpSwitchOrder
   fn @earlier_unknown_case_blocks_fold(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch 5, default bb3, [arg0 => bb1, 5 => bb2]
     bb1:
       ret 1
@@ -14,7 +14,7 @@
   }
   
   fn @constant_cases_fold() -> u256 {
-    bb0 (entry):
+    bb0:
 -     switch 5, default bb3, [1 => bb1, 5 => bb2]
 +     jump bb2
     bb1:
@@ -28,7 +28,7 @@
   }
   
   fn @unknown_case_keeps_default(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       switch 5, default bb3, [arg0 => bb1, 4 => bb2]
     bb1:
       ret 1

--- a/tests/ui/codegen/mir/storage-dse/storage_dse.mir
+++ b/tests/ui/codegen/mir/storage-dse/storage_dse.mir
@@ -1,14 +1,14 @@
 //@compile-flags: --pass storage-dse
 @module StorageDse
 fn @remove_overwritten_store(arg0: u256) {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0
     sstore 0, 7
     stop
 }
 
 fn @keep_store_observed_by_load(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0
     v1 = sload 0
     sstore 0, 7
@@ -16,7 +16,7 @@ fn @keep_store_observed_by_load(arg0: u256) -> u256 {
 }
 
 fn @remove_equal_store_after_load(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0
     v1 = sload 0
     sstore 0, arg0
@@ -24,14 +24,14 @@ fn @remove_equal_store_after_load(arg0: u256) -> u256 {
 }
 
 fn @keep_may_alias_symbolic_store(arg0: u256, arg1: u256) {
-  bb0 (entry):
+  bb0:
     sstore arg0, 1
     sstore arg1, 2
     stop
 }
 
 fn @remove_disjoint_offset_overwrite(arg0: u256) {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     sstore v1, 1
     v2 = add arg0, 2
@@ -42,7 +42,7 @@ fn @remove_disjoint_offset_overwrite(arg0: u256) {
 }
 
 fn @keep_across_call(arg0: u256, arg1: address) {
-  bb0 (entry):
+  bb0:
     sstore 0, arg0
     v1 = call 100000, arg1, 0, 0, 0, 0, 0
     sstore 0, 7

--- a/tests/ui/codegen/mir/storage-dse/storage_dse.stdout
+++ b/tests/ui/codegen/mir/storage-dse/storage_dse.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/storage-dse/storage_dse.mir (after storage-dse) ===
   @module StorageDse
   fn @remove_overwritten_store(arg0: u256) {
-    bb0 (entry):
+    bb0:
 -     sstore 0, arg0
 -     sstore 0, 7
 +     sstore 0, 7 !metadata(storage=slot(0))
@@ -10,7 +10,7 @@
   }
   
   fn @keep_store_observed_by_load(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     sstore 0, arg0
 -     v0 = sload 0
 -     sstore 0, 7
@@ -21,7 +21,7 @@
   }
   
   fn @remove_equal_store_after_load(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     sstore 0, arg0
 -     v0 = sload 0
 -     sstore 0, arg0
@@ -31,7 +31,7 @@
   }
   
   fn @keep_may_alias_symbolic_store(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
 -     sstore arg0, 1
 -     sstore arg1, 2
 +     sstore arg0, 1 !metadata(storage=symbolic(arg0))
@@ -40,7 +40,7 @@
   }
   
   fn @remove_disjoint_offset_overwrite(arg0: u256) {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     sstore v0, 1
       v1 = add arg0, 2
@@ -53,7 +53,7 @@
   }
   
   fn @keep_across_call(arg0: u256, arg1: address) {
-    bb0 (entry):
+    bb0:
 -     sstore 0, arg0
 +     sstore 0, arg0 !metadata(storage=slot(0))
       v0 = call 0x186a0, arg1, 0, 0, 0, 0, 0

--- a/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.mir
+++ b/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass storage-load-cse
 @module StorageLoadCse
 fn @reuse_across_disjoint_constant_store() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     sstore 1, 9
     v2 = sload 0
@@ -10,7 +10,7 @@ fn @reuse_across_disjoint_constant_store() -> u256 {
 }
 
 fn @keep_after_same_slot_store() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     sstore 0, 9
     v2 = sload 0
@@ -19,7 +19,7 @@ fn @keep_after_same_slot_store() -> u256 {
 }
 
 fn @keep_after_symbolic_store(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     sstore arg0, 9
     v2 = sload 0
@@ -28,7 +28,7 @@ fn @keep_after_symbolic_store(arg0: u256) -> u256 {
 }
 
 fn @reuse_across_disjoint_offset_store(arg0: u256) -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     v2 = sload v1
     v3 = add arg0, 2
@@ -40,7 +40,7 @@ fn @reuse_across_disjoint_offset_store(arg0: u256) -> u256 {
 }
 
 fn @keep_when_reuse_extends_live_range() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     sstore 1, 9
     v2 = sload 0
@@ -48,7 +48,7 @@ fn @keep_when_reuse_extends_live_range() -> u256 {
 }
 
 fn @replace_uses_after_second_load() -> u256 {
-  bb0 (entry):
+  bb0:
     v1 = sload 0
     v2 = sload 0
     v3 = add v1, v2

--- a/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.stdout
+++ b/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/storage-load-cse/storage_load_cse.mir (after storage-load-cse) ===
   @module StorageLoadCse
   fn @reuse_across_disjoint_constant_store() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sload 0
 -     sstore 1, 9
 -     v1 = sload 0
@@ -14,7 +14,7 @@
   }
   
   fn @keep_after_same_slot_store() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sload 0
 -     sstore 0, 9
 -     v1 = sload 0
@@ -26,7 +26,7 @@
   }
   
   fn @keep_after_symbolic_store(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sload 0
 -     sstore arg0, 9
 -     v1 = sload 0
@@ -38,7 +38,7 @@
   }
   
   fn @reuse_across_disjoint_offset_store(arg0: u256) -> u256 {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     v1 = sload v0
 +     v1 = sload v0 !metadata(storage=offset(arg0, 1))
@@ -53,7 +53,7 @@
   }
   
   fn @keep_when_reuse_extends_live_range() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sload 0
 -     sstore 1, 9
 -     v1 = sload 0
@@ -64,7 +64,7 @@
   }
   
   fn @replace_uses_after_second_load() -> u256 {
-    bb0 (entry):
+    bb0:
 -     v0 = sload 0
 -     v1 = sload 0
 -     v2 = add v0, v1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass storage-promotion
 @module StoragePromotion
 fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     sstore v1, 1
     jump bb1
@@ -21,7 +21,7 @@ fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
 }
 
 fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v6]
@@ -38,7 +38,7 @@ fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
 }
 
 fn @promote_store_only_without_initial_load() [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb4
@@ -52,7 +52,7 @@ fn @promote_store_only_without_initial_load() [selector=0x01020304] {
 }
 
 fn @promote_two_initialized_slots() [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     sstore 0, 1
     sstore 1, 2
     jump bb1
@@ -73,7 +73,7 @@ fn @promote_two_initialized_slots() [selector=0x01020304] {
 }
 
 fn @promote_without_init_rewrites_successor_phi() -> u256 [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     br true, bb2, bb4

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir (after storage-promotion) ===
   @module StoragePromotion
   fn @promote_recomputed_offset_slot(arg0: u256) {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     sstore v0, 1
 +     mstore 128, 1
@@ -27,7 +27,7 @@
   }
   
   fn @reject_loop_variant_offset_slot(arg0: u256) {
-    bb0 (entry):
+    bb0:
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
@@ -46,7 +46,7 @@
   }
   
   fn @promote_store_only_without_initial_load() {
-    bb0 (entry):
+    bb0:
 +     mstore 160, 0
       jump bb1
     bb1:
@@ -70,7 +70,7 @@
   }
   
   fn @promote_two_initialized_slots() {
-    bb0 (entry):
+    bb0:
 -     sstore 0, 1
 -     sstore 1, 2
 +     mstore 128, 1
@@ -101,7 +101,7 @@
   }
   
   fn @promote_without_init_rewrites_successor_phi() -> u256 {
-    bb0 (entry):
+    bb0:
 +     v3 = sload 0
 +     mstore 128, v3
 +     mstore 160, 0

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass storage-promotion
 @module StoragePromotionAlias
 fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     sstore arg0, 1
     sstore arg1, 2
     jump bb1
@@ -22,7 +22,7 @@ fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
 }
 
 fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     sstore arg0, 1
     sstore 7, 2
     jump bb1
@@ -43,7 +43,7 @@ fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
 }
 
 fn @promote_two_constant_slots() [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     sstore 0, 1
     sstore 1, 2
     jump bb1
@@ -64,7 +64,7 @@ fn @promote_two_constant_slots() [selector=0x01020304] {
 }
 
 fn @promote_same_base_distinct_offsets(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     v1 = add arg0, 1
     sstore v1, 1
     v2 = add arg0, 2

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir (after storage-promotion) ===
   @module StoragePromotionAlias
   fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) {
-    bb0 (entry):
+    bb0:
 -     sstore arg0, 1
 -     sstore arg1, 2
 +     sstore arg0, 1 !metadata(storage=symbolic(arg0))
@@ -29,7 +29,7 @@
   }
   
   fn @reject_symbolic_and_constant_slots(arg0: u256) {
-    bb0 (entry):
+    bb0:
 -     sstore arg0, 1
 -     sstore 7, 2
 +     sstore arg0, 1 !metadata(storage=symbolic(arg0))
@@ -56,7 +56,7 @@
   }
   
   fn @promote_two_constant_slots() {
-    bb0 (entry):
+    bb0:
 -     sstore 0, 1
 -     sstore 1, 2
 +     mstore 128, 1
@@ -87,7 +87,7 @@
   }
   
   fn @promote_same_base_distinct_offsets(arg0: u256) {
-    bb0 (entry):
+    bb0:
       v0 = add arg0, 1
 -     sstore v0, 1
 +     mstore 128, 1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
@@ -8,7 +8,7 @@
 // The relocated inner flush writes the same slot the outer latch updates, so
 // after re-analysis the outer loop promotes both stores consistently.
 fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     jump bb6
   bb1:
     br true, bb2, bb4
@@ -35,7 +35,7 @@ fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
 // The relocated inner flush targets a symbolic slot that may alias the outer
 // latch's constant slot, so the outer loop must not be promoted.
 fn @reject_outer_when_inner_flush_may_alias(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     jump bb6
   bb1:
     br true, bb2, bb4

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir (after storage-promotion) ===
   @module StoragePromotionNested
   fn @promote_outer_after_inner_flush_split() {
-    bb0 (entry):
+    bb0:
 +     v4 = sload 0
 +     mstore 192, v4
 +     mstore 224, 0
@@ -52,7 +52,7 @@
   }
   
   fn @reject_outer_when_inner_flush_may_alias(arg0: u256) {
-    bb0 (entry):
+    bb0:
       jump bb6
     bb1:
       br 1, bb2, bb4

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
@@ -1,7 +1,7 @@
 //@compile-flags: --pass storage-promotion
 @module StoragePromotionRevertExit
 fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb3: v2]
@@ -25,7 +25,7 @@ fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
 }
 
 fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     sstore 0, 1
     jump bb1
   bb1:
@@ -47,7 +47,7 @@ fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
 }
 
 fn @reject_revert_exit_with_call(arg0: u256) [selector=0x01020304] {
-  bb0 (entry):
+  bb0:
     sstore 0, 1
     jump bb1
   bb1:

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
@@ -2,7 +2,7 @@
 + // === ROOT/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir (after storage-promotion) ===
   @module StoragePromotionRevertExit
   fn @promote_checked_sum_loop(arg0: u256) {
-    bb0 (entry):
+    bb0:
 +     v6 = sload 0
 +     mstore 128, v6
 +     mstore 160, 0
@@ -39,7 +39,7 @@
   }
   
   fn @promote_revert_exit_reads_slot(arg0: u256) {
-    bb0 (entry):
+    bb0:
 -     sstore 0, 1
 +     mstore 128, 1
       jump bb1
@@ -67,7 +67,7 @@
   }
   
   fn @reject_revert_exit_with_call(arg0: u256) {
-    bb0 (entry):
+    bb0:
 -     sstore 0, 1
 +     sstore 0, 1 !metadata(storage=slot(0))
       jump bb1

--- a/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir
+++ b/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir
@@ -5,12 +5,12 @@
 @module TailCallRoundtrip
 @phase dispatch
 fn @wrapper(arg0: u256) {
-  bb0 (entry):
+  bb0:
     mstore 128, arg0
     returndata 128, 32
 }
 fn @entry() {
-  bb0 (entry):
+  bb0:
     v1 = calldataload 0
     v3 = shr 224, v1
     v4 = eq v3, 0x9507d39a

--- a/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
+++ b/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
@@ -3,13 +3,13 @@
   @module TailCallRoundtrip
   @phase dispatch
   fn @wrapper(arg0: u256) {
-    bb0 (entry):
+    bb0:
       mstore 128, arg0
       returndata 128, 32
   }
   
   fn @entry() {
-    bb0 (entry):
+    bb0:
       v0 = calldataload 0
       v1 = shr 224, v0
       v2 = eq v1, 0x9507d39a

--- a/tests/ui/codegen/mir/validation/tail_call_validate.mir
+++ b/tests/ui/codegen/mir/validation/tail_call_validate.mir
@@ -5,14 +5,14 @@
 // hand-written MIR is rejected with a diagnostic, not an ICE.
 @module TailCallValidate
 fn @callee(arg0: u256) {
-  bb0 (entry):
+  bb0:
     stop
 }
 fn @wrongArity() {
-  bb0 (entry):
+  bb0:
     tail_call fn0
 }
 fn @unknownTarget() {
-  bb0 (entry):
+  bb0:
     tail_call fn9
 }

--- a/tests/ui/codegen/mir/validation/validate_same_block_use.mir
+++ b/tests/ui/codegen/mir/validation/validate_same_block_use.mir
@@ -5,13 +5,13 @@
 // deliberately loose SSA rules.
 @module ValidateSameBlockUse
 fn @acyclic() -> u256 {
-  bb0 (entry):
+  bb0:
     v0 = add v1, 1
     v1 = add 2, 3
     ret v0
 }
 fn @cyclic(arg0: bool) -> u256 {
-  bb0 (entry):
+  bb0:
     jump bb1
   bb1:
     v0 = add v1, 1

--- a/tests/ui/erc7201/codegen.stdout
+++ b/tests/ui/erc7201/codegen.stdout
@@ -1,21 +1,21 @@
 // === ROOT/tests/ui/erc7201/codegen.sol:Erc7201Builtin ===
 @module Erc7201Builtin
 fn @literal() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     mstore 128, 0x183a6125c38840424c4a85fa12bab2ab606c4b6d0e7cc73c0c06ba5300eab500
     returndata 128, 32
 }
 
 fn @zeroLastByteLiteral() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     mstore 128, 0x6d0d983459328e82eacb1bf2d6fadfa38a6896e9d4cbfe0e1aa41c6281bab00
     returndata 128, 32
 }
 
 fn @memoryParam() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = mload 64 !metadata(memory=scratch)
     v1 = add v0, 64
@@ -36,7 +36,7 @@ fn @memoryParam() {
 }
 
 fn @calldataParam(arg0: memptr) {
-  bb0 (entry):
+  bb0:
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
@@ -89,7 +89,7 @@ fn @calldataParam(arg0: memptr) {
 }
 
 fn @storageValue() {
-  bb0 (entry):
+  bb0:
     mstore 128, 0
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = mload v0
@@ -104,7 +104,7 @@ fn @storageValue() {
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
-  bb0 (entry):
+  bb0:
     v0 = sload arg0 !metadata(storage=symbolic(arg0))
     v1 = and v0, 1
     v2 = eq v1, 1


### PR DESCRIPTION
This removes explicit entry-block metadata and `(entry)` markers from MIR and EVM IR. The first block is now the entry by invariant, and CFG consumers use predecessor and reachability facts instead of redundant entry special cases.

MIR parsing and validation reject functions without a block, and codegen refuses malformed zero-block functions. Dead-function elimination now removes dead functions and remaps call targets instead of encoding liveness by clearing their bodies. EVM CFG simplification similarly models the implicit program-entry edge in its reference count so block coalescing remains correct.