### PR TITLE
refactor(codegen): encapsulate IR tables

### DIFF
--- a/crates/codegen/src/analysis/alias.rs
+++ b/crates/codegen/src/analysis/alias.rs
@@ -331,7 +331,7 @@ impl PointerProvenance {
         call_summaries: Option<&MemoryCallSummaries>,
         may_reset_fmp: impl Fn(&Function, InstId, Option<&MemoryCallSummaries>) -> bool,
     ) -> Self {
-        if func.blocks.is_empty() {
+        if func.has_no_blocks() {
             return Self::default();
         }
         // The cycle classification, the FMP-reset dataflow, and the
@@ -340,16 +340,14 @@ impl PointerProvenance {
         // so skip all of it — most small functions (getters, setters, pure
         // helpers) take this path on every rebuild.
         let has_allocations = func
-            .instructions
-            .iter()
+            .instructions()
             .any(|inst| matches!(inst.kind, InstKind::Alloc { .. } | InstKind::AbiEncode { .. }));
         if !has_allocations {
             return Self::default();
         }
         let cyclic = cyclic_blocks(func);
         let block_resets: Vec<_> = func
-            .blocks
-            .iter()
+            .blocks()
             .map(|block| {
                 block.instructions.iter().any(|&inst| may_reset_fmp(func, inst, call_summaries))
             })
@@ -357,13 +355,13 @@ impl PointerProvenance {
 
         // `poisoned[block]` means at least one path into the block may have
         // recycled the FMP. The monotone OR lattice handles joins and loops.
-        let mut reachable = DenseBitSet::new_empty(func.blocks.len());
-        let mut poisoned = DenseBitSet::new_empty(func.blocks.len());
+        let mut reachable = DenseBitSet::new_empty(func.block_count());
+        let mut poisoned = DenseBitSet::new_empty(func.block_count());
         let mut worklist = VecDeque::from([BlockId::ENTRY]);
         reachable.insert(BlockId::ENTRY);
         while let Some(block) = worklist.pop_front() {
             let out = poisoned.contains(block) || block_resets[block.index()];
-            let Some(terminator) = &func.blocks[block].terminator else { continue };
+            let Some(terminator) = &func.block(block).terminator else { continue };
             for successor in terminator.successors() {
                 let mut changed = reachable.insert(successor);
                 if out {
@@ -376,11 +374,11 @@ impl PointerProvenance {
         }
 
         let mut allocations = FxHashMap::default();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             let mut reset = poisoned.contains(block_id);
             for &inst_id in &block.instructions {
                 if matches!(
-                    func.instructions[inst_id].kind,
+                    func.instruction(inst_id).kind,
                     InstKind::Alloc { .. } | InstKind::AbiEncode { .. }
                 ) {
                     allocations.insert(
@@ -486,7 +484,7 @@ impl AliasAnalysis {
         size: LocationSize,
     ) -> Option<MemoryLocation> {
         let mut address = self.memory_address(func, address)?;
-        if let Some(region) = func.instructions[inst_id].metadata.memory_region()
+        if let Some(region) = func.instruction(inst_id).metadata.memory_region()
             && region != MemoryRegion::Unknown
         {
             address.region = region;
@@ -505,7 +503,7 @@ impl AliasAnalysis {
     ) -> Option<MemoryLocation> {
         let offset = EvmMemoryLayout::object_length_offset(kind)?;
         let mut address = self.memory_address(func, object)?.checked_add(offset)?;
-        if let Some(region) = func.instructions[inst_id].metadata.memory_region()
+        if let Some(region) = func.instruction(inst_id).metadata.memory_region()
             && region != MemoryRegion::Unknown
         {
             address.region = region;
@@ -591,9 +589,9 @@ impl AliasAnalysis {
         derived.insert(root);
         loop {
             let mut changed = false;
-            for (value_id, value) in func.values.iter_enumerated() {
+            for (value_id, value) in func.values_enumerated() {
                 let Value::Inst(inst_id) = value else { continue };
-                let propagates = match &func.instructions[*inst_id].kind {
+                let propagates = match &func.instruction(*inst_id).kind {
                     InstKind::Add(first, second)
                     | InstKind::Sub(first, second)
                     | InstKind::MakeSlice { ptr: first, len: second, .. } => {
@@ -622,9 +620,9 @@ impl AliasAnalysis {
             }
         }
 
-        for block in &func.blocks {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                let kind = &func.instructions[inst_id].kind;
+                let kind = &func.instruction(inst_id).kind;
                 for operand in kind.operands() {
                     if derived.contains(&operand) && self.instruction_operand_escapes(kind, operand)
                     {
@@ -772,7 +770,7 @@ impl AliasAnalysis {
         inst_id: InstId,
         replacements: &FxHashMap<ValueId, ValueId>,
     ) -> ModRef {
-        let kind = &func.instructions[inst_id].kind;
+        let kind = &func.instruction(inst_id).kind;
         let resolve = |value| crate::mir::utils::resolve_replacement(value, replacements);
         let mut effects = ModRef::default();
         let read_memory = |effects: &mut ModRef, address, size| {
@@ -1162,7 +1160,7 @@ impl AliasAnalysis {
                 },
             )),
             Value::Undef(_) | Value::Error(_) => None,
-            Value::Inst(inst_id) => match func.instructions[*inst_id].kind {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::InternalFrameAddr(offset) => Some(MemoryAddress::internal_frame(offset)),
                 InstKind::Alloc { .. } => Some(if self.allocation_is_dynamic(func, *inst_id) {
                     MemoryAddress {
@@ -1254,7 +1252,7 @@ impl AliasAnalysis {
         let Value::Inst(inst_id) = func.value(slice) else {
             return Some(MemoryAddress::symbolic(slice, MemoryRegion::Unknown));
         };
-        match &func.instructions[*inst_id].kind {
+        match &func.instruction(*inst_id).kind {
             InstKind::MakeSlice { ptr, location, .. } => match location {
                 SliceLocation::Memory => self.memory_address_with_depth(func, *ptr, depth + 1),
                 // Calldata and returndata pointers index their own address
@@ -1313,7 +1311,7 @@ impl AliasAnalysis {
                 _ => MemoryRegion::Unknown,
             };
         };
-        match func.instructions[*inst_id].kind {
+        match func.instruction(*inst_id).kind {
             InstKind::InternalFrameAddr(_) => MemoryRegion::InternalFrame,
             InstKind::Fmp | InstKind::Alloc { .. } => MemoryRegion::Heap,
             InstKind::MLoad(address)
@@ -1345,7 +1343,7 @@ impl AliasAnalysis {
                 let Value::Inst(slice_inst) = func.value(slice) else {
                     return MemoryRegion::Unknown;
                 };
-                match &func.instructions[*slice_inst].kind {
+                match &func.instruction(*slice_inst).kind {
                     InstKind::MakeSlice { location: SliceLocation::Memory, .. }
                     | InstKind::AbiEncode { .. } => MemoryRegion::Heap,
                     _ => MemoryRegion::Unknown,
@@ -1393,7 +1391,7 @@ impl AliasAnalysis {
         inst: InstId,
         call_summaries: Option<&MemoryCallSummaries>,
     ) -> bool {
-        match func.instructions[inst].kind {
+        match func.instruction(inst).kind {
             InstKind::SetFmp(_) => true,
             InstKind::InternalCall { function, .. } => call_summaries
                 .and_then(|summaries| summaries.get(function))
@@ -1446,7 +1444,7 @@ impl AliasAnalysis {
             return Some(value);
         }
         let Value::Inst(inst) = func.value(value) else { return None };
-        match &func.instructions[*inst].kind {
+        match &func.instruction(*inst).kind {
             InstKind::Fmp | InstKind::Alloc { .. } | InstKind::AbiEncode { .. } => {
                 Some(EvmMemoryLayout::HEAP_START)
             }
@@ -1466,7 +1464,7 @@ impl AliasAnalysis {
                 .and_then(|base| base.checked_sub(func.value_u64(*offset)?)),
             InstKind::SlicePtr(slice) => {
                 let Value::Inst(slice) = func.value(*slice) else { return None };
-                match &func.instructions[*slice].kind {
+                match &func.instruction(*slice).kind {
                     InstKind::MakeSlice { ptr, location: SliceLocation::Memory, .. } => {
                         Self::pointer_lower_bound(func, *ptr, depth + 1)
                     }
@@ -1526,15 +1524,14 @@ impl AliasAnalysis {
 
 fn cyclic_blocks(func: &Function) -> DenseBitSet<BlockId> {
     let successors: Vec<Vec<_>> =
-        func.blocks
-            .iter()
+        func.blocks()
             .map(|block| {
                 block.terminator.as_ref().map_or_else(Vec::new, |terminator| {
                     terminator.successors().into_iter().collect()
                 })
             })
             .collect();
-    let mut predecessors = vec![Vec::new(); func.blocks.len()];
+    let mut predecessors = vec![Vec::new(); func.block_count()];
     for (block, block_successors) in successors.iter().enumerate() {
         for &successor in block_successors {
             predecessors[successor.index()].push(BlockId::from_usize(block));
@@ -1544,9 +1541,9 @@ fn cyclic_blocks(func: &Function) -> DenseBitSet<BlockId> {
     // Kosaraju's two linear scans classify all strongly connected components.
     // Doing one reachability search per block made constructing this analysis
     // quadratic on functions with many basic blocks.
-    let mut visited = DenseBitSet::new_empty(func.blocks.len());
-    let mut finish_order = Vec::with_capacity(func.blocks.len());
-    for start in func.blocks.indices() {
+    let mut visited = DenseBitSet::new_empty(func.block_count());
+    let mut finish_order = Vec::with_capacity(func.block_count());
+    for start in func.block_ids() {
         if !visited.insert(start) {
             continue;
         }
@@ -1565,7 +1562,7 @@ fn cyclic_blocks(func: &Function) -> DenseBitSet<BlockId> {
         }
     }
 
-    let mut cyclic = DenseBitSet::new_empty(func.blocks.len());
+    let mut cyclic = DenseBitSet::new_empty(func.block_count());
     visited.clear();
     for start in finish_order.into_iter().rev() {
         if !visited.insert(start) {
@@ -1795,7 +1792,7 @@ mod tests {
             let source = builder.imm_u64(0x20);
             let size = builder.imm_u64(32);
             builder.mcopy(dest, source, size);
-            *builder.func().blocks[builder.current_block()].instructions.last().unwrap()
+            *builder.func().block(builder.current_block()).instructions.last().unwrap()
         };
         let aa = AliasAnalysis::new(&func);
         let effects = aa.instruction_mod_ref(&func, copy);
@@ -1816,7 +1813,7 @@ mod tests {
             let offset = builder.imm_u64(0x80);
             let size = builder.imm_u64(32);
             builder.staticcall(gas, address, offset, size, offset, size);
-            *builder.func().blocks[builder.current_block()].instructions.last().unwrap()
+            *builder.func().block(builder.current_block()).instructions.last().unwrap()
         };
         let effects = AliasAnalysis::new(&func).instruction_mod_ref(&func, call);
 

--- a/crates/codegen/src/analysis/call_graph.rs
+++ b/crates/codegen/src/analysis/call_graph.rs
@@ -16,11 +16,11 @@ impl CallGraphInfo {
     /// Computes call graph facts for `module`.
     #[must_use]
     pub(crate) fn new(module: &Module) -> Self {
-        let function_count = module.functions.len();
+        let function_count = module.function_count();
         let mut callees = FxHashMap::default();
         let mut entry_functions = DenseBitSet::new_empty(function_count);
 
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if Self::is_entry_function(func) {
                 entry_functions.insert(func_id);
             }
@@ -73,14 +73,14 @@ impl CallGraphInfo {
 
     fn collect_internal_callees(func: &Function, function_count: usize) -> DenseBitSet<FunctionId> {
         let mut callees = DenseBitSet::new_empty(function_count);
-        for inst in &func.instructions {
+        for inst in func.instructions() {
             if let InstKind::InternalCall { function, .. } = inst.kind {
                 callees.insert(function);
             }
         }
         // Tail calls transfer control to another function body: for
         // reachability and recursion purposes they are call edges.
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             if let Some(Terminator::TailCall { function, .. }) = &block.terminator {
                 callees.insert(*function);
             }

--- a/crates/codegen/src/analysis/cfg.rs
+++ b/crates/codegen/src/analysis/cfg.rs
@@ -31,8 +31,7 @@ impl CfgInfo {
     #[must_use]
     pub(crate) fn new(func: &Function) -> Self {
         let successors = func
-            .blocks
-            .iter()
+            .blocks()
             .map(|block| {
                 block.terminator.as_ref().map(|term| term.successors()).unwrap_or_default()
             })

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -56,13 +56,13 @@ impl Liveness {
     /// Computes liveness for a function.
     #[must_use]
     pub(crate) fn compute(func: &Function) -> Self {
-        let num_values = func.values.len();
-        let num_blocks = func.blocks.len();
+        let num_values = func.value_count();
+        let num_blocks = func.block_count();
 
         // Precompute InstId → ValueId mapping.
         // This replaces the O(n) linear scans that were previously done per-instruction.
         let mut inst_to_value: FxHashMap<InstId, ValueId> = FxHashMap::default();
-        for (val_id, val) in func.values.iter_enumerated() {
+        for (val_id, val) in func.values_enumerated() {
             if let Value::Inst(inst_id) = val {
                 inst_to_value.insert(*inst_id, val_id);
             }
@@ -86,7 +86,7 @@ impl Liveness {
 
         let mut operand_buf = SmallVec::<[ValueId; 8]>::new();
 
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             // Process instructions in forward order to compute upward-exposed uses and defs
             for &inst_id in &block.instructions {
                 let inst = func.instruction(inst_id);
@@ -122,14 +122,14 @@ impl Liveness {
         //
         // live_out(B) = union over S in succ(B) of live_in(S)
         // live_in(B) = block_uses(B) | (live_out(B) - block_defs(B))
-        let mut worklist: VecDeque<BlockId> = func.blocks.indices().rev().collect();
+        let mut worklist: VecDeque<BlockId> = func.block_ids().rev().collect();
         let mut queued = DenseBitSet::new_filled(num_blocks);
         let mut new_live_out = LiveSet::with_capacity(num_values);
         let mut new_live_in = LiveSet::with_capacity(num_values);
 
         while let Some(block_id) = worklist.pop_front() {
             queued.remove(block_id);
-            let block = &func.blocks[block_id];
+            let block = func.block(block_id);
 
             new_live_out.clear();
             let successors =
@@ -162,7 +162,7 @@ impl Liveness {
         // For each value, track the last instruction index where it's used within each block.
         let mut last_use_in_block: FxHashMap<(ValueId, BlockId), Option<usize>> =
             FxHashMap::default();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             // Check terminator uses - these are the last use in this block
             if let Some(term) = &block.terminator {
                 operand_buf.clear();
@@ -196,8 +196,8 @@ impl Liveness {
     /// need live-in/live-out tracking. Instruction results still retain exact
     /// last-use information for stack scheduling.
     pub(crate) fn compute_block_local_for_codegen(func: &Function) -> Option<Self> {
-        let num_values = func.values.len();
-        for val in &func.values {
+        let num_values = func.value_count();
+        for val in func.values() {
             match val {
                 Value::Inst(_) => {}
                 Value::Arg { .. } => return None,
@@ -205,8 +205,8 @@ impl Liveness {
             }
         }
 
-        let mut defining_blocks = index_vec![None; func.instructions.len()];
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        let mut defining_blocks = index_vec![None; func.instruction_count()];
+        for (block_id, block) in func.blocks_enumerated() {
             for &inst_id in &block.instructions {
                 defining_blocks[inst_id] = Some(block_id);
             }
@@ -218,7 +218,7 @@ impl Liveness {
             Value::Immediate(_) | Value::Undef(_) | Value::Error(_) => true,
         };
         let mut operands = SmallVec::<[ValueId; 8]>::new();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             for &inst_id in &block.instructions {
                 operands.clear();
                 func.instruction(inst_id).kind.collect_operands(&mut operands);
@@ -240,10 +240,10 @@ impl Liveness {
                 live_in: LiveSet::new_empty(),
                 live_out: LiveSet::new_empty(),
             };
-            func.blocks.len()
+            func.block_count()
         ];
         let mut last_use_in_block = FxHashMap::default();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             if let Some(term) = &block.terminator {
                 operands.clear();
                 collect_terminator_uses(term, &mut operands);
@@ -277,7 +277,7 @@ impl Liveness {
 
     #[cfg(test)]
     fn live_at_inst(&self, func: &Function, block_id: BlockId, inst_idx: usize) -> LivenessInfo {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
         let inst_to_value = func.inst_results();
         let mut live = self.block_liveness[block_id].live_out.clone();
 
@@ -858,8 +858,8 @@ mod tests {
             crate::mir::InstKind::Phi(vec![(entry, init), (body, updated)]),
             Some(MirType::uint256()),
         ));
-        func.blocks[header].instructions.insert(0, phi_inst);
-        func.values[phi_val] = crate::mir::Value::Inst(phi_inst);
+        func.block_mut(header).instructions.insert(0, phi_inst);
+        *func.value_mut(phi_val) = crate::mir::Value::Inst(phi_inst);
 
         let liveness = Liveness::compute(&func);
 

--- a/crates/codegen/src/analysis/loop_analysis.rs
+++ b/crates/codegen/src/analysis/loop_analysis.rs
@@ -118,18 +118,18 @@ impl LoopAnalyzer {
         let Some(cfg) = &self.cfg else { return Vec::new() };
 
         for &block_id in cfg.rpo() {
-            let block = &func.blocks[block_id];
+            let block = func.block(block_id);
             if let Some(term) = &block.terminator {
                 for succ in term.successors() {
                     if cfg.dominators().dominates(succ, block_id) {
                         let loop_info = loops.entry(succ).or_insert_with(|| Loop {
                             header: succ,
-                            blocks: DenseBitSet::new_empty(func.blocks.len()),
+                            blocks: DenseBitSet::new_empty(func.block_count()),
                             back_edges: SmallVec::new(),
                             exit_blocks: SmallVec::new(),
                             preheader: None,
                             induction_vars: Vec::new(),
-                            invariant_insts: DenseBitSet::new_empty(func.instructions.len()),
+                            invariant_insts: DenseBitSet::new_empty(func.instruction_count()),
                             trip_count: None,
                             trip_guard_is_header: false,
                         });
@@ -156,7 +156,7 @@ impl LoopAnalyzer {
             worklist.push(back_edge_src);
         }
         while let Some(block) = worklist.pop() {
-            for &pred in &func.blocks[block].predecessors {
+            for &pred in &func.block(block).predecessors {
                 if blocks.insert(pred) {
                     worklist.push(pred);
                 }
@@ -166,7 +166,7 @@ impl LoopAnalyzer {
 
     fn find_exit_blocks(&self, func: &Function, loop_info: &mut Loop) {
         for block_id in &loop_info.blocks {
-            if let Some(term) = &func.blocks[block_id].terminator {
+            if let Some(term) = &func.block(block_id).terminator {
                 for succ in term.successors() {
                     if !loop_info.blocks.contains(succ) && !loop_info.exit_blocks.contains(&succ) {
                         loop_info.exit_blocks.push(succ);
@@ -177,7 +177,8 @@ impl LoopAnalyzer {
     }
 
     fn find_preheader(&self, func: &Function, loop_info: &mut Loop) {
-        let header_preds: Vec<BlockId> = func.blocks[loop_info.header]
+        let header_preds: Vec<BlockId> = func
+            .block(loop_info.header)
             .predecessors
             .iter()
             .filter(|&&pred| !loop_info.blocks.contains(pred))
@@ -192,12 +193,12 @@ impl LoopAnalyzer {
     }
 
     fn is_dedicated_preheader(&self, func: &Function, block: BlockId, header: BlockId) -> bool {
-        matches!(func.blocks[block].terminator.as_ref(), Some(Terminator::Jump(target)) if *target == header)
+        matches!(func.block(block).terminator.as_ref(), Some(Terminator::Jump(target)) if *target == header)
     }
 
     fn analyze_induction_vars(&self, func: &Function, loop_info: &mut Loop) {
-        for &inst_id in &func.blocks[loop_info.header].instructions {
-            let inst = &func.instructions[inst_id];
+        for &inst_id in &func.block(loop_info.header).instructions {
+            let inst = func.instruction(inst_id);
 
             if let InstKind::Phi(incoming) = &inst.kind {
                 let mut init_value: Option<ValueId> = None;
@@ -253,8 +254,8 @@ impl LoopAnalyzer {
         phi_val: ValueId,
         step_val: ValueId,
     ) -> Option<InstId> {
-        if let Value::Inst(inst_id) = &func.values[step_val] {
-            let inst = &func.instructions[*inst_id];
+        if let Value::Inst(inst_id) = func.value(step_val) {
+            let inst = func.instruction(*inst_id);
             match &inst.kind {
                 InstKind::Add(a, b) if *a == phi_val || *b == phi_val => return Some(*inst_id),
                 InstKind::Sub(a, _) if *a == phi_val => return Some(*inst_id),
@@ -271,7 +272,7 @@ impl LoopAnalyzer {
         inst_id: InstId,
         phi_val: ValueId,
     ) -> Option<(ValueId, bool)> {
-        let inst = &func.instructions[inst_id];
+        let inst = func.instruction(inst_id);
         match &inst.kind {
             InstKind::Add(a, b) => {
                 let step = if *a == phi_val { *b } else { *a };
@@ -279,7 +280,7 @@ impl LoopAnalyzer {
                 // constant (two's-complement negative); classify it as
                 // descending so trip-count and range reasoning bail out.
                 let descending = matches!(
-                    &func.values[step],
+                    &func.value(step),
                     Value::Immediate(imm) if imm.as_u256().is_some_and(|v| v.bit(255))
                 );
                 Some((step, descending))
@@ -290,9 +291,9 @@ impl LoopAnalyzer {
     }
 
     fn find_invariant_instructions(&self, func: &Function, loop_info: &mut Loop) {
-        let mut invariant_values = DenseBitSet::new_empty(func.values.len());
+        let mut invariant_values = DenseBitSet::new_empty(func.value_count());
 
-        for (value_id, value) in func.values.iter_enumerated() {
+        for (value_id, value) in func.values_enumerated() {
             match value {
                 Value::Immediate(_) | Value::Arg { .. } => {
                     invariant_values.insert(value_id);
@@ -301,7 +302,7 @@ impl LoopAnalyzer {
                     let in_loop = loop_info
                         .blocks
                         .iter()
-                        .any(|block| func.blocks[block].instructions.contains(inst_id));
+                        .any(|block| func.block(block).instructions.contains(inst_id));
                     if !in_loop {
                         invariant_values.insert(value_id);
                     }
@@ -314,8 +315,8 @@ impl LoopAnalyzer {
         while changed {
             changed = false;
             for block_id in &loop_info.blocks {
-                for &inst_id in &func.blocks[block_id].instructions {
-                    let inst = &func.instructions[inst_id];
+                for &inst_id in &func.block(block_id).instructions {
+                    let inst = func.instruction(inst_id);
 
                     if loop_info.invariant_insts.contains(inst_id) {
                         continue;
@@ -347,12 +348,12 @@ impl LoopAnalyzer {
 
         let iv = &loop_info.induction_vars[0];
 
-        let init = match &func.values[iv.init] {
+        let init = match func.value(iv.init) {
             Value::Immediate(imm) => imm.as_u256(),
             _ => return,
         };
 
-        let step = match &func.values[iv.step] {
+        let step = match func.value(iv.step) {
             Value::Immediate(imm) => imm.as_u256(),
             _ => return,
         };
@@ -404,7 +405,7 @@ impl LoopAnalyzer {
         let mut bound: Option<(alloy_primitives::U256, BlockId)> = None;
         for block_id in blocks {
             let Some(Terminator::Branch { condition, then_block, else_block }) =
-                &func.blocks[block_id].terminator
+                &func.block(block_id).terminator
             else {
                 continue;
             };
@@ -417,13 +418,13 @@ impl LoopAnalyzer {
             if !loop_info.back_edges.iter().all(|&latch| self.dominates(block_id, latch)) {
                 continue;
             }
-            let Value::Inst(cond_inst) = &func.values[*condition] else { continue };
-            let imm = match &func.instructions[*cond_inst].kind {
+            let Value::Inst(cond_inst) = func.value(*condition) else { continue };
+            let imm = match &func.instruction(*cond_inst).kind {
                 InstKind::Lt(a, b) if *a == iv_value => *b,
                 InstKind::Gt(a, b) if *b == iv_value => *a,
                 _ => continue,
             };
-            let Value::Immediate(imm) = &func.values[imm] else { continue };
+            let Value::Immediate(imm) = func.value(imm) else { continue };
             let Some(this_bound) = imm.as_u256() else { continue };
             match bound {
                 None => bound = Some((this_bound, block_id)),
@@ -439,7 +440,7 @@ impl LoopAnalyzer {
     }
 
     fn find_result_value(&self, func: &Function, inst_id: InstId) -> Option<ValueId> {
-        for (value_id, value) in func.values.iter_enumerated() {
+        for (value_id, value) in func.values_enumerated() {
             if let Value::Inst(id) = value
                 && *id == inst_id
             {
@@ -469,19 +470,19 @@ mod tests {
         let body = func.alloc_block();
         let exit = func.alloc_block();
 
-        func.blocks[entry].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(entry);
+        func.block_mut(entry).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(entry);
 
         let cond = func.alloc_value(Value::Immediate(Immediate::bool(true)));
-        func.blocks[header].terminator =
+        func.block_mut(header).terminator =
             Some(Terminator::Branch { condition: cond, then_block: body, else_block: exit });
-        func.blocks[body].predecessors.push(header);
-        func.blocks[exit].predecessors.push(header);
+        func.block_mut(body).predecessors.push(header);
+        func.block_mut(exit).predecessors.push(header);
 
-        func.blocks[body].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(body);
+        func.block_mut(body).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(body);
 
-        func.blocks[exit].terminator = Some(Terminator::Stop);
+        func.block_mut(exit).terminator = Some(Terminator::Stop);
 
         let mut analyzer = LoopAnalyzer::new();
         let info = analyzer.analyze(&func);

--- a/crates/codegen/src/analysis/memory_summary.rs
+++ b/crates/codegen/src/analysis/memory_summary.rs
@@ -75,26 +75,26 @@ impl MemoryCallSummaries {
     /// Computes summaries to a monotone fixpoint over the module call graph.
     #[must_use]
     pub(crate) fn new(module: &Module) -> Self {
-        let mut local = IndexVec::with_capacity(module.functions.len());
-        for func in &module.functions {
+        let mut local = IndexVec::with_capacity(module.function_count());
+        for func in module.functions() {
             local.push(local_summary(func));
         }
         let mut summaries = local.clone();
 
         loop {
             let previous = summaries.clone();
-            for (func_id, func) in module.functions.iter_enumerated() {
-                if func.blocks.is_empty() {
+            for (func_id, func) in module.iter_functions() {
+                if func.has_no_blocks() {
                     summaries[func_id] = FunctionMemorySummary::conservative(func.params.len());
                     continue;
                 }
 
                 let mut summary = local[func_id].clone();
                 let sources = parameter_sources(func);
-                for block in &func.blocks {
+                for block in func.blocks() {
                     for &inst_id in &block.instructions {
                         if let InstKind::InternalCall { function, ref args, .. } =
-                            func.instructions[inst_id].kind
+                            func.instruction(inst_id).kind
                         {
                             let callee = previous
                                 .get(function)
@@ -147,16 +147,16 @@ const fn space_index(space: AddressSpace) -> usize {
 }
 
 fn local_summary(func: &Function) -> FunctionMemorySummary {
-    if func.blocks.is_empty() {
+    if func.has_no_blocks() {
         return FunctionMemorySummary::conservative(func.params.len());
     }
 
     let mut summary = FunctionMemorySummary::empty(func.params.len());
     let sources = parameter_sources(func);
     let aa = AliasAnalysis::new(func);
-    for block in &func.blocks {
+    for block in func.blocks() {
         for &inst_id in &block.instructions {
-            let kind = &func.instructions[inst_id].kind;
+            let kind = &func.instruction(inst_id).kind;
             if matches!(kind, InstKind::InternalCall { .. }) {
                 continue;
             }
@@ -195,11 +195,11 @@ fn capture_sources(summary: &mut FunctionMemorySummary, sources: &DenseBitSet<us
 /// deliberately not guessed, and storing a parameter is already a capture.
 fn parameter_sources(func: &Function) -> IndexVec<ValueId, DenseBitSet<usize>> {
     let params = func.params.len();
-    let mut sources = IndexVec::with_capacity(func.values.len());
-    for _ in 0..func.values.len() {
+    let mut sources = IndexVec::with_capacity(func.value_count());
+    for _ in 0..func.value_count() {
         sources.push(DenseBitSet::new_empty(params));
     }
-    for (value_id, value) in func.values.iter_enumerated() {
+    for (value_id, value) in func.values_enumerated() {
         if let Value::Arg { index, .. } = value
             && (*index as usize) < params
         {
@@ -209,9 +209,9 @@ fn parameter_sources(func: &Function) -> IndexVec<ValueId, DenseBitSet<usize>> {
 
     loop {
         let mut changed = false;
-        for (value_id, value) in func.values.iter_enumerated() {
+        for (value_id, value) in func.values_enumerated() {
             let Value::Inst(inst_id) = value else { continue };
-            let operands = match &func.instructions[*inst_id].kind {
+            let operands = match &func.instruction(*inst_id).kind {
                 InstKind::Add(first, second)
                 | InstKind::Sub(first, second)
                 | InstKind::MakeSlice { ptr: first, len: second, .. } => {

--- a/crates/codegen/src/analysis/phi_elimination.rs
+++ b/crates/codegen/src/analysis/phi_elimination.rs
@@ -70,7 +70,7 @@ impl PhiEliminator {
         let mut phis_to_remove = Vec::new();
 
         // Process each block looking for phi instructions
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             for (inst_idx, &inst_id) in block.instructions.iter().enumerate() {
                 let inst = func.instruction(inst_id);
 
@@ -108,7 +108,7 @@ impl PhiEliminator {
 
 /// Finds the ValueId that is defined by a phi instruction.
 fn find_phi_dst(func: &Function, inst_id: InstId) -> Option<ValueId> {
-    for (val_id, val) in func.values.iter_enumerated() {
+    for (val_id, val) in func.values_enumerated() {
         if let Value::Inst(def_inst) = val
             && *def_inst == inst_id
         {

--- a/crates/codegen/src/analysis/scalar_evolution.rs
+++ b/crates/codegen/src/analysis/scalar_evolution.rs
@@ -111,7 +111,7 @@ impl ScalarEvolution {
     #[must_use]
     pub(crate) fn analyze(func: &Function, loop_data: &Loop) -> Self {
         let mut analysis = Self::default();
-        for value in func.values.indices() {
+        for value in func.value_ids() {
             let _ = analysis.affine_expr(func, loop_data, value);
         }
         analysis
@@ -144,7 +144,7 @@ impl ScalarEvolution {
                 if loop_data.induction_vars.iter().any(|iv| iv.value == value) {
                     AffineExpr::induction(value)
                 } else {
-                    match func.instructions[*inst_id].kind {
+                    match func.instruction(*inst_id).kind {
                         InstKind::Add(a, b) => {
                             let a = self.affine_expr(func, loop_data, a)?;
                             let b = self.affine_expr(func, loop_data, b)?;
@@ -197,7 +197,7 @@ fn value_defined_in_loop(func: &Function, value: ValueId, loop_data: &Loop) -> b
         Value::Inst(inst_id) => loop_data
             .blocks
             .iter()
-            .any(|block_id| func.blocks[block_id].instructions.contains(inst_id)),
+            .any(|block_id| func.block(block_id).instructions.contains(inst_id)),
         Value::Undef(_) | Value::Error(_) => true,
         Value::Arg { .. } | Value::Immediate(_) => false,
     }

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -6,10 +6,10 @@
 //!
 //! # Checks performed
 //!
-//! 1. **Defined-before-use**: every `ValueId` referenced as an operand has an entry in
-//!    `func.values`.
+//! 1. **Defined-before-use**: every `ValueId` referenced as an operand has an entry in the
+//!    function's value table.
 //! 2. **Block reference validity**: every `BlockId` mentioned in a terminator or phi has an entry
-//!    in `func.blocks`.
+//!    in the function's block table.
 //! 3. **Single definition**: each `InstId` is referenced by at most one `Value::Inst` entry.
 //! 4. **Terminator presence**: every block has a terminator.
 //! 5. **Predecessor back-link**: if A's terminator targets B, then B's `predecessors` contains A.
@@ -94,9 +94,9 @@ impl<'a> Validator<'a> {
 
     fn validate_function_body(&mut self, func: &Function) {
         let errors_before = self.error_count;
-        let num_values = func.values.len();
-        let num_blocks = func.blocks.len();
-        let num_insts = func.instructions.len();
+        let num_values = func.value_count();
+        let num_blocks = func.block_count();
+        let num_insts = func.instruction_count();
 
         if num_blocks == 0 {
             self.emit("function has no entry block");
@@ -108,7 +108,7 @@ impl<'a> Validator<'a> {
         let mut inst_def_count: IndexVec<InstId, usize> = index_vec![0; num_insts];
         let mut invalid_inst_def_count: FxHashMap<InstId, usize> = FxHashMap::default();
         let mut inst_results: IndexVec<InstId, Option<ValueId>> = index_vec![None; num_insts];
-        for (value_id, v) in func.values.iter_enumerated() {
+        for (value_id, v) in func.values_enumerated() {
             if let Value::Inst(inst_id) = v {
                 if inst_id.index() < num_insts {
                     inst_def_count[*inst_id] += 1;
@@ -126,11 +126,11 @@ impl<'a> Validator<'a> {
                 ));
             }
             // Only value-producing instructions may have a result value.
-            if count != 0 && func.instructions[inst_id].result_ty.is_none() {
+            if count != 0 && func.instruction(inst_id).result_ty.is_none() {
                 self.emit(format_args!(
                     "instruction inst{} (`{:?}`) has a result Value entry but no result type",
                     inst_id.index(),
-                    func.instructions[inst_id].kind
+                    func.instruction(inst_id).kind
                 ));
             }
         }
@@ -144,7 +144,7 @@ impl<'a> Validator<'a> {
         }
 
         // ----- Walk every block -----
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             // Check terminator presence.
             let term = match &block.terminator {
                 Some(t) => t,
@@ -165,7 +165,7 @@ impl<'a> Validator<'a> {
                     );
                     continue;
                 }
-                if !func.blocks[succ].predecessors.contains(&block_id) {
+                if !func.block(succ).predecessors.contains(&block_id) {
                     self.emit_at_block(
                         format_args!(
                             "successor bb{} does not list bb{} as a predecessor",
@@ -189,7 +189,7 @@ impl<'a> Validator<'a> {
                     );
                     continue;
                 }
-                let Some(pred_term) = &func.blocks[pred].terminator else {
+                let Some(pred_term) = &func.block(pred).terminator else {
                     self.emit_at_block(
                         format_args!("stored predecessor bb{} has no terminator", pred.index()),
                         block_id,
@@ -313,7 +313,7 @@ impl<'a> Validator<'a> {
         }
 
         // ----- Entry block invariants -----
-        if !func.blocks[BlockId::ENTRY].predecessors.is_empty() {
+        if !func.block(BlockId::ENTRY).predecessors.is_empty() {
             self.emit_at_block("entry block must have no predecessors", BlockId::ENTRY);
         }
 
@@ -332,7 +332,7 @@ impl<'a> Validator<'a> {
         let cfg = CfgInfo::new(func);
         let mut def_location_of: IndexVec<ValueId, Option<(BlockId, usize)>> =
             index_vec![None; num_values];
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             for (index, &inst_id) in block.instructions.iter().enumerate() {
                 if let Some(result) = inst_results[inst_id] {
                     def_location_of[result] = Some((block_id, index));
@@ -342,10 +342,10 @@ impl<'a> Validator<'a> {
         let mut reach_cache: FxHashMap<BlockId, DenseBitSet<BlockId>> = FxHashMap::default();
         let mut reaches = |from: BlockId, to: BlockId| {
             let set = reach_cache.entry(from).or_insert_with(|| {
-                let mut seen = DenseBitSet::new_empty(func.blocks.len());
+                let mut seen = DenseBitSet::new_empty(func.block_count());
                 let mut stack = vec![from];
                 while let Some(current) = stack.pop() {
-                    if let Some(term) = func.blocks[current].terminator.as_ref() {
+                    if let Some(term) = func.block(current).terminator.as_ref() {
                         for succ in term.successors() {
                             if seen.insert(succ) {
                                 stack.push(succ);
@@ -357,13 +357,13 @@ impl<'a> Validator<'a> {
             });
             set.contains(to)
         };
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             if !cfg.is_reachable(block_id) {
                 continue;
             }
             let block_in_cycle = reaches(block_id, block_id);
             for (index, &inst_id) in block.instructions.iter().enumerate() {
-                match &func.instructions[inst_id].kind {
+                match &func.instruction(inst_id).kind {
                     InstKind::Phi(incoming) => {
                         for &(pred, value) in incoming {
                             if let Some((def, _)) = def_location_of[value]
@@ -445,11 +445,11 @@ impl<'a> Validator<'a> {
 
     /// Checks that call targets exist and argument counts match.
     fn validate_calls(&mut self, module: &Module, func: &Function) {
-        for inst in &func.instructions {
+        for inst in func.instructions() {
             let InstKind::InternalCall { function, args, .. } = &inst.kind else {
                 continue;
             };
-            let Some(callee) = module.functions.get(*function) else {
+            let Some(callee) = module.get_function(*function) else {
                 self.emit(format_args!(
                     "internal_call targets nonexistent function fn{}",
                     function.index()
@@ -465,12 +465,12 @@ impl<'a> Validator<'a> {
                 ));
             }
         }
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             let Some(crate::mir::Terminator::TailCall { function, args }) = &block.terminator
             else {
                 continue;
             };
-            let Some(callee) = module.functions.get(*function) else {
+            let Some(callee) = module.get_function(*function) else {
                 self.emit(format_args!(
                     "tail_call targets nonexistent function fn{}",
                     function.index()
@@ -495,8 +495,8 @@ impl<'a> Validator<'a> {
         // From the `dispatch` phase on, routing is materialized: a module with
         // selector functions must contain the synthesized `entry`.
         if module.phase >= crate::mir::MirPhase::Dispatch
-            && module.functions.iter().any(|f| f.selector.is_some())
-            && !module.functions.iter().any(|f| f.name.name == sym::entry)
+            && module.functions().any(|f| f.selector.is_some())
+            && !module.functions().any(|f| f.name.name == sym::entry)
         {
             self.emit(format_args!(
                 "module is in the `{}` phase but has no `entry` dispatcher function",
@@ -530,7 +530,7 @@ impl<'a> Validator<'a> {
                     ));
                 }
             }
-            for value in func.values.iter() {
+            for value in func.values() {
                 if let Value::Undef(ty) = value
                     && matches!(ty, crate::mir::MirType::MemoryObject(_))
                 {
@@ -540,9 +540,9 @@ impl<'a> Validator<'a> {
                     ));
                 }
             }
-            for (block_id, block) in func.blocks.iter_enumerated() {
+            for (block_id, block) in func.blocks_enumerated() {
                 for &inst_id in &block.instructions {
-                    let inst = &func.instructions[inst_id];
+                    let inst = func.instruction(inst_id);
                     let semantic = matches!(
                         inst.kind,
                         InstKind::Alloc { kind: crate::mir::AllocationKind::Object(_), .. }
@@ -573,9 +573,9 @@ impl<'a> Validator<'a> {
         // backend. High-level memory operations must have been expanded by
         // their named lowering passes before the module enters this phase.
         if module.phase >= crate::mir::MirPhase::EvmShaped {
-            for (block_id, block) in func.blocks.iter_enumerated() {
+            for (block_id, block) in func.blocks_enumerated() {
                 for &inst_id in &block.instructions {
-                    let kind = &func.instructions[inst_id].kind;
+                    let kind = &func.instruction(inst_id).kind;
                     let semantic_op = match kind {
                         InstKind::MakeSlice { .. }
                         | InstKind::SlicePtr(_)
@@ -615,8 +615,8 @@ pub(crate) fn validate(dcx: &DiagCtxt, module: &Module) {
 mod tests {
     use super::*;
     use crate::mir::{
-        AbiLayout, AbiType, BasicBlock, Function, FunctionBuilder, FunctionId, MirPhase, MirType,
-        Module, SliceLocation, StorageField, StorageLayout, Terminator,
+        AbiLayout, AbiType, Function, FunctionBuilder, FunctionId, MirPhase, MirType, Module,
+        SliceLocation, StorageField, StorageLayout, Terminator,
     };
     use snapbox::{assert_data_eq, str};
     use solar_interface::{ColorChoice, Ident, Session};
@@ -682,7 +682,7 @@ error: [bb0] block has no terminator
             }
             // Manually corrupt: replace the terminator with a Jump to a nonexistent block.
             let bad_block = BlockId::from_usize(99);
-            func.blocks[BlockId::ENTRY].terminator = Some(Terminator::Jump(bad_block));
+            func.block_mut(BlockId::ENTRY).terminator = Some(Terminator::Jump(bad_block));
             Validator::new(&sess.dcx).validate_standalone_function(&func);
             assert!(sess.dcx.has_errors().is_err());
             assert_data_eq!(
@@ -711,7 +711,7 @@ error: [bb0] terminator references nonexistent block bb99
             Validator::new(&sess.dcx).validate_standalone_function(&func);
             assert!(sess.dcx.has_errors().is_ok());
             // Drop the back-link.
-            func.blocks[target].predecessors.clear();
+            func.block_mut(target).predecessors.clear();
             Validator::new(&sess.dcx).validate_standalone_function(&func);
             assert!(sess.dcx.has_errors().is_err());
             assert_data_eq!(
@@ -736,7 +736,7 @@ error: [bb0] successor bb1 does not list bb0 as a predecessor
                 b.stop();
             }
             // Add the invalid predecessor to the entry block.
-            func.blocks[BlockId::ENTRY].predecessors.push(BlockId::ENTRY);
+            func.block_mut(BlockId::ENTRY).predecessors.push(BlockId::ENTRY);
             Validator::new(&sess.dcx).validate_standalone_function(&func);
             assert!(sess.dcx.has_errors().is_err());
             assert_data_eq!(
@@ -772,24 +772,14 @@ error: [bb0] entry block must have no predecessors
 
             Validator::new(&sess.dcx).validate_module(&module);
             assert!(sess.dcx.has_errors().is_err());
-            let diagnostics = sess.emitted_diagnostics().unwrap().to_string();
-            assert!(diagnostics.contains("slice instruction"));
-            assert!(diagnostics.contains("ABI encoding instruction"));
-            assert!(diagnostics.contains("aggregate instruction"));
-        });
-    }
-
-    #[test]
-    fn function_without_entry_block_is_caught() {
-        with_session(|sess| {
-            let mut func = make_func();
-            func.blocks.clear();
-            Validator::new(&sess.dcx).validate_standalone_function(&func);
-            assert!(sess.dcx.has_errors().is_err());
             assert_data_eq!(
                 sess.emitted_diagnostics().unwrap().to_string(),
                 str![[r#"
-error: function has no entry block
+error: [fn0] [bb0, inst0] slice instruction `make_memory_slice` survives the `evm-shaped` phase boundary
+
+error: [fn0] [bb0, inst1] ABI encoding instruction `abi_encode` survives the `evm-shaped` phase boundary
+
+error: [fn0] [bb0, inst2] aggregate instruction `storage_to_memory` survives the `evm-shaped` phase boundary
 
 
 "#]]
@@ -832,11 +822,5 @@ error: [fn0] internal_call targets nonexistent function fn99
 "#]]
             );
         });
-    }
-
-    // Suppress the unused-import warning for `BasicBlock`.
-    #[allow(dead_code)]
-    fn _block_type_reference() -> Option<BasicBlock> {
-        None
     }
 }

--- a/crates/codegen/src/backend/evm/assembler/mod.rs
+++ b/crates/codegen/src/backend/evm/assembler/mod.rs
@@ -222,7 +222,7 @@ impl<'gcx> Assembler<'gcx> {
 
     /// Defines a label and emits a `JUMPDEST` at the current position.
     pub(crate) fn define_label(&mut self, label: Label) {
-        let mut block = ir::Block::new(self.program.blocks.len() as u32);
+        let mut block = ir::Block::new(self.program.block_count() as u32);
         if self.cold_labels.contains(label) {
             block.metadata.hotness = ir::Hotness::Cold;
         }
@@ -236,7 +236,7 @@ impl<'gcx> Assembler<'gcx> {
     pub(in crate::backend::evm) fn mark_label_cold(&mut self, label: Label) {
         self.cold_labels.insert(label);
         if let Some(&block) = self.label_blocks.get(&label) {
-            self.program.blocks[block].metadata.hotness = ir::Hotness::Cold;
+            self.program.block_mut(block).metadata.hotness = ir::Hotness::Cold;
         }
     }
 
@@ -248,7 +248,7 @@ impl<'gcx> Assembler<'gcx> {
         if let Some(block) = self.current_block {
             return block;
         }
-        let block = self.program.add_block(ir::Block::new(self.program.blocks.len() as u32));
+        let block = self.program.add_block(ir::Block::new(self.program.block_count() as u32));
         self.current_block = Some(block);
         self.block_labels.push(None);
         block
@@ -256,8 +256,8 @@ impl<'gcx> Assembler<'gcx> {
 
     fn push_ir_instruction(&mut self, instruction: ir::Instruction) -> (ir::BlockId, usize) {
         let block = self.current_block();
-        let index = self.program.blocks[block].instructions.len();
-        self.program.blocks[block].instructions.push(instruction);
+        let index = self.program.block(block).instructions.len();
+        self.program.block_mut(block).instructions.push(instruction);
         (block, index)
     }
 
@@ -278,7 +278,7 @@ impl<'gcx> Assembler<'gcx> {
     fn finish_evm_ir(&mut self) -> Option<(ir::Module, Vec<Option<Label>>)> {
         let mut module = std::mem::replace(&mut self.program, Self::new_ir_module());
         self.current_block = None;
-        if module.blocks.is_empty() {
+        if module.has_no_blocks() {
             return None;
         }
 
@@ -288,10 +288,10 @@ impl<'gcx> Assembler<'gcx> {
                 .get(&label)
                 .copied()
                 .unwrap_or_else(|| panic!("label {label:?} was never defined"));
-            module.blocks[block].instructions[instruction] = ir::Instruction::push_block(target);
+            module.block_mut(block).instructions[instruction] = ir::Instruction::push_block(target);
         }
         for (block, instruction, id) in self.deferred_relocations.drain(..) {
-            module.blocks[block].instructions[instruction] = ir::Instruction::push_deferred(id);
+            module.block_mut(block).instructions[instruction] = ir::Instruction::push_deferred(id);
         }
         // Allocation placeholders expand to more than one instruction, so they
         // splice after every in-place relocation patch above. Descending
@@ -318,7 +318,7 @@ impl<'gcx> Assembler<'gcx> {
                     ir::Instruction::opcode(op::MSTORE),
                 ],
             };
-            module.blocks[block].instructions.splice(instruction..=instruction, replacement);
+            module.block_mut(block).instructions.splice(instruction..=instruction, replacement);
         }
         self.deferred_allocations.clear();
         self.label_blocks.clear();
@@ -329,11 +329,11 @@ impl<'gcx> Assembler<'gcx> {
     }
 
     fn finalize_evm_ir(module: &mut ir::Module) {
-        for index in 0..module.blocks.len() {
+        for index in 0..module.block_count() {
             let block_id = ir::BlockId::from_usize(index);
             let next =
-                (index + 1 < module.blocks.len()).then(|| ir::BlockId::from_usize(index + 1));
-            let block = &mut module.blocks[block_id];
+                (index + 1 < module.block_count()).then(|| ir::BlockId::from_usize(index + 1));
+            let block = module.block_mut(block_id);
             let (kind, remove) = if let [.., push, jump] = block.instructions.as_slice()
                 && !jump.is_encoded_push()
                 && jump.opcode == op::JUMP
@@ -406,7 +406,7 @@ impl<'gcx> Assembler<'gcx> {
         module: &mut ir::Module,
         values: &FxHashMap<DeferredConst, U256>,
     ) {
-        for block in &mut module.blocks {
+        for block in module.blocks_mut() {
             for inst in &mut block.instructions {
                 let Some(id) = inst.deferred_push() else { continue };
                 if let Some(&value) = values.get(&id) {
@@ -440,7 +440,7 @@ impl<'gcx> Assembler<'gcx> {
 
         let evm_ir = prepared.evm_ir.as_ref().map(|module| {
             let mut module = module.clone();
-            for block in &mut module.blocks {
+            for block in module.blocks_mut() {
                 for inst in &mut block.instructions {
                     if let Some(id) = inst.deferred_push() {
                         let value = self.deferred_values.get(&id).copied().unwrap_or_else(|| {
@@ -775,7 +775,7 @@ PUSH4 0x80000000
 
 "#]]
             );
-            assert!(asm.program.blocks.is_empty());
+            assert!(asm.program.has_no_blocks());
             assert_eq!(asm.push_values.len(), 0);
 
             asm.emit_push(U256::from(2));

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -129,8 +129,7 @@ impl GlobalStackPlan {
 
         let mut entries = FxHashMap::default();
         let args_by_index: FxHashMap<_, _> = func
-            .values
-            .iter_enumerated()
+            .values_enumerated()
             .filter_map(|(value, kind)| match kind {
                 crate::mir::Value::Arg { index, .. } => Some((*index, value)),
                 _ => None,
@@ -146,9 +145,9 @@ impl GlobalStackPlan {
         }
         let mut decode_blocks = FxHashMap::default();
         let mut aliases = FxHashMap::default();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             for &inst_id in &block.instructions {
-                let InstKind::CalldataLoad(offset) = &func.instructions[inst_id].kind else {
+                let InstKind::CalldataLoad(offset) = &func.instruction(inst_id).kind else {
                     continue;
                 };
                 let Some(offset) = func.value_u64(*offset) else {
@@ -167,9 +166,9 @@ impl GlobalStackPlan {
             }
         }
 
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             if !cfg.is_reachable(block_id)
-                || func.blocks[block_id].predecessors.is_empty()
+                || func.block(block_id).predecessors.is_empty()
                 || stack_phi_plan.entries.contains_key(&block_id)
                 || Self::is_terminal_block(func, block_id)
             {
@@ -201,9 +200,9 @@ impl GlobalStackPlan {
         let mut changed = true;
         while changed {
             changed = false;
-            for block_id in func.blocks.indices() {
+            for block_id in func.block_ids() {
                 let Some(Terminator::Branch { then_block, else_block, .. }) =
-                    func.blocks[block_id].terminator.as_ref()
+                    func.block(block_id).terminator.as_ref()
                 else {
                     continue;
                 };
@@ -230,13 +229,13 @@ impl GlobalStackPlan {
         // Switch lowering owns the selector stack, and stack-phi loop headers
         // own their edge layouts. Disable their whole branch-sibling component
         // so every predecessor of every affected block still agrees.
-        let mut disabled = DenseBitSet::new_empty(func.blocks.len());
+        let mut disabled = DenseBitSet::new_empty(func.block_count());
         for &block in stack_phi_plan.entries.keys() {
             disabled.insert(block);
         }
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             if let Some(Terminator::Switch { default, cases, .. }) =
-                func.blocks[block_id].terminator.as_ref()
+                func.block(block_id).terminator.as_ref()
             {
                 disabled.insert(*default);
                 for &(_, target) in cases {
@@ -247,9 +246,9 @@ impl GlobalStackPlan {
         let mut changed = true;
         while changed {
             changed = false;
-            for block_id in func.blocks.indices() {
+            for block_id in func.block_ids() {
                 let Some(Terminator::Branch { then_block, else_block, .. }) =
-                    func.blocks[block_id].terminator.as_ref()
+                    func.block(block_id).terminator.as_ref()
                 else {
                     continue;
                 };
@@ -270,9 +269,10 @@ impl GlobalStackPlan {
         // Require enough real argument reuse to recover that fixed cost, and
         // reject dense layout plans unless a long CFG can amortize them.
         let mut arg_uses = 0usize;
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                arg_uses += func.instructions[inst_id]
+                arg_uses += func
+                    .instruction(inst_id)
                     .kind
                     .operands()
                     .iter()
@@ -340,7 +340,7 @@ impl GlobalStackPlan {
 
     fn is_terminal_block(func: &Function, block: BlockId) -> bool {
         matches!(
-            func.blocks[block].terminator,
+            func.block(block).terminator,
             Some(Terminator::Revert { .. } | Terminator::Invalid)
         )
     }
@@ -380,7 +380,7 @@ impl<'a> StackPhiPlanner<'a> {
 
     fn collect_header_results(&mut self) {
         for loop_info in &self.loops {
-            let block = &self.func.blocks[loop_info.header];
+            let block = self.func.block(loop_info.header);
             let phi_insts = self.leading_phi_insts(block);
             if let Some(results) = self.phi_result_values(&phi_insts) {
                 self.header_results.insert(loop_info.header, results);
@@ -395,8 +395,8 @@ impl<'a> StackPhiPlanner<'a> {
         let [latch] = loop_info.back_edges.as_slice() else {
             return;
         };
-        if !matches!(self.func.blocks[preheader].terminator, Some(Terminator::Jump(target)) if target == loop_info.header)
-            || !matches!(self.func.blocks[*latch].terminator, Some(Terminator::Jump(target)) if target == loop_info.header)
+        if !matches!(self.func.block(preheader).terminator, Some(Terminator::Jump(target)) if target == loop_info.header)
+            || !matches!(self.func.block(*latch).terminator, Some(Terminator::Jump(target)) if target == loop_info.header)
         {
             return;
         }
@@ -404,7 +404,7 @@ impl<'a> StackPhiPlanner<'a> {
             return;
         }
 
-        let block = &self.func.blocks[loop_info.header];
+        let block = self.func.block(loop_info.header);
         let phi_insts = self.leading_phi_insts(block);
         if phi_insts.is_empty() || phi_insts.len() > STACK_PHI_LAYOUT_LIMIT {
             return;
@@ -439,7 +439,7 @@ impl<'a> StackPhiPlanner<'a> {
 
         plan.entries.insert(loop_info.header, entry.clone());
         for (pred, sources) in edges {
-            let mut source_set = DenseBitSet::new_empty(self.func.values.len());
+            let mut source_set = DenseBitSet::new_empty(self.func.value_count());
             for &source in &sources {
                 source_set.insert(source);
             }
@@ -453,7 +453,7 @@ impl<'a> StackPhiPlanner<'a> {
             .instructions
             .iter()
             .copied()
-            .take_while(|&inst| matches!(self.func.instructions[inst].kind, InstKind::Phi(_)))
+            .take_while(|&inst| matches!(self.func.instruction(inst).kind, InstKind::Phi(_)))
             .collect()
     }
 
@@ -480,12 +480,12 @@ impl<'a> StackPhiPlanner<'a> {
 
     fn value_used_in_blocks(&self, blocks: &DenseBitSet<BlockId>, value: ValueId) -> bool {
         for block_id in blocks {
-            let block = &self.func.blocks[block_id];
+            let block = self.func.block(block_id);
             for &inst_id in &block.instructions {
-                if matches!(self.func.instructions[inst_id].kind, InstKind::Phi(_)) {
+                if matches!(self.func.instruction(inst_id).kind, InstKind::Phi(_)) {
                     continue;
                 }
-                if self.func.instructions[inst_id].kind.operands().contains(&value) {
+                if self.func.instruction(inst_id).kind.operands().contains(&value) {
                     return true;
                 }
             }
@@ -504,7 +504,7 @@ impl<'a> StackPhiPlanner<'a> {
         phi_insts
             .iter()
             .map(|&inst| {
-                let InstKind::Phi(incoming) = &self.func.instructions[inst].kind else {
+                let InstKind::Phi(incoming) = &self.func.instruction(inst).kind else {
                     return None;
                 };
                 incoming.iter().find_map(|&(block, value)| (block == pred).then_some(value))
@@ -680,10 +680,10 @@ impl<'gcx> EvmCodegen<'gcx> {
     /// Only live instructions — those still in a block — are checked, since the
     /// instruction arena retains folded-away slices the backend never emits.
     fn collect_unsupported(&mut self, module: &Module) {
-        'func: for func in module.functions.iter() {
-            for block in func.blocks.iter() {
+        'func: for func in module.functions() {
+            for block in func.blocks() {
                 for &inst_id in &block.instructions {
-                    let inst = &func.instructions[inst_id];
+                    let inst = func.instruction(inst_id);
                     let message = match inst.kind {
                         InstKind::MakeSlice { .. }
                         | InstKind::SlicePtr(_)
@@ -790,10 +790,10 @@ impl<'gcx> EvmCodegen<'gcx> {
         // An internal-only library (no external interface) has no reachable
         // runtime code — like `solc`, it produces no bytecode rather than
         // standalone bodies for functions only ever inlined elsewhere.
-        if module.is_interface || !module.functions.iter().any(Self::is_module_entry) {
+        if module.is_interface || !module.functions().any(Self::is_module_entry) {
             return EvmArtifact::default();
         }
-        if let Some(func) = module.functions.iter().find(|func| func.blocks.is_empty()) {
+        if let Some(func) = module.functions().find(|func| func.has_no_blocks()) {
             panic!("cannot codegen MIR function `{}` without an entry block", func.name);
         }
         self.run_optimization_passes(module);
@@ -930,8 +930,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         let runtime_offset = self.asm.new_deferred_const();
 
         // Find constructor function if it exists
-        let constructor =
-            module.functions.iter_enumerated().find(|(_, f)| f.attributes.is_constructor);
+        let constructor = module.iter_functions().find(|(_, f)| f.attributes.is_constructor);
 
         let constructor_arg_offset = if let Some((ctor_id, ctor)) = constructor {
             // Generate constructor bytecode
@@ -941,15 +940,15 @@ impl<'gcx> EvmCodegen<'gcx> {
             self.function_labels.clear();
             self.cold_functions =
                 if matches!(self.gcx.sess.opts.optimization, OptimizationMode::None) {
-                    DenseBitSet::new_empty(module.functions.len())
+                    DenseBitSet::new_empty(module.function_count())
                 } else {
                     Self::collect_cold_functions(module)
                 };
             self.function_static_frame_sizes.clear();
             self.function_spill_sizes.clear();
             self.pending_frame_size_consts.clear();
-            self.restorable_internal_frames = DenseBitSet::new_empty(module.functions.len());
-            self.static_frame_functions = DenseBitSet::new_empty(module.functions.len());
+            self.restorable_internal_frames = DenseBitSet::new_empty(module.function_count());
+            self.static_frame_functions = DenseBitSet::new_empty(module.function_count());
             self.stack_arg_masks.clear();
             self.runtime_stack_args = false;
             self.static_frame_addr_consts.clear();
@@ -960,7 +959,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             self.current_internal_function = None;
             self.stack_phi_sources.clear();
 
-            for (func_id, func) in module.functions.iter_enumerated() {
+            for (func_id, func) in module.iter_functions() {
                 self.function_static_frame_sizes.insert(func_id, func.internal_frame_size);
                 if !func.params.iter().chain(&func.returns).any(|ty| ty.is_memory_reference()) {
                     self.restorable_internal_frames.insert(func_id);
@@ -1006,7 +1005,7 @@ impl<'gcx> EvmCodegen<'gcx> {
                 self.asm.emit_push_label(constructor_entry);
                 self.asm.emit_op(op::JUMP);
 
-                for (func_id, func) in module.functions.iter_enumerated() {
+                for (func_id, func) in module.iter_functions() {
                     if !internal_targets.contains(func_id) {
                         continue;
                     }
@@ -1088,15 +1087,15 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.block_labels.clear();
         self.function_labels.clear();
         self.cold_functions = if matches!(self.gcx.sess.opts.optimization, OptimizationMode::None) {
-            DenseBitSet::new_empty(module.functions.len())
+            DenseBitSet::new_empty(module.function_count())
         } else {
             Self::collect_cold_functions(module)
         };
         self.function_static_frame_sizes.clear();
         self.function_spill_sizes.clear();
         self.pending_frame_size_consts.clear();
-        self.restorable_internal_frames = DenseBitSet::new_empty(module.functions.len());
-        self.static_frame_functions = DenseBitSet::new_empty(module.functions.len());
+        self.restorable_internal_frames = DenseBitSet::new_empty(module.function_count());
+        self.static_frame_functions = DenseBitSet::new_empty(module.function_count());
         self.static_frame_addr_consts.clear();
         self.external_spill_addr_consts.clear();
         self.pending_static_allocs.clear();
@@ -1109,7 +1108,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.runtime_stack_args = true;
         self.emitting_dispatch_entry = false;
 
-        if !module.functions.is_empty() {
+        if !module.has_no_functions() {
             if module.phase >= crate::mir::MirPhase::Dispatch {
                 self.generate_mir_dispatched(module);
             } else {
@@ -1132,8 +1131,7 @@ impl<'gcx> EvmCodegen<'gcx> {
     /// pop and payable check the backend dispatcher would add.
     fn generate_mir_dispatched(&mut self, module: &Module) {
         let Some((entry_id, _)) = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .find(|(_, f)| f.selector.is_none() && f.name.name == sym::entry)
         else {
             // Phase says dispatch but there is nothing to route; fall back.
@@ -1143,12 +1141,12 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         let call_graph = CallGraphInfo::new(module);
         let internal_targets = call_graph.reachable_callees_from(
-            module.functions.iter_enumerated().filter_map(|(func_id, func)| {
+            module.iter_functions().filter_map(|(func_id, func)| {
                 (func_id == entry_id || Self::is_external_entry(func)).then_some(func_id)
             }),
         );
 
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             self.function_static_frame_sizes.insert(func_id, func.internal_frame_size);
             if !func.params.iter().chain(&func.returns).any(|ty| ty.is_memory_reference()) {
                 self.restorable_internal_frames.insert(func_id);
@@ -1165,7 +1163,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.compute_stack_arg_masks(module);
 
         // Labels for every tail-call and internal-call target.
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if func_id == entry_id {
                 continue;
             }
@@ -1183,13 +1181,13 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.emitting_dispatch_entry = true;
         let entry_free = self.emit_external_free_memory_start();
         self.runtime_free_memory_const = Some(entry_free);
-        self.generate_function_body(entry_id, &module.functions[entry_id]);
+        self.generate_function_body(entry_id, module.function(entry_id));
         self.emitting_dispatch_entry = false;
         self.record_function_spill_size(entry_id);
         self.runtime_entry_funcs.push(entry_id);
 
         // External entries, reached only through `tail_call` jumps.
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if func_id == entry_id || !Self::is_external_entry(func) {
                 continue;
             }
@@ -1202,7 +1200,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         }
 
         // Internal-call targets, exactly as in the backend dispatcher path.
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if func_id == entry_id
                 || Self::is_external_entry(func)
                 || !Self::is_runtime_function(func)
@@ -1239,23 +1237,20 @@ impl<'gcx> EvmCodegen<'gcx> {
     /// ```
     fn generate_dispatcher(&mut self, module: &Module) {
         let receive_idx = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .find_map(|(func_id, func)| func.attributes.is_receive.then_some(func_id));
         let fallback_idx = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .find_map(|(func_id, func)| func.attributes.is_fallback.then_some(func_id));
 
         let call_graph = CallGraphInfo::new(module);
         let internal_targets = call_graph.reachable_callees_from(
             module
-                .functions
-                .iter_enumerated()
+                .iter_functions()
                 .filter_map(|(func_id, func)| Self::is_external_entry(func).then_some(func_id)),
         );
 
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             self.function_static_frame_sizes.insert(func_id, func.internal_frame_size);
             if !func.params.iter().chain(&func.returns).any(|ty| ty.is_memory_reference()) {
                 self.restorable_internal_frames.insert(func_id);
@@ -1271,7 +1266,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.compute_stack_arg_masks(module);
 
         // Create labels for externally reachable runtime entry points and internal-call targets.
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             let external = Self::is_external_entry(func);
             let needs_body =
                 external || (Self::is_runtime_function(func) && internal_targets.contains(func_id));
@@ -1283,13 +1278,11 @@ impl<'gcx> EvmCodegen<'gcx> {
         let revert_label = self.asm.new_label();
         self.asm.mark_label_cold(revert_label);
         let has_calldata_label = self.asm.new_label();
-        let all_external_entries_reject_value =
-            module.functions.iter().any(Self::is_external_entry)
-                && module
-                    .functions
-                    .iter()
-                    .filter(|func| Self::is_external_entry(func))
-                    .all(Self::rejects_callvalue);
+        let all_external_entries_reject_value = module.functions().any(Self::is_external_entry)
+            && module
+                .functions()
+                .filter(|func| Self::is_external_entry(func))
+                .all(Self::rejects_callvalue);
 
         // One shared free-memory store for every entry reached through the
         // dispatcher (solc does the same); its value is the maximum entry
@@ -1333,8 +1326,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.asm.emit_op(op::SHR);
 
         let mut selectors: Vec<_> = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .filter_map(|(func_id, func)| {
                 if !Self::is_external_entry(func) {
                     return None;
@@ -1352,7 +1344,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         self.emit_selector_dispatch(&selectors, fallback_label, revert_label);
 
         // Define external function entry points.
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if !Self::is_external_entry(func) {
                 continue;
             }
@@ -1380,7 +1372,7 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         // Define internal-call targets once. Calls jump here and return
         // through the stack-passed return address.
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if Self::is_external_entry(func) || !Self::is_runtime_function(func) {
                 continue;
             }
@@ -1421,7 +1413,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         for (id, callee, static_size) in std::mem::take(&mut self.pending_frame_size_consts) {
             let spill_size =
                 self.function_spill_sizes.get(&callee).copied().unwrap_or_else(|| {
-                    Self::conservative_spill_frame_size(&module.functions[callee])
+                    Self::conservative_spill_frame_size(module.function(callee))
                 });
             self.asm.set_deferred_const(id, U256::from(static_size + spill_size));
         }
@@ -1570,7 +1562,7 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         // Create labels for each block
         self.block_labels.clear();
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             let label = self.asm.new_label();
             if self.block_is_cold(block_id) {
                 self.asm.mark_label_cold(label);
@@ -1588,7 +1580,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         let mut block_entry_stacks: FxHashMap<BlockId, StackModel> = FxHashMap::default();
         let mut preserved_fallthrough: Option<BlockId> = None;
         for (pos, &block_id) in block_order.iter().enumerate() {
-            let block = &func.blocks[block_id];
+            let block = func.block(block_id);
             let fallthrough = block_order.get(pos + 1).copied();
             let entered_by_preserved_fallthrough = preserved_fallthrough == Some(block_id);
             preserved_fallthrough = None;
@@ -1625,7 +1617,7 @@ impl<'gcx> EvmCodegen<'gcx> {
 
             // Generate instructions
             for (inst_idx, &inst_id) in block.instructions.iter().enumerate() {
-                let inst = &func.instructions[inst_id];
+                let inst = func.instruction(inst_id);
 
                 // Skip phi instructions (they're handled by copies)
                 if matches!(inst.kind, InstKind::Phi(_)) {
@@ -1757,18 +1749,18 @@ impl<'gcx> EvmCodegen<'gcx> {
         block_id: BlockId,
         fallthrough: Option<BlockId>,
     ) -> Option<BlockId> {
-        let Some(Terminator::Jump(target)) = func.blocks[block_id].terminator.as_ref() else {
+        let Some(Terminator::Jump(target)) = func.block(block_id).terminator.as_ref() else {
             return None;
         };
-        if Some(*target) == fallthrough
-            || func.blocks[*target].predecessors.as_slice() != [block_id]
+        if Some(*target) == fallthrough || func.block(*target).predecessors.as_slice() != [block_id]
         {
             return None;
         }
-        let has_phi = func.blocks[*target]
+        let has_phi = func
+            .block(*target)
             .instructions
             .iter()
-            .any(|&inst| matches!(func.instructions[inst].kind, InstKind::Phi(_)));
+            .any(|&inst| matches!(func.instruction(inst).kind, InstKind::Phi(_)));
         (!has_phi).then_some(*target)
     }
 
@@ -1788,7 +1780,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         block_pos: &FxHashMap<BlockId, usize>,
     ) -> Vec<BlockId> {
         let Some(Terminator::Branch { condition, then_block, else_block }) =
-            func.blocks[block_id].terminator.as_ref()
+            func.block(block_id).terminator.as_ref()
         else {
             return Vec::new();
         };
@@ -1815,7 +1807,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         }
 
         let targets = [*then_block, *else_block];
-        let mut live_in_any_target = DenseBitSet::new_empty(func.values.len());
+        let mut live_in_any_target = DenseBitSet::new_empty(func.value_count());
         for target in targets {
             for value in liveness.live_in(target) {
                 live_in_any_target.insert(value);
@@ -1827,12 +1819,13 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         for target in targets {
             if target == block_id
-                || func.blocks[target].predecessors.as_slice() != [block_id]
+                || func.block(target).predecessors.as_slice() != [block_id]
                 || block_pos.get(&target).copied() <= Some(pos)
-                || func.blocks[target]
+                || func
+                    .block(target)
                     .instructions
                     .iter()
-                    .any(|&inst| matches!(func.instructions[inst].kind, InstKind::Phi(_)))
+                    .any(|&inst| matches!(func.instruction(inst).kind, InstKind::Phi(_)))
             {
                 return Vec::new();
             }
@@ -1844,12 +1837,12 @@ impl<'gcx> EvmCodegen<'gcx> {
     /// Finds functions whose reachable exits all abort, including chains of
     /// calls to other cold functions.
     fn collect_cold_functions(module: &Module) -> DenseBitSet<FunctionId> {
-        let mut cold = DenseBitSet::new_empty(module.functions.len());
+        let mut cold = DenseBitSet::new_empty(module.function_count());
         let mut worklist = Vec::new();
         let mut visited = GrowableBitSet::new_empty();
         loop {
             let mut changed = false;
-            for (function_id, func) in module.functions.iter_enumerated() {
+            for (function_id, func) in module.iter_functions() {
                 if cold.contains(function_id) {
                     continue;
                 }
@@ -1864,10 +1857,10 @@ impl<'gcx> EvmCodegen<'gcx> {
                     if !visited.insert(block_id) {
                         continue;
                     }
-                    let block = &func.blocks[block_id];
+                    let block = func.block(block_id);
                     if block.instructions.iter().any(|&inst_id| {
                         matches!(
-                            func.instructions[inst_id].kind,
+                            func.instruction(inst_id).kind,
                             InstKind::InternalCall { function, .. } if cold.contains(function)
                         )
                     }) {
@@ -1908,9 +1901,9 @@ impl<'gcx> EvmCodegen<'gcx> {
 
     /// Finds blocks that abort directly or can only reach other cold blocks.
     fn collect_cold_blocks(&self, func: &Function) -> DenseBitSet<BlockId> {
-        let mut cold = DenseBitSet::new_empty(func.blocks.len());
+        let mut cold = DenseBitSet::new_empty(func.block_count());
         let mut worklist = Vec::new();
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             if self.block_aborts(func, block_id) {
                 cold.insert(block_id);
                 worklist.push(block_id);
@@ -1921,11 +1914,11 @@ impl<'gcx> EvmCodegen<'gcx> {
         }
 
         while let Some(block_id) = worklist.pop() {
-            for &predecessor in &func.blocks[block_id].predecessors {
+            for &predecessor in &func.block(block_id).predecessors {
                 if cold.contains(predecessor) {
                     continue;
                 }
-                let Some(term) = func.blocks[predecessor].terminator.as_ref() else {
+                let Some(term) = func.block(predecessor).terminator.as_ref() else {
                     continue;
                 };
                 let successors = term.successors();
@@ -1943,7 +1936,7 @@ impl<'gcx> EvmCodegen<'gcx> {
     /// Returns true when a block aborts directly or calls a function whose
     /// reachable exits all abort.
     fn block_aborts(&self, func: &Function, block_id: BlockId) -> bool {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
         matches!(block.terminator, Some(Terminator::Revert { .. } | Terminator::Invalid))
             || matches!(
                 block.terminator,
@@ -1952,7 +1945,7 @@ impl<'gcx> EvmCodegen<'gcx> {
             )
             || block.instructions.iter().any(|&inst_id| {
                 matches!(
-                    func.instructions[inst_id].kind,
+                    func.instruction(inst_id).kind,
                     InstKind::InternalCall { function, .. }
                         if self.cold_functions.contains(function)
                 )
@@ -1976,11 +1969,11 @@ impl<'gcx> EvmCodegen<'gcx> {
         // transitive reachability remain unevaluated.
         let cfg = CfgInfo::new(func);
         let reachable = cfg.reachable();
-        let mut order = Vec::with_capacity(func.blocks.len());
-        let mut placed = DenseBitSet::new_empty(func.blocks.len());
+        let mut order = Vec::with_capacity(func.block_count());
+        let mut placed = DenseBitSet::new_empty(func.block_count());
 
         self.append_layout_chain(func, BlockId::ENTRY, reachable, &mut placed, &mut order);
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             if reachable.contains(block_id) {
                 self.append_layout_chain(func, block_id, reachable, &mut placed, &mut order);
             }
@@ -2003,9 +1996,9 @@ impl<'gcx> EvmCodegen<'gcx> {
             }
             order.push(block_id);
 
-            let target = match func.blocks[block_id].terminator.as_ref() {
+            let target = match func.block(block_id).terminator.as_ref() {
                 Some(Terminator::Jump(target))
-                    if func.blocks[*target].predecessors.as_slice() == [block_id] =>
+                    if func.block(*target).predecessors.as_slice() == [block_id] =>
                 {
                     *target
                 }
@@ -2197,7 +2190,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         block_id: BlockId,
         fallthrough: Option<BlockId>,
     ) -> bool {
-        let Some(Terminator::Jump(target)) = func.blocks[block_id].terminator.as_ref() else {
+        let Some(Terminator::Jump(target)) = func.block(block_id).terminator.as_ref() else {
             return false;
         };
         if Some(*target) != fallthrough {
@@ -2206,7 +2199,7 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         // This block is the target's only predecessor, so no non-fallthrough edge can observe or
         // depend on a JUMPDEST at the target label.
-        func.blocks[*target].predecessors.as_slice() == [block_id]
+        func.block(*target).predecessors.as_slice() == [block_id]
     }
 
     fn is_stack_phi_source(&self, block: BlockId, value: ValueId) -> bool {
@@ -2226,15 +2219,15 @@ impl<'gcx> EvmCodegen<'gcx> {
     }
 
     fn cross_block_spill_values(func: &Function, liveness: &Liveness) -> DenseBitSet<ValueId> {
-        let mut values = DenseBitSet::new_empty(func.values.len());
-        for block_id in func.blocks.indices() {
+        let mut values = DenseBitSet::new_empty(func.value_count());
+        for block_id in func.block_ids() {
             for val in liveness.live_in(block_id).iter().chain(liveness.live_out(block_id).iter()) {
                 if matches!(func.value(val), crate::mir::Value::Inst(_)) {
                     values.insert(val);
                 }
             }
-            for &inst_id in &func.blocks[block_id].instructions {
-                if matches!(func.instructions[inst_id].kind, InstKind::Phi(_))
+            for &inst_id in &func.block(block_id).instructions {
+                if matches!(func.instruction(inst_id).kind, InstKind::Phi(_))
                     && let Some(val) = func.inst_result_value(inst_id)
                 {
                     values.insert(val);
@@ -2262,7 +2255,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         let crate::mir::Value::Inst(inst_id) = func.value(val) else {
             return;
         };
-        for op in func.instructions[*inst_id].kind.operands() {
+        for op in func.instruction(*inst_id).kind.operands() {
             if Self::is_rematerializable_value(func, op) {
                 continue;
             }
@@ -2291,7 +2284,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         block_id: BlockId,
         exempt: &[ValueId],
     ) {
-        let mut exempt_values = DenseBitSet::new_empty(func.values.len());
+        let mut exempt_values = DenseBitSet::new_empty(func.value_count());
         for &value in exempt {
             exempt_values.insert(value);
         }
@@ -2340,7 +2333,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         let carried: Vec<ValueId> = self.scheduler.stack.iter().flatten().collect();
         for value in carried {
             if let crate::mir::Value::Inst(inst_id) = func.value(value)
-                && matches!(func.instructions[*inst_id].kind, InstKind::Phi(_))
+                && matches!(func.instruction(*inst_id).kind, InstKind::Phi(_))
             {
                 self.scheduler.spills.invalidate_stored(value);
             }
@@ -2356,8 +2349,8 @@ impl<'gcx> EvmCodegen<'gcx> {
                 self.scheduler.spills.mark_reloadable(val);
             }
         }
-        for &inst_id in &func.blocks[block_id].instructions {
-            if matches!(func.instructions[inst_id].kind, InstKind::Phi(_))
+        for &inst_id in &func.block(block_id).instructions {
+            if matches!(func.instruction(inst_id).kind, InstKind::Phi(_))
                 && let Some(val) = func.inst_result_value(inst_id)
                 && !self.scheduler.stack.contains(val)
                 && self.scheduler.spills.get(val).is_some()
@@ -2899,7 +2892,7 @@ impl<'gcx> EvmCodegen<'gcx> {
                 self.scheduler.instruction_executed(0, result_value);
             }
             InstKind::Alloc { size, .. } => {
-                debug_assert!(func.instructions[inst_id].metadata.deferred_alloc());
+                debug_assert!(func.instruction(inst_id).metadata.deferred_alloc());
                 let size =
                     func.value_u64(*size).expect("deferred allocation must have a constant size");
                 let alloc = self.asm.emit_deferred_alloc();
@@ -3553,10 +3546,10 @@ impl<'gcx> EvmCodegen<'gcx> {
         }
 
         let mut scores: FxHashMap<FunctionId, Vec<i32>> = FxHashMap::default();
-        let mut excluded = DenseBitSet::new_empty(module.functions.len());
-        for (caller_id, func) in module.functions.iter_enumerated() {
+        let mut excluded = DenseBitSet::new_empty(module.function_count());
+        for (caller_id, func) in module.iter_functions() {
             let mut has_candidate_call = false;
-            for block in func.blocks.iter() {
+            for block in func.blocks() {
                 if let Some(Terminator::TailCall { function, args }) = &block.terminator
                     && !args.is_empty()
                     && self.static_frame_functions.contains(*function)
@@ -3565,7 +3558,7 @@ impl<'gcx> EvmCodegen<'gcx> {
                 }
                 has_candidate_call |= block.instructions.iter().any(|&inst_id| {
                     matches!(
-                        &func.instructions[inst_id].kind,
+                        &func.instruction(inst_id).kind,
                         InstKind::InternalCall { function, .. }
                             if self.static_frame_functions.contains(*function)
                     )
@@ -3582,10 +3575,10 @@ impl<'gcx> EvmCodegen<'gcx> {
             // arguments (already stored at their definition).
             let mut inst_block: FxHashMap<InstId, usize> = FxHashMap::default();
             let mut use_counts: FxHashMap<ValueId, usize> = FxHashMap::default();
-            for (block_idx, block) in func.blocks.iter().enumerate() {
+            for (block_idx, block) in func.blocks().enumerate() {
                 for &inst_id in &block.instructions {
                     inst_block.insert(inst_id, block_idx);
-                    for operand in func.instructions[inst_id].kind.operands() {
+                    for operand in func.instruction(inst_id).kind.operands() {
                         *use_counts.entry(operand).or_default() += 1;
                     }
                 }
@@ -3595,10 +3588,10 @@ impl<'gcx> EvmCodegen<'gcx> {
                     }
                 }
             }
-            for (block_idx, block) in func.blocks.iter().enumerate() {
+            for (block_idx, block) in func.blocks().enumerate() {
                 for &inst_id in &block.instructions {
                     let InstKind::InternalCall { function, args, .. } =
-                        &func.instructions[inst_id].kind
+                        &func.instruction(inst_id).kind
                     else {
                         continue;
                     };
@@ -3884,7 +3877,7 @@ impl<'gcx> EvmCodegen<'gcx> {
     /// Total frame size of `func_id`: the fixed prefix plus the exact spill
     /// area recorded after its body emitted (conservative when unavailable).
     fn emitted_frame_size(&self, module: &Module, func_id: FunctionId) -> u64 {
-        let func = &module.functions[func_id];
+        let func = module.function(func_id);
         let spill = self
             .function_spill_sizes
             .get(&func_id)
@@ -3918,13 +3911,13 @@ impl<'gcx> EvmCodegen<'gcx> {
         let entry_bases: FxHashMap<FunctionId, u64> = runtime_entries
             .iter()
             .copied()
-            .map(|func_id| (func_id, Self::external_spill_base(&module.functions[func_id])))
+            .map(|func_id| (func_id, Self::external_spill_base(module.function(func_id))))
             .collect();
         let mut entry_ends: FxHashMap<FunctionId, u64> = runtime_entries
             .iter()
             .copied()
             .map(|func_id| {
-                let func = &module.functions[func_id];
+                let func = module.function(func_id);
                 let spill = self
                     .function_spill_sizes
                     .get(&func_id)
@@ -3941,23 +3934,23 @@ impl<'gcx> EvmCodegen<'gcx> {
         // would inflate every callee's depth — and with it the free-memory
         // start and the width of every frame push in the runtime.
         let mut edges = Vec::new();
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             if !self.function_labels.contains_key(&func_id) {
                 continue;
             }
-            for inst in &func.instructions {
+            for inst in func.instructions() {
                 if let InstKind::InternalCall { function, .. } = inst.kind {
                     edges.push((func_id, function));
                 }
             }
-            for block in func.blocks.iter() {
+            for block in func.blocks() {
                 if let Some(Terminator::TailCall { function, .. }) = &block.terminator {
                     edges.push((func_id, *function));
                 }
             }
         }
         let mut depth: FxHashMap<FunctionId, u64> = FxHashMap::default();
-        for _ in 0..=module.functions.len() {
+        for _ in 0..=module.function_count() {
             let mut changed = false;
             for &(caller, callee) in &edges {
                 let mut contribution = depth.get(&caller).copied().unwrap_or(0);
@@ -4082,7 +4075,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         }
 
         for (func_id, spills) in self.external_spill_addr_consts.drain() {
-            let base = Self::external_spill_base(&module.functions[func_id])
+            let base = Self::external_spill_base(module.function(func_id))
                 + static_alloc_sizes.get(&func_id).copied().unwrap_or(0);
             for (rank, (id, _)) in spills.into_iter().enumerate() {
                 self.asm.set_deferred_const(id, U256::from(base + rank as u64 * 32));
@@ -4104,7 +4097,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         // The scheduler may allocate spill slots lazily while exposing deep stack values, not only
         // for values preallocated as cross-block live-ins/live-outs. Use this only when a body's
         // exact post-emission spill size is unavailable.
-        func.values.len() as u64 * 32
+        func.value_count() as u64 * 32
     }
 
     fn external_spill_base(func: &Function) -> u64 {
@@ -4121,7 +4114,7 @@ impl<'gcx> EvmCodegen<'gcx> {
     }
 
     fn uses_internal_frame_slot(func: &Function) -> bool {
-        func.instructions.iter().any(|inst| matches!(inst.kind, InstKind::InternalCall { .. }))
+        func.instructions().any(|inst| matches!(inst.kind, InstKind::InternalCall { .. }))
     }
 
     fn emit_external_free_memory_start(&mut self) -> DeferredConst {
@@ -5618,7 +5611,7 @@ REVERT
                 }
                 let caller_id = module.add_function(caller);
                 codegen.cold_functions = EvmCodegen::collect_cold_functions(&module);
-                let caller = &module.functions[caller_id];
+                let caller = module.function(caller_id);
                 codegen.cold_blocks = codegen.collect_cold_blocks(caller);
 
                 assert!(codegen.cold_functions.contains(cold_func));
@@ -5637,7 +5630,7 @@ REVERT
         let opts = CompileOpts { optimization: OptimizationMode::None, ..Default::default() };
         with_codegen(opts, |mut codegen| {
             codegen.cold_functions = EvmCodegen::collect_cold_functions(&module);
-            let caller = &module.functions[caller_id];
+            let caller = module.function(caller_id);
             codegen.cold_blocks = codegen.collect_cold_blocks(caller);
             assert_eq!(
                 codegen.block_layout_order(caller),

--- a/crates/codegen/src/backend/evm/ir/assembly/lower.rs
+++ b/crates/codegen/src/backend/evm/ir/assembly/lower.rs
@@ -17,7 +17,7 @@ pub(in crate::backend::evm) fn lower_evm_ir(
     allocate_referenced_labels(module, labels, assembler);
 
     let mut program = Program::default();
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    for (block_id, block) in module.blocks_enumerated() {
         let original = block.label as usize;
         if let Some(label) = labels.get(original).copied().flatten() {
             program.define_label(label);
@@ -39,8 +39,8 @@ fn allocate_referenced_labels(
     labels: &mut Vec<Option<Label>>,
     assembler: &mut Assembler<'_>,
 ) {
-    let mut referenced = DenseBitSet::new_empty(module.blocks.len());
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    let mut referenced = DenseBitSet::new_empty(module.block_count());
+    for (block_id, block) in module.blocks_enumerated() {
         for inst in &block.instructions {
             if let Some(ir::PushValue::Block(target)) = &inst.value {
                 referenced.insert(*target);
@@ -53,7 +53,7 @@ fn allocate_referenced_labels(
             });
         }
     }
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    for (block_id, block) in module.blocks_enumerated() {
         let original = block.label as usize;
         if !referenced.contains(block_id)
             && let Some(label) = labels.get_mut(original)
@@ -136,7 +136,7 @@ fn lower_terminator(
 
 fn next_block(module: &ir::Module, block: BlockId) -> Option<BlockId> {
     let next = block.index() + 1;
-    (next < module.blocks.len()).then(|| BlockId::from_usize(next))
+    (next < module.block_count()).then(|| BlockId::from_usize(next))
 }
 
 fn label_for_block(
@@ -145,7 +145,7 @@ fn label_for_block(
     labels: &mut Vec<Option<Label>>,
     assembler: &mut Assembler<'_>,
 ) -> Label {
-    let original = module.blocks[block].label as usize;
+    let original = module.block(block).label as usize;
     if original >= labels.len() {
         labels.resize_with(original + 1, || None);
     }
@@ -168,11 +168,13 @@ mod tests {
         let entry = module.add_block(Block::new(0));
         let then_block = module.add_block(Block::new(1));
         let else_block = module.add_block(Block::new(2));
-        module.blocks[entry].instructions.push(Instruction::push_value(U256::ONE));
-        module.blocks[entry].terminator =
+        module.block_mut(entry).instructions.push(Instruction::push_value(U256::ONE));
+        module.block_mut(entry).terminator =
             Some(Terminator::new(TerminatorKind::JumpI { then_block, else_block }));
-        module.blocks[then_block].terminator = Some(Terminator::new(TerminatorKind::Op(op::STOP)));
-        module.blocks[else_block].terminator = Some(Terminator::new(TerminatorKind::Op(op::STOP)));
+        module.block_mut(then_block).terminator =
+            Some(Terminator::new(TerminatorKind::Op(op::STOP)));
+        module.block_mut(else_block).terminator =
+            Some(Terminator::new(TerminatorKind::Op(op::STOP)));
 
         let compiler = Compiler::new(Session::builder().opts(Default::default()).build());
         compiler.enter(|c| {

--- a/crates/codegen/src/backend/evm/ir/display.rs
+++ b/crates/codegen/src/backend/evm/ir/display.rs
@@ -96,7 +96,7 @@ fn display_push_value<'a>(module: &'a Module, value: &'a PushValue) -> impl fmt:
 }
 
 fn display_block_id(module: &Module, block: BlockId) -> impl fmt::Display + '_ {
-    fmt::from_fn(move |f| write!(f, "bb{}", module.blocks[block].label))
+    fmt::from_fn(move |f| write!(f, "bb{}", module.block(block).label))
 }
 
 fn display_u256(value: U256) -> impl fmt::Display {

--- a/crates/codegen/src/backend/evm/ir/mod.rs
+++ b/crates/codegen/src/backend/evm/ir/mod.rs
@@ -12,7 +12,11 @@
 
 use super::op;
 use alloy_primitives::U256;
-use solar_data_structures::{fmt, index::IndexVec, newtype_index};
+use solar_data_structures::{
+    fmt,
+    index::{IndexVec, index_vec},
+    newtype_index,
+};
 use solar_parse::lexer::is_ident;
 
 mod display;
@@ -47,7 +51,7 @@ pub struct Module {
     /// Program name used by tools and diagnostics.
     pub(crate) name: String,
     /// Basic blocks in layout order.
-    pub(crate) blocks: IndexVec<BlockId, Block>,
+    blocks: IndexVec<BlockId, Block>,
 }
 
 impl Module {
@@ -83,6 +87,84 @@ impl Module {
     /// Adds a block to the program.
     pub(crate) fn add_block(&mut self, block: Block) -> BlockId {
         self.blocks.push(block)
+    }
+
+    /// Returns the block for the given ID.
+    #[must_use]
+    pub(crate) fn block(&self, id: BlockId) -> &Block {
+        &self.blocks[id]
+    }
+
+    /// Returns a mutable reference to the block for the given ID.
+    pub(crate) fn block_mut(&mut self, id: BlockId) -> &mut Block {
+        &mut self.blocks[id]
+    }
+
+    /// Returns the number of blocks.
+    #[must_use]
+    pub(crate) fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Returns whether the module has no blocks.
+    #[must_use]
+    pub(crate) fn has_no_blocks(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    /// Returns the block IDs.
+    pub(crate) fn block_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = BlockId> + ExactSizeIterator + use<> {
+        self.blocks.indices()
+    }
+
+    /// Returns the blocks.
+    pub(crate) fn blocks(&self) -> impl DoubleEndedIterator<Item = &Block> + ExactSizeIterator {
+        self.blocks.iter()
+    }
+
+    /// Returns the blocks with their IDs.
+    pub(crate) fn blocks_enumerated(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (BlockId, &Block)> + ExactSizeIterator {
+        self.blocks.iter_enumerated()
+    }
+
+    /// Returns the blocks mutably.
+    pub(crate) fn blocks_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = &mut Block> + ExactSizeIterator {
+        self.blocks.iter_mut()
+    }
+
+    /// Retains the blocks in the given order and remaps every block reference.
+    pub(crate) fn retain_blocks(&mut self, order: &[BlockId]) {
+        let mut remap = index_vec![None; self.blocks.len()];
+        let mut old_blocks = std::mem::take(&mut self.blocks)
+            .into_iter()
+            .map(Some)
+            .collect::<IndexVec<BlockId, _>>();
+        let mut blocks = IndexVec::with_capacity(order.len());
+        for &old_block in order {
+            let block =
+                old_blocks[old_block].take().expect("block order must contain each block once");
+            let new_block = blocks.push(block);
+            remap[old_block] = Some(new_block);
+        }
+        self.blocks = blocks;
+        for block in &mut self.blocks {
+            for inst in &mut block.instructions {
+                if let Some(PushValue::Block(block)) = &mut inst.value {
+                    *block = remap[*block].expect("referenced block must be retained");
+                }
+            }
+            if let Some(term) = &mut block.terminator {
+                term.kind.visit_targets_mut(|target| {
+                    *target = remap[*target].expect("terminator target must be retained");
+                });
+            }
+        }
     }
 }
 

--- a/crates/codegen/src/backend/evm/ir/parse.rs
+++ b/crates/codegen/src/backend/evm/ir/parse.rs
@@ -59,7 +59,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         while !self.parser.is_eof() {
             if let Some(header) = self.try_parse_block_header()? {
                 let block_id = self.define_block(module, header.label)?;
-                module.blocks[block_id].metadata.hotness = header.hotness;
+                module.block_mut(block_id).metadata.hotness = header.hotness;
                 current_block = Some(block_id);
                 continue;
             }
@@ -161,17 +161,17 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         module: &mut Module,
         block: BlockId,
     ) -> PResult<'sess, ()> {
-        if module.blocks[block].terminator.is_some() {
+        if module.block(block).terminator.is_some() {
             return Err(self.parser.error(format!(
                 "instruction after terminator in block `bb{}`",
-                module.blocks[block].label
+                module.block(block).label
             )));
         }
 
         let mnemonic = self.parser.parse_ident()?;
         if let Some(kind) = self.parse_terminator_kind(mnemonic, module)? {
             let metadata = self.parse_metadata()?;
-            module.blocks[block].terminator = Some(Terminator { kind, metadata });
+            module.block_mut(block).terminator = Some(Terminator { kind, metadata });
             return Ok(());
         }
 
@@ -192,7 +192,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             })?),
         };
         inst.metadata = self.parse_metadata()?;
-        module.blocks[block].instructions.push(inst);
+        module.block_mut(block).instructions.push(inst);
         Ok(())
     }
 

--- a/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/block_layout.rs
@@ -33,12 +33,12 @@ impl EvmPass for BlockLayout {
 }
 
 fn layout_blocks(gcx: Gcx<'_>, module: &mut Module) -> bool {
-    if module.blocks.len() <= 1 {
+    if module.block_count() <= 1 {
         return false;
     }
     let mut state = RunState::default();
-    state.reset(module.blocks.len());
-    for block in &module.blocks {
+    state.reset(module.block_count());
+    for block in module.blocks() {
         if let Some(target) = layout_successor(block)
             && target.index() < state.predecessor_counts.len()
         {
@@ -48,9 +48,9 @@ fn layout_blocks(gcx: Gcx<'_>, module: &mut Module) -> bool {
 
     append_layout_trace(module, BlockId::ENTRY, &mut state.placed, &mut state.order);
     for cold in [false, true] {
-        for block in module.blocks.indices() {
+        for block in module.block_ids() {
             if state.predecessor_counts[block] == 0
-                && is_cold_terminal_block(&module.blocks[block]) == cold
+                && is_cold_terminal_block(module.block(block)) == cold
             {
                 append_layout_trace(module, block, &mut state.placed, &mut state.order);
             }
@@ -59,14 +59,14 @@ fn layout_blocks(gcx: Gcx<'_>, module: &mut Module) -> bool {
 
     pack_hot_terminal_blocks(gcx, module, &mut state);
     for cold in [false, true] {
-        for block in module.blocks.indices() {
-            if is_cold_terminal_block(&module.blocks[block]) == cold {
+        for block in module.block_ids() {
+            if is_cold_terminal_block(module.block(block)) == cold {
                 append_layout_trace(module, block, &mut state.placed, &mut state.order);
             }
         }
     }
 
-    if state.order.iter().copied().eq(module.blocks.indices()) {
+    if state.order.iter().copied().eq(module.block_ids()) {
         return false;
     }
     remap_block_order(module, &state.order);
@@ -128,7 +128,7 @@ struct Candidate {
 
 fn pack_hot_terminal_blocks(gcx: Gcx<'_>, module: &Module, state: &mut RunState) {
     let Some(first_terminal) = state.order.iter().enumerate().position(|(position, &block)| {
-        is_physical_terminal_boundary(&module.blocks[block], state.order.get(position + 1).copied())
+        is_physical_terminal_boundary(module.block(block), state.order.get(position + 1).copied())
     }) else {
         return;
     };
@@ -140,7 +140,7 @@ fn pack_hot_terminal_blocks(gcx: Gcx<'_>, module: &Module, state: &mut RunState)
         .map(|(index, &block)| {
             estimated_block_size(
                 gcx,
-                &module.blocks[block],
+                module.block(block),
                 state.order.get(index + 1).copied(),
                 state.references[block] != 0,
             )
@@ -153,17 +153,14 @@ fn pack_hot_terminal_blocks(gcx: Gcx<'_>, module: &Module, state: &mut RunState)
     for position in insert_at..state.order.len() {
         let block = state.order[position];
         if position == 0
-            || !is_physical_terminal_boundary(
-                &module.blocks[state.order[position - 1]],
-                Some(block),
-            )
-            || !is_terminal_block(&module.blocks[block])
+            || !is_physical_terminal_boundary(module.block(state.order[position - 1]), Some(block))
+            || !is_terminal_block(module.block(block))
         {
             continue;
         }
         let size = estimated_block_size(
             gcx,
-            &module.blocks[block],
+            module.block(block),
             state.order.get(position + 1).copied(),
             state.references[block] != 0,
         );
@@ -199,7 +196,7 @@ fn block_reference_counts(
     references: &mut IndexVec<BlockId, usize>,
 ) {
     for (position, &block_id) in order.iter().enumerate() {
-        let block = &module.blocks[block_id];
+        let block = module.block(block_id);
         for inst in &block.instructions {
             if let Some(PushValue::Block(block)) = &inst.value {
                 references[*block] += 1;
@@ -279,9 +276,9 @@ fn append_layout_trace(
     placed: &mut DenseBitSet<BlockId>,
     order: &mut Vec<BlockId>,
 ) {
-    while block.index() < module.blocks.len() && placed.insert(block) {
+    while block.index() < module.block_count() && placed.insert(block) {
         order.push(block);
-        let Some(target) = layout_successor(&module.blocks[block]) else { return };
+        let Some(target) = layout_successor(module.block(block)) else { return };
         block = target;
     }
 }

--- a/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/cfg_simplify.rs
@@ -25,7 +25,7 @@ impl EvmPass for CfgSimplify {
 
 fn simplify_cfg(_gcx: Gcx<'_>, module: &mut Module) -> bool {
     let mut state = RunState::default();
-    state.reserve(module.blocks.len());
+    state.reserve(module.block_count());
     let mut changed = false;
     loop {
         let truncated = truncate_after_terminal(module);
@@ -83,7 +83,7 @@ fn reserve_to<T>(values: &mut Vec<T>, capacity: usize) {
 
 fn truncate_after_terminal(module: &mut Module) -> bool {
     let mut changed = false;
-    for block in &mut module.blocks {
+    for block in module.blocks_mut() {
         let Some((at, opcode)) = block.instructions.iter().enumerate().find_map(|(at, inst)| {
             (!inst.is_encoded_push() && op::is_terminal(inst.opcode)).then_some((at, inst.opcode))
         }) else {
@@ -102,7 +102,7 @@ fn redirect_jump_thunks(
     order: &mut Vec<BlockId>,
 ) -> bool {
     thunks.clear();
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    for (block_id, block) in module.blocks_enumerated() {
         if block.instructions.is_empty()
             && let Some(TerminatorKind::Jump(target)) =
                 block.terminator.as_ref().map(|term| &term.kind)
@@ -114,7 +114,7 @@ fn redirect_jump_thunks(
         return false;
     }
 
-    let block_count = module.blocks.len();
+    let block_count = module.block_count();
     let resolve = |start: BlockId| {
         let mut target = start;
         for _ in 0..block_count {
@@ -128,7 +128,7 @@ fn redirect_jump_thunks(
     };
 
     let mut changed = false;
-    for block in &mut module.blocks {
+    for block in module.blocks_mut() {
         for inst in &mut block.instructions {
             if let Some(PushValue::Block(block)) = &mut inst.value {
                 let resolved = resolve(*block);
@@ -148,7 +148,7 @@ fn redirect_jump_thunks(
     if entry != BlockId::ENTRY {
         order.clear();
         order.push(entry);
-        order.extend(module.blocks.indices().filter(|&block| block != entry));
+        order.extend(module.block_ids().filter(|&block| block != entry));
         remap_block_order(module, order);
         changed = true;
     }
@@ -161,11 +161,11 @@ fn remove_unreachable_blocks(
     pending: &mut Vec<BlockId>,
     order: &mut Vec<BlockId>,
 ) -> bool {
-    if module.blocks.is_empty() {
+    if module.has_no_blocks() {
         return false;
     }
-    if reachable.domain_size() != module.blocks.len() {
-        *reachable = DenseBitSet::new_empty(module.blocks.len());
+    if reachable.domain_size() != module.block_count() {
+        *reachable = DenseBitSet::new_empty(module.block_count());
     } else {
         reachable.clear();
     }
@@ -175,7 +175,7 @@ fn remove_unreachable_blocks(
         if !reachable.insert(block_id) {
             continue;
         }
-        let block = &module.blocks[block_id];
+        let block = module.block(block_id);
         for inst in &block.instructions {
             if let Some(PushValue::Block(target)) = &inst.value {
                 pending.push(*target);
@@ -185,7 +185,7 @@ fn remove_unreachable_blocks(
             term.kind.visit_targets(|target| pending.push(target));
         }
     }
-    if reachable.count() == module.blocks.len() {
+    if reachable.count() == module.block_count() {
         return false;
     }
     order.clear();
@@ -201,12 +201,12 @@ fn coalesce_blocks(
     order: &mut Vec<BlockId>,
 ) -> bool {
     references.clear();
-    references.resize(module.blocks.len(), 0);
+    references.resize(module.block_count(), 0);
     // Count the implicit program-entry edge.
     if let Some(entry_references) = references.first_mut() {
         *entry_references = 1;
     }
-    for block in &module.blocks {
+    for block in module.blocks() {
         for inst in &block.instructions {
             if let Some(PushValue::Block(target)) = &inst.value {
                 references[*target] += 1;
@@ -217,31 +217,31 @@ fn coalesce_blocks(
         }
     }
 
-    if retained.domain_size() != module.blocks.len() {
-        *retained = DenseBitSet::new_filled(module.blocks.len());
+    if retained.domain_size() != module.block_count() {
+        *retained = DenseBitSet::new_filled(module.block_count());
     } else {
         retained.insert_all();
     }
-    for predecessor in module.blocks.indices() {
+    for predecessor in module.block_ids() {
         if !retained.contains(predecessor) {
             continue;
         }
         while let Some(TerminatorKind::Jump(target)) =
-            module.blocks[predecessor].terminator.as_ref().map(|terminator| &terminator.kind)
+            module.block(predecessor).terminator.as_ref().map(|terminator| &terminator.kind)
         {
             let target = *target;
             if target == predecessor || references[target] != 1 || !retained.contains(target) {
                 break;
             }
 
-            let mut instructions = std::mem::take(&mut module.blocks[target].instructions);
-            let terminator = module.blocks[target].terminator.take();
-            module.blocks[predecessor].instructions.append(&mut instructions);
-            module.blocks[predecessor].terminator = terminator;
+            let mut instructions = std::mem::take(&mut module.block_mut(target).instructions);
+            let terminator = module.block_mut(target).terminator.take();
+            module.block_mut(predecessor).instructions.append(&mut instructions);
+            module.block_mut(predecessor).terminator = terminator;
             retained.remove(target);
         }
     }
-    if retained.count() == module.blocks.len() {
+    if retained.count() == module.block_count() {
         return false;
     }
     order.clear();

--- a/crates/codegen/src/backend/evm/ir/passes/compact_pushes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/compact_pushes.rs
@@ -27,7 +27,7 @@ const MIN_COMPACT_MASK_WIDTH: u8 = 5;
 fn compact_pushes(gcx: Gcx<'_>, module: &mut Module) -> bool {
     let mut changed = false;
     let mut scratch = Vec::new();
-    for block in &mut module.blocks {
+    for block in module.blocks_mut() {
         if !block.instructions.iter().any(|inst| {
             immediate(inst).is_some_and(|value| !matches!(select(gcx, value), CompactPush::Literal))
         }) {

--- a/crates/codegen/src/backend/evm/ir/passes/outline.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/outline.rs
@@ -36,7 +36,7 @@ fn outline(gcx: Gcx<'_>, module: &mut Module) -> bool {
 
 fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> bool {
     let mut candidates = FxHashMap::<MachineInstSlice<'_>, SmallVec<[Site; 2]>>::default();
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    for (block_id, block) in module.blocks_enumerated() {
         for start in 0..block.instructions.len() {
             let mut height = 0i32;
             for end in start..block.instructions.len() {
@@ -70,7 +70,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
     for (_, sites) in groups {
         let mut free = SmallVec::<[Site; 2]>::new();
         for site in sites {
-            let instruction_count = module.blocks[site.block].instructions.len();
+            let instruction_count = module.block(site.block).instructions.len();
             let claimed = claimed
                 .entry(site.block)
                 .or_insert_with(|| DenseBitSet::new_empty(instruction_count));
@@ -83,7 +83,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
         }
         let first = free[0];
         let body =
-            module.blocks[first.block].instructions[first.start..first.start + first.len].to_vec();
+            module.block(first.block).instructions[first.start..first.start + first.len].to_vec();
         let run_size = lower_bound(&body);
         let stub_size = 1 + run_size + usize::from(first.height) + 1;
         let site_size = if free.len() >= 4 { 7 } else { 8 };
@@ -124,7 +124,7 @@ fn outline_closed_computations(module: &mut Module, state: &mut RunState) -> boo
 
 fn outline_repeated_pushes(gcx: Gcx<'_>, module: &mut Module, state: &mut RunState) -> bool {
     let mut sites = FxHashMap::<U256, SmallVec<[(BlockId, usize); 2]>>::default();
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    for (block_id, block) in module.blocks_enumerated() {
         for (index, inst) in block.instructions.iter().enumerate() {
             if inst.is_encoded_push()
                 && inst.deferred_push().is_none()
@@ -188,13 +188,13 @@ fn split_outline_site(
     state: &mut RunState,
 ) {
     let mut continuation = Block::new(state.next_label(module));
-    continuation.metadata = module.blocks[block].metadata;
-    continuation.instructions = module.blocks[block].instructions.split_off(start + len);
-    module.blocks[block].instructions.truncate(start);
-    continuation.terminator = module.blocks[block].terminator.take();
+    continuation.metadata = module.block(block).metadata;
+    continuation.instructions = module.block_mut(block).instructions.split_off(start + len);
+    module.block_mut(block).instructions.truncate(start);
+    continuation.terminator = module.block_mut(block).terminator.take();
     let continuation = module.add_block(continuation);
-    module.blocks[block].instructions.push(Instruction::push_block(continuation));
-    module.blocks[block].terminator = Some(Terminator::new(TerminatorKind::Jump(stub)));
+    module.block_mut(block).instructions.push(Instruction::push_block(continuation));
+    module.block_mut(block).terminator = Some(Terminator::new(TerminatorKind::Jump(stub)));
 }
 
 fn whitelisted_effect(inst: &Instruction) -> Option<(u16, u16, u16)> {
@@ -283,8 +283,7 @@ impl RunState {
     fn next_label(&mut self, module: &Module) -> u32 {
         let label = *self.next_label.get_or_insert_with(|| {
             module
-                .blocks
-                .iter()
+                .blocks()
                 .map(|block| block.label)
                 .max()
                 .unwrap_or(0)

--- a/crates/codegen/src/backend/evm/ir/passes/peephole.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/peephole.rs
@@ -27,7 +27,7 @@ const TRACE_TARGET: &str = "solar::codegen::evm_ir::peephole";
 fn optimize_module(_gcx: Gcx<'_>, module: &mut Module) -> bool {
     let mut changed = false;
     let mut scratch = Vec::new();
-    for block in &mut module.blocks {
+    for block in module.blocks_mut() {
         changed |= optimize(&mut block.instructions, &mut scratch, block.label) != 0;
     }
     changed

--- a/crates/codegen/src/backend/evm/ir/passes/share_reverts.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/share_reverts.rs
@@ -22,8 +22,8 @@ impl EvmPass for ShareReverts {
 }
 
 fn share_reverts(_gcx: Gcx<'_>, module: &mut Module) -> bool {
-    let mut empty_reverts = DenseBitSet::new_empty(module.blocks.len());
-    for block in module.blocks.indices().filter(|&block| is_empty_revert(module, block)) {
+    let mut empty_reverts = DenseBitSet::new_empty(module.block_count());
+    for block in module.block_ids().filter(|&block| is_empty_revert(module, block)) {
         empty_reverts.insert(block);
     }
     let Some(shared) = empty_reverts.iter().next() else {
@@ -33,7 +33,7 @@ fn share_reverts(_gcx: Gcx<'_>, module: &mut Module) -> bool {
         return false;
     }
     let mut changed = false;
-    for (index, block) in module.blocks.iter_mut().enumerate() {
+    for (index, block) in module.blocks_mut().enumerate() {
         let block_id = BlockId::from_usize(index);
         let Some(revert) = block.terminator.as_ref().and_then(|term| match term.kind {
             TerminatorKind::Jump(target) => Some(target),
@@ -90,7 +90,7 @@ fn preserves_shared_revert_low_address(module: &Module, shared: BlockId) -> bool
     let mut references = 0;
     let mut shared_end = 0;
     let mut total = 0;
-    for (block_id, block) in module.blocks.iter_enumerated() {
+    for (block_id, block) in module.blocks_enumerated() {
         references += block
             .instructions
             .iter()
@@ -108,7 +108,7 @@ fn preserves_shared_revert_low_address(module: &Module, shared: BlockId) -> bool
 }
 
 fn is_empty_revert(module: &Module, block: BlockId) -> bool {
-    let block = &module.blocks[block];
+    let block = module.block(block);
     let [zero, dup] = block.instructions.as_slice() else { return false };
     is_zero_push(zero)
         && dup.opcode == op::DUP1

--- a/crates/codegen/src/backend/evm/ir/passes/tail_merge.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/tail_merge.rs
@@ -26,8 +26,7 @@ fn merge_tails(_gcx: Gcx<'_>, module: &mut Module) -> bool {
         return false;
     }
     let mut next_label = module
-        .blocks
-        .iter()
+        .blocks()
         .map(|block| block.label)
         .max()
         .unwrap_or(0)
@@ -56,14 +55,14 @@ impl RunState {
     fn plan_merges(&mut self, module: &Module) {
         self.representatives.clear();
         self.merges.clear();
-        for (block_id, block) in module.blocks.iter_enumerated() {
+        for (block_id, block) in module.blocks_enumerated() {
             if !is_candidate(block) {
                 continue;
             }
 
             let mut matched = None;
             for &representative in &self.representatives {
-                let representative_block = &module.blocks[representative];
+                let representative_block = module.block(representative);
                 if block.terminator.as_ref().map(|term| &term.kind)
                     != representative_block.terminator.as_ref().map(|term| &term.kind)
                 {
@@ -112,14 +111,14 @@ impl RunState {
 
         let Self { groups, commons, tails, .. } = self;
         for group in groups.iter().take(group_count) {
-            let representative = &module.blocks[group.representative];
+            let representative = module.block(group.representative);
             let instructions = representative.instructions.clone();
             let terminator = representative.terminator.clone();
             let metadata = representative.metadata;
             let max_hot_common = group
                 .sites
                 .iter()
-                .filter(|&&(block, _)| !module.blocks[block].metadata.hotness.is_cold())
+                .filter(|&&(block, _)| !module.block(block).metadata.hotness.is_cold())
                 .map(|&(_, common)| common)
                 .max();
             commons.clear();
@@ -153,19 +152,21 @@ impl RunState {
             }
 
             let &(max_common, max_tail) = tails.last().expect("merge group must have a tail");
-            module.blocks[group.representative]
+            module
+                .block_mut(group.representative)
                 .instructions
                 .truncate(instructions.len() - max_common);
-            module.blocks[group.representative].terminator =
+            module.block_mut(group.representative).terminator =
                 Some(Terminator::new(TerminatorKind::Jump(max_tail)));
             for &(block, common) in &group.sites {
                 let tail = tails
                     .binary_search_by_key(&common, |&(known, _)| known)
                     .map(|index| tails[index].1)
                     .expect("tail must exist for every merge site");
-                let len = module.blocks[block].instructions.len();
-                module.blocks[block].instructions.truncate(len - common);
-                module.blocks[block].terminator = Some(Terminator::new(TerminatorKind::Jump(tail)));
+                let len = module.block(block).instructions.len();
+                module.block_mut(block).instructions.truncate(len - common);
+                module.block_mut(block).terminator =
+                    Some(Terminator::new(TerminatorKind::Jump(tail)));
             }
         }
     }

--- a/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/terminal_dedup.rs
@@ -31,8 +31,8 @@ struct RunState {
 fn deduplicate_terminals(_gcx: Gcx<'_>, module: &mut Module) -> bool {
     let mut state = RunState::default();
 
-    for block_id in module.blocks.indices() {
-        let block = &module.blocks[block_id];
+    for block_id in module.block_ids() {
+        let block = module.block(block_id);
         let Some(key) = terminal_block_key(block) else { continue };
         match state.canonical.entry(key) {
             StdEntry::Occupied(entry) => state.redirects.push((block_id, *entry.get())),
@@ -44,8 +44,8 @@ fn deduplicate_terminals(_gcx: Gcx<'_>, module: &mut Module) -> bool {
 
     let changed = !state.redirects.is_empty();
     for (block, target) in state.redirects.drain(..) {
-        module.blocks[block].instructions.clear();
-        module.blocks[block].terminator = Some(Terminator::new(TerminatorKind::Jump(target)));
+        module.block_mut(block).instructions.clear();
+        module.block_mut(block).terminator = Some(Terminator::new(TerminatorKind::Jump(target)));
     }
     changed
 }

--- a/crates/codegen/src/backend/evm/ir/passes/utils.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/utils.rs
@@ -5,51 +5,20 @@
 //! entry, push, and terminator reference together.
 
 use crate::backend::evm::{
-    ir::{BlockId, Module, PushValue, TerminatorKind},
+    ir::{BlockId, Module, TerminatorKind},
     op,
 };
-use solar_data_structures::index::{IndexVec, index_vec};
 
 pub(super) fn is_evm_terminal(kind: &TerminatorKind) -> bool {
     matches!(kind, TerminatorKind::Op(opcode) if op::is_terminal(*opcode))
 }
 
 pub(in crate::backend::evm::ir) fn remap_block_order(module: &mut Module, order: &[BlockId]) {
-    debug_assert_eq!(order.len(), module.blocks.len());
-    remap_blocks(module, order);
+    debug_assert_eq!(order.len(), module.block_count());
+    module.retain_blocks(order);
 }
 
 pub(super) fn retain_blocks(module: &mut Module, order: &[BlockId]) {
-    debug_assert!(order.len() <= module.blocks.len());
-    remap_blocks(module, order);
-}
-
-fn remap_blocks(module: &mut Module, order: &[BlockId]) {
-    let mut remap = index_vec![None; module.blocks.len()];
-    let mut old_blocks =
-        std::mem::take(&mut module.blocks).into_iter().map(Some).collect::<IndexVec<BlockId, _>>();
-    let mut blocks = IndexVec::with_capacity(order.len());
-    for &old_block in order {
-        let block =
-            old_blocks[old_block].take().expect("block order must contain each block exactly once");
-        let new_block = blocks.push(block);
-        remap[old_block] = Some(new_block);
-    }
-    module.blocks = blocks;
-    for block in &mut module.blocks {
-        for inst in &mut block.instructions {
-            if let Some(PushValue::Block(block)) = &mut inst.value {
-                *block = remap[*block].expect("referenced block must be retained");
-            }
-        }
-        if let Some(term) = &mut block.terminator {
-            remap_terminator_blocks(&mut term.kind, &remap);
-        }
-    }
-}
-
-fn remap_terminator_blocks(kind: &mut TerminatorKind, remap: &IndexVec<BlockId, Option<BlockId>>) {
-    kind.visit_targets_mut(|target| {
-        *target = remap[*target].expect("terminator target must be retained");
-    });
+    debug_assert!(order.len() <= module.block_count());
+    module.retain_blocks(order);
 }

--- a/crates/codegen/src/backend/evm/ir/verify.rs
+++ b/crates/codegen/src/backend/evm/ir/verify.rs
@@ -30,13 +30,13 @@ impl<'a> Verifier<'a> {
 
     fn verify_module(&self, module: &Module) {
         let errors_before = self.dcx.err_count();
-        if module.blocks.is_empty() {
+        if module.has_no_blocks() {
             self.error("program has no blocks");
             return;
         }
 
         let mut labels = FxHashSet::default();
-        for (block_id, block) in module.blocks.iter_enumerated() {
+        for (block_id, block) in module.blocks_enumerated() {
             if !labels.insert(block.label) {
                 self.error_in_block(
                     block_id,
@@ -194,11 +194,11 @@ impl<'a> Verifier<'a> {
 
     /// Checks physical stack operations along generated direct control-flow edges.
     fn verify_stack_ops(&self, module: &Module) {
-        let mut entry_depths = IndexVec::<BlockId, _>::from_vec(vec![None; module.blocks.len()]);
+        let mut entry_depths = IndexVec::<BlockId, _>::from_vec(vec![None; module.block_count()]);
         entry_depths[BlockId::ENTRY] = Some(0);
         let mut pending = vec![BlockId::ENTRY];
         while let Some(block_id) = pending.pop() {
-            let block = &module.blocks[block_id];
+            let block = module.block(block_id);
             let term =
                 block.terminator.as_ref().expect("terminator must exist after shape validation");
             let mut stack = entry_depths[block_id].unwrap();
@@ -351,12 +351,12 @@ impl<'a> Verifier<'a> {
     }
 
     fn block_exists(&self, module: &Module, block: BlockId) -> bool {
-        block.index() < module.blocks.len()
+        block.index() < module.block_count()
     }
 
     fn next_block(module: &Module, block: BlockId) -> Option<BlockId> {
         let next = block.index() + 1;
-        (next < module.blocks.len()).then(|| BlockId::from_usize(next))
+        (next < module.block_count()).then(|| BlockId::from_usize(next))
     }
 }
 

--- a/crates/codegen/src/lower/bytes.rs
+++ b/crates/codegen/src/lower/bytes.rs
@@ -174,7 +174,7 @@ impl<'gcx> Lowerer<'gcx> {
         let func = builder.func();
         match func.value(value) {
             Value::Arg { ty, .. } | Value::Undef(ty) => Some(*ty),
-            Value::Inst(inst_id) => func.instructions[*inst_id].result_ty,
+            Value::Inst(inst_id) => func.instruction(*inst_id).result_ty,
             Value::Immediate(_) | Value::Error(_) => None,
         }
     }

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -85,7 +85,7 @@ impl<'a> FunctionBuilder<'a> {
 
     /// Replaces an allocated value.
     pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
-        self.func.values[id] = value;
+        *self.func.value_mut(id) = value;
     }
 
     fn emit_inst_raw(&mut self, kind: InstKind, result_ty: Option<MirType>) -> InstId {
@@ -99,7 +99,7 @@ impl<'a> FunctionBuilder<'a> {
     /// Appends a fully constructed instruction to the current block.
     pub(crate) fn append_instruction(&mut self, inst: Instruction) -> InstId {
         let inst_id = self.func.alloc_inst(inst);
-        self.func.blocks[self.current_block].instructions.push(inst_id);
+        self.func.block_mut(self.current_block).instructions.push(inst_id);
         inst_id
     }
 
@@ -142,7 +142,7 @@ impl<'a> FunctionBuilder<'a> {
             {
                 MemoryRegion::Scratch
             }
-            Value::Inst(inst_id) => match self.func.instructions[*inst_id].kind {
+            Value::Inst(inst_id) => match self.func.instruction(*inst_id).kind {
                 InstKind::InternalFrameAddr(_) => MemoryRegion::InternalFrame,
                 InstKind::Add(lhs, rhs) if self.is_internal_frame_add(lhs, rhs) => {
                     MemoryRegion::InternalFrame
@@ -169,7 +169,7 @@ impl<'a> FunctionBuilder<'a> {
         matches!(
             self.func.value(value),
             Value::Inst(inst_id)
-                if matches!(self.func.instructions[*inst_id].kind, InstKind::InternalFrameAddr(_))
+                if matches!(self.func.instruction(*inst_id).kind, InstKind::InternalFrameAddr(_))
         )
     }
 
@@ -858,7 +858,7 @@ impl<'a> FunctionBuilder<'a> {
         let Value::Inst(inst_id) = *self.func.value(phi) else {
             panic!("add_phi_incoming: value is not an instruction result");
         };
-        let InstKind::Phi(incoming) = &mut self.func.instructions[inst_id].kind else {
+        let InstKind::Phi(incoming) = &mut self.func.instruction_mut(inst_id).kind else {
             panic!("add_phi_incoming: instruction is not a phi");
         };
         incoming.push((block, value));
@@ -925,9 +925,9 @@ impl<'a> FunctionBuilder<'a> {
     pub(crate) fn set_terminator(&mut self, terminator: Terminator) {
         let current = self.current_block;
         for successor in terminator.successors() {
-            self.func.blocks[successor].predecessors.push(current);
+            self.func.block_mut(successor).predecessors.push(current);
         }
-        self.func.blocks[current].terminator = Some(terminator);
+        self.func.block_mut(current).terminator = Some(terminator);
     }
 
     /// Returns a reference to the function.

--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -35,7 +35,7 @@ pub(crate) fn display_function_dot<'a>(
         funcs: Option<&solar_data_structures::index::IndexVec<FunctionId, Function>>,
         block_id: BlockId,
     ) -> fmt::Result {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
         let block_idx = block_id.index();
         write!(f, "bb{block_idx}:\\l")?;
 
@@ -62,7 +62,7 @@ pub(crate) fn display_function_dot<'a>(
         inst_id: InstId,
     ) -> impl fmt::Display + 'a {
         fmt::from_fn(move |f| {
-            let inst = &func.instructions[inst_id];
+            let inst = func.instruction(inst_id);
 
             write!(f, "  ")?;
             if inst.result_ty.is_some() {
@@ -150,7 +150,7 @@ pub(crate) fn display_function_dot<'a>(
         write!(
             f,
             "{}",
-            func.blocks.iter_enumerated().format_with("", |f, (block_id, _)| write!(
+            func.blocks_enumerated().format_with("", |f, (block_id, _)| write!(
                 f,
                 "{}",
                 display_dot_node(func, funcs, block_id)
@@ -162,7 +162,7 @@ pub(crate) fn display_function_dot<'a>(
         write!(
             f,
             "{}",
-            func.blocks.iter_enumerated().format_with("", |f, (block_id, block)| {
+            func.blocks_enumerated().format_with("", |f, (block_id, block)| {
                 write!(f, "{}", display_dot_edges(func, funcs, block_id, block))
             })
         )?;
@@ -221,7 +221,7 @@ pub(crate) fn display_function_text<'a>(
         inst_id: InstId,
     ) -> impl fmt::Display + 'a {
         fmt::from_fn(move |f| {
-            let inst = &func.instructions[inst_id];
+            let inst = func.instruction(inst_id);
 
             write!(f, "    ")?;
             if inst.result_ty.is_some() {
@@ -261,7 +261,7 @@ pub(crate) fn display_function_text<'a>(
         write!(
             f,
             "{}",
-            func.blocks.iter_enumerated().format_with("", |f, (block_id, block)| {
+            func.blocks_enumerated().format_with("", |f, (block_id, block)| {
                 write!(f, "{}", display_text_block(func, funcs, block_id, block))
             })
         )?;
@@ -271,12 +271,11 @@ pub(crate) fn display_function_text<'a>(
 }
 
 fn function_prints_return_values(func: &Function) -> bool {
-    func.blocks.iter().any(|block| matches!(block.terminator, Some(Terminator::Return { .. })))
+    func.blocks().any(|block| matches!(block.terminator, Some(Terminator::Return { .. })))
 }
 
 fn inst_result_index(func: &Function, inst_id: InstId) -> usize {
-    func.instructions
-        .iter_enumerated()
+    func.instructions_enumerated()
         .filter(|(_, inst)| inst.result_ty.is_some())
         .position(|(id, _)| id == inst_id)
         .expect("Value::Inst should point to a value-producing instruction")
@@ -424,7 +423,7 @@ fn display_function_ref(
 }
 
 fn display_val(vid: ValueId, func: &Function) -> impl fmt::Display + '_ {
-    fmt::from_fn(move |f| match &func.values[vid] {
+    fmt::from_fn(move |f| match func.value(vid) {
         Value::Immediate(imm) if let Some(u256) = imm.as_u256() => {
             write!(f, "{}", display_u256(u256))
         }

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -1,13 +1,14 @@
 //! MIR functions.
 
 use super::{
-    BasicBlock, BlockId, InstId, InstKind, Instruction, MirType, StorageAlias, Value, ValueId,
+    BasicBlock, BlockId, InstId, InstKind, Instruction, MirType, StorageAlias, Terminator, Value,
+    ValueId,
 };
 use alloy_primitives::U256;
 use solar_data_structures::{
     bit_set::DenseBitSet,
     fmt::{self, FmtIteratorExt},
-    index::IndexVec,
+    index::{IndexVec, index_vec},
     map::FxHashMap,
 };
 use solar_interface::Ident;
@@ -34,11 +35,11 @@ pub(crate) struct Function {
     /// Bytes reserved for the low-memory external ABI return buffer.
     pub(crate) external_static_return_size: u64,
     /// All values in this function.
-    pub(crate) values: IndexVec<ValueId, Value>,
+    values: IndexVec<ValueId, Value>,
     /// All instructions in this function.
-    pub(crate) instructions: IndexVec<InstId, Instruction>,
+    instructions: IndexVec<InstId, Instruction>,
     /// All basic blocks in this function. This is never empty; block zero is the entry.
-    pub(crate) blocks: IndexVec<BlockId, BasicBlock>,
+    blocks: IndexVec<BlockId, BasicBlock>,
 }
 
 impl Function {
@@ -69,6 +70,43 @@ impl Function {
         &self.values[id]
     }
 
+    /// Returns a mutable reference to the value for the given ID.
+    pub(crate) fn value_mut(&mut self, id: ValueId) -> &mut Value {
+        &mut self.values[id]
+    }
+
+    /// Returns the number of allocated values.
+    #[must_use]
+    pub(crate) fn value_count(&self) -> usize {
+        self.values.len()
+    }
+
+    /// Returns the allocated value IDs.
+    pub(crate) fn value_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = ValueId> + ExactSizeIterator + use<> {
+        self.values.indices()
+    }
+
+    /// Returns the allocated values.
+    pub(crate) fn values(&self) -> impl DoubleEndedIterator<Item = &Value> + ExactSizeIterator {
+        self.values.iter()
+    }
+
+    /// Returns the allocated values with their IDs.
+    pub(crate) fn values_enumerated(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (ValueId, &Value)> + ExactSizeIterator {
+        self.values.iter_enumerated()
+    }
+
+    /// Returns the allocated values mutably.
+    pub(crate) fn values_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = &mut Value> + ExactSizeIterator {
+        self.values.iter_mut()
+    }
+
     /// Returns an immediate value as U256.
     #[must_use]
     pub(crate) fn value_u256(&self, id: ValueId) -> Option<U256> {
@@ -95,6 +133,38 @@ impl Function {
     #[must_use]
     pub(crate) fn instruction(&self, id: InstId) -> &Instruction {
         &self.instructions[id]
+    }
+
+    /// Returns a mutable reference to the instruction for the given ID.
+    pub(crate) fn instruction_mut(&mut self, id: InstId) -> &mut Instruction {
+        &mut self.instructions[id]
+    }
+
+    /// Returns the number of allocated instructions.
+    #[must_use]
+    pub(crate) fn instruction_count(&self) -> usize {
+        self.instructions.len()
+    }
+
+    /// Returns the allocated instructions.
+    pub(crate) fn instructions(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &Instruction> + ExactSizeIterator {
+        self.instructions.iter()
+    }
+
+    /// Returns the allocated instructions with their IDs.
+    pub(crate) fn instructions_enumerated(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (InstId, &Instruction)> + ExactSizeIterator {
+        self.instructions.iter_enumerated()
+    }
+
+    /// Returns the allocated instructions mutably.
+    pub(crate) fn instructions_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = &mut Instruction> + ExactSizeIterator {
+        self.instructions.iter_mut()
     }
 
     /// Returns the value produced by the given instruction, if it has one.
@@ -187,6 +257,46 @@ impl Function {
         &mut self.blocks[id]
     }
 
+    /// Returns the number of allocated basic blocks.
+    #[must_use]
+    pub(crate) fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Returns whether the function has no basic blocks.
+    #[must_use]
+    pub(crate) fn has_no_blocks(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    /// Returns the allocated basic block IDs.
+    pub(crate) fn block_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = BlockId> + ExactSizeIterator + use<> {
+        self.blocks.indices()
+    }
+
+    /// Returns the allocated basic blocks.
+    pub(crate) fn blocks(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &BasicBlock> + ExactSizeIterator {
+        self.blocks.iter()
+    }
+
+    /// Returns the allocated basic blocks with their IDs.
+    pub(crate) fn blocks_enumerated(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (BlockId, &BasicBlock)> + ExactSizeIterator {
+        self.blocks.iter_enumerated()
+    }
+
+    /// Returns the allocated basic blocks mutably.
+    pub(crate) fn blocks_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = &mut BasicBlock> + ExactSizeIterator {
+        self.blocks.iter_mut()
+    }
+
     /// Allocates a new value.
     pub(crate) fn alloc_value(&mut self, value: Value) -> ValueId {
         self.values.push(value)
@@ -200,6 +310,60 @@ impl Function {
     /// Allocates a new basic block.
     pub(crate) fn alloc_block(&mut self) -> BlockId {
         self.blocks.push(BasicBlock::new())
+    }
+
+    /// Reorders the basic blocks and remaps every block reference.
+    pub(crate) fn remap_block_order(&mut self, order: &[BlockId]) -> IndexVec<BlockId, BlockId> {
+        debug_assert_eq!(order.len(), self.block_count());
+        let mut remap = index_vec![BlockId::from_usize(0); order.len()];
+        let mut old_blocks = std::mem::take(&mut self.blocks)
+            .into_iter()
+            .map(Some)
+            .collect::<IndexVec<BlockId, _>>();
+        let mut blocks = IndexVec::with_capacity(old_blocks.len());
+        for &old_block in order {
+            let block = old_blocks[old_block].take().expect("duplicate block in order");
+            remap[old_block] = blocks.push(block);
+        }
+        debug_assert!(old_blocks.into_iter().all(|block| block.is_none()));
+        self.blocks = blocks;
+
+        for block in &mut self.blocks {
+            for predecessor in &mut block.predecessors {
+                *predecessor = remap[*predecessor];
+            }
+            if let Some(terminator) = &mut block.terminator {
+                let remap_block = |block: &mut BlockId| *block = remap[*block];
+                match terminator {
+                    Terminator::Jump(target) => remap_block(target),
+                    Terminator::Branch { then_block, else_block, .. } => {
+                        remap_block(then_block);
+                        remap_block(else_block);
+                    }
+                    Terminator::Switch { default, cases, .. } => {
+                        remap_block(default);
+                        for (_, target) in cases {
+                            remap_block(target);
+                        }
+                    }
+                    Terminator::Return { .. }
+                    | Terminator::Revert { .. }
+                    | Terminator::ReturnData { .. }
+                    | Terminator::Stop
+                    | Terminator::SelfDestruct { .. }
+                    | Terminator::TailCall { .. }
+                    | Terminator::Invalid => {}
+                }
+            }
+        }
+        for inst in &mut self.instructions {
+            if let InstKind::Phi(incoming) = &mut inst.kind {
+                for (block, _) in incoming {
+                    *block = remap[*block];
+                }
+            }
+        }
+        remap
     }
 
     /// Replaces all value uses according to a one-step replacement map.

--- a/crates/codegen/src/mir/inst.rs
+++ b/crates/codegen/src/mir/inst.rs
@@ -229,7 +229,7 @@ impl StorageAlias {
     pub(crate) fn for_value(func: &Function, value: ValueId) -> Self {
         match func.value(value) {
             Value::Immediate(imm) => imm.as_u256().map_or(Self::Symbolic(value), Self::Slot),
-            Value::Inst(inst_id) => match func.instructions[*inst_id].kind {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::Add(lhs, rhs) => {
                     if let Some(offset) = Self::immediate_u256(func, rhs) {
                         Self::add_offset(func, lhs, offset)

--- a/crates/codegen/src/mir/module.rs
+++ b/crates/codegen/src/mir/module.rs
@@ -93,7 +93,7 @@ pub struct Module {
     /// Module/contract name.
     pub(crate) name: Ident,
     /// All functions in this module.
-    pub(crate) functions: IndexVec<FunctionId, Function>,
+    functions: IndexVec<FunctionId, Function>,
     /// Canonical ABI layouts referenced by semantic encoding operations.
     pub(crate) abi_layouts: Vec<AbiLayoutRef>,
     /// Canonical storage layouts referenced by semantic aggregate operations.
@@ -154,9 +154,67 @@ impl Module {
         &self.functions[id]
     }
 
+    /// Returns the function for the given ID, if it exists.
+    #[must_use]
+    pub(crate) fn get_function(&self, id: FunctionId) -> Option<&Function> {
+        self.functions.get(id)
+    }
+
     /// Returns a mutable reference to the function.
     pub(crate) fn function_mut(&mut self, id: FunctionId) -> &mut Function {
         &mut self.functions[id]
+    }
+
+    /// Returns the number of functions.
+    #[must_use]
+    pub(crate) fn function_count(&self) -> usize {
+        self.functions.len()
+    }
+
+    /// Returns whether the module has no functions.
+    #[must_use]
+    pub(crate) fn has_no_functions(&self) -> bool {
+        self.functions.is_empty()
+    }
+
+    /// Returns the function IDs.
+    pub(crate) fn function_ids(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = FunctionId> + ExactSizeIterator + use<> {
+        self.functions.indices()
+    }
+
+    /// Returns all functions.
+    pub(crate) fn functions(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &Function> + ExactSizeIterator {
+        self.functions.iter()
+    }
+
+    /// Returns all functions mutably.
+    pub(crate) fn functions_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = &mut Function> + ExactSizeIterator {
+        self.functions.iter_mut()
+    }
+
+    /// Retains the functions in the given order and returns their ID remapping.
+    pub(crate) fn retain_functions(
+        &mut self,
+        order: impl IntoIterator<Item = FunctionId>,
+    ) -> Vec<Option<FunctionId>> {
+        let mut remap = vec![None; self.functions.len()];
+        let mut old_functions: Vec<_> =
+            std::mem::take(&mut self.functions).into_iter().map(Some).collect();
+        let mut functions = IndexVec::new();
+        for old_id in order {
+            let function =
+                old_functions[old_id.index()].take().expect("retained function must exist");
+            let new_id = functions.push(function);
+            remap[old_id.index()] = Some(new_id);
+        }
+        self.functions = functions;
+        remap
     }
 
     /// Interns an ABI layout and returns its canonical shared reference.

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -220,7 +220,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         function_refs: Vec<(FunctionId, PendingFunctionRef)>,
     ) -> PResult<'sess, ()> {
         let mut functions = FxHashMap::<Symbol, Vec<FunctionId>>::default();
-        for (id, function) in module.functions.iter_enumerated() {
+        for (id, function) in module.iter_functions() {
             functions.entry(function.name.name).or_default().push(id);
         }
         for (owner, reference) in function_refs {
@@ -241,7 +241,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             match reference.target {
                 FunctionRefTarget::Instruction(inst) => {
                     let InstKind::InternalCall { function: target, .. } =
-                        &mut module.functions[owner].instructions[inst].kind
+                        &mut module.function_mut(owner).instruction_mut(inst).kind
                     else {
                         unreachable!()
                     };
@@ -249,7 +249,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 }
                 FunctionRefTarget::Terminator(block) => {
                     let Some(Terminator::TailCall { function: target, .. }) =
-                        &mut module.functions[owner].blocks[block].terminator
+                        &mut module.function_mut(owner).block_mut(block).terminator
                     else {
                         unreachable!()
                     };
@@ -539,7 +539,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         inst_id: InstId,
     ) -> PResult<'sess, ()> {
         if let Some(value) = self.value_labels.get(&label).copied() {
-            if matches!(builder.func().values[value], Value::Undef(_)) {
+            if matches!(builder.func().value(value), Value::Undef(_)) {
                 builder.set_value(value, Value::Inst(inst_id));
                 return Ok(());
             }
@@ -556,7 +556,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             .value_labels
             .iter()
             .filter_map(|(&label, &value)| {
-                matches!(func.values[value], Value::Undef(_)).then_some(label)
+                matches!(func.value(value), Value::Undef(_)).then_some(label)
             })
             .collect();
         unresolved.sort_unstable();
@@ -1617,7 +1617,7 @@ fn @add(arg0: u256, arg1: u256) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.blocks.len(), 1);
+            assert_eq!(func.block_count(), 1);
             assert_eq!(func.params.len(), 2);
             assert_eq!(func.returns.len(), 1);
             // Round-trip: print and re-parse should not error.
@@ -1639,13 +1639,13 @@ fn @increment() {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.blocks.len(), 1);
+            assert_eq!(func.block_count(), 1);
             assert_eq!(func.params.len(), 0);
             // sstore + stop are the only "no result" things; sload, add produce results.
             // So we expect 4 instructions total.
-            assert_eq!(func.instructions.len(), 3);
+            assert_eq!(func.instruction_count(), 3);
             // 0 + 1 are immediates; v0, v1 are inst results.
-            assert!(func.values.len() >= 4);
+            assert!(func.value_count() >= 4);
         });
     }
 
@@ -1664,9 +1664,9 @@ fn @max(arg0: u256, arg1: u256) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.blocks.len(), 3);
+            assert_eq!(func.block_count(), 3);
             // bb0 should have 2 successors.
-            assert_eq!(func.blocks[BlockId::ENTRY].terminator().unwrap().successors().len(), 2);
+            assert_eq!(func.block(BlockId::ENTRY).terminator().unwrap().successors().len(), 2);
         });
     }
 
@@ -1687,7 +1687,7 @@ fn @count_down(arg0: u256) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.blocks.len(), 4);
+            assert_eq!(func.block_count(), 4);
         });
     }
 
@@ -1702,7 +1702,7 @@ fn @do_call(arg0: address, arg1: u256) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.instructions.len(), 1);
+            assert_eq!(func.instruction_count(), 1);
         });
     }
 
@@ -1719,7 +1719,7 @@ fn @hash() -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.instructions.len(), 3);
+            assert_eq!(func.instruction_count(), 3);
         });
     }
 
@@ -1740,10 +1740,11 @@ fn @set(arg0: u256) {
 }
 ";
             let module = parse_module(sess, src).unwrap();
-            assert_eq!(module.functions.len(), 2);
-            let Some(Terminator::TailCall { function, .. }) =
-                &module.functions[FunctionId::from_usize(0)].blocks[BlockId::from_usize(0)]
-                    .terminator
+            assert_eq!(module.function_count(), 2);
+            let Some(Terminator::TailCall { function, .. }) = &module
+                .function(FunctionId::from_usize(0))
+                .block(BlockId::from_usize(0))
+                .terminator
             else {
                 panic!("expected tail call")
             };
@@ -1751,7 +1752,7 @@ fn @set(arg0: u256) {
             // Round-trip the printed form.
             let printed = module.to_text().to_string();
             let module2 = parse_module(sess, &printed).unwrap();
-            assert_eq!(module2.functions.len(), 2);
+            assert_eq!(module2.function_count(), 2);
         });
     }
 
@@ -1922,7 +1923,7 @@ fn @oops() {
 ";
             let func = parse_function(sess, src).unwrap();
             assert!(matches!(
-                func.blocks[BlockId::ENTRY].terminator,
+                func.block(BlockId::ENTRY).terminator,
                 Some(Terminator::Revert { .. })
             ));
         });
@@ -1942,7 +1943,7 @@ fn @env() -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.instructions.len(), 4);
+            assert_eq!(func.instruction_count(), 4);
         });
     }
 
@@ -1958,7 +1959,7 @@ fn @sel(arg0: bool, arg1: u256, arg2: u256) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.instructions.len(), 2);
+            assert_eq!(func.instruction_count(), 2);
         });
     }
 
@@ -1979,10 +1980,10 @@ fn @diamond(arg0: bool) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.blocks.len(), 4);
+            assert_eq!(func.block_count(), 4);
             // Find the phi instruction.
             let phi_inst =
-                func.instructions.iter().find(|i| matches!(i.kind, InstKind::Phi(_))).unwrap();
+                func.instructions().find(|i| matches!(i.kind, InstKind::Phi(_))).unwrap();
             if let InstKind::Phi(args) = &phi_inst.kind {
                 assert_eq!(args.len(), 2);
             } else {
@@ -2009,8 +2010,8 @@ fn @dispatch(arg0: u256) -> u256 {
 }
 ";
             let func = parse_function(sess, src).unwrap();
-            assert_eq!(func.blocks.len(), 5);
-            let term = func.blocks[BlockId::ENTRY].terminator.as_ref().unwrap();
+            assert_eq!(func.block_count(), 5);
+            let term = func.block(BlockId::ENTRY).terminator.as_ref().unwrap();
             if let Terminator::Switch { cases, .. } = term {
                 assert_eq!(cases.len(), 3);
             } else {

--- a/crates/codegen/src/mir/utils.rs
+++ b/crates/codegen/src/mir/utils.rs
@@ -3,67 +3,13 @@
 use crate::mir::{BasicBlock, BlockId, Function, InstKind, Terminator, ValueId};
 use alloy_primitives::U256;
 use smallvec::smallvec;
-use solar_data_structures::{
-    index::{IndexVec, index_vec},
-    map::FxHashMap,
-};
+use solar_data_structures::{index::IndexVec, map::FxHashMap};
 
 pub(crate) fn remap_block_order(
     func: &mut Function,
     order: &[BlockId],
 ) -> IndexVec<BlockId, BlockId> {
-    debug_assert_eq!(order.len(), func.blocks.len());
-    let mut remap = index_vec![BlockId::from_usize(0); order.len()];
-    let mut old_blocks =
-        std::mem::take(&mut func.blocks).into_iter().map(Some).collect::<IndexVec<BlockId, _>>();
-    let mut blocks = IndexVec::with_capacity(old_blocks.len());
-    for &old_block in order {
-        let block = old_blocks[old_block].take().expect("duplicate block in order");
-        remap[old_block] = blocks.push(block);
-    }
-    debug_assert!(old_blocks.into_iter().all(|block| block.is_none()));
-    func.blocks = blocks;
-
-    for block in &mut func.blocks {
-        for predecessor in &mut block.predecessors {
-            *predecessor = remap[*predecessor];
-        }
-        if let Some(terminator) = &mut block.terminator {
-            remap_terminator_blocks(terminator, &remap);
-        }
-    }
-    for inst in &mut func.instructions {
-        if let InstKind::Phi(incoming) = &mut inst.kind {
-            for (block, _) in incoming {
-                *block = remap[*block];
-            }
-        }
-    }
-    remap
-}
-
-fn remap_terminator_blocks(terminator: &mut Terminator, remap: &IndexVec<BlockId, BlockId>) {
-    let remap_block = |block: &mut BlockId| *block = remap[*block];
-    match terminator {
-        Terminator::Jump(target) => remap_block(target),
-        Terminator::Branch { then_block, else_block, .. } => {
-            remap_block(then_block);
-            remap_block(else_block);
-        }
-        Terminator::Switch { default, cases, .. } => {
-            remap_block(default);
-            for (_, target) in cases {
-                remap_block(target);
-            }
-        }
-        Terminator::Return { .. }
-        | Terminator::Revert { .. }
-        | Terminator::ReturnData { .. }
-        | Terminator::Stop
-        | Terminator::SelfDestruct { .. }
-        | Terminator::TailCall { .. }
-        | Terminator::Invalid => {}
-    }
+    func.remap_block_order(order)
 }
 
 /// Which state-access instructions should receive storage-alias metadata.
@@ -88,11 +34,12 @@ pub(crate) enum StorageAliasScope {
 /// Self-loops (`pred == succ`) are supported: the new block takes over the
 /// backedge and `succ`'s phis are rekeyed from `pred` to the new block.
 pub(crate) fn split_edge(func: &mut Function, pred: BlockId, succ: BlockId) -> BlockId {
-    let new_block = func.blocks.push(BasicBlock {
+    let new_block = func.alloc_block();
+    *func.block_mut(new_block) = BasicBlock {
         instructions: Vec::new(),
         terminator: Some(Terminator::Jump(succ)),
         predecessors: smallvec![pred],
-    });
+    };
 
     // Retarget every occurrence of `succ` among `pred`'s successors.
     let mut retargeted = false;
@@ -102,7 +49,7 @@ pub(crate) fn split_edge(func: &mut Function, pred: BlockId, succ: BlockId) -> B
             retargeted = true;
         }
     };
-    match func.blocks[pred].terminator.as_mut().expect("predecessor must have a terminator") {
+    match func.block_mut(pred).terminator.as_mut().expect("predecessor must have a terminator") {
         Terminator::Jump(target) => retarget(target),
         Terminator::Branch { then_block, else_block, .. } => {
             retarget(then_block);
@@ -121,7 +68,7 @@ pub(crate) fn split_edge(func: &mut Function, pred: BlockId, succ: BlockId) -> B
     // Replace `pred` with the new block in `succ`'s predecessor list. A
     // multi-occurrence edge may have been recorded once per occurrence;
     // they all collapse into the single split block.
-    let predecessors = &mut func.blocks[succ].predecessors;
+    let predecessors = &mut func.block_mut(succ).predecessors;
     let first = predecessors
         .iter()
         .position(|&block| block == pred)
@@ -130,8 +77,9 @@ pub(crate) fn split_edge(func: &mut Function, pred: BlockId, succ: BlockId) -> B
     predecessors.retain(|&mut block| block != pred);
 
     // Rekey `succ`'s phi incoming entries from `pred` to the new block.
-    for &inst_id in &func.blocks[succ].instructions {
-        if let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind {
+    let inst_ids = func.block(succ).instructions.clone();
+    for inst_id in inst_ids {
+        if let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind {
             for (block, _) in incoming.iter_mut() {
                 if *block == pred {
                     *block = new_block;
@@ -147,27 +95,28 @@ pub(crate) fn split_edge(func: &mut Function, pred: BlockId, succ: BlockId) -> B
 /// that are no longer predecessors. Returns true if any phi input was dropped.
 pub(crate) fn repair_reachability_phis(func: &mut Function) -> bool {
     let mut edges = Vec::new();
-    for (block, bb) in func.blocks.iter_enumerated() {
+    for (block, bb) in func.blocks_enumerated() {
         if let Some(term) = &bb.terminator {
             edges.push((block, term.successors()));
         }
     }
 
-    for block in func.blocks.iter_mut() {
+    for block in func.blocks_mut() {
         block.predecessors.clear();
     }
 
     for (block, successors) in edges {
         for succ in successors {
-            func.blocks[succ].predecessors.push(block);
+            func.block_mut(succ).predecessors.push(block);
         }
     }
 
     let mut changed = false;
-    for block_id in func.blocks.indices() {
-        let predecessors = func.blocks[block_id].predecessors.clone();
-        for &inst_id in &func.blocks[block_id].instructions {
-            if let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind {
+    for block_id in func.block_ids() {
+        let predecessors = func.block(block_id).predecessors.clone();
+        let inst_ids = func.block(block_id).instructions.clone();
+        for inst_id in inst_ids {
+            if let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind {
                 let len_before = incoming.len();
                 incoming.retain(|(pred, _)| predecessors.contains(pred));
                 changed |= incoming.len() != len_before;

--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -235,8 +235,8 @@ pub(crate) fn run_function_pass(
     mut run: impl FnMut(&mut Function, &FunctionAnalyses) -> bool,
 ) -> bool {
     let mut changed = false;
-    for func_id in module.functions.indices() {
-        if module.functions[func_id].blocks.is_empty() {
+    for func_id in module.function_ids() {
+        if module.function(func_id).has_no_blocks() {
             continue;
         }
         changed |= run_function_pass_cached(analyses, module, func_id, &mut run);
@@ -326,7 +326,7 @@ impl ModuleAnalyses {
 
 fn cfg_edges(func: &Function) -> Vec<(u32, u32)> {
     let mut edges = Vec::new();
-    for (block_id, block) in func.blocks.iter_enumerated() {
+    for (block_id, block) in func.blocks_enumerated() {
         if let Some(terminator) = &block.terminator {
             for successor in terminator.successors() {
                 edges.push((block_id.index() as u32, successor.index() as u32));
@@ -344,9 +344,9 @@ fn verified_preservation(
 ) -> (bool, bool) {
     let edges_after = cfg_edges(func);
     let keep_cfg = edges_after == edges_before;
-    let no_new_side_effects = (insts_before..func.instructions.len())
+    let no_new_side_effects = (insts_before..func.instruction_count())
         .map(InstId::from_usize)
-        .all(|inst_id| !func.instructions[inst_id].kind.has_side_effects());
+        .all(|inst_id| !func.instruction(inst_id).kind.has_side_effects());
     let keep_alias = no_new_side_effects
         && (keep_cfg || edges_after.iter().all(|edge| edges_before.binary_search(edge).is_ok()));
     (keep_alias, keep_cfg)
@@ -358,10 +358,10 @@ fn run_function_pass_cached(
     func_id: FunctionId,
     run: &mut impl FnMut(&mut Function, &FunctionAnalyses) -> bool,
 ) -> bool {
-    let bundle = analyses.bundle(func_id, &module.functions[func_id]);
-    let func = &mut module.functions[func_id];
+    let bundle = analyses.bundle(func_id, module.function(func_id));
+    let func = module.function_mut(func_id);
     let edges_before = cfg_edges(func);
-    let insts_before = func.instructions.len();
+    let insts_before = func.instruction_count();
     let changed = run(func, &bundle);
     if changed {
         let (keep_alias, keep_cfg) = verified_preservation(func, &edges_before, insts_before);

--- a/crates/codegen/src/transform/adce.rs
+++ b/crates/codegen/src/transform/adce.rs
@@ -105,9 +105,9 @@ impl AggressiveDeadCodeEliminator {
 
     fn rewrite_dead_control(&self, func: &mut Function, ctx: &AdceContext) -> usize {
         let mut rewrites = Vec::new();
-        let mut search = TargetSearch::new(func.blocks.len());
-        for block_id in func.blocks.indices() {
-            let Some(term) = &func.blocks[block_id].terminator else {
+        let mut search = TargetSearch::new(func.block_count());
+        for block_id in func.block_ids() {
+            let Some(term) = &func.block(block_id).terminator else {
                 continue;
             };
             if !matches!(term, Terminator::Branch { .. } | Terminator::Switch { .. }) {
@@ -185,7 +185,7 @@ impl AggressiveDeadCodeEliminator {
             return Some(block_id);
         }
 
-        let term = func.blocks[block_id].terminator.as_ref()?;
+        let term = func.block(block_id).terminator.as_ref()?;
         match term {
             Terminator::Jump(target) => self.transparent_target(func, ctx, *target, search),
             Terminator::Branch { .. } | Terminator::Switch { .. } => {
@@ -202,14 +202,14 @@ impl AggressiveDeadCodeEliminator {
     }
 
     fn block_has_effect(&self, func: &Function, block_id: BlockId) -> bool {
-        func.blocks[block_id]
+        func.block(block_id)
             .instructions
             .iter()
-            .any(|&inst_id| func.instructions[inst_id].kind.has_side_effects())
+            .any(|&inst_id| func.instruction(inst_id).kind.has_side_effects())
     }
 
     fn block_def_escapes(&self, func: &Function, ctx: &AdceContext, block_id: BlockId) -> bool {
-        func.blocks[block_id].instructions.iter().any(|&inst_id| {
+        func.block(block_id).instructions.iter().any(|&inst_id| {
             let Some(&value) = ctx.inst_results.get(&inst_id) else {
                 return false;
             };
@@ -220,20 +220,21 @@ impl AggressiveDeadCodeEliminator {
     }
 
     fn rewrite_to_jump(&self, func: &mut Function, block_id: BlockId, target: BlockId) {
-        let old_successors = func.blocks[block_id]
+        let old_successors = func
+            .block(block_id)
             .terminator
             .as_ref()
             .map(|term| term.successors())
             .unwrap_or_default();
 
         for successor in old_successors {
-            func.blocks[successor].predecessors.retain(|pred| *pred != block_id);
+            func.block_mut(successor).predecessors.retain(|pred| *pred != block_id);
         }
-        if !func.blocks[target].predecessors.contains(&block_id) {
-            func.blocks[target].predecessors.push(block_id);
+        if !func.block(target).predecessors.contains(&block_id) {
+            func.block_mut(target).predecessors.push(block_id);
         }
 
-        func.blocks[block_id].terminator = Some(Terminator::Jump(target));
+        func.block_mut(block_id).terminator = Some(Terminator::Jump(target));
     }
 }
 
@@ -246,18 +247,18 @@ impl AdceContext {
 
     fn value_uses(func: &Function) -> FxHashMap<ValueId, DenseBitSet<BlockId>> {
         let mut uses = FxHashMap::default();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             for &inst_id in &block.instructions {
-                for operand in func.instructions[inst_id].kind.operands() {
+                for operand in func.instruction(inst_id).kind.operands() {
                     uses.entry(operand)
-                        .or_insert_with(|| DenseBitSet::new_empty(func.blocks.len()))
+                        .or_insert_with(|| DenseBitSet::new_empty(func.block_count()))
                         .insert(block_id);
                 }
             }
             if let Some(term) = &block.terminator {
                 for operand in term.operands() {
                     uses.entry(operand)
-                        .or_insert_with(|| DenseBitSet::new_empty(func.blocks.len()))
+                        .or_insert_with(|| DenseBitSet::new_empty(func.block_count()))
                         .insert(block_id);
                 }
             }

--- a/crates/codegen/src/transform/cfg_simplify.rs
+++ b/crates/codegen/src/transform/cfg_simplify.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     pass::{MirPass, run_function_pass},
 };
-use solar_data_structures::{bit_set::DenseBitSet, index::IndexVec, map::FxHashMap};
+use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
 
 /// Function pass for CFG simplification.
 pub(crate) struct CfgSimplify;
@@ -183,8 +183,8 @@ impl CfgSimplifier {
 
         let mut kept: Vec<(BlockId, CanonBlock)> = Vec::new();
         let mut merges: Vec<(BlockId, BlockId)> = Vec::new();
-        for block_id in func.blocks.indices() {
-            if func.blocks[block_id].predecessors.is_empty() {
+        for block_id in func.block_ids() {
+            if func.block(block_id).predecessors.is_empty() {
                 continue;
             }
             let Some(canon) = Self::canonicalize_terminal_block(func, block_id, &inst_results)
@@ -199,16 +199,16 @@ impl CfgSimplifier {
         }
 
         for (dup, keep) in merges {
-            let predecessors: Vec<_> = func.blocks[dup].predecessors.to_vec();
+            let predecessors: Vec<_> = func.block(dup).predecessors.to_vec();
             for pred in predecessors {
                 self.redirect_terminator(func, pred, dup, keep);
-                if !func.blocks[keep].predecessors.contains(&pred) {
-                    func.blocks[keep].predecessors.push(pred);
+                if !func.block(keep).predecessors.contains(&pred) {
+                    func.block_mut(keep).predecessors.push(pred);
                 }
             }
-            func.blocks[dup].instructions.clear();
-            func.blocks[dup].terminator = Some(Terminator::Invalid);
-            func.blocks[dup].predecessors.clear();
+            func.block_mut(dup).instructions.clear();
+            func.block_mut(dup).terminator = Some(Terminator::Invalid);
+            func.block_mut(dup).predecessors.clear();
             self.stats.terminal_blocks_deduplicated += 1;
         }
     }
@@ -220,7 +220,7 @@ impl CfgSimplifier {
         block_id: BlockId,
         inst_results: &FxHashMap<crate::mir::InstId, ValueId>,
     ) -> Option<CanonBlock> {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
         let term = block.terminator.as_ref()?;
         if matches!(term, Terminator::Invalid) || !term.successors().is_empty() {
             return None;
@@ -237,7 +237,7 @@ impl CfgSimplifier {
             if let Some(&position) = local_defs.get(&value) {
                 return CanonOperand::Local(position);
             }
-            match &func.values[value] {
+            match func.value(value) {
                 Value::Immediate(imm) => CanonOperand::Imm(imm.clone()),
                 _ => CanonOperand::Outside(value),
             }
@@ -245,7 +245,7 @@ impl CfgSimplifier {
 
         let mut insts = Vec::with_capacity(block.instructions.len());
         for &inst_id in &block.instructions {
-            let inst = &func.instructions[inst_id];
+            let inst = func.instruction(inst_id);
             let extra = match &inst.kind {
                 InstKind::Phi(_) => return None,
                 InstKind::InternalFrameAddr(offset) => CanonPayload::FrameAddr(*offset),
@@ -275,10 +275,10 @@ impl CfgSimplifier {
         let mut candidates = Vec::new();
         let mut raw = FxHashMap::default();
 
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             let same_block_phi_results = func.block_phi_results(block_id);
-            for &inst_id in &func.blocks[block_id].instructions {
-                let InstKind::Phi(incoming) = &func.instructions[inst_id].kind else {
+            for &inst_id in &func.block(block_id).instructions {
+                let InstKind::Phi(incoming) = &func.instruction(inst_id).kind else {
                     continue;
                 };
                 let Some(phi_value) = func.inst_result_value(inst_id) else {
@@ -303,8 +303,8 @@ impl CfgSimplifier {
         // the chain or they dangle once the intermediate phi is removed.
         // Mutually-trivial cycles have no outside source; keep those phis.
         let mut replacements = FxHashMap::default();
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
-        let mut seen = DenseBitSet::new_empty(func.values.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
+        let mut seen = DenseBitSet::new_empty(func.value_count());
         for &(inst_id, phi_value) in &candidates {
             seen.clear();
             seen.insert(phi_value);
@@ -328,7 +328,7 @@ impl CfgSimplifier {
         }
 
         func.replace_uses(&replacements);
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&inst_id| !dead.contains(inst_id));
         }
         self.stats.trivial_phis_simplified += dead.count();
@@ -348,11 +348,11 @@ impl CfgSimplifier {
     }
 
     fn simplify_degenerate_terminators(&mut self, func: &mut Function) {
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
         let mut changed = false;
         for block_id in block_ids {
             let Some(Terminator::Branch { then_block, else_block, .. }) =
-                func.blocks[block_id].terminator.as_ref()
+                func.block(block_id).terminator.as_ref()
             else {
                 continue;
             };
@@ -361,7 +361,7 @@ impl CfgSimplifier {
             }
 
             let target = *then_block;
-            func.blocks[block_id].terminator = Some(Terminator::Jump(target));
+            func.block_mut(block_id).terminator = Some(Terminator::Jump(target));
             self.stats.terminators_simplified += 1;
             self.stats.gas_saved += 10;
             changed = true;
@@ -391,7 +391,7 @@ impl CfgSimplifier {
         while merged {
             merged = false;
 
-            let block_ids: Vec<_> = func.blocks.indices().collect();
+            let block_ids: Vec<_> = func.block_ids().collect();
             for block_id in block_ids {
                 if let Some(target) = self.can_merge(func, block_id) {
                     self.do_merge(func, block_id, target);
@@ -407,7 +407,7 @@ impl CfgSimplifier {
     /// Checks if block_id can be merged with its successor.
     /// Returns the target block if merge is possible.
     fn can_merge(&self, func: &Function, block_id: BlockId) -> Option<BlockId> {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
 
         let Terminator::Jump(target) = block.terminator.as_ref()? else {
             return None;
@@ -417,7 +417,7 @@ impl CfgSimplifier {
             return None;
         }
 
-        let target_block = &func.blocks[*target];
+        let target_block = func.block(*target);
         if target_block.predecessors.len() != 1 {
             return None;
         }
@@ -427,7 +427,7 @@ impl CfgSimplifier {
         }
 
         for &inst_id in &target_block.instructions {
-            let InstKind::Phi(incoming) = &func.instructions[inst_id].kind else {
+            let InstKind::Phi(incoming) = &func.instruction(inst_id).kind else {
                 continue;
             };
             if !incoming.iter().any(|(pred, _)| *pred == block_id) {
@@ -441,23 +441,24 @@ impl CfgSimplifier {
     /// Merges block_id with target, appending target's instructions and terminator to block_id.
     fn do_merge(&self, func: &mut Function, block_id: BlockId, target: BlockId) {
         let phi_replacements = self.fold_target_phis_for_merge(func, block_id, target);
-        let target_instructions: Vec<_> = func.blocks[target]
+        let target_instructions: Vec<_> = func
+            .block(target)
             .instructions
             .iter()
             .copied()
-            .filter(|&inst_id| !matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+            .filter(|&inst_id| !matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
             .collect();
-        let target_terminator = func.blocks[target].terminator.take();
+        let target_terminator = func.block_mut(target).terminator.take();
         let target_successors =
             target_terminator.as_ref().map(Terminator::successors).unwrap_or_default();
 
-        func.blocks[block_id].instructions.extend(target_instructions);
-        func.blocks[block_id].terminator = target_terminator;
+        func.block_mut(block_id).instructions.extend(target_instructions);
+        func.block_mut(block_id).terminator = target_terminator;
 
         for &succ in &target_successors {
             self.redirect_target_phi_incoming(func, target, succ, &[block_id]);
 
-            let succ_block = &mut func.blocks[succ];
+            let succ_block = func.block_mut(succ);
             for pred in &mut succ_block.predecessors {
                 if *pred == target {
                     *pred = block_id;
@@ -465,9 +466,9 @@ impl CfgSimplifier {
             }
         }
 
-        func.blocks[target].instructions.clear();
-        func.blocks[target].terminator = Some(Terminator::Invalid);
-        func.blocks[target].predecessors.clear();
+        func.block_mut(target).instructions.clear();
+        func.block_mut(target).terminator = Some(Terminator::Invalid);
+        func.block_mut(target).predecessors.clear();
 
         func.replace_uses(&phi_replacements);
     }
@@ -479,8 +480,9 @@ impl CfgSimplifier {
         target: BlockId,
     ) -> FxHashMap<ValueId, ValueId> {
         let mut replacements = FxHashMap::default();
-        for &inst_id in &func.blocks[target].instructions {
-            let InstKind::Phi(incoming) = &func.instructions[inst_id].kind else {
+        let inst_ids = func.block(target).instructions.clone();
+        for inst_id in inst_ids {
+            let InstKind::Phi(incoming) = &func.instruction(inst_id).kind else {
                 continue;
             };
             let Some(phi_value) = func.inst_result_value(inst_id) else {
@@ -503,9 +505,9 @@ impl CfgSimplifier {
             eliminated = false;
 
             let cfg = CfgInfo::new(func);
-            let block_ids: Vec<_> = func.blocks.indices().collect();
+            let block_ids: Vec<_> = func.block_ids().collect();
             for block_id in block_ids {
-                if func.blocks[block_id].predecessors.is_empty() && cfg.is_reachable(block_id) {
+                if func.block(block_id).predecessors.is_empty() && cfg.is_reachable(block_id) {
                     continue;
                 }
 
@@ -525,7 +527,7 @@ impl CfgSimplifier {
 
     /// Checks if a block is an empty forwarder (no instructions, just a jump).
     fn is_empty_forwarder(&self, func: &Function, block_id: BlockId) -> bool {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
 
         if !block.instructions.is_empty() {
             return false;
@@ -535,18 +537,18 @@ impl CfgSimplifier {
     }
 
     fn is_loop_preheader_forwarder(&self, func: &Function, block_id: BlockId) -> bool {
-        let Some(Terminator::Jump(target)) = func.blocks[block_id].terminator else {
+        let Some(Terminator::Jump(target)) = func.block(block_id).terminator else {
             return false;
         };
         if !matches!(
-            func.blocks[target].instructions.first(),
-            Some(&inst) if matches!(func.instructions[inst].kind, InstKind::Phi(_))
+            func.block(target).instructions.first(),
+            Some(&inst) if matches!(func.instruction(inst).kind, InstKind::Phi(_))
         ) {
             return false;
         }
 
         let cfg = CfgInfo::new(func);
-        func.blocks[target]
+        func.block(target)
             .predecessors
             .iter()
             .copied()
@@ -559,12 +561,12 @@ impl CfgSimplifier {
     /// branch being forwarders into the same join), since phi incoming lists
     /// are keyed per predecessor block, not per CFG edge.
     fn forwarder_elimination_preserves_phis(&self, func: &Function, block_id: BlockId) -> bool {
-        let Some(Terminator::Jump(target)) = func.blocks[block_id].terminator else {
+        let Some(Terminator::Jump(target)) = func.block(block_id).terminator else {
             return false;
         };
-        let predecessors = &func.blocks[block_id].predecessors;
-        for &inst_id in &func.blocks[target].instructions {
-            let InstKind::Phi(incoming) = &func.instructions[inst_id].kind else {
+        let predecessors = &func.block(block_id).predecessors;
+        for &inst_id in &func.block(target).instructions {
+            let InstKind::Phi(incoming) = &func.instruction(inst_id).kind else {
                 continue;
             };
             let Some(&(_, forwarded)) = incoming.iter().find(|(pred, _)| *pred == block_id) else {
@@ -581,25 +583,25 @@ impl CfgSimplifier {
 
     /// Eliminates an empty forwarder block by redirecting its predecessors.
     fn eliminate_forwarder(&self, func: &mut Function, block_id: BlockId) {
-        let target = match &func.blocks[block_id].terminator {
+        let target = match &func.block(block_id).terminator {
             Some(Terminator::Jump(t)) => *t,
             _ => return,
         };
 
-        let predecessors: Vec<_> = func.blocks[block_id].predecessors.to_vec();
+        let predecessors: Vec<_> = func.block(block_id).predecessors.to_vec();
         self.redirect_target_phi_incoming(func, block_id, target, &predecessors);
 
         for pred_id in predecessors {
             self.redirect_terminator(func, pred_id, block_id, target);
 
-            func.blocks[target].predecessors.push(pred_id);
+            func.block_mut(target).predecessors.push(pred_id);
         }
 
-        func.blocks[target].predecessors.retain(|p| *p != block_id);
+        func.block_mut(target).predecessors.retain(|p| *p != block_id);
 
-        func.blocks[block_id].instructions.clear();
-        func.blocks[block_id].terminator = Some(Terminator::Invalid);
-        func.blocks[block_id].predecessors.clear();
+        func.block_mut(block_id).instructions.clear();
+        func.block_mut(block_id).terminator = Some(Terminator::Invalid);
+        func.block_mut(block_id).predecessors.clear();
     }
 
     fn redirect_target_phi_incoming(
@@ -609,8 +611,9 @@ impl CfgSimplifier {
         target: BlockId,
         new_preds: &[BlockId],
     ) {
-        for &inst_id in &func.blocks[target].instructions {
-            let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind else {
+        let inst_ids = func.block(target).instructions.clone();
+        for inst_id in inst_ids {
+            let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind else {
                 continue;
             };
 
@@ -646,7 +649,7 @@ impl CfgSimplifier {
         old_target: BlockId,
         new_target: BlockId,
     ) {
-        let block = &mut func.blocks[block_id];
+        let block = func.block_mut(block_id);
         match &mut block.terminator {
             Some(Terminator::Jump(t)) if *t == old_target => {
                 *t = new_target;
@@ -699,31 +702,21 @@ impl DeadFunctionEliminator {
             return 0;
         }
 
-        self.stats.dead_functions_eliminated = module.functions.len() - reachable.count();
+        self.stats.dead_functions_eliminated = module.function_count() - reachable.count();
         if self.stats.dead_functions_eliminated == 0 {
             return 0;
         }
 
-        let mut remap = vec![None; module.functions.len()];
-        let mut old_functions: Vec<_> =
-            std::mem::take(&mut module.functions).into_iter().map(Some).collect();
-        let mut functions = IndexVec::with_capacity(reachable.count());
-        for old_id in reachable {
-            let function =
-                old_functions[old_id.index()].take().expect("reachable function must exist");
-            let new_id = functions.push(function);
-            remap[old_id.index()] = Some(new_id);
-        }
-        module.functions = functions;
+        let remap = module.retain_functions(reachable);
 
-        for func in &mut module.functions {
-            for inst in &mut func.instructions {
+        for func in module.functions_mut() {
+            for inst in func.instructions_mut() {
                 if let InstKind::InternalCall { function, .. } = &mut inst.kind {
                     *function = remap[function.index()]
                         .expect("reachable function cannot call an eliminated function");
                 }
             }
-            for block in &mut func.blocks {
+            for block in func.blocks_mut() {
                 if let Some(Terminator::TailCall { function, .. }) = &mut block.terminator {
                     *function = remap[function.index()]
                         .expect("reachable function cannot tail-call an eliminated function");
@@ -779,12 +772,12 @@ mod tests {
         let mut dfe = DeadFunctionEliminator::new();
         assert_eq!(dfe.run(&mut module), 1);
 
-        assert_eq!(module.functions.len(), 3);
-        assert!(module.functions.iter().all(|func| !func.blocks.is_empty()));
+        assert_eq!(module.function_count(), 3);
+        assert!(module.functions().all(|func| !func.has_no_blocks()));
         let live_helper = FunctionId::from_usize(0);
         let entry = module.function(FunctionId::from_usize(1));
         let InstKind::InternalCall { function, .. } =
-            &entry.instructions.iter().next().expect("entry call").kind
+            &entry.instructions().next().expect("entry call").kind
         else {
             panic!("expected internal call");
         };
@@ -792,7 +785,7 @@ mod tests {
 
         let tail_entry = module.function(FunctionId::from_usize(2));
         let Some(Terminator::TailCall { function, .. }) =
-            &tail_entry.blocks[BlockId::ENTRY].terminator
+            &tail_entry.block(BlockId::ENTRY).terminator
         else {
             panic!("expected tail call");
         };
@@ -831,16 +824,16 @@ mod tests {
             Some(MirType::uint256()),
         ));
         let phi_value = func.alloc_value(Value::Inst(phi_inst));
-        func.blocks[target].instructions.push(phi_inst);
-        func.blocks[target].terminator =
+        func.block_mut(target).instructions.push(phi_inst);
+        func.block_mut(target).terminator =
             Some(Terminator::Return { values: vec![phi_value].into() });
 
         let mut simplifier = CfgSimplifier::new();
         simplifier.run_to_fixpoint(&mut func);
 
-        assert!(matches!(func.blocks[forwarder].terminator, Some(Terminator::Invalid)));
-        let phi_inst = func.blocks[target].instructions[0];
-        let InstKind::Phi(incoming) = &func.instructions[phi_inst].kind else {
+        assert!(matches!(func.block(forwarder).terminator, Some(Terminator::Invalid)));
+        let phi_inst = func.block(target).instructions[0];
+        let InstKind::Phi(incoming) = &func.instruction(phi_inst).kind else {
             panic!("expected phi");
         };
         assert_eq!(incoming.as_slice(), &[(BlockId::ENTRY, value), (direct, other)]);
@@ -886,15 +879,16 @@ mod tests {
             Some(MirType::uint256()),
         ));
         let phi_value = func.alloc_value(Value::Inst(phi_inst));
-        func.blocks[exit].instructions.push(phi_inst);
-        func.blocks[exit].terminator = Some(Terminator::Return { values: vec![phi_value].into() });
+        func.block_mut(exit).instructions.push(phi_inst);
+        func.block_mut(exit).terminator =
+            Some(Terminator::Return { values: vec![phi_value].into() });
 
         let mut simplifier = CfgSimplifier::new();
         simplifier.run_to_fixpoint(&mut func);
 
-        assert!(matches!(func.blocks[middle].terminator, Some(Terminator::Invalid)));
-        let phi_inst = func.blocks[exit].instructions[0];
-        let InstKind::Phi(incoming) = &func.instructions[phi_inst].kind else {
+        assert!(matches!(func.block(middle).terminator, Some(Terminator::Invalid)));
+        let phi_inst = func.block(exit).instructions[0];
+        let InstKind::Phi(incoming) = &func.instruction(phi_inst).kind else {
             panic!("expected phi");
         };
         assert_eq!(incoming.as_slice(), &[(source, result), (other, other_value)]);

--- a/crates/codegen/src/transform/check_elim.rs
+++ b/crates/codegen/src/transform/check_elim.rs
@@ -149,7 +149,7 @@ impl CheckEliminator {
 
         // Predecessors recomputed from reachable terminators: facts must only
         // come from edges that can actually execute.
-        let mut preds = index_vec![Vec::new(); func.blocks.len()];
+        let mut preds = index_vec![Vec::new(); func.block_count()];
         for &block in cfg.rpo() {
             for &succ in cfg.successors(block) {
                 preds[succ].push(block);
@@ -166,7 +166,7 @@ impl CheckEliminator {
             return 0;
         }
         for &(block, keep) in &folds {
-            func.blocks[block].terminator = Some(Terminator::Jump(keep));
+            func.block_mut(block).terminator = Some(Terminator::Jump(keep));
         }
         repair_reachability_phis(func);
         self.stats.branches_folded = folds.len();
@@ -214,7 +214,7 @@ impl CheckEliminator {
                     }
 
                     if let Some(Terminator::Branch { condition, then_block, else_block }) =
-                        func.blocks[block].terminator.as_ref()
+                        func.block(block).terminator.as_ref()
                         && then_block != else_block
                         && let Some(truth) = self.eval_truth(func, *condition, MAX_DEPTH)
                     {
@@ -621,7 +621,7 @@ fn dominating_edge_fact(
         return None;
     }
     let Terminator::Branch { condition, then_block, else_block } =
-        func.blocks[first].terminator.as_ref()?
+        func.block(first).terminator.as_ref()?
     else {
         return None;
     };
@@ -647,7 +647,7 @@ fn const_of(func: &Function, value: ValueId) -> Option<U256> {
 
 fn inst_kind(func: &Function, value: ValueId) -> Option<&InstKind> {
     match func.value(value) {
-        Value::Inst(inst_id) => Some(&func.instructions[*inst_id].kind),
+        Value::Inst(inst_id) => Some(&func.instruction(*inst_id).kind),
         _ => None,
     }
 }

--- a/crates/codegen/src/transform/copy_elision.rs
+++ b/crates/codegen/src/transform/copy_elision.rs
@@ -48,8 +48,7 @@ struct CopyElisionCx {
 impl CopyElisionCx {
     fn run(&mut self, func: &mut Function, alias: &AliasAnalysis) -> bool {
         let allocs: Vec<(InstId, ValueId)> = func
-            .instructions
-            .iter_enumerated()
+            .instructions_enumerated()
             .filter_map(|(inst_id, inst)| match inst.kind {
                 InstKind::Alloc { .. } => {
                     func.inst_result_value(inst_id).map(|value| (inst_id, value))
@@ -74,7 +73,7 @@ impl CopyElisionCx {
         if dead.is_empty() {
             return false;
         }
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|inst| !dead.contains(inst));
         }
         true
@@ -89,9 +88,9 @@ impl CopyElisionCx {
         derived.insert(object);
         loop {
             let mut changed = false;
-            for (value_id, value) in func.values.iter_enumerated() {
+            for (value_id, value) in func.values_enumerated() {
                 let crate::mir::Value::Inst(inst_id) = value else { continue };
-                let propagates = match &func.instructions[*inst_id].kind {
+                let propagates = match &func.instruction(*inst_id).kind {
                     InstKind::Add(a, b) | InstKind::Sub(a, b) => {
                         derived.contains(a) || derived.contains(b)
                     }
@@ -110,7 +109,7 @@ impl CopyElisionCx {
         }
 
         let mut writes = Vec::new();
-        for (inst_id, inst) in func.instructions.iter_enumerated() {
+        for (inst_id, inst) in func.instructions_enumerated() {
             match &inst.kind {
                 // Writes to the allocation: the address is a derived value.
                 InstKind::MStore(addr, value) => {
@@ -175,7 +174,7 @@ impl CopyElisionCx {
 
         // Terminators never read a non-escaping allocation (that would escape),
         // but guard defensively.
-        for block in &func.blocks {
+        for block in func.blocks() {
             if let Some(term) = &block.terminator
                 && term.operands().iter().any(|op| derived.contains(op))
             {

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -232,7 +232,7 @@ impl CommonSubexprEliminator {
         self.process_global_pure(func, &inst_results, cfg);
 
         // Process each block independently (local CSE)
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         for block_id in block_ids {
             self.alias().clear_cached_addresses();
             self.process_block(func, block_id, &inst_results);
@@ -261,11 +261,11 @@ impl CommonSubexprEliminator {
         inst_results: &FxHashMap<InstId, ValueId>,
         cfg: &CfgInfo,
     ) {
-        let has_path_sensitive_expr = func.blocks.iter().any(|block| {
+        let has_path_sensitive_expr = func.blocks().any(|block| {
             block
                 .instructions
                 .iter()
-                .any(|&inst_id| Self::is_path_sensitive_kind(&func.instructions[inst_id].kind))
+                .any(|&inst_id| Self::is_path_sensitive_kind(&func.instruction(inst_id).kind))
         });
         let block_clobbers = if has_path_sensitive_expr {
             self.block_clobber_summaries(func)
@@ -279,7 +279,7 @@ impl CommonSubexprEliminator {
             (cfg.dominators(), cfg.transitive_reachability())
         };
         let mut replacements = FxHashMap::default();
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
         let mut ctx = GlobalCseContext {
             dom_tree,
             inst_results,
@@ -295,7 +295,7 @@ impl CommonSubexprEliminator {
             self.apply_replacements_to_all_blocks(func, &replacements);
         }
         if !dead.is_empty() {
-            for block in func.blocks.iter_mut() {
+            for block in func.blocks_mut() {
                 block.instructions.retain(|&id| !dead.contains(id));
             }
         }
@@ -314,12 +314,13 @@ impl CommonSubexprEliminator {
         };
         let mut candidates = Vec::new();
 
-        for block_id in func.blocks.indices() {
-            let phi_insts: Vec<_> = func.blocks[block_id]
+        for block_id in func.block_ids() {
+            let phi_insts: Vec<_> = func
+                .block(block_id)
                 .instructions
                 .iter()
                 .copied()
-                .take_while(|&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+                .take_while(|&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
                 .collect();
             for phi_inst in phi_insts {
                 if let Some(candidate) =
@@ -334,7 +335,7 @@ impl CommonSubexprEliminator {
             return;
         }
 
-        let mut dead = GrowableBitSet::with_capacity(func.instructions.len());
+        let mut dead = GrowableBitSet::with_capacity(func.instruction_count());
         let mut replacements = FxHashMap::default();
         let mut inserted_by_block: FxHashMap<BlockId, usize> = FxHashMap::default();
 
@@ -343,13 +344,14 @@ impl CommonSubexprEliminator {
                 func.alloc_inst(Instruction::new(candidate.kind, Some(candidate.result_ty)));
             let new_value = func.alloc_value(Value::Inst(new_inst));
 
-            let phi_count = func.blocks[candidate.block_id]
+            let phi_count = func
+                .block(candidate.block_id)
                 .instructions
                 .iter()
-                .take_while(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+                .take_while(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
                 .count();
             let inserted = inserted_by_block.entry(candidate.block_id).or_default();
-            func.blocks[candidate.block_id].instructions.insert(phi_count + *inserted, new_inst);
+            func.block_mut(candidate.block_id).instructions.insert(phi_count + *inserted, new_inst);
             *inserted += 1;
 
             replacements.insert(candidate.phi_result, new_value);
@@ -363,7 +365,7 @@ impl CommonSubexprEliminator {
         }
 
         self.apply_replacements_to_all_blocks(func, &replacements);
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
     }
@@ -375,7 +377,7 @@ impl CommonSubexprEliminator {
         phi_inst: InstId,
         ctx: &PhiSinkContext<'_>,
     ) -> Option<PhiExpressionCandidate> {
-        let inst = &func.instructions[phi_inst];
+        let inst = func.instruction(phi_inst);
         let result_ty = inst.result_ty?;
         let phi_result = *ctx.inst_results.get(&phi_inst)?;
         let InstKind::Phi(incoming) = &inst.kind else { return None };
@@ -389,7 +391,7 @@ impl CommonSubexprEliminator {
 
         for &(_, value) in incoming {
             let Value::Inst(inst_id) = func.value(value) else { return None };
-            let source_inst = &func.instructions[*inst_id];
+            let source_inst = func.instruction(*inst_id);
             if source_inst.kind.has_side_effects()
                 || !Self::operands_dominate_block(
                     func,
@@ -427,8 +429,8 @@ impl CommonSubexprEliminator {
     fn process_global_blocks(&mut self, func: &Function, ctx: &mut GlobalCseContext<'_>) {
         let mut worklist = vec![(BlockId::ENTRY, FxHashMap::default())];
         while let Some((block_id, mut cache)) = worklist.pop() {
-            for &inst_id in &func.blocks[block_id].instructions {
-                let kind = func.instructions[inst_id].kind.clone();
+            for &inst_id in &func.block(block_id).instructions {
+                let kind = func.instruction(inst_id).kind.clone();
                 if kind.has_side_effects() {
                     self.invalidate_for_side_effect(
                         func,
@@ -508,10 +510,10 @@ impl CommonSubexprEliminator {
     fn block_clobber_summaries(&self, func: &Function) -> FxHashMap<BlockId, Vec<Clobber>> {
         let no_replacements = FxHashMap::default();
         let mut summaries = FxHashMap::default();
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             let mut clobbers = Vec::new();
             for &inst_id in &block.instructions {
-                let kind = &func.instructions[inst_id].kind;
+                let kind = &func.instruction(inst_id).kind;
                 if kind.has_side_effects() {
                     self.side_effect_clobbers(func, inst_id, kind, &no_replacements, &mut clobbers);
                 }
@@ -559,12 +561,12 @@ impl CommonSubexprEliminator {
         let mut replacements: FxHashMap<ValueId, ValueId> = FxHashMap::default();
 
         // Instructions to remove
-        let mut to_remove = DenseBitSet::new_empty(func.instructions.len());
+        let mut to_remove = DenseBitSet::new_empty(func.instruction_count());
 
-        let instruction_count = func.blocks[block_id].instructions.len();
+        let instruction_count = func.block(block_id).instructions.len();
         for index in 0..instruction_count {
-            let inst_id = func.blocks[block_id].instructions[index];
-            let inst = &func.instructions[inst_id];
+            let inst_id = func.block(block_id).instructions[index];
+            let inst = func.instruction(inst_id);
             let kind = inst.kind.clone();
 
             if kind.has_side_effects() {
@@ -997,7 +999,7 @@ impl CommonSubexprEliminator {
             Value::Arg { .. } | Value::Undef(_) | Value::Error(_) => {
                 Some((OperandKey::Value(value), U256::ZERO))
             }
-            Value::Inst(inst_id) => match func.instructions[*inst_id].kind {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::Add(a, b) => {
                     if let Some(offset) = func.value_u256_after_replacements(b, replacements) {
                         let (base, existing) =
@@ -1065,12 +1067,12 @@ impl CommonSubexprEliminator {
 
     fn value_use_counts(func: &Function) -> FxHashMap<ValueId, usize> {
         let mut counts = FxHashMap::default();
-        for inst in func.instructions.iter() {
+        for inst in func.instructions() {
             for value in inst.operands() {
                 *counts.entry(value).or_insert(0) += 1;
             }
         }
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             if let Some(term) = &block.terminator {
                 Self::count_terminator_uses(term, &mut counts);
             }
@@ -1120,7 +1122,7 @@ impl CommonSubexprEliminator {
         func: &mut Function,
         replacements: &FxHashMap<ValueId, ValueId>,
     ) {
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
         for block_id in block_ids {
             self.apply_replacements(func, block_id, replacements);
         }
@@ -1133,10 +1135,10 @@ impl CommonSubexprEliminator {
         block_id: BlockId,
         replacements: &FxHashMap<ValueId, ValueId>,
     ) {
-        let instruction_count = func.blocks[block_id].instructions.len();
+        let instruction_count = func.block(block_id).instructions.len();
         for index in 0..instruction_count {
-            let inst_id = func.blocks[block_id].instructions[index];
-            let inst = &mut func.instructions[inst_id];
+            let inst_id = func.block(block_id).instructions[index];
+            let inst = func.instruction_mut(inst_id);
             if mir_utils::replace_inst_uses_canonicalized(&mut inst.kind, replacements) != 0 {
                 if mir_utils::is_memory_inst(&inst.kind) {
                     inst.metadata.set_memory_region(None);

--- a/crates/codegen/src/transform/dce.rs
+++ b/crates/codegen/src/transform/dce.rs
@@ -104,8 +104,7 @@ impl DeadCodeEliminator {
 
         // Collect unreachable block IDs
         let unreachable: Vec<BlockId> = func
-            .blocks
-            .iter_enumerated()
+            .blocks_enumerated()
             .filter_map(|(id, _)| if !cfg.is_reachable(id) { Some(id) } else { None })
             .collect();
 
@@ -122,10 +121,10 @@ impl DeadCodeEliminator {
     /// Collects all values that are used (appear in instructions or terminators).
     fn collect_used_values(&mut self, func: &Function) {
         self.used_values.clear();
-        self.used_values.ensure(func.values.len());
+        self.used_values.ensure(func.value_count());
 
         // Add values used in terminators
-        for (_, block) in func.blocks.iter_enumerated() {
+        for (_, block) in func.blocks_enumerated() {
             if let Some(term) = &block.terminator {
                 for operand in term.operands() {
                     self.used_values.insert(operand);
@@ -134,9 +133,9 @@ impl DeadCodeEliminator {
         }
 
         // Add values used as operands in instructions
-        for (_, block) in func.blocks.iter_enumerated() {
+        for (_, block) in func.blocks_enumerated() {
             for &inst_id in &block.instructions {
-                let inst = &func.instructions[inst_id];
+                let inst = func.instruction(inst_id);
                 for val in inst.kind.operands() {
                     self.used_values.insert(val);
                 }
@@ -152,9 +151,9 @@ impl DeadCodeEliminator {
     ) {
         self.dead.clear();
 
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             for &inst_id in &block.instructions {
-                let inst = &func.instructions[inst_id];
+                let inst = func.instruction(inst_id);
 
                 // Instructions with side effects are always kept.
                 if inst.kind.has_side_effects() {

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -233,7 +233,7 @@ impl FrameSlotPromoter {
         for info in slots {
             let inst_results = func.inst_results();
             let mut builder =
-                SlotSsaBuilder::new(&info, &cfg, &inst_results, &aa, func.instructions.len());
+                SlotSsaBuilder::new(&info, &cfg, &inst_results, &aa, func.instruction_count());
             if builder.run(func) {
                 self.stats.slots_promoted += 1;
                 self.stats.loads_promoted += builder.loads_promoted;
@@ -249,9 +249,9 @@ impl FrameSlotPromoter {
     }
 
     fn has_global_observation_barrier(func: &Function) -> bool {
-        func.blocks.iter().any(|block| {
+        func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
-                matches!(func.instructions[inst_id].kind, InstKind::Gas | InstKind::MSize)
+                matches!(func.instruction(inst_id).kind, InstKind::Gas | InstKind::MSize)
             })
         })
     }
@@ -263,19 +263,19 @@ impl FrameSlotPromoter {
     ) -> Vec<SlotAccessInfo> {
         let mut accesses: FxHashMap<PromotableSlot, SlotAccessInfo> = FxHashMap::default();
 
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             if !cfg.is_reachable(block_id) {
                 continue;
             }
 
             for &inst_id in &block.instructions {
-                let kind = &func.instructions[inst_id].kind;
+                let kind = &func.instruction(inst_id).kind;
                 match *kind {
                     InstKind::MLoad(addr) => {
                         if let Some(slot) = Self::promotable_slot(func, aa, addr) {
                             accesses
                                 .entry(slot)
-                                .or_insert_with(|| SlotAccessInfo::new(slot, func.blocks.len()))
+                                .or_insert_with(|| SlotAccessInfo::new(slot, func.block_count()))
                                 .note_load(block_id, inst_id);
                         }
                     }
@@ -283,7 +283,7 @@ impl FrameSlotPromoter {
                         if let Some(slot) = Self::promotable_slot(func, aa, addr) {
                             accesses
                                 .entry(slot)
-                                .or_insert_with(|| SlotAccessInfo::new(slot, func.blocks.len()))
+                                .or_insert_with(|| SlotAccessInfo::new(slot, func.block_count()))
                                 .note_store(block_id, inst_id, value);
                         }
                     }
@@ -360,12 +360,12 @@ impl FrameSlotPromoter {
             return false;
         }
 
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
                 if Self::inst_may_observe_external_slot(
                     func,
                     aa,
-                    &func.instructions[inst_id].kind,
+                    &func.instruction(inst_id).kind,
                     slot_addr,
                 ) {
                     return false;
@@ -382,12 +382,12 @@ impl FrameSlotPromoter {
     }
 
     fn internal_frame_slot_safe(func: &Function, aa: &AliasAnalysis, slot_offset: u64) -> bool {
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
                 if Self::inst_may_observe_internal_slot(
                     func,
                     aa,
-                    &func.instructions[inst_id].kind,
+                    &func.instruction(inst_id).kind,
                     slot_offset,
                 ) {
                     return false;
@@ -700,17 +700,17 @@ impl<'a> SlotSsaBuilder<'a> {
     }
 
     fn compute_live_in(&self, func: &Function) -> DenseBitSet<BlockId> {
-        let mut gen_set = DenseBitSet::new_empty(func.blocks.len());
-        let mut kill = DenseBitSet::new_empty(func.blocks.len());
+        let mut gen_set = DenseBitSet::new_empty(func.block_count());
+        let mut kill = DenseBitSet::new_empty(func.block_count());
 
-        for block in func.blocks.indices() {
+        for block in func.block_ids() {
             if !self.cfg.is_reachable(block) {
                 continue;
             }
 
             let mut saw_store = false;
-            for &inst_id in &func.blocks[block].instructions {
-                match func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block).instructions {
+                match func.instruction(inst_id).kind {
                     InstKind::MLoad(addr)
                         if !saw_store
                             && FrameSlotPromoter::promotable_slot(func, self.aa, addr)
@@ -738,7 +738,7 @@ impl<'a> SlotSsaBuilder<'a> {
         let mut changed = true;
         while changed {
             changed = false;
-            for block in func.blocks.indices() {
+            for block in func.block_ids() {
                 if !self.cfg.is_reachable(block) || live_in.contains(block) || kill.contains(block)
                 {
                     continue;
@@ -760,7 +760,7 @@ impl<'a> SlotSsaBuilder<'a> {
         live_in: &DenseBitSet<BlockId>,
     ) -> DenseBitSet<BlockId> {
         let frontiers = self.compute_dominance_frontiers(func);
-        let mut phi_blocks = DenseBitSet::new_empty(func.blocks.len());
+        let mut phi_blocks = DenseBitSet::new_empty(func.block_count());
         let mut worklist = sorted_blocks(&self.info.def_blocks);
 
         while let Some(block) = worklist.pop() {
@@ -777,13 +777,14 @@ impl<'a> SlotSsaBuilder<'a> {
     }
 
     fn compute_dominance_frontiers(&self, func: &Function) -> IndexVec<BlockId, Vec<BlockId>> {
-        let mut frontiers = index_vec![Vec::new(); func.blocks.len()];
-        for block in func.blocks.indices() {
+        let mut frontiers = index_vec![Vec::new(); func.block_count()];
+        for block in func.block_ids() {
             if !self.cfg.is_reachable(block) {
                 continue;
             }
 
-            let preds: Vec<_> = func.blocks[block]
+            let preds: Vec<_> = func
+                .block(block)
                 .predecessors
                 .iter()
                 .copied()
@@ -836,18 +837,19 @@ impl<'a> SlotSsaBuilder<'a> {
         for pending in self.phis.values() {
             let mut incoming = pending.incoming.clone();
             incoming.sort_by_key(|(block, _)| block.index());
-            func.instructions[pending.inst].kind = InstKind::Phi(incoming);
-            let insert_pos = func.blocks[pending.block]
+            func.instruction_mut(pending.inst).kind = InstKind::Phi(incoming);
+            let insert_pos = func
+                .block(pending.block)
                 .instructions
                 .iter()
-                .take_while(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+                .take_while(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
                 .count();
-            func.blocks[pending.block].instructions.insert(insert_pos, pending.inst);
+            func.block_mut(pending.block).instructions.insert(insert_pos, pending.inst);
         }
 
         func.replace_uses_canonicalized(&self.replacements);
 
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !self.dead.contains(id));
         }
     }
@@ -864,8 +866,8 @@ impl<'a> SlotSsaBuilder<'a> {
 
         let mut current = None;
         let mut changed = false;
-        for &inst_id in &func.blocks[block].instructions {
-            match func.instructions[inst_id].kind {
+        for &inst_id in &func.block(block).instructions {
+            match func.instruction(inst_id).kind {
                 InstKind::MLoad(addr)
                     if FrameSlotPromoter::promotable_slot(func, self.aa, addr)
                         == Some(self.info.slot) =>
@@ -918,7 +920,7 @@ impl<'a> SlotSsaBuilder<'a> {
     }
 
     fn inst_position(func: &Function, block: BlockId, inst: InstId) -> Option<usize> {
-        func.blocks[block].instructions.iter().position(|&candidate| candidate == inst)
+        func.block(block).instructions.iter().position(|&candidate| candidate == inst)
     }
 
     fn replace_load(&mut self, inst_id: InstId, value: ValueId) {
@@ -943,10 +945,10 @@ impl<'a> SlotSsaBuilder<'a> {
             current = Some(phi.value);
         }
 
-        let instruction_count = func.blocks[block].instructions.len();
+        let instruction_count = func.block(block).instructions.len();
         for index in 0..instruction_count {
-            let inst_id = func.blocks[block].instructions[index];
-            match func.instructions[inst_id].kind {
+            let inst_id = func.block(block).instructions[index];
+            match func.instruction(inst_id).kind {
                 InstKind::MLoad(addr)
                     if FrameSlotPromoter::promotable_slot(func, self.aa, addr)
                         == Some(self.info.slot) =>
@@ -999,7 +1001,7 @@ impl<'a> SlotSsaBuilder<'a> {
                 block,
                 inst,
                 value,
-                incoming: Vec::with_capacity(func.blocks[block].predecessors.len()),
+                incoming: Vec::with_capacity(func.block(block).predecessors.len()),
             },
         );
         value
@@ -1021,9 +1023,9 @@ mod tests {
         let mut stores = 0;
         let aa = AliasAnalysis::new(func);
 
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                match func.instructions[inst_id].kind {
+                match func.instruction(inst_id).kind {
                     InstKind::MLoad(addr)
                         if FrameSlotPromoter::internal_frame_offset(func, &aa, addr)
                             == Some(offset) =>
@@ -1087,7 +1089,7 @@ mod tests {
         assert_eq!(stats.phis_inserted, 1);
         assert_eq!(count_active_frame_ops(&func, 128), (0, 0));
 
-        let Some(Terminator::Return { values }) = &func.blocks[exit].terminator else {
+        let Some(Terminator::Return { values }) = &func.block(exit).terminator else {
             panic!("expected return");
         };
         assert_ne!(values.as_slice(), &[result]);

--- a/crates/codegen/src/transform/gvn.rs
+++ b/crates/codegen/src/transform/gvn.rs
@@ -182,14 +182,14 @@ impl GlobalValueNumberer {
         // Immediates, arguments, and undefs are available everywhere, so their
         // classes start with a leader. This folds phi-of-same over constants.
         let mut leaders: FxHashMap<ClassId, ValueId> = FxHashMap::default();
-        for (value_id, value) in func.values.iter_enumerated() {
+        for (value_id, value) in func.values_enumerated() {
             if !matches!(value, Value::Inst(_)) && vn[value_id] == value_id {
                 leaders.insert(value_id, value_id);
             }
         }
 
         let mut replacements = FxHashMap::default();
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
         let mut ctx = ReplaceCtx {
             vn: &vn,
             cfg: &cfg,
@@ -203,7 +203,7 @@ impl GlobalValueNumberer {
             return false;
         }
         Self::apply_replacements_to_all_blocks(func, &replacements);
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
         true
@@ -218,10 +218,10 @@ impl GlobalValueNumberer {
         rpo: &[BlockId],
         inst_results: &FxHashMap<InstId, ValueId>,
     ) -> Option<IndexVec<ValueId, ClassId>> {
-        let mut vn = func.values.indices().collect::<IndexVec<ValueId, _>>();
+        let mut vn = func.value_ids().collect::<IndexVec<ValueId, _>>();
         let mut immediate_reps: FxHashMap<Immediate, ValueId> = FxHashMap::default();
         let mut arg_reps: FxHashMap<u32, ValueId> = FxHashMap::default();
-        for (value_id, value) in func.values.iter_enumerated() {
+        for (value_id, value) in func.values_enumerated() {
             match value {
                 Value::Immediate(imm) => {
                     vn[value_id] = *immediate_reps.entry(imm.clone()).or_insert(value_id);
@@ -237,9 +237,9 @@ impl GlobalValueNumberer {
             let mut table: FxHashMap<ExprKey, ClassId> = FxHashMap::default();
             let mut changed = false;
             for &block_id in rpo {
-                for &inst_id in &func.blocks[block_id].instructions {
+                for &inst_id in &func.block(block_id).instructions {
                     let Some(&result) = inst_results.get(&inst_id) else { continue };
-                    let inst = &func.instructions[inst_id];
+                    let inst = func.instruction(inst_id);
                     let Some(ty) = inst.result_ty else { continue };
                     let Some(class) =
                         Self::instruction_class(block_id, &inst.kind, ty, result, &vn, &mut table)
@@ -403,9 +403,9 @@ impl GlobalValueNumberer {
         leaders: &mut FxHashMap<ClassId, ValueId>,
         ctx: &mut ReplaceCtx<'_>,
     ) {
-        for &inst_id in &func.blocks[block_id].instructions {
+        for &inst_id in &func.block(block_id).instructions {
             let Some(&result) = ctx.inst_results.get(&inst_id) else { continue };
-            let kind = &func.instructions[inst_id].kind;
+            let kind = &func.instruction(inst_id).kind;
             if !matches!(kind, InstKind::Phi(_)) && Self::expr_kind(kind, ctx.vn).is_none() {
                 continue;
             }
@@ -435,7 +435,7 @@ impl GlobalValueNumberer {
         func: &mut Function,
         replacements: &FxHashMap<ValueId, ValueId>,
     ) {
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
         for block_id in block_ids {
             Self::apply_replacements(func, block_id, replacements);
         }
@@ -447,10 +447,10 @@ impl GlobalValueNumberer {
         block_id: BlockId,
         replacements: &FxHashMap<ValueId, ValueId>,
     ) {
-        let instruction_count = func.blocks[block_id].instructions.len();
+        let instruction_count = func.block(block_id).instructions.len();
         for index in 0..instruction_count {
-            let inst_id = func.blocks[block_id].instructions[index];
-            let inst = &mut func.instructions[inst_id];
+            let inst_id = func.block(block_id).instructions[index];
+            let inst = func.instruction_mut(inst_id);
             if mir_utils::replace_inst_uses_canonicalized(&mut inst.kind, replacements) != 0 {
                 if mir_utils::is_memory_inst(&inst.kind) {
                     inst.metadata.set_memory_region(None);
@@ -467,7 +467,7 @@ impl GlobalValueNumberer {
             }
         }
 
-        if let Some(term) = &mut func.blocks[block_id].terminator {
+        if let Some(term) = &mut func.block_mut(block_id).terminator {
             mir_utils::replace_terminator_uses_canonicalized(term, replacements);
         }
     }

--- a/crates/codegen/src/transform/indvar_simplify.rs
+++ b/crates/codegen/src/transform/indvar_simplify.rs
@@ -119,7 +119,7 @@ impl IndVarSimplifier {
         let mut blocks: Vec<_> = loop_data.blocks.iter().collect();
         blocks.sort_by_key(|block| block.index());
         for block in blocks {
-            for &inst_id in &func.blocks[block].instructions {
+            for &inst_id in &func.block(block).instructions {
                 let Some(&value) = inst_results.get(&inst_id) else { continue };
                 if !self.is_reducible_result(func, inst_id) {
                     continue;
@@ -165,7 +165,7 @@ impl IndVarSimplifier {
         update_inst: Option<InstId>,
     ) -> Option<i128> {
         let update_inst = update_inst?;
-        let InstKind::Add(a, b) = func.instructions[update_inst].kind else {
+        let InstKind::Add(a, b) = func.instruction(update_inst).kind else {
             return None;
         };
         let step = if a == iv_value {
@@ -227,7 +227,7 @@ impl IndVarSimplifier {
             InstKind::Add(phi_value, delta),
             Some(MirType::uint256()),
         );
-        let InstKind::Phi(incoming) = &mut func.instructions[phi_inst].kind else {
+        let InstKind::Phi(incoming) = &mut func.instruction_mut(phi_inst).kind else {
             return None;
         };
         incoming.push((latch, next));
@@ -269,25 +269,26 @@ impl IndVarSimplifier {
         ty: Option<MirType>,
     ) -> ValueId {
         let inst = func.alloc_inst(Instruction::new(kind, ty));
-        func.blocks[block].instructions.push(inst);
+        func.block_mut(block).instructions.push(inst);
         func.alloc_value(Value::Inst(inst))
     }
 
     fn insert_header_phi(&self, func: &mut Function, header: BlockId, phi_inst: InstId) {
-        let insert_pos = func.blocks[header]
+        let insert_pos = func
+            .block(header)
             .instructions
             .iter()
-            .take_while(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+            .take_while(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
             .count();
-        func.blocks[header].instructions.insert(insert_pos, phi_inst);
+        func.block_mut(header).instructions.insert(insert_pos, phi_inst);
     }
 
     fn is_reducible_result(&self, func: &Function, inst_id: InstId) -> bool {
-        if func.instructions[inst_id].result_ty != Some(MirType::uint256()) {
+        if func.instruction(inst_id).result_ty != Some(MirType::uint256()) {
             return false;
         }
         matches!(
-            func.instructions[inst_id].kind,
+            func.instruction(inst_id).kind,
             InstKind::Add(_, _) | InstKind::Sub(_, _) | InstKind::Mul(_, _) | InstKind::Shl(_, _)
         )
     }
@@ -302,13 +303,14 @@ impl IndVarSimplifier {
 
     fn has_non_address_loop_use(&self, func: &Function, loop_data: &Loop, value: ValueId) -> bool {
         for block in &loop_data.blocks {
-            for &inst_id in &func.blocks[block].instructions {
-                let kind = &func.instructions[inst_id].kind;
+            for &inst_id in &func.block(block).instructions {
+                let kind = &func.instruction(inst_id).kind;
                 if kind.operands().contains(&value) && !Self::is_address_builder(kind) {
                     return true;
                 }
             }
-            if func.blocks[block]
+            if func
+                .block(block)
                 .terminator
                 .as_ref()
                 .is_some_and(|term| term.operands().contains(&value))
@@ -334,15 +336,15 @@ impl IndVarSimplifier {
     ) -> usize {
         let mut replaced = 0;
         for block in &loop_data.blocks {
-            let instruction_count = func.blocks[block].instructions.len();
+            let instruction_count = func.block(block).instructions.len();
             for index in 0..instruction_count {
-                let inst_id = func.blocks[block].instructions[index];
+                let inst_id = func.block(block).instructions[index];
                 replaced += mir_utils::replace_inst_uses(
-                    &mut func.instructions[inst_id].kind,
+                    &mut func.instruction_mut(inst_id).kind,
                     replacements,
                 );
             }
-            if let Some(term) = &mut func.blocks[block].terminator {
+            if let Some(term) = &mut func.block_mut(block).terminator {
                 replaced += mir_utils::replace_terminator_uses(term, replacements);
             }
         }

--- a/crates/codegen/src/transform/inline.rs
+++ b/crates/codegen/src/transform/inline.rs
@@ -163,7 +163,7 @@ impl MirInliner {
         let mut call_counts = self.call_counts(module);
         let recursive_functions = self.recursive_functions(module);
 
-        for caller_id in module.functions.indices().collect::<Vec<_>>() {
+        for caller_id in module.function_ids().collect::<Vec<_>>() {
             let loop_depths = block_loop_depths(module.function(caller_id));
             // Bound how much each caller may grow from inlining so a function
             // calling many internal helpers (e.g. a large verifier) cannot
@@ -218,19 +218,15 @@ impl MirInliner {
     }
 
     fn summarize_module(&self, module: &Module) -> FxHashMap<MirFunctionId, MirInlineSummary> {
-        module
-            .functions
-            .iter_enumerated()
-            .map(|(id, func)| (id, summarize_function(func)))
-            .collect()
+        module.iter_functions().map(|(id, func)| (id, summarize_function(func))).collect()
     }
 
     fn call_counts(&self, module: &Module) -> FxHashMap<MirFunctionId, usize> {
         let mut counts = FxHashMap::default();
-        for func in module.functions.iter() {
-            for block in func.blocks.iter() {
+        for func in module.functions() {
+            for block in func.blocks() {
                 for &inst_id in &block.instructions {
-                    if let InstKind::InternalCall { function, .. } = func.instructions[inst_id].kind
+                    if let InstKind::InternalCall { function, .. } = func.instruction(inst_id).kind
                     {
                         *counts.entry(function).or_default() += 1;
                     }
@@ -241,9 +237,9 @@ impl MirInliner {
     }
 
     fn recursive_functions(&self, module: &Module) -> DenseBitSet<MirFunctionId> {
-        let mut recursive = DenseBitSet::new_empty(module.functions.len());
-        let mut visiting = DenseBitSet::new_empty(module.functions.len());
-        for func_id in module.functions.indices() {
+        let mut recursive = DenseBitSet::new_empty(module.function_count());
+        let mut visiting = DenseBitSet::new_empty(module.function_count());
+        for func_id in module.function_ids() {
             visiting.clear();
             if self.function_reaches(module, func_id, func_id, &mut visiting) {
                 recursive.insert(func_id);
@@ -274,9 +270,9 @@ impl MirInliner {
 
     fn function_callees(&self, func: &Function) -> Vec<MirFunctionId> {
         let mut callees = Vec::new();
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                if let InstKind::InternalCall { function, .. } = func.instructions[inst_id].kind {
+                if let InstKind::InternalCall { function, .. } = func.instruction(inst_id).kind {
                     callees.push(function);
                 }
             }
@@ -290,11 +286,11 @@ impl MirInliner {
         start: (usize, usize),
         loop_depths: &FxHashMap<BlockId, usize>,
     ) -> Option<CallSite> {
-        for (block, bb) in func.blocks.iter_enumerated().skip(start.0) {
+        for (block, bb) in func.blocks_enumerated().skip(start.0) {
             let start_inst = if block.index() == start.0 { start.1 } else { 0 };
             for (inst_index, &inst_id) in bb.instructions.iter().enumerate().skip(start_inst) {
                 if let InstKind::InternalCall { function, ref args, returns } =
-                    func.instructions[inst_id].kind
+                    func.instruction(inst_id).kind
                 {
                     return Some(CallSite {
                         block,
@@ -382,7 +378,7 @@ struct CallSite {
 
 fn summarize_function(func: &Function) -> MirInlineSummary {
     let mut summary = MirInlineSummary {
-        block_count: func.blocks.len(),
+        block_count: func.block_count(),
         param_count: func.params.len(),
         internal_frame_size: func.internal_frame_size,
         is_entry_point: func.is_public()
@@ -394,9 +390,9 @@ fn summarize_function(func: &Function) -> MirInlineSummary {
         ..MirInlineSummary::default()
     };
 
-    for block in func.blocks.iter() {
+    for block in func.blocks() {
         for &inst_id in &block.instructions {
-            let kind = &func.instructions[inst_id].kind;
+            let kind = &func.instruction(inst_id).kind;
             summary.instruction_count += match kind {
                 InstKind::MappingSlot(..) => 3,
                 InstKind::MappingSlotMemory(..) => 8,
@@ -666,8 +662,8 @@ fn inline_call_impl(
     call_inst_index: usize,
     callee: &Function,
 ) -> Option<()> {
-    let call_inst = caller.blocks[call_block].instructions[call_inst_index];
-    let InstKind::InternalCall { args, returns, .. } = caller.instructions[call_inst].kind.clone()
+    let call_inst = caller.block(call_block).instructions[call_inst_index];
+    let InstKind::InternalCall { args, returns, .. } = caller.instruction(call_inst).kind.clone()
     else {
         return None;
     };
@@ -682,15 +678,15 @@ fn inline_call_impl(
     }
 
     let continuation = caller.alloc_block();
-    let old_terminator = caller.blocks[call_block].terminator.take();
+    let old_terminator = caller.block_mut(call_block).terminator.take();
     let old_successors = old_terminator.as_ref().map(Terminator::successors).unwrap_or_default();
     let suffix = {
-        let block = &mut caller.blocks[call_block];
+        let block = caller.block_mut(call_block);
         block.instructions.split_off(call_inst_index + 1)
     };
-    caller.blocks[call_block].instructions.pop();
-    caller.blocks[continuation].instructions = suffix;
-    caller.blocks[continuation].terminator = old_terminator;
+    caller.block_mut(call_block).instructions.pop();
+    caller.block_mut(continuation).instructions = suffix;
+    caller.block_mut(continuation).terminator = old_terminator;
     redirect_phi_predecessors(caller, &old_successors, call_block, continuation);
 
     let caller_is_external =
@@ -708,7 +704,7 @@ fn inline_call_impl(
 
     let mut cloner = InlineCloner::new(caller, callee, frame_base, callee_frame_prefix, &args);
     let cloned_entry = cloner.clone_blocks(continuation)?;
-    cloner.caller.blocks[call_block].terminator = Some(Terminator::Jump(cloned_entry));
+    cloner.caller.block_mut(call_block).terminator = Some(Terminator::Jump(cloned_entry));
 
     let mut replacements = FxHashMap::default();
     if returns > 0 {
@@ -747,7 +743,7 @@ impl<'a> InlineCloner<'a> {
         args: &[ValueId],
     ) -> Self {
         let mut value_map = FxHashMap::default();
-        for (callee_value, value) in callee.values.iter_enumerated() {
+        for (callee_value, value) in callee.values_enumerated() {
             if let Value::Arg { index, .. } = value
                 && let Some(&arg) = args.get(*index as usize)
             {
@@ -766,15 +762,15 @@ impl<'a> InlineCloner<'a> {
     }
 
     fn clone_blocks(&mut self, continuation: BlockId) -> Option<BlockId> {
-        for block_id in self.callee.blocks.indices() {
+        for block_id in self.callee.block_ids() {
             self.block_map.insert(block_id, self.caller.alloc_block());
         }
 
-        for (callee_block, block) in self.callee.blocks.iter_enumerated() {
+        for (callee_block, block) in self.callee.blocks_enumerated() {
             let caller_block = self.block_map[&callee_block];
             let mut instructions = Vec::with_capacity(block.instructions.len());
             for &inst_id in &block.instructions {
-                let inst = self.callee.instructions[inst_id].clone();
+                let inst = self.callee.instruction(inst_id).clone();
                 let kind = self.clone_inst_kind(inst.kind)?;
                 let new_inst = self.caller.alloc_inst(Instruction::new(kind, inst.result_ty));
                 instructions.push(new_inst);
@@ -783,14 +779,14 @@ impl<'a> InlineCloner<'a> {
                     self.value_map.insert(callee_result, new_result);
                 }
             }
-            self.caller.blocks[caller_block].instructions = instructions;
+            self.caller.block_mut(caller_block).instructions = instructions;
         }
 
-        for (callee_block, block) in self.callee.blocks.iter_enumerated() {
+        for (callee_block, block) in self.callee.blocks_enumerated() {
             let caller_block = self.block_map[&callee_block];
             let term =
                 self.clone_terminator(block.terminator.as_ref()?, caller_block, continuation)?;
-            self.caller.blocks[caller_block].terminator = Some(term);
+            self.caller.block_mut(caller_block).terminator = Some(term);
         }
 
         Some(self.block_map[&BlockId::ENTRY])
@@ -801,7 +797,7 @@ impl<'a> InlineCloner<'a> {
             return Some(mapped);
         }
 
-        let cloned = match self.callee.values[value].clone() {
+        let cloned = match self.callee.value(value).clone() {
             Value::Immediate(imm) => self.caller.alloc_value(Value::Immediate(imm)),
             Value::Undef(ty) => self.caller.alloc_value(Value::Undef(ty)),
             Value::Error(guar) => self.caller.alloc_value(Value::Error(guar)),
@@ -1126,7 +1122,7 @@ fn build_return_values(
             .map(|(block, edge_values)| Some((*block, *edge_values.get(index)?)))
             .collect::<Option<Vec<_>>>()?;
         let phi = caller.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(ty)));
-        caller.blocks[continuation].instructions.insert(index, phi);
+        caller.block_mut(continuation).instructions.insert(index, phi);
         values.push(caller.alloc_value(Value::Inst(phi)));
     }
     Some(values)
@@ -1138,16 +1134,17 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
     }
 
     // Insert the stores right after the continuation block's leading phis.
-    let phi_count = caller.blocks[continuation]
+    let phi_count = caller
+        .block(continuation)
         .instructions
         .iter()
-        .take_while(|&&inst_id| matches!(caller.instructions[inst_id].kind, InstKind::Phi(_)))
+        .take_while(|&&inst_id| matches!(caller.instruction(inst_id).kind, InstKind::Phi(_)))
         .count();
 
     let base_load = caller.alloc_inst(Instruction::new(InstKind::Fmp, Some(MirType::MemPtr)));
     let base = caller.alloc_value(Value::Inst(base_load));
     let mut insert_at = phi_count;
-    caller.blocks[continuation].instructions.insert(insert_at, base_load);
+    caller.block_mut(continuation).instructions.insert(insert_at, base_load);
     insert_at += 1;
 
     for (index, &value) in values.iter().enumerate() {
@@ -1157,8 +1154,8 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
             .alloc_inst(Instruction::new(InstKind::Add(base, offset), Some(MirType::uint256())));
         let addr_value = caller.alloc_value(Value::Inst(addr));
         let store = caller.alloc_inst(Instruction::new(InstKind::MStore(addr_value, value), None));
-        caller.blocks[continuation].instructions.insert(insert_at, addr);
-        caller.blocks[continuation].instructions.insert(insert_at + 1, store);
+        caller.block_mut(continuation).instructions.insert(insert_at, addr);
+        caller.block_mut(continuation).instructions.insert(insert_at + 1, store);
         insert_at += 2;
     }
 
@@ -1166,7 +1163,7 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
         EvmMemoryLayout::MULTI_RETURN_BUFFER_PTR_SLOT,
     ))));
     let publish = caller.alloc_inst(Instruction::new(InstKind::MStore(ptr_slot, base), None));
-    caller.blocks[continuation].instructions.insert(insert_at, publish);
+    caller.block_mut(continuation).instructions.insert(insert_at, publish);
 }
 
 fn redirect_phi_predecessors(
@@ -1180,8 +1177,9 @@ fn redirect_phi_predecessors(
     }
 
     for &succ in successors {
-        for &inst_id in &func.blocks[succ].instructions {
-            if let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind {
+        let inst_ids = func.block(succ).instructions.clone();
+        for inst_id in inst_ids {
+            if let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind {
                 for (pred, _) in incoming {
                     if *pred == old_pred {
                         *pred = new_pred;
@@ -1194,28 +1192,29 @@ fn redirect_phi_predecessors(
 
 fn recompute_cfg(func: &mut Function) {
     let mut edges = Vec::new();
-    for (block, bb) in func.blocks.iter_enumerated() {
+    for (block, bb) in func.blocks_enumerated() {
         if let Some(term) = &bb.terminator {
             edges.push((block, term.successors()));
         }
     }
 
-    for block in func.blocks.iter_mut() {
+    for block in func.blocks_mut() {
         block.predecessors.clear();
     }
 
     for (block, successors) in edges {
         for succ in successors {
-            func.blocks[succ].predecessors.push(block);
+            func.block_mut(succ).predecessors.push(block);
         }
     }
 }
 
 fn prune_phi_incoming_to_predecessors(func: &mut Function) {
-    for block_id in func.blocks.indices() {
-        let predecessors = func.blocks[block_id].predecessors.clone();
-        for &inst_id in &func.blocks[block_id].instructions {
-            if let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind {
+    for block_id in func.block_ids() {
+        let predecessors = func.block(block_id).predecessors.clone();
+        let inst_ids = func.block(block_id).instructions.clone();
+        for inst_id in inst_ids {
+            if let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind {
                 incoming.retain(|(pred, _)| predecessors.contains(pred));
             }
         }
@@ -1289,16 +1288,16 @@ mod tests {
         assert_eq!(stats.inlined, 1);
 
         let caller = module.function(caller_id);
-        assert!(caller.blocks.iter().all(|block| {
+        assert!(caller.blocks().all(|block| {
             block.instructions.iter().all(|&inst| {
-                !matches!(caller.instructions[inst].kind, InstKind::InternalCall { .. })
+                !matches!(caller.instruction(inst).kind, InstKind::InternalCall { .. })
             })
         }));
-        assert!(caller.blocks.iter().any(|block| {
+        assert!(caller.blocks().any(|block| {
             block
                 .instructions
                 .iter()
-                .any(|&inst| matches!(caller.instructions[inst].kind, InstKind::Phi(_)))
+                .any(|&inst| matches!(caller.instruction(inst).kind, InstKind::Phi(_)))
         }));
     }
 }

--- a/crates/codegen/src/transform/inst_simplify.rs
+++ b/crates/codegen/src/transform/inst_simplify.rs
@@ -60,7 +60,7 @@ impl RunState {
         Self {
             inst_results: func.inst_results(),
             replacements: FxHashMap::default(),
-            dead: DenseBitSet::new_empty(func.instructions.len()),
+            dead: DenseBitSet::new_empty(func.instruction_count()),
         }
     }
 }
@@ -82,14 +82,14 @@ impl InstSimplifier {
 
         state.replacements.clear();
         state.dead.clear();
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
 
         for block_id in block_ids {
-            let instruction_count = func.blocks[block_id].instructions.len();
+            let instruction_count = func.block(block_id).instructions.len();
             for index in 0..instruction_count {
-                let inst_id = func.blocks[block_id].instructions[index];
+                let inst_id = func.block(block_id).instructions[index];
                 loop {
-                    let kind = func.instructions[inst_id].kind.clone();
+                    let kind = func.instruction(inst_id).kind.clone();
 
                     if self.is_dead_noop_inst(func, &kind, &state.replacements) {
                         tracing::trace!(
@@ -113,7 +113,7 @@ impl InstSimplifier {
                             output = %new_kind,
                             "mir_inst_simplify"
                         );
-                        func.instructions[inst_id].kind = new_kind;
+                        func.instruction_mut(inst_id).kind = new_kind;
                         self.simplified_count += 1;
                         continue;
                     }
@@ -150,7 +150,7 @@ impl InstSimplifier {
             func.replace_uses_canonicalized(&state.replacements);
         }
         if !state.dead.is_empty() {
-            for block in func.blocks.iter_mut() {
+            for block in func.blocks_mut() {
                 block.instructions.retain(|&id| !state.dead.contains(id));
             }
         }
@@ -812,7 +812,7 @@ impl InstSimplifier {
 
     fn offset_base(func: &Function, value: ValueId) -> Option<(ValueId, U256)> {
         let Value::Inst(inst_id) = func.value(value) else { return None };
-        match func.instructions[*inst_id].kind {
+        match func.instruction(*inst_id).kind {
             InstKind::Add(a, b) => Self::const_operand(func, a, b),
             InstKind::Sub(a, b) => {
                 let offset = func.value_u256(b)?;
@@ -824,7 +824,7 @@ impl InstSimplifier {
 
     fn and_mask_base(func: &Function, value: ValueId) -> Option<(ValueId, U256)> {
         let Value::Inst(inst_id) = func.value(value) else { return None };
-        match func.instructions[*inst_id].kind {
+        match func.instruction(*inst_id).kind {
             InstKind::And(a, b) => Self::const_operand(func, a, b),
             _ => None,
         }
@@ -858,17 +858,17 @@ impl InstSimplifier {
     }
 
     fn is_bool_value(func: &Function, value: ValueId) -> bool {
-        match &func.values[value] {
+        match func.value(value) {
             Value::Immediate(Immediate::Bool(_)) => true,
             Value::Arg { ty: MirType::Bool, .. } => true,
-            Value::Inst(inst_id) => func.instructions[*inst_id].result_ty == Some(MirType::Bool),
+            Value::Inst(inst_id) => func.instruction(*inst_id).result_ty == Some(MirType::Bool),
             _ => false,
         }
     }
 
     fn same_value(func: &Function, a: ValueId, b: ValueId) -> bool {
         a == b
-            || match (&func.values[a], &func.values[b]) {
+            || match (func.value(a), func.value(b)) {
                 (Value::Immediate(a), Value::Immediate(b)) => a == b,
                 _ => false,
             }
@@ -884,9 +884,9 @@ impl InstSimplifier {
     }
 
     fn is_clean_address(func: &Function, value: ValueId) -> bool {
-        match &func.values[value] {
+        match func.value(value) {
             Value::Inst(inst_id) => matches!(
-                func.instructions[*inst_id].kind,
+                func.instruction(*inst_id).kind,
                 InstKind::Address
                     | InstKind::Caller
                     | InstKind::Origin
@@ -899,8 +899,8 @@ impl InstSimplifier {
     }
 
     fn is_current_address(func: &Function, value: ValueId) -> bool {
-        match &func.values[value] {
-            Value::Inst(inst_id) => matches!(func.instructions[*inst_id].kind, InstKind::Address),
+        match func.value(value) {
+            Value::Inst(inst_id) => matches!(func.instruction(*inst_id).kind, InstKind::Address),
             _ => false,
         }
     }
@@ -913,9 +913,9 @@ impl InstSimplifier {
         let externally_terminating =
             func.selector.is_some() || func.attributes.is_receive || func.attributes.is_fallback;
         let mut rewrites = 0;
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             loop {
-                let Some(Terminator::Branch { condition, .. }) = func.blocks[block_id].terminator
+                let Some(Terminator::Branch { condition, .. }) = func.block(block_id).terminator
                 else {
                     break;
                 };
@@ -931,7 +931,7 @@ impl InstSimplifier {
                 };
                 let inner = mir_utils::resolve_replacement(inner, replacements);
                 let Some(Terminator::Branch { condition, then_block, else_block }) =
-                    &mut func.blocks[block_id].terminator
+                    &mut func.block_mut(block_id).terminator
                 else {
                     unreachable!()
                 };
@@ -951,10 +951,10 @@ impl InstSimplifier {
             }
 
             if externally_terminating
-                && let Some(Terminator::ReturnData { size, .. }) = func.blocks[block_id].terminator
+                && let Some(Terminator::ReturnData { size, .. }) = func.block(block_id).terminator
                 && Self::is_zero(func, mir_utils::resolve_replacement(size, replacements))
             {
-                func.blocks[block_id].terminator = Some(Terminator::Stop);
+                func.block_mut(block_id).terminator = Some(Terminator::Stop);
                 rewrites += 1;
             }
         }
@@ -965,8 +965,8 @@ impl InstSimplifier {
     /// Returns `x` when `value` computes `gt(x, 0)` or `lt(0, x)`, both of
     /// which are the unsigned nonzero test.
     fn nonzero_test_operand(func: &Function, value: ValueId) -> Option<ValueId> {
-        match &func.values[value] {
-            Value::Inst(inst_id) => match func.instructions[*inst_id].kind {
+        match func.value(value) {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::Gt(a, b) if Self::is_zero(func, b) => Some(a),
                 InstKind::Lt(a, b) if Self::is_zero(func, a) => Some(b),
                 _ => None,
@@ -976,8 +976,8 @@ impl InstSimplifier {
     }
 
     fn iszero_operand(func: &Function, value: ValueId) -> Option<ValueId> {
-        match &func.values[value] {
-            Value::Inst(inst_id) => match func.instructions[*inst_id].kind {
+        match func.value(value) {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::IsZero(inner) => Some(inner),
                 _ => None,
             },
@@ -986,8 +986,8 @@ impl InstSimplifier {
     }
 
     fn not_operand(func: &Function, value: ValueId) -> Option<ValueId> {
-        match &func.values[value] {
-            Value::Inst(inst_id) => match func.instructions[*inst_id].kind {
+        match func.value(value) {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::Not(inner) => Some(inner),
                 _ => None,
             },
@@ -1022,7 +1022,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1042,7 +1042,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
@@ -1060,13 +1060,13 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
         assert_eq!(
-            func.values[values[0]].as_immediate().and_then(Immediate::as_u256),
+            func.value(values[0]).as_immediate().and_then(Immediate::as_u256),
             Some(U256::ZERO)
         );
     }
@@ -1084,14 +1084,14 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 3);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
         assert_eq!(&values[..2], &[arg, arg]);
         assert_eq!(
-            func.values[values[2]].as_immediate().and_then(Immediate::as_u256),
+            func.value(values[2]).as_immediate().and_then(Immediate::as_u256),
             Some(U256::ZERO)
         );
     }
@@ -1108,7 +1108,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
@@ -1126,13 +1126,13 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert!(block.instructions.is_empty());
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
         assert_eq!(
-            func.values[values[0]].as_immediate().and_then(Immediate::as_u256),
+            func.value(values[0]).as_immediate().and_then(Immediate::as_u256),
             Some(U256::from(1))
         );
     }
@@ -1149,9 +1149,9 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 1);
-        let eq_inst = func.instructions[block.instructions[0]].kind.clone();
+        let eq_inst = func.instruction(block.instructions[0]).kind.clone();
         assert!(matches!(eq_inst, InstKind::IsZero(value) if value == arg));
     }
 
@@ -1167,7 +1167,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
         };
@@ -1186,7 +1186,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 1);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1205,9 +1205,9 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 2);
-        let balance_inst = func.instructions[*block.instructions.last().unwrap()].kind.clone();
+        let balance_inst = func.instruction(*block.instructions.last().unwrap()).kind.clone();
         assert!(matches!(balance_inst, InstKind::SelfBalance));
     }
 
@@ -1226,7 +1226,7 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run(&mut func), 2);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         let Some(Terminator::Branch { condition, then_block: new_then, else_block: new_else }) =
             block.terminator
         else {
@@ -1250,9 +1250,9 @@ mod tests {
         let mut pass = InstSimplifier::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 2);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 2);
-        let balance_inst = func.instructions[*block.instructions.last().unwrap()].kind.clone();
+        let balance_inst = func.instruction(*block.instructions.last().unwrap()).kind.clone();
         assert!(matches!(balance_inst, InstKind::SelfBalance));
     }
 }

--- a/crates/codegen/src/transform/jump_threading.rs
+++ b/crates/codegen/src/transform/jump_threading.rs
@@ -89,7 +89,7 @@ impl JumpThreader {
 
         if !forwarders.is_empty() {
             // Resolve the final target for each forwarder (following chains)
-            let final_targets = self.resolve_final_targets(&forwarders, func.blocks.len());
+            let final_targets = self.resolve_final_targets(&forwarders, func.block_count());
 
             // Update all terminators to use final targets
             self.thread_jumps(func, &final_targets);
@@ -129,7 +129,7 @@ impl JumpThreader {
     fn find_forwarder_blocks(&self, func: &Function) -> FxHashMap<BlockId, BlockId> {
         let mut forwarders = FxHashMap::default();
 
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             if block.predecessors.is_empty() {
                 continue;
             }
@@ -192,13 +192,13 @@ impl JumpThreader {
 
     /// Updates all terminators to use the final targets.
     fn thread_jumps(&mut self, func: &mut Function, final_targets: &FxHashMap<BlockId, BlockId>) {
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
         for block_id in block_ids {
-            let Some(mut term) = func.blocks[block_id].terminator.clone() else {
+            let Some(mut term) = func.block(block_id).terminator.clone() else {
                 continue;
             };
             self.thread_terminator(func, &mut term, final_targets);
-            func.blocks[block_id].terminator = Some(term);
+            func.block_mut(block_id).terminator = Some(term);
         }
     }
 
@@ -280,10 +280,11 @@ impl JumpThreader {
             return false;
         }
 
-        for (other_block, block) in func.blocks.iter_enumerated() {
+        for (other_block, block) in func.blocks_enumerated() {
             if other_block != block_id {
                 for &inst_id in &block.instructions {
-                    if func.instructions[inst_id]
+                    if func
+                        .instruction(inst_id)
                         .kind
                         .operands()
                         .iter()
@@ -309,7 +310,7 @@ impl JumpThreader {
 
     fn thread_phi_constant_edges(&mut self, func: &mut Function) -> usize {
         let mut rewrites = Vec::new();
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
 
         for block_id in block_ids {
             if !func.block_has_only_phis(block_id) {
@@ -319,10 +320,10 @@ impl JumpThreader {
                 continue;
             }
 
-            let Some(term) = &func.blocks[block_id].terminator else {
+            let Some(term) = &func.block(block_id).terminator else {
                 continue;
             };
-            let predecessors = func.blocks[block_id].predecessors.clone();
+            let predecessors = func.block(block_id).predecessors.clone();
             if predecessors.is_empty() {
                 continue;
             }
@@ -393,10 +394,10 @@ impl JumpThreader {
         let Value::Inst(inst_id) = func.value(value) else {
             return Some(value);
         };
-        if !func.blocks[block_id].instructions.contains(inst_id) {
+        if !func.block(block_id).instructions.contains(inst_id) {
             return None;
         }
-        let InstKind::Phi(incoming) = &func.instructions[*inst_id].kind else {
+        let InstKind::Phi(incoming) = &func.instruction(*inst_id).kind else {
             return None;
         };
         incoming.iter().find_map(|(incoming_block, incoming_value)| {
@@ -405,7 +406,7 @@ impl JumpThreader {
     }
 
     fn successor_count(func: &Function, pred: BlockId, target: BlockId) -> usize {
-        func.blocks[pred]
+        func.block(pred)
             .terminator
             .as_ref()
             .map(|term| term.successors().into_iter().filter(|&succ| succ == target).count())
@@ -418,7 +419,7 @@ impl JumpThreader {
         old_target: BlockId,
         new_target: BlockId,
     ) -> bool {
-        let Some(term) = &mut func.blocks[pred].terminator else {
+        let Some(term) = &mut func.block_mut(pred).terminator else {
             return false;
         };
         match term {
@@ -468,20 +469,21 @@ impl JumpThreader {
 
     /// Updates CFG edges after threading.
     fn update_cfg_edges(&self, func: &mut Function) {
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
         for block_id in &block_ids {
-            func.blocks[*block_id].predecessors.clear();
+            func.block_mut(*block_id).predecessors.clear();
         }
 
         for block_id in block_ids {
-            let successors = func.blocks[block_id]
+            let successors = func
+                .block(block_id)
                 .terminator
                 .as_ref()
                 .map(|t| t.successors())
                 .unwrap_or_default();
 
             for succ in successors {
-                func.blocks[succ].predecessors.push(block_id);
+                func.block_mut(succ).predecessors.push(block_id);
             }
         }
     }

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -323,10 +323,10 @@ impl LoadRedundancyEliminator {
             self.alias = Some(Rc::new(AliasAnalysis::new(func)));
         }
 
-        let rewrite_limit = func.instructions.len().saturating_mul(2).max(64);
+        let rewrite_limit = func.instruction_count().saturating_mul(2).max(64);
         let mut rewrites = 0usize;
         let mut eliminated_keys: FxHashSet<(LoadKey, BlockId)> = FxHashSet::default();
-        let mut inserted_insts = GrowableBitSet::with_capacity(func.instructions.len());
+        let mut inserted_insts = GrowableBitSet::with_capacity(func.instruction_count());
 
         while rewrites < rewrite_limit {
             let Some(analysis) = self.compute_analysis(func) else { break };
@@ -364,7 +364,7 @@ impl LoadRedundancyEliminator {
         let mut keys = Vec::new();
         let mut key_index: FxHashMap<LoadKey, usize> = FxHashMap::default();
         for &block in rpo {
-            for &inst_id in &func.blocks[block].instructions {
+            for &inst_id in &func.block(block).instructions {
                 if let Some((key, _)) = self.gen_key_value(func, inst_id) {
                     key_index.entry(key).or_insert_with(|| {
                         keys.push(key);
@@ -385,8 +385,8 @@ impl LoadRedundancyEliminator {
         for &block in rpo {
             let mut gen_set = KeySet::new_empty(key_count);
             let mut kill_set = KeySet::new_empty(key_count);
-            for &inst_id in &func.blocks[block].instructions {
-                if func.instructions[inst_id].kind.has_side_effects() {
+            for &inst_id in &func.block(block).instructions {
+                if func.instruction(inst_id).kind.has_side_effects() {
                     for (idx, &key) in keys.iter().enumerate() {
                         if self.inst_kills_key(func, inst_id, key) {
                             kill_set.insert(idx);
@@ -414,7 +414,7 @@ impl LoadRedundancyEliminator {
         let mut outs: FxHashMap<BlockId, KeySet> = rpo
             .iter()
             .map(|&block| {
-                let out = if func.blocks[block].predecessors.is_empty() {
+                let out = if func.block(block).predecessors.is_empty() {
                     gens[&block].clone()
                 } else {
                     KeySet::new_filled(key_count)
@@ -426,7 +426,7 @@ impl LoadRedundancyEliminator {
             let mut changed = false;
             for &block in rpo {
                 let mut acc: Option<KeySet> = None;
-                for &pred in &func.blocks[block].predecessors {
+                for &pred in &func.block(block).predecessors {
                     // Unreachable predecessors never execute and cannot
                     // contribute a path.
                     let Some(out) = outs.get(&pred) else { continue };
@@ -477,10 +477,10 @@ impl LoadRedundancyEliminator {
         let mut batch = Vec::new();
         // Candidates whose analysis would be invalidated by an earlier
         // candidate in this batch are deferred to the next round.
-        let mut modified_blocks = DenseBitSet::new_empty(func.blocks.len());
-        let mut eliminated_values = DenseBitSet::new_empty(func.values.len());
+        let mut modified_blocks = DenseBitSet::new_empty(func.block_count());
+        let mut eliminated_values = DenseBitSet::new_empty(func.value_count());
 
-        'targets: for target in func.blocks.indices() {
+        'targets: for target in func.block_ids() {
             if !cx.analysis.cfg.is_reachable(target) {
                 continue;
             }
@@ -559,7 +559,7 @@ impl LoadRedundancyEliminator {
         let mut taken = KeySet::new_empty(key_count);
         let mut found = Vec::new();
 
-        for &inst_id in &func.blocks[target].instructions {
+        for &inst_id in &func.block(target).instructions {
             if let Some((key, GenSource::LoadResult)) = self.gen_key_value(func, inst_id) {
                 if let Some(&idx) = analysis.key_index.get(&key)
                     && !blocked.contains(idx)
@@ -569,7 +569,7 @@ impl LoadRedundancyEliminator {
                 }
                 continue;
             }
-            let kind = &func.instructions[inst_id].kind;
+            let kind = &func.instruction(inst_id).kind;
             match kind {
                 // `gas` blocks every space, so nothing after it can be a
                 // candidate.
@@ -609,7 +609,7 @@ impl LoadRedundancyEliminator {
         let mut loads = Vec::new();
         let mut past_first = false;
 
-        for &inst_id in &func.blocks[target].instructions {
+        for &inst_id in &func.block(target).instructions {
             if inst_id == first_inst {
                 past_first = true;
             }
@@ -618,7 +618,7 @@ impl LoadRedundancyEliminator {
             }
 
             if inst_id != first_inst {
-                let kind = &func.instructions[inst_id].kind;
+                let kind = &func.instruction(inst_id).kind;
                 if matches!(kind, InstKind::Gas) {
                     break;
                 }
@@ -652,7 +652,7 @@ impl LoadRedundancyEliminator {
         key_idx: usize,
         predecessors: &[BlockId],
     ) -> Option<Candidate> {
-        let instruction = &func.instructions[inst];
+        let instruction = func.instruction(inst);
         let result = *cx.analysis.inst_results.get(&inst)?;
         let result_ty = instruction.result_ty?;
         let key = cx.analysis.keys[key_idx];
@@ -795,7 +795,7 @@ impl LoadRedundancyEliminator {
         key_idx: usize,
     ) -> Option<ValueId> {
         let key = cx.analysis.keys[key_idx];
-        for &inst_id in func.blocks[block].instructions.iter().rev() {
+        for &inst_id in func.block(block).instructions.iter().rev() {
             if let Some((gen_key, source)) = self.gen_key_value(func, inst_id)
                 && gen_key == key
             {
@@ -850,7 +850,7 @@ impl LoadRedundancyEliminator {
                 metadata: metadata.clone(),
             });
             let value = func.alloc_value(Value::Inst(new_inst));
-            func.blocks[block].instructions.push(new_inst);
+            func.block_mut(block).instructions.push(new_inst);
             incoming.push((block, value));
             inserted_insts.insert(new_inst);
             self.stats.loads_inserted += 1;
@@ -873,14 +873,15 @@ impl LoadRedundancyEliminator {
                 let phi_inst =
                     func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
                 let phi_value = func.alloc_value(Value::Inst(phi_inst));
-                let phi_count = func.blocks[target]
+                let phi_count = func
+                    .block(target)
                     .instructions
                     .iter()
                     .take_while(|&&inst_id| {
-                        matches!(func.instructions[inst_id].kind, InstKind::Phi(_))
+                        matches!(func.instruction(inst_id).kind, InstKind::Phi(_))
                     })
                     .count();
-                func.blocks[target].instructions.insert(phi_count, phi_inst);
+                func.block_mut(target).instructions.insert(phi_count, phi_inst);
                 phi_value
             }
         };
@@ -888,11 +889,11 @@ impl LoadRedundancyEliminator {
         for &(_, load_result) in &loads {
             Self::replace_uses(func, load_result, replacement);
         }
-        let mut load_insts = DenseBitSet::new_empty(func.instructions.len());
+        let mut load_insts = DenseBitSet::new_empty(func.instruction_count());
         for &(inst_id, _) in &loads {
             load_insts.insert(inst_id);
         }
-        func.blocks[target].instructions.retain(|&inst_id| !load_insts.contains(inst_id));
+        func.block_mut(target).instructions.retain(|&inst_id| !load_insts.contains(inst_id));
         self.stats.loads_eliminated += loads.len();
     }
 
@@ -901,7 +902,7 @@ impl LoadRedundancyEliminator {
     /// Returns the key an instruction gens and where its value comes from.
     fn gen_key_value(&self, func: &Function, inst_id: InstId) -> Option<(LoadKey, GenSource)> {
         let aa = self.alias();
-        match func.instructions[inst_id].kind {
+        match func.instruction(inst_id).kind {
             InstKind::SLoad(slot) => Some((
                 LoadKey::Storage(aa.storage_alias(func, inst_id, slot)),
                 GenSource::LoadResult,
@@ -989,7 +990,7 @@ impl LoadRedundancyEliminator {
     // ----- CFG helpers -----
 
     fn can_insert_on_edge(func: &Function, pred: BlockId, target: BlockId) -> bool {
-        matches!(func.blocks[pred].terminator, Some(Terminator::Jump(jump_target)) if jump_target == target)
+        matches!(func.block(pred).terminator, Some(Terminator::Jump(jump_target)) if jump_target == target)
     }
 
     fn operands_dominate_block(
@@ -1010,7 +1011,7 @@ impl LoadRedundancyEliminator {
     // ----- Rewriting -----
 
     fn replace_uses(func: &mut Function, from: ValueId, to: ValueId) {
-        for inst in func.instructions.iter_mut() {
+        for inst in func.instructions_mut() {
             let mut changed = false;
             inst.kind.visit_operands_mut(|value| {
                 if *value == from {
@@ -1036,7 +1037,7 @@ impl LoadRedundancyEliminator {
             }
         }
 
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             if let Some(term) = &mut block.terminator {
                 Self::replace_terminator_uses(term, from, to);
             }

--- a/crates/codegen/src/transform/loop_canonicalize.rs
+++ b/crates/codegen/src/transform/loop_canonicalize.rs
@@ -106,8 +106,8 @@ impl LoopCanonicalizer {
         func: &Function,
         loop_data: &crate::analysis::Loop,
     ) -> Vec<BlockId> {
-        let mut seen = DenseBitSet::new_empty(func.blocks.len());
-        func.blocks[loop_data.header]
+        let mut seen = DenseBitSet::new_empty(func.block_count());
+        func.block(loop_data.header)
             .predecessors
             .iter()
             .copied()
@@ -128,8 +128,8 @@ impl LoopCanonicalizer {
             }
         }
 
-        for &inst_id in &func.blocks[header].instructions {
-            let InstKind::Phi(incoming) = &func.instructions[inst_id].kind else {
+        for &inst_id in &func.block(header).instructions {
+            let InstKind::Phi(incoming) = &func.instruction(inst_id).kind else {
                 continue;
             };
             if outside_preds
@@ -144,7 +144,7 @@ impl LoopCanonicalizer {
     }
 
     fn terminator_targets(&self, func: &Function, block: BlockId, target: BlockId) -> bool {
-        func.blocks[block]
+        func.block(block)
             .terminator
             .as_ref()
             .is_some_and(|term| term.successors().contains(&target))
@@ -157,7 +157,7 @@ impl LoopCanonicalizer {
         outside_preds: &[BlockId],
     ) {
         let preheader = func.alloc_block();
-        func.blocks[preheader].terminator = Some(Terminator::Jump(header));
+        func.block_mut(preheader).terminator = Some(Terminator::Jump(header));
 
         for &pred in outside_preds {
             self.redirect_terminator(func, pred, header, preheader);
@@ -175,11 +175,12 @@ impl LoopCanonicalizer {
         preheader: BlockId,
         outside_preds: &[BlockId],
     ) {
-        let phi_insts: Vec<_> = func.blocks[header]
+        let phi_insts: Vec<_> = func
+            .block(header)
             .instructions
             .iter()
             .copied()
-            .take_while(|&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+            .take_while(|&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
             .collect();
 
         let mut preheader_insert_pos = 0;
@@ -188,22 +189,23 @@ impl LoopCanonicalizer {
             let preheader_value =
                 self.canonical_preheader_value(func, inst_id, external_incoming, preheader);
 
-            let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind else {
+            let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind else {
                 continue;
             };
             incoming.retain(|(pred, _)| !outside_preds.contains(pred));
             incoming.push((preheader, preheader_value));
             self.stats.header_phis_rewritten += 1;
 
-            if let Value::Inst(phi_inst) = func.values[preheader_value]
-                && func.blocks[preheader].instructions.contains(&phi_inst)
-                && let Some(pos) = func.blocks[preheader]
+            if let Value::Inst(phi_inst) = func.value(preheader_value)
+                && func.block(preheader).instructions.contains(phi_inst)
+                && let Some(pos) = func
+                    .block(preheader)
                     .instructions
                     .iter()
-                    .position(|&existing| existing == phi_inst)
+                    .position(|&existing| existing == *phi_inst)
             {
-                let phi_inst = func.blocks[preheader].instructions.remove(pos);
-                func.blocks[preheader].instructions.insert(preheader_insert_pos, phi_inst);
+                let phi_inst = func.block_mut(preheader).instructions.remove(pos);
+                func.block_mut(preheader).instructions.insert(preheader_insert_pos, phi_inst);
                 preheader_insert_pos += 1;
             }
         }
@@ -215,7 +217,7 @@ impl LoopCanonicalizer {
         inst_id: InstId,
         outside_preds: &[BlockId],
     ) -> Vec<(BlockId, ValueId)> {
-        let InstKind::Phi(incoming) = &func.instructions[inst_id].kind else {
+        let InstKind::Phi(incoming) = &func.instruction(inst_id).kind else {
             return Vec::new();
         };
         outside_preds
@@ -243,10 +245,10 @@ impl LoopCanonicalizer {
         }
 
         let result_ty =
-            func.instructions[header_phi].result_ty.expect("header phi should have result type");
+            func.instruction(header_phi).result_ty.expect("header phi should have result type");
         let preheader_phi =
             func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
-        func.blocks[preheader].instructions.push(preheader_phi);
+        func.block_mut(preheader).instructions.push(preheader_phi);
         self.stats.preheader_phis_inserted += 1;
         func.alloc_value(Value::Inst(preheader_phi))
     }
@@ -258,7 +260,7 @@ impl LoopCanonicalizer {
         old_target: BlockId,
         new_target: BlockId,
     ) {
-        let Some(term) = &mut func.blocks[block_id].terminator else {
+        let Some(term) = &mut func.block_mut(block_id).terminator else {
             return;
         };
         match term {

--- a/crates/codegen/src/transform/loop_opt.rs
+++ b/crates/codegen/src/transform/loop_opt.rs
@@ -159,9 +159,9 @@ impl LoopOptimizer {
                 .then_with(|| a.index().cmp(&b.index()))
         });
 
-        let mut selected = DenseBitSet::new_empty(func.instructions.len());
+        let mut selected = DenseBitSet::new_empty(func.instruction_count());
         let mut closure = Vec::new();
-        let mut visiting = DenseBitSet::new_empty(func.instructions.len());
+        let mut visiting = DenseBitSet::new_empty(func.instruction_count());
         for root in roots {
             closure.clear();
             visiting.clear();
@@ -193,7 +193,7 @@ impl LoopOptimizer {
             // the same instruction in two blocks.
             let mut removed = false;
             for block_id in &loop_data.blocks {
-                let block = &mut func.blocks[block_id];
+                let block = func.block_mut(block_id);
                 if let Some(pos) = block.instructions.iter().position(|&id| id == inst_id) {
                     block.instructions.remove(pos);
                     removed = true;
@@ -201,7 +201,7 @@ impl LoopOptimizer {
                 }
             }
             if removed {
-                func.blocks[preheader].instructions.push(inst_id);
+                func.block_mut(preheader).instructions.push(inst_id);
                 self.stats.instructions_hoisted += 1;
             }
         }
@@ -229,7 +229,7 @@ impl LoopOptimizer {
             return false;
         }
 
-        let inst = &func.instructions[inst_id];
+        let inst = func.instruction(inst_id);
         for operand in inst.kind.operands() {
             if let Value::Inst(dep_inst) = func.value(operand)
                 && self.inst_in_loop(func, *dep_inst, ctx.loop_data)
@@ -244,7 +244,7 @@ impl LoopOptimizer {
     }
 
     fn can_hoist_safely(&self, func: &Function, inst_id: InstId, ctx: LoopOptContext<'_>) -> bool {
-        let inst = &func.instructions[inst_id];
+        let inst = func.instruction(inst_id);
 
         if inst.kind.has_side_effects() {
             return false;
@@ -334,7 +334,7 @@ impl LoopOptimizer {
         let Some(inst_block) = loop_data
             .blocks
             .iter()
-            .find(|&block| func.blocks[block].instructions.contains(&inst_id))
+            .find(|&block| func.block(block).instructions.contains(&inst_id))
         else {
             return false;
         };
@@ -362,7 +362,7 @@ impl LoopOptimizer {
     fn live_exiting_blocks(&self, func: &Function, loop_data: &Loop) -> Vec<BlockId> {
         let mut exiting = Vec::new();
         for block_id in &loop_data.blocks {
-            let Some(term) = &func.blocks[block_id].terminator else { continue };
+            let Some(term) = &func.block(block_id).terminator else { continue };
             let escapes = match term {
                 Terminator::Branch { condition, then_block, else_block } => {
                     match self.const_condition(func, *condition) {
@@ -384,19 +384,19 @@ impl LoopOptimizer {
     }
 
     fn function_observes_msize(&self, func: &Function) -> bool {
-        func.blocks.iter().any(|block| {
+        func.blocks().any(|block| {
             block
                 .instructions
                 .iter()
-                .any(|&inst_id| matches!(func.instructions[inst_id].kind, InstKind::MSize))
+                .any(|&inst_id| matches!(func.instruction(inst_id).kind, InstKind::MSize))
         })
     }
 
     fn loop_contains_call_or_create(&self, func: &Function, loop_data: &Loop) -> bool {
         loop_data.blocks.iter().any(|block_id| {
-            func.blocks[block_id].instructions.iter().any(|&inst_id| {
+            func.block(block_id).instructions.iter().any(|&inst_id| {
                 matches!(
-                    func.instructions[inst_id].kind,
+                    func.instruction(inst_id).kind,
                     InstKind::Call { .. }
                         | InstKind::StaticCall { .. }
                         | InstKind::DelegateCall { .. }
@@ -409,11 +409,11 @@ impl LoopOptimizer {
     }
 
     fn inst_in_loop(&self, func: &Function, inst_id: InstId, loop_data: &Loop) -> bool {
-        loop_data.blocks.iter().any(|block| func.blocks[block].instructions.contains(&inst_id))
+        loop_data.blocks.iter().any(|block| func.block(block).instructions.contains(&inst_id))
     }
 
     fn licm_profit(&self, func: &Function, inst_id: InstId) -> u16 {
-        match func.instructions[inst_id].kind {
+        match func.instruction(inst_id).kind {
             InstKind::SLoad(_) => 100,
             InstKind::TLoad(_) => 100,
             InstKind::Keccak256(_, _) => 30,
@@ -452,8 +452,8 @@ impl LoopOptimizer {
 
     fn loop_observes_gas(&self, func: &Function, loop_data: &Loop) -> bool {
         for block_id in &loop_data.blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                if matches!(func.instructions[inst_id].kind, InstKind::Gas) {
+            for &inst_id in &func.block(block_id).instructions {
+                if matches!(func.instruction(inst_id).kind, InstKind::Gas) {
                     return true;
                 }
             }
@@ -471,7 +471,7 @@ impl LoopOptimizer {
         let Some(inst_block) = loop_data
             .blocks
             .iter()
-            .find(|&block| func.blocks[block].instructions.contains(&inst_id))
+            .find(|&block| func.block(block).instructions.contains(&inst_id))
         else {
             return false;
         };
@@ -487,8 +487,8 @@ impl LoopOptimizer {
     ) -> bool {
         let aa = self.alias();
         for block_id in &ctx.loop_data.blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                match func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                match func.instruction(inst_id).kind {
                     InstKind::MStore(addr, _) => {
                         if self.memory_ranges_may_alias(
                             func, ctx, load_addr, load_width, addr, 32, block_id,
@@ -536,8 +536,8 @@ impl LoopOptimizer {
         }
 
         for block_id in &ctx.loop_data.blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                match (space, &func.instructions[inst_id].kind) {
+            for &inst_id in &func.block(block_id).instructions {
+                match (space, &func.instruction(inst_id).kind) {
                     (StorageSpace::Persistent, InstKind::SStore(slot, _))
                     | (StorageSpace::Transient, InstKind::TStore(slot, _)) => {
                         let Some(store_alias) =
@@ -735,8 +735,8 @@ impl LoopOptimizer {
     ) -> bool {
         let Some(result) = func.inst_result_value(inst_id) else { return false };
         for block_id in &ctx.loop_data.blocks {
-            for &user_inst in &func.blocks[block_id].instructions {
-                let kind = &func.instructions[user_inst].kind;
+            for &user_inst in &func.block(block_id).instructions {
+                let kind = &func.instruction(user_inst).kind;
                 let mut address_operands = ArrayVec::<ValueId, 2>::new();
                 match kind {
                     InstKind::MLoad(addr)
@@ -789,7 +789,7 @@ impl LoopOptimizer {
         if !self.inst_in_loop(func, *inst_id, ctx.loop_data) {
             return false;
         }
-        func.instructions[*inst_id]
+        func.instruction(*inst_id)
             .kind
             .operands()
             .iter()
@@ -798,12 +798,12 @@ impl LoopOptimizer {
     }
 
     fn topological_sort_instructions(&self, func: &Function, insts: &[InstId]) -> Vec<InstId> {
-        let mut inst_set = DenseBitSet::new_empty(func.instructions.len());
+        let mut inst_set = DenseBitSet::new_empty(func.instruction_count());
         for &inst_id in insts {
             inst_set.insert(inst_id);
         }
         let mut result = Vec::new();
-        let mut visited = DenseBitSet::new_empty(func.instructions.len());
+        let mut visited = DenseBitSet::new_empty(func.instruction_count());
 
         fn visit(
             func: &Function,
@@ -816,9 +816,9 @@ impl LoopOptimizer {
                 return;
             }
 
-            let inst = &func.instructions[inst_id];
+            let inst = func.instruction(inst_id);
             for operand in inst.kind.operands() {
-                if let Value::Inst(dep_inst) = &func.values[operand]
+                if let Value::Inst(dep_inst) = func.value(operand)
                     && inst_set.contains(*dep_inst)
                 {
                     visit(func, *dep_inst, inst_set, visited, result);
@@ -881,14 +881,14 @@ mod tests {
             panic!("mul should be an instruction");
         };
         let mul_inst = *mul_inst;
-        assert!(func.blocks[body].instructions.contains(&mul_inst));
+        assert!(func.block(body).instructions.contains(&mul_inst));
 
         let mut optimizer = LoopOptimizer::with_limits(5, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[entry].instructions.contains(&mul_inst));
-        assert!(!func.blocks[body].instructions.contains(&mul_inst));
-        assert!(matches!(func.blocks[header].terminator, Some(Terminator::Branch { .. })));
+        assert!(func.block(entry).instructions.contains(&mul_inst));
+        assert!(!func.block(body).instructions.contains(&mul_inst));
+        assert!(matches!(func.block(header).terminator, Some(Terminator::Branch { .. })));
     }
 
     #[test]
@@ -928,13 +928,13 @@ mod tests {
             panic!("mload should be an instruction");
         };
         let load_inst = *load_inst;
-        assert!(func.blocks[body].instructions.contains(&load_inst));
+        assert!(func.block(body).instructions.contains(&load_inst));
 
         let mut optimizer = LoopOptimizer::with_limits(3, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[entry].instructions.contains(&load_inst));
-        assert!(!func.blocks[body].instructions.contains(&load_inst));
+        assert!(func.block(entry).instructions.contains(&load_inst));
+        assert!(!func.block(body).instructions.contains(&load_inst));
     }
 
     #[test]
@@ -976,7 +976,7 @@ mod tests {
         let mut optimizer = LoopOptimizer::with_limits(3, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[body].instructions.contains(&load_inst));
+        assert!(func.block(body).instructions.contains(&load_inst));
     }
 
     #[test]
@@ -1021,8 +1021,8 @@ mod tests {
         let mut optimizer = LoopOptimizer::with_limits(5, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[entry].instructions.contains(&hash_inst));
-        assert!(!func.blocks[body].instructions.contains(&hash_inst));
+        assert!(func.block(entry).instructions.contains(&hash_inst));
+        assert!(!func.block(body).instructions.contains(&hash_inst));
     }
 
     #[test]
@@ -1065,7 +1065,7 @@ mod tests {
         let mut optimizer = LoopOptimizer::with_limits(5, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[body].instructions.contains(&hash_inst));
+        assert!(func.block(body).instructions.contains(&hash_inst));
     }
 
     #[test]
@@ -1109,8 +1109,8 @@ mod tests {
         let mut optimizer = LoopOptimizer::with_limits(5, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[entry].instructions.contains(&load_inst));
-        assert!(!func.blocks[body].instructions.contains(&load_inst));
+        assert!(func.block(entry).instructions.contains(&load_inst));
+        assert!(!func.block(body).instructions.contains(&load_inst));
     }
 
     #[test]
@@ -1151,7 +1151,7 @@ mod tests {
         let mut optimizer = LoopOptimizer::with_limits(5, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[body].instructions.contains(&load_inst));
+        assert!(func.block(body).instructions.contains(&load_inst));
     }
 
     #[test]
@@ -1192,6 +1192,6 @@ mod tests {
         let mut optimizer = LoopOptimizer::with_limits(5, 4);
         optimizer.optimize(&mut func);
 
-        assert!(func.blocks[body].instructions.contains(&mul_inst));
+        assert!(func.block(body).instructions.contains(&mul_inst));
     }
 }

--- a/crates/codegen/src/transform/lower_abi.rs
+++ b/crates/codegen/src/transform/lower_abi.rs
@@ -114,8 +114,7 @@ impl LowerAbiCx {
         // returns (a memory pointer to bytes/array/struct data) still need an
         // encoder the wrappers do not have.
         let wrappable: Vec<FunctionId> = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .filter_map(|(id, func)| is_wrappable_external(func).then_some(id))
             .collect();
         for &id in &wrappable {
@@ -124,15 +123,15 @@ impl LowerAbiCx {
         }
 
         let mut targets = Vec::new();
-        let mut internally_called = DenseBitSet::new_empty(module.functions.len());
+        let mut internally_called = DenseBitSet::new_empty(module.function_count());
         let mut callvalue = super::utils::DispatchCallvalue::default();
-        for (id, func) in module.functions.iter_enumerated() {
+        for (id, func) in module.iter_functions() {
             callvalue.observe(func);
             if is_wrappable_external(func) {
                 targets.push(id);
                 self.stats.skipped_dynamic += usize::from(has_live_value_return(func));
             }
-            for function in func.instructions.iter().filter_map(|inst| {
+            for function in func.instructions().filter_map(|inst| {
                 if let InstKind::InternalCall { function, .. } = &inst.kind {
                     Some(*function)
                 } else {
@@ -180,8 +179,8 @@ impl LowerAbiCx {
         // original call semantics: retarget them to the extracted body. The
         // wrappers' own calls already target the bodies and are not affected.
         if !body_of_wrapper.is_empty() {
-            for func in module.functions.iter_mut() {
-                for inst in func.instructions.iter_mut() {
+            for func in module.functions_mut() {
+                for inst in func.instructions_mut() {
                     if let InstKind::InternalCall { function, .. } = &mut inst.kind
                         && let Some(&body_id) = body_of_wrapper.get(function)
                     {
@@ -254,7 +253,7 @@ impl LowerAbiCx {
         builder.revert(zero, zero);
 
         let order = std::iter::once(guard)
-            .chain(func.blocks.indices().filter(|&block| block != guard))
+            .chain(func.block_ids().filter(|&block| block != guard))
             .collect::<Vec<_>>();
         crate::mir::utils::remap_block_order(func, &order);
     }
@@ -276,7 +275,7 @@ fn is_wrappable_external(func: &Function) -> bool {
 /// any count are fine: each stays an `Arg` head word the backend
 /// rematerializes lazily.
 fn has_live_value_return(func: &Function) -> bool {
-    func.blocks.iter().any(|block| {
+    func.blocks().any(|block| {
         matches!(&block.terminator, Some(Terminator::Return { values }) if !values.is_empty())
     })
 }
@@ -285,7 +284,7 @@ fn has_live_value_return(func: &Function) -> bool {
 fn value_type(func: &Function, value: crate::mir::ValueId) -> Option<MirType> {
     match func.value(value) {
         Value::Arg { ty, .. } | Value::Undef(ty) => Some(*ty),
-        Value::Inst(inst) => func.instructions[*inst].result_ty,
+        Value::Inst(inst) => func.instruction(*inst).result_ty,
         Value::Immediate(_) => Some(MirType::uint256()),
         Value::Error(_) => None,
     }
@@ -312,10 +311,10 @@ fn is_static_word_return(func: &Function, value: crate::mir::ValueId) -> bool {
 /// the fused `returndata` encoding the backend expects: consecutive head words
 /// from the return buffer, then `RETURN`. Returns whether anything changed.
 fn fuse_static_word_returns(func: &mut Function) -> bool {
-    let block_ids: Vec<_> = func.blocks.indices().collect();
+    let block_ids: Vec<_> = func.block_ids().collect();
     let mut changed = false;
     for block_id in block_ids {
-        let Some(Terminator::Return { values }) = &func.blocks[block_id].terminator else {
+        let Some(Terminator::Return { values }) = &func.block(block_id).terminator else {
             continue;
         };
         if values.is_empty() || !values.iter().all(|&v| is_static_word_return(func, v)) {

--- a/crates/codegen/src/transform/lower_abi_encode.rs
+++ b/crates/codegen/src/transform/lower_abi_encode.rs
@@ -29,7 +29,7 @@ impl MirPass for LowerAbiEncode {
         _analyses: &mut crate::pass::ModuleAnalyses,
     ) -> bool {
         let mut changed = false;
-        for func in module.functions.iter_mut() {
+        for func in module.functions_mut() {
             changed |= lower_function(func);
         }
         changed
@@ -50,11 +50,11 @@ struct AbiValueDest {
 }
 
 fn lower_function(func: &mut Function) -> bool {
-    let has_encodes = func.blocks.iter().any(|block| {
+    let has_encodes = func.blocks().any(|block| {
         block
             .instructions
             .iter()
-            .any(|&inst| matches!(func.instructions[inst].kind, InstKind::AbiEncode { .. }))
+            .any(|&inst| matches!(func.instruction(inst).kind, InstKind::AbiEncode { .. }))
     });
     if !has_encodes {
         return false;
@@ -62,14 +62,14 @@ fn lower_function(func: &mut Function) -> bool {
 
     let inst_results = func.inst_results();
     let mut replacements = FxHashMap::default();
-    let blocks: Vec<_> = func.blocks.indices().collect();
+    let blocks: Vec<_> = func.block_ids().collect();
     for block in blocks {
-        let instructions = std::mem::take(&mut func.blocks[block].instructions);
-        let original_terminator = func.blocks[block].terminator.take();
+        let instructions = std::mem::take(&mut func.block_mut(block).instructions);
+        let original_terminator = func.block_mut(block).terminator.take();
         let mut builder = FunctionBuilder::new(func);
         builder.switch_to_block(block);
         for inst in instructions {
-            let encode = match &builder.func().instructions[inst].kind {
+            let encode = match &builder.func().instruction(inst).kind {
                 InstKind::AbiEncode { selector, args, layout } => Some((
                     selector.map(|value| resolve(value, &replacements)),
                     args.iter().map(|&value| resolve(value, &replacements)).collect::<Vec<_>>(),
@@ -82,7 +82,7 @@ fn lower_function(func: &mut Function) -> bool {
                 replacements.insert(inst_results[&inst], replacement);
             } else {
                 let current = builder.current_block();
-                builder.func_mut().blocks[current].instructions.push(inst);
+                builder.func_mut().block_mut(current).instructions.push(inst);
             }
         }
         move_terminator(&mut builder, block, original_terminator);
@@ -108,9 +108,10 @@ fn move_terminator(
     let Some(terminator) = terminator else { return };
     if final_block != original_block {
         for successor in terminator.successors() {
-            let instructions = builder.func().blocks[successor].instructions.clone();
+            let instructions = builder.func().block(successor).instructions.clone();
             for inst in instructions {
-                if let InstKind::Phi(incoming) = &mut builder.func_mut().instructions[inst].kind {
+                if let InstKind::Phi(incoming) = &mut builder.func_mut().instruction_mut(inst).kind
+                {
                     for (predecessor, _) in incoming {
                         if *predecessor == original_block {
                             *predecessor = final_block;
@@ -120,7 +121,7 @@ fn move_terminator(
             }
         }
     }
-    builder.func_mut().blocks[final_block].terminator = Some(terminator);
+    builder.func_mut().block_mut(final_block).terminator = Some(terminator);
 }
 
 fn lower_encode(

--- a/crates/codegen/src/transform/lower_aggregates.rs
+++ b/crates/codegen/src/transform/lower_aggregates.rs
@@ -26,7 +26,7 @@ impl MirPass for LowerAggregates {
         _analyses: &mut crate::pass::ModuleAnalyses,
     ) -> bool {
         let mut changed = false;
-        for func in module.functions.iter_mut() {
+        for func in module.functions_mut() {
             changed |= lower_function(func);
         }
         changed
@@ -40,10 +40,10 @@ enum AggregateOp {
 }
 
 fn lower_function(func: &mut Function) -> bool {
-    let has_aggregates = func.blocks.iter().any(|block| {
+    let has_aggregates = func.blocks().any(|block| {
         block.instructions.iter().any(|&inst| {
             matches!(
-                func.instructions[inst].kind,
+                func.instruction(inst).kind,
                 InstKind::StorageToMemory { .. }
                     | InstKind::MemoryToStorage { .. }
                     | InstKind::ClearStorage { .. }
@@ -54,13 +54,13 @@ fn lower_function(func: &mut Function) -> bool {
         return false;
     }
 
-    let blocks: Vec<_> = func.blocks.indices().collect();
+    let blocks: Vec<_> = func.block_ids().collect();
     for block in blocks {
-        let instructions = std::mem::take(&mut func.blocks[block].instructions);
+        let instructions = std::mem::take(&mut func.block_mut(block).instructions);
         let mut builder = FunctionBuilder::new(func);
         builder.switch_to_block(block);
         for inst in instructions {
-            let op = match &builder.func().instructions[inst].kind {
+            let op = match &builder.func().instruction(inst).kind {
                 InstKind::StorageToMemory { storage, memory, layout } => {
                     Some(AggregateOp::StorageToMemory {
                         storage: *storage,
@@ -91,7 +91,7 @@ fn lower_function(func: &mut Function) -> bool {
                 Some(AggregateOp::ClearStorage { storage, layout }) => {
                     lower_clear_storage(&mut builder, &layout, storage);
                 }
-                None => builder.func_mut().blocks[block].instructions.push(inst),
+                None => builder.func_mut().block_mut(block).instructions.push(inst),
             }
         }
     }

--- a/crates/codegen/src/transform/lower_alloc.rs
+++ b/crates/codegen/src/transform/lower_alloc.rs
@@ -40,8 +40,8 @@ impl MirPass for LowerAlloc {
 
 fn lower_alloc(module: &mut Module) -> bool {
     let mut changed = false;
-    for func in module.functions.iter_mut() {
-        if !func.blocks.is_empty() {
+    for func in module.functions_mut() {
+        if !func.has_no_blocks() {
             changed |= lower_function(func);
         }
     }
@@ -49,10 +49,10 @@ fn lower_alloc(module: &mut Module) -> bool {
 }
 
 fn lower_function(func: &mut Function) -> bool {
-    let has_abstract_memory = func.blocks.iter().any(|block| {
+    let has_abstract_memory = func.blocks().any(|block| {
         block.instructions.iter().any(|&inst| {
             matches!(
-                func.instructions[inst].kind,
+                func.instruction(inst).kind,
                 InstKind::Fmp | InstKind::SetFmp(_) | InstKind::Alloc { .. }
             )
         })
@@ -64,17 +64,17 @@ fn lower_function(func: &mut Function) -> bool {
     let inst_results = func.inst_results();
     let mut changed = false;
     let mut block_index = 0;
-    while block_index < func.blocks.len() {
+    while block_index < func.block_count() {
         let block = BlockId::from_usize(block_index);
         let checked =
-            func.blocks[block].instructions.iter().copied().enumerate().find(|(_, inst)| {
+            func.block(block).instructions.iter().copied().enumerate().find(|(_, inst)| {
                 matches!(
-                    func.instructions[*inst].kind,
+                    func.instruction(*inst).kind,
                     InstKind::Alloc {
                         semantics: AllocationSemantics { failure: AllocationFailure::Panic, .. },
                         ..
                     }
-                ) && !func.instructions[*inst].metadata.deferred_alloc()
+                ) && !func.instruction(*inst).metadata.deferred_alloc()
             });
         if let Some((position, inst)) = checked {
             lower_checked_alloc(func, block, position, inst, inst_results[&inst]);
@@ -83,40 +83,40 @@ fn lower_function(func: &mut Function) -> bool {
         block_index += 1;
     }
 
-    let blocks: Vec<BlockId> = func.blocks.indices().collect();
+    let blocks: Vec<BlockId> = func.block_ids().collect();
     for block in blocks {
-        let instructions = std::mem::take(&mut func.blocks[block].instructions);
+        let instructions = std::mem::take(&mut func.block_mut(block).instructions);
         let mut builder = FunctionBuilder::new(func);
         builder.switch_to_block(block);
         for inst in instructions {
-            match builder.func().instructions[inst].kind {
+            match builder.func().instruction(inst).kind {
                 InstKind::Fmp => {
                     changed = true;
                     rewrite_as_fmp_load(&mut builder, inst);
-                    builder.func_mut().blocks[block].instructions.push(inst);
+                    builder.func_mut().block_mut(block).instructions.push(inst);
                 }
                 InstKind::SetFmp(ptr) => {
                     changed = true;
                     rewrite_as_fmp_store(&mut builder, inst, ptr);
-                    builder.func_mut().blocks[block].instructions.push(inst);
+                    builder.func_mut().block_mut(block).instructions.push(inst);
                 }
                 InstKind::Alloc { size, semantics, .. } => {
-                    if builder.func().instructions[inst].metadata.deferred_alloc() {
-                        builder.func_mut().blocks[block].instructions.push(inst);
+                    if builder.func().instruction(inst).metadata.deferred_alloc() {
+                        builder.func_mut().block_mut(block).instructions.push(inst);
                         continue;
                     }
                     debug_assert_eq!(semantics.failure, AllocationFailure::Infallible);
                     changed = true;
                     let ptr = inst_results[&inst];
                     rewrite_as_fmp_load(&mut builder, inst);
-                    builder.func_mut().blocks[block].instructions.push(inst);
+                    builder.func_mut().block_mut(block).instructions.push(inst);
                     let size = aligned_size(&mut builder, size, semantics.alignment).0;
                     let next = builder.add(ptr, size);
                     store_fmp(&mut builder, next);
                     initialize(&mut builder, ptr, size, semantics.initialization);
                 }
                 _ => {
-                    builder.func_mut().blocks[block].instructions.push(inst);
+                    builder.func_mut().block_mut(block).instructions.push(inst);
                 }
             }
         }
@@ -131,19 +131,19 @@ fn lower_checked_alloc(
     inst: InstId,
     ptr: ValueId,
 ) {
-    let InstKind::Alloc { size, semantics, .. } = func.instructions[inst].kind else {
+    let InstKind::Alloc { size, semantics, .. } = func.instruction(inst).kind else {
         unreachable!()
     };
     debug_assert_eq!(semantics.failure, AllocationFailure::Panic);
 
-    let mut instructions = std::mem::take(&mut func.blocks[block].instructions);
+    let mut instructions = std::mem::take(&mut func.block_mut(block).instructions);
     let tail = instructions.split_off(position + 1);
-    func.blocks[block].instructions = instructions;
-    let old_terminator = func.blocks[block].terminator.take();
+    func.block_mut(block).instructions = instructions;
+    let old_terminator = func.block_mut(block).terminator.take();
 
     let continuation = func.alloc_block();
-    func.blocks[continuation].instructions = tail;
-    func.blocks[continuation].terminator = old_terminator;
+    func.block_mut(continuation).instructions = tail;
+    func.block_mut(continuation).terminator = old_terminator;
     redirect_successor_predecessors(func, block, continuation);
 
     let panic = func.alloc_block();
@@ -161,11 +161,11 @@ fn lower_checked_alloc(
     }
     builder.branch(invalid, panic, continuation);
 
-    let tail = std::mem::take(&mut builder.func_mut().blocks[continuation].instructions);
+    let tail = std::mem::take(&mut builder.func_mut().block_mut(continuation).instructions);
     builder.switch_to_block(continuation);
     store_fmp(&mut builder, next);
     initialize(&mut builder, ptr, size, semantics.initialization);
-    builder.func_mut().blocks[continuation].instructions.extend(tail);
+    builder.func_mut().block_mut(continuation).instructions.extend(tail);
 
     builder.switch_to_block(panic);
     let zero = builder.imm_u64(0);
@@ -180,21 +180,24 @@ fn lower_checked_alloc(
 
 fn redirect_successor_predecessors(func: &mut Function, from: BlockId, to: BlockId) {
     let successors =
-        func.blocks[to].terminator.as_ref().map(Terminator::successors).unwrap_or_default();
+        func.block(to).terminator.as_ref().map(Terminator::successors).unwrap_or_default();
     for successor in successors {
-        for predecessor in &mut func.blocks[successor].predecessors {
+        for predecessor in &mut func.block_mut(successor).predecessors {
             if *predecessor == from {
                 *predecessor = to;
             }
         }
-        let phi_insts: Vec<_> = func.blocks[successor]
+        let phi_insts: Vec<_> = func
+            .block(successor)
             .instructions
             .iter()
             .copied()
-            .take_while(|inst| matches!(func.instructions[*inst].kind, InstKind::Phi(_)))
+            .take_while(|inst| matches!(func.instruction(*inst).kind, InstKind::Phi(_)))
             .collect();
         for phi in phi_insts {
-            let InstKind::Phi(incoming) = &mut func.instructions[phi].kind else { unreachable!() };
+            let InstKind::Phi(incoming) = &mut func.instruction_mut(phi).kind else {
+                unreachable!()
+            };
             for (predecessor, _) in incoming {
                 if *predecessor == from {
                     *predecessor = to;
@@ -238,7 +241,7 @@ fn initialize(
 
 fn rewrite_as_fmp_load(builder: &mut FunctionBuilder<'_>, inst: crate::mir::InstId) {
     let slot = builder.imm_u64(EvmMemoryLayout::FMP_SLOT);
-    let instruction = &mut builder.func_mut().instructions[inst];
+    let instruction = builder.func_mut().instruction_mut(inst);
     instruction.kind = InstKind::MLoad(slot);
     instruction.metadata.set_memory_region(Some(MemoryRegion::Scratch));
 }
@@ -249,7 +252,7 @@ fn rewrite_as_fmp_store(
     ptr: crate::mir::ValueId,
 ) {
     let slot = builder.imm_u64(EvmMemoryLayout::FMP_SLOT);
-    let instruction = &mut builder.func_mut().instructions[inst];
+    let instruction = builder.func_mut().instruction_mut(inst);
     instruction.kind = InstKind::MStore(slot, ptr);
     instruction.metadata.set_memory_region(Some(MemoryRegion::Scratch));
 }

--- a/crates/codegen/src/transform/lower_dispatch.rs
+++ b/crates/codegen/src/transform/lower_dispatch.rs
@@ -87,7 +87,7 @@ impl LowerDispatchCx {
         let mut receive = None;
         let mut fallback = None;
         let mut callvalue = super::utils::DispatchCallvalue::default();
-        for (id, func) in module.functions.iter_enumerated() {
+        for (id, func) in module.iter_functions() {
             callvalue.observe(func);
             if func.attributes.is_receive && receive.is_none() {
                 receive = Some(id);

--- a/crates/codegen/src/transform/lower_evm_shaped.rs
+++ b/crates/codegen/src/transform/lower_evm_shaped.rs
@@ -35,11 +35,11 @@ impl MirPass for LowerEvmShaped {
 
     fn is_enabled(&self, _gcx: solar_sema::Gcx<'_>, module: &Module) -> bool {
         module.phase == MirPhase::MemoryLowered
-            && module.functions.iter().all(|func| {
-                func.blocks.iter().all(|block| {
+            && module.functions().all(|func| {
+                func.blocks().all(|block| {
                     block.instructions.iter().all(|&inst| {
                         !matches!(
-                            func.instructions[inst].kind,
+                            func.instruction(inst).kind,
                             InstKind::MakeSlice { .. }
                                 | InstKind::SlicePtr(_)
                                 | InstKind::SliceLen(_)
@@ -88,8 +88,8 @@ impl LowerEvmShapedCx {
         // Dispatch already uses explicit tail calls. Most modules have no
         // resultless internal call left to reshape, so avoid building a call
         // graph and classifying every function in that common case.
-        let has_candidate = module.functions.iter().any(|func| {
-            func.instructions.iter().any(|inst| {
+        let has_candidate = module.functions().any(|func| {
+            func.instructions().any(|inst| {
                 inst.result_ty.is_none() && matches!(inst.kind, InstKind::InternalCall { .. })
             })
         });
@@ -99,8 +99,8 @@ impl LowerEvmShapedCx {
         }
 
         let call_graph = CallGraphInfo::new(module);
-        let mut tail_callable = DenseBitSet::new_empty(module.functions.len());
-        for (func_id, func) in module.functions.iter_enumerated() {
+        let mut tail_callable = DenseBitSet::new_empty(module.function_count());
+        for (func_id, func) in module.iter_functions() {
             if function_cannot_return(func)
                 && func.selector.is_none()
                 && !func.attributes.is_receive
@@ -117,24 +117,23 @@ impl LowerEvmShapedCx {
         // rewrites need no frame addressing and stay valid on both paths.
         let mut constructor_reachable = call_graph.reachable_callees_from(
             module
-                .functions
-                .iter_enumerated()
+                .iter_functions()
                 .filter_map(|(id, func)| func.attributes.is_constructor.then_some(id)),
         );
-        for (id, func) in module.functions.iter_enumerated() {
+        for (id, func) in module.iter_functions() {
             if func.attributes.is_constructor {
                 constructor_reachable.insert(id);
             }
         }
 
-        let function_ids: Vec<_> = module.functions.indices().collect();
+        let function_ids: Vec<_> = module.function_ids().collect();
         for func_id in function_ids {
-            let func = &mut module.functions[func_id];
+            let func = module.function_mut(func_id);
             let mut changed = false;
-            for block_id in (0..func.blocks.len()).map(crate::mir::BlockId::from_usize) {
-                let insts = &func.blocks[block_id].instructions;
+            for block_id in (0..func.block_count()).map(crate::mir::BlockId::from_usize) {
+                let insts = &func.block(block_id).instructions;
                 let Some(position) = insts.iter().position(|&inst_id| {
-                    let inst = &func.instructions[inst_id];
+                    let inst = func.instruction(inst_id);
                     inst.result_ty.is_none()
                         && matches!(
                             &inst.kind,
@@ -147,17 +146,16 @@ impl LowerEvmShapedCx {
                     continue;
                 };
 
-                let inst_id = func.blocks[block_id].instructions[position];
-                let InstKind::InternalCall { function, args, .. } =
-                    &func.instructions[inst_id].kind
+                let inst_id = func.block(block_id).instructions[position];
+                let InstKind::InternalCall { function, args, .. } = &func.instruction(inst_id).kind
                 else {
                     unreachable!("position matched an internal call");
                 };
                 let (function, args) = (*function, args.iter().copied().collect());
 
                 // Control never comes back: everything after the call is dead.
-                func.blocks[block_id].instructions.truncate(position);
-                func.blocks[block_id].terminator = Some(Terminator::TailCall { function, args });
+                func.block_mut(block_id).instructions.truncate(position);
+                func.block_mut(block_id).terminator = Some(Terminator::TailCall { function, args });
                 self.stats.tail_calls += 1;
                 changed = true;
             }
@@ -175,7 +173,6 @@ impl LowerEvmShapedCx {
 /// and no `stop` terminator (`stop` is the internal return of a void function).
 fn function_cannot_return(func: &Function) -> bool {
     !func
-        .blocks
-        .iter()
+        .blocks()
         .any(|block| matches!(block.terminator, Some(Terminator::Return { .. } | Terminator::Stop)))
 }

--- a/crates/codegen/src/transform/lower_mapping_slots.rs
+++ b/crates/codegen/src/transform/lower_mapping_slots.rs
@@ -30,10 +30,10 @@ impl MirPass for LowerMappingSlots {
         analyses: &mut crate::pass::ModuleAnalyses,
     ) -> bool {
         run_function_pass(module, analyses, |func, _| {
-            let has_mapping_slots = func.blocks.iter().any(|block| {
+            let has_mapping_slots = func.blocks().any(|block| {
                 block.instructions.iter().any(|&inst_id| {
                     matches!(
-                        func.instructions[inst_id].kind,
+                        func.instruction(inst_id).kind,
                         InstKind::MappingSlot(_, _)
                             | InstKind::MappingSlotMemory(_, _)
                             | InstKind::MappingSlotCalldata(_, _)
@@ -46,13 +46,13 @@ impl MirPass for LowerMappingSlots {
 
             let inst_results = func.inst_results();
             let mut replacements = FxHashMap::default();
-            let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+            let block_ids: Vec<BlockId> = func.block_ids().collect();
             for block_id in block_ids {
-                let instructions = std::mem::take(&mut func.blocks[block_id].instructions);
+                let instructions = std::mem::take(&mut func.block_mut(block_id).instructions);
                 let mut builder = FunctionBuilder::new(func);
                 builder.switch_to_block(block_id);
                 for inst_id in instructions {
-                    let replacement = match builder.func().instructions[inst_id].kind {
+                    let replacement = match builder.func().instruction(inst_id).kind {
                         InstKind::MappingSlot(key, slot) => {
                             Some(lower_word_mapping_slot(&mut builder, key, slot))
                         }
@@ -63,7 +63,7 @@ impl MirPass for LowerMappingSlots {
                             Some(lower_calldata_mapping_slot(&mut builder, key, slot))
                         }
                         _ => {
-                            builder.func_mut().blocks[block_id].instructions.push(inst_id);
+                            builder.func_mut().block_mut(block_id).instructions.push(inst_id);
                             None
                         }
                     };

--- a/crates/codegen/src/transform/lower_memory_objects.rs
+++ b/crates/codegen/src/transform/lower_memory_objects.rs
@@ -31,7 +31,7 @@ impl MirPass for LowerMemoryObjects {
         }
         let mut stats = LowerMemoryObjectsStats::default();
         let mut changed = false;
-        for func in module.functions.iter_mut() {
+        for func in module.functions_mut() {
             changed |= lower_function::<EvmMemoryLayout>(func, &mut stats);
         }
         if module.phase == MirPhase::Dispatch {
@@ -57,11 +57,11 @@ fn lower_function<P: MemoryLayoutPolicy>(
     stats: &mut LowerMemoryObjectsStats,
 ) -> bool {
     let has_objects = func.params.iter().chain(&func.returns).any(is_object_type)
-        || func.values.iter().any(|value| match value {
+        || func.values().any(|value| match value {
             Value::Arg { ty, .. } | Value::Undef(ty) => is_object_type(ty),
             Value::Inst(_) | Value::Immediate(_) | Value::Error(_) => false,
         })
-        || func.instructions.iter().any(|inst| {
+        || func.instructions().any(|inst| {
             inst.result_ty.as_ref().is_some_and(is_object_type)
                 || matches!(
                     inst.kind,
@@ -81,37 +81,37 @@ fn lower_function<P: MemoryLayoutPolicy>(
     let inst_results = func.inst_results();
     let mut replacements = FxHashMap::default();
     let mut removed = FxHashSet::default();
-    let blocks: Vec<_> = func.blocks.indices().collect();
+    let blocks: Vec<_> = func.block_ids().collect();
 
     for block in blocks {
-        let instructions = std::mem::take(&mut func.blocks[block].instructions);
+        let instructions = std::mem::take(&mut func.block_mut(block).instructions);
         let mut builder = FunctionBuilder::new(func);
         builder.switch_to_block(block);
         for inst in instructions {
-            let kind = builder.func().instructions[inst].kind.clone();
+            let kind = builder.func().instruction(inst).kind.clone();
             match kind {
                 InstKind::Alloc { size, kind: AllocationKind::Object(_), semantics } => {
-                    let instruction = &mut builder.func_mut().instructions[inst];
+                    let instruction = builder.func_mut().instruction_mut(inst);
                     instruction.kind =
                         InstKind::Alloc { size, kind: AllocationKind::Raw, semantics };
                     stats.allocations += 1;
                 }
                 InstKind::MemoryObjectLen(object, kind) => {
                     let Some(offset) = P::object_length_offset(kind) else {
-                        builder.func_mut().blocks[block].instructions.push(inst);
+                        builder.func_mut().block_mut(block).instructions.push(inst);
                         continue;
                     };
                     let address = offset_address(&mut builder, object, offset);
-                    builder.func_mut().instructions[inst].kind = InstKind::MLoad(address);
+                    builder.func_mut().instruction_mut(inst).kind = InstKind::MLoad(address);
                     stats.accesses += 1;
                 }
                 InstKind::SetMemoryObjectLen(object, len, kind) => {
                     let Some(offset) = P::object_length_offset(kind) else {
-                        builder.func_mut().blocks[block].instructions.push(inst);
+                        builder.func_mut().block_mut(block).instructions.push(inst);
                         continue;
                     };
                     let address = offset_address(&mut builder, object, offset);
-                    builder.func_mut().instructions[inst].kind = InstKind::MStore(address, len);
+                    builder.func_mut().instruction_mut(inst).kind = InstKind::MStore(address, len);
                     stats.accesses += 1;
                 }
                 InstKind::MemoryObjectData(object, kind) => {
@@ -123,13 +123,14 @@ fn lower_function<P: MemoryLayoutPolicy>(
                         removed.insert(inst);
                     } else {
                         let offset = builder.imm_u64(offset);
-                        builder.func_mut().instructions[inst].kind = InstKind::Add(object, offset);
+                        builder.func_mut().instruction_mut(inst).kind =
+                            InstKind::Add(object, offset);
                     }
                     stats.accesses += 1;
                 }
                 InstKind::MemoryObjectFieldAddr { object, layout, field } => {
                     let Some(offset) = P::field_offset(layout, field) else {
-                        builder.func_mut().blocks[block].instructions.push(inst);
+                        builder.func_mut().block_mut(block).instructions.push(inst);
                         continue;
                     };
                     if offset == 0 {
@@ -139,25 +140,26 @@ fn lower_function<P: MemoryLayoutPolicy>(
                         removed.insert(inst);
                     } else {
                         let offset = builder.imm_u64(offset);
-                        builder.func_mut().instructions[inst].kind = InstKind::Add(object, offset);
+                        builder.func_mut().instruction_mut(inst).kind =
+                            InstKind::Add(object, offset);
                     }
                     stats.accesses += 1;
                 }
                 InstKind::Keccak256Bytes(object) => {
                     let kind = crate::mir::MemoryObjectKind::Bytes;
                     let Some(length_offset) = P::object_length_offset(kind) else {
-                        builder.func_mut().blocks[block].instructions.push(inst);
+                        builder.func_mut().block_mut(block).instructions.push(inst);
                         continue;
                     };
                     let length_address = offset_address(&mut builder, object, length_offset);
                     let len = builder.mload(length_address);
                     let data = offset_address(&mut builder, object, P::object_data_offset(kind));
-                    builder.func_mut().instructions[inst].kind = InstKind::Keccak256(data, len);
+                    builder.func_mut().instruction_mut(inst).kind = InstKind::Keccak256(data, len);
                     stats.accesses += 1;
                 }
                 InstKind::MemoryObjectElementAddr { object, layout, index } => {
                     let Some(stride) = P::element_stride(layout) else {
-                        builder.func_mut().blocks[block].instructions.push(inst);
+                        builder.func_mut().block_mut(block).instructions.push(inst);
                         continue;
                     };
                     debug_assert!(stride.is_multiple_of(P::WORD_SIZE));
@@ -165,13 +167,13 @@ fn lower_function<P: MemoryLayoutPolicy>(
                         offset_address(&mut builder, object, P::object_data_offset(layout.kind()));
                     let stride = builder.imm_u64(stride);
                     let offset = builder.mul(index, stride);
-                    builder.func_mut().instructions[inst].kind = InstKind::Add(base, offset);
+                    builder.func_mut().instruction_mut(inst).kind = InstKind::Add(base, offset);
                     stats.accesses += 1;
                 }
                 _ => {}
             }
             if !removed.contains(&inst) {
-                builder.func_mut().blocks[block].instructions.push(inst);
+                builder.func_mut().block_mut(block).instructions.push(inst);
             }
         }
     }
@@ -200,13 +202,13 @@ fn erase_object_types(func: &mut Function, stats: &mut LowerMemoryObjectsStats) 
     for ty in func.params.iter_mut().chain(&mut func.returns) {
         erase_object_type(ty, stats);
     }
-    for value in func.values.iter_mut() {
+    for value in func.values_mut() {
         match value {
             Value::Arg { ty, .. } | Value::Undef(ty) => erase_object_type(ty, stats),
             Value::Inst(_) | Value::Immediate(_) | Value::Error(_) => {}
         }
     }
-    for inst in func.instructions.iter_mut() {
+    for inst in func.instructions_mut() {
         if let Some(ty) = &mut inst.result_ty {
             erase_object_type(ty, stats);
         }

--- a/crates/codegen/src/transform/lower_slices.rs
+++ b/crates/codegen/src/transform/lower_slices.rs
@@ -71,7 +71,7 @@ struct LowerSlicesCx {
 fn value_slice_location(func: &Function, value: ValueId) -> Option<SliceLocation> {
     let ty = match func.value(value) {
         Value::Arg { ty, .. } | Value::Undef(ty) => Some(*ty),
-        Value::Inst(inst) => func.instructions[*inst].result_ty,
+        Value::Inst(inst) => func.instruction(*inst).result_ty,
         Value::Immediate(_) | Value::Error(_) => None,
     };
     match ty {
@@ -123,12 +123,12 @@ impl LowerSlicesCx {
         let mut replacements = FxHashMap::default();
 
         // Selects: rewrite in place within their block.
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         for block_id in &block_ids {
-            let insts = std::mem::take(&mut func.blocks[*block_id].instructions);
+            let insts = std::mem::take(&mut func.block_mut(*block_id).instructions);
             let mut out = Vec::with_capacity(insts.len());
             for inst_id in insts {
-                if let InstKind::Select(cond, a, b) = func.instructions[inst_id].kind
+                if let InstKind::Select(cond, a, b) = func.instruction(inst_id).kind
                     && let Some(location) = value_slice_location(func, a)
                 {
                     let old = func.inst_result_value(inst_id).expect("select has a result");
@@ -147,7 +147,7 @@ impl LowerSlicesCx {
                 }
                 out.push(inst_id);
             }
-            func.blocks[*block_id].instructions = out;
+            func.block_mut(*block_id).instructions = out;
         }
 
         // Phis: project each incoming slice in its predecessor, phi the
@@ -158,8 +158,8 @@ impl LowerSlicesCx {
             // paired words allocates instructions and values.
             type SlicePhi = (InstId, Vec<(BlockId, ValueId)>, SliceLocation);
             let mut slice_phis: Vec<SlicePhi> = Vec::new();
-            for &inst_id in &func.blocks[block_id].instructions {
-                match &func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                match &func.instruction(inst_id).kind {
                     InstKind::Phi(incoming) => {
                         if let Some(location) = incoming
                             .first()
@@ -178,8 +178,8 @@ impl LowerSlicesCx {
                 for (pred, value) in incoming {
                     let (pi, pv) = new_word_inst(func, InstKind::SlicePtr(value));
                     let (li, lv) = new_word_inst(func, InstKind::SliceLen(value));
-                    func.blocks[pred].instructions.push(pi);
-                    func.blocks[pred].instructions.push(li);
+                    func.block_mut(pred).instructions.push(pi);
+                    func.block_mut(pred).instructions.push(li);
                     ptr_incoming.push((pred, pv));
                     len_incoming.push((pred, lv));
                 }
@@ -200,8 +200,8 @@ impl LowerSlicesCx {
             let mut phis = Vec::new();
             let mut makes = Vec::new();
             let mut rest = Vec::new();
-            for &inst_id in &func.blocks[block_id].instructions {
-                if matches!(func.instructions[inst_id].kind, InstKind::Phi(_)) {
+            for &inst_id in &func.block(block_id).instructions {
+                if matches!(func.instruction(inst_id).kind, InstKind::Phi(_)) {
                     if let Some(&(sp, sl, ms)) = split_map.get(&inst_id) {
                         phis.push(sp);
                         phis.push(sl);
@@ -215,7 +215,7 @@ impl LowerSlicesCx {
             }
             phis.extend(makes);
             phis.extend(rest);
-            func.blocks[block_id].instructions = phis;
+            func.block_mut(block_id).instructions = phis;
         }
 
         if changed {
@@ -230,13 +230,13 @@ impl LowerSlicesCx {
         signatures: &FxHashMap<FunctionId, Vec<ParamRepr>>,
     ) -> bool {
         let mut changed = false;
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         for block_id in block_ids {
-            let instructions = std::mem::take(&mut func.blocks[block_id].instructions);
+            let instructions = std::mem::take(&mut func.block_mut(block_id).instructions);
             let mut builder = FunctionBuilder::new(func);
             builder.switch_to_block(block_id);
             for inst_id in instructions {
-                let call = match &builder.func().instructions[inst_id].kind {
+                let call = match &builder.func().instruction(inst_id).kind {
                     InstKind::InternalCall { function, args, .. } => {
                         Some((*function, args.to_vec()))
                     }
@@ -259,14 +259,14 @@ impl LowerSlicesCx {
                         self.stats.call_args += usize::from(repr != ParamRepr::Word);
                     }
                     let InstKind::InternalCall { args, .. } =
-                        &mut builder.func_mut().instructions[inst_id].kind
+                        &mut builder.func_mut().instruction_mut(inst_id).kind
                     else {
                         unreachable!()
                     };
                     *args = expanded.into();
                     changed = true;
                 }
-                builder.func_mut().blocks[block_id].instructions.push(inst_id);
+                builder.func_mut().block_mut(block_id).instructions.push(inst_id);
             }
         }
         changed
@@ -274,7 +274,7 @@ impl LowerSlicesCx {
 
     fn lower_params(&mut self, func: &mut Function, signature: &[ParamRepr]) -> bool {
         if func.selector.is_some()
-            || func.blocks.is_empty()
+            || func.has_no_blocks()
             || !func.params.iter().any(Self::is_slice)
         {
             return false;
@@ -299,7 +299,7 @@ impl LowerSlicesCx {
             next_index += 1;
         }
 
-        for value in func.values.iter_mut() {
+        for value in func.values_mut() {
             if let Value::Arg { index, ty } = value
                 && !matches!(ty, MirType::Slice(_))
             {
@@ -308,8 +308,7 @@ impl LowerSlicesCx {
         }
 
         let slice_args: Vec<_> = func
-            .values
-            .iter_enumerated()
+            .values_enumerated()
             .filter_map(|(value, kind)| match kind {
                 Value::Arg { index, ty: MirType::Slice(location) } => {
                     Some((value, *index, *location))
@@ -349,9 +348,9 @@ impl LowerSlicesCx {
         let inst_results = builder.func().inst_results();
         let mut replacements = FxHashMap::default();
         let mut removed = FxHashSet::default();
-        for block in builder.func().blocks.iter() {
+        for block in builder.func().blocks() {
             for &inst_id in &block.instructions {
-                let replacement = match builder.func().instructions[inst_id].kind {
+                let replacement = match builder.func().instruction(inst_id).kind {
                     InstKind::SlicePtr(slice) => components.get(&slice).map(|&(ptr, _)| ptr),
                     InstKind::SliceLen(slice) => components.get(&slice).map(|&(_, len)| len),
                     _ => None,
@@ -366,7 +365,7 @@ impl LowerSlicesCx {
             }
         }
         builder.func_mut().replace_uses_canonicalized(&replacements);
-        for block in builder.func_mut().blocks.iter_mut() {
+        for block in builder.func_mut().blocks_mut() {
             block.instructions.retain(|inst| !removed.contains(inst));
         }
         if !compact_heads.is_empty() {
@@ -382,15 +381,15 @@ impl LowerSlicesCx {
     ) {
         let inst_results = func.inst_results();
         let mut replacements = raw_heads.clone();
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         for block_id in block_ids {
-            let instructions = std::mem::take(&mut func.blocks[block_id].instructions);
+            let instructions = std::mem::take(&mut func.block_mut(block_id).instructions);
             let mut builder = FunctionBuilder::new(func);
             builder.switch_to_block(block_id);
             let mut lengths = FxHashMap::default();
             let mut pointers = FxHashMap::default();
             for inst_id in instructions {
-                let projection = match builder.func().instructions[inst_id].kind {
+                let projection = match builder.func().instruction(inst_id).kind {
                     InstKind::SlicePtr(slice) => raw_heads.get(&slice).map(|&head| (head, true)),
                     InstKind::SliceLen(slice) => raw_heads.get(&slice).map(|&head| (head, false)),
                     _ => None,
@@ -411,7 +410,7 @@ impl LowerSlicesCx {
                     replacements.insert(inst_results[&inst_id], replacement);
                     self.stats.projections += 1;
                 } else {
-                    builder.func_mut().blocks[block_id].instructions.push(inst_id);
+                    builder.func_mut().block_mut(block_id).instructions.push(inst_id);
                 }
             }
         }
@@ -419,12 +418,11 @@ impl LowerSlicesCx {
     }
 
     fn lower_external_args(&mut self, func: &mut Function) -> bool {
-        if func.selector.is_none() || func.blocks.is_empty() {
+        if func.selector.is_none() || func.has_no_blocks() {
             return false;
         }
         let slice_args: FxHashMap<_, _> = func
-            .values
-            .iter_enumerated()
+            .values_enumerated()
             .filter_map(|(value, kind)| match kind {
                 Value::Arg { index, ty: MirType::Slice(SliceLocation::Calldata) } => {
                     Some((value, *index))
@@ -450,8 +448,7 @@ impl LowerSlicesCx {
 
     fn infer_compact_params(module: &Module) -> FxHashSet<(FunctionId, usize)> {
         let mut compact: FxHashSet<_> = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .flat_map(|(function, func)| {
                 func.params.iter().enumerate().filter_map(move |(index, ty)| {
                     matches!(ty, MirType::Slice(SliceLocation::Calldata))
@@ -463,9 +460,9 @@ impl LowerSlicesCx {
         loop {
             let mut removed = FxHashSet::default();
             let mut seen = FxHashSet::default();
-            for (caller_id, caller) in module.functions.iter_enumerated() {
-                for &inst_id in caller.blocks.iter().flat_map(|block| &block.instructions) {
-                    let inst = &caller.instructions[inst_id];
+            for (caller_id, caller) in module.iter_functions() {
+                for &inst_id in caller.blocks().flat_map(|block| &block.instructions) {
+                    let inst = caller.instruction(inst_id);
                     let InstKind::InternalCall { function: callee, args, .. } = &inst.kind else {
                         continue;
                     };
@@ -510,14 +507,14 @@ impl LowerSlicesCx {
     fn lower_projections(&mut self, func: &mut Function) -> bool {
         let inst_results = func.inst_results();
         let live_insts: FxHashSet<_> =
-            func.blocks.iter().flat_map(|block| block.instructions.iter().copied()).collect();
+            func.blocks().flat_map(|block| block.instructions.iter().copied()).collect();
         let mut components = FxHashMap::<ValueId, (ValueId, ValueId, InstId)>::default();
         let mut projections = FxHashMap::<ValueId, (ValueId, InstId, bool)>::default();
         for (&inst, &result) in &inst_results {
             if !live_insts.contains(&inst) {
                 continue;
             }
-            match func.instructions[inst].kind {
+            match func.instruction(inst).kind {
                 InstKind::MakeSlice { ptr, len, .. } => {
                     components.insert(result, (ptr, len, inst));
                 }
@@ -538,7 +535,7 @@ impl LowerSlicesCx {
         // slices intact instead of guessing at a one-word representation.
         let mut removable: FxHashSet<ValueId> = components.keys().copied().collect();
         for inst_id in &live_insts {
-            let inst = &func.instructions[*inst_id];
+            let inst = func.instruction(*inst_id);
             for operand in inst.kind.operands() {
                 if components.contains_key(&operand)
                     && !matches!(inst.kind, InstKind::SlicePtr(v) | InstKind::SliceLen(v) if v == operand)
@@ -547,7 +544,7 @@ impl LowerSlicesCx {
                 }
             }
         }
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             if let Some(term) = &block.terminator {
                 for operand in term.operands() {
                     removable.remove(&operand);
@@ -575,7 +572,7 @@ impl LowerSlicesCx {
         }
 
         func.replace_uses_canonicalized(&replacements);
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|inst| !removed.contains(inst));
         }
         true
@@ -587,8 +584,7 @@ impl LowerSlicesCx {
         self.stats = LowerSlicesStats::default();
         let compact = Self::infer_compact_params(module);
         let signatures: FxHashMap<_, _> = module
-            .functions
-            .iter_enumerated()
+            .iter_functions()
             .map(|(id, func)| {
                 let signature = func
                     .params
@@ -608,16 +604,16 @@ impl LowerSlicesCx {
             })
             .collect();
         let mut changed = false;
-        for func in module.functions.iter_mut() {
+        for func in module.functions_mut() {
             // Eliminate slice-typed `select`/`phi` first, so every remaining
             // slice is a `make_slice` result or a projection that the later
             // stages can expand or fold.
             changed |= self.split_slice_aggregates(func);
         }
-        for func in module.functions.iter_mut() {
+        for func in module.functions_mut() {
             changed |= self.expand_call_args(func, &signatures);
         }
-        let function_ids: Vec<_> = module.functions.indices().collect();
+        let function_ids: Vec<_> = module.function_ids().collect();
         for id in function_ids {
             let func = module.function_mut(id);
             changed |= self.lower_external_args(func);

--- a/crates/codegen/src/transform/memory_dse.rs
+++ b/crates/codegen/src/transform/memory_dse.rs
@@ -141,7 +141,7 @@ impl BlockScratch {
             stored_values: FxHashMap::default(),
             stored_words: FxHashMap::default(),
             replacements: FxHashMap::default(),
-            dead: DenseBitSet::new_empty(func.instructions.len()),
+            dead: DenseBitSet::new_empty(func.instruction_count()),
         }
     }
 }
@@ -164,10 +164,10 @@ impl MemoryStoreEliminator {
         // Both store elimination and store-to-load forwarding need at least
         // one memory write to act on; functions without any skip the whole
         // scan and never build the alias snapshot.
-        let has_memory_writes = func.blocks.iter().any(|block| {
+        let has_memory_writes = func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
                 matches!(
-                    func.instructions[inst_id].kind,
+                    func.instruction(inst_id).kind,
                     InstKind::MStore(_, _)
                         | InstKind::MStore8(_, _)
                         | InstKind::MCopy(_, _, _)
@@ -192,10 +192,10 @@ impl MemoryStoreEliminator {
             self.alias = Some(Rc::new(AliasAnalysis::new(func)));
         }
 
-        let needs_inst_results = func.blocks.iter().any(|block| {
+        let needs_inst_results = func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
                 matches!(
-                    func.instructions[inst_id].kind,
+                    func.instruction(inst_id).kind,
                     InstKind::MLoad(_)
                         | InstKind::MemoryObjectLen(_, _)
                         | InstKind::Keccak256(_, _)
@@ -209,10 +209,10 @@ impl MemoryStoreEliminator {
         self.alias().clear_cached_addresses();
         self.remove_unused_internal_frame_stores(func);
 
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
-        let has_precise_reads = func.blocks.iter().any(|block| {
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
+        let has_precise_reads = func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
-                Self::constant_range_read(&func.instructions[inst_id].kind).is_some()
+                Self::constant_range_read(&func.instruction(inst_id).kind).is_some()
             })
         });
         if has_precise_reads {
@@ -255,15 +255,15 @@ impl MemoryStoreEliminator {
     /// call, `msize` — widens to all-memory-live, which only ever keeps a
     /// store, never drops a live one.
     fn remove_dead_memory_stores(&mut self, func: &mut Function) {
-        if !func.blocks.iter().any(|block| {
+        if !func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
-                matches!(func.instructions[inst_id].kind, InstKind::MStore(addr, _) if self.word_aligned_const(func, addr).is_some())
+                matches!(func.instruction(inst_id).kind, InstKind::MStore(addr, _) if self.word_aligned_const(func, addr).is_some())
             })
         }) {
             return;
         }
 
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         if block_ids.is_empty() {
             return;
         }
@@ -294,7 +294,7 @@ impl MemoryStoreEliminator {
         }
 
         // Collect dead stores using the stabilized live-out of each block.
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
         for &block_id in &block_ids {
             let out = Self::live_out(func, block_id, &live_in);
             let mut collector = Some(&mut dead);
@@ -305,14 +305,14 @@ impl MemoryStoreEliminator {
             return;
         }
         self.eliminated_count += dead.count();
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
     }
 
     fn live_out(func: &Function, block: BlockId, live_in: &FxHashMap<BlockId, MemLive>) -> MemLive {
         let mut out = MemLive::Only(FxHashSet::default());
-        if let Some(term) = func.blocks[block].terminator.as_ref() {
+        if let Some(term) = func.block(block).terminator.as_ref() {
             for succ in term.successors() {
                 if let Some(in_set) = live_in.get(&succ) {
                     out.join(in_set);
@@ -333,7 +333,7 @@ impl MemoryStoreEliminator {
         dead: &mut Option<&mut DenseBitSet<InstId>>,
     ) -> MemLive {
         // Terminator first: it executes after every instruction in the block.
-        match func.blocks[block].terminator.as_ref() {
+        match func.block(block).terminator.as_ref() {
             Some(Terminator::Revert { offset, size })
             | Some(Terminator::ReturnData { offset, size }) => {
                 Self::mark_read(func, &mut live, *offset, *size);
@@ -354,8 +354,8 @@ impl MemoryStoreEliminator {
             | None => {}
         }
 
-        for &inst_id in func.blocks[block].instructions.iter().rev() {
-            match &func.instructions[inst_id].kind {
+        for &inst_id in func.block(block).instructions.iter().rev() {
+            match &func.instruction(inst_id).kind {
                 InstKind::MStore(addr, _) => {
                     if let Some(slot) = self.word_aligned_const(func, *addr) {
                         if !live.contains(slot)
@@ -462,10 +462,10 @@ impl MemoryStoreEliminator {
         func: &mut Function,
         inst_results: &FxHashMap<InstId, ValueId>,
     ) {
-        let has_candidate = func.blocks.iter().any(|block| {
+        let has_candidate = func.blocks().any(|block| {
             block.instructions.windows(2).any(|window| {
-                matches!(func.instructions[window[0]].kind, InstKind::CodeCopy(_, _, _))
-                    && matches!(func.instructions[window[1]].kind, InstKind::MLoad(_))
+                matches!(func.instruction(window[0]).kind, InstKind::CodeCopy(_, _, _))
+                    && matches!(func.instruction(window[1]).kind, InstKind::MLoad(_))
             })
         });
         if !has_candidate {
@@ -475,14 +475,14 @@ impl MemoryStoreEliminator {
         let cfg = self.cfg.as_ref().map_or_else(|| Rc::new(CfgInfo::new(func)), Rc::clone);
         let mut cached: FxHashMap<ImmutableCopyKey, CachedImmutableCopy> = FxHashMap::default();
         let mut replacements = FxHashMap::default();
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
 
-        for (block_id, block) in func.blocks.iter_enumerated() {
-            let insts = block.instructions.clone();
+        for block_id in func.block_ids() {
+            let insts = func.block(block_id).instructions.clone();
             for (index, window) in insts.windows(2).enumerate() {
                 let codecopy = window[0];
                 let load = window[1];
-                let InstKind::CodeCopy(dest, src, size) = func.instructions[codecopy].kind else {
+                let InstKind::CodeCopy(dest, src, size) = func.instruction(codecopy).kind else {
                     continue;
                 };
                 if func.value_u64(size) != Some(32) {
@@ -491,7 +491,7 @@ impl MemoryStoreEliminator {
                 let Some(key) = Self::immutable_copy_key(func, src) else {
                     continue;
                 };
-                let InstKind::MLoad(load_addr) = func.instructions[load].kind else {
+                let InstKind::MLoad(load_addr) = func.instruction(load).kind else {
                     continue;
                 };
                 if self.mem_addr_key(func, dest) != self.mem_addr_key(func, load_addr) {
@@ -505,7 +505,7 @@ impl MemoryStoreEliminator {
                     && Self::copy_dominates(cfg.dominators(), cached_copy, block_id, index)
                 {
                     replacements.insert(loaded_value, cached_copy.value);
-                    func.instructions[codecopy].kind = InstKind::MStore(dest, cached_copy.value);
+                    func.instruction_mut(codecopy).kind = InstKind::MStore(dest, cached_copy.value);
                     dead.insert(load);
                     self.eliminated_count += 1;
                 } else {
@@ -522,15 +522,15 @@ impl MemoryStoreEliminator {
         }
 
         func.replace_uses_canonicalized(&replacements);
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
     }
 
     fn remove_unused_internal_frame_stores(&mut self, func: &mut Function) {
-        let has_candidate = func.blocks.iter().any(|block| {
+        let has_candidate = func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
-                matches!(func.instructions[inst_id].kind, InstKind::MStore(addr, _) if self.internal_frame_offset(func, addr).is_some())
+                matches!(func.instruction(inst_id).kind, InstKind::MStore(addr, _) if self.internal_frame_offset(func, addr).is_some())
             })
         });
         if !has_candidate {
@@ -543,11 +543,11 @@ impl MemoryStoreEliminator {
         let Some(reads) = self.internal_frame_read_ranges(func) else {
             return;
         };
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
 
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                let InstKind::MStore(addr, _) = func.instructions[inst_id].kind else {
+                let InstKind::MStore(addr, _) = func.instruction(inst_id).kind else {
                     continue;
                 };
                 let Some(offset) = self.internal_frame_offset(func, addr) else {
@@ -577,7 +577,7 @@ impl MemoryStoreEliminator {
         }
 
         self.eliminated_count += dead.count();
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
     }
@@ -593,8 +593,8 @@ impl MemoryStoreEliminator {
         let mut memory_writes = 0;
         let mut has_load = false;
         let mut has_keccak = false;
-        for &inst_id in &func.blocks[block_id].instructions {
-            match func.instructions[inst_id].kind {
+        for &inst_id in &func.block(block_id).instructions {
+            match func.instruction(inst_id).kind {
                 InstKind::MStore(_, _) | InstKind::SetMemoryObjectLen(_, _, _) => {
                     mstores += 1;
                     memory_writes += 1;
@@ -635,8 +635,8 @@ impl MemoryStoreEliminator {
         scratch.overwritten.clear();
         scratch.dead.clear();
 
-        for &inst_id in func.blocks[block_id].instructions.iter().rev() {
-            let inst = &func.instructions[inst_id];
+        for &inst_id in func.block(block_id).instructions.iter().rev() {
+            let inst = func.instruction(inst_id);
             match &inst.kind {
                 InstKind::MStore(addr, _) => {
                     if let Some(key) = self.mem_addr_key(func, *addr) {
@@ -729,7 +729,7 @@ impl MemoryStoreEliminator {
             return;
         }
 
-        func.blocks[block_id].instructions.retain(|&id| !scratch.dead.contains(id));
+        func.block_mut(block_id).instructions.retain(|&id| !scratch.dead.contains(id));
     }
 
     fn apply_memory_effects(
@@ -842,10 +842,9 @@ impl MemoryStoreEliminator {
     /// predecessor's exit constants, and a store matching one is dead.
     fn remove_cross_block_equal_const_stores(&mut self, func: &mut Function) {
         if func
-            .blocks
-            .iter()
+            .blocks()
             .flat_map(|block| &block.instructions)
-            .filter(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::MStore(_, _)))
+            .filter(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::MStore(_, _)))
             .take(2)
             .count()
             < 2
@@ -862,20 +861,20 @@ impl MemoryStoreEliminator {
         };
 
         let mut exit: FxHashMap<BlockId, FxHashMap<u64, U256>> = FxHashMap::default();
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
 
         // Block index order approximates reverse postorder for this builder,
         // so a single predecessor is usually already computed; when it is not,
         // the block simply starts from no known constants.
-        for block_id in func.blocks.indices() {
-            let preds = &func.blocks[block_id].predecessors;
+        for block_id in func.block_ids() {
+            let preds = &func.block(block_id).predecessors;
             let mut known: FxHashMap<u64, U256> = match preds.as_slice() {
                 [pred] => exit.get(pred).cloned().unwrap_or_default(),
                 _ => FxHashMap::default(),
             };
 
-            for &inst_id in &func.blocks[block_id].instructions {
-                match &func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                match &func.instruction(inst_id).kind {
                     InstKind::MStore(addr, value) => match const_store(func, *addr, *value) {
                         Some((a, v)) => {
                             if known.get(&a) == Some(&v) {
@@ -912,17 +911,16 @@ impl MemoryStoreEliminator {
         if dead.is_empty() {
             return;
         }
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
     }
 
     fn remove_cross_block_overwrites(&mut self, func: &mut Function) {
         if func
-            .blocks
-            .iter()
+            .blocks()
             .flat_map(|block| &block.instructions)
-            .filter(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::MStore(_, _)))
+            .filter(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::MStore(_, _)))
             .take(2)
             .count()
             < 2
@@ -930,13 +928,13 @@ impl MemoryStoreEliminator {
             return;
         }
 
-        let mut dead = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead = DenseBitSet::new_empty(func.instruction_count());
 
-        for pred in func.blocks.indices() {
+        for pred in func.block_ids() {
             let Some(succ) = Self::single_jump_successor(func, pred) else {
                 continue;
             };
-            if func.blocks[succ].predecessors.as_slice() != [pred] {
+            if func.block(succ).predecessors.as_slice() != [pred] {
                 continue;
             }
 
@@ -956,13 +954,13 @@ impl MemoryStoreEliminator {
         }
 
         self.eliminated_count += dead.count();
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|&id| !dead.contains(id));
         }
     }
 
     fn single_jump_successor(func: &Function, block: BlockId) -> Option<BlockId> {
-        let Some(Terminator::Jump(target)) = func.blocks[block].terminator.as_ref() else {
+        let Some(Terminator::Jump(target)) = func.block(block).terminator.as_ref() else {
             return None;
         };
         Some(*target)
@@ -973,8 +971,8 @@ impl MemoryStoreEliminator {
         func: &Function,
         block: BlockId,
     ) -> Option<(InstId, MemAddrKey)> {
-        for &inst_id in func.blocks[block].instructions.iter().rev() {
-            match func.instructions[inst_id].kind {
+        for &inst_id in func.block(block).instructions.iter().rev() {
+            match func.instruction(inst_id).kind {
                 InstKind::MStore(addr, _) => {
                     let key = self.mem_addr_key(func, addr)?;
                     return Some((inst_id, key));
@@ -987,8 +985,8 @@ impl MemoryStoreEliminator {
     }
 
     fn first_cross_block_overwrite(&self, func: &Function, block: BlockId) -> Option<MemAddrKey> {
-        for &inst_id in &func.blocks[block].instructions {
-            match func.instructions[inst_id].kind {
+        for &inst_id in &func.block(block).instructions {
+            match func.instruction(inst_id).kind {
                 InstKind::MStore(addr, _) => return self.mem_addr_key(func, addr),
                 _ if self.cross_block_memory_barrier(func, inst_id) => return None,
                 _ => {}
@@ -1008,9 +1006,9 @@ impl MemoryStoreEliminator {
         scratch.replacements.clear();
         scratch.dead.clear();
 
-        for index in 0..func.blocks[block_id].instructions.len() {
-            let inst_id = func.blocks[block_id].instructions[index];
-            match &func.instructions[inst_id].kind {
+        for index in 0..func.block(block_id).instructions.len() {
+            let inst_id = func.block(block_id).instructions[index];
+            match &func.instruction(inst_id).kind {
                 InstKind::MStore(addr, value) => {
                     let Some(key) = self.mem_addr_key(func, *addr) else {
                         scratch.stored_words.clear();
@@ -1050,7 +1048,7 @@ impl MemoryStoreEliminator {
         }
 
         func.replace_uses_canonicalized(&scratch.replacements);
-        func.blocks[block_id].instructions.retain(|&id| !scratch.dead.contains(id));
+        func.block_mut(block_id).instructions.retain(|&id| !scratch.dead.contains(id));
     }
 
     fn remove_equal_stores(
@@ -1062,8 +1060,8 @@ impl MemoryStoreEliminator {
         scratch.stored_values.clear();
         scratch.dead.clear();
 
-        for &inst_id in &func.blocks[block_id].instructions {
-            let inst = &func.instructions[inst_id];
+        for &inst_id in &func.block(block_id).instructions {
+            let inst = func.instruction(inst_id);
             match &inst.kind {
                 InstKind::MStore(addr, value) => {
                     let Some(key) = self.mem_addr_key(func, *addr) else {
@@ -1091,7 +1089,7 @@ impl MemoryStoreEliminator {
             return;
         }
 
-        func.blocks[block_id].instructions.retain(|&id| !scratch.dead.contains(id));
+        func.block_mut(block_id).instructions.retain(|&id| !scratch.dead.contains(id));
     }
 
     fn forward_loads(
@@ -1105,8 +1103,8 @@ impl MemoryStoreEliminator {
         scratch.replacements.clear();
         scratch.dead.clear();
 
-        for &inst_id in &func.blocks[block_id].instructions {
-            let inst = &func.instructions[inst_id];
+        for &inst_id in &func.block(block_id).instructions {
+            let inst = func.instruction(inst_id);
             match &inst.kind {
                 InstKind::MStore(addr, value) => {
                     if let Some(key) = self.mem_addr_key(func, *addr) {
@@ -1216,7 +1214,7 @@ impl MemoryStoreEliminator {
 
         func.replace_uses_canonicalized(&scratch.replacements);
         self.eliminated_count += scratch.dead.count();
-        func.blocks[block_id].instructions.retain(|&id| !scratch.dead.contains(id));
+        func.block_mut(block_id).instructions.retain(|&id| !scratch.dead.contains(id));
     }
 
     fn mem_addr_key(&self, func: &Function, value: ValueId) -> Option<MemAddrKey> {
@@ -1236,8 +1234,8 @@ impl MemoryStoreEliminator {
     }
 
     fn immutable_copy_key(func: &Function, src: ValueId) -> Option<ImmutableCopyKey> {
-        match func.values[src] {
-            Value::Inst(inst_id) => match func.instructions[inst_id].kind {
+        match func.value(src) {
+            Value::Inst(inst_id) => match func.instruction(*inst_id).kind {
                 InstKind::Sub(code_size, len) if Self::is_codesize(func, code_size) => {
                     Some(ImmutableCopyKey { len: func.value_u64(len)?, offset: 0 })
                 }
@@ -1262,7 +1260,7 @@ impl MemoryStoreEliminator {
     }
 
     fn is_codesize(func: &Function, value: ValueId) -> bool {
-        matches!(func.values[value], Value::Inst(inst_id) if matches!(func.instructions[inst_id].kind, InstKind::CodeSize))
+        matches!(func.value(value), Value::Inst(inst_id) if matches!(func.instruction(*inst_id).kind, InstKind::CodeSize))
     }
 
     fn copy_dominates(
@@ -1393,12 +1391,12 @@ impl MemoryStoreEliminator {
     }
 
     fn has_frame_observer(&self, func: &Function) -> bool {
-        func.blocks.iter().any(|block| {
+        func.blocks().any(|block| {
             block.instructions.iter().any(|&inst_id| {
                 let effects = self.alias().instruction_mod_ref(func, inst_id);
                 effects.observes_gas()
                     || effects.observes_memory_size()
-                    || matches!(func.instructions[inst_id].kind, InstKind::InternalCall { .. })
+                    || matches!(func.instruction(inst_id).kind, InstKind::InternalCall { .. })
             })
         })
     }
@@ -1406,7 +1404,7 @@ impl MemoryStoreEliminator {
     fn internal_frame_read_ranges(&self, func: &Function) -> Option<Vec<(u64, u64)>> {
         let mut reads = Vec::new();
 
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
                 Self::push_frame_reads(
                     &mut reads,
@@ -1415,7 +1413,7 @@ impl MemoryStoreEliminator {
             }
         }
 
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             if let Some(terminator) = &block.terminator {
                 Self::push_frame_reads(
                     &mut reads,
@@ -1481,7 +1479,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 1);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 1);
     }
 
     #[test]
@@ -1499,7 +1497,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 2);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 1);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1525,7 +1523,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
         // The keccak and the surviving store remain.
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 2);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 2);
     }
 
     #[test]
@@ -1546,7 +1544,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 3);
     }
 
     #[test]
@@ -1577,10 +1575,11 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
-        let entry_stores = func.blocks[BlockId::ENTRY]
+        let entry_stores = func
+            .block(BlockId::ENTRY)
             .instructions
             .iter()
-            .filter(|&&id| matches!(func.instructions[id].kind, InstKind::MStore(_, _)))
+            .filter(|&&id| matches!(func.instruction(id).kind, InstKind::MStore(_, _)))
             .count();
         assert_eq!(entry_stores, 0);
     }
@@ -1612,10 +1611,11 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 0);
-        let entry_stores = func.blocks[BlockId::ENTRY]
+        let entry_stores = func
+            .block(BlockId::ENTRY)
             .instructions
             .iter()
-            .filter(|&&id| matches!(func.instructions[id].kind, InstKind::MStore(_, _)))
+            .filter(|&&id| matches!(func.instruction(id).kind, InstKind::MStore(_, _)))
             .count();
         assert_eq!(entry_stores, 1);
     }
@@ -1635,10 +1635,11 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 0);
-        let stores = func.blocks[BlockId::ENTRY]
+        let stores = func
+            .block(BlockId::ENTRY)
             .instructions
             .iter()
-            .filter(|&&id| matches!(func.instructions[id].kind, InstKind::MStore(_, _)))
+            .filter(|&&id| matches!(func.instruction(id).kind, InstKind::MStore(_, _)))
             .count();
         assert_eq!(stores, 1);
     }
@@ -1657,7 +1658,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 3);
     }
 
     #[test]
@@ -1674,7 +1675,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 1);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 1);
     }
 
     #[test]
@@ -1693,7 +1694,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 3);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1717,7 +1718,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 3);
     }
 
     #[test]
@@ -1731,7 +1732,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 1);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 1);
     }
 
     #[test]
@@ -1759,12 +1760,12 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run_to_fixpoint(&mut func), 1);
 
-        let active_insts = func.blocks.iter().flat_map(|block| block.instructions.iter().copied());
+        let active_insts = func.blocks().flat_map(|block| block.instructions.iter().copied());
         let mut code_copies = 0;
         let mut loads = 0;
         let mut stores = 0;
         for inst_id in active_insts {
-            match func.instructions[inst_id].kind {
+            match func.instruction(inst_id).kind {
                 InstKind::CodeCopy(_, _, _) => code_copies += 1,
                 InstKind::MLoad(_) => loads += 1,
                 InstKind::MStore(_, _) => stores += 1,
@@ -1775,8 +1776,8 @@ mod tests {
         assert_eq!(loads, 1);
         assert_eq!(stores, 1);
 
-        let add = match &func.values[sum] {
-            Value::Inst(inst_id) => &func.instructions[*inst_id].kind,
+        let add = match func.value(sum) {
+            Value::Inst(inst_id) => &func.instruction(*inst_id).kind,
             _ => panic!("expected add instruction"),
         };
         let InstKind::Add(lhs, rhs) = *add else {
@@ -1802,7 +1803,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 4);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 4);
     }
 
     #[test]
@@ -1818,7 +1819,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 1);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1841,7 +1842,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 1);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 2);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");
@@ -1864,7 +1865,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 3);
     }
 
     #[test]
@@ -1880,7 +1881,7 @@ mod tests {
 
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 0);
-        assert_eq!(func.blocks[BlockId::ENTRY].instructions.len(), 3);
+        assert_eq!(func.block(BlockId::ENTRY).instructions.len(), 3);
     }
 
     #[test]
@@ -1899,7 +1900,7 @@ mod tests {
         let mut pass = MemoryStoreEliminator::new();
         assert_eq!(pass.run(&mut func), 2);
 
-        let block = &func.blocks[BlockId::ENTRY];
+        let block = func.block(BlockId::ENTRY);
         assert_eq!(block.instructions.len(), 2);
         let Some(Terminator::Return { values }) = &block.terminator else {
             panic!("expected return terminator");

--- a/crates/codegen/src/transform/outline_reverts.rs
+++ b/crates/codegen/src/transform/outline_reverts.rs
@@ -63,8 +63,8 @@ impl OutlineRevertsCx {
     fn run(&mut self, module: &mut Module) -> bool {
         // Collect every constant revert block, keyed by shape.
         let mut shapes: FxHashMap<RevertShape, Vec<(usize, usize)>> = FxHashMap::default();
-        for (func_idx, func) in module.functions.iter().enumerate() {
-            for block_idx in 0..func.blocks.len() {
+        for (func_idx, func) in module.functions().enumerate() {
+            for block_idx in 0..func.block_count() {
                 if let Some(shape) = constant_revert_shape(func, block_idx)
                     && estimated_inline_size(&shape) >= MIN_OUTLINED_SIZE
                 {
@@ -84,8 +84,8 @@ impl OutlineRevertsCx {
         for (shape, sites) in worth_outlining {
             let helper = self.synthesize_helper(module, &shape);
             for (func_idx, block_idx) in sites {
-                let func = &mut module.functions[crate::mir::FunctionId::from_usize(func_idx)];
-                let block = &mut func.blocks[crate::mir::BlockId::from_usize(block_idx)];
+                let func = module.function_mut(crate::mir::FunctionId::from_usize(func_idx));
+                let block = func.block_mut(crate::mir::BlockId::from_usize(block_idx));
                 block.instructions.clear();
                 block.terminator =
                     Some(Terminator::TailCall { function: helper, args: Default::default() });
@@ -126,7 +126,7 @@ const MIN_OUTLINED_SIZE: usize = 12;
 /// Returns the block's shape when every instruction is a fully-constant
 /// `mstore` and the terminator is a fully-constant `revert`.
 fn constant_revert_shape(func: &Function, block_idx: usize) -> Option<RevertShape> {
-    let block = &func.blocks[crate::mir::BlockId::from_usize(block_idx)];
+    let block = func.block(crate::mir::BlockId::from_usize(block_idx));
     let Some(Terminator::Revert { offset, size }) = block.terminator else {
         return None;
     };
@@ -136,7 +136,7 @@ fn constant_revert_shape(func: &Function, block_idx: usize) -> Option<RevertShap
     };
     let mut stores = SmallVec::with_capacity(block.instructions.len());
     for &inst_id in &block.instructions {
-        let InstKind::MStore(store_offset, value) = func.instructions[inst_id].kind else {
+        let InstKind::MStore(store_offset, value) = func.instruction(inst_id).kind else {
             return None;
         };
         stores.push((imm(store_offset)?, imm(value)?));

--- a/crates/codegen/src/transform/pre.rs
+++ b/crates/codegen/src/transform/pre.rs
@@ -152,8 +152,8 @@ impl PartialRedundancyEliminator {
         let mut inst_blocks = func.inst_blocks();
 
         let mut eliminated_keys = FxHashSet::default();
-        let mut inserted_insts = GrowableBitSet::with_capacity(func.instructions.len());
-        let rewrite_limit = func.instructions.len().saturating_mul(2).max(64);
+        let mut inserted_insts = GrowableBitSet::with_capacity(func.instruction_count());
+        let rewrite_limit = func.instruction_count().saturating_mul(2).max(64);
         let mut rewrites = 0usize;
 
         while rewrites < rewrite_limit {
@@ -205,16 +205,16 @@ impl PartialRedundancyEliminator {
         let mut batch = Vec::new();
         // Candidates whose analysis would be invalidated by an earlier
         // candidate in this batch are deferred to the next scan.
-        let mut modified_blocks = DenseBitSet::new_empty(func.blocks.len());
-        let mut eliminated_values = DenseBitSet::new_empty(func.values.len());
+        let mut modified_blocks = DenseBitSet::new_empty(func.block_count());
+        let mut eliminated_values = DenseBitSet::new_empty(func.value_count());
 
-        'targets: for target in func.blocks.indices() {
+        'targets: for target in func.block_ids() {
             let predecessors = func.unique_predecessors(target);
             if predecessors.len() < 2 {
                 continue;
             }
 
-            for &inst in &func.blocks[target].instructions {
+            for &inst in &func.block(target).instructions {
                 if batch.len() >= limit {
                     break 'targets;
                 }
@@ -223,7 +223,7 @@ impl PartialRedundancyEliminator {
                 if inserted_insts.contains(inst) {
                     continue;
                 }
-                let instruction = &func.instructions[inst];
+                let instruction = func.instruction(inst);
                 if !Self::is_pre_expression(&instruction.kind) {
                     continue;
                 }
@@ -296,7 +296,7 @@ impl PartialRedundancyEliminator {
         dominators: &DominatorTree,
         eliminated_keys: &FxHashSet<(ExprKey, BlockId)>,
     ) -> Option<PreCandidate> {
-        let original = &func.instructions[inst].kind;
+        let original = &func.instruction(inst).kind;
         let mut incoming = Vec::with_capacity(predecessors.len());
         let mut insertions = Vec::new();
         let mut available = 0usize;
@@ -351,7 +351,7 @@ impl PartialRedundancyEliminator {
         let PreCandidate { target, inst, result, result_ty, metadata, mut incoming, insertions } =
             candidate;
 
-        if let Some(key) = Self::make_expr_key(func, &func.instructions[inst].kind) {
+        if let Some(key) = Self::make_expr_key(func, &func.instruction(inst).kind) {
             eliminated_keys.insert((key, target));
         }
 
@@ -362,7 +362,7 @@ impl PartialRedundancyEliminator {
             // the edge critical: split it so the computation runs only on the
             // edge into the join. The split block sits on that edge, so the
             // per-edge phi translation that held for `pred` holds for it too.
-            let block = match func.blocks[pred].terminator {
+            let block = match func.block(pred).terminator {
                 Some(Terminator::Jump(jump_target)) => {
                     debug_assert_eq!(jump_target, target);
                     pred
@@ -375,7 +375,7 @@ impl PartialRedundancyEliminator {
                 metadata: metadata.clone(),
             });
             let value = func.alloc_value(Value::Inst(new_inst));
-            func.blocks[block].instructions.push(new_inst);
+            func.block_mut(block).instructions.push(new_inst);
             incoming.push((block, value));
             inst_results.insert(new_inst, value);
             inst_blocks.insert(new_inst, block);
@@ -399,14 +399,15 @@ impl PartialRedundancyEliminator {
                 let phi_inst =
                     func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
                 let phi_value = func.alloc_value(Value::Inst(phi_inst));
-                let phi_count = func.blocks[target]
+                let phi_count = func
+                    .block(target)
                     .instructions
                     .iter()
                     .take_while(|&&inst_id| {
-                        matches!(func.instructions[inst_id].kind, InstKind::Phi(_))
+                        matches!(func.instruction(inst_id).kind, InstKind::Phi(_))
                     })
                     .count();
-                func.blocks[target].instructions.insert(phi_count, phi_inst);
+                func.block_mut(target).instructions.insert(phi_count, phi_inst);
                 inst_results.insert(phi_inst, phi_value);
                 inst_blocks.insert(phi_inst, target);
                 phi_value
@@ -415,7 +416,7 @@ impl PartialRedundancyEliminator {
 
         let replacements = FxHashMap::from_iter([(result, replacement)]);
         func.replace_uses(&replacements);
-        func.blocks[target].instructions.retain(|&inst_id| inst_id != inst);
+        func.block_mut(target).instructions.retain(|&inst_id| inst_id != inst);
         inst_results.remove(&inst);
         inst_blocks.remove(&inst);
         self.stats.expressions_eliminated += 1;
@@ -452,9 +453,9 @@ impl PartialRedundancyEliminator {
         match func.value(value) {
             Value::Inst(inst_id)
                 if inst_blocks.get(inst_id).copied() == Some(target)
-                    && matches!(func.instructions[*inst_id].kind, InstKind::Phi(_)) =>
+                    && matches!(func.instruction(*inst_id).kind, InstKind::Phi(_)) =>
             {
-                let InstKind::Phi(incoming) = &func.instructions[*inst_id].kind else {
+                let InstKind::Phi(incoming) = &func.instruction(*inst_id).kind else {
                     return None;
                 };
                 incoming.iter().find_map(|(incoming_pred, incoming_value)| {
@@ -514,8 +515,8 @@ impl PartialRedundancyEliminator {
         key: &ExprKey,
         inst_results: &FxHashMap<InstId, ValueId>,
     ) -> Option<ValueId> {
-        func.blocks[block].instructions.iter().rev().find_map(|&inst| {
-            let instruction = &func.instructions[inst];
+        func.block(block).instructions.iter().rev().find_map(|&inst| {
+            let instruction = func.instruction(inst);
             if !Self::is_pre_expression(&instruction.kind) {
                 return None;
             }

--- a/crates/codegen/src/transform/pure_eval.rs
+++ b/crates/codegen/src/transform/pure_eval.rs
@@ -87,7 +87,7 @@ impl PureEvaluator {
     /// report a change (and allocate fresh immediates) without progress.
     fn is_already_folded(&self, func: &Function, values: &[U256]) -> bool {
         let entry = BlockId::ENTRY;
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             if !block.instructions.is_empty() {
                 return false;
             }
@@ -95,7 +95,7 @@ impl PureEvaluator {
                 return false;
             }
         }
-        let Some(Terminator::Return { values: ret }) = &func.blocks[entry].terminator else {
+        let Some(Terminator::Return { values: ret }) = &func.block(entry).terminator else {
             return false;
         };
         ret.len() == values.len()
@@ -108,9 +108,9 @@ impl PureEvaluator {
     }
 
     fn is_side_effect_free(&self, func: &Function) -> bool {
-        for block in &func.blocks {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                if func.instructions[inst_id].kind.has_side_effects() {
+                if func.instruction(inst_id).kind.has_side_effects() {
                     return false;
                 }
             }
@@ -120,7 +120,7 @@ impl PureEvaluator {
 
     fn evaluate(&self, func: &Function) -> Option<Vec<U256>> {
         let mut env = FxHashMap::default();
-        for (value_id, value) in func.values.iter_enumerated() {
+        for (value_id, value) in func.values_enumerated() {
             if let Value::Immediate(imm) = value
                 && let Some(value) = imm.as_u256()
             {
@@ -133,10 +133,10 @@ impl PureEvaluator {
         let mut fuel = self.fuel;
         while fuel != 0 {
             fuel -= 1;
-            let block = &func.blocks[current];
+            let block = func.block(current);
 
             for &inst_id in &block.instructions {
-                let inst = &func.instructions[inst_id];
+                let inst = func.instruction(inst_id);
                 let result = match &inst.kind {
                     InstKind::Phi(incoming) => {
                         let pred = predecessor?;
@@ -247,9 +247,9 @@ impl PureEvaluator {
 
     fn rewrite_to_return(&self, func: &mut Function, values: &[U256]) {
         let entry = BlockId::ENTRY;
-        let block_ids: Vec<_> = func.blocks.indices().collect();
+        let block_ids: Vec<_> = func.block_ids().collect();
         for block_id in block_ids {
-            let block = &mut func.blocks[block_id];
+            let block = func.block_mut(block_id);
             block.instructions.clear();
             if block_id == entry {
                 block.predecessors.clear();
@@ -263,6 +263,6 @@ impl PureEvaluator {
             .iter()
             .map(|&value| func.alloc_value(Value::Immediate(Immediate::uint256(value))))
             .collect();
-        func.blocks[entry].terminator = Some(Terminator::Return { values });
+        func.block_mut(entry).terminator = Some(Terminator::Return { values });
     }
 }

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -109,12 +109,11 @@ impl SccpCx {
     fn run(&mut self, func: &mut Function) -> usize {
         self.stats = SccpStats::default();
 
-        let num_values = func.values.len();
+        let num_values = func.value_count();
 
         // Precompute InstId → ValueId map.
         let inst_to_value: FxHashMap<InstId, ValueId> = func
-            .values
-            .iter_enumerated()
+            .values_enumerated()
             .filter_map(
                 |(vid, val)| {
                     if let Value::Inst(iid) = val { Some((*iid, vid)) } else { None }
@@ -126,7 +125,7 @@ impl SccpCx {
         let mut lattice = index_vec![LatticeValue::Top; num_values];
 
         // Arguments are overdefined (we don't know their runtime values).
-        for (vid, val) in func.values.iter_enumerated() {
+        for (vid, val) in func.values_enumerated() {
             match val {
                 Value::Arg { .. } => lattice[vid] = LatticeValue::Bottom,
                 Value::Immediate(imm) => {
@@ -142,7 +141,7 @@ impl SccpCx {
         }
 
         // Track which blocks are executable.
-        let mut executable_blocks = DenseBitSet::new_empty(func.blocks.len());
+        let mut executable_blocks = DenseBitSet::new_empty(func.block_count());
         // Track which CFG edges have been taken.
         let mut executable_edges: FxHashSet<(BlockId, BlockId)> = FxHashSet::default();
 
@@ -248,15 +247,15 @@ impl SccpCx {
         cfg_worklist: &mut VecDeque<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
     ) {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
 
         for &inst_id in &block.instructions {
-            if matches!(func.instructions[inst_id].kind, InstKind::Phi(_)) {
+            if matches!(func.instruction(inst_id).kind, InstKind::Phi(_)) {
                 continue;
             }
             if let Some(&vid) = inst_to_value.get(&inst_id) {
                 let new_val =
-                    self.evaluate_instruction(func, &func.instructions[inst_id].kind, lattice);
+                    self.evaluate_instruction(func, &func.instruction(inst_id).kind, lattice);
                 if self.update_lattice(lattice, vid, new_val) {
                     ssa_worklist.push_back(vid);
                 }
@@ -279,9 +278,9 @@ impl SccpCx {
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
     ) {
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
         for &inst_id in &block.instructions {
-            let inst = &func.instructions[inst_id];
+            let inst = func.instruction(inst_id);
             if let InstKind::Phi(incoming) = &inst.kind
                 && let Some(&vid) = inst_to_value.get(&inst_id)
             {
@@ -596,12 +595,12 @@ impl SccpCx {
         }
 
         // Find all instructions that use this value and re-evaluate them.
-        for (block_id, block) in func.blocks.iter_enumerated() {
+        for (block_id, block) in func.blocks_enumerated() {
             if !executable_blocks.contains(block_id) {
                 continue;
             }
             for &inst_id in &block.instructions {
-                let inst = &func.instructions[inst_id];
+                let inst = func.instruction(inst_id);
                 if matches!(inst.kind, InstKind::Phi(_)) {
                     continue;
                 }
@@ -637,16 +636,16 @@ impl SccpCx {
         // Phase 1: Replace instructions whose results are constant with
         // immediate values, and remove the instruction from the block.
         let mut const_values: FxHashMap<ValueId, ValueId> = FxHashMap::default();
-        let mut dead_insts = DenseBitSet::new_empty(func.instructions.len());
+        let mut dead_insts = DenseBitSet::new_empty(func.instruction_count());
 
         for (&inst_id, &vid) in inst_to_value {
             if let LatticeValue::Constant(c) = &lattice[vid] {
                 // Don't fold side-effecting instructions.
-                if func.instructions[inst_id].kind.has_side_effects() {
+                if func.instruction(inst_id).kind.has_side_effects() {
                     continue;
                 }
                 // Create an immediate replacement of the instruction's result type.
-                let imm = immediate_for_type(func.instructions[inst_id].result_ty, *c);
+                let imm = immediate_for_type(func.instruction(inst_id).result_ty, *c);
                 let imm_vid = func.alloc_value(Value::Immediate(imm));
                 const_values.insert(vid, imm_vid);
                 dead_insts.insert(inst_id);
@@ -656,14 +655,14 @@ impl SccpCx {
 
         // Phase 2: Collect branch rewrites BEFORE operand replacement, because
         // replacement may allocate new ValueIds that don't have lattice entries.
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         let mut control_rewrites: Vec<(BlockId, BlockId)> = Vec::new();
-        let mut executable_successors = DenseBitSet::new_empty(func.blocks.len());
+        let mut executable_successors = DenseBitSet::new_empty(func.block_count());
         for &block_id in &block_ids {
             if !executable_blocks.contains(block_id) {
                 continue;
             }
-            let Some(term) = &func.blocks[block_id].terminator else {
+            let Some(term) = &func.block(block_id).terminator else {
                 continue;
             };
             if !matches!(term, Terminator::Branch { .. } | Terminator::Switch { .. }) {
@@ -685,16 +684,18 @@ impl SccpCx {
         // Phase 3: Replace all uses of folded values with immediates.
         if !const_values.is_empty() {
             let all_insts: Vec<InstId> = func
-                .blocks
-                .iter()
+                .blocks()
                 .flat_map(|block| block.instructions.iter().copied())
                 .filter(|&id| !dead_insts.contains(id))
                 .collect();
             for inst_id in all_insts {
-                mir_utils::replace_inst_uses(&mut func.instructions[inst_id].kind, &const_values);
+                mir_utils::replace_inst_uses(
+                    &mut func.instruction_mut(inst_id).kind,
+                    &const_values,
+                );
             }
             for &block_id in &block_ids {
-                if let Some(term) = &mut func.blocks[block_id].terminator {
+                if let Some(term) = &mut func.block_mut(block_id).terminator {
                     mir_utils::replace_terminator_uses(term, &const_values);
                 }
             }
@@ -702,25 +703,26 @@ impl SccpCx {
 
         // Phase 4: Remove dead (folded) instructions from blocks.
         for &block_id in &block_ids {
-            func.blocks[block_id].instructions.retain(|&id| !dead_insts.contains(id));
+            func.block_mut(block_id).instructions.retain(|&id| !dead_insts.contains(id));
         }
 
         // Phase 5: Apply branch/switch rewrites.
         for (block_id, target) in control_rewrites {
-            let old_successors = func.blocks[block_id]
+            let old_successors = func
+                .block(block_id)
                 .terminator
                 .as_ref()
                 .map(Terminator::successors)
                 .unwrap_or_default();
             let was_switch =
-                matches!(func.blocks[block_id].terminator, Some(Terminator::Switch { .. }));
+                matches!(func.block(block_id).terminator, Some(Terminator::Switch { .. }));
             for successor in old_successors {
-                func.blocks[successor].predecessors.retain(|pred| *pred != block_id);
+                func.block_mut(successor).predecessors.retain(|pred| *pred != block_id);
             }
-            if !func.blocks[target].predecessors.contains(&block_id) {
-                func.blocks[target].predecessors.push(block_id);
+            if !func.block(target).predecessors.contains(&block_id) {
+                func.block_mut(target).predecessors.push(block_id);
             }
-            func.blocks[block_id].terminator = Some(Terminator::Jump(target));
+            func.block_mut(block_id).terminator = Some(Terminator::Jump(target));
             if was_switch {
                 self.stats.switches_folded += 1;
             } else {
@@ -733,7 +735,7 @@ impl SccpCx {
             if executable_blocks.contains(block_id) {
                 continue;
             }
-            let block = &mut func.blocks[block_id];
+            let block = func.block_mut(block_id);
             // Predecessor lists are rebuilt from terminators by
             // `repair_reachability_phis` below, so a never-taken switch target
             // keeps a predecessor entry; checking it here would re-count the

--- a/crates/codegen/src/transform/sroa.rs
+++ b/crates/codegen/src/transform/sroa.rs
@@ -61,10 +61,10 @@ fn is_fixed_aggregate(layout: MemoryObjectLayout) -> bool {
 impl SroaCx {
     fn run(&mut self, func: &mut Function, alias: &AliasAnalysis) -> bool {
         let mut allocs: Vec<(BlockId, InstId, ValueId)> = Vec::new();
-        for block_id in func.blocks.indices() {
-            for &inst_id in &func.blocks[block_id].instructions {
+        for block_id in func.block_ids() {
+            for &inst_id in &func.block(block_id).instructions {
                 if let InstKind::Alloc { kind: AllocationKind::Object(layout), .. } =
-                    func.instructions[inst_id].kind
+                    func.instruction(inst_id).kind
                     && is_fixed_aggregate(layout)
                     && let Some(object) = func.inst_result_value(inst_id)
                 {
@@ -109,8 +109,7 @@ impl SroaCx {
         // address, in this block.
         let mut slot_of: FxHashMap<ValueId, u64> = FxHashMap::default();
         let mut address_insts: FxHashSet<InstId> = FxHashSet::default();
-        for (inst_id, kind) in func.instructions.iter_enumerated().map(|(i, inst)| (i, &inst.kind))
-        {
+        for (inst_id, kind) in func.instructions_enumerated().map(|(i, inst)| (i, &inst.kind)) {
             let slot = match *kind {
                 InstKind::MemoryObjectFieldAddr { object: base, field, .. } if base == object => {
                     Some(field)
@@ -136,9 +135,9 @@ impl SroaCx {
 
         // Every field address must be used only as the address of an
         // `MStore`/`MLoad` in this block.
-        let block = &func.blocks[block_id];
+        let block = func.block(block_id);
         let block_insts: FxHashSet<InstId> = block.instructions.iter().copied().collect();
-        for (inst_id, inst) in func.instructions.iter_enumerated() {
+        for (inst_id, inst) in func.instructions_enumerated() {
             let kind = &inst.kind;
             let addr = match *kind {
                 InstKind::MStore(addr, value) => {
@@ -171,7 +170,7 @@ impl SroaCx {
         let mut replacements: FxHashMap<ValueId, ValueId> = FxHashMap::default();
         let mut dead: FxHashSet<InstId> = FxHashSet::default();
         for &inst_id in &block.instructions {
-            match func.instructions[inst_id].kind {
+            match func.instruction(inst_id).kind {
                 InstKind::MStore(addr, value) if slot_of.contains_key(&addr) => {
                     current.insert(slot_of[&addr], value);
                     dead.insert(inst_id);
@@ -196,10 +195,10 @@ impl SroaCx {
 
     fn apply(&self, func: &mut Function, block_id: BlockId, plan: Plan) {
         func.replace_uses_canonicalized(&plan.replacements);
-        func.blocks[block_id].instructions.retain(|inst| !plan.dead.contains(inst));
+        func.block_mut(block_id).instructions.retain(|inst| !plan.dead.contains(inst));
         // Address instructions live in the same block; remove any that ended up
         // elsewhere defensively.
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             block.instructions.retain(|inst| !plan.dead.contains(inst));
         }
     }

--- a/crates/codegen/src/transform/static_alloc.rs
+++ b/crates/codegen/src/transform/static_alloc.rs
@@ -44,8 +44,7 @@ impl MirPass for StaticAlloc {
         // the others can grow into without moving the shared static-frame
         // region or any spill base above it. Placements stay inside it.
         let shadow = module
-            .functions
-            .iter()
+            .functions()
             .filter(|func| is_entry(func))
             .map(|func| {
                 EvmMemoryLayout::HEAP_START
@@ -56,7 +55,7 @@ impl MirPass for StaticAlloc {
 
         let summaries = Arc::new(MemoryCallSummaries::new(module));
         let mut changed = false;
-        for func in module.functions.iter_mut() {
+        for func in module.functions_mut() {
             if !is_entry(func) || has_msize(func) {
                 continue;
             }
@@ -83,7 +82,7 @@ impl MirPass for DeferAlloc {
     ) -> bool {
         let summaries = Arc::new(MemoryCallSummaries::new(module));
         let mut candidates = Vec::new();
-        for (func_id, func) in module.functions.iter_enumerated() {
+        for (func_id, func) in module.iter_functions() {
             let aa = AliasAnalysis::with_call_summaries(func, Arc::clone(&summaries));
             candidates.extend(
                 eligible_static_allocations(func, &aa)
@@ -94,7 +93,7 @@ impl MirPass for DeferAlloc {
 
         let mut changed = false;
         for (func_id, alloc) in candidates {
-            let metadata = &mut module.functions[func_id].instructions[alloc].metadata;
+            let metadata = &mut module.function_mut(func_id).instruction_mut(alloc).metadata;
             if !metadata.deferred_alloc() {
                 metadata.set_deferred_alloc();
                 changed = true;
@@ -137,9 +136,9 @@ fn eligible_static_allocations(func: &Function, aa: &AliasAnalysis) -> Vec<Stati
     let cfg = CfgInfo::new(func);
     let mut cyclic = FxHashMap::default();
     let mut candidates = Vec::new();
-    for block in func.blocks.indices() {
-        for &alloc in &func.blocks[block].instructions {
-            let InstKind::Alloc { size, semantics, .. } = func.instructions[alloc].kind else {
+    for block in func.block_ids() {
+        for &alloc in &func.block(block).instructions {
+            let InstKind::Alloc { size, semantics, .. } = func.instruction(alloc).kind else {
                 continue;
             };
             if semantics != crate::mir::AllocationSemantics::INTERNAL {
@@ -164,20 +163,20 @@ fn eligible_static_allocations(func: &Function, aa: &AliasAnalysis) -> Vec<Stati
 }
 
 fn has_msize(func: &Function) -> bool {
-    func.blocks.iter().any(|block| {
+    func.blocks().any(|block| {
         block
             .instructions
             .iter()
-            .any(|&inst| matches!(func.instructions[inst].kind, InstKind::MSize))
+            .any(|&inst| matches!(func.instruction(inst).kind, InstKind::MSize))
     })
 }
 
 /// Returns true when `block` can execute more than once: it can reach itself.
 fn block_in_cycle(func: &Function, block: BlockId) -> bool {
     let mut stack = vec![block];
-    let mut seen = DenseBitSet::new_empty(func.blocks.len());
+    let mut seen = DenseBitSet::new_empty(func.block_count());
     while let Some(current) = stack.pop() {
-        let Some(term) = func.blocks[current].terminator.as_ref() else { continue };
+        let Some(term) = func.block(current).terminator.as_ref() else { continue };
         for succ in term.successors() {
             if succ == block {
                 return true;
@@ -200,9 +199,9 @@ fn candidate_uses_are_safe(func: &Function, cand: &StaticAllocCandidate) -> bool
     derived.insert(cand.ptr, 0);
     for _ in 0..4 {
         let mut grew = false;
-        for block in func.blocks.iter() {
+        for block in func.blocks() {
             for &inst_id in &block.instructions {
-                if let InstKind::Add(a, b) = func.instructions[inst_id].kind
+                if let InstKind::Add(a, b) = func.instruction(inst_id).kind
                     && let Some(&result) = inst_results.get(&inst_id)
                     && !derived.contains_key(&result)
                 {
@@ -234,12 +233,12 @@ fn candidate_uses_are_safe(func: &Function, cand: &StaticAllocCandidate) -> bool
 
     // Every use of every derived address must be a bounded memory access.
     let in_range = |off: u64, len: u64| off.checked_add(len).is_some_and(|end| end <= cand.size);
-    for block in func.blocks.iter() {
+    for block in func.blocks() {
         for &inst_id in &block.instructions {
             if inst_id == cand.alloc {
                 continue;
             }
-            let kind = &func.instructions[inst_id].kind;
+            let kind = &func.instruction(inst_id).kind;
             for &operand in kind.operands().iter() {
                 let Some(&off) = derived.get(&operand) else { continue };
                 let ok = match *kind {
@@ -317,7 +316,7 @@ fn apply_candidate(func: &mut Function, cand: &StaticAllocCandidate, shadow: u64
     let mut replacements = FxHashMap::default();
     replacements.insert(cand.ptr, replacement);
     func.replace_uses_canonicalized(&replacements);
-    let block = &mut func.blocks[cand.block];
+    let block = func.block_mut(cand.block);
     block.instructions.retain(|&inst| inst != cand.alloc);
     true
 }

--- a/crates/codegen/src/transform/storage_dse.rs
+++ b/crates/codegen/src/transform/storage_dse.rs
@@ -57,7 +57,7 @@ impl RunState {
         Self {
             later_writes: FxHashSet::default(),
             stored_values: FxHashMap::default(),
-            dead: DenseBitSet::new_empty(func.instructions.len()),
+            dead: DenseBitSet::new_empty(func.instruction_count()),
         }
     }
 }
@@ -75,7 +75,7 @@ impl StorageStoreEliminator {
             self.alias = Some(Rc::new(AliasAnalysis::new(func)));
         }
 
-        let block_ids: Vec<BlockId> = func.blocks.indices().collect();
+        let block_ids: Vec<BlockId> = func.block_ids().collect();
         for block_id in block_ids {
             self.remove_overwritten_stores(
                 func,
@@ -114,8 +114,8 @@ impl StorageStoreEliminator {
         later_writes.clear();
         dead.clear();
 
-        for &inst_id in func.blocks[block_id].instructions.iter().rev() {
-            match &func.instructions[inst_id].kind {
+        for &inst_id in func.block(block_id).instructions.iter().rev() {
+            match &func.instruction(inst_id).kind {
                 InstKind::SStore(slot, _) => {
                     let alias = aa.storage_alias(func, inst_id, *slot);
                     if later_writes.contains(&alias) {
@@ -142,7 +142,7 @@ impl StorageStoreEliminator {
             return;
         }
 
-        func.blocks[block_id].instructions.retain(|&id| !dead.contains(id));
+        func.block_mut(block_id).instructions.retain(|&id| !dead.contains(id));
     }
 
     fn remove_equal_stores(
@@ -156,8 +156,8 @@ impl StorageStoreEliminator {
         stored_values.clear();
         dead.clear();
 
-        for &inst_id in &func.blocks[block_id].instructions {
-            match &func.instructions[inst_id].kind {
+        for &inst_id in &func.block(block_id).instructions {
+            match &func.instruction(inst_id).kind {
                 InstKind::SStore(slot, value) => {
                     let alias = aa.storage_alias(func, inst_id, *slot);
                     if stored_values.get(&alias).is_some_and(|&stored| stored == *value) {
@@ -180,7 +180,7 @@ impl StorageStoreEliminator {
             return;
         }
 
-        func.blocks[block_id].instructions.retain(|&id| !dead.contains(id));
+        func.block_mut(block_id).instructions.retain(|&id| !dead.contains(id));
     }
 
     fn remove_aliasing_set(

--- a/crates/codegen/src/transform/storage_load_cse.rs
+++ b/crates/codegen/src/transform/storage_load_cse.rs
@@ -51,7 +51,7 @@ impl RunState {
     fn new(func: &Function) -> Self {
         Self {
             replacements: FxHashMap::default(),
-            dead: DenseBitSet::new_empty(func.instructions.len()),
+            dead: DenseBitSet::new_empty(func.instruction_count()),
             cached_loads: FxHashMap::default(),
         }
     }
@@ -76,7 +76,7 @@ impl StorageLoadCseCx {
         state.replacements.clear();
         state.dead.clear();
 
-        for block_id in func.blocks.indices() {
+        for block_id in func.block_ids() {
             state.cached_loads.clear();
             self.process_block(func, block_id, liveness, &inst_results, state);
         }
@@ -85,7 +85,7 @@ impl StorageLoadCseCx {
             Self::replace_uses(func, &state.replacements);
         }
         if !state.dead.is_empty() {
-            for block in func.blocks.iter_mut() {
+            for block in func.blocks_mut() {
                 block.instructions.retain(|&id| !state.dead.contains(id));
             }
         }
@@ -116,8 +116,8 @@ impl StorageLoadCseCx {
         state: &mut RunState,
     ) {
         let aa = self.alias.as_ref().expect("storage-load CSE alias snapshot is initialized");
-        for (inst_idx, &inst_id) in func.blocks[block_id].instructions.iter().enumerate() {
-            match &func.instructions[inst_id].kind {
+        for (inst_idx, &inst_id) in func.block(block_id).instructions.iter().enumerate() {
+            match &func.instruction(inst_id).kind {
                 InstKind::SLoad(slot) => {
                     let alias = aa.storage_alias_after_replacements(
                         func,
@@ -187,14 +187,14 @@ impl StorageLoadCseCx {
             return;
         }
 
-        for inst in func.instructions.iter_mut() {
+        for inst in func.instructions_mut() {
             mir_utils::replace_inst_uses_canonicalized(&mut inst.kind, replacements);
             if matches!(inst.kind, InstKind::SLoad(_) | InstKind::SStore(_, _)) {
                 inst.metadata.set_storage_alias(None);
             }
         }
 
-        for block in func.blocks.iter_mut() {
+        for block in func.blocks_mut() {
             if let Some(term) = &mut block.terminator {
                 mir_utils::replace_terminator_uses_canonicalized(term, replacements);
             }

--- a/crates/codegen/src/transform/storage_promotion.rs
+++ b/crates/codegen/src/transform/storage_promotion.rs
@@ -147,8 +147,8 @@ impl StorageScalarPromoter {
         let mut saw_loop_store = false;
 
         for block_id in &loop_data.blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                if let InstKind::SStore(store_slot, _) = &func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                if let InstKind::SStore(store_slot, _) = &func.instruction(inst_id).kind {
                     let store_key =
                         self.storage_alias_for_loop_value(func, *store_slot, loop_data)?;
                     match slot {
@@ -174,9 +174,9 @@ impl StorageScalarPromoter {
             return None;
         }
         let saw_loop_load = rewrite_blocks.iter().any(|&block_id| {
-            func.blocks[block_id].instructions.iter().any(|&inst_id| {
+            func.block(block_id).instructions.iter().any(|&inst_id| {
                 matches!(
-                    &func.instructions[inst_id].kind,
+                    &func.instruction(inst_id).kind,
                     InstKind::SLoad(load_slot)
                         if self.storage_alias(func, inst_id, *load_slot) == slot
                 )
@@ -216,8 +216,8 @@ impl StorageScalarPromoter {
 
         let mut stores: FxHashMap<StorageAlias, ValueId> = FxHashMap::default();
         for block_id in &loop_data.blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                if let InstKind::SStore(store_slot, _) = &func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                if let InstKind::SStore(store_slot, _) = &func.instruction(inst_id).kind {
                     let store_key =
                         self.storage_alias_for_loop_value(func, *store_slot, loop_data)?;
                     stores.entry(store_key).or_insert(*store_slot);
@@ -269,11 +269,11 @@ impl StorageScalarPromoter {
 
     fn has_isolated_promotable_exits(&self, func: &Function, loop_data: &Loop) -> bool {
         loop_data.exit_blocks.iter().all(|&exit| {
-            func.blocks[exit].predecessors.iter().all(|&pred| loop_data.blocks.contains(pred))
+            func.block(exit).predecessors.iter().all(|&pred| loop_data.blocks.contains(pred))
                 && if self.exit_rolls_back(func, exit) {
                     self.rollback_exit_has_no_observable_effects(func, exit)
                 } else {
-                    !matches!(func.blocks[exit].terminator, Some(Terminator::SelfDestruct { .. }))
+                    !matches!(func.block(exit).terminator, Some(Terminator::SelfDestruct { .. }))
                 }
         })
     }
@@ -281,19 +281,16 @@ impl StorageScalarPromoter {
     /// Returns true if the exit block ends by rolling back all storage writes
     /// of the frame, which makes skipping the promoted-value flush sound.
     fn exit_rolls_back(&self, func: &Function, exit: BlockId) -> bool {
-        matches!(
-            func.blocks[exit].terminator,
-            Some(Terminator::Revert { .. } | Terminator::Invalid)
-        )
+        matches!(func.block(exit).terminator, Some(Terminator::Revert { .. } | Terminator::Invalid))
     }
 
     /// A rollback exit must not contain calls (a callee could observe the
     /// unflushed slot and leak that observation into the revert data) or
     /// other instructions whose results escape the rolled-back frame.
     fn rollback_exit_has_no_observable_effects(&self, func: &Function, exit: BlockId) -> bool {
-        func.blocks[exit].instructions.iter().all(|&inst_id| {
+        func.block(exit).instructions.iter().all(|&inst_id| {
             !matches!(
-                &func.instructions[inst_id].kind,
+                &func.instruction(inst_id).kind,
                 InstKind::Call { .. }
                     | InstKind::StaticCall { .. }
                     | InstKind::DelegateCall { .. }
@@ -319,7 +316,7 @@ impl StorageScalarPromoter {
     fn loop_has_no_unpromotable_side_effects(&self, func: &Function, loop_data: &Loop) -> bool {
         for block_id in &loop_data.blocks {
             if matches!(
-                func.blocks[block_id].terminator,
+                func.block(block_id).terminator,
                 Some(
                     Terminator::Return { .. }
                         | Terminator::Revert { .. }
@@ -332,8 +329,8 @@ impl StorageScalarPromoter {
                 return false;
             }
 
-            for &inst_id in &func.blocks[block_id].instructions {
-                let inst = &func.instructions[inst_id];
+            for &inst_id in &func.block(block_id).instructions {
+                let inst = func.instruction(inst_id);
                 match &inst.kind {
                     InstKind::SLoad(_) | InstKind::SStore(_, _) => {}
                     InstKind::TStore(_, _)
@@ -358,8 +355,8 @@ impl StorageScalarPromoter {
         candidate: &StorageAlias,
     ) -> bool {
         for &block_id in blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                match &func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                match &func.instruction(inst_id).kind {
                     InstKind::SLoad(slot) => {
                         let alias = self.storage_alias(func, inst_id, *slot);
                         if alias != *candidate && self.storage_may_alias(*candidate, alias) {
@@ -386,8 +383,8 @@ impl StorageScalarPromoter {
         candidates: &[Candidate],
     ) -> bool {
         for &block_id in blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                match &func.instructions[inst_id].kind {
+            for &inst_id in &func.block(block_id).instructions {
+                match &func.instruction(inst_id).kind {
                     InstKind::SLoad(slot) => {
                         let alias = self.storage_alias(func, inst_id, *slot);
                         if self.candidate_index(candidates, &alias).is_none()
@@ -417,9 +414,9 @@ impl StorageScalarPromoter {
         preheader: BlockId,
         slot: &StorageAlias,
     ) -> Option<InstId> {
-        func.blocks[preheader].instructions.iter().rev().copied().find(|&inst_id| {
+        func.block(preheader).instructions.iter().rev().copied().find(|&inst_id| {
             matches!(
-                &func.instructions[inst_id].kind,
+                &func.instruction(inst_id).kind,
                 InstKind::SStore(store_slot, _)
                     if self.storage_alias(func, inst_id, *store_slot) == *slot
             )
@@ -427,7 +424,7 @@ impl StorageScalarPromoter {
     }
 
     fn store_slot(&self, func: &Function, inst_id: InstId) -> Option<ValueId> {
-        match func.instructions[inst_id].kind {
+        match func.instruction(inst_id).kind {
             InstKind::SStore(slot, _) => Some(slot),
             _ => None,
         }
@@ -441,13 +438,13 @@ impl StorageScalarPromoter {
         slot: &StorageAlias,
     ) -> bool {
         let Some(init_pos) =
-            func.blocks[preheader].instructions.iter().position(|&inst_id| inst_id == init_store)
+            func.block(preheader).instructions.iter().position(|&inst_id| inst_id == init_store)
         else {
             return false;
         };
 
-        for &inst_id in &func.blocks[preheader].instructions[init_pos + 1..] {
-            match &func.instructions[inst_id].kind {
+        for &inst_id in &func.block(preheader).instructions[init_pos + 1..] {
+            match &func.instruction(inst_id).kind {
                 InstKind::SLoad(load_slot) => {
                     let alias = self.storage_alias(func, inst_id, *load_slot);
                     if alias != *slot && self.storage_may_alias(*slot, alias) {
@@ -474,7 +471,7 @@ impl StorageScalarPromoter {
             .iter()
             .filter_map(|candidate| candidate.init_store)
             .filter_map(|inst_id| {
-                func.blocks[preheader]
+                func.block(preheader)
                     .instructions
                     .iter()
                     .position(|&candidate| candidate == inst_id)
@@ -484,8 +481,8 @@ impl StorageScalarPromoter {
             return false;
         };
 
-        for &inst_id in &func.blocks[preheader].instructions[first_init + 1..] {
-            match &func.instructions[inst_id].kind {
+        for &inst_id in &func.block(preheader).instructions[first_init + 1..] {
+            match &func.instruction(inst_id).kind {
                 InstKind::SLoad(load_slot) | InstKind::SStore(load_slot, _) => {
                     let alias = self.storage_alias(func, inst_id, *load_slot);
                     if self.candidate_index(candidates, &alias).is_none()
@@ -553,28 +550,31 @@ impl StorageScalarPromoter {
         let mut temps: FxHashMap<StorageAlias, (ValueId, usize)> = FxHashMap::default();
         for candidate in promoted {
             if let Some(init_store) = candidate.candidate.init_store
-                && let InstKind::SStore(_, init) = &func.instructions[init_store].kind
+                && let InstKind::SStore(_, init) = &func.instruction(init_store).kind
             {
-                let init_pos = func.blocks[preheader]
+                let init_pos = func
+                    .block(preheader)
                     .instructions
                     .iter()
                     .position(|&inst_id| inst_id == init_store)
                     .expect("candidate init store should be in the preheader");
                 temps.insert(candidate.candidate.slot, (candidate.temp_addr, init_pos));
-                func.instructions[init_store].kind = InstKind::MStore(candidate.temp_addr, *init);
-                func.instructions[init_store].metadata.set_storage_alias(None);
+                func.instruction_mut(init_store).kind =
+                    InstKind::MStore(candidate.temp_addr, *init);
+                func.instruction_mut(init_store).metadata.set_storage_alias(None);
                 self.stats.stores_promoted += 1;
             }
         }
 
-        for (pos, inst_id) in func.blocks[preheader].instructions.iter().copied().enumerate() {
-            if let InstKind::SLoad(load_slot) = &func.instructions[inst_id].kind {
+        let preheader_insts = func.block(preheader).instructions.clone();
+        for (pos, inst_id) in preheader_insts.into_iter().enumerate() {
+            if let InstKind::SLoad(load_slot) = &func.instruction(inst_id).kind {
                 let alias = self.storage_alias(func, inst_id, *load_slot);
                 if let Some(&(temp_addr, init_pos)) = temps.get(&alias)
                     && pos > init_pos
                 {
-                    func.instructions[inst_id].kind = InstKind::MLoad(temp_addr);
-                    func.instructions[inst_id].metadata.set_storage_alias(None);
+                    func.instruction_mut(inst_id).kind = InstKind::MLoad(temp_addr);
+                    func.instruction_mut(inst_id).metadata.set_storage_alias(None);
                     self.stats.loads_promoted += 1;
                 }
             }
@@ -591,8 +591,9 @@ impl StorageScalarPromoter {
             promoted.iter().map(|promoted| (promoted.candidate.slot, promoted.temp_addr)).collect();
 
         for &block_id in blocks {
-            for &inst_id in &func.blocks[block_id].instructions {
-                let replacement = match &func.instructions[inst_id].kind {
+            let block_insts = func.block(block_id).instructions.clone();
+            for inst_id in block_insts {
+                let replacement = match &func.instruction(inst_id).kind {
                     InstKind::SLoad(slot) => {
                         let alias = self.storage_alias(func, inst_id, *slot);
                         temps.get(&alias).copied().map(InstKind::MLoad)
@@ -610,8 +611,8 @@ impl StorageScalarPromoter {
                         InstKind::MStore(_, _) => self.stats.stores_promoted += 1,
                         _ => {}
                     }
-                    func.instructions[inst_id].kind = new_kind;
-                    func.instructions[inst_id].metadata.set_storage_alias(None);
+                    func.instruction_mut(inst_id).kind = new_kind;
+                    func.instruction_mut(inst_id).metadata.set_storage_alias(None);
                 }
             }
         }
@@ -631,9 +632,9 @@ impl StorageScalarPromoter {
             // need to update the dirty flag.
             let track_dirty = loop_data.blocks.contains(block_id);
             let mut index = 0;
-            while index < func.blocks[block_id].instructions.len() {
-                let inst_id = func.blocks[block_id].instructions[index];
-                let replacement = match &func.instructions[inst_id].kind {
+            while index < func.block(block_id).instructions.len() {
+                let inst_id = func.block(block_id).instructions[index];
+                let replacement = match &func.instruction(inst_id).kind {
                     InstKind::SLoad(slot)
                         if self.storage_alias(func, inst_id, *slot) == candidate.slot =>
                     {
@@ -653,16 +654,16 @@ impl StorageScalarPromoter {
                         InstKind::MStore(_, _) => self.stats.stores_promoted += 1,
                         _ => {}
                     }
-                    func.instructions[inst_id].kind = new_kind;
-                    func.instructions[inst_id].metadata.set_storage_alias(None);
+                    func.instruction_mut(inst_id).kind = new_kind;
+                    func.instruction_mut(inst_id).metadata.set_storage_alias(None);
                     if track_dirty
                         && let (Some(dirty_addr), Some(dirty_value)) =
                             (promoted.dirty_addr, promoted.dirty_value)
-                        && matches!(func.instructions[inst_id].kind, InstKind::MStore(_, _))
+                        && matches!(func.instruction(inst_id).kind, InstKind::MStore(_, _))
                     {
                         let dirty_store =
                             self.alloc_void_inst(func, InstKind::MStore(dirty_addr, dirty_value));
-                        func.blocks[block_id].instructions.insert(index + 1, dirty_store);
+                        func.block_mut(block_id).instructions.insert(index + 1, dirty_store);
                         index += 1;
                     }
                 }
@@ -694,30 +695,33 @@ impl StorageScalarPromoter {
         let candidate = &promoted.candidate;
         match candidate.init_store {
             Some(init_store) => {
-                if let InstKind::SStore(_, init) = &func.instructions[init_store].kind {
-                    func.instructions[init_store].kind =
+                if let InstKind::SStore(_, init) = &func.instruction(init_store).kind {
+                    func.instruction_mut(init_store).kind =
                         InstKind::MStore(promoted.temp_addr, *init);
-                    func.instructions[init_store].metadata.set_storage_alias(None);
+                    func.instruction_mut(init_store).metadata.set_storage_alias(None);
                     self.stats.stores_promoted += 1;
                 }
 
-                let init_pos = func.blocks[candidate.preheader]
+                let init_pos = func
+                    .block(candidate.preheader)
                     .instructions
                     .iter()
                     .position(|&inst_id| inst_id == init_store)
                     .expect("candidate init store should be in the preheader");
-                for &inst_id in &func.blocks[candidate.preheader].instructions[init_pos + 1..] {
-                    if let InstKind::SLoad(load_slot) = &func.instructions[inst_id].kind
+                let later_insts =
+                    func.block(candidate.preheader).instructions[init_pos + 1..].to_vec();
+                for inst_id in later_insts {
+                    if let InstKind::SLoad(load_slot) = &func.instruction(inst_id).kind
                         && self.storage_alias(func, inst_id, *load_slot) == candidate.slot
                     {
-                        func.instructions[inst_id].kind = InstKind::MLoad(promoted.temp_addr);
-                        func.instructions[inst_id].metadata.set_storage_alias(None);
+                        func.instruction_mut(inst_id).kind = InstKind::MLoad(promoted.temp_addr);
+                        func.instruction_mut(inst_id).metadata.set_storage_alias(None);
                         self.stats.loads_promoted += 1;
                     }
                 }
             }
             None => {
-                let insert_pos = func.blocks[candidate.preheader].instructions.len();
+                let insert_pos = func.block(candidate.preheader).instructions.len();
                 let mut inserted = 0;
 
                 if candidate.needs_initial_load {
@@ -728,11 +732,11 @@ impl StorageScalarPromoter {
                     );
                     let store_inst = self
                         .alloc_void_inst(func, InstKind::MStore(promoted.temp_addr, load_value));
-                    func.blocks[candidate.preheader]
+                    func.block_mut(candidate.preheader)
                         .instructions
                         .insert(insert_pos + inserted, load_inst);
                     inserted += 1;
-                    func.blocks[candidate.preheader]
+                    func.block_mut(candidate.preheader)
                         .instructions
                         .insert(insert_pos + inserted, store_inst);
                     inserted += 1;
@@ -742,7 +746,7 @@ impl StorageScalarPromoter {
                     let false_word = self.bool_word(func, false);
                     let dirty_store =
                         self.alloc_void_inst(func, InstKind::MStore(dirty_addr, false_word));
-                    func.blocks[candidate.preheader]
+                    func.block_mut(candidate.preheader)
                         .instructions
                         .insert(insert_pos + inserted, dirty_store);
                 }
@@ -763,13 +767,14 @@ impl StorageScalarPromoter {
         let store_inst =
             func.alloc_inst(Instruction::new(InstKind::SStore(slot_value, load_value), None));
 
-        let insert_pos = func.blocks[exit]
+        let insert_pos = func
+            .block(exit)
             .instructions
             .iter()
-            .take_while(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+            .take_while(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
             .count();
-        func.blocks[exit].instructions.insert(insert_pos, store_inst);
-        func.blocks[exit].instructions.insert(insert_pos, load_inst);
+        func.block_mut(exit).instructions.insert(insert_pos, store_inst);
+        func.block_mut(exit).instructions.insert(insert_pos, load_inst);
     }
 
     fn insert_conditional_final_store(
@@ -783,15 +788,15 @@ impl StorageScalarPromoter {
         let continuation = func.alloc_block();
         let store_block = func.alloc_block();
 
-        let old_instructions = std::mem::take(&mut func.blocks[exit].instructions);
-        let old_terminator = func.blocks[exit].terminator.take();
+        let old_instructions = std::mem::take(&mut func.block_mut(exit).instructions);
+        let old_terminator = func.block_mut(exit).terminator.take();
         let old_successors =
             old_terminator.as_ref().map(Terminator::successors).unwrap_or_default();
 
         // Keep existing exit phis in place; only the non-phi tail moves behind the dirty check.
         let split_pos = old_instructions
             .iter()
-            .take_while(|&&inst_id| matches!(func.instructions[inst_id].kind, InstKind::Phi(_)))
+            .take_while(|&&inst_id| matches!(func.instruction(inst_id).kind, InstKind::Phi(_)))
             .count();
         let mut exit_instructions = old_instructions[..split_pos].to_vec();
         let continuation_instructions = old_instructions[split_pos..].to_vec();
@@ -801,8 +806,8 @@ impl StorageScalarPromoter {
         let dirty_value = func.alloc_value(Value::Inst(dirty_load_inst));
         exit_instructions.push(dirty_load_inst);
 
-        func.blocks[exit].instructions = exit_instructions;
-        func.blocks[exit].terminator = Some(Terminator::Branch {
+        func.block_mut(exit).instructions = exit_instructions;
+        func.block_mut(exit).terminator = Some(Terminator::Branch {
             condition: dirty_value,
             then_block: store_block,
             else_block: continuation,
@@ -814,19 +819,19 @@ impl StorageScalarPromoter {
         let store_inst =
             func.alloc_inst(Instruction::new(InstKind::SStore(slot_value, load_value), None));
 
-        func.blocks[store_block].predecessors.push(exit);
-        func.blocks[store_block].instructions.push(load_inst);
-        func.blocks[store_block].instructions.push(store_inst);
-        func.blocks[store_block].terminator = Some(Terminator::Jump(continuation));
+        func.block_mut(store_block).predecessors.push(exit);
+        func.block_mut(store_block).instructions.push(load_inst);
+        func.block_mut(store_block).instructions.push(store_inst);
+        func.block_mut(store_block).terminator = Some(Terminator::Jump(continuation));
 
-        func.blocks[continuation].predecessors.push(exit);
-        func.blocks[continuation].predecessors.push(store_block);
-        func.blocks[continuation].instructions = continuation_instructions;
-        func.blocks[continuation].terminator = old_terminator;
+        func.block_mut(continuation).predecessors.push(exit);
+        func.block_mut(continuation).predecessors.push(store_block);
+        func.block_mut(continuation).instructions = continuation_instructions;
+        func.block_mut(continuation).terminator = old_terminator;
 
         self.redirect_successor_phi_incoming(func, exit, continuation, &old_successors);
         for successor in old_successors {
-            for pred in &mut func.blocks[successor].predecessors {
+            for pred in &mut func.block_mut(successor).predecessors {
                 if *pred == exit {
                     *pred = continuation;
                 }
@@ -849,12 +854,12 @@ impl StorageScalarPromoter {
         successors: &[BlockId],
     ) {
         for &successor in successors {
-            for idx in 0..func.blocks[successor].instructions.len() {
-                let inst_id = func.blocks[successor].instructions[idx];
-                if !matches!(func.instructions[inst_id].kind, InstKind::Phi(_)) {
+            for idx in 0..func.block(successor).instructions.len() {
+                let inst_id = func.block(successor).instructions[idx];
+                if !matches!(func.instruction(inst_id).kind, InstKind::Phi(_)) {
                     break;
                 }
-                let InstKind::Phi(incoming) = &mut func.instructions[inst_id].kind else {
+                let InstKind::Phi(incoming) = &mut func.instruction_mut(inst_id).kind else {
                     continue;
                 };
                 for (pred, _) in incoming {
@@ -907,7 +912,7 @@ impl StorageScalarPromoter {
             Value::Inst(inst_id) => loop_data
                 .blocks
                 .iter()
-                .any(|block_id| func.blocks[block_id].instructions.contains(inst_id)),
+                .any(|block_id| func.block(block_id).instructions.contains(inst_id)),
             Value::Undef(_) | Value::Error(_) => true,
             Value::Arg { .. } | Value::Immediate(_) => false,
         }
@@ -960,7 +965,7 @@ mod tests {
         ty: Option<MirType>,
     ) -> (InstId, ValueId) {
         let inst = func.alloc_inst(Instruction::new(kind, ty));
-        func.blocks[block].instructions.push(inst);
+        func.block_mut(block).instructions.push(inst);
         let value = func.alloc_value(Value::Inst(inst));
         (inst, value)
     }
@@ -987,16 +992,16 @@ mod tests {
         let cond = imm(&mut func, 1);
 
         let entry_store = inst(&mut func, entry, InstKind::SStore(slot, one), None);
-        func.blocks[entry].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(entry);
+        func.block_mut(entry).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(entry);
 
-        func.blocks[header].terminator =
+        func.block_mut(header).terminator =
             Some(Terminator::Branch { condition: cond, then_block: body, else_block: exit });
-        func.blocks[body].predecessors.push(header);
-        func.blocks[exit].predecessors.push(header);
+        func.block_mut(body).predecessors.push(header);
+        func.block_mut(exit).predecessors.push(header);
 
         let body_load = inst(&mut func, body, InstKind::SLoad(slot), Some(MirType::uint256()));
-        let loaded = match func.values.iter_enumerated().find_map(|(value_id, value)| match value {
+        let loaded = match func.values_enumerated().find_map(|(value_id, value)| match value {
             Value::Inst(inst_id) if *inst_id == body_load => Some(value_id),
             _ => None,
         }) {
@@ -1004,22 +1009,21 @@ mod tests {
             None => panic!("missing load result"),
         };
         let mul = inst(&mut func, body, InstKind::Mul(loaded, two), Some(MirType::uint256()));
-        let product =
-            match func.values.iter_enumerated().find_map(|(value_id, value)| match value {
-                Value::Inst(inst_id) if *inst_id == mul => Some(value_id),
-                _ => None,
-            }) {
-                Some(value) => value,
-                None => panic!("missing product result"),
-            };
+        let product = match func.values_enumerated().find_map(|(value_id, value)| match value {
+            Value::Inst(inst_id) if *inst_id == mul => Some(value_id),
+            _ => None,
+        }) {
+            Some(value) => value,
+            None => panic!("missing product result"),
+        };
         let body_store = inst(&mut func, body, InstKind::SStore(slot, product), None);
-        func.blocks[body].terminator = Some(Terminator::Jump(update));
-        func.blocks[update].predecessors.push(body);
+        func.block_mut(body).terminator = Some(Terminator::Jump(update));
+        func.block_mut(update).predecessors.push(body);
 
-        func.blocks[update].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(update);
+        func.block_mut(update).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(update);
 
-        func.blocks[exit].terminator = Some(Terminator::Stop);
+        func.block_mut(exit).terminator = Some(Terminator::Stop);
 
         TestLoop { func, entry_store, body_load, body_store, exit }
     }
@@ -1038,16 +1042,16 @@ mod tests {
         let two = imm(&mut func, 2);
         let cond = imm(&mut func, 1);
 
-        func.blocks[entry].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(entry);
+        func.block_mut(entry).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(entry);
 
-        func.blocks[header].terminator =
+        func.block_mut(header).terminator =
             Some(Terminator::Branch { condition: cond, then_block: body, else_block: exit });
-        func.blocks[body].predecessors.push(header);
-        func.blocks[exit].predecessors.push(header);
+        func.block_mut(body).predecessors.push(header);
+        func.block_mut(exit).predecessors.push(header);
 
         let body_load = inst(&mut func, body, InstKind::SLoad(slot), Some(MirType::uint256()));
-        let loaded = match func.values.iter_enumerated().find_map(|(value_id, value)| match value {
+        let loaded = match func.values_enumerated().find_map(|(value_id, value)| match value {
             Value::Inst(inst_id) if *inst_id == body_load => Some(value_id),
             _ => None,
         }) {
@@ -1055,7 +1059,7 @@ mod tests {
             None => panic!("missing load result"),
         };
         let add = inst(&mut func, body, InstKind::Add(loaded, two), Some(MirType::uint256()));
-        let sum = match func.values.iter_enumerated().find_map(|(value_id, value)| match value {
+        let sum = match func.values_enumerated().find_map(|(value_id, value)| match value {
             Value::Inst(inst_id) if *inst_id == add => Some(value_id),
             _ => None,
         }) {
@@ -1063,13 +1067,13 @@ mod tests {
             None => panic!("missing sum result"),
         };
         let body_store = inst(&mut func, body, InstKind::SStore(slot, sum), None);
-        func.blocks[body].terminator = Some(Terminator::Jump(update));
-        func.blocks[update].predecessors.push(body);
+        func.block_mut(body).terminator = Some(Terminator::Jump(update));
+        func.block_mut(update).predecessors.push(body);
 
-        func.blocks[update].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(update);
+        func.block_mut(update).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(update);
 
-        func.blocks[exit].terminator = Some(Terminator::Stop);
+        func.block_mut(exit).terminator = Some(Terminator::Stop);
 
         NoInitLoop { func, body_load, body_store, exit }
     }
@@ -1088,22 +1092,22 @@ mod tests {
         let value = imm(&mut func, 2);
         let cond = imm(&mut func, 1);
 
-        func.blocks[entry].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(entry);
+        func.block_mut(entry).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(entry);
 
-        func.blocks[header].terminator =
+        func.block_mut(header).terminator =
             Some(Terminator::Branch { condition: cond, then_block: body, else_block: exit });
-        func.blocks[body].predecessors.push(header);
-        func.blocks[exit].predecessors.push(header);
+        func.block_mut(body).predecessors.push(header);
+        func.block_mut(exit).predecessors.push(header);
 
         let body_store = inst(&mut func, body, InstKind::SStore(slot, value), None);
-        func.blocks[body].terminator = Some(Terminator::Jump(update));
-        func.blocks[update].predecessors.push(body);
+        func.block_mut(body).terminator = Some(Terminator::Jump(update));
+        func.block_mut(update).predecessors.push(body);
 
-        func.blocks[update].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(update);
+        func.block_mut(update).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(update);
 
-        func.blocks[exit].terminator = Some(Terminator::Stop);
+        func.block_mut(exit).terminator = Some(Terminator::Stop);
 
         NoInitLoop { func, body_load: body_store, body_store, exit }
     }
@@ -1125,26 +1129,26 @@ mod tests {
         let cond = imm(&mut func, 1);
 
         let entry_store = inst(&mut func, entry, InstKind::SStore(slot, one), None);
-        func.blocks[entry].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(entry);
+        func.block_mut(entry).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(entry);
 
-        func.blocks[header].terminator =
+        func.block_mut(header).terminator =
             Some(Terminator::Branch { condition: cond, then_block: body, else_block: exit });
-        func.blocks[body].predecessors.push(header);
-        func.blocks[exit].predecessors.push(header);
+        func.block_mut(body).predecessors.push(header);
+        func.block_mut(exit).predecessors.push(header);
 
         let (body_load, loaded) =
             inst_value(&mut func, body, InstKind::SLoad(slot), Some(MirType::uint256()));
         let (_, product) =
             inst_value(&mut func, body, InstKind::Mul(loaded, two), Some(MirType::uint256()));
         let body_store = inst(&mut func, body, InstKind::SStore(slot, product), None);
-        func.blocks[body].terminator = Some(Terminator::Jump(update));
-        func.blocks[update].predecessors.push(body);
+        func.block_mut(body).terminator = Some(Terminator::Jump(update));
+        func.block_mut(update).predecessors.push(body);
 
-        func.blocks[update].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(update);
+        func.block_mut(update).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(update);
 
-        func.blocks[exit].terminator = Some(Terminator::Stop);
+        func.block_mut(exit).terminator = Some(Terminator::Stop);
 
         TestLoop { func, entry_store, body_load, body_store, exit }
     }
@@ -1165,13 +1169,13 @@ mod tests {
         let two = imm(&mut func, 2);
         let cond = imm(&mut func, 1);
 
-        func.blocks[entry].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(entry);
+        func.block_mut(entry).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(entry);
 
-        func.blocks[header].terminator =
+        func.block_mut(header).terminator =
             Some(Terminator::Branch { condition: cond, then_block: body, else_block: exit });
-        func.blocks[body].predecessors.push(header);
-        func.blocks[exit].predecessors.push(header);
+        func.block_mut(body).predecessors.push(header);
+        func.block_mut(exit).predecessors.push(header);
 
         let (_, slot) =
             inst_value(&mut func, body, InstKind::Add(seed, zero), Some(MirType::uint256()));
@@ -1180,13 +1184,13 @@ mod tests {
         let (_, sum) =
             inst_value(&mut func, body, InstKind::Add(loaded, two), Some(MirType::uint256()));
         let body_store = inst(&mut func, body, InstKind::SStore(slot, sum), None);
-        func.blocks[body].terminator = Some(Terminator::Jump(update));
-        func.blocks[update].predecessors.push(body);
+        func.block_mut(body).terminator = Some(Terminator::Jump(update));
+        func.block_mut(update).predecessors.push(body);
 
-        func.blocks[update].terminator = Some(Terminator::Jump(header));
-        func.blocks[header].predecessors.push(update);
+        func.block_mut(update).terminator = Some(Terminator::Jump(header));
+        func.block_mut(header).predecessors.push(update);
 
-        func.blocks[exit].terminator = Some(Terminator::Stop);
+        func.block_mut(exit).terminator = Some(Terminator::Stop);
 
         NoInitLoop { func, body_load, body_store, exit }
     }
@@ -1196,8 +1200,7 @@ mod tests {
         let const_slot = imm(&mut test.func, 0);
         let body = test
             .func
-            .blocks
-            .iter_enumerated()
+            .blocks_enumerated()
             .find_map(|(block_id, block)| {
                 block.instructions.contains(&test.body_load).then_some(block_id)
             })
@@ -1215,15 +1218,15 @@ mod tests {
         assert_eq!(stats.loops_promoted, 1);
         assert_eq!(stats.loads_promoted, 1);
         assert_eq!(stats.stores_promoted, 2);
-        assert!(matches!(test.func.instructions[test.entry_store].kind, InstKind::MStore(_, _)));
-        assert!(matches!(test.func.instructions[test.body_load].kind, InstKind::MLoad(_)));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::MStore(_, _)));
+        assert!(matches!(test.func.instruction(test.entry_store).kind, InstKind::MStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_load).kind, InstKind::MLoad(_)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::MStore(_, _)));
         assert!(matches!(
-            test.func.instructions[test.func.blocks[test.exit].instructions[0]].kind,
+            test.func.instruction(test.func.block(test.exit).instructions[0]).kind,
             InstKind::MLoad(_)
         ));
         assert!(matches!(
-            test.func.instructions[test.func.blocks[test.exit].instructions[1]].kind,
+            test.func.instruction(test.func.block(test.exit).instructions[1]).kind,
             InstKind::SStore(_, _)
         ));
     }
@@ -1235,9 +1238,9 @@ mod tests {
         let stats = pass.run(&mut test.func);
 
         assert_eq!(stats.loops_promoted, 0);
-        assert!(matches!(test.func.instructions[test.entry_store].kind, InstKind::SStore(_, _)));
-        assert!(matches!(test.func.instructions[test.body_load].kind, InstKind::SLoad(_)));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::SStore(_, _)));
+        assert!(matches!(test.func.instruction(test.entry_store).kind, InstKind::SStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_load).kind, InstKind::SLoad(_)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::SStore(_, _)));
     }
 
     #[test]
@@ -1251,21 +1254,21 @@ mod tests {
         assert_eq!(stats.loads_promoted, 1);
         assert_eq!(stats.stores_promoted, 1);
         assert!(matches!(
-            test.func.instructions[test.func.blocks[entry].instructions[0]].kind,
+            test.func.instruction(test.func.block(entry).instructions[0]).kind,
             InstKind::SLoad(_)
         ));
         assert!(matches!(
-            test.func.instructions[test.func.blocks[entry].instructions[1]].kind,
+            test.func.instruction(test.func.block(entry).instructions[1]).kind,
             InstKind::MStore(_, _)
         ));
         assert!(matches!(
-            test.func.instructions[test.func.blocks[entry].instructions[2]].kind,
+            test.func.instruction(test.func.block(entry).instructions[2]).kind,
             InstKind::MStore(_, _)
         ));
-        assert!(matches!(test.func.instructions[test.body_load].kind, InstKind::MLoad(_)));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::MStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_load).kind, InstKind::MLoad(_)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::MStore(_, _)));
 
-        let dirty_store_pos = test.func.blocks.iter().find_map(|block| {
+        let dirty_store_pos = test.func.blocks().find_map(|block| {
             block
                 .instructions
                 .iter()
@@ -1276,28 +1279,28 @@ mod tests {
             panic!("missing promoted body store");
         };
         assert!(matches!(
-            test.func.instructions[body_block.instructions[dirty_store_pos]].kind,
+            test.func.instruction(body_block.instructions[dirty_store_pos]).kind,
             InstKind::MStore(_, _)
         ));
 
         assert!(matches!(
-            test.func.instructions[test.func.blocks[test.exit].instructions[0]].kind,
+            test.func.instruction(test.func.block(test.exit).instructions[0]).kind,
             InstKind::MLoad(_)
         ));
         let Some(Terminator::Branch { then_block, else_block, .. }) =
-            test.func.blocks[test.exit].terminator.as_ref()
+            test.func.block(test.exit).terminator.as_ref()
         else {
             panic!("dirty exit should branch");
         };
         assert!(matches!(
-            test.func.instructions[test.func.blocks[*then_block].instructions[0]].kind,
+            test.func.instruction(test.func.block(*then_block).instructions[0]).kind,
             InstKind::MLoad(_)
         ));
         assert!(matches!(
-            test.func.instructions[test.func.blocks[*then_block].instructions[1]].kind,
+            test.func.instruction(test.func.block(*then_block).instructions[1]).kind,
             InstKind::SStore(_, _)
         ));
-        assert_eq!(test.func.blocks[*else_block].terminator, Some(Terminator::Stop));
+        assert_eq!(test.func.block(*else_block).terminator, Some(Terminator::Stop));
     }
 
     #[test]
@@ -1310,27 +1313,27 @@ mod tests {
         assert_eq!(stats.loops_promoted, 1);
         assert_eq!(stats.loads_promoted, 0);
         assert_eq!(stats.stores_promoted, 1);
-        assert_eq!(test.func.blocks[entry].instructions.len(), 1);
+        assert_eq!(test.func.block(entry).instructions.len(), 1);
         assert!(matches!(
-            test.func.instructions[test.func.blocks[entry].instructions[0]].kind,
+            test.func.instruction(test.func.block(entry).instructions[0]).kind,
             InstKind::MStore(_, _)
         ));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::MStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::MStore(_, _)));
 
         let Some(Terminator::Branch { then_block, else_block, .. }) =
-            test.func.blocks[test.exit].terminator.as_ref()
+            test.func.block(test.exit).terminator.as_ref()
         else {
             panic!("dirty exit should branch");
         };
         assert!(matches!(
-            test.func.instructions[test.func.blocks[*then_block].instructions[0]].kind,
+            test.func.instruction(test.func.block(*then_block).instructions[0]).kind,
             InstKind::MLoad(_)
         ));
         assert!(matches!(
-            test.func.instructions[test.func.blocks[*then_block].instructions[1]].kind,
+            test.func.instruction(test.func.block(*then_block).instructions[1]).kind,
             InstKind::SStore(_, _)
         ));
-        assert_eq!(test.func.blocks[*else_block].terminator, Some(Terminator::Stop));
+        assert_eq!(test.func.block(*else_block).terminator, Some(Terminator::Stop));
     }
 
     #[test]
@@ -1342,9 +1345,9 @@ mod tests {
         assert_eq!(stats.loops_promoted, 1);
         assert_eq!(stats.loads_promoted, 1);
         assert_eq!(stats.stores_promoted, 2);
-        assert!(matches!(test.func.instructions[test.entry_store].kind, InstKind::MStore(_, _)));
-        assert!(matches!(test.func.instructions[test.body_load].kind, InstKind::MLoad(_)));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::MStore(_, _)));
+        assert!(matches!(test.func.instruction(test.entry_store).kind, InstKind::MStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_load).kind, InstKind::MLoad(_)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::MStore(_, _)));
     }
 
     #[test]
@@ -1354,8 +1357,8 @@ mod tests {
         let stats = pass.run(&mut test.func);
 
         assert_eq!(stats.loops_promoted, 0);
-        assert!(matches!(test.func.instructions[test.body_load].kind, InstKind::SLoad(_)));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::SStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_load).kind, InstKind::SLoad(_)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::SStore(_, _)));
     }
 
     #[test]
@@ -1365,8 +1368,8 @@ mod tests {
         let stats = pass.run(&mut test.func);
 
         assert_eq!(stats.loops_promoted, 0);
-        assert!(matches!(test.func.instructions[test.entry_store].kind, InstKind::SStore(_, _)));
-        assert!(matches!(test.func.instructions[test.body_load].kind, InstKind::SLoad(_)));
-        assert!(matches!(test.func.instructions[test.body_store].kind, InstKind::SStore(_, _)));
+        assert!(matches!(test.func.instruction(test.entry_store).kind, InstKind::SStore(_, _)));
+        assert!(matches!(test.func.instruction(test.body_load).kind, InstKind::SLoad(_)));
+        assert!(matches!(test.func.instruction(test.body_store).kind, InstKind::SStore(_, _)));
     }
 }


### PR DESCRIPTION
MIR values, instructions, blocks, and functions were stored in crate-visible `IndexVec`s, so passes and tests could bypass the typed lookup API, replace backing storage directly, and construct states that the IR owners guarantee cannot exist. EVM IR blocks had the same problem.

This makes those tables private and routes lookup, iteration, mutation, allocation, and counts through the owning `Function` or `Module`. Block and function compaction now also live on those owners, which keeps storage replacement and ID remapping behind the same boundary.

Passes, lowering, backend codegen, parsers, and tests now use the typed API. The validator test that cleared the entire block table is removed because every MIR function has an entry block by construction, and the remaining phase-validation test uses an exact diagnostic snapshot.