### PR TITLE
test: snapshot string output

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2 }
 status-level = "leak"
+
+[profile.ci]
+fail-fast = false
+status-level = "all"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,10 @@ jobs:
       - name: build
         run: cargo build
       - name: test
-        run: cargo nextest run --workspace
+        run: cargo nextest run --profile ci --workspace
       - name: test --features nightly
         if: matrix.rust == 'nightly'
-        run: cargo nextest run --workspace --features nightly
+        run: cargo nextest run --profile ci --workspace --features nightly
       - name: doctest
         run: cargo test --doc --workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,6 +3500,7 @@ dependencies = [
  "colorchoice",
  "serde",
  "serde_json",
+ "snapbox",
  "strum 0.28.0",
  "vergen-gitcl",
 ]

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -772,10 +772,18 @@ error: [bb0] entry block must have no predecessors
 
             Validator::new(&sess.dcx).validate_module(&module);
             assert!(sess.dcx.has_errors().is_err());
-            let diagnostics = sess.emitted_diagnostics().unwrap().to_string();
-            assert!(diagnostics.contains("slice instruction"));
-            assert!(diagnostics.contains("ABI encoding instruction"));
-            assert!(diagnostics.contains("aggregate instruction"));
+            assert_data_eq!(
+                sess.emitted_diagnostics().unwrap().to_string(),
+                str![[r#"
+error: [fn0] [bb0, inst0] slice instruction `make_memory_slice` survives the `evm-shaped` phase boundary
+
+error: [fn0] [bb0, inst1] ABI encoding instruction `abi_encode` survives the `evm-shaped` phase boundary
+
+error: [fn0] [bb0, inst2] aggregate instruction `storage_to_memory` survives the `evm-shaped` phase boundary
+
+
+"#]]
+            );
         });
     }
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -32,6 +32,7 @@ serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
+snapbox.workspace = true
 
 [features]
 nightly = []

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -408,6 +408,7 @@ pub struct UnstableOpts {
 mod tests {
     use super::*;
     use clap::CommandFactory;
+    use snapbox::{assert_data_eq, str};
 
     #[test]
     fn verify_cli() {
@@ -451,14 +452,36 @@ mod tests {
             CompileOpts::try_parse_from(["solar", "--standard-json", "input1.json", "input2.json"])
                 .unwrap();
         let error = opts.finish().unwrap_err().render().ansi().to_string();
-        assert!(error.contains("Too many input files for --standard-json."));
+        assert_data_eq!(
+            error,
+            str![[r#"
+[1m[31merror:[0m Too many input files for --standard-json.
+Please either specify a single file name or provide its content on standard input.
+
+[1m[4mUsage:[0m [1msolar[0m [OPTIONS] [INPUT]...
+
+For more information, try '[1m--help[0m'.
+
+"#]]
+        );
     }
 
     #[test]
     fn standard_json_rejects_remappings() {
         let mut opts = CompileOpts::try_parse_from(["solar", "--standard-json", "a=b"]).unwrap();
         let error = opts.finish().unwrap_err().render().ansi().to_string();
-        assert!(error.contains("Import remappings are not accepted on the command line"));
+        assert_data_eq!(
+            error,
+            str![[r#"
+[1m[31merror:[0m Import remappings are not accepted on the command line in Standard JSON mode.
+Please put them under 'settings.remappings' in the JSON input.
+
+[1m[4mUsage:[0m [1msolar[0m [OPTIONS] [INPUT]...
+
+For more information, try '[1m--help[0m'.
+
+"#]]
+        );
     }
 
     #[test]

--- a/crates/interface/src/diagnostics/emitter/json.rs
+++ b/crates/interface/src/diagnostics/emitter/json.rs
@@ -501,6 +501,7 @@ fn to_severity(level: Level) -> Severity {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapbox::{Assert, str};
 
     #[test]
     fn whole_line_deletion_includes_newline() {
@@ -543,8 +544,12 @@ mod tests {
         };
 
         let json = serde_json::to_string(&diagnostic).unwrap();
-        assert!(json.contains(r#""type":"Exception\nquoted""#));
-        assert!(json.contains(r#""message":"borrowed \"message\"""#));
+        Assert::new().normalize_paths(false).eq(
+            json,
+            str![[
+                r#"{"sourceLocation":{"file":"input.sol","start":0,"end":1,"message":"borrowed \"message\""},"secondarySourceLocations":[],"type":"Exception\nquoted","component":"general","severity":"error","errorCode":"1234","message":"borrowed message","formattedMessage":null}"#
+            ]],
+        );
 
         assert!(matches!(diagnostic.r#type, Cow::Borrowed(_)));
         assert!(matches!(diagnostic.component, Cow::Borrowed("general")));

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1387,15 +1387,19 @@ note: mutable variables should use mixedCase
 
         let formatted = [ColorChoice::Always, ColorChoice::Auto].map(|color| {
             let mut emitter = JsonEmitter::new(Box::new(std::io::sink()), Arc::clone(&sm), color);
-            emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap()
+            let formatted = emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap();
+            let has_ansi = formatted.bytes().any(|byte| byte == b'\x1b');
+            format!("ansi: {has_ansi}\n{}", anstream::adapter::strip_str(&formatted))
         });
         assert_data_eq!(
             formatted.join("\n---\n"),
             str![[r#"
-[1m[91merror[0m[1m: mismatched types[0m
+ansi: true
+error: mismatched types
 
 
 ---
+ansi: false
 error: mismatched types
 
 

--- a/crates/interface/src/diagnostics/mod.rs
+++ b/crates/interface/src/diagnostics/mod.rs
@@ -1385,11 +1385,22 @@ note: mutable variables should use mixedCase
         sm.new_source_file(source_map::FileName::custom("test.sol"), CONTRACT.to_string()).unwrap();
         let diagnostic = Diag::new(Level::Error, "mismatched types");
 
-        for (color, expected) in [(ColorChoice::Always, true), (ColorChoice::Auto, false)] {
+        let formatted = [ColorChoice::Always, ColorChoice::Auto].map(|color| {
             let mut emitter = JsonEmitter::new(Box::new(std::io::sink()), Arc::clone(&sm), color);
-            let formatted = emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap();
-            assert_eq!(formatted.contains("\x1b["), expected, "{formatted:?}");
-        }
+            emitter.solc_diagnostic(&diagnostic).formatted_message.unwrap()
+        });
+        assert_data_eq!(
+            formatted.join("\n---\n"),
+            str![[r#"
+[1m[91merror[0m[1m: mismatched types[0m
+
+
+---
+error: mismatched types
+
+
+"#]]
+        );
     }
 
     #[test]
@@ -1420,26 +1431,40 @@ warning: confusable spelling
     #[test]
     fn test_allowed_diagnostic_code_suppresses_warning() {
         let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never)
-            .with_allowed_diagnostic_codes(["1234".to_string()]);
+            .with_allowed_diagnostic_codes(["1234".to_string()])
+            .with_flags(|flags| flags.track_diagnostics = false);
 
         dcx.warn("suppressed warning").code(crate::error_code!(1234)).emit();
         dcx.warn("emitted warning").code(crate::error_code!(5678)).emit();
 
-        let diagnostics = dcx.emitted_diagnostics().unwrap().to_string();
         assert_eq!(dcx.warn_count(), 1);
-        assert!(diagnostics.contains("emitted warning"));
-        assert!(!diagnostics.contains("suppressed warning"));
+        assert_data_eq!(
+            dcx.emitted_diagnostics().unwrap().to_string(),
+            str![[r#"
+warning[5678]: emitted warning
+
+
+"#]]
+        );
     }
 
     #[test]
     fn test_allowed_diagnostic_code_does_not_suppress_error() {
         let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never)
-            .with_allowed_diagnostic_codes(["1234".to_string()]);
+            .with_allowed_diagnostic_codes(["1234".to_string()])
+            .with_flags(|flags| flags.track_diagnostics = false);
 
         let _ = dcx.err("emitted error").code(crate::error_code!(1234)).emit();
 
         assert!(dcx.has_errors().is_err());
-        assert!(dcx.emitted_diagnostics().unwrap().to_string().contains("emitted error"));
+        assert_data_eq!(
+            dcx.emitted_diagnostics().unwrap().to_string(),
+            str![[r#"
+error[1234]: emitted error
+
+
+"#]]
+        );
     }
 
     #[test]

--- a/crates/interface/src/session.rs
+++ b/crates/interface/src/session.rs
@@ -517,7 +517,15 @@ fn in_rayon() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapbox::{assert_data_eq, str};
     use std::path::PathBuf;
+
+    fn buffer_session() -> Session {
+        let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never).with_flags(|flags| {
+            flags.track_diagnostics = false;
+        });
+        Session::builder().dcx(dcx).build()
+    }
 
     /// Session to test `enter`.
     fn enter_tests_session() -> Session {
@@ -599,11 +607,18 @@ mod tests {
         assert!(sess.emitted_diagnostics().is_none());
         assert!(sess.emitted_errors().is_none());
 
-        let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        let sess = buffer_session();
         sess.dcx.err("test").emit();
         let err = sess.dcx.emitted_errors().unwrap().unwrap_err();
         let err = Box::new(err) as Box<dyn std::error::Error>;
-        assert!(err.to_string().contains("error: test"), "{err:?}");
+        assert_data_eq!(
+            err.to_string(),
+            str![[r#"
+error: test
+
+
+"#]]
+        );
     }
 
     #[test]
@@ -640,19 +655,32 @@ mod tests {
 
     #[test]
     fn enter_diags() {
-        let sess = Session::builder().with_buffer_emitter(ColorChoice::Never).build();
+        let sess = buffer_session();
         assert!(sess.dcx.emitted_errors().unwrap().is_ok());
         sess.enter(|| {
             sess.dcx.err("test1").emit();
             assert!(sess.dcx.emitted_errors().unwrap().is_err());
         });
-        assert!(sess.dcx.emitted_errors().unwrap().unwrap_err().to_string().contains("test1"));
+        let test1 = sess.dcx.emitted_errors().unwrap().unwrap_err().to_string();
         sess.enter(|| {
             sess.dcx.err("test2").emit();
             assert!(sess.dcx.emitted_errors().unwrap().is_err());
         });
-        assert!(sess.dcx.emitted_errors().unwrap().unwrap_err().to_string().contains("test1"));
-        assert!(sess.dcx.emitted_errors().unwrap().unwrap_err().to_string().contains("test2"));
+        let test1_test2 = sess.dcx.emitted_errors().unwrap().unwrap_err().to_string();
+        assert_data_eq!(
+            format!("{test1}\n---\n{test1_test2}"),
+            str![[r#"
+error: test1
+
+
+---
+error: test1
+
+error: test2
+
+
+"#]]
+        );
     }
 
     #[test]

--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -2,6 +2,7 @@
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use lsp_types::{GotoDefinitionResponse, HoverContents, Position};
+use snapbox::{assert_data_eq, str};
 use solar_lsp::{
     BenchmarkAnalysis, BenchmarkProject, BenchmarkRequest, BenchmarkResponse,
     benchmark_selection_ranges,
@@ -201,7 +202,14 @@ fn assert_unifap_response(name: &str, response: BenchmarkResponse) {
             let HoverContents::Markup(markup) = hover.contents else {
                 panic!("the SELECTOR hover should contain markup")
             };
-            assert!(markup.value.contains("SELECTOR"));
+            assert_data_eq!(
+                markup.value,
+                str![[r#"
+```solidity
+bytes4 public constant SELECTOR
+```
+"#]]
+            );
         }
         (
             "goto-definition",
@@ -231,8 +239,16 @@ fn assert_unifap_response(name: &str, response: BenchmarkResponse) {
         }
         ("workspace-symbols", BenchmarkResponse::WorkspaceSymbols(symbols)) => {
             assert_eq!(symbols.len(), 3);
-            assert!(symbols.iter().all(|symbol| symbol.name.contains("UnifapV2Pair")));
-            assert!(symbols.iter().any(|symbol| symbol.name == "UnifapV2Pair"));
+            let mut names = symbols.iter().map(|symbol| symbol.name.as_str()).collect::<Vec<_>>();
+            names.sort_unstable();
+            assert_data_eq!(
+                names.join("\n"),
+                str![[r#"
+IUnifapV2Pair
+TestUnifapV2Pair
+UnifapV2Pair
+"#]]
+            );
         }
         _ => panic!("unexpected `{name}` response for the unifap-v2 benchmark"),
     }

--- a/crates/lsp/src/tests/hover.rs
+++ b/crates/lsp/src/tests/hover.rs
@@ -5,7 +5,7 @@ use lsp_types::{
     HoverContents, HoverParams, Position, TextDocumentIdentifier, TextDocumentPositionParams, Url,
     WorkDoneProgressParams,
 };
-use snapbox::str;
+use snapbox::{assert_data_eq, str};
 use solar_config::CompileOpts;
 use std::task::{Context, Poll, Waker};
 
@@ -1065,5 +1065,12 @@ fn waits_for_latest_analysis_before_returning_hover() {
     let HoverContents::Markup(contents) = hover.contents else {
         panic!("hover should use markdown");
     };
-    assert!(contents.value.contains("address newValue"));
+    assert_data_eq!(
+        contents.value,
+        str![[r#"
+```solidity
+address newValue
+```
+"#]]
+    );
 }

--- a/crates/sema/src/compiler.rs
+++ b/crates/sema/src/compiler.rs
@@ -306,11 +306,12 @@ fn log_ast_arenas_stats(arenas: &mut ThreadLocal<solar_ast::Arena>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapbox::{assert_data_eq, str};
     use std::path::PathBuf;
 
     // --- copy from `crates/interface/src/session.rs`
     use solar_ast::{Span, Symbol};
-    use solar_interface::{BytePos, ColorChoice};
+    use solar_interface::{BytePos, ColorChoice, diagnostics::DiagCtxt};
 
     /// Session to test `enter`.
     fn enter_tests_session() -> Session {
@@ -384,22 +385,20 @@ mod tests {
         assert_eq!(compiler.enter(|c| c.gcx().sources.asts().count()), 0);
     }
 
-    fn stage_test(expected: Result<(), &str>, f: fn(&mut CompilerRef<'_>)) {
-        let sess =
-            Session::builder().with_buffer_emitter(solar_interface::ColorChoice::Never).build();
+    fn stage_test(expect_error: bool, f: fn(&mut CompilerRef<'_>)) -> Option<String> {
+        let dcx = DiagCtxt::with_buffer_emitter(None, ColorChoice::Never).with_flags(|flags| {
+            flags.track_diagnostics = false;
+        });
+        let sess = Session::builder().dcx(dcx).build();
         let mut compiler = Compiler::new(sess);
         let r = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| compiler.enter_mut(f)));
         let errs = compiler.sess().dcx.emitted_errors().unwrap();
-        match expected {
-            Ok(()) => assert!(r.is_ok(), "panicked: {errs:#?}"),
-            Err(e) => {
-                assert!(r.is_err(), "didn't panic: {errs:#?}");
-                let errs = errs.unwrap_err();
-                let d = errs.to_string();
-                assert!(d.contains("invalid compiler stage transition:"), "{d}");
-                assert!(d.contains(e), "{d}");
-                assert!(d.contains("stages must be advanced sequentially"), "{d}");
-            }
+        if expect_error {
+            assert!(r.is_err(), "didn't panic: {errs:#?}");
+            Some(errs.unwrap_err().to_string())
+        } else {
+            assert!(r.is_ok(), "panicked: {errs:#?}");
+            None
         }
     }
 
@@ -411,36 +410,69 @@ mod tests {
 
     #[test]
     fn stage_tests() {
+        let mut diagnostics = Vec::new();
+
         // Backwards.
-        stage_test(Err("from `lowering` to `parsing`"), |c| {
+        diagnostics.extend(stage_test(true, |c| {
             parse_dummy_file(c);
             assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
             parse_dummy_file(c);
-        });
+        }));
 
         // Too far ahead.
-        stage_test(Err("from `none` to `analysis`"), |c| {
+        diagnostics.extend(stage_test(true, |c| {
             assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
-        });
+        }));
 
         // Same stage.
-        stage_test(Err("from `lowering` to `lowering`"), |c| {
+        diagnostics.extend(stage_test(true, |c| {
             parse_dummy_file(c);
             assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
             assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
             assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
-        });
-        stage_test(Err("from `analysis` to `analysis`"), |c| {
+        }));
+        diagnostics.extend(stage_test(true, |c| {
             parse_dummy_file(c);
             assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
             assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
             assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
-        });
+        }));
+
         // Parsing is special cased.
-        stage_test(Ok(()), |c| {
+        diagnostics.extend(stage_test(false, |c| {
             parse_dummy_file(c);
             parse_dummy_file(c);
-        });
+        }));
+
+        assert_data_eq!(
+            diagnostics.join("\n"),
+            str![[r#"
+error: internal compiler error: invalid compiler stage transition: cannot advance from `lowering` to `parsing`
+  │
+  ├ note: expected next stage: `analysis`
+  ╰ note: stages must be advanced sequentially
+
+
+error: internal compiler error: invalid compiler stage transition: cannot advance from `none` to `analysis`
+  │
+  ├ note: expected next stage: `parsing`
+  ╰ note: stages must be advanced sequentially
+
+
+error: internal compiler error: invalid compiler stage transition: cannot advance from `lowering` to `lowering`
+  │
+  ├ note: expected next stage: `analysis`
+  ╰ note: stages must be advanced sequentially
+
+
+error: internal compiler error: invalid compiler stage transition: cannot advance from `analysis` to `analysis`
+  │
+  ├ note: expected next stage: none (current stage is the last)
+  ╰ note: stages must be advanced sequentially
+
+
+"#]]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace substring-based assertions for diagnostics, hover text, JSON serialization, and LSP benchmark responses with exact snapbox snapshots. This catches unexpected output changes and shows the complete diff on failure; diagnostics with unstable creation-site locations disable tracking, and JSON path normalization is disabled so escaped backslashes remain covered.