### PR TITLE
refactor(codegen): rename MIR br to jumpi

### DIFF
--- a/crates/codegen/src/mir/block.rs
+++ b/crates/codegen/src/mir/block.rs
@@ -133,7 +133,7 @@ impl Terminator {
     pub(crate) const fn mnemonic(&self) -> &'static str {
         match self {
             Self::Jump(_) => "jump",
-            Self::Branch { .. } => "branch",
+            Self::Branch { .. } => "jumpi",
             Self::Switch { .. } => "switch",
             Self::Return { .. } => "return",
             Self::Revert { .. } => "revert",
@@ -179,7 +179,7 @@ impl fmt::Display for Terminator {
             Self::Branch { condition, then_block, else_block } => {
                 write!(
                     f,
-                    "branch v{}, bb{}, bb{}",
+                    "jumpi v{}, bb{}, bb{}",
                     condition.index(),
                     then_block.index(),
                     else_block.index()

--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -178,7 +178,7 @@ pub(crate) fn display_function_dot<'a>(
 /// fn @name(arg0: uint256, arg1: bool) -> uint256 {
 ///   bb0:
 ///     v0 = add arg0, 1
-///     br arg1, bb1, bb2
+///     jumpi arg1, bb1, bb2
 ///   bb1:
 ///     ret v0
 ///   bb2:
@@ -535,7 +535,7 @@ fn display_terminator<'a>(
         Terminator::Jump(target) => write!(f, "jump bb{}", target.index()),
         Terminator::Branch { condition, then_block, else_block } => write!(
             f,
-            "br {}, bb{}, bb{}",
+            "jumpi {}, bb{}, bb{}",
             display_val(*condition, func),
             then_block.index(),
             else_block.index()

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -838,7 +838,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
                 builder.set_terminator(Terminator::Jump(target));
                 return Ok(());
             }
-            sym::br => {
+            sym::jumpi => {
                 let condition = self.parse_value(builder)?;
                 self.parser.expect(TokenKind::Comma)?;
                 let then_block = self.parse_block_id(builder)?;

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -977,7 +977,6 @@ symbols! {
         assert,
         at,
         block,
-        br,
         built,
         calldata_array,
         calldata_bytes,

--- a/tests/ui/codegen/lowering/abi_decode_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_calldata_slice.stdout
@@ -5,7 +5,7 @@ fn @decode(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,7 +13,7 @@ fn @decode(arg0: calldataslice) {
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 4
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -25,7 +25,7 @@ fn @decode(arg0: calldataslice) {
     v9 = slice_len v8
     v10 = add v9, 31
     v11 = lt v10, v9
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -37,7 +37,7 @@ fn @decode(arg0: calldataslice) {
     v15 = select v14, 32, v13
     v16 = add 32, v15
     v17 = lt v16, v15
-    br v17, bb7, bb8
+    jumpi v17, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -53,7 +53,7 @@ fn @decode(arg0: calldataslice) {
     calldatacopy v19, v22, v9
     v23 = memory_object_len memorybytes, v18
     v24 = lt v23, 32
-    br v24, bb9, bb10
+    jumpi v24, bb9, bb10
   bb9:
     revert 0, 0
   bb10:

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.stdout
@@ -5,7 +5,7 @@ fn @decode(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -25,7 +25,7 @@ fn @decode(arg0: memorybytes) {
     mstore 192, 0
     v12 = memory_object_len memorybytes, v9
     v13 = lt v12, 96
-    br v13, bb3, bb4
+    jumpi v13, bb3, bb4
   bb3:
     revert 0, 0
   bb4:
@@ -34,18 +34,18 @@ fn @decode(arg0: memorybytes) {
     v16 = add v14, 32
     v17 = mload v16
     v18 = lt v17, 96
-    br v18, bb5, bb6
+    jumpi v18, bb5, bb6
   bb5:
     revert 0, 0
   bb6:
     v19 = add v17, 32
     v20 = lt v19, v17
-    br v20, bb7, bb8
+    jumpi v20, bb7, bb8
   bb7:
     revert 0, 0
   bb8:
     v21 = gt v19, v12
-    br v21, bb9, bb10
+    jumpi v21, bb9, bb10
   bb9:
     revert 0, 0
   bb10:
@@ -53,7 +53,7 @@ fn @decode(arg0: memorybytes) {
     v23 = mload v22
     v24 = add v23, 31
     v25 = lt v24, v23
-    br v25, bb11, bb12
+    jumpi v25, bb11, bb12
   bb11:
     revert 0, 0
   bb12:
@@ -61,12 +61,12 @@ fn @decode(arg0: memorybytes) {
     v27 = and v24, v26
     v28 = add v19, v27
     v29 = lt v28, v19
-    br v29, bb13, bb14
+    jumpi v29, bb13, bb14
   bb13:
     revert 0, 0
   bb14:
     v30 = gt v28, v12
-    br v30, bb15, bb16
+    jumpi v30, bb15, bb16
   bb15:
     revert 0, 0
   bb16:
@@ -74,7 +74,7 @@ fn @decode(arg0: memorybytes) {
     v32 = select v31, 32, v27
     v33 = add 32, v32
     v34 = lt v33, v32
-    br v34, bb17, bb18
+    jumpi v34, bb17, bb18
   bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -91,18 +91,18 @@ fn @decode(arg0: memorybytes) {
     v40 = add v14, 64
     v41 = mload v40
     v42 = lt v41, 96
-    br v42, bb19, bb20
+    jumpi v42, bb19, bb20
   bb19:
     revert 0, 0
   bb20:
     v43 = add v41, 32
     v44 = lt v43, v41
-    br v44, bb21, bb22
+    jumpi v44, bb21, bb22
   bb21:
     revert 0, 0
   bb22:
     v45 = gt v43, v12
-    br v45, bb23, bb24
+    jumpi v45, bb23, bb24
   bb23:
     revert 0, 0
   bb24:
@@ -110,7 +110,7 @@ fn @decode(arg0: memorybytes) {
     v47 = mload v46
     v48 = add v47, 31
     v49 = lt v48, v47
-    br v49, bb25, bb26
+    jumpi v49, bb25, bb26
   bb25:
     revert 0, 0
   bb26:
@@ -118,12 +118,12 @@ fn @decode(arg0: memorybytes) {
     v51 = and v48, v50
     v52 = add v43, v51
     v53 = lt v52, v43
-    br v53, bb27, bb28
+    jumpi v53, bb27, bb28
   bb27:
     revert 0, 0
   bb28:
     v54 = gt v52, v12
-    br v54, bb29, bb30
+    jumpi v54, bb29, bb30
   bb29:
     revert 0, 0
   bb30:
@@ -131,7 +131,7 @@ fn @decode(arg0: memorybytes) {
     v56 = select v55, 32, v51
     v57 = add 32, v56
     v58 = lt v57, v56
-    br v58, bb31, bb32
+    jumpi v58, bb31, bb32
   bb31:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -169,7 +169,7 @@ fn @decode(arg0: memorybytes) {
     v79 = and v78, v77
     v80 = add v73, 32
     v81 = iszero v79
-    br v81, bb34, bb33
+    jumpi v81, bb34, bb33
   bb33:
     v82 = sub v79, 32
     v83 = add v80, v82
@@ -189,7 +189,7 @@ fn @decode(arg0: memorybytes) {
     v91 = and v90, v89
     v92 = add v85, 32
     v93 = iszero v91
-    br v93, bb36, bb35
+    jumpi v93, bb36, bb35
   bb35:
     v94 = sub v91, 32
     v95 = add v92, v94
@@ -208,7 +208,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -251,7 +251,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v29 = and v28, v27
     v30 = add v23, 32
     v31 = iszero v29
-    br v31, bb4, bb3
+    jumpi v31, bb4, bb3
   bb3:
     v32 = sub v29, 32
     v33 = add v30, v32
@@ -271,7 +271,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v41 = and v40, v39
     v42 = add v35, 32
     v43 = iszero v41
-    br v43, bb6, bb5
+    jumpi v43, bb6, bb5
   bb5:
     v44 = sub v41, 32
     v45 = add v42, v44
@@ -288,7 +288,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     set_fmp v50
     v51 = memory_object_len memorybytes, v21
     v52 = lt v51, 96
-    br v52, bb7, bb8
+    jumpi v52, bb7, bb8
   bb7:
     revert 0, 0
   bb8:
@@ -297,18 +297,18 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v55 = add v53, 32
     v56 = mload v55
     v57 = lt v56, 96
-    br v57, bb9, bb10
+    jumpi v57, bb9, bb10
   bb9:
     revert 0, 0
   bb10:
     v58 = add v56, 32
     v59 = lt v58, v56
-    br v59, bb11, bb12
+    jumpi v59, bb11, bb12
   bb11:
     revert 0, 0
   bb12:
     v60 = gt v58, v51
-    br v60, bb13, bb14
+    jumpi v60, bb13, bb14
   bb13:
     revert 0, 0
   bb14:
@@ -316,7 +316,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v62 = mload v61
     v63 = add v62, 31
     v64 = lt v63, v62
-    br v64, bb15, bb16
+    jumpi v64, bb15, bb16
   bb15:
     revert 0, 0
   bb16:
@@ -324,12 +324,12 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v66 = and v63, v65
     v67 = add v58, v66
     v68 = lt v67, v58
-    br v68, bb17, bb18
+    jumpi v68, bb17, bb18
   bb17:
     revert 0, 0
   bb18:
     v69 = gt v67, v51
-    br v69, bb19, bb20
+    jumpi v69, bb19, bb20
   bb19:
     revert 0, 0
   bb20:
@@ -337,7 +337,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v71 = select v70, 32, v66
     v72 = add 32, v71
     v73 = lt v72, v71
-    br v73, bb21, bb22
+    jumpi v73, bb21, bb22
   bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -354,18 +354,18 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v79 = add v53, 64
     v80 = mload v79
     v81 = lt v80, 96
-    br v81, bb23, bb24
+    jumpi v81, bb23, bb24
   bb23:
     revert 0, 0
   bb24:
     v82 = add v80, 32
     v83 = lt v82, v80
-    br v83, bb25, bb26
+    jumpi v83, bb25, bb26
   bb25:
     revert 0, 0
   bb26:
     v84 = gt v82, v51
-    br v84, bb27, bb28
+    jumpi v84, bb27, bb28
   bb27:
     revert 0, 0
   bb28:
@@ -373,7 +373,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v86 = mload v85
     v87 = add v86, 31
     v88 = lt v87, v86
-    br v88, bb29, bb30
+    jumpi v88, bb29, bb30
   bb29:
     revert 0, 0
   bb30:
@@ -381,12 +381,12 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v90 = and v87, v89
     v91 = add v82, v90
     v92 = lt v91, v82
-    br v92, bb31, bb32
+    jumpi v92, bb31, bb32
   bb31:
     revert 0, 0
   bb32:
     v93 = gt v91, v51
-    br v93, bb33, bb34
+    jumpi v93, bb33, bb34
   bb33:
     revert 0, 0
   bb34:
@@ -394,7 +394,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v95 = select v94, 32, v90
     v96 = add 32, v95
     v97 = lt v96, v95
-    br v97, bb35, bb36
+    jumpi v97, bb35, bb36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -432,7 +432,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v118 = and v117, v116
     v119 = add v112, 32
     v120 = iszero v118
-    br v120, bb38, bb37
+    jumpi v120, bb38, bb37
   bb37:
     v121 = sub v118, 32
     v122 = add v119, v121
@@ -452,7 +452,7 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) {
     v130 = and v129, v128
     v131 = add v124, 32
     v132 = iszero v130
-    br v132, bb40, bb39
+    jumpi v132, bb40, bb39
   bb39:
     v133 = sub v130, 32
     v134 = add v131, v133
@@ -471,7 +471,7 @@ fn @decodeBytes(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -489,25 +489,25 @@ fn @decodeBytes(arg0: memorybytes) {
     mstore 128, 0
     v12 = memory_object_len memorybytes, v9
     v13 = lt v12, 32
-    br v13, bb3, bb4
+    jumpi v13, bb3, bb4
   bb3:
     revert 0, 0
   bb4:
     v14 = memory_object_data memorybytes, v9
     v15 = mload v14
     v16 = lt v15, 32
-    br v16, bb5, bb6
+    jumpi v16, bb5, bb6
   bb5:
     revert 0, 0
   bb6:
     v17 = add v15, 32
     v18 = lt v17, v15
-    br v18, bb7, bb8
+    jumpi v18, bb7, bb8
   bb7:
     revert 0, 0
   bb8:
     v19 = gt v17, v12
-    br v19, bb9, bb10
+    jumpi v19, bb9, bb10
   bb9:
     revert 0, 0
   bb10:
@@ -515,7 +515,7 @@ fn @decodeBytes(arg0: memorybytes) {
     v21 = mload v20
     v22 = add v21, 31
     v23 = lt v22, v21
-    br v23, bb11, bb12
+    jumpi v23, bb11, bb12
   bb11:
     revert 0, 0
   bb12:
@@ -523,12 +523,12 @@ fn @decodeBytes(arg0: memorybytes) {
     v25 = and v22, v24
     v26 = add v17, v25
     v27 = lt v26, v17
-    br v27, bb13, bb14
+    jumpi v27, bb13, bb14
   bb13:
     revert 0, 0
   bb14:
     v28 = gt v26, v12
-    br v28, bb15, bb16
+    jumpi v28, bb15, bb16
   bb15:
     revert 0, 0
   bb16:
@@ -536,7 +536,7 @@ fn @decodeBytes(arg0: memorybytes) {
     v30 = select v29, 32, v25
     v31 = add 32, v30
     v32 = lt v31, v30
-    br v32, bb17, bb18
+    jumpi v32, bb17, bb18
   bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/abi_decode_static_tuple.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_static_tuple.stdout
@@ -5,7 +5,7 @@ fn @decode(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -25,7 +25,7 @@ fn @decode(arg0: memorybytes) {
     mstore 192, 0
     v12 = memory_object_len memorybytes, v9
     v13 = lt v12, 96
-    br v13, bb3, bb4
+    jumpi v13, bb3, bb4
   bb3:
     revert 0, 0
   bb4:
@@ -37,7 +37,7 @@ fn @decode(arg0: memorybytes) {
     v19 = iszero v18
     v20 = eq v17, v19
     v21 = iszero v20
-    br v21, bb5, bb6
+    jumpi v21, bb5, bb6
   bb5:
     revert 0, 0
   bb6:
@@ -46,7 +46,7 @@ fn @decode(arg0: memorybytes) {
     v24 = and v23, 0xffffffffffffffffffffffffffffffffffffffff
     v25 = eq v23, v24
     v26 = iszero v25
-    br v26, bb7, bb8
+    jumpi v26, bb7, bb8
   bb7:
     revert 0, 0
   bb8:

--- a/tests/ui/codegen/lowering/abi_encode_bytes.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_bytes.stdout
@@ -5,7 +5,7 @@ fn @hash3(arg0: u256, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -26,7 +26,7 @@ fn @encode3(arg0: u256, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -71,7 +71,7 @@ fn @encodeDynamic(arg0: u256, arg1: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -101,7 +101,7 @@ fn @encodeDynamic(arg0: u256, arg1: memorybytes) {
     v20 = and v19, v18
     v21 = add v14, 32
     v22 = iszero v20
-    br v22, bb4, bb3
+    jumpi v22, bb4, bb3
   bb3:
     v23 = sub v20, 32
     v24 = add v21, v23
@@ -125,7 +125,7 @@ fn @hashDynamic(arg0: u256, arg1: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -154,7 +154,7 @@ fn @hashDynamic(arg0: u256, arg1: memorybytes) {
     v19 = and v18, v17
     v20 = add v13, 32
     v21 = iszero v19
-    br v21, bb4, bb3
+    jumpi v21, bb4, bb3
   bb3:
     v22 = sub v19, 32
     v23 = add v20, v22
@@ -175,7 +175,7 @@ fn @roundtrip(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -189,7 +189,7 @@ fn @roundtrip(arg0: u256) {
     set_fmp v6
     v7 = memory_object_len memorybytes, v3
     v8 = lt v7, 32
-    br v8, bb3, bb4
+    jumpi v8, bb3, bb4
   bb3:
     revert 0, 0
   bb4:

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
@@ -5,21 +5,21 @@ fn @fixedBytesArg(arg0: u256, arg1: address, arg2: bytes2) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 68
     v7 = and v6, 0xffff000000000000000000000000000000000000000000000000000000000000
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -41,7 +41,7 @@ fn @dynamicArg(arg0: bytes32, arg1: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -75,14 +75,14 @@ fn @materialized(arg0: u16, arg1: memorybytes, arg2: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -101,7 +101,7 @@ fn @materialized(arg0: u16, arg1: memorybytes, arg2: bool) {
     v16 = iszero v15
     v17 = iszero v16
     v18 = eq v15, v17
-    br v18, bb6, bb5
+    jumpi v18, bb6, bb5
   bb5:
     revert 0, 0
   bb6:

--- a/tests/ui/codegen/lowering/abi_encode_packed_static_hash.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_static_hash.stdout
@@ -5,21 +5,21 @@ fn @hash(arg0: u64, arg1: u64, arg2: bytes32) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:

--- a/tests/ui/codegen/lowering/abi_encode_semantic.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_semantic.stdout
@@ -5,14 +5,14 @@ fn @forward(arg0: address, arg1: u256, arg2: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -26,7 +26,7 @@ fn @forward(arg0: address, arg1: u256, arg2: calldataslice) {
     v11 = mload 32 !metadata(memory=scratch)
     v12 = call v10, v9, 0, v11, v8, 0, 32
     v13 = iszero v12
-    br v13, bb5, bb6
+    jumpi v13, bb5, bb6
   bb5:
     v14 = returndatasize
     returndatacopy 0, 0, v14 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/abi_nested_return.stdout
+++ b/tests/ui/codegen/lowering/abi_nested_return.stdout
@@ -5,7 +5,7 @@ fn @structArray(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,7 +13,7 @@ fn @structArray(arg0: u256) {
     v3 = mul 1, 32
     v4 = div v3, 32
     v5 = eq v4, 1
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -21,7 +21,7 @@ fn @structArray(arg0: u256) {
   bb4:
     v6 = add v3, 32
     v7 = lt v6, v3
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -34,7 +34,7 @@ fn @structArray(arg0: u256) {
     mstore v10, arg0
     v11 = add arg0, 1
     v12 = lt v11, arg0
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -44,7 +44,7 @@ fn @structArray(arg0: u256) {
     mstore v13, v11
     v14 = memory_object_len memoryarray, v8
     v15 = lt 0, v14
-    br v15, bb10, bb9
+    jumpi v15, bb10, bb9
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -76,7 +76,7 @@ fn @structArray(arg0: u256) {
   bb11:
     v30 = mload v17
     v31 = gt v30, 0
-    br v31, bb12, bb13
+    jumpi v31, bb12, bb13
   bb12:
     v32 = mload v28
     v33 = mload v32
@@ -113,7 +113,7 @@ fn @nestedArray(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -121,7 +121,7 @@ fn @nestedArray(arg0: u256) {
     v3 = mul 1, 32
     v4 = div v3, 32
     v5 = eq v4, 1
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -129,7 +129,7 @@ fn @nestedArray(arg0: u256) {
   bb4:
     v6 = add v3, 32
     v7 = lt v6, v3
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -140,7 +140,7 @@ fn @nestedArray(arg0: u256) {
     v9 = mul arg0, 32
     v10 = div v9, 32
     v11 = eq v10, arg0
-    br v11, bb8, bb7
+    jumpi v11, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -148,7 +148,7 @@ fn @nestedArray(arg0: u256) {
   bb8:
     v12 = add v9, 32
     v13 = lt v12, v9
-    br v13, bb9, bb10
+    jumpi v13, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -158,7 +158,7 @@ fn @nestedArray(arg0: u256) {
     set_memory_object_len memoryarray, v14, arg0
     v15 = memory_object_len memoryarray, v8
     v16 = lt 0, v15
-    br v16, bb12, bb11
+    jumpi v16, bb12, bb11
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -190,7 +190,7 @@ fn @nestedArray(arg0: u256) {
   bb13:
     v31 = mload v18
     v32 = gt v31, 0
-    br v32, bb14, bb15
+    jumpi v32, bb14, bb15
   bb14:
     v33 = mload v29
     v34 = mload v33

--- a/tests/ui/codegen/lowering/array_bounds_panic.stdout
+++ b/tests/ui/codegen/lowering/array_bounds_panic.stdout
@@ -5,7 +5,7 @@ fn @memFix(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -20,7 +20,7 @@ fn @memFix(arg0: u256) {
     v7 = memory_object_element_addr memoryfixedarray<3, 1>, v3, 1
     mstore v7, 20
     v8 = lt arg0, 3
-    br v8, bb4, bb3
+    jumpi v8, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -60,7 +60,7 @@ fn @memFixConstOob() {
     mstore v2, 0
     v3 = memory_object_element_addr memoryfixedarray<3, 1>, v0, 2
     mstore v3, 0
-    br 1, bb1, bb2
+    jumpi 1, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -77,7 +77,7 @@ fn @memDyn(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -85,7 +85,7 @@ fn @memDyn(arg0: u256, arg1: u256) {
     v3 = mul arg0, 32
     v4 = div v3, 32
     v5 = eq v4, arg0
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -93,7 +93,7 @@ fn @memDyn(arg0: u256, arg1: u256) {
   bb4:
     v6 = add v3, 32
     v7 = lt v6, v3
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -103,7 +103,7 @@ fn @memDyn(arg0: u256, arg1: u256) {
     set_memory_object_len memoryarray, v8, arg0
     v9 = memory_object_len memoryarray, v8
     v10 = lt arg1, v9
-    br v10, bb8, bb7
+    jumpi v10, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -120,14 +120,14 @@ fn @stDyn(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = lt arg0, v3
-    br v4, bb4, bb3
+    jumpi v4, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -146,13 +146,13 @@ fn @stDynWrite(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = lt arg0, v3
-    br v4, bb4, bb3
+    jumpi v4, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -170,13 +170,13 @@ fn @stFix(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = lt arg0, 3
-    br v3, bb4, bb3
+    jumpi v3, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -193,14 +193,14 @@ fn @cdDyn(arg0: calldataslice, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = slice_len arg0
     v4 = lt arg1, v3
-    br v4, bb4, bb3
+    jumpi v4, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -219,7 +219,7 @@ fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 128
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -232,7 +232,7 @@ fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) {
     mstore v6, arg2
     mstore 128, 0
     v7 = lt arg3, 3
-    br v7, bb4, bb3
+    jumpi v7, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -249,14 +249,14 @@ fn @cdBytes(arg0: calldataslice, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = slice_len arg0
     v4 = lt arg1, v3
-    br v4, bb4, bb3
+    jumpi v4, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/backend_control_flow.sol
+++ b/tests/ui/codegen/lowering/backend_control_flow.sol
@@ -9,7 +9,7 @@ contract BackendControlFlow {
 
     // CHECK-LABEL: fn @localVarInConditional
     // CHECK: [[VALUE:v[0-9]+]] = sload [[SLOT:[0-9]+]]
-    // CHECK: br
+    // CHECK: jumpi
     // CHECK: [[RESULT:v[0-9]+]] = sub [[VALUE]], 1
     // CHECK: sstore [[SLOT]], [[RESULT]]
     function localVarInConditional() public {
@@ -19,7 +19,7 @@ contract BackendControlFlow {
 
     // CHECK-LABEL: fn @directStorageInConditional
     // CHECK: sload [[SLOT:[0-9]+]]
-    // CHECK: br
+    // CHECK: jumpi
     // CHECK: [[VALUE:v[0-9]+]] = sload [[SLOT]]
     // CHECK: [[RESULT:v[0-9]+]] = sub [[VALUE]], 1
     // CHECK: sstore [[SLOT]], [[RESULT]]
@@ -28,7 +28,7 @@ contract BackendControlFlow {
     }
 
     // CHECK-LABEL: fn @phiAfterBranch
-    // CHECK: br
+    // CHECK: jumpi
     // CHECK: [[LIQUIDITY:v[0-9]+]] = mload {{[0-9]+}}
     // CHECK: [[SUPPLY:v[0-9]+]] = sload [[SUPPLY_SLOT:[0-9]+]]
     // CHECK: [[TOTAL:v[0-9]+]] = add [[SUPPLY]], [[LIQUIDITY]]
@@ -43,7 +43,7 @@ contract BackendControlFlow {
     }
 
     // CHECK-LABEL: fn @phiUsedMultipleTimes
-    // CHECK: br
+    // CHECK: jumpi
     // CHECK: [[LIQUIDITY:v[0-9]+]] = mload [[PHI_ADDR:[0-9]+]]
     // CHECK: [[SUPPLY:v[0-9]+]] = sload [[SUPPLY_SLOT:[0-9]+]]
     // CHECK: [[TOTAL:v[0-9]+]] = add [[SUPPLY]], [[LIQUIDITY]]
@@ -65,7 +65,7 @@ contract BackendControlFlow {
     }
 
     // CHECK-LABEL: fn @phiWithTernary
-    // CHECK: br
+    // CHECK: jumpi
     // CHECK: [[LIQUIDITY:v[0-9]+]] = mload [[RESULT_ADDR:[0-9]+]]
     // CHECK: [[SUPPLY:v[0-9]+]] = sload [[SUPPLY_SLOT:[0-9]+]]
     // CHECK: [[TOTAL:v[0-9]+]] = add [[SUPPLY]], [[LIQUIDITY]]

--- a/tests/ui/codegen/lowering/backend_control_flow.stdout
+++ b/tests/ui/codegen/lowering/backend_control_flow.stdout
@@ -37,11 +37,11 @@ fn @localVarInConditional() {
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = eq v0, 0
     v2 = iszero v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     v3 = sub v0, 1
     v4 = lt v0, 1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb2:
     stop
   bb3:
@@ -58,12 +58,12 @@ fn @directStorageInConditional() {
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = eq v0, 0
     v2 = iszero v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = sub v3, 1
     v5 = lt v3, 1
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb2:
     stop
   bb3:
@@ -80,7 +80,7 @@ fn @phiAfterBranch() {
     mstore 128, 0
     v0 = sload 1 !metadata(storage=slot(1))
     v1 = eq v0, 0
-    br v1, bb1, bb3
+    jumpi v1, bb1, bb3
   bb1:
     mstore 128, 1
     jump bb2
@@ -89,7 +89,7 @@ fn @phiAfterBranch() {
     v3 = sload 1 !metadata(storage=slot(1))
     v4 = add v3, v2
     v5 = lt v4, v3
-    br v5, bb4, bb5
+    jumpi v5, bb4, bb5
   bb3:
     mstore 128, 2
     jump bb2
@@ -110,7 +110,7 @@ fn @phiUsedMultipleTimes() {
     mstore 160, 0
     v0 = sload 1 !metadata(storage=slot(1))
     v1 = eq v0, 0
-    br v1, bb1, bb3
+    jumpi v1, bb1, bb3
   bb1:
     mstore 160, 1
     jump bb2
@@ -119,7 +119,7 @@ fn @phiUsedMultipleTimes() {
     v3 = sload 1 !metadata(storage=slot(1))
     v4 = add v3, v2
     v5 = lt v4, v3
-    br v5, bb4, bb5
+    jumpi v5, bb4, bb5
   bb3:
     mstore 160, 2
     jump bb2
@@ -136,7 +136,7 @@ fn @phiUsedMultipleTimes() {
     v10 = eq v9, v6
     v11 = or v8, v10
     v12 = iszero v11
-    br v12, bb6, bb7
+    jumpi v12, bb6, bb7
   bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -145,7 +145,7 @@ fn @phiUsedMultipleTimes() {
     v13 = mload 160
     v14 = add v7, v13
     v15 = lt v14, v7
-    br v15, bb8, bb9
+    jumpi v15, bb8, bb9
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -162,7 +162,7 @@ fn @phiWithTernary() {
     mstore 128, 0
     v0 = sload 1 !metadata(storage=slot(1))
     v1 = eq v0, 0
-    br v1, bb1, bb3
+    jumpi v1, bb1, bb3
   bb1:
     v2 = mul 100, 200
     v3 = iszero 200
@@ -170,13 +170,13 @@ fn @phiWithTernary() {
     v5 = eq v4, 100
     v6 = or v3, v5
     v7 = iszero v6
-    br v7, bb4, bb5
+    jumpi v7, bb4, bb5
   bb2:
     v28 = mload 128
     v29 = sload 1 !metadata(storage=slot(1))
     v30 = add v29, v28
     v31 = lt v30, v29
-    br v31, bb17, bb18
+    jumpi v31, bb17, bb18
   bb3:
     v8 = sload 1 !metadata(storage=slot(1))
     v9 = mul 100, v8
@@ -185,7 +185,7 @@ fn @phiWithTernary() {
     v12 = eq v11, 100
     v13 = or v10, v12
     v14 = iszero v13
-    br v14, bb6, bb7
+    jumpi v14, bb6, bb7
   bb4:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -199,7 +199,7 @@ fn @phiWithTernary() {
     revert 0, 36
   bb7:
     v15 = sload 2 !metadata(storage=slot(2))
-    br v15, bb9, bb8
+    jumpi v15, bb9, bb8
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -213,14 +213,14 @@ fn @phiWithTernary() {
     v21 = eq v20, 200
     v22 = or v19, v21
     v23 = iszero v22
-    br v23, bb10, bb11
+    jumpi v23, bb10, bb11
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb11:
     v24 = sload 3 !metadata(storage=slot(3))
-    br v24, bb13, bb12
+    jumpi v24, bb13, bb12
   bb12:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -228,7 +228,7 @@ fn @phiWithTernary() {
   bb13:
     v25 = div v18, v24
     v26 = lt v16, v25
-    br v26, bb14, bb15
+    jumpi v26, bb14, bb15
   bb14:
     mstore 0, v16 !metadata(memory=scratch)
     jump bb16

--- a/tests/ui/codegen/lowering/branch.stdout
+++ b/tests/ui/codegen/lowering/branch.stdout
@@ -5,13 +5,13 @@ fn @max(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = gt arg0, arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 128, arg0
     returndata 128, 32
@@ -25,18 +25,18 @@ fn @abs_diff(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = lt arg0, arg1
     v4 = iszero v3
-    br v4, bb3, bb5
+    jumpi v4, bb3, bb5
   bb3:
     v5 = sub arg0, arg1
     v6 = lt arg0, arg1
-    br v6, bb6, bb7
+    jumpi v6, bb6, bb7
   bb4:
     v9 = mload 128
     mstore 128, v9
@@ -44,7 +44,7 @@ fn @abs_diff(arg0: u256, arg1: u256) {
   bb5:
     v7 = sub arg1, arg0
     v8 = lt arg1, arg0
-    br v8, bb8, bb9
+    jumpi v8, bb8, bb9
   bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
@@ -5,7 +5,7 @@ fn @am(arg0: u256, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -20,7 +20,7 @@ fn @mm(arg0: u256, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/bytes_memory_elements.stdout
+++ b/tests/ui/codegen/lowering/bytes_memory_elements.stdout
@@ -5,7 +5,7 @@ fn @alloc() {
     mstore 128, 0
     v0 = add 96, 31
     v1 = lt v0, 96
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -15,7 +15,7 @@ fn @alloc() {
     v3 = and v0, v2
     v4 = add v3, 32
     v5 = lt v4, v3
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -25,7 +25,7 @@ fn @alloc() {
     set_memory_object_len memorybytes, v6, 96
     v7 = memory_object_len memorybytes, v6
     v8 = lt 5, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -36,7 +36,7 @@ fn @alloc() {
     mstore8 v10, 170
     v11 = memory_object_len memorybytes, v6
     v12 = lt 95, v11
-    br v12, bb8, bb7
+    jumpi v12, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -60,7 +60,7 @@ fn @literal() {
     mstore v2, 0x1020304050607080900000000000000000000000000000000000000000000
     v3 = memory_object_len memorybytes, v0
     v4 = lt 5, v3
-    br v4, bb2, bb1
+    jumpi v4, bb2, bb1
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -79,14 +79,14 @@ fn @allocDynamic(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, 31
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -96,7 +96,7 @@ fn @allocDynamic(arg0: u256) {
     v6 = and v3, v5
     v7 = add v6, 32
     v8 = lt v7, v6
-    br v8, bb5, bb6
+    jumpi v8, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -114,7 +114,7 @@ fn @readWrite(arg0: memorybytes, arg1: u256, arg2: bytes1) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -132,14 +132,14 @@ fn @readWrite(arg0: memorybytes, arg1: u256, arg2: bytes1) {
     v12 = calldataload 68
     v13 = and v12, 0xff00000000000000000000000000000000000000000000000000000000000000
     v14 = eq v12, v13
-    br v14, bb4, bb3
+    jumpi v14, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     mstore 128, 0
     v15 = memory_object_len memorybytes, v9
     v16 = lt arg1, v15
-    br v16, bb6, bb5
+    jumpi v16, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -151,7 +151,7 @@ fn @readWrite(arg0: memorybytes, arg1: u256, arg2: bytes1) {
     mstore8 v18, v19
     v20 = memory_object_len memorybytes, v9
     v21 = lt arg1, v20
-    br v21, bb8, bb7
+    jumpi v21, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/calldata_array_subslice.stdout
+++ b/tests/ui/codegen/lowering/calldata_array_subslice.stdout
@@ -5,7 +5,7 @@ fn @word(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,7 +13,7 @@ fn @word(arg0: calldataslice) {
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 1
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -26,7 +26,7 @@ fn @word(arg0: calldataslice) {
     v10 = slice_len v9
     v11 = slice_ptr v9
     v12 = shr 251, v10
-    br v12, bb5, bb6
+    jumpi v12, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/calldata_nested_forward.stdout
+++ b/tests/ui/codegen/lowering/calldata_nested_forward.stdout
@@ -5,21 +5,21 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = slice_ptr arg0
     v7 = slice_len arg0
     v8 = shr 251, v7
-    br v8, bb5, bb6
+    jumpi v8, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -28,7 +28,7 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v9 = mul v7, 32
     v10 = add 32, v9
     v11 = lt v10, v9
-    br v11, bb7, bb8
+    jumpi v11, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -47,7 +47,7 @@ fn @forward(arg0: calldataslice, arg1: address) {
   bb9:
     v17 = mload v13
     v18 = gt v17, 0
-    br v18, bb10, bb11
+    jumpi v18, bb10, bb11
   bb10:
     v19 = mload v14
     v20 = calldataload v19
@@ -55,7 +55,7 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v22 = calldataload v21
     v23 = add v22, 31
     v24 = lt v23, v22
-    br v24, bb12, bb13
+    jumpi v24, bb12, bb13
   bb11:
     v43 = abi_encode [memory_array<memory_bytes>], selector 0x3731ba7300000000000000000000000000000000000000000000000000000000, args v12
     v44 = slice_ptr v43
@@ -67,7 +67,7 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v48 = mload 32 !metadata(memory=scratch)
     v49 = call v47, v46, 0, v48, v45, 0, 32
     v50 = iszero v49
-    br v50, bb16, bb17
+    jumpi v50, bb16, bb17
   bb12:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -79,7 +79,7 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v28 = select v27, 32, v26
     v29 = add 32, v28
     v30 = lt v29, v28
-    br v30, bb14, bb15
+    jumpi v30, bb14, bb15
   bb14:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -119,21 +119,21 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = slice_ptr arg0
     v7 = slice_len arg0
     v8 = shr 251, v7
-    br v8, bb5, bb6
+    jumpi v8, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -142,7 +142,7 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v9 = mul v7, 32
     v10 = add 32, v9
     v11 = lt v10, v9
-    br v11, bb7, bb8
+    jumpi v11, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -161,7 +161,7 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
   bb9:
     v17 = mload v13
     v18 = gt v17, 0
-    br v18, bb10, bb11
+    jumpi v18, bb10, bb11
   bb10:
     v19 = mload v14
     v20 = calldataload v19
@@ -175,7 +175,7 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v27 = calldataload v26
     v28 = add v27, 31
     v29 = lt v28, v27
-    br v29, bb12, bb13
+    jumpi v29, bb12, bb13
   bb11:
     v49 = abi_encode [memory_array<tuple<word, memory_bytes>>], selector 0x8419297e00000000000000000000000000000000000000000000000000000000, args v12
     v50 = slice_ptr v49
@@ -187,7 +187,7 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v54 = mload 32 !metadata(memory=scratch)
     v55 = call v53, v52, 0, v54, v51, 0, 32
     v56 = iszero v55
-    br v56, bb16, bb17
+    jumpi v56, bb16, bb17
   bb12:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -199,7 +199,7 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v33 = select v32, 32, v31
     v34 = add 32, v33
     v35 = lt v34, v33
-    br v35, bb14, bb15
+    jumpi v35, bb14, bb15
   bb14:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/calldata_slice_control_flow.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_control_flow.stdout
@@ -5,7 +5,7 @@ fn @trimLen(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -21,7 +21,7 @@ fn @trimLen(arg0: calldataslice) {
     mstore 192, v7
     v8 = slice_len arg0
     v9 = gt v8, 8
-    br v9, bb4, bb5
+    jumpi v9, bb4, bb5
   bb3:
     v28 = mload 160
     v29 = mload 192
@@ -65,7 +65,7 @@ fn @_trim(arg0: calldataslice) -> memorybytes {
     mstore v1, arg0 !metadata(memory=internal_frame)
     v2 = slice_len arg0
     v3 = gt v2, 8
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     v4 = slice_ptr arg0
     v5 = add v4, 8
@@ -86,7 +86,7 @@ fn @forward(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -143,7 +143,7 @@ fn @forward(arg0: calldataslice) {
     v42 = eq v41, v38
     v43 = or v40, v42
     v44 = iszero v43
-    br v44, bb3, bb4
+    jumpi v44, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -152,7 +152,7 @@ fn @forward(arg0: calldataslice) {
     v45 = slice_len v37
     v46 = add v39, v45
     v47 = lt v46, v39
-    br v47, bb5, bb6
+    jumpi v47, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -173,7 +173,7 @@ fn @_sum(arg0: calldataslice, arg1: calldataslice) -> u256 {
     v5 = eq v4, v1
     v6 = or v3, v5
     v7 = iszero v6
-    br v7, bb1, bb2
+    jumpi v7, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -182,7 +182,7 @@ fn @_sum(arg0: calldataslice, arg1: calldataslice) -> u256 {
     v8 = slice_len arg1
     v9 = add v2, v8
     v10 = lt v9, v2
-    br v10, bb3, bb4
+    jumpi v10, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -196,7 +196,7 @@ fn @explicitTrim(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -208,7 +208,7 @@ fn @explicitTrim(arg0: calldataslice) {
     mstore 192, v5
     v6 = slice_len arg0
     v7 = gt v6, 4
-    br v7, bb4, bb5
+    jumpi v7, bb4, bb5
   bb3:
     v18 = mload 160
     v19 = mload 192
@@ -220,7 +220,7 @@ fn @explicitTrim(arg0: calldataslice) {
     v8 = slice_ptr arg0
     v9 = slice_len arg0
     v10 = lt v9, 4
-    br v10, bb6, bb7
+    jumpi v10, bb6, bb7
   bb5:
     v16 = slice_ptr arg0
     v17 = slice_len arg0
@@ -248,12 +248,12 @@ fn @_explicitTrim(arg0: calldataslice) -> memorybytes {
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = slice_len arg0
     v2 = gt v1, 4
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 4
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb2:
     ret arg0
   bb3:
@@ -272,7 +272,7 @@ fn @headTail(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -296,7 +296,7 @@ fn @headTail(arg0: calldataslice) {
     v12 = slice_len arg0
     v13 = slice_len arg0
     v14 = lt v12, v13
-    br v14, bb4, bb5
+    jumpi v14, bb4, bb5
   bb3:
     v40 = mload 192
     v41 = mload 224
@@ -328,7 +328,7 @@ fn @headTail(arg0: calldataslice) {
     mstore 288, v19
     v20 = slice_len arg0
     v21 = gt v20, 8
-    br v21, bb6, bb7
+    jumpi v21, bb6, bb7
   bb6:
     v22 = slice_ptr arg0
     v23 = add v22, 8
@@ -369,7 +369,7 @@ fn @_split(arg0: calldataslice) -> (memorybytes, memorybytes) {
     v4 = slice_len arg0
     v5 = slice_len arg0
     v6 = lt v4, v5
-    br v6, bb1, bb2
+    jumpi v6, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -382,7 +382,7 @@ fn @_split(arg0: calldataslice) -> (memorybytes, memorybytes) {
     mstore v10, v9 !metadata(memory=internal_frame)
     v11 = slice_len arg0
     v12 = gt v11, 8
-    br v12, bb3, bb4
+    jumpi v12, bb3, bb4
   bb3:
     v13 = slice_ptr arg0
     v14 = add v13, 8

--- a/tests/ui/codegen/lowering/calldata_slice_encode.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_encode.stdout
@@ -5,7 +5,7 @@ fn @encode(arg0: calldataslice, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,7 +13,7 @@ fn @encode(arg0: calldataslice, arg1: u256) {
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, arg1
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -34,7 +34,7 @@ fn @encode(arg0: calldataslice, arg1: u256) {
     v16 = and v15, v14
     v17 = add v11, 32
     v18 = iszero v16
-    br v18, bb6, bb5
+    jumpi v18, bb6, bb5
   bb5:
     v19 = sub v16, 32
     v20 = add v17, v19
@@ -78,7 +78,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -89,7 +89,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v5 = calldataload 68
     v6 = and v5, 0xffffffffffffffffffffffffffffffffffffffff
     v7 = eq v5, v6
-    br v7, bb4, bb3
+    jumpi v7, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -99,7 +99,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v11 = slice_ptr v10
     v12 = slice_len v10
     v13 = lt v12, arg1
-    br v13, bb5, bb6
+    jumpi v13, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -125,7 +125,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v27 = mload 32 !metadata(memory=scratch)
     v28 = call v26, v25, 0, v27, v24, 0, 32
     v29 = iszero v28
-    br v29, bb7, bb8
+    jumpi v29, bb7, bb8
   bb7:
     v30 = returndatasize
     returndatacopy 0, 0, v30 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/calldata_slice_rebind.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_rebind.stdout
@@ -5,7 +5,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -16,7 +16,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v5 = calldataload 68
     v6 = and v5, 0xffffffffffffffffffffffffffffffffffffffff
     v7 = eq v5, v6
-    br v7, bb4, bb3
+    jumpi v7, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -26,7 +26,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v11 = slice_ptr v10
     v12 = slice_len v10
     v13 = lt v12, arg1
-    br v13, bb5, bb6
+    jumpi v13, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -52,7 +52,7 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v27 = mload 32 !metadata(memory=scratch)
     v28 = call v26, v25, 0, v27, v24, 0, 32
     v29 = iszero v28
-    br v29, bb7, bb8
+    jumpi v29, bb7, bb8
   bb7:
     v30 = returndatasize
     returndatacopy 0, 0, v30 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/calldata_slice_ternary.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_ternary.stdout
@@ -5,7 +5,7 @@ fn @pick(arg0: bool, arg1: calldataslice, arg2: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,12 +13,12 @@ fn @pick(arg0: bool, arg1: calldataslice, arg2: calldataslice) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     mstore 128, 0
-    br arg0, bb5, bb6
+    jumpi arg0, bb5, bb6
   bb5:
     v7 = slice_ptr arg1
     v8 = slice_len arg1
@@ -45,7 +45,7 @@ fn @adopt(arg0: bool, arg1: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -53,7 +53,7 @@ fn @adopt(arg0: bool, arg1: calldataslice) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -63,12 +63,12 @@ fn @adopt(arg0: bool, arg1: calldataslice) {
     v8 = memory_object_data memorybytes, v7
     v9 = add v8, 0
     mstore v9, 0xaabb000000000000000000000000000000000000000000000000000000000000
-    br arg0, bb5, bb6
+    jumpi arg0, bb5, bb6
   bb5:
     v10 = slice_len arg1
     v11 = add v10, 31
     v12 = lt v11, v10
-    br v12, bb8, bb9
+    jumpi v12, bb8, bb9
   bb6:
     mstore 0, v7 !metadata(memory=scratch)
     jump bb7
@@ -87,7 +87,7 @@ fn @adopt(arg0: bool, arg1: calldataslice) {
     v16 = select v15, 32, v14
     v17 = add 32, v16
     v18 = lt v17, v16
-    br v18, bb10, bb11
+    jumpi v18, bb10, bb11
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/calldata_slice_yul_bounds.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_yul_bounds.stdout
@@ -32,7 +32,7 @@ fn @trimLen(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -76,7 +76,7 @@ fn @conditional(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -87,7 +87,7 @@ fn @conditional(arg0: calldataslice) {
     mstore 192, v4
     v5 = slice_len arg0
     v6 = gt v5, 32
-    br v6, bb3, bb4
+    jumpi v6, bb3, bb4
   bb3:
     v7 = mload 160
     v8 = mload 192

--- a/tests/ui/codegen/lowering/calldata_validation.stdout
+++ b/tests/ui/codegen/lowering/calldata_validation.stdout
@@ -5,14 +5,14 @@ fn @vUint8(arg0: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -26,14 +26,14 @@ fn @vInt16(arg0: i16) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 1, v3
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -47,7 +47,7 @@ fn @vBool(arg0: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -55,7 +55,7 @@ fn @vBool(arg0: bool) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -69,14 +69,14 @@ fn @vAddress(arg0: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -90,14 +90,14 @@ fn @vBytes4(arg0: bytes4) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffff00000000000000000000000000000000000000000000000000000000
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -111,13 +111,13 @@ fn @vEnum(arg0: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = lt v3, 3
-    br v4, bb4, bb3
+    jumpi v4, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -131,21 +131,21 @@ fn @vMulti(arg0: u32, arg1: i8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = signextend 0, v6
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -156,7 +156,7 @@ fn @vMulti(arg0: u32, arg1: i8) {
     v12 = and v11, 255
     v13 = add v9, v12
     v14 = lt v13, v9
-    br v14, bb7, bb8
+    jumpi v14, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -171,14 +171,14 @@ fn @vFull(arg0: u256, arg1: bytes32, arg2: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, arg1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -186,7 +186,7 @@ fn @vFull(arg0: u256, arg1: bytes32, arg2: i256) {
   bb4:
     v5 = add v3, arg2
     v6 = lt v5, v3
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/chained_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/chained_calldata_slice.stdout
@@ -5,7 +5,7 @@ fn @bytesChain(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,7 +13,7 @@ fn @bytesChain(arg0: calldataslice) {
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 1
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -25,7 +25,7 @@ fn @bytesChain(arg0: calldataslice) {
     v9 = slice_ptr v8
     v10 = slice_len v8
     v11 = lt v10, 1
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -37,7 +37,7 @@ fn @bytesChain(arg0: calldataslice) {
     v15 = slice_len v14
     v16 = add v15, 31
     v17 = lt v16, v15
-    br v17, bb7, bb8
+    jumpi v17, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -49,7 +49,7 @@ fn @bytesChain(arg0: calldataslice) {
     v21 = select v20, 32, v19
     v22 = add 32, v21
     v23 = lt v22, v21
-    br v23, bb9, bb10
+    jumpi v23, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -92,7 +92,7 @@ fn @arrChain(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -100,7 +100,7 @@ fn @arrChain(arg0: calldataslice) {
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 1
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -113,7 +113,7 @@ fn @arrChain(arg0: calldataslice) {
     v10 = slice_ptr v9
     v11 = slice_len v9
     v12 = lt v11, 1
-    br v12, bb5, bb6
+    jumpi v12, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -125,7 +125,7 @@ fn @arrChain(arg0: calldataslice) {
     v16 = make_calldata_slice v15, v13
     v17 = slice_len v16
     v18 = lt 0, v17
-    br v18, bb8, bb7
+    jumpi v18, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/checked_arithmetic_panic.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_panic.stdout
@@ -5,14 +5,14 @@ fn @add(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, arg1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -27,14 +27,14 @@ fn @sub(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = sub arg0, arg1
     v4 = lt arg0, arg1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -49,7 +49,7 @@ fn @mul(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -60,7 +60,7 @@ fn @mul(arg0: u256, arg1: u256) {
     v6 = eq v5, arg0
     v7 = or v4, v6
     v8 = iszero v7
-    br v8, bb3, bb4
+    jumpi v8, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -75,12 +75,12 @@ fn @div_zero(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
-    br arg1, bb4, bb3
+    jumpi arg1, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -96,29 +96,29 @@ fn @pow(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = iszero arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     v31 = phi [bb2: 1], [bb4: 0], [bb5: 1], [bb10: v8], [bb11: v16], [bb19: v30]
     mstore 128, v31
     returndata 128, 32
   bb4:
     v4 = iszero arg0
-    br v4, bb3, bb5
+    jumpi v4, bb3, bb5
   bb5:
     v5 = eq arg0, 1
-    br v5, bb3, bb6
+    jumpi v5, bb3, bb6
   bb6:
     v6 = eq arg0, 2
-    br v6, bb7, bb8
+    jumpi v6, bb7, bb8
   bb7:
     v7 = gt arg1, 255
-    br v7, bb9, bb10
+    jumpi v7, bb9, bb10
   bb8:
     v9 = lt arg0, 11
     v10 = lt arg1, 78
@@ -127,7 +127,7 @@ fn @pow(arg0: u256, arg1: u256) {
     v13 = lt arg1, 32
     v14 = and v12, v13
     v15 = or v11, v14
-    br v15, bb11, bb12
+    jumpi v15, bb11, bb12
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -145,15 +145,15 @@ fn @pow(arg0: u256, arg1: u256) {
     v18 = phi [bb12: arg0], [bb17: v26]
     v19 = phi [bb12: arg1], [bb17: v27]
     v20 = gt v19, 1
-    br v20, bb14, bb15
+    jumpi v20, bb14, bb15
   bb14:
     v21 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
     v22 = gt v18, v21
-    br v22, bb16, bb17
+    jumpi v22, bb16, bb17
   bb15:
     v28 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
     v29 = gt v17, v28
-    br v29, bb18, bb19
+    jumpi v29, bb18, bb19
   bb16:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -179,7 +179,7 @@ fn @signed_add(arg0: i256, arg1: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -188,7 +188,7 @@ fn @signed_add(arg0: i256, arg1: i256) {
     v4 = slt arg0, 0
     v5 = slt v3, arg1
     v6 = xor v4, v5
-    br v6, bb3, bb4
+    jumpi v6, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -203,13 +203,13 @@ fn @signed_neg(arg0: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -225,28 +225,28 @@ fn @narrow_add(arg0: u8, arg1: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 255
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
     mstore 128, 0
     v9 = add arg0, arg1
     v10 = gt v9, 255
-    br v10, bb7, bb8
+    jumpi v10, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -261,7 +261,7 @@ fn @unchecked_add(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -276,7 +276,7 @@ fn @unchecked_neg(arg0: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -291,7 +291,7 @@ fn @unchecked_pow(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -306,14 +306,14 @@ fn @unchecked_call(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, arg1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -329,7 +329,7 @@ fn @checked_inner(arg0: u256, arg1: u256) -> u256 {
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = add arg0, arg1
     v2 = lt v1, arg0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
@@ -5,7 +5,7 @@ fn @sadd(arg0: i256, arg1: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -14,7 +14,7 @@ fn @sadd(arg0: i256, arg1: i256) {
     v4 = slt arg0, 0
     v5 = slt v3, arg1
     v6 = xor v4, v5
-    br v6, bb3, bb4
+    jumpi v6, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -29,7 +29,7 @@ fn @ssub(arg0: i256, arg1: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -38,7 +38,7 @@ fn @ssub(arg0: i256, arg1: i256) {
     v4 = slt arg1, 0
     v5 = sgt v3, arg0
     v6 = xor v4, v5
-    br v6, bb3, bb4
+    jumpi v6, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -53,7 +53,7 @@ fn @smul(arg0: i256, arg1: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -68,7 +68,7 @@ fn @smul(arg0: i256, arg1: i256) {
     v10 = slt arg1, 0
     v11 = and v9, v10
     v12 = or v8, v11
-    br v12, bb3, bb4
+    jumpi v12, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -83,12 +83,12 @@ fn @sdiv(arg0: i256, arg1: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
-    br arg1, bb4, bb3
+    jumpi arg1, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -97,7 +97,7 @@ fn @sdiv(arg0: i256, arg1: i256) {
     v3 = eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
     v4 = eq arg1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     v5 = and v3, v4
-    br v5, bb5, bb6
+    jumpi v5, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -113,12 +113,12 @@ fn @smod(arg0: i256, arg1: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
-    br arg1, bb4, bb3
+    jumpi arg1, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -134,13 +134,13 @@ fn @neg(arg0: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -156,14 +156,14 @@ fn @inc(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, 1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -178,14 +178,14 @@ fn @dec(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = sub arg0, 1
     v4 = lt arg0, 1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -200,28 +200,28 @@ fn @uadd128(arg0: u128, arg1: u128) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
     mstore 128, 0
     v9 = add arg0, arg1
     v10 = gt v9, 0xffffffffffffffffffffffffffffffff
-    br v10, bb7, bb8
+    jumpi v10, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -236,28 +236,28 @@ fn @umul128(arg0: u128, arg1: u128) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
     mstore 128, 0
     v9 = mul arg0, arg1
     v10 = gt v9, 0xffffffffffffffffffffffffffffffff
-    br v10, bb7, bb8
+    jumpi v10, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -272,21 +272,21 @@ fn @smul128(arg0: i128, arg1: i128) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 15, v3
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = signextend 15, v6
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -295,7 +295,7 @@ fn @smul128(arg0: i128, arg1: i128) {
     v10 = slt v9, 0xffffffffffffffffffffffffffffffff80000000000000000000000000000000
     v11 = sgt v9, 0x7fffffffffffffffffffffffffffffff
     v12 = or v10, v11
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -310,21 +310,21 @@ fn @umul192(arg0: u192, arg1: u192) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -337,7 +337,7 @@ fn @umul192(arg0: u192, arg1: u192) {
     v14 = iszero v13
     v15 = gt v9, 0xffffffffffffffffffffffffffffffffffffffffffffffff
     v16 = or v14, v15
-    br v16, bb7, bb8
+    jumpi v16, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/checked_pow_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.stdout
@@ -5,29 +5,29 @@ fn @upow(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = iszero arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     v31 = phi [bb2: 1], [bb4: 0], [bb5: 1], [bb10: v8], [bb11: v16], [bb19: v30]
     mstore 128, v31
     returndata 128, 32
   bb4:
     v4 = iszero arg0
-    br v4, bb3, bb5
+    jumpi v4, bb3, bb5
   bb5:
     v5 = eq arg0, 1
-    br v5, bb3, bb6
+    jumpi v5, bb3, bb6
   bb6:
     v6 = eq arg0, 2
-    br v6, bb7, bb8
+    jumpi v6, bb7, bb8
   bb7:
     v7 = gt arg1, 255
-    br v7, bb9, bb10
+    jumpi v7, bb9, bb10
   bb8:
     v9 = lt arg0, 11
     v10 = lt arg1, 78
@@ -36,7 +36,7 @@ fn @upow(arg0: u256, arg1: u256) {
     v13 = lt arg1, 32
     v14 = and v12, v13
     v15 = or v11, v14
-    br v15, bb11, bb12
+    jumpi v15, bb11, bb12
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -54,15 +54,15 @@ fn @upow(arg0: u256, arg1: u256) {
     v18 = phi [bb12: arg0], [bb17: v26]
     v19 = phi [bb12: arg1], [bb17: v27]
     v20 = gt v19, 1
-    br v20, bb14, bb15
+    jumpi v20, bb14, bb15
   bb14:
     v21 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
     v22 = gt v18, v21
-    br v22, bb16, bb17
+    jumpi v22, bb16, bb17
   bb15:
     v28 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
     v29 = gt v17, v28
-    br v29, bb18, bb19
+    jumpi v29, bb18, bb19
   bb16:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -88,32 +88,32 @@ fn @spow(arg0: i256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = iszero arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     v48 = phi [bb2: 1], [bb4: arg0], [bb5: 0], [bb7: 1], [bb14: v15], [bb17: v21], [bb29: v47]
     mstore 128, v48
     returndata 128, 32
   bb4:
     v4 = eq arg1, 1
-    br v4, bb3, bb5
+    jumpi v4, bb3, bb5
   bb5:
     v5 = iszero arg0
-    br v5, bb3, bb6
+    jumpi v5, bb3, bb6
   bb6:
     v6 = sgt arg0, 0
-    br v6, bb7, bb8
+    jumpi v6, bb7, bb8
   bb7:
     v7 = eq arg0, 1
-    br v7, bb3, bb10
+    jumpi v7, bb3, bb10
   bb8:
     v19 = eq arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v19, bb17, bb18
+    jumpi v19, bb17, bb18
   bb9:
     v24 = and arg1, 1
     v25 = select v24, arg0, 1
@@ -128,15 +128,15 @@ fn @spow(arg0: i256, arg1: u256) {
     v12 = lt arg1, 32
     v13 = and v11, v12
     v14 = or v10, v13
-    br v14, bb11, bb12
+    jumpi v14, bb11, bb12
   bb11:
     v15 = exp arg0, arg1
     v16 = gt v15, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v16, bb13, bb14
+    jumpi v16, bb13, bb14
   bb12:
     v17 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, arg0
     v18 = gt arg0, v17
-    br v18, bb15, bb16
+    jumpi v18, bb15, bb16
   bb13:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -156,7 +156,7 @@ fn @spow(arg0: i256, arg1: u256) {
   bb18:
     v22 = sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, arg0
     v23 = slt arg0, v22
-    br v23, bb19, bb20
+    jumpi v23, bb19, bb20
   bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -168,17 +168,17 @@ fn @spow(arg0: i256, arg1: u256) {
     v29 = phi [bb9: v26], [bb25: v37]
     v30 = phi [bb9: v27], [bb25: v38]
     v31 = gt v30, 1
-    br v31, bb22, bb23
+    jumpi v31, bb22, bb23
   bb22:
     v32 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v29
     v33 = gt v29, v32
-    br v33, bb24, bb25
+    jumpi v33, bb24, bb25
   bb23:
     v39 = sgt v28, 0
     v40 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v29
     v41 = gt v28, v40
     v42 = and v39, v41
-    br v42, bb26, bb27
+    jumpi v42, bb26, bb27
   bb24:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -199,7 +199,7 @@ fn @spow(arg0: i256, arg1: u256) {
     v44 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, v29
     v45 = slt v28, v44
     v46 = and v43, v45
-    br v46, bb28, bb29
+    jumpi v46, bb28, bb29
   bb28:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -214,43 +214,43 @@ fn @upow8(arg0: u8, arg1: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 255
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
     mstore 128, 0
     v9 = iszero arg1
-    br v9, bb7, bb8
+    jumpi v9, bb7, bb8
   bb7:
     v39 = phi [bb6: 1], [bb8: 0], [bb9: 1], [bb16: v14], [bb20: v23], [bb27: v38]
     mstore 128, v39
     returndata 128, 32
   bb8:
     v10 = iszero arg0
-    br v10, bb7, bb9
+    jumpi v10, bb7, bb9
   bb9:
     v11 = eq arg0, 1
-    br v11, bb7, bb10
+    jumpi v11, bb7, bb10
   bb10:
     v12 = eq arg0, 2
-    br v12, bb11, bb12
+    jumpi v12, bb11, bb12
   bb11:
     v13 = gt arg1, 255
-    br v13, bb13, bb14
+    jumpi v13, bb13, bb14
   bb12:
     v16 = lt arg0, 11
     v17 = lt arg1, 78
@@ -259,7 +259,7 @@ fn @upow8(arg0: u8, arg1: u8) {
     v20 = lt arg1, 32
     v21 = and v19, v20
     v22 = or v18, v21
-    br v22, bb17, bb18
+    jumpi v22, bb17, bb18
   bb13:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -267,7 +267,7 @@ fn @upow8(arg0: u8, arg1: u8) {
   bb14:
     v14 = shl arg1, 1
     v15 = gt v14, 255
-    br v15, bb15, bb16
+    jumpi v15, bb15, bb16
   bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -277,7 +277,7 @@ fn @upow8(arg0: u8, arg1: u8) {
   bb17:
     v23 = exp arg0, arg1
     v24 = gt v23, 255
-    br v24, bb19, bb20
+    jumpi v24, bb19, bb20
   bb18:
     jump bb21
   bb19:
@@ -291,15 +291,15 @@ fn @upow8(arg0: u8, arg1: u8) {
     v26 = phi [bb18: arg0], [bb25: v34]
     v27 = phi [bb18: arg1], [bb25: v35]
     v28 = gt v27, 1
-    br v28, bb22, bb23
+    jumpi v28, bb22, bb23
   bb22:
     v29 = div 255, v26
     v30 = gt v26, v29
-    br v30, bb24, bb25
+    jumpi v30, bb24, bb25
   bb23:
     v36 = div 255, v26
     v37 = gt v25, v36
-    br v37, bb26, bb27
+    jumpi v37, bb26, bb27
   bb24:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -325,46 +325,46 @@ fn @spow8(arg0: i8, arg1: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 0, v3
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 255
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
     mstore 128, 0
     v9 = iszero arg1
-    br v9, bb7, bb8
+    jumpi v9, bb7, bb8
   bb7:
     v54 = phi [bb6: 1], [bb8: arg0], [bb9: 0], [bb11: 1], [bb18: v21], [bb21: v27], [bb33: v53]
     mstore 128, v54
     returndata 128, 32
   bb8:
     v10 = eq arg1, 1
-    br v10, bb7, bb9
+    jumpi v10, bb7, bb9
   bb9:
     v11 = iszero arg0
-    br v11, bb7, bb10
+    jumpi v11, bb7, bb10
   bb10:
     v12 = sgt arg0, 0
-    br v12, bb11, bb12
+    jumpi v12, bb11, bb12
   bb11:
     v13 = eq arg0, 1
-    br v13, bb7, bb14
+    jumpi v13, bb7, bb14
   bb12:
     v25 = eq arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v25, bb21, bb22
+    jumpi v25, bb21, bb22
   bb13:
     v30 = and arg1, 1
     v31 = select v30, arg0, 1
@@ -379,15 +379,15 @@ fn @spow8(arg0: i8, arg1: u8) {
     v18 = lt arg1, 32
     v19 = and v17, v18
     v20 = or v16, v19
-    br v20, bb15, bb16
+    jumpi v20, bb15, bb16
   bb15:
     v21 = exp arg0, arg1
     v22 = gt v21, 127
-    br v22, bb17, bb18
+    jumpi v22, bb17, bb18
   bb16:
     v23 = div 127, arg0
     v24 = gt arg0, v23
-    br v24, bb19, bb20
+    jumpi v24, bb19, bb20
   bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -407,7 +407,7 @@ fn @spow8(arg0: i8, arg1: u8) {
   bb22:
     v28 = sdiv 127, arg0
     v29 = slt arg0, v28
-    br v29, bb23, bb24
+    jumpi v29, bb23, bb24
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -419,17 +419,17 @@ fn @spow8(arg0: i8, arg1: u8) {
     v35 = phi [bb13: v32], [bb29: v43]
     v36 = phi [bb13: v33], [bb29: v44]
     v37 = gt v36, 1
-    br v37, bb26, bb27
+    jumpi v37, bb26, bb27
   bb26:
     v38 = div 127, v35
     v39 = gt v35, v38
-    br v39, bb28, bb29
+    jumpi v39, bb28, bb29
   bb27:
     v45 = sgt v34, 0
     v46 = div 127, v35
     v47 = gt v34, v46
     v48 = and v45, v47
-    br v48, bb30, bb31
+    jumpi v48, bb30, bb31
   bb28:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -450,7 +450,7 @@ fn @spow8(arg0: i8, arg1: u8) {
     v50 = sdiv 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80, v35
     v51 = slt v34, v50
     v52 = and v49, v51
-    br v52, bb32, bb33
+    jumpi v52, bb32, bb33
   bb32:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -465,13 +465,13 @@ fn @const2(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = gt arg0, 255
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -487,13 +487,13 @@ fn @const10(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = gt arg0, 77
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -509,13 +509,13 @@ fn @const_neg2(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = eq 2, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -523,26 +523,26 @@ fn @const_neg2(arg0: u256) {
   bb4:
     v4 = sub 0, 2
     v5 = iszero arg0
-    br v5, bb5, bb6
+    jumpi v5, bb5, bb6
   bb5:
     v50 = phi [bb4: 1], [bb6: v4], [bb7: 0], [bb9: 1], [bb16: v17], [bb19: v23], [bb31: v49]
     mstore 128, v50
     returndata 128, 32
   bb6:
     v6 = eq arg0, 1
-    br v6, bb5, bb7
+    jumpi v6, bb5, bb7
   bb7:
     v7 = iszero v4
-    br v7, bb5, bb8
+    jumpi v7, bb5, bb8
   bb8:
     v8 = sgt v4, 0
-    br v8, bb9, bb10
+    jumpi v8, bb9, bb10
   bb9:
     v9 = eq v4, 1
-    br v9, bb5, bb12
+    jumpi v9, bb5, bb12
   bb10:
     v21 = eq v4, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v21, bb19, bb20
+    jumpi v21, bb19, bb20
   bb11:
     v26 = and arg0, 1
     v27 = select v26, v4, 1
@@ -557,15 +557,15 @@ fn @const_neg2(arg0: u256) {
     v14 = lt arg0, 32
     v15 = and v13, v14
     v16 = or v12, v15
-    br v16, bb13, bb14
+    jumpi v16, bb13, bb14
   bb13:
     v17 = exp v4, arg0
     v18 = gt v17, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v18, bb15, bb16
+    jumpi v18, bb15, bb16
   bb14:
     v19 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v4
     v20 = gt v4, v19
-    br v20, bb17, bb18
+    jumpi v20, bb17, bb18
   bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -585,7 +585,7 @@ fn @const_neg2(arg0: u256) {
   bb20:
     v24 = sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v4
     v25 = slt v4, v24
-    br v25, bb21, bb22
+    jumpi v25, bb21, bb22
   bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -597,17 +597,17 @@ fn @const_neg2(arg0: u256) {
     v31 = phi [bb11: v28], [bb27: v39]
     v32 = phi [bb11: v29], [bb27: v40]
     v33 = gt v32, 1
-    br v33, bb24, bb25
+    jumpi v33, bb24, bb25
   bb24:
     v34 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v31
     v35 = gt v31, v34
-    br v35, bb26, bb27
+    jumpi v35, bb26, bb27
   bb25:
     v41 = sgt v30, 0
     v42 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v31
     v43 = gt v30, v42
     v44 = and v41, v43
-    br v44, bb28, bb29
+    jumpi v44, bb28, bb29
   bb26:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -628,7 +628,7 @@ fn @const_neg2(arg0: u256) {
     v46 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, v31
     v47 = slt v30, v46
     v48 = and v45, v47
-    br v48, bb30, bb31
+    jumpi v48, bb30, bb31
   bb30:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -643,21 +643,21 @@ fn @unchecked_pow8(arg0: u8, arg1: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 255
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:

--- a/tests/ui/codegen/lowering/comparison.stdout
+++ b/tests/ui/codegen/lowering/comparison.stdout
@@ -5,7 +5,7 @@ fn @eq(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -20,7 +20,7 @@ fn @lt(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -35,7 +35,7 @@ fn @is_zero(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/compound_assign.stdout
+++ b/tests/ui/codegen/lowering/compound_assign.stdout
@@ -13,14 +13,14 @@ fn @add_to_value(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = add v3, arg0
     v5 = lt v4, v3
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -35,14 +35,14 @@ fn @sub_from_value(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = sub v3, arg0
     v5 = lt v3, arg0
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -57,7 +57,7 @@ fn @mul_value(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -68,7 +68,7 @@ fn @mul_value(arg0: u256) {
     v7 = eq v6, v3
     v8 = or v5, v7
     v9 = iszero v8
-    br v9, bb3, bb4
+    jumpi v9, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -84,7 +84,7 @@ fn @bump_post() {
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = add v0, 1
     v2 = lt v1, v0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -101,7 +101,7 @@ fn @bump_pre() {
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = add v0, 1
     v2 = lt v1, v0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/constructor_abi_validation.stdout
+++ b/tests/ui/codegen/lowering/constructor_abi_validation.stdout
@@ -25,7 +25,7 @@ fn @_anonymous(arg0: bool, arg1: u256, arg2: u256) {
     v1 = iszero v0
     v2 = iszero v1
     v3 = eq v0, v2
-    br v3, bb2, bb1
+    jumpi v3, bb2, bb1
   bb1:
     revert 0, 0
   bb2:
@@ -34,7 +34,7 @@ fn @_anonymous(arg0: bool, arg1: u256, arg2: u256) {
     v6 = iszero v5
     v7 = iszero v6
     v8 = eq v5, v7
-    br v8, bb4, bb3
+    jumpi v8, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -44,7 +44,7 @@ fn @_anonymous(arg0: bool, arg1: u256, arg2: u256) {
     v11 = iszero v10
     v12 = iszero v11
     v13 = eq v10, v12
-    br v13, bb6, bb5
+    jumpi v13, bb6, bb5
   bb5:
     revert 0, 0
   bb6:

--- a/tests/ui/codegen/lowering/constructor_internal_call.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_call.stdout
@@ -21,7 +21,7 @@ fn @helper(arg0: u256) -> u256 {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     ret 1
   bb2:
@@ -31,7 +31,7 @@ fn @helper(arg0: u256) -> u256 {
     v5 = eq v4, arg0
     v6 = or v3, v5
     v7 = iszero v6
-    br v7, bb3, bb4
+    jumpi v7, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -39,7 +39,7 @@ fn @helper(arg0: u256) -> u256 {
   bb4:
     v8 = sub arg0, 1
     v9 = lt arg0, 1
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -48,7 +48,7 @@ fn @helper(arg0: u256) -> u256 {
     v10 = internal_call @helper, 1, v8
     v11 = add v2, v10
     v12 = lt v11, v2
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
@@ -5,7 +5,7 @@ fn @helper(arg0: u256) -> u256 {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     ret 1
   bb2:
@@ -15,7 +15,7 @@ fn @helper(arg0: u256) -> u256 {
     v5 = eq v4, arg0
     v6 = or v3, v5
     v7 = iszero v6
-    br v7, bb3, bb4
+    jumpi v7, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -23,7 +23,7 @@ fn @helper(arg0: u256) -> u256 {
   bb4:
     v8 = sub arg0, 1
     v9 = lt arg0, 1
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -32,7 +32,7 @@ fn @helper(arg0: u256) -> u256 {
     v10 = internal_call @helper, 1, v8
     v11 = add v2, v10
     v12 = lt v11, v2
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -64,7 +64,7 @@ fn @helper(arg0: u256) -> u256 {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     ret 1
   bb2:
@@ -74,7 +74,7 @@ fn @helper(arg0: u256) -> u256 {
     v5 = eq v4, arg0
     v6 = or v3, v5
     v7 = iszero v6
-    br v7, bb3, bb4
+    jumpi v7, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -82,7 +82,7 @@ fn @helper(arg0: u256) -> u256 {
   bb4:
     v8 = sub arg0, 1
     v9 = lt arg0, 1
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -91,7 +91,7 @@ fn @helper(arg0: u256) -> u256 {
     v10 = internal_call @helper, 1, v8
     v11 = add v2, v10
     v12 = lt v11, v2
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/custom_error_payloads.stdout
+++ b/tests/ui/codegen/lowering/custom_error_payloads.stdout
@@ -31,7 +31,7 @@ fn @revert_args() {
     v11 = and v10, v9
     v12 = add v5, 32
     v13 = iszero v11
-    br v13, bb2, bb1
+    jumpi v13, bb2, bb1
   bb1:
     v14 = sub v11, 32
     v15 = add v12, v14
@@ -51,7 +51,7 @@ fn @require_empty(arg0: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -59,12 +59,12 @@ fn @require_empty(arg0: bool) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v7 = iszero arg0
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     v8 = alloc raw, exact, uninitialized, infallible, 4
     mstore v8, 0x4f3d7def00000000000000000000000000000000000000000000000000000000
@@ -80,7 +80,7 @@ fn @require_named(arg0: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -88,12 +88,12 @@ fn @require_named(arg0: bool) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v7 = iszero arg0
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     v8 = alloc memorybytes, exact, uninitialized, infallible, 64
     set_memory_object_len memorybytes, v8, 6
@@ -115,7 +115,7 @@ fn @require_named(arg0: bool) {
     v19 = and v18, v17
     v20 = add v13, 32
     v21 = iszero v19
-    br v21, bb8, bb7
+    jumpi v21, bb8, bb7
   bb6:
     stop
   bb7:

--- a/tests/ui/codegen/lowering/dynamic_struct_param.stdout
+++ b/tests/ui/codegen/lowering/dynamic_struct_param.stdout
@@ -5,12 +5,12 @@ fn @init(arg0: u256, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = gt arg0, 0xffffffffffffffff
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     revert 0, 0
   bb4:
@@ -19,7 +19,7 @@ fn @init(arg0: u256, arg1: address) {
     v6 = calldataload v4
     v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -28,7 +28,7 @@ fn @init(arg0: u256, arg1: address) {
     v10 = calldataload v9
     v11 = and v10, 255
     v12 = eq v10, v11
-    br v12, bb8, bb7
+    jumpi v12, bb8, bb7
   bb7:
     revert 0, 0
   bb8:
@@ -40,7 +40,7 @@ fn @init(arg0: u256, arg1: address) {
     v17 = calldataload v16
     v18 = add v17, 31
     v19 = lt v18, v17
-    br v19, bb9, bb10
+    jumpi v19, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -52,7 +52,7 @@ fn @init(arg0: u256, arg1: address) {
     v23 = select v22, 32, v21
     v24 = add 32, v23
     v25 = lt v24, v23
-    br v25, bb11, bb12
+    jumpi v25, bb11, bb12
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -74,7 +74,7 @@ fn @init(arg0: u256, arg1: address) {
     v35 = calldataload v34
     v36 = add v35, 31
     v37 = lt v36, v35
-    br v37, bb13, bb14
+    jumpi v37, bb13, bb14
   bb13:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -86,7 +86,7 @@ fn @init(arg0: u256, arg1: address) {
     v41 = select v40, 32, v39
     v42 = add 32, v41
     v43 = lt v42, v41
-    br v43, bb15, bb16
+    jumpi v43, bb15, bb16
   bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -105,7 +105,7 @@ fn @init(arg0: u256, arg1: address) {
     v50 = calldataload 36
     v51 = and v50, 0xffffffffffffffffffffffffffffffffffffffff
     v52 = eq v50, v51
-    br v52, bb18, bb17
+    jumpi v52, bb18, bb17
   bb17:
     revert 0, 0
   bb18:
@@ -115,7 +115,7 @@ fn @init(arg0: u256, arg1: address) {
     v55 = and arg1, 0xffffffffffffffffffffffffffffffffffffffff
     v56 = add v54, v55
     v57 = gt v56, 0xffffffffffffffffffffffffffffffffffffffff
-    br v57, bb19, bb20
+    jumpi v57, bb19, bb20
   bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -130,7 +130,7 @@ fn @flat(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -140,7 +140,7 @@ fn @flat(arg0: u256, arg1: u256) {
     v5 = calldataload 36
     v6 = and v5, 0xffffffffffffffffffffffffffffffffffffffff
     v7 = eq v5, v6
-    br v7, bb4, bb3
+    jumpi v7, bb4, bb3
   bb3:
     revert 0, 0
   bb4:

--- a/tests/ui/codegen/lowering/event_dynamic_data.stdout
+++ b/tests/ui/codegen/lowering/event_dynamic_data.stdout
@@ -5,7 +5,7 @@ fn @text(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -31,7 +31,7 @@ fn @text(arg0: memorybytes) {
     v18 = and v17, v16
     v19 = add v13, 32
     v20 = iszero v18
-    br v20, bb4, bb3
+    jumpi v20, bb4, bb3
   bb3:
     v21 = sub v18, 32
     v22 = add v19, v21
@@ -71,7 +71,7 @@ fn @literal() {
     v9 = and v8, v7
     v10 = add v4, 32
     v11 = iszero v9
-    br v11, bb2, bb1
+    jumpi v11, bb2, bb1
   bb1:
     v12 = sub v9, 32
     v13 = add v10, v12
@@ -98,7 +98,7 @@ fn @blob(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -124,7 +124,7 @@ fn @blob(arg0: memorybytes) {
     v18 = and v17, v16
     v19 = add v13, 32
     v20 = iszero v18
-    br v20, bb4, bb3
+    jumpi v20, bb4, bb3
   bb3:
     v21 = sub v18, 32
     v22 = add v19, v21

--- a/tests/ui/codegen/lowering/event_overloads.stdout
+++ b/tests/ui/codegen/lowering/event_overloads.stdout
@@ -5,14 +5,14 @@ fn @emitBoth(arg0: address, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:

--- a/tests/ui/codegen/lowering/fixed_bytes_canonical.stdout
+++ b/tests/ui/codegen/lowering/fixed_bytes_canonical.stdout
@@ -5,14 +5,14 @@ fn @fromUint(arg0: u8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -35,7 +35,7 @@ fn @compareElement(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -53,7 +53,7 @@ fn @compareElement(arg0: memorybytes) {
     mstore 128, 0
     v12 = memory_object_len memorybytes, v9
     v13 = lt 0, v12
-    br v13, bb4, bb3
+    jumpi v13, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -76,14 +76,14 @@ fn @narrow(arg0: bytes4) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffff00000000000000000000000000000000000000000000000000000000
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:

--- a/tests/ui/codegen/lowering/function_call.stdout
+++ b/tests/ui/codegen/lowering/function_call.stdout
@@ -6,7 +6,7 @@ fn @double(arg0: u256) -> u256 {
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = add arg0, arg0
     v2 = lt v1, arg0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -20,14 +20,14 @@ fn @quadruple(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, arg0
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -35,7 +35,7 @@ fn @quadruple(arg0: u256) {
   bb4:
     v5 = add v3, v3
     v6 = lt v5, v3
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -50,14 +50,14 @@ fn @sum_then_double(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, arg1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -65,7 +65,7 @@ fn @sum_then_double(arg0: u256, arg1: u256) {
   bb4:
     v5 = add v3, v3
     v6 = lt v5, v3
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/immutable_getter.stdout
+++ b/tests/ui/codegen/lowering/immutable_getter.stdout
@@ -13,7 +13,7 @@ fn @_anonymous(arg0: address) {
     v0 = mload 128
     v1 = and v0, 0xffffffffffffffffffffffffffffffffffffffff
     v2 = eq v0, v1
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/immutable_reads.stdout
+++ b/tests/ui/codegen/lowering/immutable_reads.stdout
@@ -22,7 +22,7 @@ fn @_anonymous(arg0: u256) {
     v0 = mload 0x2000
     v1 = add v0, 1
     v2 = lt v1, v0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -39,7 +39,7 @@ fn @end() {
     v1 = loadimmutable 32
     v2 = add v0, v1
     v3 = lt v2, v0
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/internal_call_fallbacks.stdout
+++ b/tests/ui/codegen/lowering/internal_call_fallbacks.stdout
@@ -5,7 +5,7 @@ fn @recurse(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -20,14 +20,14 @@ fn @a(arg0: u256) -> u256 {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     mstore 0, 0 !metadata(memory=scratch)
     jump bb3
   bb2:
     v2 = sub arg0, 1
     v3 = lt arg0, 1
-    br v3, bb4, bb5
+    jumpi v3, bb4, bb5
   bb3:
     v5 = mload 0 !metadata(memory=scratch)
     ret v5
@@ -46,14 +46,14 @@ fn @b(arg0: u256) -> u256 {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     mstore 0, 0 !metadata(memory=scratch)
     jump bb3
   bb2:
     v2 = sub arg0, 1
     v3 = lt arg0, 1
-    br v3, bb4, bb5
+    jumpi v3, bb4, bb5
   bb3:
     v5 = mload 0 !metadata(memory=scratch)
     ret v5
@@ -72,7 +72,7 @@ fn @multi(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -96,7 +96,7 @@ fn @pair(arg0: u256) -> (u256, u256) {
     mstore v1, 0 !metadata(memory=internal_frame)
     v2 = add arg0, 1
     v3 = lt v2, arg0
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/internal_loop_call.stdout
+++ b/tests/ui/codegen/lowering/internal_loop_call.stdout
@@ -11,7 +11,7 @@ fn @sumTo(arg0: u256) -> u256 {
     v2 = internal_frame_addr 160
     v3 = mload v2 !metadata(memory=internal_frame)
     v4 = lt v3, arg0
-    br v4, bb4, bb5
+    jumpi v4, bb4, bb5
   bb2:
     v17 = internal_frame_addr 128
     v18 = mload v17 !metadata(memory=internal_frame)
@@ -21,7 +21,7 @@ fn @sumTo(arg0: u256) -> u256 {
     v13 = mload v12 !metadata(memory=internal_frame)
     v14 = add v13, 1
     v15 = lt v14, v13
-    br v15, bb8, bb9
+    jumpi v15, bb8, bb9
   bb4:
     v5 = internal_frame_addr 160
     v6 = mload v5 !metadata(memory=internal_frame)
@@ -29,7 +29,7 @@ fn @sumTo(arg0: u256) -> u256 {
     v8 = mload v7 !metadata(memory=internal_frame)
     v9 = add v8, v6
     v10 = lt v9, v8
-    br v10, bb6, bb7
+    jumpi v10, bb6, bb7
   bb5:
     jump bb2
   bb6:
@@ -55,7 +55,7 @@ fn @run(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/internal_void_call.stdout
+++ b/tests/ui/codegen/lowering/internal_void_call.stdout
@@ -13,13 +13,13 @@ fn @set(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = eq arg0, 0
     v4 = iszero v3
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     sstore 0, arg0 !metadata(storage=slot(0))
     jump bb4
@@ -32,12 +32,12 @@ fn @setUnlessZero(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = eq arg0, 0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     stop
   bb4:
@@ -49,7 +49,7 @@ fn @writeIfNonZero(arg0: u256) {
   bb0:
     v0 = eq arg0, 0
     v1 = iszero v0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     sstore 0, arg0 !metadata(storage=slot(0))
     jump bb2

--- a/tests/ui/codegen/lowering/linear.stdout
+++ b/tests/ui/codegen/lowering/linear.stdout
@@ -5,14 +5,14 @@ fn @add(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, arg1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -27,14 +27,14 @@ fn @sub(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = sub arg0, arg1
     v4 = lt arg0, arg1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -49,14 +49,14 @@ fn @add_one(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, 1
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/loop_simple.stdout
+++ b/tests/ui/codegen/lowering/loop_simple.stdout
@@ -5,7 +5,7 @@ fn @sum_to(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -16,7 +16,7 @@ fn @sum_to(arg0: u256) {
   bb3:
     v3 = mload 192
     v4 = lt v3, arg0
-    br v4, bb6, bb7
+    jumpi v4, bb6, bb7
   bb4:
     v12 = mload 160
     mstore 128, v12
@@ -25,13 +25,13 @@ fn @sum_to(arg0: u256) {
     v9 = mload 192
     v10 = add v9, 1
     v11 = lt v10, v9
-    br v11, bb10, bb11
+    jumpi v11, bb10, bb11
   bb6:
     v5 = mload 160
     v6 = mload 192
     v7 = add v5, v6
     v8 = lt v7, v5
-    br v8, bb8, bb9
+    jumpi v8, bb8, bb9
   bb7:
     jump bb4
   bb8:

--- a/tests/ui/codegen/lowering/low_level_call_returndata.stdout
+++ b/tests/ui/codegen/lowering/low_level_call_returndata.stdout
@@ -5,21 +5,21 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -43,21 +43,21 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
     returndatacopy v23, v16, v17
     mstore 160, v22
     v24 = mload 128
-    br v24, bb7, bb8
+    jumpi v24, bb7, bb8
   bb7:
     v25 = mload 160
     v26 = mload v25
     v27 = eq v26, 0
-    br v27, bb10, bb9
+    jumpi v27, bb10, bb9
   bb8:
     v38 = phi [bb6: 0], [bb10: v37]
     v39 = iszero v38
-    br v39, bb15, bb16
+    jumpi v39, bb15, bb16
   bb9:
     v28 = mload 160
     v29 = memory_object_len memorybytes, v28
     v30 = lt v29, 32
-    br v30, bb11, bb12
+    jumpi v30, bb11, bb12
   bb10:
     v37 = phi [bb7: 1], [bb14: v34]
     jump bb8
@@ -70,7 +70,7 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
     v34 = iszero v33
     v35 = eq v32, v34
     v36 = iszero v35
-    br v36, bb13, bb14
+    jumpi v36, bb13, bb14
   bb13:
     revert 0, 0
   bb14:
@@ -96,14 +96,14 @@ fn @balanceOf(arg0: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -131,14 +131,14 @@ fn @balanceOf(arg0: address) {
     mstore 192, v21
     v23 = mload 160
     v24 = iszero v23
-    br v24, bb5, bb6
+    jumpi v24, bb5, bb6
   bb5:
     revert 0, 0
   bb6:
     v25 = mload 192
     v26 = memory_object_len memorybytes, v25
     v27 = lt v26, 32
-    br v27, bb7, bb8
+    jumpi v27, bb7, bb8
   bb7:
     revert 0, 0
   bb8:
@@ -153,14 +153,14 @@ fn @forward(arg0: address, arg1: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -196,7 +196,7 @@ fn @forward(arg0: address, arg1: memorybytes) {
     mstore 192, v27
     v29 = mload 160
     v30 = iszero v29
-    br v30, bb5, bb6
+    jumpi v30, bb5, bb6
   bb5:
     revert 0, 0
   bb6:

--- a/tests/ui/codegen/lowering/mapping.stdout
+++ b/tests/ui/codegen/lowering/mapping.stdout
@@ -5,7 +5,7 @@ fn @balances(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -21,21 +21,21 @@ fn @allowances(arg0: address, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -52,7 +52,7 @@ fn @set_balance(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -66,7 +66,7 @@ fn @add_balance(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -74,7 +74,7 @@ fn @add_balance(arg0: u256, arg1: u256) {
     v4 = sload v3 !metadata(storage=symbolic(v3))
     v5 = add v4, arg1
     v6 = lt v5, v4
-    br v6, bb3, bb4
+    jumpi v6, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -90,21 +90,21 @@ fn @approve(arg0: address, arg1: address, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -119,21 +119,21 @@ fn @get_allowance(arg0: address, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:

--- a/tests/ui/codegen/lowering/mapping_bytes_values.stdout
+++ b/tests/ui/codegen/lowering/mapping_bytes_values.stdout
@@ -5,7 +5,7 @@ fn @set(arg0: u256, arg1: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -43,7 +43,7 @@ fn @set(arg0: u256, arg1: memorybytes) {
     v32 = alloc raw, exact, uninitialized, infallible, 32
     mstore v32, v12
     v33 = keccak256 v32, 32
-    br v30, bb4, bb3
+    jumpi v30, bb4, bb3
   bb3:
     v34 = mload v14
     v35 = mul v13, 8
@@ -63,7 +63,7 @@ fn @set(arg0: u256, arg1: memorybytes) {
   bb5:
     v43 = mload v32
     v44 = lt v43, v31
-    br v44, bb6, bb7
+    jumpi v44, bb6, bb7
   bb6:
     v45 = mload v32
     v46 = add v33, v45
@@ -80,7 +80,7 @@ fn @set(arg0: u256, arg1: memorybytes) {
   bb8:
     v51 = mload v32
     v52 = lt v51, v26
-    br v52, bb9, bb10
+    jumpi v52, bb9, bb10
   bb9:
     v53 = mload v32
     v54 = add v33, v53
@@ -97,7 +97,7 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -136,7 +136,7 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
     v33 = alloc raw, exact, uninitialized, infallible, 32
     mstore v33, v13
     v34 = keccak256 v33, 32
-    br v31, bb4, bb3
+    jumpi v31, bb4, bb3
   bb3:
     v35 = mload v15
     v36 = mul v14, 8
@@ -156,7 +156,7 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
   bb5:
     v44 = mload v33
     v45 = lt v44, v32
-    br v45, bb6, bb7
+    jumpi v45, bb6, bb7
   bb6:
     v46 = mload v33
     v47 = add v34, v46
@@ -173,7 +173,7 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
   bb8:
     v52 = mload v33
     v53 = lt v52, v27
-    br v53, bb9, bb10
+    jumpi v53, bb9, bb10
   bb9:
     v54 = mload v33
     v55 = add v34, v54
@@ -190,7 +190,7 @@ fn @get(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -220,7 +220,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -237,7 +237,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -272,7 +272,7 @@ fn @getNested(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/mapping_dynamic_key.stdout
+++ b/tests/ui/codegen/lowering/mapping_dynamic_key.stdout
@@ -5,7 +5,7 @@ fn @lookup(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -21,7 +21,7 @@ fn @set(arg0: memorybytes, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -39,7 +39,7 @@ fn @set(arg0: memorybytes, arg1: address) {
     v12 = calldataload 36
     v13 = and v12, 0xffffffffffffffffffffffffffffffffffffffff
     v14 = eq v12, v13
-    br v14, bb4, bb3
+    jumpi v14, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -53,7 +53,7 @@ fn @get(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -82,7 +82,7 @@ fn @flat(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -98,14 +98,14 @@ fn @nestedFirst(arg0: calldataslice, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -122,14 +122,14 @@ fn @nestedSecond(arg0: address, arg1: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -168,7 +168,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -185,7 +185,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -220,7 +220,7 @@ fn @setLit(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -240,7 +240,7 @@ fn @setLitLong(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -262,7 +262,7 @@ fn @setNestedFirst(arg0: memorybytes, arg1: address, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -280,7 +280,7 @@ fn @setNestedFirst(arg0: memorybytes, arg1: address, arg2: u256) {
     v12 = calldataload 36
     v13 = and v12, 0xffffffffffffffffffffffffffffffffffffffff
     v14 = eq v12, v13
-    br v14, bb4, bb3
+    jumpi v14, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -295,7 +295,7 @@ fn @getNestedFirst(arg0: memorybytes, arg1: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -313,7 +313,7 @@ fn @getNestedFirst(arg0: memorybytes, arg1: address) {
     v12 = calldataload 36
     v13 = and v12, 0xffffffffffffffffffffffffffffffffffffffff
     v14 = eq v12, v13
-    br v14, bb4, bb3
+    jumpi v14, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -330,14 +330,14 @@ fn @setNestedSecond(arg0: address, arg1: memorybytes, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -363,7 +363,7 @@ fn @setSkey(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -400,7 +400,7 @@ fn @setSkey(arg0: memorybytes) {
     v31 = alloc raw, exact, uninitialized, infallible, 32
     mstore v31, 3
     v32 = keccak256 v31, 32
-    br v29, bb4, bb3
+    jumpi v29, bb4, bb3
   bb3:
     v33 = mload v13
     v34 = mul v12, 8
@@ -420,7 +420,7 @@ fn @setSkey(arg0: memorybytes) {
   bb5:
     v42 = mload v31
     v43 = lt v42, v30
-    br v43, bb6, bb7
+    jumpi v43, bb6, bb7
   bb6:
     v44 = mload v31
     v45 = add v32, v44
@@ -437,7 +437,7 @@ fn @setSkey(arg0: memorybytes) {
   bb8:
     v50 = mload v31
     v51 = lt v50, v25
-    br v51, bb9, bb10
+    jumpi v51, bb9, bb10
   bb9:
     v52 = mload v31
     v53 = add v32, v52
@@ -454,7 +454,7 @@ fn @setViaStorageKey(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -469,7 +469,7 @@ fn @setThenAlloc(arg0: calldataslice, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -478,7 +478,7 @@ fn @setThenAlloc(arg0: calldataslice, arg1: u256) {
     sstore v3, arg1 !metadata(storage=symbolic(v3))
     v4 = add 32, 31
     v5 = lt v4, 32
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -488,7 +488,7 @@ fn @setThenAlloc(arg0: calldataslice, arg1: u256) {
     v7 = and v4, v6
     v8 = add v7, 32
     v9 = lt v8, v7
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/mapping_nested_struct_copy.stdout
+++ b/tests/ui/codegen/lowering/mapping_nested_struct_copy.stdout
@@ -5,7 +5,7 @@ fn @set(arg0: u256, arg1: u256, arg2: u256, arg3: u256, arg4: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 160
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -31,7 +31,7 @@ fn @get(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -69,7 +69,7 @@ fn @clear(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/mapping_struct_getter.stdout
+++ b/tests/ui/codegen/lowering/mapping_struct_getter.stdout
@@ -11,7 +11,7 @@ fn @items(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/memory_allocation_panic.stdout
+++ b/tests/ui/codegen/lowering/memory_allocation_panic.stdout
@@ -5,14 +5,14 @@ fn @makeBytes(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = add arg0, 31
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -22,7 +22,7 @@ fn @makeBytes(arg0: u256) {
     v6 = and v3, v5
     v7 = add v6, 32
     v8 = lt v7, v6
-    br v8, bb5, bb6
+    jumpi v8, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -40,7 +40,7 @@ fn @makeArray(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -48,7 +48,7 @@ fn @makeArray(arg0: u256) {
     v3 = mul arg0, 32
     v4 = div v3, 32
     v5 = eq v4, arg0
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -56,7 +56,7 @@ fn @makeArray(arg0: u256) {
   bb4:
     v6 = add v3, 32
     v7 = lt v6, v3
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/memory_fixed_array_alloc.stdout
+++ b/tests/ui/codegen/lowering/memory_fixed_array_alloc.stdout
@@ -5,7 +5,7 @@ fn @guardedFix(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -18,7 +18,7 @@ fn @guardedFix(arg0: u256) {
     v6 = memory_object_element_addr memoryfixedarray<3, 1>, v3, 2
     mstore v6, 0
     v7 = lt arg0, 3
-    br v7, bb4, bb3
+    jumpi v7, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -35,7 +35,7 @@ fn @structArr(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -53,7 +53,7 @@ fn @structArr(arg0: u256) {
     v9 = memory_object_field_addr memorystruct<1>, v3, 0
     v10 = mload v9
     v11 = lt arg0, 3
-    br v11, bb4, bb3
+    jumpi v11, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -70,7 +70,7 @@ fn @nested(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -102,7 +102,7 @@ fn @nested(arg0: u256, arg1: u256) {
     v18 = memory_object_element_addr memoryfixedarray<2, 1>, v17, 0
     mstore v18, 1
     v19 = lt arg0, 3
-    br v19, bb4, bb3
+    jumpi v19, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -111,7 +111,7 @@ fn @nested(arg0: u256, arg1: u256) {
     v20 = memory_object_element_addr memoryfixedarray<3, 1>, v3, arg0
     v21 = mload v20
     v22 = lt arg1, 2
-    br v22, bb6, bb5
+    jumpi v22, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -139,7 +139,7 @@ fn @fmpIntegrity() {
     v5 = mul 1, 32
     v6 = div v5, 32
     v7 = eq v6, 1
-    br v7, bb2, bb1
+    jumpi v7, bb2, bb1
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -147,7 +147,7 @@ fn @fmpIntegrity() {
   bb2:
     v8 = add v5, 32
     v9 = lt v8, v5
-    br v9, bb3, bb4
+    jumpi v9, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -157,7 +157,7 @@ fn @fmpIntegrity() {
     set_memory_object_len memoryarray, v10, 1
     v11 = memory_object_len memoryarray, v10
     v12 = lt 0, v11
-    br v12, bb6, bb5
+    jumpi v12, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -169,7 +169,7 @@ fn @fmpIntegrity() {
     v15 = mload v14
     v16 = memory_object_len memoryarray, v10
     v17 = lt 0, v16
-    br v17, bb8, bb7
+    jumpi v17, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -220,7 +220,7 @@ fn @namedReturn() {
     mstore v7, 3
     v8 = add 32, 31
     v9 = lt v8, 32
-    br v9, bb1, bb2
+    jumpi v9, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -230,7 +230,7 @@ fn @namedReturn() {
     v11 = and v8, v10
     v12 = add v11, 32
     v13 = lt v12, v11
-    br v13, bb3, bb4
+    jumpi v13, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -240,7 +240,7 @@ fn @namedReturn() {
     set_memory_object_len memorybytes, v14, 32
     v15 = memory_object_len memorybytes, v14
     v16 = lt 0, v15
-    br v16, bb6, bb5
+    jumpi v16, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -251,7 +251,7 @@ fn @namedReturn() {
     mstore8 v18, 238
     v19 = memory_object_len memorybytes, v14
     v20 = lt 0, v19
-    br v20, bb8, bb7
+    jumpi v20, bb8, bb7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/mir_alloc_ops.stdout
+++ b/tests/ui/codegen/lowering/mir_alloc_ops.stdout
@@ -5,7 +5,7 @@ fn @fixedArray(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -28,7 +28,7 @@ fn @dynamic(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -36,7 +36,7 @@ fn @dynamic(arg0: calldataslice) {
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -48,7 +48,7 @@ fn @dynamic(arg0: calldataslice) {
     v9 = select v8, 32, v7
     v10 = add 32, v9
     v11 = lt v10, v9
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/msg_data.stdout
+++ b/tests/ui/codegen/lowering/msg_data.stdout
@@ -18,7 +18,7 @@ fn @copy() {
     v2 = slice_len v1
     v3 = add v2, 31
     v4 = lt v3, v2
-    br v4, bb1, bb2
+    jumpi v4, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -30,7 +30,7 @@ fn @copy() {
     v8 = select v7, 32, v6
     v9 = add 32, v8
     v10 = lt v9, v8
-    br v10, bb3, bb4
+    jumpi v10, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -73,7 +73,7 @@ fn @tail(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -83,14 +83,14 @@ fn @tail(arg0: u256, arg1: u256) {
     v5 = slice_ptr v4
     v6 = slice_len v4
     v7 = gt arg1, v6
-    br v7, bb3, bb4
+    jumpi v7, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb4:
     v8 = lt arg1, arg0
-    br v8, bb5, bb6
+    jumpi v8, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -102,7 +102,7 @@ fn @tail(arg0: u256, arg1: u256) {
     v12 = slice_len v11
     v13 = add v12, 31
     v14 = lt v13, v12
-    br v14, bb7, bb8
+    jumpi v14, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -114,7 +114,7 @@ fn @tail(arg0: u256, arg1: u256) {
     v18 = select v17, 32, v16
     v19 = add 32, v18
     v20 = lt v19, v18
-    br v20, bb9, bb10
+    jumpi v20, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/multi_return.stdout
+++ b/tests/ui/codegen/lowering/multi_return.stdout
@@ -5,20 +5,20 @@ fn @div_mod(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
-    br arg1, bb4, bb3
+    jumpi arg1, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
     revert 0, 36
   bb4:
     v3 = div arg0, arg1
-    br arg1, bb6, bb5
+    jumpi arg1, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -36,14 +36,14 @@ fn @min_max(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
     v3 = lt arg0, arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 128, arg0
     v4 = add 128, 32
@@ -61,7 +61,7 @@ fn @triple(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -70,7 +70,7 @@ fn @triple(arg0: u256) {
     mstore 192, 0
     v3 = add arg0, arg0
     v4 = lt v3, arg0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -78,7 +78,7 @@ fn @triple(arg0: u256) {
   bb4:
     v5 = add arg0, arg0
     v6 = lt v5, arg0
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -86,7 +86,7 @@ fn @triple(arg0: u256) {
   bb6:
     v7 = add v5, arg0
     v8 = lt v7, v5
-    br v8, bb7, bb8
+    jumpi v8, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/multi_return_call.stdout
+++ b/tests/ui/codegen/lowering/multi_return_call.stdout
@@ -29,7 +29,7 @@ fn @sat(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -42,7 +42,7 @@ fn @sat(arg0: u256, arg1: u256) {
     mstore 192, v6
     v7 = mload 160
     v8 = iszero v7
-    br v8, bb3, bb4
+    jumpi v8, bb3, bb4
   bb3:
     mstore 128, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     returndata 128, 32
@@ -79,7 +79,7 @@ fn @tryA(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/multi_return_named_init.stdout
+++ b/tests/ui/codegen/lowering/multi_return_named_init.stdout
@@ -15,7 +15,7 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v4 = internal_frame_addr 256
     v5 = mload v4 !metadata(memory=internal_frame)
     v6 = lt v5, 8
-    br v6, bb4, bb5
+    jumpi v6, bb4, bb5
   bb2:
     v35 = internal_frame_addr 192
     v36 = mload v35 !metadata(memory=internal_frame)
@@ -27,7 +27,7 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v31 = mload v30 !metadata(memory=internal_frame)
     v32 = add v31, 1
     v33 = lt v32, v31
-    br v33, bb10, bb11
+    jumpi v33, bb10, bb11
   bb4:
     v7 = internal_frame_addr 192
     v8 = mload v7 !metadata(memory=internal_frame)
@@ -38,7 +38,7 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v12 = mload v11 !metadata(memory=internal_frame)
     v13 = slice_len arg0
     v14 = lt v12, v13
-    br v14, bb7, bb6
+    jumpi v14, bb7, bb6
   bb5:
     jump bb2
   bb6:
@@ -61,7 +61,7 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v26 = mload v25 !metadata(memory=internal_frame)
     v27 = add v26, 1
     v28 = lt v27, v26
-    br v28, bb8, bb9
+    jumpi v28, bb8, bb9
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -85,7 +85,7 @@ fn @readTwice(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/multi_return_scratch.stdout
+++ b/tests/ui/codegen/lowering/multi_return_scratch.stdout
@@ -5,7 +5,7 @@ fn @stored(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -25,13 +25,13 @@ fn @triple(arg0: u256) -> (u256, u256, u256) {
     v2 = internal_frame_addr 256
     mstore v2, 0 !metadata(memory=internal_frame)
     v3 = eq arg0, 0
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     ret 1, 2, 3
   bb2:
     v4 = add arg0, 1
     v5 = lt v4, arg0
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -39,7 +39,7 @@ fn @triple(arg0: u256) -> (u256, u256, u256) {
   bb4:
     v6 = add arg0, 2
     v7 = lt v6, arg0
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -53,7 +53,7 @@ fn @assign(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/nested_loops.stdout
+++ b/tests/ui/codegen/lowering/nested_loops.stdout
@@ -5,7 +5,7 @@ fn @sum_grid(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -16,7 +16,7 @@ fn @sum_grid(arg0: u256, arg1: u256) {
   bb3:
     v3 = mload 192
     v4 = lt v3, arg0
-    br v4, bb6, bb7
+    jumpi v4, bb6, bb7
   bb4:
     v24 = mload 160
     mstore 128, v24
@@ -25,7 +25,7 @@ fn @sum_grid(arg0: u256, arg1: u256) {
     v21 = mload 192
     v22 = add v21, 1
     v23 = lt v22, v21
-    br v23, bb19, bb20
+    jumpi v23, bb19, bb20
   bb6:
     mstore 224, 0
     jump bb8
@@ -34,14 +34,14 @@ fn @sum_grid(arg0: u256, arg1: u256) {
   bb8:
     v5 = mload 224
     v6 = lt v5, arg1
-    br v6, bb11, bb12
+    jumpi v6, bb11, bb12
   bb9:
     jump bb5
   bb10:
     v18 = mload 224
     v19 = add v18, 1
     v20 = lt v19, v18
-    br v20, bb17, bb18
+    jumpi v20, bb17, bb18
   bb11:
     v7 = mload 160
     v8 = mload 192
@@ -52,7 +52,7 @@ fn @sum_grid(arg0: u256, arg1: u256) {
     v13 = eq v12, v8
     v14 = or v11, v13
     v15 = iszero v14
-    br v15, bb13, bb14
+    jumpi v15, bb13, bb14
   bb12:
     jump bb9
   bb13:
@@ -62,7 +62,7 @@ fn @sum_grid(arg0: u256, arg1: u256) {
   bb14:
     v16 = add v7, v10
     v17 = lt v16, v7
-    br v17, bb15, bb16
+    jumpi v17, bb15, bb16
   bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -91,7 +91,7 @@ fn @find_first(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -101,7 +101,7 @@ fn @find_first(arg0: u256, arg1: u256) {
   bb3:
     v3 = mload 160
     v4 = lt v3, arg0
-    br v4, bb6, bb7
+    jumpi v4, bb6, bb7
   bb4:
     mstore 128, arg0
     returndata 128, 32
@@ -109,7 +109,7 @@ fn @find_first(arg0: u256, arg1: u256) {
     v16 = mload 160
     v17 = add v16, 1
     v18 = lt v17, v16
-    br v18, bb19, bb20
+    jumpi v18, bb19, bb20
   bb6:
     mstore 192, 0
     jump bb8
@@ -118,20 +118,20 @@ fn @find_first(arg0: u256, arg1: u256) {
   bb8:
     v5 = mload 192
     v6 = lt v5, arg0
-    br v6, bb11, bb12
+    jumpi v6, bb11, bb12
   bb9:
     jump bb5
   bb10:
     v13 = mload 192
     v14 = add v13, 1
     v15 = lt v14, v13
-    br v15, bb17, bb18
+    jumpi v15, bb17, bb18
   bb11:
     v7 = mload 160
     v8 = mload 192
     v9 = add v7, v8
     v10 = lt v9, v7
-    br v10, bb13, bb14
+    jumpi v10, bb13, bb14
   bb12:
     jump bb9
   bb13:
@@ -140,7 +140,7 @@ fn @find_first(arg0: u256, arg1: u256) {
     revert 0, 36
   bb14:
     v11 = eq v9, arg1
-    br v11, bb15, bb16
+    jumpi v11, bb15, bb16
   bb15:
     v12 = mload 160
     mstore 128, v12

--- a/tests/ui/codegen/lowering/nested_static_struct_param.stdout
+++ b/tests/ui/codegen/lowering/nested_static_struct_param.stdout
@@ -5,7 +5,7 @@ fn @take(arg0: u256, arg1: u256, arg2: u256, arg3: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/packed_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/packed_calldata_slice.stdout
@@ -5,7 +5,7 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,14 +13,14 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) {
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = gt arg2, v4
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb4:
     v6 = lt arg2, arg1
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -32,7 +32,7 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) {
     v10 = slice_len v9
     v11 = add v10, 31
     v12 = lt v11, v10
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -44,7 +44,7 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) {
     v16 = select v15, 32, v14
     v17 = add 32, v16
     v18 = lt v17, v16
-    br v18, bb9, bb10
+    jumpi v18, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -106,7 +106,7 @@ fn @all() {
     v2 = slice_len v1
     v3 = add v2, 31
     v4 = lt v3, v2
-    br v4, bb1, bb2
+    jumpi v4, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -118,7 +118,7 @@ fn @all() {
     v8 = select v7, 32, v6
     v9 = add 32, v8
     v10 = lt v9, v8
-    br v10, bb3, bb4
+    jumpi v10, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/recursive.stdout
+++ b/tests/ui/codegen/lowering/recursive.stdout
@@ -5,21 +5,21 @@ fn @fact(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = gt arg0, 1
     v4 = iszero v3
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 128, 1
     returndata 128, 32
   bb4:
     v5 = sub arg0, 1
     v6 = lt arg0, 1
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -32,7 +32,7 @@ fn @fact(arg0: u256) {
     v11 = eq v10, arg0
     v12 = or v9, v11
     v13 = iszero v12
-    br v13, bb7, bb8
+    jumpi v13, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -48,13 +48,13 @@ fn @fact(arg0: u256) -> u256 {
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = gt arg0, 1
     v2 = iszero v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     ret 1
   bb2:
     v3 = sub arg0, 1
     v4 = lt arg0, 1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -67,7 +67,7 @@ fn @fact(arg0: u256) -> u256 {
     v9 = eq v8, arg0
     v10 = or v7, v9
     v11 = iszero v10
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -81,21 +81,21 @@ fn @fib(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = gt arg0, 1
     v4 = iszero v3
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 128, arg0
     returndata 128, 32
   bb4:
     v5 = sub arg0, 1
     v6 = lt arg0, 1
-    br v6, bb5, bb6
+    jumpi v6, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -104,7 +104,7 @@ fn @fib(arg0: u256) {
     v7 = internal_call fn3, 1, v5
     v8 = sub arg0, 2
     v9 = lt arg0, 2
-    br v9, bb7, bb8
+    jumpi v9, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -113,7 +113,7 @@ fn @fib(arg0: u256) {
     v10 = internal_call fn3, 1, v8
     v11 = add v7, v10
     v12 = lt v11, v7
-    br v12, bb9, bb10
+    jumpi v12, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -129,13 +129,13 @@ fn @fib(arg0: u256) -> u256 {
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = gt arg0, 1
     v2 = iszero v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     ret arg0
   bb2:
     v3 = sub arg0, 1
     v4 = lt arg0, 1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -144,7 +144,7 @@ fn @fib(arg0: u256) -> u256 {
     v5 = internal_call fn3, 1, v3
     v6 = sub arg0, 2
     v7 = lt arg0, 2
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -153,7 +153,7 @@ fn @fib(arg0: u256) -> u256 {
     v8 = internal_call fn3, 1, v6
     v9 = add v5, v8
     v10 = lt v9, v5
-    br v10, bb7, bb8
+    jumpi v10, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -167,20 +167,20 @@ fn @isEven(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = eq arg0, 0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 128, 1
     returndata 128, 32
   bb4:
     v4 = sub arg0, 1
     v5 = lt arg0, 1
-    br v5, bb5, bb6
+    jumpi v5, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -196,13 +196,13 @@ fn @isOdd(arg0: u256) -> bool {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     ret 0
   bb2:
     v2 = sub arg0, 1
     v3 = lt arg0, 1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -217,13 +217,13 @@ fn @isEven(arg0: u256) -> bool {
     v0 = internal_frame_addr 128
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = eq arg0, 0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     ret 1
   bb2:
     v2 = sub arg0, 1
     v3 = lt arg0, 1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -238,20 +238,20 @@ fn @isOdd(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = eq arg0, 0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 128, 0
     returndata 128, 32
   bb4:
     v4 = sub arg0, 1
     v5 = lt arg0, 1
-    br v5, bb5, bb6
+    jumpi v5, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/recursive_memory_return.stdout
+++ b/tests/ui/codegen/lowering/recursive_memory_return.stdout
@@ -5,14 +5,14 @@ fn @build(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     mstore 128, v3
     v4 = eq arg0, 0
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     v5 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     v6 = memory_object_field_addr memorystruct<2>, v5, 0
@@ -31,7 +31,7 @@ fn @build(arg0: u256) {
   bb4:
     v14 = sub arg0, 1
     v15 = lt arg0, 1
-    br v15, bb5, bb6
+    jumpi v15, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -43,7 +43,7 @@ fn @build(arg0: u256) {
     v19 = mload v18
     v20 = add v19, arg0
     v21 = lt v20, v19
-    br v21, bb7, bb8
+    jumpi v21, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -55,7 +55,7 @@ fn @build(arg0: u256) {
     v24 = mload v23
     v25 = add v24, 1
     v26 = lt v25, v24
-    br v26, bb9, bb10
+    jumpi v26, bb9, bb10
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -80,7 +80,7 @@ fn @build(arg0: u256) -> memorystruct {
     v1 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     mstore v0, v1 !metadata(memory=internal_frame)
     v2 = eq arg0, 0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     v3 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     v4 = memory_object_field_addr memorystruct<2>, v3, 0
@@ -91,7 +91,7 @@ fn @build(arg0: u256) -> memorystruct {
   bb2:
     v6 = sub arg0, 1
     v7 = lt arg0, 1
-    br v7, bb3, bb4
+    jumpi v7, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -103,7 +103,7 @@ fn @build(arg0: u256) -> memorystruct {
     v11 = mload v10
     v12 = add v11, arg0
     v13 = lt v12, v11
-    br v13, bb5, bb6
+    jumpi v13, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -115,7 +115,7 @@ fn @build(arg0: u256) -> memorystruct {
     v16 = mload v15
     v17 = add v16, 1
     v18 = lt v17, v16
-    br v18, bb7, bb8
+    jumpi v18, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -131,7 +131,7 @@ fn @mkArr(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -139,7 +139,7 @@ fn @mkArr(arg0: u256) {
     v3 = mul arg0, 32
     v4 = div v3, 32
     v5 = eq v4, arg0
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -147,7 +147,7 @@ fn @mkArr(arg0: u256) {
   bb4:
     v6 = add v3, 32
     v7 = lt v6, v3
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -160,7 +160,7 @@ fn @mkArr(arg0: u256) {
   bb7:
     v9 = mload 160
     v10 = lt v9, arg0
-    br v10, bb10, bb11
+    jumpi v10, bb10, bb11
   bb8:
     v25 = alloc raw, exact, uninitialized, infallible, 32
     v26 = add v25, 32
@@ -179,7 +179,7 @@ fn @mkArr(arg0: u256) {
     v22 = mload 160
     v23 = add v22, 1
     v24 = lt v23, v22
-    br v24, bb16, bb17
+    jumpi v24, bb16, bb17
   bb10:
     v11 = mload 160
     v12 = mul v11, 10
@@ -188,7 +188,7 @@ fn @mkArr(arg0: u256) {
     v15 = eq v14, v11
     v16 = or v13, v15
     v17 = iszero v16
-    br v17, bb12, bb13
+    jumpi v17, bb12, bb13
   bb11:
     jump bb8
   bb12:
@@ -199,7 +199,7 @@ fn @mkArr(arg0: u256) {
     v18 = mload 160
     v19 = memory_object_len memoryarray, v8
     v20 = lt v18, v19
-    br v20, bb15, bb14
+    jumpi v20, bb15, bb14
   bb14:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -223,7 +223,7 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
     mstore v0, 0 !metadata(memory=internal_frame)
     v1 = mload arg0
     v2 = eq arg1, v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     ret arg0
   bb2:
@@ -233,7 +233,7 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
     v6 = eq v5, arg1
     v7 = or v4, v6
     v8 = iszero v7
-    br v8, bb3, bb4
+    jumpi v8, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -241,7 +241,7 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
   bb4:
     v9 = memory_object_len memoryarray, arg0
     v10 = lt arg1, v9
-    br v10, bb6, bb5
+    jumpi v10, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -251,7 +251,7 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
     mstore v11, v3
     v12 = add arg1, 1
     v13 = lt v12, arg1
-    br v13, bb7, bb8
+    jumpi v13, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -266,7 +266,7 @@ fn @squares(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -274,7 +274,7 @@ fn @squares(arg0: u256) {
     v3 = mul arg0, 32
     v4 = div v3, 32
     v5 = eq v4, arg0
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -282,7 +282,7 @@ fn @squares(arg0: u256) {
   bb4:
     v6 = add v3, 32
     v7 = lt v6, v3
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/revert_payloads.stdout
+++ b/tests/ui/codegen/lowering/revert_payloads.stdout
@@ -5,7 +5,7 @@ fn @assert_panic(arg0: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,12 +13,12 @@ fn @assert_panic(arg0: bool) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v7 = iszero arg0
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
@@ -32,7 +32,7 @@ fn @require_message(arg0: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -40,12 +40,12 @@ fn @require_message(arg0: bool) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v7 = iszero arg0
-    br v7, bb5, bb6
+    jumpi v7, bb5, bb6
   bb5:
     internal_call @__revert_error, 0, 3, 0x6261640000000000000000000000000000000000000000000000000000000000
     invalid

--- a/tests/ui/codegen/lowering/signed_constant_ops.stdout
+++ b/tests/ui/codegen/lowering/signed_constant_ops.stdout
@@ -4,7 +4,7 @@ fn @lt() {
   bb0:
     mstore 128, 0
     v0 = eq 1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v0, bb1, bb2
+    jumpi v0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -20,14 +20,14 @@ fn @div() {
   bb0:
     mstore 128, 0
     v0 = eq 7, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
-    br v0, bb1, bb2
+    jumpi v0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb2:
     v1 = sub 0, 7
-    br 2, bb4, bb3
+    jumpi 2, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
@@ -36,7 +36,7 @@ fn @div() {
     v2 = eq v1, 0x8000000000000000000000000000000000000000000000000000000000000000
     v3 = eq 2, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     v4 = and v2, v3
-    br v4, bb5, bb6
+    jumpi v4, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -51,7 +51,7 @@ fn @shr() {
   bb0:
     mstore 128, 0
     v0 = eq 8, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
-    br v0, bb1, bb2
+    jumpi v0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/storage.stdout
+++ b/tests/ui/codegen/lowering/storage.stdout
@@ -13,7 +13,7 @@ fn @increment() {
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = add v0, 1
     v2 = lt v1, v0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -28,7 +28,7 @@ fn @set(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/storage_bytes_elements.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.stdout
@@ -27,7 +27,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -44,7 +44,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -79,7 +79,7 @@ fn @init(arg0: memorybytes) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -116,7 +116,7 @@ fn @init(arg0: memorybytes) {
     v31 = alloc raw, exact, uninitialized, infallible, 32
     mstore v31, 0
     v32 = keccak256 v31, 32
-    br v29, bb4, bb3
+    jumpi v29, bb4, bb3
   bb3:
     v33 = mload v13
     v34 = mul v12, 8
@@ -136,7 +136,7 @@ fn @init(arg0: memorybytes) {
   bb5:
     v42 = mload v31
     v43 = lt v42, v30
-    br v43, bb6, bb7
+    jumpi v43, bb6, bb7
   bb6:
     v44 = mload v31
     v45 = add v32, v44
@@ -153,7 +153,7 @@ fn @init(arg0: memorybytes) {
   bb8:
     v50 = mload v31
     v51 = lt v50, v25
-    br v51, bb9, bb10
+    jumpi v51, bb9, bb10
   bb9:
     v52 = mload v31
     v53 = add v32, v52
@@ -175,13 +175,13 @@ fn @poke() {
     v5 = shr 1, v0
     v6 = select v2, v5, v4
     v7 = lt 5, v6
-    br v7, bb2, bb1
+    jumpi v7, bb2, bb1
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb2:
-    br v2, bb4, bb3
+    jumpi v2, bb4, bb3
   bb3:
     v8 = sub 31, 5
     v9 = mul v8, 8
@@ -250,7 +250,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -267,7 +267,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -351,7 +351,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v37 = alloc raw, exact, uninitialized, infallible, 32
     mstore v37, 0
     v38 = keccak256 v37, 32
-    br v35, bb2, bb1
+    jumpi v35, bb2, bb1
   bb1:
     v39 = mload v19
     v40 = mul v18, 8
@@ -371,7 +371,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb3:
     v48 = mload v37
     v49 = lt v48, v36
-    br v49, bb4, bb5
+    jumpi v49, bb4, bb5
   bb4:
     v50 = mload v37
     v51 = add v38, v50
@@ -388,7 +388,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb6:
     v56 = mload v37
     v57 = lt v56, v31
-    br v57, bb7, bb8
+    jumpi v57, bb7, bb8
   bb7:
     v58 = mload v37
     v59 = add v38, v58
@@ -419,7 +419,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v80 = alloc raw, exact, uninitialized, infallible, 32
     mstore v80, 1
     v81 = keccak256 v80, 32
-    br v78, bb10, bb9
+    jumpi v78, bb10, bb9
   bb9:
     v82 = mload v62
     v83 = mul v61, 8
@@ -439,7 +439,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb11:
     v91 = mload v80
     v92 = lt v91, v79
-    br v92, bb12, bb13
+    jumpi v92, bb12, bb13
   bb12:
     v93 = mload v80
     v94 = add v81, v93
@@ -456,7 +456,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb14:
     v99 = mload v80
     v100 = lt v99, v74
-    br v100, bb15, bb16
+    jumpi v100, bb15, bb16
   bb15:
     v101 = mload v80
     v102 = add v81, v101
@@ -497,7 +497,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -514,7 +514,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -598,7 +598,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v37 = alloc raw, exact, uninitialized, infallible, 32
     mstore v37, 0
     v38 = keccak256 v37, 32
-    br v35, bb2, bb1
+    jumpi v35, bb2, bb1
   bb1:
     v39 = mload v19
     v40 = mul v18, 8
@@ -618,7 +618,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb3:
     v48 = mload v37
     v49 = lt v48, v36
-    br v49, bb4, bb5
+    jumpi v49, bb4, bb5
   bb4:
     v50 = mload v37
     v51 = add v38, v50
@@ -635,7 +635,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb6:
     v56 = mload v37
     v57 = lt v56, v31
-    br v57, bb7, bb8
+    jumpi v57, bb7, bb8
   bb7:
     v58 = mload v37
     v59 = add v38, v58
@@ -666,7 +666,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v80 = alloc raw, exact, uninitialized, infallible, 32
     mstore v80, 1
     v81 = keccak256 v80, 32
-    br v78, bb10, bb9
+    jumpi v78, bb10, bb9
   bb9:
     v82 = mload v62
     v83 = mul v61, 8
@@ -686,7 +686,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb11:
     v91 = mload v80
     v92 = lt v91, v79
-    br v92, bb12, bb13
+    jumpi v92, bb12, bb13
   bb12:
     v93 = mload v80
     v94 = add v81, v93
@@ -703,7 +703,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
   bb14:
     v99 = mload v80
     v100 = lt v99, v74
-    br v100, bb15, bb16
+    jumpi v100, bb15, bb16
   bb15:
     v101 = mload v80
     v102 = add v81, v101
@@ -751,7 +751,7 @@ fn @_anonymous() {
     v25 = alloc raw, exact, uninitialized, infallible, 32
     mstore v25, 0
     v26 = keccak256 v25, 32
-    br v23, bb2, bb1
+    jumpi v23, bb2, bb1
   bb1:
     v27 = mload v7
     v28 = mul v6, 8
@@ -771,7 +771,7 @@ fn @_anonymous() {
   bb3:
     v36 = mload v25
     v37 = lt v36, v24
-    br v37, bb4, bb5
+    jumpi v37, bb4, bb5
   bb4:
     v38 = mload v25
     v39 = add v26, v38
@@ -788,7 +788,7 @@ fn @_anonymous() {
   bb6:
     v44 = mload v25
     v45 = lt v44, v19
-    br v45, bb7, bb8
+    jumpi v45, bb7, bb8
   bb7:
     v46 = mload v25
     v47 = add v26, v46
@@ -819,7 +819,7 @@ fn @_anonymous() {
     v68 = alloc raw, exact, uninitialized, infallible, 32
     mstore v68, 1
     v69 = keccak256 v68, 32
-    br v66, bb10, bb9
+    jumpi v66, bb10, bb9
   bb9:
     v70 = mload v50
     v71 = mul v49, 8
@@ -839,7 +839,7 @@ fn @_anonymous() {
   bb11:
     v79 = mload v68
     v80 = lt v79, v67
-    br v80, bb12, bb13
+    jumpi v80, bb12, bb13
   bb12:
     v81 = mload v68
     v82 = add v69, v81
@@ -856,7 +856,7 @@ fn @_anonymous() {
   bb14:
     v87 = mload v68
     v88 = lt v87, v62
-    br v88, bb15, bb16
+    jumpi v88, bb15, bb16
   bb15:
     v89 = mload v68
     v90 = add v69, v89
@@ -895,7 +895,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -912,7 +912,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -986,7 +986,7 @@ fn @constructor() {
     v25 = alloc raw, exact, uninitialized, infallible, 32
     mstore v25, 0
     v26 = keccak256 v25, 32
-    br v23, bb2, bb1
+    jumpi v23, bb2, bb1
   bb1:
     v27 = mload v7
     v28 = mul v6, 8
@@ -1006,7 +1006,7 @@ fn @constructor() {
   bb3:
     v36 = mload v25
     v37 = lt v36, v24
-    br v37, bb4, bb5
+    jumpi v37, bb4, bb5
   bb4:
     v38 = mload v25
     v39 = add v26, v38
@@ -1023,7 +1023,7 @@ fn @constructor() {
   bb6:
     v44 = mload v25
     v45 = lt v44, v19
-    br v45, bb7, bb8
+    jumpi v45, bb7, bb8
   bb7:
     v46 = mload v25
     v47 = add v26, v46
@@ -1054,7 +1054,7 @@ fn @constructor() {
     v68 = alloc raw, exact, uninitialized, infallible, 32
     mstore v68, 1
     v69 = keccak256 v68, 32
-    br v66, bb10, bb9
+    jumpi v66, bb10, bb9
   bb9:
     v70 = mload v50
     v71 = mul v49, 8
@@ -1074,7 +1074,7 @@ fn @constructor() {
   bb11:
     v79 = mload v68
     v80 = lt v79, v67
-    br v80, bb12, bb13
+    jumpi v80, bb12, bb13
   bb12:
     v81 = mload v68
     v82 = add v69, v81
@@ -1091,7 +1091,7 @@ fn @constructor() {
   bb14:
     v87 = mload v68
     v88 = lt v87, v62
-    br v88, bb15, bb16
+    jumpi v88, bb15, bb16
   bb15:
     v89 = mload v68
     v90 = add v69, v89
@@ -1130,7 +1130,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -1147,7 +1147,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23

--- a/tests/ui/codegen/lowering/storage_bytes_from_calldata.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_from_calldata.stdout
@@ -5,14 +5,14 @@ fn @setText(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -24,7 +24,7 @@ fn @setText(arg0: calldataslice) {
     v9 = select v8, 32, v7
     v10 = add 32, v9
     v11 = lt v10, v9
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -60,7 +60,7 @@ fn @setText(arg0: calldataslice) {
     v36 = alloc raw, exact, uninitialized, infallible, 32
     mstore v36, 0
     v37 = keccak256 v36, 32
-    br v34, bb8, bb7
+    jumpi v34, bb8, bb7
   bb7:
     v38 = mload v18
     v39 = mul v17, 8
@@ -80,7 +80,7 @@ fn @setText(arg0: calldataslice) {
   bb9:
     v47 = mload v36
     v48 = lt v47, v35
-    br v48, bb10, bb11
+    jumpi v48, bb10, bb11
   bb10:
     v49 = mload v36
     v50 = add v37, v49
@@ -97,7 +97,7 @@ fn @setText(arg0: calldataslice) {
   bb12:
     v55 = mload v36
     v56 = lt v55, v30
-    br v56, bb13, bb14
+    jumpi v56, bb13, bb14
   bb13:
     v57 = mload v36
     v58 = add v37, v57
@@ -114,14 +114,14 @@ fn @setBlob(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -133,7 +133,7 @@ fn @setBlob(arg0: calldataslice) {
     v9 = select v8, 32, v7
     v10 = add 32, v9
     v11 = lt v10, v9
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -169,7 +169,7 @@ fn @setBlob(arg0: calldataslice) {
     v36 = alloc raw, exact, uninitialized, infallible, 32
     mstore v36, 1
     v37 = keccak256 v36, 32
-    br v34, bb8, bb7
+    jumpi v34, bb8, bb7
   bb7:
     v38 = mload v18
     v39 = mul v17, 8
@@ -189,7 +189,7 @@ fn @setBlob(arg0: calldataslice) {
   bb9:
     v47 = mload v36
     v48 = lt v47, v35
-    br v48, bb10, bb11
+    jumpi v48, bb10, bb11
   bb10:
     v49 = mload v36
     v50 = add v37, v49
@@ -206,7 +206,7 @@ fn @setBlob(arg0: calldataslice) {
   bb12:
     v55 = mload v36
     v56 = lt v55, v30
-    br v56, bb13, bb14
+    jumpi v56, bb13, bb14
   bb13:
     v57 = mload v36
     v58 = add v37, v57
@@ -245,7 +245,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -262,7 +262,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
@@ -6,7 +6,7 @@ fn @_anonymous() {
     v1 = memory_object_len memorybytes, v0
     v2 = add v1, 1
     v3 = lt v2, v1
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -51,7 +51,7 @@ fn @_anonymous() {
     v36 = alloc raw, exact, uninitialized, infallible, 32
     mstore v36, 0
     v37 = keccak256 v36, 32
-    br v34, bb4, bb3
+    jumpi v34, bb4, bb3
   bb3:
     v38 = mload v18
     v39 = mul v17, 8
@@ -71,7 +71,7 @@ fn @_anonymous() {
   bb5:
     v47 = mload v36
     v48 = lt v47, v35
-    br v48, bb6, bb7
+    jumpi v48, bb6, bb7
   bb6:
     v49 = mload v36
     v50 = add v37, v49
@@ -88,7 +88,7 @@ fn @_anonymous() {
   bb8:
     v55 = mload v36
     v56 = lt v55, v30
-    br v56, bb9, bb10
+    jumpi v56, bb9, bb10
   bb9:
     v57 = mload v36
     v58 = add v37, v57
@@ -101,7 +101,7 @@ fn @_anonymous() {
     v61 = memory_object_len memorybytes, v60
     v62 = add v61, 1
     v63 = lt v62, v61
-    br v63, bb11, bb12
+    jumpi v63, bb11, bb12
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -146,7 +146,7 @@ fn @_anonymous() {
     v96 = alloc raw, exact, uninitialized, infallible, 32
     mstore v96, 0
     v97 = keccak256 v96, 32
-    br v94, bb14, bb13
+    jumpi v94, bb14, bb13
   bb13:
     v98 = mload v78
     v99 = mul v77, 8
@@ -166,7 +166,7 @@ fn @_anonymous() {
   bb15:
     v107 = mload v96
     v108 = lt v107, v95
-    br v108, bb16, bb17
+    jumpi v108, bb16, bb17
   bb16:
     v109 = mload v96
     v110 = add v97, v109
@@ -183,7 +183,7 @@ fn @_anonymous() {
   bb18:
     v115 = mload v96
     v116 = lt v115, v90
-    br v116, bb19, bb20
+    jumpi v116, bb19, bb20
   bb19:
     v117 = mload v96
     v118 = add v97, v117
@@ -214,7 +214,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -231,7 +231,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -246,14 +246,14 @@ fn @pushValue(arg0: bytes1) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xff00000000000000000000000000000000000000000000000000000000000000
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -261,7 +261,7 @@ fn @pushValue(arg0: bytes1) {
     v7 = memory_object_len memorybytes, v6
     v8 = add v7, 1
     v9 = lt v8, v7
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -307,7 +307,7 @@ fn @pushValue(arg0: bytes1) {
     v43 = alloc raw, exact, uninitialized, infallible, 32
     mstore v43, 0
     v44 = keccak256 v43, 32
-    br v41, bb8, bb7
+    jumpi v41, bb8, bb7
   bb7:
     v45 = mload v25
     v46 = mul v24, 8
@@ -327,7 +327,7 @@ fn @pushValue(arg0: bytes1) {
   bb9:
     v54 = mload v43
     v55 = lt v54, v42
-    br v55, bb10, bb11
+    jumpi v55, bb10, bb11
   bb10:
     v56 = mload v43
     v57 = add v44, v56
@@ -344,7 +344,7 @@ fn @pushValue(arg0: bytes1) {
   bb12:
     v62 = mload v43
     v63 = lt v62, v37
-    br v63, bb13, bb14
+    jumpi v63, bb13, bb14
   bb13:
     v64 = mload v43
     v65 = add v44, v64
@@ -362,7 +362,7 @@ fn @pushZero() {
     v1 = memory_object_len memorybytes, v0
     v2 = add v1, 1
     v3 = lt v2, v1
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -407,7 +407,7 @@ fn @pushZero() {
     v36 = alloc raw, exact, uninitialized, infallible, 32
     mstore v36, 0
     v37 = keccak256 v36, 32
-    br v34, bb4, bb3
+    jumpi v34, bb4, bb3
   bb3:
     v38 = mload v18
     v39 = mul v17, 8
@@ -427,7 +427,7 @@ fn @pushZero() {
   bb5:
     v47 = mload v36
     v48 = lt v47, v35
-    br v48, bb6, bb7
+    jumpi v48, bb6, bb7
   bb6:
     v49 = mload v36
     v50 = add v37, v49
@@ -444,7 +444,7 @@ fn @pushZero() {
   bb8:
     v55 = mload v36
     v56 = lt v55, v30
-    br v56, bb9, bb10
+    jumpi v56, bb9, bb10
   bb9:
     v57 = mload v36
     v58 = add v37, v57
@@ -460,7 +460,7 @@ fn @popValue() {
   bb0:
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = memory_object_len memorybytes, v0
-    br v1, bb2, bb1
+    jumpi v1, bb2, bb1
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 49 !metadata(memory=scratch)
@@ -503,7 +503,7 @@ fn @popValue() {
     v33 = alloc raw, exact, uninitialized, infallible, 32
     mstore v33, 0
     v34 = keccak256 v33, 32
-    br v31, bb4, bb3
+    jumpi v31, bb4, bb3
   bb3:
     v35 = mload v15
     v36 = mul v14, 8
@@ -523,7 +523,7 @@ fn @popValue() {
   bb5:
     v44 = mload v33
     v45 = lt v44, v32
-    br v45, bb6, bb7
+    jumpi v45, bb6, bb7
   bb6:
     v46 = mload v33
     v47 = add v34, v46
@@ -540,7 +540,7 @@ fn @popValue() {
   bb8:
     v52 = mload v33
     v53 = lt v52, v27
-    br v53, bb9, bb10
+    jumpi v53, bb9, bb10
   bb9:
     v54 = mload v33
     v55 = add v34, v54

--- a/tests/ui/codegen/lowering/storage_checked_arithmetic.stdout
+++ b/tests/ui/codegen/lowering/storage_checked_arithmetic.stdout
@@ -5,14 +5,14 @@ fn @storage_sub(arg0: address, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -20,7 +20,7 @@ fn @storage_sub(arg0: address, arg1: u256) {
     v7 = sload v6 !metadata(storage=symbolic(v6))
     v8 = sub v7, arg1
     v9 = lt v7, arg1
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -36,14 +36,14 @@ fn @storage_binary_sub(arg0: address, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -51,7 +51,7 @@ fn @storage_binary_sub(arg0: address, arg1: u256) {
     v7 = sload v6 !metadata(storage=symbolic(v6))
     v8 = sub v7, arg1
     v9 = lt v7, arg1
-    br v9, bb5, bb6
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -67,21 +67,21 @@ fn @storage_struct_add(arg0: address, arg1: u128) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffffffffffffffffffffffffffff
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -89,7 +89,7 @@ fn @storage_struct_add(arg0: address, arg1: u128) {
     v10 = sload v9 !metadata(storage=symbolic(v9))
     v11 = add v10, arg1
     v12 = gt v11, 0xffffffffffffffffffffffffffffffff
-    br v12, bb7, bb8
+    jumpi v12, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -105,21 +105,21 @@ fn @storage_struct_signed_sub(arg0: address, arg1: i8) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = signextend 0, v6
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -130,7 +130,7 @@ fn @storage_struct_signed_sub(arg0: address, arg1: i8) {
     v13 = slt v12, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80
     v14 = sgt v12, 127
     v15 = or v13, v14
-    br v15, bb7, bb8
+    jumpi v15, bb7, bb8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
@@ -27,7 +27,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -44,7 +44,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23

--- a/tests/ui/codegen/lowering/storage_packed_bool.stdout
+++ b/tests/ui/codegen/lowering/storage_packed_bool.stdout
@@ -24,7 +24,7 @@ fn @set(arg0: bool, arg1: bool) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -32,7 +32,7 @@ fn @set(arg0: bool, arg1: bool) {
     v4 = iszero v3
     v5 = iszero v4
     v6 = eq v3, v5
-    br v6, bb4, bb3
+    jumpi v6, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -40,7 +40,7 @@ fn @set(arg0: bool, arg1: bool) {
     v8 = iszero v7
     v9 = iszero v8
     v10 = eq v7, v9
-    br v10, bb6, bb5
+    jumpi v10, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -63,7 +63,7 @@ fn @both() {
     mstore 128, 0
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = and v0, 255
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     v2 = sload 0 !metadata(storage=slot(0))
     v3 = shr 8, v2

--- a/tests/ui/codegen/lowering/storage_reference.stdout
+++ b/tests/ui/codegen/lowering/storage_reference.stdout
@@ -5,7 +5,7 @@ fn @setDirect(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -19,7 +19,7 @@ fn @getViaRef(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -35,7 +35,7 @@ fn @bump(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -44,7 +44,7 @@ fn @bump(arg0: u256) {
     v5 = sload v4 !metadata(storage=offset(v3, 1))
     v6 = add v5, 1
     v7 = lt v6, v5
-    br v7, bb3, bb4
+    jumpi v7, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/storage_struct_array.stdout
+++ b/tests/ui/codegen/lowering/storage_struct_array.stdout
@@ -5,12 +5,12 @@ fn @setS(arg0: u256, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = lt arg0, 3
-    br v3, bb4, bb3
+    jumpi v3, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -20,7 +20,7 @@ fn @setS(arg0: u256, arg1: u256, arg2: u256) {
     v5 = add 0, v4
     sstore v5, arg1 !metadata(storage=symbolic(v4))
     v6 = lt arg0, 3
-    br v6, bb6, bb5
+    jumpi v6, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -38,14 +38,14 @@ fn @getS(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
     v3 = lt arg0, 3
-    br v3, bb4, bb3
+    jumpi v3, bb4, bb3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -55,7 +55,7 @@ fn @getS(arg0: u256) {
     v5 = add 0, v4
     v6 = sload v5 !metadata(storage=symbolic(v4))
     v7 = lt arg0, 3
-    br v7, bb6, bb5
+    jumpi v7, bb6, bb5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/ternary.stdout
+++ b/tests/ui/codegen/lowering/ternary.stdout
@@ -5,13 +5,13 @@ fn @max(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = gt arg0, arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, arg0 !metadata(memory=scratch)
     jump bb5
@@ -29,19 +29,19 @@ fn @clamp(arg0: u256, arg1: u256, arg2: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 96
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = lt arg0, arg1
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb3:
     mstore 0, arg1 !metadata(memory=scratch)
     jump bb5
   bb4:
     v4 = gt arg0, arg2
-    br v4, bb6, bb7
+    jumpi v4, bb6, bb7
   bb5:
     v6 = mload 0 !metadata(memory=scratch)
     mstore 128, v6
@@ -63,22 +63,22 @@ fn @abs_diff(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     mstore 128, 0
     v3 = lt arg0, arg1
     v4 = iszero v3
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     v5 = sub arg0, arg1
     v6 = lt arg0, arg1
-    br v6, bb6, bb7
+    jumpi v6, bb6, bb7
   bb4:
     v7 = sub arg1, arg0
     v8 = lt arg1, arg0
-    br v8, bb8, bb9
+    jumpi v8, bb8, bb9
   bb5:
     v9 = mload 0 !metadata(memory=scratch)
     mstore 128, v9

--- a/tests/ui/codegen/lowering/type_conversion.stdout
+++ b/tests/ui/codegen/lowering/type_conversion.stdout
@@ -5,14 +5,14 @@ fn @narrowAddress(arg0: address) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
@@ -28,7 +28,7 @@ fn @narrowUint(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -43,7 +43,7 @@ fn @narrowSigned(arg0: i256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/using_for_struct.stdout
+++ b/tests/ui/codegen/lowering/using_for_struct.stdout
@@ -34,7 +34,7 @@ fn @viaMethod(arg0: bytes32, arg1: bytes32) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/while_loop.stdout
+++ b/tests/ui/codegen/lowering/while_loop.stdout
@@ -5,7 +5,7 @@ fn @count_down(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -15,7 +15,7 @@ fn @count_down(arg0: u256) {
   bb3:
     v3 = mload 160
     v4 = gt v3, 0
-    br v4, bb5, bb7
+    jumpi v4, bb5, bb7
   bb4:
     v8 = mload 160
     mstore 128, v8
@@ -24,7 +24,7 @@ fn @count_down(arg0: u256) {
     v5 = mload 160
     v6 = sub v5, 1
     v7 = lt v5, 1
-    br v7, bb8, bb9
+    jumpi v7, bb8, bb9
   bb6:
     jump bb3
   bb7:
@@ -43,7 +43,7 @@ fn @do_at_least_once(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -54,7 +54,7 @@ fn @do_at_least_once(arg0: u256) {
     v3 = mload 160
     v4 = add v3, 1
     v5 = lt v4, v3
-    br v5, bb5, bb6
+    jumpi v5, bb5, bb6
   bb4:
     v8 = mload 160
     mstore 128, v8
@@ -67,7 +67,7 @@ fn @do_at_least_once(arg0: u256) {
     mstore 160, v4
     v6 = mload 160
     v7 = lt v6, arg0
-    br v7, bb7, bb9
+    jumpi v7, bb7, bb9
   bb7:
     jump bb3
   bb8:
@@ -81,7 +81,7 @@ fn @break_when_found(arg0: u256, arg1: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -91,7 +91,7 @@ fn @break_when_found(arg0: u256, arg1: u256) {
   bb3:
     v3 = mload 160
     v4 = lt v3, arg0
-    br v4, bb5, bb7
+    jumpi v4, bb5, bb7
   bb4:
     v10 = mload 160
     mstore 128, v10
@@ -99,7 +99,7 @@ fn @break_when_found(arg0: u256, arg1: u256) {
   bb5:
     v5 = mload 160
     v6 = eq v5, arg1
-    br v6, bb8, bb9
+    jumpi v6, bb8, bb9
   bb6:
     jump bb3
   bb7:
@@ -110,7 +110,7 @@ fn @break_when_found(arg0: u256, arg1: u256) {
     v7 = mload 160
     v8 = add v7, 1
     v9 = lt v8, v7
-    br v9, bb10, bb11
+    jumpi v9, bb10, bb11
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/yul_calldata_array.stdout
+++ b/tests/ui/codegen/lowering/yul_calldata_array.stdout
@@ -5,7 +5,7 @@ fn @probe(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/lowering/yul_local_phi.stdout
+++ b/tests/ui/codegen/lowering/yul_local_phi.stdout
@@ -5,7 +5,7 @@ fn @branchLocal(arg0: u256) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -13,7 +13,7 @@ fn @branchLocal(arg0: u256) {
     mstore 160, 1
     v3 = eq arg0, 0
     v4 = iszero v3
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     mstore 160, 2
     jump bb4

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
@@ -5,21 +5,21 @@ fn @safeCall(arg0: address, arg1: bytes4) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 64
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
     v5 = eq v3, v4
-    br v5, bb4, bb3
+    jumpi v5, bb4, bb3
   bb3:
     revert 0, 0
   bb4:
     v6 = calldataload 36
     v7 = and v6, 0xffffffff00000000000000000000000000000000000000000000000000000000
     v8 = eq v6, v7
-    br v8, bb6, bb5
+    jumpi v8, bb6, bb5
   bb5:
     revert 0, 0
   bb6:
@@ -36,7 +36,7 @@ fn @safeCall(arg0: address, arg1: bytes4) {
     v16 = iszero v15
     v17 = eq v16, 0
     v18 = iszero v17
-    br v18, bb7, bb8
+    jumpi v18, bb7, bb8
   bb7:
     v19 = returndatasize
     returndatacopy v9, 0, v19

--- a/tests/ui/codegen/mir/adce/adce.mir
+++ b/tests/ui/codegen/mir/adce/adce.mir
@@ -2,7 +2,7 @@
 @module Adce
 fn @removes_dead_branch_region(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = add 1, 2
     jump bb3
@@ -15,7 +15,7 @@ fn @removes_dead_branch_region(arg0: bool) -> u256 {
 
 fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 0, 1
     jump bb3
@@ -27,7 +27,7 @@ fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
 
 fn @keeps_phi_target(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/adce/adce.stdout
+++ b/tests/ui/codegen/mir/adce/adce.stdout
@@ -3,7 +3,7 @@
   @module Adce
   fn @removes_dead_branch_region(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
+-     jumpi arg0, bb1, bb2
 -   bb1:
 -     v0 = add 1, 2
       jump bb3
@@ -19,7 +19,7 @@
   
   fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 0, 1
       jump bb3
@@ -31,7 +31,7 @@
   
   fn @keeps_phi_target(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
@@ -4,7 +4,7 @@ fn @keeps_branch_cycle(arg0: bool) -> u256 {
   bb0:
     jump bb1
   bb1:
-    br arg0, bb2, bb3
+    jumpi arg0, bb2, bb3
   bb2:
     jump bb1
   bb3:
@@ -15,16 +15,16 @@ fn @keeps_branch_self_loop(arg0: bool) -> u256 {
   bb0:
     jump bb1
   bb1:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb2:
     ret 7
 }
 
 fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb2:
     jump bb5
   bb3:

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
@@ -5,7 +5,7 @@
     bb0:
       jump bb1
     bb1:
-      br arg0, bb2, bb3
+      jumpi arg0, bb2, bb3
     bb2:
       jump bb1
     bb3:
@@ -16,17 +16,17 @@
     bb0:
       jump bb1
     bb1:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb2:
       ret 7
   }
   
   fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
+-     jumpi arg0, bb1, bb2
 +     jump bb5
     bb1:
--     br arg1, bb3, bb4
+-     jumpi arg1, bb3, bb4
 +     invalid
     bb2:
 -     jump bb5

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.mir
@@ -14,7 +14,7 @@ fn @sequential(arg0: u256) -> u256 {
 
 fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     ret 1
   bb2:
@@ -25,7 +25,7 @@ fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
 
 fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb1
+    jumpi arg0, bb1, bb1
   bb1:
     ret 1
 }

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
@@ -15,7 +15,7 @@
   
   fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       ret 1
     bb2:
@@ -26,7 +26,7 @@
   
   fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb1
+-     jumpi arg0, bb1, bb1
 -   bb1:
       ret 1
   }

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.mir
@@ -4,13 +4,13 @@
 // Two structurally identical panic blocks collapse into one shared block.
 fn @dedup_identical_panics(arg0: u256, arg1: u256) {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
     revert 0, 36
   bb2:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
@@ -22,13 +22,13 @@ fn @dedup_identical_panics(arg0: u256, arg1: u256) {
 // Panic blocks with different panic codes must NOT merge.
 fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
     revert 0, 36
   bb2:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 18
@@ -40,13 +40,13 @@ fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
 // Identical instructions but different terminator operands must NOT merge.
 fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
     revert 0, 36
   bb2:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
@@ -59,13 +59,13 @@ fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
 // computations merge.
 fn @dedup_local_computations(arg0: u256, arg1: u256) {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v10 = add arg0, 1
     mstore 0, v10
     revert 0, 32
   bb2:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb3:
     v20 = add arg0, 1
     mstore 0, v20
@@ -77,12 +77,12 @@ fn @dedup_local_computations(arg0: u256, arg1: u256) {
 // Blocks reading different outside values must NOT merge.
 fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 0, arg0
     revert 0, 32
   bb2:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb3:
     mstore 0, arg1
     revert 0, 32

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
@@ -3,14 +3,14 @@
   @module CfgDedupTerminalBlocks
   fn @dedup_identical_panics(arg0: u256, arg1: u256) {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 17
       revert 0, 36
     bb2:
--     br arg1, bb3, bb4
-+     br arg1, bb1, bb3
+-     jumpi arg1, bb3, bb4
++     jumpi arg1, bb1, bb3
     bb3:
 -     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
 -     mstore 4, 17
@@ -21,13 +21,13 @@
   
   fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 17
       revert 0, 36
     bb2:
-      br arg1, bb3, bb4
+      jumpi arg1, bb3, bb4
     bb3:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 18
@@ -38,13 +38,13 @@
   
   fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 17
       revert 0, 36
     bb2:
-      br arg1, bb3, bb4
+      jumpi arg1, bb3, bb4
     bb3:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 17
@@ -55,14 +55,14 @@
   
   fn @dedup_local_computations(arg0: u256, arg1: u256) {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = add arg0, 1
       mstore 0, v0
       revert 0, 32
     bb2:
--     br arg1, bb3, bb4
-+     br arg1, bb1, bb3
+-     jumpi arg1, bb3, bb4
++     jumpi arg1, bb1, bb3
     bb3:
 -     v1 = add arg0, 1
 -     mstore 0, v1
@@ -73,12 +73,12 @@
   
   fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 0, arg0
       revert 0, 32
     bb2:
-      br arg1, bb3, bb4
+      jumpi arg1, bb3, bb4
     bb3:
       mstore 0, arg1
       revert 0, 32

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.mir
@@ -5,7 +5,7 @@
 @module CfgSimplifyPhiForwarders
 fn @keep_conflicting_diamond(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -19,7 +19,7 @@ fn @keep_conflicting_diamond(arg0: bool) -> u256 {
 // keeps a single entry per predecessor.
 fn @fold_equal_value_diamond(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
@@ -3,8 +3,8 @@
   @module CfgSimplifyPhiForwarders
   fn @keep_conflicting_diamond(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
-+     br arg0, bb2, bb1
+-     jumpi arg0, bb1, bb2
++     jumpi arg0, bb2, bb1
     bb1:
 -     jump bb3
 +     jump bb2
@@ -18,8 +18,8 @@
   
   fn @fold_equal_value_diamond(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
-+     br arg0, bb2, bb1
+-     jumpi arg0, bb1, bb2
++     jumpi arg0, bb2, bb1
     bb1:
 -     jump bb3
 +     jump bb2

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.mir
@@ -4,8 +4,8 @@
 
 // CHECK-LABEL: @empty_forwarder
 // CHECK:       [[ENTRY:bb[0-9]+]]:
-// CHECK: -     br arg0, [[OTHER_BLOCK:bb[0-9]+]], [[REMOVED_BLOCK:bb[0-9]+]]
-// CHECK: +     br arg0, [[MERGE:bb[0-9]+]], [[OTHER_BLOCK]]
+// CHECK: -     jumpi arg0, [[OTHER_BLOCK:bb[0-9]+]], [[REMOVED_BLOCK:bb[0-9]+]]
+// CHECK: +     jumpi arg0, [[MERGE:bb[0-9]+]], [[OTHER_BLOCK]]
 // CHECK:       [[OTHER_BLOCK]]:
 // CHECK: -     jump [[OLD_MERGE:bb[0-9]+]]
 // CHECK: -     [[REMOVED_BLOCK]]:
@@ -18,7 +18,7 @@
 // CHECK:       ret [[PHI]]
 fn @empty_forwarder(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -31,8 +31,8 @@ fn @empty_forwarder(arg0: bool) -> u256 {
 
 // CHECK-LABEL: @block_merge
 // CHECK:       {{bb[0-9]+}}:
-// CHECK: -     br arg0, [[LEFT_BLOCK:bb[0-9]+]], [[OLD_RIGHT:bb[0-9]+]]
-// CHECK: +     br arg0, [[LEFT_BLOCK]], [[RIGHT_BLOCK:bb[0-9]+]]
+// CHECK: -     jumpi arg0, [[LEFT_BLOCK:bb[0-9]+]], [[OLD_RIGHT:bb[0-9]+]]
+// CHECK: +     jumpi arg0, [[LEFT_BLOCK]], [[RIGHT_BLOCK:bb[0-9]+]]
 // CHECK:       [[LEFT_BLOCK]]:
 // CHECK: -     jump [[OLD_LEFT:bb[0-9]+]]
 // CHECK: -     [[OLD_LEFT]]:
@@ -50,7 +50,7 @@ fn @empty_forwarder(arg0: bool) -> u256 {
 // CHECK:       ret [[PHI]]
 fn @block_merge(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb3
+    jumpi arg0, bb1, bb3
   bb1:
     jump bb2
   bb2:

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.stdout
@@ -3,8 +3,8 @@
   @module CfgSimplifyPhiRewrites
   fn @empty_forwarder(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
-+     br arg0, bb2, bb1
+-     jumpi arg0, bb1, bb2
++     jumpi arg0, bb2, bb1
     bb1:
 -     jump bb3
 -   bb2:
@@ -20,8 +20,8 @@
   
   fn @block_merge(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb3
-+     br arg0, bb1, bb2
+-     jumpi arg0, bb1, bb3
++     jumpi arg0, bb1, bb2
     bb1:
 -     jump bb2
 -   bb2:

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir
@@ -2,7 +2,7 @@
 @module CfgSimplifyTrivialPhi
 fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     log0 0, 0
     jump bb3
@@ -19,7 +19,7 @@ fn @fold_self_incoming_phi(arg0: u256, arg1: bool) -> u256 {
     jump bb1
   bb1:
     v2 = phi [bb0: arg0], [bb2: v2]
-    br arg1, bb2, bb3
+    jumpi arg1, bb2, bb3
   bb2:
     log0 0, 0
     jump bb1

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
@@ -3,7 +3,7 @@
   @module CfgSimplifyTrivialPhi
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       log0 0, 0
       jump bb3
@@ -21,7 +21,7 @@
       jump bb1
     bb1:
 -     v0 = phi [bb0: arg0], [bb2: v0]
-      br arg1, bb2, bb3
+      jumpi arg1, bb2, bb3
     bb2:
       log0 0, 0
       jump bb1
@@ -35,7 +35,7 @@
   @module CfgSimplifyTrivialPhi
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       log0 0, 0
       jump bb3
@@ -50,7 +50,7 @@
     bb0:
       jump bb1
     bb1:
-      br arg1, bb2, bb3
+      jumpi arg1, bb2, bb3
     bb2:
       log0 0, 0
       jump bb1

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
@@ -8,11 +8,11 @@ fn @chained_trivial(arg0: u256) -> u256 {
     jump bb1
   bb1:
     v1 = phi [bb0: arg0], [bb3: v1]
-    br arg0, bb2, bb4
+    jumpi arg0, bb2, bb4
   bb2:
     v2 = phi [bb1: v1], [bb2: v2]
     v3 = add v2, 1
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb3:
     jump bb1
   bb4:

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
@@ -6,14 +6,14 @@
       jump bb1
     bb1:
 -     v0 = phi [bb0: arg0], [bb3: v0]
--     br arg0, bb2, bb4
-+     br arg0, bb2, bb3
+-     jumpi arg0, bb2, bb4
++     jumpi arg0, bb2, bb3
     bb2:
 -     v1 = phi [bb1: v0], [bb2: v1]
 -     v2 = add v1, 1
--     br v2, bb2, bb3
+-     jumpi v2, bb2, bb3
 +     v2 = add arg0, 1
-+     br v2, bb2, bb1
++     jumpi v2, bb2, bb1
     bb3:
 -     jump bb1
 -   bb4:

--- a/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.mir
@@ -6,11 +6,11 @@
 fn @fold_exact_boundary(arg0: u256) -> u256 {
   bb0:
     v1 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     v2 = add arg0, 2
     v3 = lt v2, arg0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb2:
     ret 0
   bb3:
@@ -24,11 +24,11 @@ fn @fold_exact_boundary(arg0: u256) -> u256 {
 fn @keep_wrappable_boundary(arg0: u256) -> u256 {
   bb0:
     v1 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     v2 = add arg0, 2
     v3 = lt v2, arg0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb2:
     ret 0
   bb3:

--- a/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
@@ -4,11 +4,11 @@
   fn @fold_exact_boundary(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
-      br v0, bb1, bb2
+      jumpi v0, bb1, bb2
     bb1:
       v1 = add arg0, 2
       v2 = lt v1, arg0
--     br v2, bb3, bb4
+-     jumpi v2, bb3, bb4
 +     jump bb4
     bb2:
       ret 0
@@ -21,11 +21,11 @@
   fn @keep_wrappable_boundary(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-      br v0, bb1, bb2
+      jumpi v0, bb1, bb2
     bb1:
       v1 = add arg0, 2
       v2 = lt v1, arg0
-      br v2, bb3, bb4
+      jumpi v2, bb3, bb4
     bb2:
       ret 0
     bb3:

--- a/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_index_guard.mir
@@ -7,10 +7,10 @@
 fn @fold_const_len_check(arg0: u256) -> u256 {
   bb0:
     v1 = lt arg0, 3
-    br v1, bb1, bb4
+    jumpi v1, bb1, bb4
   bb1:
     v2 = lt arg0, 3
-    br v2, bb3, bb2
+    jumpi v2, bb3, bb2
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 50
@@ -30,10 +30,10 @@ fn @fold_dyn_len_check(arg0: u256) -> u256 {
   bb0:
     v1 = sload 0
     v2 = lt arg0, v1
-    br v2, bb1, bb4
+    jumpi v2, bb1, bb4
   bb1:
     v3 = lt arg0, v1
-    br v3, bb3, bb2
+    jumpi v3, bb3, bb2
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 50
@@ -51,10 +51,10 @@ fn @fold_dyn_len_check(arg0: u256) -> u256 {
 fn @keep_weaker_guard(arg0: u256) -> u256 {
   bb0:
     v1 = lt arg0, 5
-    br v1, bb1, bb4
+    jumpi v1, bb1, bb4
   bb1:
     v2 = lt arg0, 3
-    br v2, bb3, bb2
+    jumpi v2, bb3, bb2
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 50

--- a/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
@@ -4,10 +4,10 @@
   fn @fold_const_len_check(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 3
-      br v0, bb1, bb4
+      jumpi v0, bb1, bb4
     bb1:
       v1 = lt arg0, 3
--     br v1, bb3, bb2
+-     jumpi v1, bb3, bb2
 +     jump bb3
     bb2:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -25,10 +25,10 @@
     bb0:
       v0 = sload 0
       v1 = lt arg0, v0
-      br v1, bb1, bb4
+      jumpi v1, bb1, bb4
     bb1:
       v2 = lt arg0, v0
--     br v2, bb3, bb2
+-     jumpi v2, bb3, bb2
 +     jump bb3
     bb2:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
@@ -45,10 +45,10 @@
   fn @keep_weaker_guard(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 5
-      br v0, bb1, bb4
+      jumpi v0, bb1, bb4
     bb1:
       v1 = lt arg0, 3
-      br v1, bb3, bb2
+      jumpi v1, bb3, bb2
     bb2:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 50

--- a/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.mir
@@ -9,11 +9,11 @@ fn @fold_increment_check(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb4: v3]
     v2 = lt v1, arg0
-    br v2, bb2, bb5
+    jumpi v2, bb2, bb5
   bb2:
     v3 = add v1, 1
     v4 = lt v3, v1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     revert 0, 0
   bb4:
@@ -26,16 +26,16 @@ fn @fold_increment_check(arg0: u256) -> u256 {
 // so the overflow check must stay.
 fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v1 = lt arg0, 100
-    br v1, bb3, bb2
+    jumpi v1, bb3, bb2
   bb2:
     jump bb3
   bb3:
     v2 = add arg0, 1
     v3 = lt v2, arg0
-    br v3, bb4, bb5
+    jumpi v3, bb4, bb5
   bb4:
     revert 0, 0
   bb5:

--- a/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
@@ -7,11 +7,11 @@
     bb1:
       v0 = phi [bb0: 0], [bb4: v2]
       v1 = lt v0, arg0
-      br v1, bb2, bb5
+      jumpi v1, bb2, bb5
     bb2:
       v2 = add v0, 1
       v3 = lt v2, v0
--     br v3, bb3, bb4
+-     jumpi v3, bb3, bb4
 +     jump bb4
     bb3:
       revert 0, 0
@@ -23,16 +23,16 @@
   
   fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = lt arg0, 100
-      br v0, bb3, bb2
+      jumpi v0, bb3, bb2
     bb2:
       jump bb3
     bb3:
       v1 = add arg0, 1
       v2 = lt v1, arg0
-      br v2, bb4, bb5
+      jumpi v2, bb4, bb5
     bb4:
       revert 0, 0
     bb5:

--- a/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_mul_div.mir
@@ -7,13 +7,13 @@
 fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
   bb0:
     v1 = lt arg0, 100
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     v2 = mul arg0, 3
     v3 = div v2, 3
     v4 = eq v3, arg0
     v5 = iszero v4
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb2:
     ret 0
   bb3:
@@ -29,7 +29,7 @@ fn @keep_mul_check_without_bound(arg0: u256) -> u256 {
     v2 = div v1, 3
     v3 = eq v2, arg0
     v4 = iszero v3
-    br v4, bb1, bb2
+    jumpi v4, bb1, bb2
   bb1:
     revert 0, 0
   bb2:

--- a/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
@@ -4,13 +4,13 @@
   fn @fold_mul_check_with_bound(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 100
-      br v0, bb1, bb2
+      jumpi v0, bb1, bb2
     bb1:
       v1 = mul arg0, 3
       v2 = div v1, 3
       v3 = eq v2, arg0
       v4 = iszero v3
--     br v4, bb3, bb4
+-     jumpi v4, bb3, bb4
 +     jump bb4
     bb2:
       ret 0
@@ -26,7 +26,7 @@
       v1 = div v0, 3
       v2 = eq v1, arg0
       v3 = iszero v2
-      br v3, bb1, bb2
+      jumpi v3, bb1, bb2
     bb1:
       revert 0, 0
     bb2:

--- a/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.mir
@@ -6,16 +6,16 @@
 fn @keep_check_on_loop_phi(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v1 = lt arg0, 100
-    br v1, bb1, bb5
+    jumpi v1, bb1, bb5
   bb1:
     jump bb2
   bb2:
     v2 = phi [bb1: arg0], [bb3: v3]
     v3 = add v2, 1
     v4 = lt v3, v2
-    br v4, bb4, bb3
+    jumpi v4, bb4, bb3
   bb3:
-    br arg1, bb2, bb6
+    jumpi arg1, bb2, bb6
   bb4:
     revert 0, 0
   bb5:

--- a/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
@@ -4,16 +4,16 @@
   fn @keep_check_on_loop_phi(arg0: u256, arg1: bool) -> u256 {
     bb0:
       v0 = lt arg0, 100
-      br v0, bb1, bb5
+      jumpi v0, bb1, bb5
     bb1:
       jump bb2
     bb2:
       v1 = phi [bb1: arg0], [bb3: v2]
       v2 = add v1, 1
       v3 = lt v2, v1
-      br v3, bb4, bb3
+      jumpi v3, bb4, bb3
     bb3:
-      br arg1, bb2, bb6
+      jumpi arg1, bb2, bb6
     bb4:
       revert 0, 0
     bb5:

--- a/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir
+++ b/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.mir
@@ -9,13 +9,13 @@ fn @fold_sub_after_ge_guard(arg0: u256, arg1: u256) -> u256 {
     v1 = gt arg1, arg0
     v2 = iszero v1
     v3 = iszero v2
-    br v3, bb1, bb2
+    jumpi v3, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v4 = sub arg0, arg1
     v5 = lt arg0, arg1
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     revert 0, 0
   bb4:
@@ -27,7 +27,7 @@ fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v1 = sub arg0, arg1
     v2 = lt arg0, arg1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -39,14 +39,14 @@ fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
 fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v1 = gt arg1, arg0
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v2 = mload 0
     v3 = sub v2, arg1
     v4 = lt v2, arg1
-    br v4, bb3, bb4
+    jumpi v4, bb3, bb4
   bb3:
     revert 0, 0
   bb4:

--- a/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
@@ -6,13 +6,13 @@
       v0 = gt arg1, arg0
       v1 = iszero v0
       v2 = iszero v1
-      br v2, bb1, bb2
+      jumpi v2, bb1, bb2
     bb1:
       revert 0, 0
     bb2:
       v3 = sub arg0, arg1
       v4 = lt arg0, arg1
--     br v4, bb3, bb4
+-     jumpi v4, bb3, bb4
 +     jump bb4
     bb3:
       revert 0, 0
@@ -24,7 +24,7 @@
     bb0:
       v0 = sub arg0, arg1
       v1 = lt arg0, arg1
-      br v1, bb1, bb2
+      jumpi v1, bb1, bb2
     bb1:
       revert 0, 0
     bb2:
@@ -34,14 +34,14 @@
   fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
     bb0:
       v0 = gt arg1, arg0
-      br v0, bb1, bb2
+      jumpi v0, bb1, bb2
     bb1:
       revert 0, 0
     bb2:
       v1 = mload 0
       v2 = sub v1, arg1
       v3 = lt v1, arg1
-      br v3, bb3, bb4
+      jumpi v3, bb3, bb4
     bb3:
       revert 0, 0
     bb4:

--- a/tests/ui/codegen/mir/cse/alias_builder_cases.mir
+++ b/tests/ui/codegen/mir/cse/alias_builder_cases.mir
@@ -102,7 +102,7 @@ fn @distinct_loop_allocations(arg0: bool) -> u256 {
     mstore v1, 9
     v3 = mload v0
     v4 = add v2, v3
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb2:
     ret v4
 }

--- a/tests/ui/codegen/mir/cse/alias_builder_cases.stdout
+++ b/tests/ui/codegen/mir/cse/alias_builder_cases.stdout
@@ -73,7 +73,7 @@
 -     v3 = mload v0
 -     v4 = add v2, v3
 +     v4 = add v2, v2
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb2:
       ret v4
   }

--- a/tests/ui/codegen/mir/cse/cse_global.mir
+++ b/tests/ui/codegen/mir/cse/cse_global.mir
@@ -3,7 +3,7 @@
 fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
   bb0:
     v3 = add arg0, arg1
-    br arg2, bb1, bb2
+    jumpi arg2, bb1, bb2
   bb1:
     v4 = add arg0, arg1
     v5 = mul v4, 2

--- a/tests/ui/codegen/mir/cse/cse_global.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global.stdout
@@ -4,7 +4,7 @@
   fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
     bb0:
       v0 = add arg0, arg1
-      br arg2, bb1, bb2
+      jumpi arg2, bb1, bb2
     bb1:
 -     v1 = add arg0, arg1
 -     v2 = mul v1, 2

--- a/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_clobber_paths.mir
@@ -3,7 +3,7 @@
 fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
   bb0:
     v1 = sload 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     sstore 0, 7
     jump bb3
@@ -18,7 +18,7 @@ fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
 fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
   bb0:
     v1 = sload 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -32,7 +32,7 @@ fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
 fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
   bb0:
     v1 = sload 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     sstore 1, 7
     jump bb3
@@ -51,7 +51,7 @@ fn @loop_sload_clobbered_body(arg0: u256) -> u256 {
   bb1:
     v2 = sload 0
     v3 = lt v2, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     sstore 0, 7
     jump bb1
@@ -67,7 +67,7 @@ fn @loop_sload_clean_body(arg0: u256) -> u256 {
   bb1:
     v2 = sload 0
     v3 = lt v2, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     jump bb1
   bb3:
@@ -79,7 +79,7 @@ fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
   bb0:
     mstore 0, 11
     v1 = mload 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 0, 22
     jump bb3
@@ -95,7 +95,7 @@ fn @diamond_call_clobbers_account_reads(arg0: bool, arg1: address) -> u256 {
   bb0:
     v1 = balance arg1
     v2 = extcodesize arg1
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v3 = call 100000, arg1, 0, 0, 0, 0, 0
     jump bb3

--- a/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
@@ -4,7 +4,7 @@
   fn @diamond_sload_clobbered_arm(arg0: bool) -> u256 {
     bb0:
       v0 = sload 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       sstore 0, 7
       jump bb3
@@ -19,7 +19,7 @@
   fn @diamond_sload_clean_arms(arg0: bool) -> u256 {
     bb0:
       v0 = sload 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:
@@ -34,7 +34,7 @@
   fn @diamond_sload_distinct_slot_store(arg0: bool) -> u256 {
     bb0:
       v0 = sload 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       sstore 1, 7
       jump bb3
@@ -54,7 +54,7 @@
     bb1:
       v1 = sload 0
       v2 = lt v1, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       sstore 0, 7
       jump bb1
@@ -71,7 +71,7 @@
 -     v1 = sload 0
 -     v2 = lt v1, arg0
 +     v2 = lt v0, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       jump bb1
     bb3:
@@ -84,7 +84,7 @@
     bb0:
       mstore 0, 11
       v0 = mload 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 0, 22
       jump bb3
@@ -100,7 +100,7 @@
     bb0:
       v0 = balance arg1
       v1 = extcodesize arg1
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v2 = call 0x186a0, arg1, 0, 0, 0, 0, 0
       jump bb3

--- a/tests/ui/codegen/mir/cse/cse_global_loads.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.mir
@@ -4,7 +4,7 @@ fn @dominating_mload(arg0: bool) -> u256 {
   bb0:
     mstore 0, 11
     v1 = mload 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v2 = mload 0
     ret v2
@@ -17,7 +17,7 @@ fn @dominating_mload(arg0: bool) -> u256 {
 fn @dominating_sload(arg0: bool) -> u256 {
   bb0:
     v1 = sload 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v2 = sload 0
     ret v2

--- a/tests/ui/codegen/mir/cse/cse_global_loads.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.stdout
@@ -5,7 +5,7 @@
     bb0:
       mstore 0, 11
       v0 = mload 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
 -     v1 = mload 0
 -     ret v1
@@ -19,7 +19,7 @@
   fn @dominating_sload(arg0: bool) -> u256 {
     bb0:
       v0 = sload 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
 -     v1 = sload 0
 -     ret v1

--- a/tests/ui/codegen/mir/cse/cse_gvn.mir
+++ b/tests/ui/codegen/mir/cse/cse_gvn.mir
@@ -4,7 +4,7 @@ fn @nested_offsets_across_dominator(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v2 = add arg0, 16
     v3 = add v2, 16
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v4 = add arg0, 32
     v5 = add v3, v4
@@ -17,7 +17,7 @@ fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v2 = add 16, arg0
     v3 = add 16, v2
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v4 = add arg0, 32
     ret v4
@@ -30,7 +30,7 @@ fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
     v2 = add arg0, 16
     v3 = add v2, 16
     v4 = keccak256 v3, 32
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v5 = add arg0, 32
     v6 = keccak256 v5, 32
@@ -44,7 +44,7 @@ fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256
     v2 = add arg0, 16
     v3 = add v2, 16
     v4 = mload v3
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v5 = add arg0, 32
     mstore v5, 7
@@ -66,7 +66,7 @@ fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
 
 fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
   bb0:
-    br arg2, bb1, bb2
+    jumpi arg2, bb1, bb2
   bb1:
     v3 = add arg0, arg1
     jump bb3
@@ -81,7 +81,7 @@ fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
 
 fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1
     v3 = mul v2, 2

--- a/tests/ui/codegen/mir/cse/cse_gvn.stdout
+++ b/tests/ui/codegen/mir/cse/cse_gvn.stdout
@@ -5,7 +5,7 @@
     bb0:
       v0 = add arg0, 16
       v1 = add v0, 16
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
 -     v2 = add arg0, 32
 -     v3 = add v1, v2
@@ -19,7 +19,7 @@
     bb0:
       v0 = add 16, arg0
       v1 = add 16, v0
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
 -     v2 = add arg0, 32
 -     ret v2
@@ -33,7 +33,7 @@
       v0 = add arg0, 16
       v1 = add v0, 16
       v2 = keccak256 v1, 32
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
 -     v3 = add arg0, 32
 -     v4 = keccak256 v3, 32
@@ -48,7 +48,7 @@
       v0 = add arg0, 16
       v1 = add v0, 16
       v2 = mload v1
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
 -     v3 = add arg0, 32
 -     mstore v3, 7
@@ -71,7 +71,7 @@
   
   fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
     bb0:
-      br arg2, bb1, bb2
+      jumpi arg2, bb1, bb2
     bb1:
 -     v0 = add arg0, arg1
       jump bb3
@@ -88,7 +88,7 @@
   
   fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1
       v1 = mul v0, 2

--- a/tests/ui/codegen/mir/dce/dce_cross_block.mir
+++ b/tests/ui/codegen/mir/dce/dce_cross_block.mir
@@ -5,7 +5,7 @@
 fn @cross(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v2 = add arg0, 1
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v3 = mul arg0, arg0
     jump bb2

--- a/tests/ui/codegen/mir/dce/dce_cross_block.stdout
+++ b/tests/ui/codegen/mir/dce/dce_cross_block.stdout
@@ -4,7 +4,7 @@
   fn @cross(arg0: u256, arg1: bool) -> u256 {
     bb0:
       v0 = add arg0, 1
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
 -     v1 = mul arg0, arg0
       jump bb2

--- a/tests/ui/codegen/mir/dump_cfg.sol
+++ b/tests/ui/codegen/mir/dump_cfg.sol
@@ -4,7 +4,7 @@
 contract DumpCfg {
     // CHECK-LABEL: digraph "f" {
     // CHECK: node [shape=box
-    // CHECK: [[BRANCH:bb[0-9]+]] [label="[[BRANCH]]:\l{{.*}}[[COND:v[0-9]+]] = eq arg0, 0\l  br [[COND]], [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]\l"];
+    // CHECK: [[BRANCH:bb[0-9]+]] [label="[[BRANCH]]:\l{{.*}}[[COND:v[0-9]+]] = eq arg0, 0\l  jumpi [[COND]], [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]\l"];
     // CHECK: [[BRANCH]] -> [[THEN]] [label="[[COND]] == true", color="green"];
     // CHECK-NEXT: [[BRANCH]] -> [[ELSE]] [label="false", color="red"];
     function f(uint x) public pure returns (uint) {

--- a/tests/ui/codegen/mir/dump_cfg.stdout
+++ b/tests/ui/codegen/mir/dump_cfg.stdout
@@ -3,9 +3,9 @@ digraph "f" {
     node [shape=box, fontname="Courier", fontsize=10];
     edge [fontname="Courier", fontsize=9];
 
-    bb0 [label="bb0:\l  v0 = calldatasize\l  v1 = sub v0, 4\l  v2 = slt v1, 32\l  br v2, bb1, bb2\l"];
+    bb0 [label="bb0:\l  v0 = calldatasize\l  v1 = sub v0, 4\l  v2 = slt v1, 32\l  jumpi v2, bb1, bb2\l"];
     bb1 [label="bb1:\l  revert 0, 0\l"];
-    bb2 [label="bb2:\l  mstore 128, 0\l  v3 = eq arg0, 0\l  br v3, bb3, bb4\l"];
+    bb2 [label="bb2:\l  mstore 128, 0\l  v3 = eq arg0, 0\l  jumpi v3, bb3, bb4\l"];
     bb3 [label="bb3:\l  mstore 128, 1\l  returndata 128, 32\l"];
     bb4 [label="bb4:\l  mstore 128, arg0\l  returndata 128, 32\l"];
 
@@ -20,7 +20,7 @@ digraph "storageOps" {
     node [shape=box, fontname="Courier", fontsize=10];
     edge [fontname="Courier", fontsize=9];
 
-    bb0 [label="bb0:\l  v0 = calldatasize\l  v1 = sub v0, 4\l  v2 = slt v1, 64\l  br v2, bb1, bb2\l"];
+    bb0 [label="bb0:\l  v0 = calldatasize\l  v1 = sub v0, 4\l  v2 = slt v1, 64\l  jumpi v2, bb1, bb2\l"];
     bb1 [label="bb1:\l  revert 0, 0\l"];
     bb2 [label="bb2:\l  mstore 128, 0\l  sstore arg0, arg1\l  v3 = sload arg0\l  mstore 128, v3\l  v4 = mload 128\l  mstore 128, v4\l  returndata 128, 32\l"];
 

--- a/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.mir
@@ -13,7 +13,7 @@
 // CHECK: -     [[OLD_INDEX:v[0-9]+]] = mload [[HEADER_FRAME]]
 // CHECK: -     {{v[0-9]+}} = lt [[OLD_INDEX]], 4
 // CHECK:       [[COND:v[0-9]+]] = lt [[INDEX]], 4
-// CHECK:       br [[COND]], [[BODY]], [[EXIT:bb[0-9]+]]
+// CHECK:       jumpi [[COND]], [[BODY]], [[EXIT:bb[0-9]+]]
 // CHECK:       [[BODY]]:
 // CHECK:       [[BODY_LOAD_FRAME:v[0-9]+]] = internal_frame_addr
 // CHECK: -     [[OLD_BODY_INDEX:v[0-9]+]] = mload [[BODY_LOAD_FRAME]]
@@ -36,7 +36,7 @@ fn @loop_carried() -> u256 {
     v1 = internal_frame_addr 128
     v2 = mload v1
     v3 = lt v2, 4
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     v4 = internal_frame_addr 128
     v5 = mload v4

--- a/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.stdout
@@ -12,7 +12,7 @@
 -     v2 = mload v1
 -     v3 = lt v2, 4
 +     v3 = lt v10, 4
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
       v4 = internal_frame_addr 128
 -     v5 = mload v4

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
@@ -2,7 +2,7 @@
 @module FramePromotionDeadMerge
 fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -15,7 +15,7 @@ fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
     v2 = internal_frame_addr 128
     v3 = mload v2
     v4 = lt v3, arg0
-    br v4, bb5, bb6
+    jumpi v4, bb5, bb6
   bb5:
     v5 = add v3, 1
     v6 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
@@ -3,7 +3,7 @@
   @module FramePromotionDeadMerge
   fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       jump bb3
     bb2:
@@ -18,7 +18,7 @@
 -     v2 = mload v1
 -     v3 = lt v2, arg0
 +     v3 = lt v8, arg0
-      br v3, bb5, bb6
+      jumpi v3, bb5, bb6
     bb5:
 -     v4 = add v2, 1
 +     v4 = add v8, 1

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
@@ -11,7 +11,7 @@ fn @nested(arg0: u256, arg1: u256) -> u256 {
     v3 = internal_frame_addr 160
     v4 = mload v3
     v5 = lt v4, arg0
-    br v5, bb2, bb6
+    jumpi v5, bb2, bb6
   bb2:
     v6 = internal_frame_addr 192
     mstore v6, 0
@@ -20,7 +20,7 @@ fn @nested(arg0: u256, arg1: u256) -> u256 {
     v7 = internal_frame_addr 192
     v8 = mload v7
     v9 = lt v8, arg1
-    br v9, bb4, bb5
+    jumpi v9, bb4, bb5
   bb4:
     v10 = internal_frame_addr 128
     v11 = mload v10

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
@@ -15,7 +15,7 @@
 -     v3 = mload v2
 -     v4 = lt v3, arg0
 +     v4 = lt v25, arg0
-      br v4, bb2, bb6
+      jumpi v4, bb2, bb6
     bb2:
       v5 = internal_frame_addr 192
 -     mstore v5, 0
@@ -27,7 +27,7 @@
 -     v7 = mload v6
 -     v8 = lt v7, arg1
 +     v8 = lt v26, arg1
-      br v8, bb4, bb5
+      jumpi v8, bb4, bb5
     bb4:
       v9 = internal_frame_addr 128
 -     v10 = mload v9
@@ -70,7 +70,7 @@
       v25 = phi [bb0: 0], [bb5: v19]
       v2 = internal_frame_addr 160
       v4 = lt v25, arg0
-      br v4, bb2, bb6
+      jumpi v4, bb2, bb6
     bb2:
       v5 = internal_frame_addr 192
       jump bb3
@@ -79,7 +79,7 @@
       v26 = phi [bb2: 0], [bb4: v15]
       v6 = internal_frame_addr 192
       v8 = lt v26, arg1
-      br v8, bb4, bb5
+      jumpi v8, bb4, bb5
     bb4:
       v9 = internal_frame_addr 128
       v11 = add v24, 1
@@ -111,7 +111,7 @@
       v25 = phi [bb0: 0], [bb5: v19]
 -     v2 = internal_frame_addr 160
       v4 = lt v25, arg0
-      br v4, bb2, bb6
+      jumpi v4, bb2, bb6
     bb2:
 -     v5 = internal_frame_addr 192
       jump bb3
@@ -120,7 +120,7 @@
       v26 = phi [bb2: 0], [bb4: v15]
 -     v6 = internal_frame_addr 192
       v8 = lt v26, arg1
-      br v8, bb4, bb5
+      jumpi v8, bb4, bb5
     bb4:
 -     v9 = internal_frame_addr 128
       v11 = add v24, 1

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir
@@ -11,7 +11,7 @@ fn @sequential(arg0: u256) -> u256 {
     v3 = internal_frame_addr 160
     v4 = mload v3
     v5 = lt v4, arg0
-    br v5, bb2, bb3
+    jumpi v5, bb2, bb3
   bb2:
     v6 = internal_frame_addr 128
     v7 = mload v6
@@ -32,7 +32,7 @@ fn @sequential(arg0: u256) -> u256 {
     v15 = internal_frame_addr 192
     v16 = mload v15
     v17 = lt v16, arg0
-    br v17, bb5, bb6
+    jumpi v17, bb5, bb6
   bb5:
     v18 = internal_frame_addr 128
     v19 = mload v18

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
@@ -15,7 +15,7 @@
 -     v3 = mload v2
 -     v4 = lt v3, arg0
 +     v4 = lt v29, arg0
-      br v4, bb2, bb3
+      jumpi v4, bb2, bb3
     bb2:
       v5 = internal_frame_addr 128
 -     v6 = mload v5
@@ -41,7 +41,7 @@
 -     v15 = mload v14
 -     v16 = lt v15, arg0
 +     v16 = lt v30, arg0
-      br v16, bb5, bb6
+      jumpi v16, bb5, bb6
     bb5:
       v17 = internal_frame_addr 128
 -     v18 = mload v17
@@ -76,7 +76,7 @@
       v29 = phi [bb0: 0], [bb2: v11]
       v2 = internal_frame_addr 160
       v4 = lt v29, arg0
-      br v4, bb2, bb3
+      jumpi v4, bb2, bb3
     bb2:
       v5 = internal_frame_addr 128
       v7 = add v27, 1
@@ -93,7 +93,7 @@
       v30 = phi [bb3: 0], [bb5: v23]
       v14 = internal_frame_addr 192
       v16 = lt v30, arg0
-      br v16, bb5, bb6
+      jumpi v16, bb5, bb6
     bb5:
       v17 = internal_frame_addr 128
       v19 = add v28, 1
@@ -120,7 +120,7 @@
       v29 = phi [bb0: 0], [bb2: v11]
 -     v2 = internal_frame_addr 160
       v4 = lt v29, arg0
-      br v4, bb2, bb3
+      jumpi v4, bb2, bb3
     bb2:
 -     v5 = internal_frame_addr 128
       v7 = add v27, 1
@@ -137,7 +137,7 @@
       v30 = phi [bb3: 0], [bb5: v23]
 -     v14 = internal_frame_addr 192
       v16 = lt v30, arg0
-      br v16, bb5, bb6
+      jumpi v16, bb5, bb6
     bb5:
 -     v17 = internal_frame_addr 128
       v19 = add v28, 1

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
@@ -9,7 +9,7 @@ fn @promote_loop_carried_slot(arg0: u256) -> u256 {
     v2 = internal_frame_addr 128
     v3 = mload v2
     v4 = lt v3, arg0
-    br v4, bb2, bb3
+    jumpi v4, bb2, bb3
   bb2:
     v5 = internal_frame_addr 128
     v6 = mload v5

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
@@ -12,7 +12,7 @@
 -     v2 = mload v1
 -     v3 = lt v2, arg0
 +     v3 = lt v10, arg0
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
       v4 = internal_frame_addr 128
 -     v5 = mload v4
@@ -39,7 +39,7 @@
       v10 = phi [bb0: 0], [bb2: v6]
 -     v1 = internal_frame_addr 128
       v3 = lt v10, arg0
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
 -     v4 = internal_frame_addr 128
       v6 = add v10, 1

--- a/tests/ui/codegen/mir/gvn/gvn.mir
+++ b/tests/ui/codegen/mir/gvn/gvn.mir
@@ -57,7 +57,7 @@ fn @keep_state_dependent_reads(arg0: u256) -> u256 {
 // the mul class, but no member dominates bb3 so nothing is replaced.
 fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1
     v3 = mul v2, 3

--- a/tests/ui/codegen/mir/gvn/gvn.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn.stdout
@@ -50,7 +50,7 @@
   
   fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1
       v1 = mul v0, 3

--- a/tests/ui/codegen/mir/gvn/gvn_phi.mir
+++ b/tests/ui/codegen/mir/gvn/gvn_phi.mir
@@ -4,7 +4,7 @@
 // Two phis in one block with pairwise-congruent incoming collapse to one.
 fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
   bb0:
-    br arg2, bb1, bb2
+    jumpi arg2, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -20,7 +20,7 @@ fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
 fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v2 = add arg0, 1
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -36,7 +36,7 @@ fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
 fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v2 = add arg0, 1
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v3 = add arg0, 1
     jump bb3
@@ -50,7 +50,7 @@ fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
 // Phi-of-same over equal immediates folds onto the constant.
 fn @phi_of_equal_immediates(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -70,7 +70,7 @@ fn @lockstep_loop_phis_stay(arg0: u256) -> u256 {
     v1 = phi [bb0: 0], [bb2: v4]
     v2 = phi [bb0: 0], [bb2: v5]
     v3 = lt v1, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     v4 = add v1, 1
     v5 = add v2, 1

--- a/tests/ui/codegen/mir/gvn/gvn_phi.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn_phi.stdout
@@ -3,7 +3,7 @@
   @module GvnPhi
   fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
     bb0:
-      br arg2, bb1, bb2
+      jumpi arg2, bb1, bb2
     bb1:
       jump bb3
     bb2:
@@ -19,7 +19,7 @@
   fn @phi_of_same_folds_to_dominating_operand(arg0: u256, arg1: bool) -> u256 {
     bb0:
       v0 = add arg0, 1
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       jump bb3
     bb2:
@@ -34,7 +34,7 @@
   fn @phi_of_congruent_incoming(arg0: u256, arg1: bool) -> u256 {
     bb0:
       v0 = add arg0, 1
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
 -     v1 = add arg0, 1
       jump bb3
@@ -48,7 +48,7 @@
   
   fn @phi_of_equal_immediates(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:
@@ -66,7 +66,7 @@
       v0 = phi [bb0: 0], [bb2: v3]
       v1 = phi [bb0: 0], [bb2: v4]
       v2 = lt v0, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       v3 = add v0, 1
       v4 = add v1, 1

--- a/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir
+++ b/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.mir
@@ -6,7 +6,7 @@ fn @strength_reduce_shifted_address(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v6]
     v2 = lt v1, 4
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = shl 5, v1
     v4 = add arg0, v3
@@ -23,7 +23,7 @@ fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
     v2 = lt v1, 4
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = mul v1, 32
     v4 = add arg0, v3
@@ -41,7 +41,7 @@ fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v5]
     v2 = lt v1, 4
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = add arg0, v1
     mstore8 v3, v1

--- a/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
+++ b/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
@@ -8,7 +8,7 @@
       v0 = phi [bb0: 0], [bb2: v4]
 +     v5 = phi [bb0: arg0], [bb2: v6]
       v1 = lt v0, 4
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = shl 5, v0
       v3 = add arg0, v2
@@ -29,7 +29,7 @@
       v0 = phi [bb0: 0], [bb2: v5]
 +     v7 = phi [bb0: v6], [bb2: v8]
       v1 = lt v0, 4
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = mul v0, 32
       v3 = add arg0, v2
@@ -50,7 +50,7 @@
       v0 = phi [bb0: 0], [bb2: v3]
 +     v4 = phi [bb0: arg0], [bb2: v5]
       v1 = lt v0, 4
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = add arg0, v0
 -     mstore8 v2, v0

--- a/tests/ui/codegen/mir/inline/inline_loop_return.mir
+++ b/tests/ui/codegen/mir/inline/inline_loop_return.mir
@@ -24,7 +24,7 @@ fn @callee(arg0: u256) -> u256 {
     v2 = internal_frame_addr 128
     v3 = mload v2
     v4 = lt v3, arg0
-    br v4, bb2, bb3
+    jumpi v4, bb2, bb3
   bb2:
     v5 = internal_frame_addr 128
     v6 = mload v5

--- a/tests/ui/codegen/mir/inline/inline_loop_return.stdout
+++ b/tests/ui/codegen/mir/inline/inline_loop_return.stdout
@@ -18,7 +18,7 @@
 +     v3 = internal_frame_addr 0
 +     v4 = mload v3
 +     v5 = lt v4, 4
-+     br v5, bb4, bb5
++     jumpi v5, bb4, bb5
 +   bb4:
 +     v6 = internal_frame_addr 0
 +     v7 = mload v6
@@ -41,7 +41,7 @@
       v1 = internal_frame_addr 128
       v2 = mload v1
       v3 = lt v2, arg0
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
       v4 = internal_frame_addr 128
       v5 = mload v4

--- a/tests/ui/codegen/mir/inst-simplify/identities.mir
+++ b/tests/ui/codegen/mir/inst-simplify/identities.mir
@@ -113,13 +113,13 @@ fn @own_balance() -> u256 {
 }
 
 // CHECK-LABEL: @invert_iszero_branch
-// CHECK: -     br {{v[0-9]+}}, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
-// CHECK:       br arg0, [[ELSE]], [[THEN]]
+// CHECK: -     jumpi {{v[0-9]+}}, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
+// CHECK:       jumpi arg0, [[ELSE]], [[THEN]]
 fn @invert_iszero_branch(arg0: u256) {
   bb0:
     v1 = lt 0, arg0
     v2 = iszero v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     stop
   bb2:

--- a/tests/ui/codegen/mir/inst-simplify/identities.stdout
+++ b/tests/ui/codegen/mir/inst-simplify/identities.stdout
@@ -80,8 +80,8 @@
     bb0:
       v0 = lt 0, arg0
       v1 = iszero v0
--     br v1, bb1, bb2
-+     br arg0, bb2, bb1
+-     jumpi v1, bb1, bb2
++     jumpi arg0, bb2, bb1
     bb1:
       stop
     bb2:

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_branch.mir
@@ -4,7 +4,7 @@
 @module ThreadingBranch
 fn @branch_forwarders(arg0: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
@@ -3,8 +3,8 @@
   @module ThreadingBranch
   fn @branch_forwarders(arg0: u256) -> u256 {
     bb0:
--     br arg0, bb1, bb2
-+     br arg0, bb3, bb4
+-     jumpi arg0, bb1, bb2
++     jumpi arg0, bb3, bb4
     bb1:
       jump bb3
     bb2:

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.mir
@@ -2,14 +2,14 @@
 @module JumpThreadingPhiConstants
 fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
     jump bb3
   bb3:
     v1 = phi [bb1: 0], [bb2: 1]
-    br v1, bb4, bb5
+    jumpi v1, bb4, bb5
   bb4:
     ret 11
   bb5:
@@ -18,7 +18,7 @@ fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
 
 fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -36,14 +36,14 @@ fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
 
 fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
     jump bb3
   bb3:
     v1 = phi [bb1: arg1], [bb2: arg2]
-    br v1, bb4, bb5
+    jumpi v1, bb4, bb5
   bb4:
     ret 11
   bb5:
@@ -52,14 +52,14 @@ fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
 
 fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
     jump bb3
   bb3:
     v1 = phi [bb1: 0], [bb2: 1]
-    br v1, bb4, bb5
+    jumpi v1, bb4, bb5
   bb4:
     v2 = add v1, 1
     ret v2

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
@@ -3,8 +3,8 @@
   @module JumpThreadingPhiConstants
   fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
-+     br arg0, bb5, bb4
+-     jumpi arg0, bb1, bb2
++     jumpi arg0, bb5, bb4
     bb1:
 -     jump bb3
 +     jump bb5
@@ -14,7 +14,7 @@
     bb3:
 -     v0 = phi [bb1: 0], [bb2: 1]
 +     v0 = phi
-      br v0, bb4, bb5
+      jumpi v0, bb4, bb5
     bb4:
       ret 11
     bb5:
@@ -23,8 +23,8 @@
   
   fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb2
-+     br arg0, bb4, bb5
+-     jumpi arg0, bb1, bb2
++     jumpi arg0, bb4, bb5
     bb1:
 -     jump bb3
 +     jump bb4
@@ -45,14 +45,14 @@
   
   fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:
       jump bb3
     bb3:
       v0 = phi [bb1: arg1], [bb2: arg2]
-      br v0, bb4, bb5
+      jumpi v0, bb4, bb5
     bb4:
       ret 11
     bb5:
@@ -61,14 +61,14 @@
   
   fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:
       jump bb3
     bb3:
       v0 = phi [bb1: 0], [bb2: 1]
-      br v0, bb4, bb5
+      jumpi v0, bb4, bb5
     bb4:
       v1 = add v0, 1
       ret v1

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.mir
@@ -4,7 +4,7 @@
 @module JumpThreadingPhiForwarder
 fn @keep_phi_only_block(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
@@ -3,7 +3,7 @@
   @module JumpThreadingPhiForwarder
   fn @keep_phi_only_block(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:

--- a/tests/ui/codegen/mir/licm/builder_cases.mir
+++ b/tests/ui/codegen/mir/licm/builder_cases.mir
@@ -6,14 +6,14 @@
 // CHECK: +     [[MUL:v[0-9]+]] = mul arg0, 7
 // CHECK-NEXT: {{^ +}}jump [[HEADER:bb[0-9]+]]
 // CHECK: {{^ +}}[[HEADER]]:
-// CHECK-NEXT: {{^ +}}br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-NEXT: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK: {{^ +}}[[BODY]]:
 // CHECK: -     [[MUL]] = mul arg0, 7
 fn @hoist_mul(arg0: u256) {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v1 = mul arg0, 7
     jump bb1
@@ -30,7 +30,7 @@ fn @hoist_non_aliasing_sload() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = sload 0
     sstore 1, 1
@@ -40,7 +40,7 @@ fn @hoist_non_aliasing_sload() -> u256 {
 }
 
 // CHECK-LABEL: @keep_aliasing_sload
-// CHECK: {{^ +}}br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK: {{^ +}}[[BODY]]:
 // CHECK: +     {{v[0-9]+}} = sload [[SLOT:[0-9]+]]
 // CHECK: +     sstore [[SLOT]], 1
@@ -48,7 +48,7 @@ fn @keep_aliasing_sload() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = sload 0
     sstore 0, 1
@@ -58,7 +58,7 @@ fn @keep_aliasing_sload() -> u256 {
 }
 
 // CHECK-LABEL: @keep_work_after_gas
-// CHECK: {{^ +}}br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK: {{^ +}}[[BODY]]:
 // CHECK: {{^ +}}{{v[0-9]+}} = gas
 // CHECK: {{^ +}}[[MUL:v[0-9]+]] = mul arg0, 7
@@ -68,7 +68,7 @@ fn @keep_work_after_gas(arg0: u256) -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v1 = gas
     v2 = mul arg0, 7

--- a/tests/ui/codegen/mir/licm/builder_cases.stdout
+++ b/tests/ui/codegen/mir/licm/builder_cases.stdout
@@ -6,7 +6,7 @@
 +     v0 = mul arg0, 7
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
 -     v0 = mul arg0, 7
       jump bb1
@@ -19,7 +19,7 @@
 +     v0 = sload 0 !metadata(storage=slot(0))
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
 -     v0 = sload 0
 -     sstore 1, 1
@@ -33,7 +33,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
 -     v0 = sload 0
 -     sstore 0, 1
@@ -48,7 +48,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = gas
       v1 = mul arg0, 7

--- a/tests/ui/codegen/mir/licm/licm_descending_iv.mir
+++ b/tests/ui/codegen/mir/licm/licm_descending_iv.mir
@@ -11,7 +11,7 @@ fn @keep_mload_descending_iv() -> u256 {
   bb1:
     v1 = phi [bb0: 64], [bb2: v9]
     v2 = lt v1, 100
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = mload 0
     sstore v1, v3
@@ -30,7 +30,7 @@ fn @hoist_mload_ascending_iv() -> u256 {
   bb1:
     v1 = phi [bb0: 64], [bb2: v9]
     v2 = lt v1, 100
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = mload 0
     sstore v1, v3

--- a/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
+++ b/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
@@ -7,7 +7,7 @@
     bb1:
       v0 = phi [bb0: 64], [bb2: v3]
       v1 = lt v0, 100
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = mload 0
 -     sstore v0, v2
@@ -26,7 +26,7 @@
     bb1:
       v0 = phi [bb0: 64], [bb2: v3]
       v1 = lt v0, 100
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = mload 0
 -     sstore v0, v2

--- a/tests/ui/codegen/mir/licm/licm_env_reads.mir
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.mir
@@ -7,7 +7,7 @@ fn @keep_balance_with_call() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = balance 0xbeef
     v1 = mul v0, 3
@@ -22,7 +22,7 @@ fn @hoist_balance_without_calls() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = balance 0xbeef
     v1 = mul v0, 3
@@ -36,7 +36,7 @@ fn @keep_extcodesize_with_create() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = extcodesize 0xbeef
     v1 = mul v0, 3
@@ -51,7 +51,7 @@ fn @keep_returndatasize_with_staticcall() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = returndatasize
     v1 = mul v0, 3
@@ -66,7 +66,7 @@ fn @keep_msize() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = msize
     v1 = mul v0, 3

--- a/tests/ui/codegen/mir/licm/licm_env_reads.stdout
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.stdout
@@ -5,7 +5,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = balance 0xbeef
       v1 = mul v0, 3
@@ -21,7 +21,7 @@
 +     v1 = mul v0, 3
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
 -     v0 = balance 0xbeef
 -     v1 = mul v0, 3
@@ -34,7 +34,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = extcodesize 0xbeef
       v1 = mul v0, 3
@@ -48,7 +48,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = returndatasize
       v1 = mul v0, 3
@@ -62,7 +62,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = msize
       v1 = mul v0, 3

--- a/tests/ui/codegen/mir/licm/licm_loop_bound.mir
+++ b/tests/ui/codegen/mir/licm/licm_loop_bound.mir
@@ -10,13 +10,13 @@ fn @keep_mload_non_exiting_bound() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb4: v9]
     v2 = eq v1, 100
-    br v2, bb5, bb2
+    jumpi v2, bb5, bb2
   bb2:
     v3 = mload 64
     v4 = mul v1, 32
     mstore v4, 1
     v5 = lt v1, 2
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     jump bb4
   bb4:
@@ -35,13 +35,13 @@ fn @keep_mload_inner_branch_bound() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb4: v9]
     v2 = lt v1, 100
-    br v2, bb2, bb5
+    jumpi v2, bb2, bb5
   bb2:
     v3 = mload 64
     v4 = mul v1, 32
     mstore v4, 1
     v5 = lt v1, 2
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     jump bb4
   bb4:

--- a/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
+++ b/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
@@ -7,13 +7,13 @@
     bb1:
       v0 = phi [bb0: 0], [bb4: v5]
       v1 = eq v0, 100
-      br v1, bb5, bb2
+      jumpi v1, bb5, bb2
     bb2:
       v2 = mload 64
       v3 = mul v0, 32
       mstore v3, 1
       v4 = lt v0, 2
-      br v4, bb3, bb4
+      jumpi v4, bb3, bb4
     bb3:
       jump bb4
     bb4:
@@ -29,13 +29,13 @@
     bb1:
       v0 = phi [bb0: 0], [bb4: v5]
       v1 = lt v0, 100
-      br v1, bb2, bb5
+      jumpi v1, bb2, bb5
     bb2:
       v2 = mload 64
       v3 = mul v0, 32
       mstore v3, 1
       v4 = lt v0, 2
-      br v4, bb3, bb4
+      jumpi v4, bb3, bb4
     bb3:
       jump bb4
     bb4:

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.mir
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.mir
@@ -11,7 +11,7 @@ fn @hoist_non_aliasing_mload() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = mload 0
     mstore 64, 1
@@ -21,7 +21,7 @@ fn @hoist_non_aliasing_mload() -> u256 {
 }
 
 // CHECK-LABEL: @keep_aliasing_mload
-// CHECK: {{^ +}}br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK: {{^ +}}[[BODY]]:
 // CHECK: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
 // CHECK: {{^ +}}mstore {{[0-9]+}}, 1
@@ -29,7 +29,7 @@ fn @keep_aliasing_mload() -> u256 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = mload 0
     mstore 16, 1
@@ -47,7 +47,7 @@ fn @hoist_non_aliasing_keccak() -> bytes32 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = keccak256 0, 32
     mstore 64, 1
@@ -57,7 +57,7 @@ fn @hoist_non_aliasing_keccak() -> bytes32 {
 }
 
 // CHECK-LABEL: @keep_aliasing_keccak
-// CHECK: {{^ +}}br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK: {{^ +}}[[BODY]]:
 // CHECK: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
 // CHECK: {{^ +}}mstore {{[0-9]+}}, 1
@@ -65,7 +65,7 @@ fn @keep_aliasing_keccak() -> bytes32 {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v0 = keccak256 0, 32
     mstore 16, 1

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
@@ -6,7 +6,7 @@
 +     v0 = mload 0
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
 -     v0 = mload 0
       mstore 64, 1
@@ -19,7 +19,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = mload 0
       mstore 16, 1
@@ -33,7 +33,7 @@
 +     v0 = keccak256 0, 32
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
 -     v0 = keccak256 0, 32
       mstore 64, 1
@@ -46,7 +46,7 @@
     bb0:
       jump bb1
     bb1:
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v0 = keccak256 0, 32
       mstore 16, 1

--- a/tests/ui/codegen/mir/licm/licm_multi_latch.mir
+++ b/tests/ui/codegen/mir/licm/licm_multi_latch.mir
@@ -11,13 +11,13 @@ fn @multi_latch_mixed_step() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v8], [bb3: v9]
     v2 = lt v1, 10
-    br v2, bb4, bb5
+    jumpi v2, bb4, bb5
   bb4:
     v6 = mul v1, 32
     mstore v6, 1
     v3 = mload 288
     v7 = calldataload 0
-    br v7, bb2, bb3
+    jumpi v7, bb2, bb3
   bb2:
     v8 = add v1, 1
     jump bb1
@@ -36,14 +36,14 @@ fn @multi_latch_same_value() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v8], [bb3: v8]
     v2 = lt v1, 10
-    br v2, bb4, bb5
+    jumpi v2, bb4, bb5
   bb4:
     v6 = mul v1, 32
     mstore v6, 1
     v3 = mload 320
     v8 = add v1, 1
     v7 = calldataload 0
-    br v7, bb2, bb3
+    jumpi v7, bb2, bb3
   bb2:
     jump bb1
   bb3:

--- a/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
+++ b/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
@@ -8,13 +8,13 @@
     bb1:
       v0 = phi [bb0: 0], [bb3: v5], [bb4: v6]
       v1 = lt v0, 10
-      br v1, bb2, bb5
+      jumpi v1, bb2, bb5
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
       v3 = mload 288
 -     v4 = calldataload 0
-      br v4, bb3, bb4
+      jumpi v4, bb3, bb4
     bb3:
       v5 = add v0, 1
       jump bb1
@@ -33,14 +33,14 @@
     bb1:
       v0 = phi [bb0: 0], [bb3: v4], [bb4: v4]
       v1 = lt v0, 10
-      br v1, bb2, bb5
+      jumpi v1, bb2, bb5
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
 -     v3 = mload 320
       v4 = add v0, 1
 -     v5 = calldataload 0
-      br v5, bb3, bb4
+      jumpi v5, bb3, bb4
     bb3:
       jump bb1
     bb4:

--- a/tests/ui/codegen/mir/licm/licm_rotated_guard.mir
+++ b/tests/ui/codegen/mir/licm/licm_rotated_guard.mir
@@ -14,7 +14,7 @@ fn @rotated_guard_overlap() -> u256 {
     mstore v4, 1
     v3 = mload 320
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v9 = add v1, 1
     jump bb1
@@ -34,7 +34,7 @@ fn @dowhile_latch_guard_overlap() -> u256 {
     v3 = mload 320
     v9 = add v1, 1
     v2 = lt v1, 10
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb2:
     ret v3
 }
@@ -48,7 +48,7 @@ fn @top_tested_control() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v4 = mul v1, 32
     mstore v4, 1
@@ -71,7 +71,7 @@ fn @disjoint_past_widened_range() -> u256 {
     mstore v4, 1
     v3 = mload 384
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v9 = add v1, 1
     jump bb1

--- a/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
+++ b/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
@@ -10,7 +10,7 @@
       mstore v1, 1
       v2 = mload 320
       v3 = lt v0, 10
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
       v4 = add v0, 1
       jump bb1
@@ -28,7 +28,7 @@
       v2 = mload 320
       v3 = add v0, 1
       v4 = lt v0, 10
-      br v4, bb1, bb2
+      jumpi v4, bb1, bb2
     bb2:
       ret v2
   }
@@ -40,7 +40,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
@@ -61,7 +61,7 @@
       mstore v1, 1
 -     v2 = mload 384
       v3 = lt v0, 10
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
       v4 = add v0, 1
       jump bb1

--- a/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir
+++ b/tests/ui/codegen/mir/licm/licm_staticcall_storage.mir
@@ -9,7 +9,7 @@ fn @hoist_sload_with_staticcall() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = sload 5
     v4 = staticcall 1000, 0xbeef, 0, 0, 0, 0
@@ -26,7 +26,7 @@ fn @hoist_tload_with_staticcall() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = tload 5
     v4 = staticcall 1000, 0xbeef, 0, 0, 0, 0
@@ -43,7 +43,7 @@ fn @keep_sload_with_call() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = sload 5
     v4 = call 1000, 0xbeef, 0, 0, 0, 0, 0

--- a/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
+++ b/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
@@ -8,7 +8,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = sload 5
       v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
@@ -25,7 +25,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = tload 5
       v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
@@ -41,7 +41,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = sload 5
 +     v2 = sload 5 !metadata(storage=slot(5))

--- a/tests/ui/codegen/mir/licm/licm_v2.mir
+++ b/tests/ui/codegen/mir/licm/licm_v2.mir
@@ -6,7 +6,7 @@ fn @hoist_symbolic_offset_sload(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
     v2 = lt v1, 4
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = add arg0, 1
     v4 = sload v3
@@ -24,7 +24,7 @@ fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
     v2 = lt v1, 4
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = add arg0, 1
     v4 = sload v3
@@ -40,7 +40,7 @@ fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jump bb1
   bb1:
-    br arg1, bb2, bb3
+    jumpi arg1, bb2, bb3
   bb2:
     v1 = add arg0, 1
     v2 = sload v1
@@ -57,7 +57,7 @@ fn @hoist_affine_memory_base(arg0: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
     v2 = lt v1, 4
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = add arg0, 32
     v4 = mul v1, 32
@@ -75,7 +75,7 @@ fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v7]
     v2 = lt v1, arg1
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = add arg0, 32
     v4 = mul v1, 32

--- a/tests/ui/codegen/mir/licm/licm_v2.stdout
+++ b/tests/ui/codegen/mir/licm/licm_v2.stdout
@@ -10,7 +10,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, 4
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = add arg0, 1
 -     v3 = sload v2
@@ -31,7 +31,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, 4
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = add arg0, 1
 -     v3 = sload v2
@@ -51,7 +51,7 @@
 +     v2 = add arg0, 2
       jump bb1
     bb1:
-      br arg1, bb2, bb3
+      jumpi arg1, bb2, bb3
     bb2:
 -     v0 = add arg0, 1
 -     v1 = sload v0
@@ -71,7 +71,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, 4
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = add arg0, 32
       v3 = mul v0, 32
@@ -90,7 +90,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, arg1
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = add arg0, 32
       v3 = mul v0, 32

--- a/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir
+++ b/tests/ui/codegen/mir/licm/licm_wrap_add_descending.mir
@@ -9,7 +9,7 @@ fn @wrap_add_descending() -> u256 {
   bb1:
     v1 = phi [bb0: 64], [bb2: v9]
     v2 = lt v1, 100
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v4 = mul v1, 32
     mstore v4, 1

--- a/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
+++ b/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
@@ -7,7 +7,7 @@
     bb1:
       v0 = phi [bb0: 64], [bb2: v4]
       v1 = lt v0, 100
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = mul v0, 32
       mstore v2, 1

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.mir
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.mir
@@ -10,7 +10,7 @@ fn @keep_sload_zero_trip() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, v0
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = sload 5
     v9 = add v1, 1
@@ -28,7 +28,7 @@ fn @keep_mload_zero_trip() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, v0
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = mload 0x1000000
     v9 = add v1, 1
@@ -45,7 +45,7 @@ fn @hoist_sload_known_trip() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = sload 5
     v9 = add v1, 1
@@ -63,7 +63,7 @@ fn @hoist_mload_dominates_exits() -> u256 {
     v0 = mload 64
     v1 = calldataload 0
     v2 = lt v0, v1
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb2:
     ret v0
 }
@@ -76,7 +76,7 @@ fn @keep_mload_msize_in_function() -> u256 {
   bb1:
     v1 = phi [bb0: 0], [bb2: v9]
     v2 = lt v1, 10
-    br v2, bb2, bb3
+    jumpi v2, bb2, bb3
   bb2:
     v3 = mload 64
     v9 = add v1, 1

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
@@ -8,7 +8,7 @@
     bb1:
       v1 = phi [bb0: 0], [bb2: v4]
       v2 = lt v1, v0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
 -     v3 = sload 5
 +     v3 = sload 5 !metadata(storage=slot(5))
@@ -25,7 +25,7 @@
     bb1:
       v1 = phi [bb0: 0], [bb2: v4]
       v2 = lt v1, v0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       v3 = mload 0x1000000
       v4 = add v1, 1
@@ -41,7 +41,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v3]
       v1 = lt v0, 10
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
 -     v2 = sload 5
       v3 = add v0, 1
@@ -59,7 +59,7 @@
 +     jump bb1
 +   bb1:
       v2 = lt v0, v1
-      br v2, bb1, bb2
+      jumpi v2, bb1, bb2
     bb2:
       ret v0
   }
@@ -70,7 +70,7 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v3]
       v1 = lt v0, 10
-      br v1, bb2, bb3
+      jumpi v1, bb2, bb3
     bb2:
       v2 = mload 64
       v3 = add v0, 1

--- a/tests/ui/codegen/mir/load-pre/load_pre.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre.mir
@@ -7,7 +7,7 @@
 @module LoadPre
 fn @full_diamond(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = sload 5
     jump bb3
@@ -21,7 +21,7 @@ fn @full_diamond(arg0: bool) -> u256 {
 
 fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     sstore 5, arg1
     jump bb3
@@ -35,7 +35,7 @@ fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
 
 fn @partial_insert_diamond(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = sload 5
     jump bb3
@@ -48,7 +48,7 @@ fn @partial_insert_diamond(arg0: bool) -> u256 {
 
 fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     tstore 5, arg1
     jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre.stdout
@@ -3,7 +3,7 @@
   @module LoadPre
   fn @full_diamond(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = sload 5
       jump bb3
@@ -19,7 +19,7 @@
   
   fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       sstore 5, arg1
       jump bb3
@@ -35,7 +35,7 @@
   
   fn @partial_insert_diamond(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = sload 5
       jump bb3
@@ -51,7 +51,7 @@
   
   fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       tstore 5, arg1
       jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_clobbers.mir
@@ -8,10 +8,10 @@
 fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
   bb0:
     v1 = sload 5
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     sstore arg1, 7
-    br arg0, bb3, bb4
+    jumpi arg0, bb3, bb4
   bb2:
     jump bb3
   bb3:
@@ -24,10 +24,10 @@ fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
 fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
   bb0:
     v1 = sload 5
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v2 = call 100000, arg1, 0, 0, 0, 0, 0
-    br arg0, bb3, bb4
+    jumpi arg0, bb3, bb4
   bb2:
     jump bb3
   bb3:
@@ -40,10 +40,10 @@ fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
 fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
   bb0:
     v1 = sload 5
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v2 = staticcall 100000, arg1, 0, 0, 0, 0
-    br arg0, bb3, bb4
+    jumpi arg0, bb3, bb4
   bb2:
     jump bb3
   bb3:
@@ -55,7 +55,7 @@ fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
 
 fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = sload 5
     sstore arg1, 7
@@ -70,7 +70,7 @@ fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
 
 fn @gas_blocks_rewrite(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = sload 5
     jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
@@ -4,10 +4,10 @@
   fn @kill_blocks_reuse(arg0: bool, arg1: u256) -> u256 {
     bb0:
       v0 = sload 5
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       sstore arg1, 7
-      br arg0, bb3, bb4
+      jumpi arg0, bb3, bb4
     bb2:
       jump bb3
     bb3:
@@ -20,10 +20,10 @@
   fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
     bb0:
       v0 = sload 5
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
-      br arg0, bb3, bb4
+      jumpi arg0, bb3, bb4
     bb2:
       jump bb3
     bb3:
@@ -36,10 +36,10 @@
   fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
     bb0:
       v0 = sload 5
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
-      br arg0, bb3, bb4
+      jumpi arg0, bb3, bb4
     bb2:
       jump bb3
     bb3:
@@ -52,7 +52,7 @@
   
   fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = sload 5
       sstore arg1, 7
@@ -70,7 +70,7 @@
   
   fn @gas_blocks_rewrite(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = sload 5
       jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_keccak.mir
@@ -5,7 +5,7 @@
 @module LoadPreKeccak
 fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = keccak256 0, arg1
     jump bb3
@@ -19,7 +19,7 @@ fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
 
 fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = keccak256 0, arg1
     jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
@@ -3,7 +3,7 @@
   @module LoadPreKeccak
   fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = keccak256 0, arg1
       jump bb3
@@ -19,7 +19,7 @@
   
   fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = keccak256 0, arg1
       jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre_loop.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_loop.mir
@@ -13,7 +13,7 @@ fn @loop_header_reload(arg0: u256) -> u256 {
   bb1:
     v2 = sload 5
     v3 = lt v2, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     jump bb1
   bb3:
@@ -27,7 +27,7 @@ fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
   bb1:
     v2 = sload 5
     v3 = lt v2, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     sstore arg1, 9
     jump bb1
@@ -42,10 +42,10 @@ fn @loop_clobbered_no_insert(arg0: u256, arg1: u256) -> u256 {
   bb1:
     v2 = sload 5
     v3 = lt v2, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     sstore arg1, 9
-    br v3, bb1, bb3
+    jumpi v3, bb1, bb3
   bb3:
     ret v2
 }

--- a/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
@@ -10,7 +10,7 @@
 -     v2 = lt v1, arg0
 +     v3 = phi [bb0: v0], [bb2: v3]
 +     v2 = lt v3, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       jump bb1
     bb3:
@@ -25,7 +25,7 @@
     bb1:
       v1 = sload 5
       v2 = lt v1, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       sstore arg1, 9
       jump bb1
@@ -40,10 +40,10 @@
     bb1:
       v1 = sload 5
       v2 = lt v1, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       sstore arg1, 9
-      br v2, bb1, bb3
+      jumpi v2, bb1, bb3
     bb3:
       ret v1
   }

--- a/tests/ui/codegen/mir/load-pre/load_pre_memory.mir
+++ b/tests/ui/codegen/mir/load-pre/load_pre_memory.mir
@@ -6,7 +6,7 @@
 @module LoadPreMemory
 fn @mload_full_diamond(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = mload 128
     jump bb3
@@ -20,7 +20,7 @@ fn @mload_full_diamond(arg0: bool) -> u256 {
 
 fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 128, arg1
     jump bb3
@@ -35,10 +35,10 @@ fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
 fn @mstore8_overlap_kills(arg0: bool) -> u256 {
   bb0:
     v1 = mload 128
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore8 159, 7
-    br arg0, bb3, bb4
+    jumpi arg0, bb3, bb4
   bb2:
     jump bb3
   bb3:
@@ -50,7 +50,7 @@ fn @mstore8_overlap_kills(arg0: bool) -> u256 {
 
 fn @mload_partial_rejected(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = mload 128
     jump bb3
@@ -63,7 +63,7 @@ fn @mload_partial_rejected(arg0: bool) -> u256 {
 
 fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = mload 128
     jump bb3
@@ -99,7 +99,7 @@ fn @mload_loop_header(arg0: u256) -> u256 {
   bb1:
     v2 = mload 128
     v3 = lt v2, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     jump bb1
   bb3:
@@ -109,10 +109,10 @@ fn @mload_loop_header(arg0: u256) -> u256 {
 fn @staticcall_zero_return_preserves_memory(arg0: bool, arg1: address) -> u256 {
   bb0:
     v1 = mload 128
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v2 = staticcall 100000, arg1, 0, 0, 0, 0
-    br arg0, bb3, bb4
+    jumpi arg0, bb3, bb4
   bb2:
     jump bb3
   bb3:
@@ -124,7 +124,7 @@ fn @staticcall_zero_return_preserves_memory(arg0: bool, arg1: address) -> u256 {
 
 fn @msize_blocks_memory(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v1 = mload 128
     jump bb3

--- a/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
@@ -3,7 +3,7 @@
   @module LoadPreMemory
   fn @mload_full_diamond(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = mload 128
       jump bb3
@@ -17,7 +17,7 @@
   
   fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 128, arg1
       jump bb3
@@ -32,10 +32,10 @@
   fn @mstore8_overlap_kills(arg0: bool) -> u256 {
     bb0:
       v0 = mload 128
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore8 159, 7
-      br arg0, bb3, bb4
+      jumpi arg0, bb3, bb4
     bb2:
       jump bb3
     bb3:
@@ -47,7 +47,7 @@
   
   fn @mload_partial_rejected(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = mload 128
       jump bb3
@@ -60,7 +60,7 @@
   
   fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = mload 128
       jump bb3
@@ -101,7 +101,7 @@
 -     v2 = lt v1, arg0
 +     v3 = phi [bb0: v0], [bb2: v3]
 +     v2 = lt v3, arg0
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       jump bb1
     bb3:
@@ -112,10 +112,10 @@
   fn @staticcall_zero_return_preserves_memory(arg0: bool, arg1: address) -> u256 {
     bb0:
       v0 = mload 128
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
-      br arg0, bb3, bb4
+      jumpi arg0, bb3, bb4
     bb2:
       jump bb3
     bb3:
@@ -128,7 +128,7 @@
   
   fn @msize_blocks_memory(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       v0 = mload 128
       jump bb3

--- a/tests/ui/codegen/mir/load-pre/memory_object_load_pre.mir
+++ b/tests/ui/codegen/mir/load-pre/memory_object_load_pre.mir
@@ -3,7 +3,7 @@
 
 fn @forward_length_across_join(arg0: memorybytes, arg1: bool, arg2: u256) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     set_memory_object_len memorybytes, arg0, arg2
     jump bb3

--- a/tests/ui/codegen/mir/load-pre/memory_object_load_pre.stdout
+++ b/tests/ui/codegen/mir/load-pre/memory_object_load_pre.stdout
@@ -3,7 +3,7 @@
   @module MemoryObjectLoadPre
   fn @forward_length_across_join(arg0: memorybytes, arg1: bool, arg2: u256) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       set_memory_object_len memorybytes, arg0, arg2
       jump bb3

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
@@ -2,14 +2,14 @@
 @module LoopCanonicalize
 fn @insert_preheader(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:
     jump bb3
   bb3:
     v1 = phi [bb1: 10], [bb2: 20], [bb4: 30]
-    br true, bb4, bb5
+    jumpi true, bb4, bb5
   bb4:
     jump bb3
   bb5:
@@ -18,10 +18,10 @@ fn @insert_preheader(arg0: bool) -> u256 {
 
 fn @split_conditional_predecessor(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb3
+    jumpi arg0, bb1, bb3
   bb1:
     v1 = phi [bb0: 0], [bb2: 1]
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     jump bb1
   bb3:

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
@@ -3,7 +3,7 @@
   @module LoopCanonicalize
   fn @insert_preheader(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
 -     jump bb3
 +     jump bb6
@@ -13,7 +13,7 @@
     bb3:
 -     v0 = phi [bb1: 10], [bb2: 20], [bb4: 30]
 +     v0 = phi [bb4: 30], [bb6: v1]
-      br 1, bb4, bb5
+      jumpi 1, bb4, bb5
     bb4:
       jump bb3
     bb5:
@@ -25,12 +25,12 @@
   
   fn @split_conditional_predecessor(arg0: bool) -> u256 {
     bb0:
--     br arg0, bb1, bb3
-+     br arg0, bb4, bb3
+-     jumpi arg0, bb1, bb3
++     jumpi arg0, bb4, bb3
     bb1:
 -     v0 = phi [bb0: 0], [bb2: 1]
 +     v0 = phi [bb2: 1], [bb4: 0]
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       jump bb1
     bb3:

--- a/tests/ui/codegen/mir/lower-abi-encode/lower_abi_encode.stdout
+++ b/tests/ui/codegen/mir/lower-abi-encode/lower_abi_encode.stdout
@@ -28,7 +28,7 @@
 +     v7 = and v6, v5
 +     v8 = add v2, 32
 +     v9 = iszero v7
-+     br v9, bb2, bb1
++     jumpi v9, bb2, bb1
 +   bb1:
 +     v10 = sub v7, 32
 +     v11 = add v8, v10

--- a/tests/ui/codegen/mir/lower-alloc/allocation_policy.mir
+++ b/tests/ui/codegen/mir/lower-alloc/allocation_policy.mir
@@ -2,7 +2,7 @@
 //@filecheck: --match-full-lines
 // CHECK-LABEL:   fn @checked(arg0: u256) -> memorybytes {
 // CHECK: +     v0 = mload 64 !metadata(memory=scratch)
-// CHECK: +     br v8, bb2, bb1
+// CHECK: +     jumpi v8, bb2, bb1
 // CHECK: +     calldatacopy v0, v9, v3
 // CHECK: +     revert 0, 36
 // CHECK-LABEL:   fn @internal() -> memptr {

--- a/tests/ui/codegen/mir/lower-alloc/allocation_policy.stdout
+++ b/tests/ui/codegen/mir/lower-alloc/allocation_policy.stdout
@@ -13,7 +13,7 @@
 +     v6 = gt v4, 0xffffffffffffffff
 +     v7 = or v5, v6
 +     v8 = or v7, v2
-+     br v8, bb2, bb1
++     jumpi v8, bb2, bb1
 +   bb1:
 +     mstore 64, v4 !metadata(memory=scratch)
 +     v9 = calldatasize

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.mir
@@ -11,7 +11,7 @@ fn @word(arg0: u256) -> u256 {
 fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
   bb0:
     v2 = mapping_slot arg0, 7
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     mstore 0, 1
     revert 0, 0

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
@@ -13,7 +13,7 @@
   fn @word_across_reverting_branch(arg0: u256, arg1: bool) -> u256 {
     bb0:
       v0 = mapping_slot arg0, 7
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       mstore 0, 1
       revert 0, 0
@@ -62,7 +62,7 @@
 +     mstore 0, arg0 !metadata(memory=scratch)
 +     mstore 32, 7 !metadata(memory=scratch)
 +     v3 = keccak256 0, 64 !metadata(memory=scratch)
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       mstore 0, 1
       revert 0, 0
@@ -131,7 +131,7 @@
       mstore 0, arg0 !metadata(memory=scratch)
       mstore 32, 7 !metadata(memory=scratch)
       v3 = keccak256 0, 64 !metadata(memory=scratch)
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       mstore 0, 1
       revert 0, 0

--- a/tests/ui/codegen/mir/lower-slices/split_aggregates.mir
+++ b/tests/ui/codegen/mir/lower-slices/split_aggregates.mir
@@ -10,7 +10,7 @@ fn @select_slice(arg0: calldataslice, arg1: calldataslice, arg2: bool) -> u256 {
 
 fn @phi_slice(arg0: calldataslice, arg1: calldataslice, arg2: bool) -> u256 {
   bb0:
-    br arg2, bb1, bb2
+    jumpi arg2, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/lower-slices/split_aggregates.stdout
+++ b/tests/ui/codegen/mir/lower-slices/split_aggregates.stdout
@@ -15,8 +15,8 @@
 - fn @phi_slice(arg0: calldataslice, arg1: calldataslice, arg2: bool) -> u256 {
 + fn @phi_slice(arg0: calldataptr, arg1: u256, arg2: calldataptr, arg3: u256, arg4: bool) -> u256 {
     bb0:
--     br arg2, bb1, bb2
-+     br arg4, bb1, bb2
+-     jumpi arg2, bb1, bb2
++     jumpi arg4, bb1, bb2
     bb1:
       jump bb3
     bb2:

--- a/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_abi_then_dispatch.stdout
@@ -23,10 +23,10 @@
 + fn @entry() {
 +   bb0:
 +     v0 = callvalue
-+     br v0, bb4, bb1
++     jumpi v0, bb4, bb1
 +   bb1:
 +     v1 = calldatasize
-+     br v1, bb2, bb4
++     jumpi v1, bb2, bb4
 +   bb2:
 +     v2 = calldataload 0
 +     v3 = shr 224, v2

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
@@ -16,10 +16,10 @@
 + fn @entry() {
 +   bb0:
 +     v0 = callvalue
-+     br v0, bb5, bb1
++     jumpi v0, bb5, bb1
 +   bb1:
 +     v1 = calldatasize
-+     br v1, bb2, bb5
++     jumpi v1, bb2, bb5
 +   bb2:
 +     v2 = calldataload 0
 +     v3 = shr 224, v2

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
@@ -16,10 +16,10 @@
 + fn @entry() {
 +   bb0:
 +     v0 = callvalue
-+     br v0, bb5, bb1
++     jumpi v0, bb5, bb1
 +   bb1:
 +     v1 = calldatasize
-+     br v1, bb2, bb5
++     jumpi v1, bb2, bb5
 +   bb2:
 +     v2 = calldataload 0
 +     v3 = shr 224, v2

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
@@ -28,7 +28,7 @@
 +     jump bb1
 +   bb1:
 +     v0 = calldatasize
-+     br v0, bb3, bb2
++     jumpi v0, bb3, bb2
 +   bb2:
 +     tail_call @recv
 +   bb3:

--- a/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pass_bounds.stdout
@@ -32,10 +32,10 @@
 + fn @entry() {
 +   bb0:
 +     v0 = callvalue
-+     br v0, bb4, bb1
++     jumpi v0, bb4, bb1
 +   bb1:
 +     v1 = calldatasize
-+     br v1, bb2, bb4
++     jumpi v1, bb2, bb4
 +   bb2:
 +     v2 = calldataload 0
 +     v3 = shr 224, v2
@@ -59,10 +59,10 @@
   fn @entry() {
     bb0:
       v0 = callvalue
-      br v0, bb4, bb1
+      jumpi v0, bb4, bb1
     bb1:
       v1 = calldatasize
-      br v1, bb2, bb4
+      jumpi v1, bb2, bb4
     bb2:
       v2 = calldataload 0
       v3 = shr 224, v2

--- a/tests/ui/codegen/mir/lowering/phase_pipeline_resume.stdout
+++ b/tests/ui/codegen/mir/lowering/phase_pipeline_resume.stdout
@@ -9,10 +9,10 @@ fn @ping() {
 fn @entry() {
   bb0:
     v0 = callvalue
-    br v0, bb4, bb1
+    jumpi v0, bb4, bb1
   bb1:
     v1 = calldatasize
-    br v1, bb2, bb4
+    jumpi v1, bb2, bb4
   bb2:
     v2 = calldataload 0
     v3 = shr 224, v2

--- a/tests/ui/codegen/mir/memory-dse/builder_cases.mir
+++ b/tests/ui/codegen/mir/memory-dse/builder_cases.mir
@@ -52,14 +52,14 @@ fn @overlapping_keccak() {
 
 // CHECK-LABEL: @cross_block_dead_store
 // CHECK: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK:       br arg0, [[READ:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       jumpi arg0, [[READ:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK:       [[READ]]:
 // CHECK:       mstore [[ADDR]], 1
 // CHECK:       returndata [[ADDR]]
 fn @cross_block_dead_store(arg0: u256) {
   bb0:
     mstore 128, 0
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 128, 1
     returndata 128, 32
@@ -69,7 +69,7 @@ fn @cross_block_dead_store(arg0: u256) {
 
 // CHECK-LABEL: @cross_block_read_path
 // CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 7
-// CHECK: {{^ +}}br arg0, [[READ:bb[0-9]+]], [[OVERWRITE:bb[0-9]+]]
+// CHECK: {{^ +}}jumpi arg0, [[READ:bb[0-9]+]], [[OVERWRITE:bb[0-9]+]]
 // CHECK: {{^ +}}[[READ]]:
 // CHECK: {{^ +}}returndata [[ADDR]]
 // CHECK: {{^ +}}[[OVERWRITE]]:
@@ -77,7 +77,7 @@ fn @cross_block_dead_store(arg0: u256) {
 fn @cross_block_read_path(arg0: u256) {
   bb0:
     mstore 128, 7
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     returndata 128, 32
   bb2:

--- a/tests/ui/codegen/mir/memory-dse/builder_cases.stdout
+++ b/tests/ui/codegen/mir/memory-dse/builder_cases.stdout
@@ -36,7 +36,7 @@
   fn @cross_block_dead_store(arg0: u256) {
     bb0:
 -     mstore 128, 0
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 128, 1
       returndata 128, 32
@@ -47,7 +47,7 @@
   fn @cross_block_read_path(arg0: u256) {
     bb0:
       mstore 128, 7
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       returndata 128, 32
     bb2:

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.mir
@@ -23,7 +23,7 @@ fn @keep_store_read_before_successor_overwrite() -> u256 {
 
 fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     mstore 128, 1
     jump bb3

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
@@ -24,7 +24,7 @@
   
   fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       mstore 128, 1
       jump bb3

--- a/tests/ui/codegen/mir/none/display.mir
+++ b/tests/ui/codegen/mir/none/display.mir
@@ -13,14 +13,14 @@ fn @linear(arg0: u256) -> u256 {
 }
 
 // CHECK-LABEL: @diamond
-// CHECK: {{^ +}}br arg1, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
+// CHECK: {{^ +}}jumpi arg1, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
 // CHECK: {{^ +}}[[THEN]]:
 // CHECK: {{^ +}}ret arg0
 // CHECK: {{^ +}}[[ELSE]]:
 // CHECK: {{^ +}}ret arg0
 fn @diamond(arg0: u256, arg1: bool) {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     ret arg0
   bb2:

--- a/tests/ui/codegen/mir/none/display.stdout
+++ b/tests/ui/codegen/mir/none/display.stdout
@@ -9,7 +9,7 @@
   
   fn @diamond(arg0: u256, arg1: bool) {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       ret arg0
     bb2:

--- a/tests/ui/codegen/mir/none/phi.mir
+++ b/tests/ui/codegen/mir/none/phi.mir
@@ -2,7 +2,7 @@
 @module PhiTest
 fn @diamond(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/none/phi.stdout
+++ b/tests/ui/codegen/mir/none/phi.stdout
@@ -3,7 +3,7 @@
   @module PhiTest
   fn @diamond(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
@@ -10,7 +10,7 @@ fn @first(arg0: u256) {
   bb0:
     v1 = add arg0, 1
     v2 = lt v1, arg0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
@@ -23,7 +23,7 @@ fn @second(arg0: u256) {
   bb0:
     v1 = mul arg0, 2
     v2 = lt v1, arg0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 17
@@ -36,7 +36,7 @@ fn @third(arg0: u256) {
   bb0:
     v1 = sub arg0, 1
     v2 = gt v1, arg0
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
     mstore 4, 18

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
@@ -5,7 +5,7 @@
     bb0:
       v0 = add arg0, 1
       v1 = lt v0, arg0
-      br v1, bb1, bb2
+      jumpi v1, bb1, bb2
     bb1:
 -     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
 -     mstore 4, 17
@@ -20,7 +20,7 @@
     bb0:
       v0 = mul arg0, 2
       v1 = lt v0, arg0
-      br v1, bb1, bb2
+      jumpi v1, bb1, bb2
     bb1:
 -     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
 -     mstore 4, 17
@@ -35,7 +35,7 @@
     bb0:
       v0 = sub arg0, 1
       v1 = gt v0, arg0
-      br v1, bb1, bb2
+      jumpi v1, bb1, bb2
     bb1:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 18

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
@@ -13,7 +13,7 @@ fn @sum(arg0: u256) {
   bb1:
     v44 = phi [bb0: 0], [bb9: v28]
     v9 = lt v44, arg0
-    br v9, bb4, bb5
+    jumpi v9, bb4, bb5
   bb2:
     v40 = mload 128
     mstore 128, v40
@@ -21,12 +21,12 @@ fn @sum(arg0: u256) {
   bb3:
     v28 = add v44, 1
     v29 = lt v28, v44
-    br v29, bb8, bb9
+    jumpi v29, bb8, bb9
   bb4:
     v13 = mload 128
     v14 = add v13, v44
     v15 = lt v14, v13
-    br v15, bb6, bb7
+    jumpi v15, bb6, bb7
   bb5:
     jump bb2
   bb6:

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
@@ -8,7 +8,7 @@ fn @sum(arg0: u256) {
   bb1:
     v0 = phi [bb0: 0], [bb5: v3]
     v1 = lt v0, arg0
-    br v1, bb3, bb2
+    jumpi v1, bb3, bb2
   bb2:
     v2 = mload 128
     mstore 128, v2
@@ -17,7 +17,7 @@ fn @sum(arg0: u256) {
     v5 = mload 128
     v6 = add v5, v0
     v7 = lt v6, v5
-    br v7, bb4, bb5
+    jumpi v7, bb4, bb5
   bb4:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.mir
@@ -10,13 +10,13 @@ fn @guarded(arg0: u256, arg1: u256) {
     v5 = gt arg1, arg0
     v6 = iszero v5
     v7 = iszero v6
-    br v7, bb1, bb2
+    jumpi v7, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
     v10 = sub arg0, arg1
     v11 = lt arg0, arg1
-    br v11, bb3, bb4
+    jumpi v11, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
@@ -33,7 +33,7 @@ fn @unguarded(arg0: u256, arg1: u256) {
     mstore 128, 0
     v5 = sub arg0, arg1
     v6 = lt arg0, arg1
-    br v6, bb1, bb2
+    jumpi v6, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
@@ -4,7 +4,7 @@
 fn @guarded(arg0: u256, arg1: u256) {
   bb0:
     v0 = gt arg1, arg0
-    br v0, bb1, bb2
+    jumpi v0, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -17,7 +17,7 @@ fn @unguarded(arg0: u256, arg1: u256) {
   bb0:
     v0 = sub arg0, arg1
     v1 = lt arg0, arg1
-    br v1, bb1, bb2
+    jumpi v1, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir
+++ b/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.mir
@@ -15,7 +15,7 @@ fn @constant_index() -> u256 {
     calldatacopy v2, 0, 96
     v3 = mload v0
     v4 = lt 1, v3
-    br v4, bb2, bb1
+    jumpi v4, bb2, bb1
   bb1:
     revert 0, 36
   bb2:
@@ -35,7 +35,7 @@ fn @runtime_index(arg0: u256) -> u256 {
     calldatacopy v4, 0, v1
     v5 = mload v0
     v6 = lt 1, v5
-    br v6, bb2, bb1
+    jumpi v6, bb2, bb1
   bb1:
     revert 0, 36
   bb2:

--- a/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
+++ b/tests/ui/codegen/mir/pipeline/fresh_array_bounds_pipeline.stdout
@@ -24,7 +24,7 @@ fn @runtime_index(arg0: u256) -> u256 {
     calldatacopy v4, 0, v1
     v5 = mload v0
     v6 = lt 1, v5
-    br v6, bb2, bb1
+    jumpi v6, bb2, bb1
   bb1:
     revert 0, 36
   bb2:

--- a/tests/ui/codegen/mir/pipeline/pipeline_cleanup.mir
+++ b/tests/ui/codegen/mir/pipeline/pipeline_cleanup.mir
@@ -4,7 +4,7 @@ fn @fold_phi_after_promotion(arg0: bool) -> u256 {
   bb0:
     v1 = internal_frame_addr 128
     mstore v1, 1
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     v2 = internal_frame_addr 128
     mstore v2, 1

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.mir
@@ -9,7 +9,7 @@ fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
     v2 = internal_frame_addr 128
     v3 = mload v2
     v4 = lt v3, arg0
-    br v4, bb2, bb3
+    jumpi v4, bb2, bb3
   bb2:
     v5 = mul v3, 32
     v6 = add arg1, v5

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
@@ -8,7 +8,7 @@ fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
     v8 = phi [bb0: 0], [bb2: v6]
     v9 = phi [bb0: arg1], [bb2: v10]
     v3 = lt v8, arg0
-    br v3, bb2, bb3
+    jumpi v3, bb2, bb3
   bb2:
     mstore v9, v8
     v6 = add v8, 1

--- a/tests/ui/codegen/mir/pre/memory_object_pre.mir
+++ b/tests/ui/codegen/mir/pre/memory_object_pre.mir
@@ -3,7 +3,7 @@
 
 fn @hoist_projection(arg0: memorystruct, arg1: bool) -> memptr {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v2 = memory_object_field_addr memorystruct<3>, arg0, 2
     jump bb3

--- a/tests/ui/codegen/mir/pre/memory_object_pre.stdout
+++ b/tests/ui/codegen/mir/pre/memory_object_pre.stdout
@@ -3,7 +3,7 @@
   @module MemoryObjectPre
   fn @hoist_projection(arg0: memorystruct, arg1: bool) -> memptr {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = memory_object_field_addr memorystruct<3>, arg0, 2
       jump bb3

--- a/tests/ui/codegen/mir/pre/pre.mir
+++ b/tests/ui/codegen/mir/pre/pre.mir
@@ -35,7 +35,7 @@ fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
 
 fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1
     jump bb3
@@ -48,12 +48,12 @@ fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
 
 fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v2 = add arg0, 1
     jump bb3
   bb2:
-    br arg1, bb3, bb4
+    jumpi arg1, bb3, bb4
   bb3:
     v3 = add arg0, 1
     ret v3

--- a/tests/ui/codegen/mir/pre/pre.stdout
+++ b/tests/ui/codegen/mir/pre/pre.stdout
@@ -42,7 +42,7 @@
   
   fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1
       jump bb3
@@ -58,13 +58,13 @@
   
   fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = add arg0, 1
       jump bb3
     bb2:
--     br arg1, bb3, bb4
-+     br arg1, bb5, bb4
+-     jumpi arg1, bb3, bb4
++     jumpi arg1, bb5, bb4
     bb3:
 -     v1 = add arg0, 1
 -     ret v1

--- a/tests/ui/codegen/mir/pre/pre_join_shapes.mir
+++ b/tests/ui/codegen/mir/pre/pre_join_shapes.mir
@@ -35,7 +35,7 @@ fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
   bb4:
     v4 = add arg0, 7
     v5 = eq arg1, v4
-    br v5, bb4, bb5
+    jumpi v5, bb4, bb5
   bb5:
     ret v4
 }
@@ -59,7 +59,7 @@ fn @outer_phi_operand(arg0: u256, arg1: u256) -> u256 {
   bb5:
     v7 = add v2, 7
     v8 = lt v7, arg1
-    br v8, bb6, bb7
+    jumpi v8, bb6, bb7
   bb6:
     v20 = add v2, 1
     jump bb1

--- a/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
+++ b/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
@@ -37,7 +37,7 @@
 -     v3 = eq arg1, v2
 +     v5 = phi [bb1: v0], [bb2: v1], [bb3: v4], [bb4: v5]
 +     v3 = eq arg1, v5
-      br v3, bb4, bb5
+      jumpi v3, bb4, bb5
     bb5:
 -     ret v2
 +     ret v5
@@ -63,7 +63,7 @@
 -     v4 = lt v3, arg1
 +     v7 = phi [bb2: v1], [bb3: v2], [bb4: v6]
 +     v4 = lt v7, arg1
-      br v4, bb6, bb7
+      jumpi v4, bb6, bb7
     bb6:
       v5 = add v0, 1
       jump bb1

--- a/tests/ui/codegen/mir/pre/pre_loop_invariant.mir
+++ b/tests/ui/codegen/mir/pre/pre_loop_invariant.mir
@@ -10,7 +10,7 @@ fn @hoist_header_expr(arg0: u256, arg1: u256) -> u256 {
     v2 = phi [bb0: arg0], [bb2: v5]
     v3 = add v2, 7
     v4 = lt v3, arg1
-    br v4, bb2, bb3
+    jumpi v4, bb2, bb3
   bb2:
     v5 = add v2, 1
     v6 = add v5, 7
@@ -26,7 +26,7 @@ fn @hoist_header_expr_two_latches(arg0: u256, arg1: u256) -> u256 {
     v2 = phi [bb0: arg0], [bb3: v5], [bb4: v8]
     v3 = add v2, 7
     v4 = lt v3, arg1
-    br v4, bb2, bb5
+    jumpi v4, bb2, bb5
   bb2:
     switch arg1, default bb3, [1 => bb4]
   bb3:

--- a/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
+++ b/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
@@ -11,7 +11,7 @@
 -     v2 = lt v1, arg1
 +     v6 = phi [bb0: v5], [bb2: v4]
 +     v2 = lt v6, arg1
-      br v2, bb2, bb3
+      jumpi v2, bb2, bb3
     bb2:
       v3 = add v0, 1
       v4 = add v3, 7
@@ -31,7 +31,7 @@
 -     v2 = lt v1, arg1
 +     v8 = phi [bb0: v7], [bb3: v4], [bb4: v6]
 +     v2 = lt v8, arg1
-      br v2, bb2, bb5
+      jumpi v2, bb2, bb5
     bb2:
       switch arg1, default bb3, [1 => bb4]
     bb3:

--- a/tests/ui/codegen/mir/pre/pre_split_edges.mir
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.mir
@@ -24,12 +24,12 @@ fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
 // one phi entry.
 fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
   bb0:
-    br arg1, bb1, bb2
+    jumpi arg1, bb1, bb2
   bb1:
     v2 = add arg0, 7
     jump bb3
   bb2:
-    br arg1, bb3, bb3
+    jumpi arg1, bb3, bb3
   bb3:
     v3 = add arg0, 7
     ret v3
@@ -49,7 +49,7 @@ fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
     v4 = add v3, 1
     v5 = add v3, 7
     v6 = lt v4, arg1
-    br v6, bb2, bb3
+    jumpi v6, bb2, bb3
   bb3:
     ret v5
 }
@@ -59,12 +59,12 @@ fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
 fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = lt arg0, arg1
-    br v2, bb1, bb4
+    jumpi v2, bb1, bb4
   bb1:
     v3 = phi [bb0: arg0], [bb2: v5]
     v4 = add v3, 7
     v9 = lt v4, arg1
-    br v9, bb2, bb3
+    jumpi v9, bb2, bb3
   bb2:
     v5 = add v3, 1
     v6 = add v5, 7

--- a/tests/ui/codegen/mir/pre/pre_split_edges.stdout
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.stdout
@@ -24,13 +24,13 @@
   
   fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
     bb0:
-      br arg1, bb1, bb2
+      jumpi arg1, bb1, bb2
     bb1:
       v0 = add arg0, 7
       jump bb3
     bb2:
--     br arg1, bb3, bb3
-+     br arg1, bb4, bb4
+-     jumpi arg1, bb3, bb3
++     jumpi arg1, bb4, bb4
     bb3:
 -     v1 = add arg0, 7
 -     ret v1
@@ -54,8 +54,8 @@
       v2 = add v1, 1
 -     v3 = add v1, 7
       v4 = lt v2, arg1
--     br v4, bb2, bb3
-+     br v4, bb4, bb3
+-     jumpi v4, bb2, bb3
++     jumpi v4, bb4, bb3
     bb3:
 -     ret v3
 +     ret v6
@@ -67,8 +67,8 @@
   fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
     bb0:
       v0 = lt arg0, arg1
--     br v0, bb1, bb4
-+     br v0, bb5, bb4
+-     jumpi v0, bb1, bb4
++     jumpi v0, bb5, bb4
     bb1:
 -     v1 = phi [bb0: arg0], [bb2: v4]
 -     v2 = add v1, 7
@@ -76,7 +76,7 @@
 +     v1 = phi [bb5: arg0], [bb2: v4]
 +     v7 = phi [bb2: v5], [bb5: v6]
 +     v3 = lt v7, arg1
-      br v3, bb2, bb3
+      jumpi v3, bb2, bb3
     bb2:
       v4 = add v1, 1
       v5 = add v4, 7

--- a/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir
+++ b/tests/ui/codegen/mir/pure-eval/pure_eval_loop.mir
@@ -6,7 +6,7 @@ fn @bounded_loop() -> u256 {
   bb1:
     v0 = phi [bb0: 0], [bb2: 3]
     v1 = lt v0, 3
-    br v1, bb2, bb3
+    jumpi v1, bb2, bb3
   bb2:
     jump bb1
   bb3:

--- a/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
+++ b/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
@@ -8,7 +8,7 @@
     bb1:
 -     v0 = phi [bb0: 0], [bb2: 3]
 -     v1 = lt v0, 3
--     br v1, bb2, bb3
+-     jumpi v1, bb2, bb3
 +     invalid
     bb2:
 -     jump bb1

--- a/tests/ui/codegen/mir/sccp/sccp_branch.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_branch.mir
@@ -5,7 +5,7 @@
 fn @const_branch() -> u256 {
   bb0:
     v0 = lt 5, 10
-    br v0, bb1, bb2
+    jumpi v0, bb1, bb2
   bb1:
     ret 1
   bb2:

--- a/tests/ui/codegen/mir/sccp/sccp_branch.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_branch.stdout
@@ -4,7 +4,7 @@
   fn @const_branch() -> u256 {
     bb0:
 -     v0 = lt 5, 10
--     br v0, bb1, bb2
+-     jumpi v0, bb1, bb2
 +     jump bb1
     bb1:
       ret 1

--- a/tests/ui/codegen/mir/sccp/sccp_edge.mir
+++ b/tests/ui/codegen/mir/sccp/sccp_edge.mir
@@ -3,7 +3,7 @@
 fn @phi_ignores_unreachable_predecessor() -> u256 {
   bb0:
     v0 = eq 1, 1
-    br v0, bb1, bb2
+    jumpi v0, bb1, bb2
   bb1:
     jump bb3
   bb2:
@@ -15,7 +15,7 @@ fn @phi_ignores_unreachable_predecessor() -> u256 {
 
 fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
   bb0:
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb1:
     jump bb3
   bb2:

--- a/tests/ui/codegen/mir/sccp/sccp_edge.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_edge.stdout
@@ -4,7 +4,7 @@
   fn @phi_ignores_unreachable_predecessor() -> u256 {
     bb0:
 -     v0 = eq 1, 1
--     br v0, bb1, bb2
+-     jumpi v0, bb1, bb2
 +     jump bb1
     bb1:
       jump bb3
@@ -19,7 +19,7 @@
   
   fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
     bb0:
-      br arg0, bb1, bb2
+      jumpi arg0, bb1, bb2
     bb1:
       jump bb3
     bb2:

--- a/tests/ui/codegen/mir/storage-promotion/non_external.mir
+++ b/tests/ui/codegen/mir/storage-promotion/non_external.mir
@@ -12,7 +12,7 @@ fn @non_external() {
     sstore 0, 1
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v0 = sload 0
     v1 = mul v0, 2

--- a/tests/ui/codegen/mir/storage-promotion/non_external.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/non_external.stdout
@@ -6,7 +6,7 @@
       sstore 0, 1
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
       v0 = sload 0
       v1 = mul v0, 2

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
@@ -6,7 +6,7 @@
 // CHECK:       [[SLOT:v[0-9]+]] = add arg0, 1
 // CHECK: -     sstore [[SLOT]], 1
 // CHECK:       mstore [[VALUE_ADDR:[0-9]+]], 1
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
 // CHECK:       [[BODY]]:
 // CHECK:       [[BODY_SLOT:v[0-9]+]] = add arg0, 1
 // CHECK: -     {{v[0-9]+}} = sload [[BODY_SLOT]]
@@ -24,7 +24,7 @@ fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
     sstore v1, 1
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v2 = add arg0, 1
     v3 = sload v2
@@ -48,7 +48,7 @@ fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
     jump bb1
   bb1:
     v1 = phi [bb0: 0], [bb2: v6]
-    br true, bb2, bb3
+    jumpi true, bb2, bb3
   bb2:
     v2 = add arg0, v1
     v3 = sload v2
@@ -66,7 +66,7 @@ fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
 // CHECK:       mstore [[VALUE_ADDR:[0-9]+]], 7
 // CHECK:       mstore [[DIRTY_ADDR]], 1
 // CHECK:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
-// CHECK:       br [[DIRTY]], [[FLUSH:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK:       [[FLUSH]]:
 // CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
 // CHECK:       sstore [[SLOT]], [[VALUE]]
@@ -74,7 +74,7 @@ fn @promote_store_only_without_initial_load() [selector=0x01020304] {
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     sstore 0, 7
     jump bb3
@@ -89,7 +89,7 @@ fn @promote_store_only_without_initial_load() [selector=0x01020304] {
 // CHECK: -     sstore [[ONE_SLOT:[0-9]+]], 2
 // CHECK:       mstore [[ZERO_ADDR:[0-9]+]], 1
 // CHECK:       mstore [[ONE_ADDR:[0-9]+]], 2
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
 // CHECK:       [[BODY]]:
 // CHECK: -     {{v[0-9]+}} = sload [[ZERO_SLOT]]
 // CHECK:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
@@ -112,7 +112,7 @@ fn @promote_two_initialized_slots() [selector=0x01020304] {
     sstore 1, 2
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v1 = sload 0
     v2 = mul v1, 2
@@ -131,7 +131,7 @@ fn @promote_two_initialized_slots() [selector=0x01020304] {
 // CHECK:       [[INIT:v[0-9]+]] = sload [[SLOT:[0-9]+]]
 // CHECK:       mstore [[VALUE_ADDR:[0-9]+]], [[INIT]]
 // CHECK:       mstore [[DIRTY_ADDR:[0-9]+]], 0
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], [[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[LOOP_EXIT:bb[0-9]+]]
 // CHECK:       [[BODY]]:
 // CHECK: -     {{v[0-9]+}} = sload [[SLOT]]
 // CHECK:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
@@ -141,7 +141,7 @@ fn @promote_two_initialized_slots() [selector=0x01020304] {
 // CHECK:       mstore [[DIRTY_ADDR]], 1
 // CHECK:       [[LOOP_EXIT]]:
 // CHECK:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
-// CHECK:       br [[DIRTY]], [[FLUSH:bb[0-9]+]], [[CLEAN:bb[0-9]+]]
+// CHECK:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], [[CLEAN:bb[0-9]+]]
 // CHECK:       [[MERGE:bb[0-9]+]]:
 // CHECK:       [[PHI:v[0-9]+]] = phi [[[CLEAN]]: 7], [[[OTHER:bb[0-9]+]]: 9]
 // CHECK:       ret [[PHI]]
@@ -157,7 +157,7 @@ fn @promote_without_init_rewrites_successor_phi() -> u256 [selector=0x01020304] 
   bb0:
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v1 = sload 0
     v2 = add v1, 2

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
@@ -8,7 +8,7 @@
 +     mstore 128, 1
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
       v1 = add arg0, 1
 -     v2 = sload v1
@@ -31,7 +31,7 @@
       jump bb1
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
-      br 1, bb2, bb3
+      jumpi 1, bb2, bb3
     bb2:
       v1 = add arg0, v0
 -     v2 = sload v1
@@ -50,7 +50,7 @@
 +     mstore 160, 0
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     sstore 0, 7
 +     mstore 128, 7
@@ -60,7 +60,7 @@
       jump bb1
     bb4:
 +     v0 = mload 160
-+     br v0, bb6, bb5
++     jumpi v0, bb6, bb5
 +   bb5:
       stop
 +   bb6:
@@ -77,7 +77,7 @@
 +     mstore 160, 2
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -107,7 +107,7 @@
 +     mstore 160, 0
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -121,7 +121,7 @@
     bb4:
 -     jump bb5
 +     v4 = mload 160
-+     br v4, bb8, bb7
++     jumpi v4, bb8, bb7
     bb5:
 -     v2 = phi [bb4: 7], [bb6: 9]
 +     v2 = phi [bb7: 7], [bb6: 9]

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
@@ -5,7 +5,7 @@
 // CHECK-LABEL: @reject_two_symbolic_slots
 // CHECK: +     sstore arg0, 1
 // CHECK: +     sstore arg1, 2
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK:       [[BODY]]:
 // CHECK: +     [[FIRST:v[0-9]+]] = sload arg0
 // CHECK:       [[FIRST_UPDATED:v[0-9]+]] = mul [[FIRST]], 2
@@ -19,7 +19,7 @@ fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
     sstore arg1, 2
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v1 = sload arg0
     v2 = mul v1, 2
@@ -37,7 +37,7 @@ fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
 // CHECK-LABEL: @reject_symbolic_and_constant_slots
 // CHECK: +     sstore arg0, 1
 // CHECK: +     sstore [[CONSTANT_SLOT:[0-9]+]], 2
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
 // CHECK:       [[BODY]]:
 // CHECK: +     [[SYMBOLIC:v[0-9]+]] = sload arg0
 // CHECK:       [[SYMBOLIC_UPDATED:v[0-9]+]] = mul [[SYMBOLIC]], 2
@@ -51,7 +51,7 @@ fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
     sstore 7, 2
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v1 = sload arg0
     v2 = mul v1, 2
@@ -71,7 +71,7 @@ fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
 // CHECK: -     sstore [[ONE_SLOT:[0-9]+]], 2
 // CHECK:       mstore [[ZERO_ADDR:[0-9]+]], 1
 // CHECK:       mstore [[ONE_ADDR:[0-9]+]], 2
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
 // CHECK:       [[BODY]]:
 // CHECK: -     {{v[0-9]+}} = sload [[ZERO_SLOT]]
 // CHECK:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
@@ -94,7 +94,7 @@ fn @promote_two_constant_slots() [selector=0x01020304] {
     sstore 1, 2
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v1 = sload 0
     v2 = mul v1, 2
@@ -116,7 +116,7 @@ fn @promote_two_constant_slots() [selector=0x01020304] {
 // CHECK:       [[TWO_SLOT:v[0-9]+]] = add arg0, 2
 // CHECK: -     sstore [[TWO_SLOT]], 2
 // CHECK:       mstore [[TWO_ADDR:[0-9]+]], 2
-// CHECK:       br {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
 // CHECK:       [[BODY]]:
 // CHECK:       [[BODY_ONE_SLOT:v[0-9]+]] = add arg0, 1
 // CHECK: -     {{v[0-9]+}} = sload [[BODY_ONE_SLOT]]
@@ -145,7 +145,7 @@ fn @promote_same_base_distinct_offsets(arg0: u256) [selector=0x01020304] {
     sstore v2, 2
     jump bb1
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     v3 = add arg0, 1
     v4 = sload v3

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
@@ -9,7 +9,7 @@
 +     sstore arg1, 2 !metadata(storage=symbolic(arg1))
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     v0 = sload arg0
 +     v0 = sload arg0 !metadata(storage=symbolic(arg0))
@@ -36,7 +36,7 @@
 +     sstore 7, 2 !metadata(storage=slot(7))
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     v0 = sload arg0
 +     v0 = sload arg0 !metadata(storage=symbolic(arg0))
@@ -63,7 +63,7 @@
 +     mstore 160, 2
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -96,7 +96,7 @@
 +     mstore 160, 2
       jump bb1
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
       v2 = add arg0, 1
 -     v3 = sload v2

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
@@ -11,7 +11,7 @@ fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
   bb0:
     jump bb6
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     sstore 0, 7
     jump bb3
@@ -25,7 +25,7 @@ fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
     sstore 0, v2
     jump bb6
   bb6:
-    br true, bb7, bb8
+    jumpi true, bb7, bb8
   bb7:
     jump bb1
   bb8:
@@ -38,7 +38,7 @@ fn @reject_outer_when_inner_flush_may_alias(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb6
   bb1:
-    br true, bb2, bb4
+    jumpi true, bb2, bb4
   bb2:
     sstore arg0, 7
     jump bb3
@@ -52,7 +52,7 @@ fn @reject_outer_when_inner_flush_may_alias(arg0: u256) [selector=0x01020304] {
     sstore 0, v2
     jump bb6
   bb6:
-    br true, bb7, bb8
+    jumpi true, bb7, bb8
   bb7:
     jump bb1
   bb8:

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
@@ -8,7 +8,7 @@
 +     mstore 224, 0
       jump bb6
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     sstore 0, 7
 +     mstore 128, 7
@@ -19,7 +19,7 @@
     bb4:
 -     jump bb5
 +     v2 = mload 160
-+     br v2, bb10, bb9
++     jumpi v2, bb10, bb9
     bb5:
 -     v0 = sload 0
 +     v0 = mload 192
@@ -29,13 +29,13 @@
 +     mstore 224, 1
       jump bb6
     bb6:
-      br 1, bb7, bb8
+      jumpi 1, bb7, bb8
     bb7:
 +     mstore 160, 0
       jump bb1
     bb8:
 +     v5 = mload 224
-+     br v5, bb12, bb11
++     jumpi v5, bb12, bb11
 +   bb9:
 +     jump bb5
 +   bb10:
@@ -55,7 +55,7 @@
     bb0:
       jump bb6
     bb1:
-      br 1, bb2, bb4
+      jumpi 1, bb2, bb4
     bb2:
 -     sstore arg0, 7
 +     mstore 128, 7
@@ -66,7 +66,7 @@
     bb4:
 -     jump bb5
 +     v2 = mload 160
-+     br v2, bb10, bb9
++     jumpi v2, bb10, bb9
     bb5:
 -     v0 = sload 0
 +     v0 = sload 0 !metadata(storage=slot(0))
@@ -75,7 +75,7 @@
 +     sstore 0, v1 !metadata(storage=slot(0))
       jump bb6
     bb6:
-      br 1, bb7, bb8
+      jumpi 1, bb7, bb8
     bb7:
 +     mstore 160, 0
       jump bb1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
@@ -6,12 +6,12 @@ fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
   bb1:
     v1 = phi [bb0: 0], [bb3: v2]
     v3 = lt v1, arg0
-    br v3, bb2, bb6
+    jumpi v3, bb2, bb6
   bb2:
     v4 = sload 0
     v5 = add v4, v1
     v6 = lt v5, v4
-    br v6, bb4, bb5
+    jumpi v6, bb4, bb5
   bb4:
     revert 0, 0
   bb5:
@@ -29,13 +29,13 @@ fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
     sstore 0, 1
     jump bb1
   bb1:
-    br true, bb2, bb5
+    jumpi true, bb2, bb5
   bb2:
     v1 = sload 0
     v2 = mul v1, 2
     sstore 0, v2
     v3 = lt v2, arg0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb4:
     v4 = sload 0
     mstore 0, v4
@@ -51,13 +51,13 @@ fn @reject_revert_exit_with_call(arg0: u256) [selector=0x01020304] {
     sstore 0, 1
     jump bb1
   bb1:
-    br true, bb2, bb5
+    jumpi true, bb2, bb5
   bb2:
     v1 = sload 0
     v2 = mul v1, 2
     sstore 0, v2
     v3 = lt v2, arg0
-    br v3, bb3, bb4
+    jumpi v3, bb3, bb4
   bb4:
     v4 = call 100, arg0, 0, 0, 0, 0, 32
     revert 0, 32

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
@@ -10,13 +10,13 @@
     bb1:
       v0 = phi [bb0: 0], [bb5: v5]
       v1 = lt v0, arg0
-      br v1, bb2, bb6
+      jumpi v1, bb2, bb6
     bb2:
 -     v2 = sload 0
 +     v2 = mload 128
       v3 = add v2, v0
       v4 = lt v3, v2
-      br v4, bb3, bb4
+      jumpi v4, bb3, bb4
     bb3:
       revert 0, 0
     bb4:
@@ -29,7 +29,7 @@
       jump bb1
     bb6:
 +     v7 = mload 160
-+     br v7, bb8, bb7
++     jumpi v7, bb8, bb7
 +   bb7:
       stop
 +   bb8:
@@ -44,7 +44,7 @@
 +     mstore 128, 1
       jump bb1
     bb1:
-      br 1, bb2, bb5
+      jumpi 1, bb2, bb5
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -52,7 +52,7 @@
 -     sstore 0, v1
 +     mstore 128, v1
       v2 = lt v1, arg0
-      br v2, bb4, bb3
+      jumpi v2, bb4, bb3
     bb3:
 -     v3 = sload 0
 +     v3 = mload 128
@@ -72,7 +72,7 @@
 +     sstore 0, 1 !metadata(storage=slot(0))
       jump bb1
     bb1:
-      br 1, bb2, bb5
+      jumpi 1, bb2, bb5
     bb2:
 -     v0 = sload 0
 +     v0 = sload 0 !metadata(storage=slot(0))
@@ -80,7 +80,7 @@
 -     sstore 0, v1
 +     sstore 0, v1 !metadata(storage=slot(0))
       v2 = lt v1, arg0
-      br v2, bb4, bb3
+      jumpi v2, bb4, bb3
     bb3:
       v3 = call 100, arg0, 0, 0, 0, 0, 32
       revert 0, 32

--- a/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir
+++ b/tests/ui/codegen/mir/validation/tail_call_roundtrip.mir
@@ -14,7 +14,7 @@ fn @entry() {
     v1 = calldataload 0
     v3 = shr 224, v1
     v4 = eq v3, 0x9507d39a
-    br v4, bb1, bb2
+    jumpi v4, bb1, bb2
   bb1:
     v6 = calldataload 4
     tail_call fn0, v6

--- a/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
+++ b/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
@@ -13,7 +13,7 @@
       v0 = calldataload 0
       v1 = shr 224, v0
       v2 = eq v1, 0x9507d39a
-      br v2, bb1, bb2
+      jumpi v2, bb1, bb2
     bb1:
       v3 = calldataload 4
       tail_call @wrapper, v3

--- a/tests/ui/codegen/mir/validation/validate_same_block_use.mir
+++ b/tests/ui/codegen/mir/validation/validate_same_block_use.mir
@@ -16,7 +16,7 @@ fn @cyclic(arg0: bool) -> u256 {
   bb1:
     v0 = add v1, 1
     v1 = add v0, 1
-    br arg0, bb1, bb2
+    jumpi arg0, bb1, bb2
   bb2:
     ret v0
 }

--- a/tests/ui/erc7201/codegen.stdout
+++ b/tests/ui/erc7201/codegen.stdout
@@ -36,7 +36,7 @@ fn @calldataParam(arg0: calldataslice) {
     v0 = calldatasize
     v1 = sub v0, 4
     v2 = slt v1, 32
-    br v2, bb1, bb2
+    jumpi v2, bb1, bb2
   bb1:
     revert 0, 0
   bb2:
@@ -44,7 +44,7 @@ fn @calldataParam(arg0: calldataslice) {
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
-    br v5, bb3, bb4
+    jumpi v5, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -56,7 +56,7 @@ fn @calldataParam(arg0: calldataslice) {
     v9 = select v8, 32, v7
     v10 = add 32, v9
     v11 = lt v10, v9
-    br v11, bb5, bb6
+    jumpi v11, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
@@ -111,7 +111,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v14 = alloc memorybytes, exact, uninitialized, infallible, v12
     set_memory_object_len memorybytes, v14, v6
     v15 = memory_object_data memorybytes, v14
-    br v2, bb2, bb1
+    jumpi v2, bb2, bb1
   bb1:
     v16 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     mstore v15, v16
@@ -128,7 +128,7 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
-    br v22, bb5, bb3
+    jumpi v22, bb5, bb3
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23


### PR DESCRIPTION
This renames the MIR conditional branch mnemonic from `br` to `jumpi`, matching EVM IR and the opcode it lowers to. The parser, printer, FileCheck assertions, and MIR snapshots now use the same spelling, and the obsolete pre-interned `br` symbol is removed.