### PR TITLE
feat(tester): add run-call directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - os: "windows-latest"
             rust: "stable"
           - os: "ubuntu-latest"
-            rust: "1.95" # MSRV
+            rust: "1.96" # MSRV
           - os: "ubuntu-latest"
             rust: "nightly"
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,13 @@ Common file-level UI directives:
 - `//@ ignore-host: windows`: Skip a test on a specific host.
 - `//@[name] compile-flags: ...`: Define revision-specific flags for tests with
   multiple revisions.
+- `//@ run-call: add 1, 2 => 3`: Deploy a fresh contract, ABI-encode and call the
+  named function, then compare its ABI-encoded return values. Omit `=>` when no
+  return data is expected. Raw calldata and return data may be written as hex.
+- `//@ run-call-fail: fail()`: Like `run-call`, but require the call to fail.
+  Add `=> 0x...` to check exact revert data. Both directives use the EVM version
+  selected by `--evm-version`. Calls to functions named `test*` run a
+  zero-argument `setUp()` first when the contract defines it.
 - `//@ filecheck: ...`: Run LLVM FileCheck against the generated `.stdout` file
   after the UI test. Arguments after `filecheck:` are passed directly to
   FileCheck, for example `--check-prefix=ABI` or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,12 @@ Common file-level UI directives:
 - `//@ run-call: add 1, 2 => 3`: Deploy a fresh contract, ABI-encode and call the
   named function, then compare its ABI-encoded return values. Omit `=>` when no
   return data is expected. Raw calldata and return data may be written as hex.
+  Add settings after a semicolon, for example
+  `add 2; constructor=[40], gas=100000, value=3 => 45`. Settings are
+  comma-separated. `constructor=[...]` supplies ABI-encoded constructor
+  arguments, `gas` sets the call transaction's gas limit, and `value` sets its
+  value in wei. Numeric settings accept decimal and `0x`-prefixed integers.
+  Deployment and `setUp()` use the default gas limit and zero value.
 - `//@ run-call-fail: fail()`: Like `run-call`, but require the call to fail.
   Add `=> 0x...` to check exact revert data. Both directives use the EVM version
   selected by `--evm-version`. Calls to functions named `test*` run a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,14 @@ Common file-level UI directives:
   FileCheck, for example `--check-prefix=ABI` or
   `--implicit-check-not=UnusedSymbol`.
 
+Prefer `run-call` and `run-call-fail` for small runtime checks that fit one
+isolated entry-point call and an exact output or failure expectation. Each
+directive deploys a fresh contract, so calls never share state. Put more
+complex runtime tests under `tests/foundry/` and run them with
+`cargo tq foundry`. Use Foundry for multi-transaction sequences, persistent
+state, multiple actors or contracts, event assertions, cheatcodes, and complex
+setup.
+
 Use FileCheck when exact full-output snapshots are too brittle or when a test
 needs to assert selected output properties such as ordering, presence, or
 absence. Put `// CHECK:`, `// CHECK-LABEL:`, `// CHECK-NOT:`, and related

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
- "k256",
+ "k256 0.13.4",
  "once_cell",
  "secp256k1 0.30.0",
  "serde",
@@ -121,7 +121,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
- "k256",
+ "k256 0.13.4",
  "serde",
  "thiserror 2.0.19",
 ]
@@ -191,7 +191,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
- "k256",
+ "k256 0.13.4",
  "keccak-asm",
  "paste",
  "proptest",
@@ -883,6 +883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codspeed"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1456,6 +1474,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1562,6 +1586,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,7 +1617,19 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1634,7 +1686,17 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1714,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1726,7 +1788,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1768,12 +1832,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1810,15 +1889,35 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1877,9 +1976,10 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=9595c0ede98d977d40d81de4fe6efa70542cb6eb#9595c0ede98d977d40d81de4fe6efa70542cb6eb"
+source = "git+https://github.com/alloy-rs/evm2?rev=f85cf2657362c742ce7f6e4e6d39d4ac14823cb3#f85cf2657362c742ce7f6e4e6d39d4ac14823cb3"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "ark-bls12-381",
@@ -1889,24 +1989,28 @@ dependencies = [
  "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
+ "auto_impl",
+ "bitvec",
  "c-kzg",
  "cfg-if",
  "derive-where",
  "evm2-macros",
- "k256",
+ "k256 0.14.0",
  "once_cell",
  "p256",
+ "phf 0.14.0",
  "ripemd",
  "secp256k1 0.31.1",
  "serde",
  "sha2 0.11.0",
  "thiserror 2.0.19",
+ "typeid",
 ]
 
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=9595c0ede98d977d40d81de4fe6efa70542cb6eb#9595c0ede98d977d40d81de4fe6efa70542cb6eb"
+source = "git+https://github.com/alloy-rs/evm2?rev=f85cf2657362c742ce7f6e4e6d39d4ac14823cb3#f85cf2657362c742ce7f6e4e6d39d4ac14823cb3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1958,6 +2062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2162,6 +2276,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2182,8 +2297,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2306,12 +2432,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -2536,10 +2673,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "k256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
+dependencies = [
+ "cpubits",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primeorder",
+ "sha2 0.11.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -3009,14 +3160,15 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
  "primeorder",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3114,8 +3266,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -3124,8 +3287,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -3134,8 +3307,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3146,6 +3332,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -3162,8 +3357,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3213,12 +3418,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
- "elliptic-curve",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -3376,6 +3599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,8 +3717,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3663,10 +3902,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -3836,6 +4089,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +4173,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3996,7 +4269,7 @@ dependencies = [
  "itertools 0.12.1",
  "lalrpop",
  "lalrpop-util",
- "phf",
+ "phf 0.11.3",
  "thiserror 1.0.69",
  "unicode-xid",
 ]
@@ -4291,7 +4564,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -4336,7 +4619,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
 ]
 
@@ -4875,6 +5158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5338,6 +5627,17 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,10 +1877,9 @@ dependencies = [
 [[package]]
 name = "evm2"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=9595c0ede98d977d40d81de4fe6efa70542cb6eb#9595c0ede98d977d40d81de4fe6efa70542cb6eb"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "ark-bls12-381",
@@ -1890,7 +1889,6 @@ dependencies = [
  "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
- "bitvec",
  "c-kzg",
  "cfg-if",
  "derive-where",
@@ -1898,19 +1896,17 @@ dependencies = [
  "k256",
  "once_cell",
  "p256",
- "phf 0.14.0",
  "ripemd",
  "secp256k1 0.31.1",
  "serde",
  "sha2 0.11.0",
  "thiserror 2.0.19",
- "typeid",
 ]
 
 [[package]]
 name = "evm2-macros"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+source = "git+https://github.com/alloy-rs/evm2?rev=9595c0ede98d977d40d81de4fe6efa70542cb6eb#9595c0ede98d977d40d81de4fe6efa70542cb6eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3118,19 +3114,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
-dependencies = [
- "phf_macros 0.14.0",
- "phf_shared 0.14.0",
- "serde",
+ "phf_macros",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3139,18 +3124,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.7",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
-dependencies = [
- "fastrand",
- "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -3159,21 +3134,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
-dependencies = [
- "phf_generator 0.14.0",
- "phf_shared 0.14.0",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3184,15 +3146,6 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -4043,7 +3996,7 @@ dependencies = [
  "itertools 0.12.1",
  "lalrpop",
  "lalrpop-util",
- "phf 0.11.3",
+ "phf",
  "thiserror 1.0.69",
  "unicode-xid",
 ]
@@ -4383,7 +4336,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -4920,12 +4873,6 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4307,6 +4307,7 @@ dependencies = [
 name = "solar-tester"
 version = "0.2.0"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy-consensus"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "k256",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,7 +187,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash",
+ "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
@@ -75,7 +199,7 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
- "secp256k1",
+ "secp256k1 0.31.1",
  "serde",
  "sha3",
 ]
@@ -86,8 +210,79 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.14.0",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.119",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -98,6 +293,46 @@ checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
 dependencies = [
  "serde",
  "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -199,6 +434,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.6.0",
+ "ark-r1cs-std",
+ "ark-std 0.6.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -368,6 +648,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.6.0",
+ "ark-relations",
+ "ark-std 0.6.0",
+ "educe",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
+dependencies = [
+ "ark-ff 0.6.0",
+ "ark-poly",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.14.0",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +832,16 @@ dependencies = [
  "tower-service",
  "tracing",
  "waitpid-any",
+]
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
 ]
 
 [[package]]
@@ -655,6 +1000,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +1033,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -729,6 +1110,21 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -1080,6 +1476,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1656,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1453,6 +1875,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "evm2"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eip7928",
+ "alloy-eips",
+ "alloy-primitives",
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "bitvec",
+ "c-kzg",
+ "cfg-if",
+ "derive-where",
+ "evm2-macros",
+ "k256",
+ "once_cell",
+ "p256",
+ "phf 0.14.0",
+ "ripemd",
+ "secp256k1 0.31.1",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "typeid",
+]
+
+[[package]]
+name = "evm2-macros"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/evm2?rev=0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9#0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1998,18 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1781,7 +2258,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -2065,7 +2543,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2232,6 +2710,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,12 +2846,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -2378,6 +2890,16 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -2403,12 +2925,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -2463,6 +3009,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
 dependencies = [
  "nonmax",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2560,8 +3118,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -2570,8 +3139,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -2580,8 +3159,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2592,6 +3184,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -2659,6 +3260,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2690,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
@@ -2930,6 +3540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3101,13 +3720,33 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.7",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
+name = "secp256k1"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.9.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3227,7 +3866,20 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
+ "serde_with_macros",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3239,6 +3891,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3380,7 +4043,7 @@ dependencies = [
  "itertools 0.12.1",
  "lalrpop",
  "lalrpop-util",
- "phf",
+ "phf 0.11.3",
  "thiserror 1.0.69",
  "unicode-xid",
 ]
@@ -3549,7 +4212,7 @@ dependencies = [
  "solar-data-structures",
  "solar-macros",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tracing",
  "tracing-subscriber",
  "unicode-width",
@@ -3573,7 +4236,7 @@ dependencies = [
  "solar-parse",
  "solar-sema",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "toml_edit",
@@ -3644,6 +4307,10 @@ dependencies = [
 name = "solar-tester"
 version = "0.2.0"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "evm2",
  "regex",
  "serde_json",
  "tempfile",
@@ -3715,7 +4382,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
 ]
 
@@ -3805,6 +4472,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3881,6 +4560,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -4231,6 +4919,12 @@ dependencies = [
  "cc",
  "tree-sitter-language",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,8 +119,14 @@ solar-sema = { version = "=0.2.0", path = "crates/sema", default-features = fals
 solar-tester = { path = "tools/tester" }
 
 # Ethereum
+alloy-dyn-abi = "1.6"
 alloy-primitives = "1.3"
 alloy-json-abi = "1.3"
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9", default-features = false, features = [
+    "std",
+    "map-foldhash",
+    "asm-keccak",
+] }
 ruint = { version = "1.16", features = ["num-integer"] }
 
 num-bigint = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ solar-sema = { version = "=0.2.0", path = "crates/sema", default-features = fals
 solar-tester = { path = "tools/tester" }
 
 # Ethereum
+alloy-consensus = "2.2"
 alloy-dyn-abi = "1.6"
 alloy-primitives = "1.3"
 alloy-json-abi = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ alloy-consensus = "2.2"
 alloy-dyn-abi = "1.6"
 alloy-primitives = "1.3"
 alloy-json-abi = "1.3"
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "0b5f142e839f9e124ff847cbd7b965a8c1cdb9a9", default-features = false, features = [
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "9595c0ede98d977d40d81de4fe6efa70542cb6eb", default-features = false, features = [
     "std",
     "map-foldhash",
     "asm-keccak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.95" # MSRV
+rust-version = "1.96" # MSRV
 authors = ["DaniPopes <57450786+DaniPopes@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paradigmxyz/solar"
@@ -123,7 +123,7 @@ alloy-consensus = "2.2"
 alloy-dyn-abi = "1.6"
 alloy-primitives = "1.3"
 alloy-json-abi = "1.3"
-evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "9595c0ede98d977d40d81de4fe6efa70542cb6eb", default-features = false, features = [
+evm2 = { git = "https://github.com/alloy-rs/evm2", rev = "f85cf2657362c742ce7f6e4e6d39d4ac14823cb3", default-features = false, features = [
     "std",
     "map-foldhash",
     "asm-keccak",

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ exceptions = [
     # CC0 is a permissive license but somewhat unclear status for source code
     # so we prefer to not have dependencies using it
     # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
+    { allow = ["CC0-1.0"], name = "aurora-engine-modexp" },
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
 ]
 
@@ -44,6 +45,7 @@ allow-git = [
     # Used only for testing.
     "https://github.com/DaniPopes/ui_test",
     "https://github.com/oli-obk/ui_test",
+    "https://github.com/alloy-rs/evm2",
     # Used only for benchmarks.
     "https://github.com/DaniPopes/codspeed-rust",
 ]

--- a/tests/ui/codegen/run-call/basic.sol
+++ b/tests/ui/codegen/run-call/basic.sol
@@ -1,0 +1,42 @@
+//@ run-call: add 2 => 42
+//@ run-call: negate(bool) true => false
+//@ run-call: pair 41, true => 42, false
+//@ run-call: sum(uint256[]) [1, 2, 3] => 6
+//@ run-call: increment => 41
+//@ run-call: increment => 41
+//@ run-call: testInline()
+//@ run-call: 0x1003e2d20000000000000000000000000000000000000000000000000000000000000002 => 0x000000000000000000000000000000000000000000000000000000000000002a
+
+contract RunCall {
+    uint256 private base;
+
+    constructor() {
+        base = 40;
+    }
+
+    function add(uint256 value) external view returns (uint256) {
+        return base + value;
+    }
+
+    function negate(bool value) external pure returns (bool) {
+        return !value;
+    }
+
+    function pair(uint256 value, bool flag) external pure returns (uint256, bool) {
+        return (value + 1, !flag);
+    }
+
+    function sum(uint256[] calldata values) external pure returns (uint256 result) {
+        for (uint256 i = 0; i < values.length; i++) {
+            result += values[i];
+        }
+    }
+
+    function increment() external returns (uint256) {
+        return ++base;
+    }
+
+    function testInline() external view {
+        assert(base == 40);
+    }
+}

--- a/tests/ui/codegen/run-call/evm_version.sol
+++ b/tests/ui/codegen/run-call/evm_version.sol
@@ -1,0 +1,14 @@
+//@ revisions: paris shanghai
+//@[paris] compile-flags: --evm-version paris
+//@[shanghai] compile-flags: --evm-version shanghai
+//@[paris] run-call-fail: 0x
+//@[shanghai] run-call: 0x => 0x0000000000000000000000000000000000000000000000000000000000000000
+
+contract ForkRuntime {
+    constructor() {
+        bytes memory runtime = hex"5f60005260206000f3";
+        assembly {
+            return(add(runtime, 0x20), mload(runtime))
+        }
+    }
+}

--- a/tests/ui/codegen/run-call/failure.sol
+++ b/tests/ui/codegen/run-call/failure.sol
@@ -1,0 +1,12 @@
+//@ run-call-fail: empty()
+//@ run-call-fail: panic() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000001
+
+contract RunCallFail {
+    function empty() external pure {
+        revert();
+    }
+
+    function panic() external pure {
+        assert(false);
+    }
+}

--- a/tests/ui/codegen/run-call/settings.sol
+++ b/tests/ui/codegen/run-call/settings.sol
@@ -1,0 +1,16 @@
+//@ run-call: configured 2; constructor=[40, true], gas=100000, value=3 => 45, true
+
+contract RunCallSettings {
+    uint256 private base;
+    bool private flag;
+
+    constructor(uint256 base_, bool flag_) {
+        base = base_;
+        flag = flag_;
+    }
+
+    function configured(uint256 x) external payable returns (uint256, bool) {
+        require(gasleft() < 200_000);
+        return (base + x + msg.value, flag);
+    }
+}

--- a/tools/tester/Cargo.toml
+++ b/tools/tester/Cargo.toml
@@ -17,6 +17,10 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
+alloy-dyn-abi.workspace = true
+alloy-json-abi.workspace = true
+alloy-primitives.workspace = true
+evm2.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/tools/tester/Cargo.toml
+++ b/tools/tester/Cargo.toml
@@ -17,6 +17,7 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
+alloy-consensus.workspace = true
 alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -22,6 +22,7 @@ use ui_test::{
 };
 
 mod errors;
+mod run_call;
 mod solc;
 mod standard_json;
 mod utils;
@@ -169,7 +170,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
             )*
         };
     }
-    register_custom_flags![FileCheck];
+    register_custom_flags![FileCheck, run_call::RunCall, run_call::RunCallFail];
 
     config.comment_defaults.base().exit_status = None.into();
     config.infer_exit_status_from_annotations = !mode.is_solc();
@@ -328,6 +329,10 @@ fn per_file_config(config: &mut ui_test::Config, file: &Spanned<Vec<u8>>, cfg: M
     }
 
     assert_eq!(config.comment_start, "//");
+    if matches!(cfg.mode, Mode::Ui) && src.lines().any(run_call::is_directive) {
+        config.program.args.extend(["-Zcodegen".into(), "--emit=abi,bin".into()]);
+        config.stdout_filter(r"(?s).+", "");
+    }
     if src.lines().any(|line| {
         let line = line.trim_start();
         line.starts_with("//@")

--- a/tools/tester/src/run_call.rs
+++ b/tools/tester/src/run_call.rs
@@ -1,13 +1,12 @@
+use alloy_consensus::{TxLegacy, transaction::Recovered};
 use alloy_dyn_abi::{FunctionExt, JsonAbiExt, Specifier};
 use alloy_json_abi::{Function, JsonAbi};
-use alloy_primitives::{Address, Bytes, U256, hex};
+use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
 use evm2::{
-    BaseEvmTypes, Evm, Precompiles, SpecId,
-    bytecode::Bytecode,
-    env::{BlockEnv, TxEnv},
+    BaseEvmTypes, Evm, Precompiles, SpecId, TxResult,
+    env::BlockEnv,
+    ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, InMemoryDB},
-    interpreter::{Host, Message, MessageKind},
-    registry::TxRegistry,
 };
 use serde_json::Value;
 use std::path::Path;
@@ -19,9 +18,8 @@ use ui_test::{
     spanned::{Span, Spanned},
 };
 
-const CONTRACT: Address = Address::repeat_byte(0x11);
 const CALLER: Address = Address::repeat_byte(0x22);
-const GAS_LIMIT: u64 = 30_000_000;
+const GAS_LIMIT: u64 = 10_000_000;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RunCall {
@@ -399,31 +397,27 @@ fn execute(
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec_id,
         BlockEnv::default(),
-        TxRegistry::new(),
+        ethereum_tx_registry(spec_id),
         database,
         Precompiles::base(spec_id),
     );
-    let mut deployment = Message {
-        kind: MessageKind::Create,
-        destination: CONTRACT,
-        caller: CALLER,
-        code_address: CONTRACT,
-        gas_limit: GAS_LIMIT,
-        ..Message::default()
-    };
-    let result = Host::execute_message(
-        &mut evm,
-        &TxEnv::default(),
-        Bytecode::new_legacy(Bytes::copy_from_slice(initcode)),
-        &mut deployment,
-    );
-    if !result.stop.is_success() {
-        return Err(format!("contract deployment failed with {:?}", result.stop));
+    let result = transact(&mut evm, 0, TxKind::Create, Bytes::copy_from_slice(initcode))?;
+    if !result.status {
+        return Err(format!(
+            "contract deployment failed with {:?}: 0x{}",
+            result.stop,
+            hex::encode(result.output)
+        ));
     }
+    let contract = result
+        .created_address
+        .ok_or_else(|| "contract deployment did not return an address".to_owned())?;
 
-    let runtime = Bytecode::new_legacy(result.output);
+    let mut nonce = 1;
     if let Some(setup) = setup {
-        let result = execute_message(&mut evm, runtime.clone(), setup);
+        let result =
+            outcome(transact(&mut evm, nonce, TxKind::Call(contract), Bytes::from(setup))?);
+        nonce += 1;
         if !result.success {
             return Err(format!(
                 "`setUp()` failed with {}: 0x{}",
@@ -432,21 +426,35 @@ fn execute(
             ));
         }
     }
-    Ok(execute_message(&mut evm, runtime, input))
+    transact(&mut evm, nonce, TxKind::Call(contract), Bytes::from(input)).map(outcome)
 }
 
-fn execute_message(evm: &mut Evm<'_, BaseEvmTypes>, runtime: Bytecode, input: Vec<u8>) -> Outcome {
-    let mut call = Message {
-        destination: CONTRACT,
-        caller: CALLER,
-        input: Bytes::from(input),
-        code_address: CONTRACT,
-        gas_limit: GAS_LIMIT,
-        ..Message::default()
-    };
-    let result = Host::execute_message(evm, &TxEnv::default(), runtime, &mut call);
+fn transact(
+    evm: &mut Evm<'_, BaseEvmTypes>,
+    nonce: u64,
+    to: TxKind,
+    input: Bytes,
+) -> Result<TxResult, String> {
+    let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
+        TxLegacy {
+            nonce,
+            to,
+            input,
+            gas_price: 0,
+            value: U256::ZERO,
+            chain_id: None,
+            gas_limit: GAS_LIMIT,
+        },
+        CALLER,
+    ));
+    evm.transact(&tx)
+        .map(evm2::ExecutedTx::commit)
+        .map_err(|err| format!("transaction rejected: {err}"))
+}
+
+fn outcome(result: TxResult) -> Outcome {
     Outcome {
-        success: result.stop.is_success(),
+        success: result.status,
         output: result.output.into(),
         stop: format!("{:?}", result.stop),
     }

--- a/tools/tester/src/run_call.rs
+++ b/tools/tester/src/run_call.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId, TxResult,
     env::BlockEnv,
-    ethereum::{RecoveredTxEnvelope, ethereum_tx_registry},
+    ethereum::{TxEnvelope, ethereum_tx_registry},
     evm::{AccountInfo, InMemoryDB},
 };
 use serde_json::Value;
@@ -396,7 +396,7 @@ fn execute(
     database.insert_account_info(&CALLER, AccountInfo::default().with_balance(U256::MAX));
     let mut evm = Evm::<BaseEvmTypes>::new(
         spec_id,
-        BlockEnv::default(),
+        BlockEnv::<BaseEvmTypes>::default(),
         ethereum_tx_registry(spec_id),
         database,
         Precompiles::base(spec_id),
@@ -409,7 +409,9 @@ fn execute(
             hex::encode(result.output)
         ));
     }
-    let contract = CALLER.create(0);
+    let contract = result
+        .created_address
+        .ok_or_else(|| "contract deployment did not return an address".to_owned())?;
 
     let mut nonce = 1;
     if let Some(setup) = setup {
@@ -428,13 +430,13 @@ fn execute(
 }
 
 fn transact(
-    evm: &mut Evm<BaseEvmTypes>,
+    evm: &mut Evm<'_, BaseEvmTypes>,
     nonce: u64,
     to: TxKind,
     input: Bytes,
 ) -> Result<TxResult, String> {
-    let tx = RecoveredTxEnvelope::Legacy(Recovered::new_unchecked(
-        TxLegacy {
+    let tx = Recovered::new_unchecked(
+        TxEnvelope::Legacy(TxLegacy {
             nonce,
             to,
             input,
@@ -442,10 +444,12 @@ fn transact(
             value: U256::ZERO,
             chain_id: None,
             gas_limit: GAS_LIMIT,
-        },
+        }),
         CALLER,
-    ));
-    evm.transact(&tx).map_err(|err| format!("transaction rejected: {err}"))
+    );
+    evm.transact(&tx)
+        .map(evm2::ExecutedTx::commit)
+        .map_err(|err| format!("transaction rejected: {err}"))
 }
 
 fn outcome(result: TxResult) -> Outcome {

--- a/tools/tester/src/run_call.rs
+++ b/tools/tester/src/run_call.rs
@@ -1,0 +1,512 @@
+use alloy_dyn_abi::{FunctionExt, JsonAbiExt, Specifier};
+use alloy_json_abi::{Function, JsonAbi};
+use alloy_primitives::{Address, Bytes, U256, hex};
+use evm2::{
+    BaseEvmTypes, Evm, Precompiles, SpecId,
+    bytecode::Bytecode,
+    env::{BlockEnv, TxEnv},
+    evm::{AccountInfo, InMemoryDB},
+    interpreter::{Host, Message, MessageKind},
+    registry::TxRegistry,
+};
+use serde_json::Value;
+use std::path::Path;
+use ui_test::{
+    CommentParser, Errored, Revisioned,
+    build_manager::BuildManager,
+    custom_flags::Flag,
+    per_test_config::TestConfig,
+    spanned::{Span, Spanned},
+};
+
+const CONTRACT: Address = Address::repeat_byte(0x11);
+const CALLER: Address = Address::repeat_byte(0x22);
+const GAS_LIMIT: u64 = 30_000_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RunCall {
+    call: String,
+    expected: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RunCallFail {
+    call: String,
+    expected: String,
+}
+
+#[derive(Debug)]
+struct Artifact {
+    name: String,
+    abi: JsonAbi,
+    bytecode: Vec<u8>,
+}
+
+struct Outcome {
+    success: bool,
+    output: Vec<u8>,
+    stop: String,
+}
+
+struct ResolvedCall<'a> {
+    artifact: &'a Artifact,
+    function: Option<&'a Function>,
+    input: Vec<u8>,
+    expected: Vec<u8>,
+}
+
+pub(crate) fn is_directive(line: &str) -> bool {
+    let Some(mut directive) = line.trim_start().strip_prefix("//@") else {
+        return false;
+    };
+    directive = directive.trim_start();
+    if let Some(revision) = directive.strip_prefix('[')
+        && let Some((_, rest)) = revision.split_once(']')
+    {
+        directive = rest.trim_start();
+    }
+    directive.starts_with("run-call:") || directive.starts_with("run-call-fail:")
+}
+
+impl RunCall {
+    pub(crate) const NAME: &'static str = "run-call";
+    pub(crate) const DEFAULT: Option<Self> = None;
+
+    pub(crate) fn parse(
+        parser: &mut CommentParser<&mut Revisioned>,
+        args: Spanned<&str>,
+        span: Span,
+    ) {
+        match parse_call(*args) {
+            Ok((call, expected)) => parser.add_custom_spanned(
+                Self::NAME,
+                Self { call: call.to_owned(), expected: expected.to_owned() },
+                span,
+            ),
+            Err(err) => parser.error(args.span(), err),
+        }
+    }
+
+    fn run(&self, output: &[u8], test_path: &Path, spec_id: SpecId) -> Result<(), String> {
+        let artifacts = parse_artifacts(output)?;
+        let call = resolve_call(&artifacts, test_path, &self.call, &self.expected, false)?;
+        let setup = setup_call(call.artifact, call.function)?;
+        let actual = execute(&call.artifact.bytecode, setup, call.input, spec_id)?;
+        if !actual.success {
+            return Err(format!(
+                "`{}` failed with {}: 0x{}",
+                display_call(&self.call, call.function),
+                actual.stop,
+                hex::encode(actual.output)
+            ));
+        }
+        if actual.output != call.expected {
+            return Err(format!(
+                "`{}` returned 0x{}, expected 0x{}",
+                display_call(&self.call, call.function),
+                hex::encode(actual.output),
+                hex::encode(call.expected)
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl RunCallFail {
+    pub(crate) const NAME: &'static str = "run-call-fail";
+    pub(crate) const DEFAULT: Option<Self> = None;
+
+    pub(crate) fn parse(
+        parser: &mut CommentParser<&mut Revisioned>,
+        args: Spanned<&str>,
+        span: Span,
+    ) {
+        match parse_call(*args) {
+            Ok((call, expected)) => parser.add_custom_spanned(
+                Self::NAME,
+                Self { call: call.to_owned(), expected: expected.to_owned() },
+                span,
+            ),
+            Err(err) => parser.error(args.span(), err),
+        }
+    }
+
+    fn run(&self, output: &[u8], test_path: &Path, spec_id: SpecId) -> Result<(), String> {
+        let artifacts = parse_artifacts(output)?;
+        let call = resolve_call(&artifacts, test_path, &self.call, &self.expected, true)?;
+        let setup = setup_call(call.artifact, call.function)?;
+        let actual = execute(&call.artifact.bytecode, setup, call.input, spec_id)?;
+        if actual.success {
+            return Err(format!(
+                "`{}` succeeded with 0x{}, expected failure",
+                display_call(&self.call, call.function),
+                hex::encode(actual.output)
+            ));
+        }
+        if actual.output != call.expected {
+            return Err(format!(
+                "`{}` reverted with 0x{}, expected 0x{}",
+                display_call(&self.call, call.function),
+                hex::encode(actual.output),
+                hex::encode(call.expected)
+            ));
+        }
+        Ok(())
+    }
+}
+
+macro_rules! impl_flag {
+    ($ty:ty) => {
+        impl Flag for $ty {
+            fn clone_inner(&self) -> Box<dyn Flag> {
+                Box::new(self.clone())
+            }
+
+            fn post_test_action(
+                &self,
+                config: &TestConfig,
+                output: &std::process::Output,
+                _build_manager: &BuildManager,
+            ) -> Result<(), Errored> {
+                let spec_id = spec_id(config).map_err(|message| flag_error(Self::NAME, message))?;
+                self.run(&output.stdout, config.status.path(), spec_id)
+                    .map_err(|message| flag_error(Self::NAME, message))
+            }
+
+            fn must_be_unique(&self) -> bool {
+                false
+            }
+        }
+    };
+}
+
+impl_flag!(RunCall);
+impl_flag!(RunCallFail);
+
+fn parse_call(args: &str) -> Result<(&str, &str), &'static str> {
+    let (call, expected) = args.split_once("=>").unwrap_or((args, ""));
+    let call = call.trim();
+    if call.is_empty() {
+        return Err("call directive requires calldata or a function name");
+    }
+    Ok((call, expected.trim()))
+}
+
+fn resolve_call<'a>(
+    artifacts: &'a [Artifact],
+    test_path: &Path,
+    call: &str,
+    expected: &str,
+    failure: bool,
+) -> Result<ResolvedCall<'a>, String> {
+    if call.starts_with("0x") {
+        let artifact = only_artifact(artifacts, test_path)?;
+        let input = decode_hex(call, "calldata")?;
+        let expected = decode_hex(expected, "expected result")?;
+        return Ok(ResolvedCall { artifact, function: None, input, expected });
+    }
+
+    let (function_name, args) = call.split_once(char::is_whitespace).unwrap_or((call, ""));
+    let (artifact, function) = find_function(artifacts, function_name)?;
+    let input = encode_values(function, args, false)?;
+    let expected = if failure {
+        decode_hex(expected, "expected revert data")?
+    } else {
+        encode_values(function, expected, true)?
+    };
+    Ok(ResolvedCall { artifact, function: Some(function), input, expected })
+}
+
+fn flag_error(command: &str, message: String) -> Errored {
+    Errored {
+        command: command.into(),
+        errors: vec![ui_test::Error::ConfigError(message)],
+        stderr: vec![],
+        stdout: vec![],
+    }
+}
+
+fn display_call(call: &str, function: Option<&Function>) -> String {
+    function.map_or_else(|| call.to_owned(), Function::signature)
+}
+
+fn parse_artifacts(output: &[u8]) -> Result<Vec<Artifact>, String> {
+    let output: Value = serde_json::from_slice(output)
+        .map_err(|err| format!("failed to parse compiler output: {err}"))?;
+    let contracts = output
+        .get("contracts")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "compiler output does not contain contracts".to_owned())?;
+    contracts
+        .iter()
+        .filter_map(|(name, value)| {
+            let bytecode = value.get("bin")?.as_str()?;
+            Some((name, value, bytecode))
+        })
+        .map(|(name, value, bytecode)| {
+            let abi = serde_json::from_value(value.get("abi").cloned().unwrap_or_default())
+                .map_err(|err| format!("failed to parse ABI for `{name}`: {err}"))?;
+            let bytecode = hex::decode(bytecode)
+                .map_err(|err| format!("invalid bytecode for `{name}`: {err}"))?;
+            Ok(Artifact { name: name.clone(), abi, bytecode })
+        })
+        .collect()
+}
+
+fn only_artifact<'a>(artifacts: &'a [Artifact], test_path: &Path) -> Result<&'a Artifact, String> {
+    let primary = artifacts
+        .iter()
+        .filter(|artifact| {
+            artifact.name.rsplit_once(':').is_some_and(|(source, _)| Path::new(source) == test_path)
+        })
+        .collect::<Vec<_>>();
+    let candidates =
+        if primary.is_empty() { artifacts.iter().collect::<Vec<_>>() } else { primary };
+    match candidates.as_slice() {
+        [artifact] => Ok(artifact),
+        [] => Err("compiler output does not contain deployable contracts".to_owned()),
+        _ => {
+            Err("raw calldata is ambiguous because the source contains multiple contracts"
+                .to_owned())
+        }
+    }
+}
+
+fn find_function<'a>(
+    artifacts: &'a [Artifact],
+    name: &str,
+) -> Result<(&'a Artifact, &'a Function), String> {
+    let (contract_name, function_name) = name
+        .split_once("::")
+        .map_or((None, name), |(contract, function)| (Some(contract), function));
+    let mut matches = artifacts.iter().flat_map(|artifact| {
+        let contract_matches =
+            contract_name.is_none_or(|name| artifact.name.ends_with(&format!(":{name}")));
+        artifact
+            .abi
+            .functions()
+            .filter(move |function| {
+                contract_matches
+                    && (function.signature() == function_name
+                        || (!function_name.contains('(') && function.name == function_name))
+            })
+            .map(move |function| (artifact, function))
+    });
+    let Some(found) = matches.next() else {
+        return Err(format!("function `{name}` was not found in compiler output"));
+    };
+    if matches.next().is_some() {
+        return Err(format!(
+            "function `{name}` is ambiguous; use its full signature or qualify it as \
+             `Contract::{function_name}`"
+        ));
+    }
+    Ok(found)
+}
+
+fn encode_values(function: &Function, values: &str, output: bool) -> Result<Vec<u8>, String> {
+    let params = if output { &function.outputs } else { &function.inputs };
+    let values = split_values(values, params.len())?;
+    let values = params
+        .iter()
+        .zip(values)
+        .map(|(param, value)| {
+            param
+                .resolve()
+                .and_then(|ty| ty.coerce_str(value))
+                .map_err(|err| format!("invalid value `{value}` for `{}`: {err}", param.ty))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if output { function.abi_encode_output(&values) } else { function.abi_encode_input(&values) }
+        .map_err(|err| format!("failed to encode values for `{}`: {err}", function.signature()))
+}
+
+fn split_values(values: &str, expected: usize) -> Result<Vec<&str>, String> {
+    let values = values.trim();
+    if expected == 0 {
+        return if values.is_empty() || values == "0x" {
+            Ok(Vec::new())
+        } else {
+            Err(format!("expected no values, found `{values}`"))
+        };
+    }
+
+    let mut result = Vec::with_capacity(expected);
+    let mut start = 0;
+    let mut depth = 0_u32;
+    let mut quote = None;
+    for (offset, ch) in values.char_indices() {
+        if let Some(active) = quote {
+            if ch == active && !is_escaped(values, offset) {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '[' | '(' => depth += 1,
+            ']' | ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                result.push(values[start..offset].trim());
+                start = offset + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    result.push(values[start..].trim());
+    if result.len() != expected || result.iter().any(|value| value.is_empty()) {
+        return Err(format!(
+            "expected {expected} comma-separated values, found {}",
+            result.iter().filter(|value| !value.is_empty()).count()
+        ));
+    }
+    Ok(result)
+}
+
+fn is_escaped(value: &str, offset: usize) -> bool {
+    value[..offset].bytes().rev().take_while(|byte| *byte == b'\\').count() % 2 == 1
+}
+
+fn decode_hex(value: &str, description: &str) -> Result<Vec<u8>, String> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    if value.is_empty() {
+        Ok(Vec::new())
+    } else {
+        hex::decode(value).map_err(|err| format!("invalid {description}: {err}"))
+    }
+}
+
+fn setup_call(artifact: &Artifact, function: Option<&Function>) -> Result<Option<Vec<u8>>, String> {
+    function
+        .filter(|function| function.name.starts_with("test"))
+        .and_then(|_| artifact.abi.functions().find(|function| function.signature() == "setUp()"))
+        .map(|function| {
+            function
+                .abi_encode_input(&[])
+                .map_err(|err| format!("failed to encode `setUp()`: {err}"))
+        })
+        .transpose()
+}
+
+fn execute(
+    initcode: &[u8],
+    setup: Option<Vec<u8>>,
+    input: Vec<u8>,
+    spec_id: SpecId,
+) -> Result<Outcome, String> {
+    let mut database = InMemoryDB::default();
+    database.insert_account_info(&CALLER, AccountInfo::default().with_balance(U256::MAX));
+    let mut evm = Evm::<BaseEvmTypes>::new(
+        spec_id,
+        BlockEnv::default(),
+        TxRegistry::new(),
+        database,
+        Precompiles::base(spec_id),
+    );
+    let mut deployment = Message {
+        kind: MessageKind::Create,
+        destination: CONTRACT,
+        caller: CALLER,
+        code_address: CONTRACT,
+        gas_limit: GAS_LIMIT,
+        ..Message::default()
+    };
+    let result = Host::execute_message(
+        &mut evm,
+        &TxEnv::default(),
+        Bytecode::new_legacy(Bytes::copy_from_slice(initcode)),
+        &mut deployment,
+    );
+    if !result.stop.is_success() {
+        return Err(format!("contract deployment failed with {:?}", result.stop));
+    }
+
+    let runtime = Bytecode::new_legacy(result.output);
+    if let Some(setup) = setup {
+        let result = execute_message(&mut evm, runtime.clone(), setup);
+        if !result.success {
+            return Err(format!(
+                "`setUp()` failed with {}: 0x{}",
+                result.stop,
+                hex::encode(result.output)
+            ));
+        }
+    }
+    Ok(execute_message(&mut evm, runtime, input))
+}
+
+fn execute_message(evm: &mut Evm<'_, BaseEvmTypes>, runtime: Bytecode, input: Vec<u8>) -> Outcome {
+    let mut call = Message {
+        destination: CONTRACT,
+        caller: CALLER,
+        input: Bytes::from(input),
+        code_address: CONTRACT,
+        gas_limit: GAS_LIMIT,
+        ..Message::default()
+    };
+    let result = Host::execute_message(evm, &TxEnv::default(), runtime, &mut call);
+    Outcome {
+        success: result.stop.is_success(),
+        output: result.output.into(),
+        stop: format!("{:?}", result.stop),
+    }
+}
+
+fn spec_id(config: &TestConfig) -> Result<SpecId, String> {
+    let flags = config.comments().flat_map(|comments| &comments.compile_flags);
+    let mut version = None;
+    let mut expects_value = false;
+    for flag in flags {
+        if expects_value {
+            version = Some(flag.as_str());
+            expects_value = false;
+        } else if flag == "--evm-version" {
+            expects_value = true;
+        } else if let Some(value) = flag.strip_prefix("--evm-version=") {
+            version = Some(value);
+        }
+    }
+    if expects_value {
+        return Err("`--evm-version` requires a value".to_owned());
+    }
+    match version.unwrap_or("osaka") {
+        "homestead" => Ok(SpecId::HOMESTEAD),
+        "tangerineWhistle" => Ok(SpecId::TANGERINE),
+        "spuriousDragon" => Ok(SpecId::SPURIOUS_DRAGON),
+        "byzantium" => Ok(SpecId::BYZANTIUM),
+        "constantinople" | "petersburg" => Ok(SpecId::PETERSBURG),
+        "istanbul" => Ok(SpecId::ISTANBUL),
+        "berlin" => Ok(SpecId::BERLIN),
+        "london" => Ok(SpecId::LONDON),
+        "paris" => Ok(SpecId::MERGE),
+        "shanghai" => Ok(SpecId::SHANGHAI),
+        "cancun" => Ok(SpecId::CANCUN),
+        "prague" => Ok(SpecId::PRAGUE),
+        "osaka" => Ok(SpecId::OSAKA),
+        "amsterdam" => Ok(SpecId::AMSTERDAM),
+        version => Err(format!("unsupported EVM version `{version}`")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_empty_expected_output() {
+        assert_eq!(parse_call("f()"), Ok(("f()", "")));
+        assert_eq!(parse_call("f() =>"), Ok(("f()", "")));
+    }
+
+    #[test]
+    fn rejects_empty_call() {
+        assert_eq!(parse_call(""), Err("call directive requires calldata or a function name"));
+        assert_eq!(parse_call(" => 1"), Err("call directive requires calldata or a function name"));
+    }
+
+    #[test]
+    fn splits_only_top_level_commas() {
+        assert_eq!(split_values("[1, 2], (true, false)", 2), Ok(vec!["[1, 2]", "(true, false)"]));
+        assert!(split_values("1 true", 2).is_err());
+    }
+}

--- a/tools/tester/src/run_call.rs
+++ b/tools/tester/src/run_call.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::{TxLegacy, transaction::Recovered};
-use alloy_dyn_abi::{FunctionExt, JsonAbiExt, Specifier};
-use alloy_json_abi::{Function, JsonAbi};
+use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt, Specifier};
+use alloy_json_abi::{Function, JsonAbi, Param};
 use alloy_primitives::{Address, Bytes, TxKind, U256, hex};
 use evm2::{
     BaseEvmTypes, Evm, Precompiles, SpecId, TxResult,
@@ -19,18 +19,27 @@ use ui_test::{
 };
 
 const CALLER: Address = Address::repeat_byte(0x22);
-const GAS_LIMIT: u64 = 10_000_000;
+const DEFAULT_GAS_LIMIT: u64 = 10_000_000;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RunCall {
     call: String,
     expected: String,
+    settings: CallSettings,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct RunCallFail {
     call: String,
     expected: String,
+    settings: CallSettings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct CallSettings {
+    constructor: Option<String>,
+    gas: Option<u64>,
+    value: Option<U256>,
 }
 
 #[derive(Debug)]
@@ -49,8 +58,18 @@ struct Outcome {
 struct ResolvedCall<'a> {
     artifact: &'a Artifact,
     function: Option<&'a Function>,
+    constructor_args: Vec<u8>,
     input: Vec<u8>,
     expected: Vec<u8>,
+    gas_limit: u64,
+    value: U256,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ParsedCall<'a> {
+    call: &'a str,
+    expected: &'a str,
+    settings: CallSettings,
 }
 
 pub(crate) fn is_directive(line: &str) -> bool {
@@ -76,9 +95,13 @@ impl RunCall {
         span: Span,
     ) {
         match parse_call(*args) {
-            Ok((call, expected)) => parser.add_custom_spanned(
+            Ok(parsed) => parser.add_custom_spanned(
                 Self::NAME,
-                Self { call: call.to_owned(), expected: expected.to_owned() },
+                Self {
+                    call: parsed.call.to_owned(),
+                    expected: parsed.expected.to_owned(),
+                    settings: parsed.settings,
+                },
                 span,
             ),
             Err(err) => parser.error(args.span(), err),
@@ -87,9 +110,18 @@ impl RunCall {
 
     fn run(&self, output: &[u8], test_path: &Path, spec_id: SpecId) -> Result<(), String> {
         let artifacts = parse_artifacts(output)?;
-        let call = resolve_call(&artifacts, test_path, &self.call, &self.expected, false)?;
+        let call =
+            resolve_call(&artifacts, test_path, &self.call, &self.expected, &self.settings, false)?;
         let setup = setup_call(call.artifact, call.function)?;
-        let actual = execute(&call.artifact.bytecode, setup, call.input, spec_id)?;
+        let actual = execute(
+            &call.artifact.bytecode,
+            &call.constructor_args,
+            setup,
+            call.input,
+            call.gas_limit,
+            call.value,
+            spec_id,
+        )?;
         if !actual.success {
             return Err(format!(
                 "`{}` failed with {}: 0x{}",
@@ -120,9 +152,13 @@ impl RunCallFail {
         span: Span,
     ) {
         match parse_call(*args) {
-            Ok((call, expected)) => parser.add_custom_spanned(
+            Ok(parsed) => parser.add_custom_spanned(
                 Self::NAME,
-                Self { call: call.to_owned(), expected: expected.to_owned() },
+                Self {
+                    call: parsed.call.to_owned(),
+                    expected: parsed.expected.to_owned(),
+                    settings: parsed.settings,
+                },
                 span,
             ),
             Err(err) => parser.error(args.span(), err),
@@ -131,9 +167,18 @@ impl RunCallFail {
 
     fn run(&self, output: &[u8], test_path: &Path, spec_id: SpecId) -> Result<(), String> {
         let artifacts = parse_artifacts(output)?;
-        let call = resolve_call(&artifacts, test_path, &self.call, &self.expected, true)?;
+        let call =
+            resolve_call(&artifacts, test_path, &self.call, &self.expected, &self.settings, true)?;
         let setup = setup_call(call.artifact, call.function)?;
-        let actual = execute(&call.artifact.bytecode, setup, call.input, spec_id)?;
+        let actual = execute(
+            &call.artifact.bytecode,
+            &call.constructor_args,
+            setup,
+            call.input,
+            call.gas_limit,
+            call.value,
+            spec_id,
+        )?;
         if actual.success {
             return Err(format!(
                 "`{}` succeeded with 0x{}, expected failure",
@@ -181,13 +226,88 @@ macro_rules! impl_flag {
 impl_flag!(RunCall);
 impl_flag!(RunCallFail);
 
-fn parse_call(args: &str) -> Result<(&str, &str), &'static str> {
-    let (call, expected) = args.split_once("=>").unwrap_or((args, ""));
+fn parse_call(args: &str) -> Result<ParsedCall<'_>, String> {
+    let (call_and_settings, expected) = split_expected(args).unwrap_or((args, ""));
+    let (call, settings) =
+        split_top_level_once(call_and_settings, ';').unwrap_or((call_and_settings, ""));
     let call = call.trim();
     if call.is_empty() {
-        return Err("call directive requires calldata or a function name");
+        return Err("call directive requires calldata or a function name".to_owned());
     }
-    Ok((call, expected.trim()))
+    Ok(ParsedCall { call, expected: expected.trim(), settings: parse_settings(settings)? })
+}
+
+fn split_expected(value: &str) -> Option<(&str, &str)> {
+    let mut depth = 0_u32;
+    let mut quote = None;
+    for (offset, ch) in value.char_indices() {
+        if let Some(active) = quote {
+            if ch == active && !is_escaped(value, offset) {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '[' | '(' => depth += 1,
+            ']' | ')' => depth = depth.saturating_sub(1),
+            '=' if depth == 0 && value[offset..].starts_with("=>") => {
+                return Some((&value[..offset], &value[offset + 2..]));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn parse_settings(settings: &str) -> Result<CallSettings, String> {
+    let settings = settings.trim();
+    if settings.is_empty() {
+        return Ok(CallSettings::default());
+    }
+
+    let mut parsed = CallSettings::default();
+    for setting in split_top_level(settings, ',') {
+        let setting = setting.trim();
+        let (key, value) = setting
+            .split_once('=')
+            .map(|(key, value)| (key.trim(), value.trim()))
+            .ok_or_else(|| format!("setting `{setting}` requires a value"))?;
+        if key.is_empty() || value.is_empty() {
+            return Err(format!("setting `{setting}` requires a value"));
+        }
+        match key {
+            "constructor" => {
+                if parsed.constructor.replace(value.to_owned()).is_some() {
+                    return Err("duplicate `constructor` setting".to_owned());
+                }
+            }
+            "gas" => {
+                if parsed.gas.is_some() {
+                    return Err("duplicate `gas` setting".to_owned());
+                }
+                let gas = parse_integer(value, "gas")?;
+                parsed.gas = Some(
+                    gas.try_into()
+                        .map_err(|_| format!("`gas` value `{value}` does not fit in a u64"))?,
+                );
+            }
+            "value" => {
+                if parsed.value.is_some() {
+                    return Err("duplicate `value` setting".to_owned());
+                }
+                parsed.value = Some(parse_integer(value, "value")?);
+            }
+            _ => return Err(format!("unknown run-call setting `{key}`")),
+        }
+    }
+    Ok(parsed)
+}
+
+fn parse_integer(value: &str, setting: &str) -> Result<U256, String> {
+    let (digits, radix) = value.strip_prefix("0x").map_or((value, 10), |digits| (digits, 16));
+    U256::from_str_radix(digits, radix)
+        .map_err(|err| format!("invalid `{setting}` value `{value}`: {err}"))
 }
 
 fn resolve_call<'a>(
@@ -195,24 +315,43 @@ fn resolve_call<'a>(
     test_path: &Path,
     call: &str,
     expected: &str,
+    settings: &CallSettings,
     failure: bool,
 ) -> Result<ResolvedCall<'a>, String> {
     if call.starts_with("0x") {
         let artifact = only_artifact(artifacts, test_path)?;
+        let constructor_args = encode_constructor(artifact, settings.constructor.as_deref())?;
         let input = decode_hex(call, "calldata")?;
         let expected = decode_hex(expected, "expected result")?;
-        return Ok(ResolvedCall { artifact, function: None, input, expected });
+        return Ok(ResolvedCall {
+            artifact,
+            function: None,
+            constructor_args,
+            input,
+            expected,
+            gas_limit: settings.gas.unwrap_or(DEFAULT_GAS_LIMIT),
+            value: settings.value.unwrap_or_default(),
+        });
     }
 
     let (function_name, args) = call.split_once(char::is_whitespace).unwrap_or((call, ""));
     let (artifact, function) = find_function(artifacts, function_name)?;
+    let constructor_args = encode_constructor(artifact, settings.constructor.as_deref())?;
     let input = encode_values(function, args, false)?;
     let expected = if failure {
         decode_hex(expected, "expected revert data")?
     } else {
         encode_values(function, expected, true)?
     };
-    Ok(ResolvedCall { artifact, function: Some(function), input, expected })
+    Ok(ResolvedCall {
+        artifact,
+        function: Some(function),
+        constructor_args,
+        input,
+        expected,
+        gas_limit: settings.gas.unwrap_or(DEFAULT_GAS_LIMIT),
+        value: settings.value.unwrap_or_default(),
+    })
 }
 
 fn flag_error(command: &str, message: String) -> Errored {
@@ -304,8 +443,43 @@ fn find_function<'a>(
 
 fn encode_values(function: &Function, values: &str, output: bool) -> Result<Vec<u8>, String> {
     let params = if output { &function.outputs } else { &function.inputs };
+    let values = coerce_values(params, values)?;
+    if output { function.abi_encode_output(&values) } else { function.abi_encode_input(&values) }
+        .map_err(|err| format!("failed to encode values for `{}`: {err}", function.signature()))
+}
+
+fn encode_constructor(artifact: &Artifact, values: Option<&str>) -> Result<Vec<u8>, String> {
+    let Some(values) = values else {
+        if let Some(constructor) = &artifact.abi.constructor
+            && !constructor.inputs.is_empty()
+        {
+            return Err(format!(
+                "constructor for `{}` expects {} arguments; add `constructor=[...]`",
+                artifact.name,
+                constructor.inputs.len()
+            ));
+        }
+        return Ok(Vec::new());
+    };
+    let Some(values) = values.strip_prefix('[').and_then(|values| values.strip_suffix(']')) else {
+        return Err("`constructor` must be a bracketed argument list".to_owned());
+    };
+    let Some(constructor) = &artifact.abi.constructor else {
+        return if values.trim().is_empty() {
+            Ok(Vec::new())
+        } else {
+            Err(format!("contract `{}` has no constructor arguments", artifact.name))
+        };
+    };
+    let values = coerce_values(&constructor.inputs, values)?;
+    constructor
+        .abi_encode_input(&values)
+        .map_err(|err| format!("failed to encode constructor arguments: {err}"))
+}
+
+fn coerce_values(params: &[Param], values: &str) -> Result<Vec<DynSolValue>, String> {
     let values = split_values(values, params.len())?;
-    let values = params
+    params
         .iter()
         .zip(values)
         .map(|(param, value)| {
@@ -314,9 +488,7 @@ fn encode_values(function: &Function, values: &str, output: bool) -> Result<Vec<
                 .and_then(|ty| ty.coerce_str(value))
                 .map_err(|err| format!("invalid value `{value}` for `{}`: {err}", param.ty))
         })
-        .collect::<Result<Vec<_>, _>>()?;
-    if output { function.abi_encode_output(&values) } else { function.abi_encode_input(&values) }
-        .map_err(|err| format!("failed to encode values for `{}`: {err}", function.signature()))
+        .collect()
 }
 
 fn split_values(values: &str, expected: usize) -> Result<Vec<&str>, String> {
@@ -329,13 +501,24 @@ fn split_values(values: &str, expected: usize) -> Result<Vec<&str>, String> {
         };
     }
 
-    let mut result = Vec::with_capacity(expected);
+    let result = split_top_level(values, ',');
+    if result.len() != expected || result.iter().any(|value| value.is_empty()) {
+        return Err(format!(
+            "expected {expected} comma-separated values, found {}",
+            result.iter().filter(|value| !value.is_empty()).count()
+        ));
+    }
+    Ok(result)
+}
+
+fn split_top_level(value: &str, separator: char) -> Vec<&str> {
+    let mut result = Vec::new();
     let mut start = 0;
     let mut depth = 0_u32;
     let mut quote = None;
-    for (offset, ch) in values.char_indices() {
+    for (offset, ch) in value.char_indices() {
         if let Some(active) = quote {
-            if ch == active && !is_escaped(values, offset) {
+            if ch == active && !is_escaped(value, offset) {
                 quote = None;
             }
             continue;
@@ -344,21 +527,38 @@ fn split_values(values: &str, expected: usize) -> Result<Vec<&str>, String> {
             '\'' | '"' => quote = Some(ch),
             '[' | '(' => depth += 1,
             ']' | ')' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                result.push(values[start..offset].trim());
+            ch if ch == separator && depth == 0 => {
+                result.push(value[start..offset].trim());
                 start = offset + ch.len_utf8();
             }
             _ => {}
         }
     }
-    result.push(values[start..].trim());
-    if result.len() != expected || result.iter().any(|value| value.is_empty()) {
-        return Err(format!(
-            "expected {expected} comma-separated values, found {}",
-            result.iter().filter(|value| !value.is_empty()).count()
-        ));
+    result.push(value[start..].trim());
+    result
+}
+
+fn split_top_level_once(value: &str, separator: char) -> Option<(&str, &str)> {
+    let mut depth = 0_u32;
+    let mut quote = None;
+    for (offset, ch) in value.char_indices() {
+        if let Some(active) = quote {
+            if ch == active && !is_escaped(value, offset) {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '[' | '(' => depth += 1,
+            ']' | ')' => depth = depth.saturating_sub(1),
+            ch if ch == separator && depth == 0 => {
+                return Some((&value[..offset], &value[offset + ch.len_utf8()..]));
+            }
+            _ => {}
+        }
     }
-    Ok(result)
+    None
 }
 
 fn is_escaped(value: &str, offset: usize) -> bool {
@@ -388,8 +588,11 @@ fn setup_call(artifact: &Artifact, function: Option<&Function>) -> Result<Option
 
 fn execute(
     initcode: &[u8],
+    constructor_args: &[u8],
     setup: Option<Vec<u8>>,
     input: Vec<u8>,
+    gas_limit: u64,
+    value: U256,
     spec_id: SpecId,
 ) -> Result<Outcome, String> {
     let mut database = InMemoryDB::default();
@@ -401,7 +604,8 @@ fn execute(
         database,
         Precompiles::base(spec_id),
     );
-    let result = transact(&mut evm, 0, TxKind::Create, Bytes::copy_from_slice(initcode))?;
+    let initcode = Bytes::from_iter(initcode.iter().chain(constructor_args).copied());
+    let result = transact(&mut evm, 0, TxKind::Create, initcode, DEFAULT_GAS_LIMIT, U256::ZERO)?;
     if !result.status {
         return Err(format!(
             "contract deployment failed with {:?}: 0x{}",
@@ -415,8 +619,14 @@ fn execute(
 
     let mut nonce = 1;
     if let Some(setup) = setup {
-        let result =
-            outcome(transact(&mut evm, nonce, TxKind::Call(contract), Bytes::from(setup))?);
+        let result = outcome(transact(
+            &mut evm,
+            nonce,
+            TxKind::Call(contract),
+            Bytes::from(setup),
+            DEFAULT_GAS_LIMIT,
+            U256::ZERO,
+        )?);
         nonce += 1;
         if !result.success {
             return Err(format!(
@@ -426,7 +636,8 @@ fn execute(
             ));
         }
     }
-    transact(&mut evm, nonce, TxKind::Call(contract), Bytes::from(input)).map(outcome)
+    transact(&mut evm, nonce, TxKind::Call(contract), Bytes::from(input), gas_limit, value)
+        .map(outcome)
 }
 
 fn transact(
@@ -434,6 +645,8 @@ fn transact(
     nonce: u64,
     to: TxKind,
     input: Bytes,
+    gas_limit: u64,
+    value: U256,
 ) -> Result<TxResult, String> {
     let tx = Recovered::new_unchecked(
         TxEnvelope::Legacy(TxLegacy {
@@ -441,9 +654,9 @@ fn transact(
             to,
             input,
             gas_price: 0,
-            value: U256::ZERO,
+            value,
             chain_id: None,
-            gas_limit: GAS_LIMIT,
+            gas_limit,
         }),
         CALLER,
     );
@@ -502,19 +715,52 @@ mod tests {
 
     #[test]
     fn parses_empty_expected_output() {
-        assert_eq!(parse_call("f()"), Ok(("f()", "")));
-        assert_eq!(parse_call("f() =>"), Ok(("f()", "")));
+        assert_eq!(
+            parse_call("f()"),
+            Ok(ParsedCall { call: "f()", expected: "", settings: CallSettings::default() })
+        );
+        assert_eq!(
+            parse_call("f() =>"),
+            Ok(ParsedCall { call: "f()", expected: "", settings: CallSettings::default() })
+        );
     }
 
     #[test]
     fn rejects_empty_call() {
-        assert_eq!(parse_call(""), Err("call directive requires calldata or a function name"));
-        assert_eq!(parse_call(" => 1"), Err("call directive requires calldata or a function name"));
+        let error = "call directive requires calldata or a function name".to_owned();
+        assert_eq!(parse_call(""), Err(error.clone()));
+        assert_eq!(parse_call(" => 1"), Err(error));
     }
 
     #[test]
     fn splits_only_top_level_commas() {
         assert_eq!(split_values("[1, 2], (true, false)", 2), Ok(vec!["[1, 2]", "(true, false)"]));
         assert!(split_values("1 true", 2).is_err());
+    }
+
+    #[test]
+    fn parses_call_settings() {
+        assert_eq!(
+            parse_call("f 1; constructor=[\"=>\", [3, 4]], gas=0x100, value=5 => 6"),
+            Ok(ParsedCall {
+                call: "f 1",
+                expected: "6",
+                settings: CallSettings {
+                    constructor: Some("[\"=>\", [3, 4]]".to_owned()),
+                    gas: Some(256),
+                    value: Some(U256::from(5)),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_call_settings() {
+        assert_eq!(
+            parse_call("f; unknown=1"),
+            Err("unknown run-call setting `unknown`".to_owned())
+        );
+        assert_eq!(parse_call("f; gas=1, gas=2"), Err("duplicate `gas` setting".to_owned()));
+        assert_eq!(parse_call("f; value"), Err("setting `value` requires a value".to_owned()));
     }
 }

--- a/tools/tester/src/run_call.rs
+++ b/tools/tester/src/run_call.rs
@@ -409,9 +409,7 @@ fn execute(
             hex::encode(result.output)
         ));
     }
-    let contract = result
-        .created_address
-        .ok_or_else(|| "contract deployment did not return an address".to_owned())?;
+    let contract = CALLER.create(0);
 
     let mut nonce = 1;
     if let Some(setup) = setup {
@@ -430,7 +428,7 @@ fn execute(
 }
 
 fn transact(
-    evm: &mut Evm<'_, BaseEvmTypes>,
+    evm: &mut Evm<BaseEvmTypes>,
     nonce: u64,
     to: TxKind,
     input: Bytes,
@@ -447,9 +445,7 @@ fn transact(
         },
         CALLER,
     ));
-    evm.transact(&tx)
-        .map(evm2::ExecutedTx::commit)
-        .map_err(|err| format!("transaction rejected: {err}"))
+    evm.transact(&tx).map_err(|err| format!("transaction rejected: {err}"))
 }
 
 fn outcome(result: TxResult) -> Outcome {


### PR DESCRIPTION
Adds `run-call` and `run-call-fail` UI directives for small runtime checks. Each annotation emits ABI and creation bytecode, deploys a fresh contract, and executes real legacy transactions through evm2 at the test's selected EVM version. The syntax is intentionally independent of Solidity and solc's semantic-test grammar. Per-call settings follow the arguments after a semicolon; `constructor=[...]` supplies deployment arguments, while `gas` and `value` configure the tested transaction. evm2 is pinned to upstream `f85cf265`, and the workspace MSRV is 1.96 to match it.

| Capability | `run-call` UI directives | solc semantic test runner |
| --- | --- | --- |
| Test syntax | `//@ run-call:` and `//@ run-call-fail:` directives | Calls and expectations after `// ----`, with settings under `// ====` |
| Function selection | Unambiguous name, full signature, or `Contract::function`; overloads require disambiguation | Full function signature, plus low-level calls |
| Arguments | Comma-separated ABI-coerced values, including nested arrays and tuples | Semantic-test values encoded from the declared parameter types |
| Per-call settings | Comma-separated `key=value` settings after `;` | Value is part of the call syntax; other configuration is file-wide |
| Raw mode | Whole calldata and expected output as hex | Low-level calldata and expected bytes |
| Successful output | ABI-coerced return values or exact bytes; omitted `=>` asserts empty output | Expected values or bytes after the call |
| Reverts | `run-call-fail`, with exact optional revert bytes | `FAILURE`, with optional expected revert bytes |
| Deployment | Fresh deployment for every directive | One deployment per compiler configuration, shared by its ordered calls |
| State between annotations | None | Preserved across calls |
| Execution entry point | `Evm::transact` with legacy transaction envelopes | Top-level calls through the semantic test VM |
| Setup | Runs `setUp()` before functions whose names start with `test` | Constructor call can initialize the deployed contract |
| Constructor arguments | `constructor=[...]` per directive | Supported by the first constructor annotation |
| Constructor value | Fixed at zero | Supported by the first constructor annotation |
| Call value | `value=<wei>` per directive | Per-call value with `wei` or `ether` units |
| Call gas limit | `gas=<u64>` per directive | Uses the framework's fixed transaction gas budget |
| Contract and library selection | Contract-qualified functions; raw calls require one unambiguous artifact | Deploys requested libraries and the selected contract |
| EVM version | Uses `--evm-version`, including revision-specific flags | Uses the semantic test's EVM-version settings |
| Events, storage, and balances | Not asserted by this syntax | Dedicated event and state/balance expectations |
| Gas-cost expectations | Not supported | Per-pipeline gas expectations |
| Compiler configurations | Standard UI revisions | Can run the same calls through legacy, IR, and optimizer configurations |
| Expectation regeneration | Reports the mismatched call | Can print updated semantic-test expectations |

The narrower state model is deliberate: use these directives for isolated entry-point checks inside ordinary UI fixtures. Stateful flows, multiple actors, and other multi-transaction scenarios belong in the Foundry tests under `tests/foundry/`.
