### PR TITLE
perf(codegen): keep join phis on stack

### DIFF
--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -92,7 +92,7 @@ struct StackArgRetentionPlan {
 struct StackPhiPlan {
     entries: FxHashMap<BlockId, Vec<ValueId>>,
     edges: FxHashMap<BlockId, StackPhiEdge>,
-    edge_sources: FxHashMap<BlockId, DenseBitSet<ValueId>>,
+    edge_sources: FxHashMap<BlockId, Vec<ValueId>>,
 }
 
 #[derive(Clone, Debug)]
@@ -436,11 +436,7 @@ impl<'a> StackPhiPlanner<'a> {
 
         plan.entries.insert(loop_info.header, entry.clone());
         for (pred, sources) in edges {
-            let mut source_set = DenseBitSet::new_empty(self.func.values.len());
-            for &source in &sources {
-                source_set.insert(source);
-            }
-            plan.edge_sources.insert(pred, source_set);
+            plan.edge_sources.insert(pred, sources.clone());
             plan.edges.insert(pred, StackPhiEdge { sources, results: entry.clone() });
         }
     }
@@ -478,11 +474,7 @@ impl<'a> StackPhiPlanner<'a> {
 
         plan.entries.insert(block_id, results.clone());
         for (pred, sources) in edges {
-            let mut source_set = DenseBitSet::new_empty(self.func.values.len());
-            for &source in &sources {
-                source_set.insert(source);
-            }
-            plan.edge_sources.insert(pred, source_set);
+            plan.edge_sources.insert(pred, sources.clone());
             plan.edges.insert(pred, StackPhiEdge { sources, results: results.clone() });
         }
     }
@@ -619,7 +611,7 @@ pub struct EvmCodegen<'gcx> {
     /// Copies to insert at block exits (from phi elimination).
     block_copies: FxHashMap<BlockId, Vec<ParallelCopy>>,
     /// Values carried by planned stack-resident phi edges, keyed by predecessor block.
-    stack_phi_sources: FxHashMap<BlockId, DenseBitSet<ValueId>>,
+    stack_phi_sources: FxHashMap<BlockId, Vec<ValueId>>,
     /// Whether the current function has canonical cross-block argument layouts.
     global_stack_active: bool,
     /// Calldata words physically identical to arguments in the active global
@@ -1972,7 +1964,7 @@ impl<'gcx> EvmCodegen<'gcx> {
     }
 
     fn is_stack_phi_source(&self, block: BlockId, value: ValueId) -> bool {
-        self.stack_phi_sources.get(&block).is_some_and(|sources| sources.contains(value))
+        self.stack_phi_sources.get(&block).is_some_and(|sources| sources.contains(&value))
     }
 
     /// Preallocates stable spill slots for values that may cross block boundaries.

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -378,7 +378,7 @@ impl<'a> StackPhiPlanner<'a> {
     fn collect_header_results(&mut self) {
         for loop_info in &self.loops {
             let block = &self.func.blocks[loop_info.header];
-            let phi_insts = self.leading_phi_insts(block);
+            let phi_insts = self.phi_insts(block);
             if let Some(results) = self.phi_result_values(&phi_insts) {
                 self.header_results.insert(loop_info.header, results);
             }
@@ -402,7 +402,7 @@ impl<'a> StackPhiPlanner<'a> {
         }
 
         let block = &self.func.blocks[loop_info.header];
-        let phi_insts = self.leading_phi_insts(block);
+        let phi_insts = self.phi_insts(block);
         if phi_insts.is_empty() || phi_insts.len() > STACK_PHI_LAYOUT_LIMIT {
             return;
         }
@@ -451,7 +451,7 @@ impl<'a> StackPhiPlanner<'a> {
             return;
         }
 
-        let phi_insts = self.leading_phi_insts(block);
+        let phi_insts = self.phi_insts(block);
         if phi_insts.is_empty() || phi_insts.len() > STACK_PHI_LAYOUT_LIMIT {
             return;
         }
@@ -487,12 +487,12 @@ impl<'a> StackPhiPlanner<'a> {
         }
     }
 
-    fn leading_phi_insts(&self, block: &crate::mir::BasicBlock) -> Vec<InstId> {
+    fn phi_insts(&self, block: &crate::mir::BasicBlock) -> Vec<InstId> {
         block
             .instructions
             .iter()
             .copied()
-            .take_while(|&inst| matches!(self.func.inst(inst).kind, InstKind::Phi(_)))
+            .filter(|&inst| matches!(self.func.inst(inst).kind, InstKind::Phi(_)))
             .collect()
     }
 

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -369,6 +369,9 @@ impl<'a> StackPhiPlanner<'a> {
         for loop_info in &self.loops {
             self.plan_loop(loop_info, &mut plan);
         }
+        for block in self.func.blocks.indices() {
+            self.plan_join(block, &mut plan);
+        }
         plan
     }
 
@@ -439,6 +442,48 @@ impl<'a> StackPhiPlanner<'a> {
             }
             plan.edge_sources.insert(pred, source_set);
             plan.edges.insert(pred, StackPhiEdge { sources, results: entry.clone() });
+        }
+    }
+
+    fn plan_join(&self, block_id: BlockId, plan: &mut StackPhiPlan) {
+        let block = &self.func.blocks[block_id];
+        if plan.entries.contains_key(&block_id) || block.predecessors.len() < 2 {
+            return;
+        }
+
+        let phi_insts = self.leading_phi_insts(block);
+        if phi_insts.is_empty() || phi_insts.len() > STACK_PHI_LAYOUT_LIMIT {
+            return;
+        }
+        let Some(results) = self.phi_result_values(&phi_insts) else {
+            return;
+        };
+        if block.predecessors.iter().any(|pred| {
+            plan.edges.contains_key(pred)
+                || !matches!(
+                    self.func.blocks[*pred].terminator,
+                    Some(Terminator::Jump(target)) if target == block_id
+                )
+        }) {
+            return;
+        }
+
+        let mut edges = Vec::with_capacity(block.predecessors.len());
+        for &pred in &block.predecessors {
+            let Some(sources) = self.phi_sources_for_pred(&phi_insts, pred) else {
+                return;
+            };
+            edges.push((pred, sources));
+        }
+
+        plan.entries.insert(block_id, results.clone());
+        for (pred, sources) in edges {
+            let mut source_set = DenseBitSet::new_empty(self.func.values.len());
+            for &source in &sources {
+                source_set.insert(source);
+            }
+            plan.edge_sources.insert(pred, source_set);
+            plan.edges.insert(pred, StackPhiEdge { sources, results: results.clone() });
         }
     }
 

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -220,7 +220,7 @@ impl GlobalStackPlan {
             }
         }
 
-        // Switch lowering owns the selector stack, and stack-phi loop headers
+        // Switch lowering owns the selector stack, and stack-phi entries
         // own their edge layouts. Disable their whole branch-sibling component
         // so every predecessor of every affected block still agrees.
         let mut disabled = DenseBitSet::new_empty(func.blocks.len());

--- a/tests/ui/codegen/lowering/acyclic_stack_phi.sol
+++ b/tests/ui/codegen/lowering/acyclic_stack_phi.sol
@@ -1,0 +1,18 @@
+//@ compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@ filecheck:
+
+contract AcyclicStackPhi {
+    // CHECK-LABEL: @module runtime
+    // CHECK: push 0xbcc0f6fa
+    // CHECK-NEXT: eq
+    // CHECK-NEXT: push [[ENTRY:bb[0-9]+]]
+    // CHECK: [[ENTRY]]:
+    // CHECK: jump [[MERGE:bb[0-9]+]]
+    // CHECK-NEXT: [[MERGE]]:
+    // CHECK-NEXT: pop
+    // CHECK-NEXT: dup1
+    function trim(bytes calldata data) external pure returns (bytes calldata) {
+        if (data.length > 4) return data[4:];
+        return data;
+    }
+}

--- a/tests/ui/codegen/lowering/acyclic_stack_phi.sol
+++ b/tests/ui/codegen/lowering/acyclic_stack_phi.sol
@@ -19,6 +19,7 @@ contract AcyclicStackPhi {
     // CHECK-NEXT: [[MERGE]]:
     // CHECK-NEXT: dup2
     // CHECK-NEXT: dup1
+    // CHECK: [[TRIM]]:
     function trimLen(bytes calldata data) external pure returns (uint256) {
         return trim(data).length;
     }

--- a/tests/ui/codegen/lowering/acyclic_stack_phi.sol
+++ b/tests/ui/codegen/lowering/acyclic_stack_phi.sol
@@ -3,15 +3,27 @@
 
 contract AcyclicStackPhi {
     // CHECK-LABEL: @module runtime
-    // CHECK: push 0xbcc0f6fa
-    // CHECK-NEXT: eq
-    // CHECK-NEXT: push [[ENTRY:bb[0-9]+]]
-    // CHECK: [[ENTRY]]:
+    // CHECK: push 0x341fda35
+    // CHECK: calldataload
+    // CHECK-NEXT: add
+    // CHECK-NEXT: calldataload
+    // CHECK-NEXT: dup1
+    // CHECK-NEXT: push {{[0-9]+}}
+    // CHECK-NEXT: mstore
+    // CHECK-NEXT: push 4
+    // CHECK-NEXT: dup2
+    // CHECK-NEXT: gt
+    // CHECK-NEXT: push [[TRIM:bb[0-9]+]]
+    // CHECK-NEXT: jumpi
     // CHECK: jump [[MERGE:bb[0-9]+]]
     // CHECK-NEXT: [[MERGE]]:
-    // CHECK-NEXT: pop
+    // CHECK-NEXT: dup2
     // CHECK-NEXT: dup1
-    function trim(bytes calldata data) external pure returns (bytes calldata) {
+    function trimLen(bytes calldata data) external pure returns (uint256) {
+        return trim(data).length;
+    }
+
+    function trim(bytes calldata data) internal pure returns (bytes calldata) {
         if (data.length > 4) return data[4:];
         return data;
     }

--- a/tests/ui/codegen/lowering/acyclic_stack_phi.stdout
+++ b/tests/ui/codegen/lowering/acyclic_stack_phi.stdout
@@ -1,0 +1,325 @@
+// === ROOT/tests/ui/codegen/lowering/acyclic_stack_phi.sol:AcyclicStackPhi (runtime) ===
+@module runtime
+bb0:
+  push 608
+  push 64
+  mstore
+  callvalue
+  push bb4
+  jumpi
+  calldatasize
+  iszero
+  push bb4
+  jumpi
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0xbcc0f6fa
+  eq
+  push bb5
+  jumpi
+  jump bb4
+bb4 [cold]:
+  push 0
+  dup1
+  revert
+bb12 [cold]:
+  push 0x4e487b71
+  push 224
+  shl
+  push 0
+  mstore
+  push 65
+  push 4
+  mstore
+  push 36
+  push 0
+  revert
+bb5:
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 32
+  sgt
+  push bb4
+  jumpi
+  push 0
+  push 128
+  mstore
+  push 4
+  push 4
+  calldataload
+  add
+  calldataload
+  dup1
+  push 288
+  mstore
+  push 4
+  dup2
+  gt
+  push bb8
+  jumpi
+  push 31
+  dup2
+  add
+  push 31
+  not
+  and
+  dup1
+  push 384
+  mstore
+  iszero
+  push 384
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  swap1
+  pop
+  push 32
+  dup2
+  add
+  push 64
+  mload
+  dup1
+  push 448
+  mstore
+  dup2
+  dup2
+  add
+  swap2
+  pop
+  dup2
+  push 64
+  mstore
+  swap1
+  pop
+  dup3
+  dup1
+  push 288
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  dup4
+  sub
+  swap3
+  pop
+  dup3
+  dup2
+  add
+  swap3
+  pop
+  push 0
+  dup4
+  mstore
+  swap2
+  pop
+  push 36
+  push 4
+  calldataload
+  add
+  dup4
+  dup1
+  push 288
+  mstore
+  dup2
+  dup5
+  calldatacopy
+  pop
+  swap2
+  pop
+  jump bb14
+bb14:
+  pop
+  dup1
+  push 544
+  mstore
+  push 64
+  mload
+  dup1
+  push 576
+  mstore
+  push 32
+  dup2
+  mstore
+  push 544
+  mload
+  mload
+  push 32
+  dup3
+  add
+  dup2
+  swap1
+  mstore
+  push 31
+  dup2
+  add
+  push 31
+  not
+  and
+  push 64
+  dup4
+  add
+  push 32
+  dup3
+  sub
+  dup2
+  add
+  push 0
+  swap1
+  mstore
+  push 32
+  push 544
+  mload
+  add
+  dup4
+  dup2
+  dup4
+  mcopy
+  pop
+  pop
+  swap1
+  pop
+  push 64
+  add
+  dup2
+  return
+bb8:
+  push 36
+  push 4
+  calldataload
+  add
+  push 4
+  dup3
+  sub
+  dup1
+  push 160
+  mstore
+  swap2
+  pop
+  dup2
+  push 160
+  mstore
+  push 4
+  add
+  dup1
+  push 192
+  mstore
+  push 31
+  dup3
+  add
+  dup1
+  push 320
+  mstore
+  dup3
+  dup1
+  push 160
+  mstore
+  gt
+  swap2
+  pop
+  pop
+  push bb12
+  jumpi
+  push 31
+  not
+  push 320
+  mload
+  and
+  dup1
+  push 352
+  mstore
+  iszero
+  push 352
+  mload
+  push 32
+  dup3
+  dup3
+  dup3
+  sub
+  mul
+  swap1
+  pop
+  add
+  dup1
+  push 224
+  mstore
+  swap1
+  pop
+  dup1
+  push 224
+  mstore
+  push 32
+  dup2
+  add
+  dup1
+  push 256
+  mstore
+  dup2
+  dup1
+  push 224
+  mstore
+  gt
+  swap1
+  pop
+  push bb12
+  jumpi
+  push 64
+  mload
+  dup1
+  push 416
+  mstore
+  push 256
+  mload
+  dup1
+  push 256
+  mstore
+  dup2
+  add
+  push 64
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  dup2
+  mstore
+  push 32
+  dup2
+  add
+  push 32
+  push 224
+  mload
+  sub
+  dup2
+  add
+  push 0
+  swap1
+  mstore
+  push 160
+  mload
+  dup1
+  push 160
+  mstore
+  push 192
+  mload
+  dup1
+  push 192
+  mstore
+  dup3
+  calldatacopy
+  jump bb14

--- a/tests/ui/codegen/lowering/acyclic_stack_phi.stdout
+++ b/tests/ui/codegen/lowering/acyclic_stack_phi.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/acyclic_stack_phi.sol:AcyclicStackPhi (runtime) ===
 @module runtime
 bb0:
-  push 608
+  push 416
   push 64
   mstore
   callvalue
@@ -16,28 +16,10 @@ bb0:
   push 224
   shr
   dup1
-  push 0xbcc0f6fa
-  eq
-  push bb5
+  push 0x341fda35
+  sub
+  push bb4
   jumpi
-  jump bb4
-bb4 [cold]:
-  push 0
-  dup1
-  revert
-bb12 [cold]:
-  push 0x4e487b71
-  push 224
-  shl
-  push 0
-  mstore
-  push 65
-  push 4
-  mstore
-  push 36
-  push 0
-  revert
-bb5:
   calldatasize
   push 4
   swap1
@@ -46,158 +28,41 @@ bb5:
   sgt
   push bb4
   jumpi
-  push 0
+  push 4
+  push 4
+  calldataload
+  add
+  calldataload
+  dup1
+  push 224
+  mstore
+  push 4
+  dup2
+  gt
+  push bb9
+  jumpi
+  push 36
+  push 4
+  calldataload
+  add
+  jump bb8
+bb8:
+  dup2
+  dup1
+  push 256
+  mstore
   push 128
   mstore
-  push 4
-  push 4
-  calldataload
-  add
-  calldataload
-  dup1
-  push 288
-  mstore
-  push 4
-  dup2
-  gt
-  push bb8
-  jumpi
-  push 31
-  dup2
-  add
-  push 31
-  not
-  and
-  dup1
-  push 384
-  mstore
-  iszero
-  push 384
-  mload
-  push 32
-  dup3
-  dup3
-  dup3
-  sub
-  mul
-  swap1
   pop
-  add
-  swap1
   pop
   push 32
-  dup2
-  add
-  push 64
-  mload
-  dup1
-  push 448
-  mstore
-  dup2
-  dup2
-  add
-  swap2
-  pop
-  dup2
-  push 64
-  mstore
-  swap1
-  pop
-  dup3
-  dup1
-  push 288
-  mstore
-  dup2
-  mstore
-  push 32
-  dup2
-  add
-  push 32
-  dup4
-  sub
-  swap3
-  pop
-  dup3
-  dup2
-  add
-  swap3
-  pop
-  push 0
-  dup4
-  mstore
-  swap2
-  pop
-  push 36
-  push 4
-  calldataload
-  add
-  dup4
-  dup1
-  push 288
-  mstore
-  dup2
-  dup5
-  calldatacopy
-  pop
-  swap2
-  pop
-  jump bb14
-bb14:
-  pop
-  dup1
-  push 544
-  mstore
-  push 64
-  mload
-  dup1
-  push 576
-  mstore
-  push 32
-  dup2
-  mstore
-  push 544
-  mload
-  mload
-  push 32
-  dup3
-  add
-  dup2
-  swap1
-  mstore
-  push 31
-  dup2
-  add
-  push 31
-  not
-  and
-  push 64
-  dup4
-  add
-  push 32
-  dup3
-  sub
-  dup2
-  add
-  push 0
-  swap1
-  mstore
-  push 32
-  push 544
-  mload
-  add
-  dup4
-  dup2
-  dup4
-  mcopy
-  pop
-  pop
-  swap1
-  pop
-  push 64
-  add
-  dup2
+  push 128
   return
-bb8:
+bb4 [cold]:
+  push 0
+  dup1
+  revert
+bb9:
   push 36
   push 4
   calldataload
@@ -205,121 +70,11 @@ bb8:
   push 4
   dup3
   sub
-  dup1
-  push 160
-  mstore
-  swap2
-  pop
-  dup2
-  push 160
-  mstore
   push 4
-  add
-  dup1
-  push 192
-  mstore
-  push 31
   dup3
   add
-  dup1
-  push 320
-  mstore
-  dup3
-  dup1
-  push 160
-  mstore
-  gt
   swap2
   pop
+  swap2
   pop
-  push bb12
-  jumpi
-  push 31
-  not
-  push 320
-  mload
-  and
-  dup1
-  push 352
-  mstore
-  iszero
-  push 352
-  mload
-  push 32
-  dup3
-  dup3
-  dup3
-  sub
-  mul
-  swap1
-  pop
-  add
-  dup1
-  push 224
-  mstore
-  swap1
-  pop
-  dup1
-  push 224
-  mstore
-  push 32
-  dup2
-  add
-  dup1
-  push 256
-  mstore
-  dup2
-  dup1
-  push 224
-  mstore
-  gt
-  swap1
-  pop
-  push bb12
-  jumpi
-  push 64
-  mload
-  dup1
-  push 416
-  mstore
-  push 256
-  mload
-  dup1
-  push 256
-  mstore
-  dup2
-  add
-  push 64
-  mstore
-  push 160
-  mload
-  dup1
-  push 160
-  mstore
-  dup2
-  mstore
-  push 32
-  dup2
-  add
-  push 32
-  push 224
-  mload
-  sub
-  dup2
-  add
-  push 0
-  swap1
-  mstore
-  push 160
-  mload
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  dup1
-  push 192
-  mstore
-  dup3
-  calldatacopy
-  jump bb14
+  jump bb8

--- a/tests/ui/codegen/run-call/acyclic_stack_phi.sol
+++ b/tests/ui/codegen/run-call/acyclic_stack_phi.sol
@@ -1,0 +1,29 @@
+//@ run-call: trimLen(bytes) 0x010203 => 3
+//@ run-call: trimLen(bytes) 0x010203040506 => 2
+//@ run-call: repeatedSourceJoin(bool,uint256,uint256) true, 7, 9 => 7, 7
+//@ run-call: repeatedSourceJoin(bool,uint256,uint256) false, 7, 9 => 9, 7
+
+contract AcyclicStackPhi {
+    function trimLen(bytes calldata data) external pure returns (uint256) {
+        return trim(data).length;
+    }
+
+    function trim(bytes calldata data) internal pure returns (bytes calldata) {
+        if (data.length > 4) return data[4:];
+        return data;
+    }
+
+    function repeatedSourceJoin(
+        bool first,
+        uint256 a,
+        uint256 b
+    ) external pure returns (uint256 x, uint256 y) {
+        if (first) {
+            x = a;
+            y = a;
+        } else {
+            x = b;
+            y = a;
+        }
+    }
+}

--- a/tests/ui/codegen/run-call/acyclic_stack_phi.sol
+++ b/tests/ui/codegen/run-call/acyclic_stack_phi.sol
@@ -2,6 +2,8 @@
 //@ run-call: trimLen(bytes) 0x010203040506 => 2
 //@ run-call: repeatedSourceJoin(bool,uint256,uint256) true, 7, 9 => 7, 7
 //@ run-call: repeatedSourceJoin(bool,uint256,uint256) false, 7, 9 => 9, 7
+//@ run-call: loopJoin(uint256) 0 => 0
+//@ run-call: loopJoin(uint256) 4 => 12
 
 contract AcyclicStackPhi {
     function trimLen(bytes calldata data) external pure returns (uint256) {
@@ -24,6 +26,18 @@ contract AcyclicStackPhi {
         } else {
             x = b;
             y = a;
+        }
+    }
+
+    function loopJoin(uint256 n) external pure returns (uint256 result) {
+        for (uint256 i; i < n; ++i) {
+            uint256 value;
+            if (i & 1 == 0) {
+                value = i + 1;
+            } else {
+                value = i + 2;
+            }
+            result += value;
         }
     }
 }


### PR DESCRIPTION
Keep phi values at eligible unconditional joins on the EVM stack instead of storing each incoming value to memory and loading it at the merge. This extends the existing loop-header planner to ordinary joins, uses the same bounded eight-value layout, and scans every phi in loose MIR so preserved edges account for all copies. Source membership stays in bounded vectors rather than allocating a function-wide bitset per edge.

On existing UI codegen inputs, the only bytecode change is `calldata_slice_control_flow`, which loses 23 deploy and runtime bytes in both `-Ogas` and `-Osize`. On the pinned CI corpus, Nitro loses 50 deploy and runtime bytes in both modes and 10,800 deployment gas under `-Ogas`. All 111 hot runtime checks pass, and all 133 hot gas calls match `main`.

The FileCheck fixture pins the stack layout. Runtime UI coverage exercises both branch arms, repeated phi sources, and a loop-local join.
