### PR TITLE
feat(codegen): support storage array push

### DIFF
--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -1160,11 +1160,21 @@ impl<'gcx> Lowerer<'gcx> {
             return self.lower_storage_bytes_method_call(builder, slot, method, args);
         }
 
-        // Handle dynamic array methods (push, pop)
-        if let Some(method) = array_method
-            && let Some((var_id, slot)) = self.get_dyn_array_base_slot(base)
+        // Resolve the receiver's slot at runtime so storage dynamic-array methods
+        // work on references, nested arrays, mapping values, and struct fields.
+        if let Some(builtin @ (Builtin::ArrayPush0 | Builtin::ArrayPush | Builtin::ArrayPop)) =
+            builtin
+            && let Some((slot, element_ty, element_slots)) =
+                self.storage_dynamic_array_info(builder, base)
         {
-            return self.lower_array_method_call(builder, var_id, slot, method, args);
+            return self.lower_array_method_call(
+                builder,
+                slot,
+                element_ty,
+                element_slots,
+                builtin,
+                args,
+            );
         }
 
         // Handle `using X for Y` library calls: x.method(args) -> Library.method(x, args)

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::mir::{FunctionBuilder, MemoryObjectKind, MirType, ValueId};
 use alloy_primitives::U256;
 use solar_ast::{LitKind, StrKind};
-use solar_interface::{Ident, Span, Symbol, kw, sym};
+use solar_interface::{Ident, Span, sym};
 use solar_sema::{
     builtins::Builtin,
     hir::{self, CallArgs, ElementaryType, ExprKind},
@@ -1437,6 +1437,13 @@ impl<'gcx> Lowerer<'gcx> {
                 let base_val = self.lower_expr(builder, base);
                 builder.mstore(base_val, rhs);
             }
+            ExprKind::Call(..) => {
+                if let Some(slot) = self.lower_lvalue_slot(builder, lhs)
+                    && let Some(ty) = self.get_expr_type(lhs)
+                {
+                    self.store_storage_value_at(builder, ty, slot, rhs);
+                }
+            }
             ExprKind::YulMember(base, member) => {
                 // `r.slot := x` sets the storage pointer's slot value. The pointer
                 // is modeled as an SSA slot in `locals`, marked as a storage ref so
@@ -1668,66 +1675,48 @@ impl<'gcx> Lowerer<'gcx> {
         None
     }
 
-    /// Checks if an expression is a dynamic array state variable and returns its var_id and
-    /// storage slot.
-    pub(super) fn get_dyn_array_base_slot(
-        &self,
-        expr: &hir::Expr<'_>,
-    ) -> Option<(hir::VariableId, u64)> {
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
-            // Check if this variable has dynamic array type (Array with no size)
-            if let hir::TypeKind::Array(arr) = &var.ty.kind
-                && arr.size.is_none()
-                && let Some(&slot) = self.storage_slots.get(var_id)
-            {
-                return Some((*var_id, slot));
-            }
+    /// Resolves an array living in storage and returns its element type and
+    /// constant length (`None` for a dynamic array).
+    fn storage_array_type_of_expr(&self, expr: &hir::Expr<'_>) -> Option<(Ty<'gcx>, Option<u64>)> {
+        let ty = self.get_expr_type(expr)?;
+        let TyKind::Ref(inner, solar_ast::DataLocation::Storage) = ty.kind else {
+            return None;
+        };
+        match inner.kind {
+            TyKind::Array(element, len) => Some((element, Some(u64::try_from(len).ok()?))),
+            TyKind::DynArray(element) => Some((element, None)),
+            _ => None,
         }
-        None
     }
 
-    /// Resolves an indexing base that is an array living in storage: an array state variable
-    /// or an array storage-reference local. Returns the base slot as a runtime value and the
-    /// constant length for fixed-size arrays (`None` for dynamic arrays, whose length is
-    /// stored at the base slot). Fixed-size elements occupy one slot each starting at the
-    /// base slot (this codebase does not pack storage).
+    /// Resolves an array living in storage: a state variable, storage-reference
+    /// local, mapping value, struct field, or nested array element. Returns its
+    /// runtime base slot, constant length (`None` for dynamic arrays), and the
+    /// number of storage slots occupied by one element.
     pub(super) fn storage_array_slot_of_base(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         expr: &hir::Expr<'_>,
     ) -> Option<(ValueId, Option<u64>, u64)> {
-        let ExprKind::Ident(res_slice) = &expr.kind else { return None };
-        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+        let (element, fixed_len) = self.storage_array_type_of_expr(expr)?;
+        let elem_slots = self.calculate_storage_slots_for_ty(element, expr.span);
+        let slot = self.lower_lvalue_slot(builder, expr)?;
+        Some((slot, fixed_len, elem_slots))
+    }
+
+    /// Resolves a dynamic array living in storage.
+    pub(super) fn storage_dynamic_array_info(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        expr: &hir::Expr<'_>,
+    ) -> Option<(ValueId, Ty<'gcx>, u64)> {
+        let (element, fixed_len) = self.storage_array_type_of_expr(expr)?;
+        if fixed_len.is_some() {
             return None;
-        };
-        let var = self.gcx.hir.variable(*var_id);
-        let hir::TypeKind::Array(arr) = &var.ty.kind else { return None };
-        let fixed_len = if arr.size.is_some() {
-            let solar_sema::ty::TyKind::Array(_, len) =
-                self.gcx.type_of_hir_ty(&var.ty).peel_refs().kind
-            else {
-                return None;
-            };
-            // Larger lengths already produced a layout diagnostic.
-            Some(u64::try_from(len).ok()?)
-        } else {
-            None
-        };
-        let elem_slots = self.calculate_storage_slots_for_ty(
-            self.gcx.type_of_hir_ty(&arr.element),
-            arr.element.span,
-        );
-        if let Some(&slot) = self.storage_slots.get(var_id) {
-            return Some((builder.imm_u64(slot), fixed_len, elem_slots));
         }
-        if self.storage_ref_locals.contains(*var_id) {
-            let slot_val = self.locals.get(var_id).copied()?;
-            return Some((slot_val, fixed_len, elem_slots));
-        }
-        None
+        let element_slots = self.calculate_storage_slots_for_ty(element, expr.span);
+        let slot = self.lower_lvalue_slot(builder, expr)?;
+        Some((slot, element, element_slots))
     }
 
     /// Emits the bounds check for a storage array access and returns the element slot.
@@ -2389,6 +2378,20 @@ impl<'gcx> Lowerer<'gcx> {
                 }
                 None
             }
+            ExprKind::Call(callee, args, _)
+                if self.gcx.builtin_callee(callee.id) == Some(Builtin::ArrayPush0) =>
+            {
+                let ExprKind::Member(base, _) = &callee.kind else { return None };
+                let (slot, element_ty, element_slots) =
+                    self.storage_dynamic_array_info(builder, base)?;
+                Some(self.lower_storage_array_push_slot(
+                    builder,
+                    slot,
+                    element_ty,
+                    element_slots,
+                    args,
+                ))
+            }
             // A call to a function returning a storage reference (e.g. the
             // ERC-7201 `_layout()` getter) yields the slot value directly.
             ExprKind::Call(callee, ..) if self.call_returns_storage_ref(callee) => {
@@ -2586,86 +2589,103 @@ impl<'gcx> Lowerer<'gcx> {
         None
     }
 
-    /// Lowers dynamic array method calls (push, pop).
-    /// For dynamic arrays:
-    /// - Length is stored at the base slot
-    /// - Elements are stored at keccak256(slot) + index
+    /// Appends a zero-initialized element and returns its storage slot.
+    fn lower_storage_array_push_slot(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        slot: ValueId,
+        element_ty: Ty<'gcx>,
+        element_slots: u64,
+        args: &CallArgs<'_>,
+    ) -> ValueId {
+        debug_assert!(args.is_empty());
+
+        let length = builder.sload(slot);
+        let one = builder.imm_u64(1);
+        let new_length = builder.add(length, one);
+        let overflow = builder.lt(new_length, length);
+        self.emit_panic_if(builder, overflow, PanicCode::MemoryAllocationOverflow);
+
+        let scratch = builder.imm_u64(0);
+        builder.mstore(scratch, slot);
+        let word = builder.imm_u64(32);
+        let data_slot = builder.keccak256(scratch, word);
+        let offset = Self::scale_index_by_slots(builder, length, element_slots);
+        let element_slot = builder.add(data_slot, offset);
+
+        self.clear_storage_value_at(builder, element_ty, element_slot);
+        builder.sstore(slot, new_length);
+        element_slot
+    }
+
+    /// Lowers dynamic storage-array method calls.
     pub(super) fn lower_array_method_call(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
-        _var_id: hir::VariableId,
-        slot: u64,
-        method: Symbol,
+        slot: ValueId,
+        element_ty: Ty<'gcx>,
+        element_slots: u64,
+        builtin: Builtin,
         args: &CallArgs<'_>,
     ) -> ValueId {
-        let slot_val = builder.imm_u64(slot);
+        match builtin {
+            Builtin::ArrayPush0 => {
+                let element_slot = self.lower_storage_array_push_slot(
+                    builder,
+                    slot,
+                    element_ty,
+                    element_slots,
+                    args,
+                );
+                if element_ty.is_reference_type() { element_slot } else { builder.imm_u64(0) }
+            }
+            Builtin::ArrayPush => {
+                let value = args
+                    .exprs()
+                    .next()
+                    .map(|arg| match element_ty.peel_refs().kind {
+                        TyKind::Elementary(ElementaryType::Bytes | ElementaryType::String) => {
+                            self.lower_expr_as_memory_bytes(builder, arg)
+                        }
+                        TyKind::DynArray(_) => self.lower_expr_as_memory_dyn_array(builder, arg),
+                        _ => self.lower_expr(builder, arg),
+                    })
+                    .unwrap_or_else(|| builder.imm_u64(0));
 
-        match method {
-            sym::push => {
-                // 1. Load current length from slot
-                let length = builder.sload(slot_val);
-
-                // 2. Compute data slot: keccak256(slot)
-                let mem_0 = builder.imm_u64(0);
-                builder.mstore(mem_0, slot_val);
-                let size_32 = builder.imm_u64(32);
-                let data_slot = builder.keccak256(mem_0, size_32);
-
-                // 3. Compute element slot: data_slot + length
-                let element_slot = builder.add(data_slot, length);
-
-                // 4. Store the new value at element slot
-                let mut exprs = args.exprs();
-                let value = if let Some(first) = exprs.next() {
-                    self.lower_expr(builder, first)
-                } else {
-                    builder.imm_u64(0)
-                };
-                builder.sstore(element_slot, value);
-
-                // 5. Increment length and store back
+                let length = builder.sload(slot);
                 let one = builder.imm_u64(1);
                 let new_length = builder.add(length, one);
-                let slot_val2 = builder.imm_u64(slot);
-                builder.sstore(slot_val2, new_length);
+                let overflow = builder.lt(new_length, length);
+                self.emit_panic_if(builder, overflow, PanicCode::MemoryAllocationOverflow);
 
-                // push returns void, return dummy
+                let scratch = builder.imm_u64(0);
+                builder.mstore(scratch, slot);
+                let word = builder.imm_u64(32);
+                let data_slot = builder.keccak256(scratch, word);
+                let offset = Self::scale_index_by_slots(builder, length, element_slots);
+                let element_slot = builder.add(data_slot, offset);
+                self.store_storage_value_at(builder, element_ty, element_slot, value);
+                builder.sstore(slot, new_length);
                 builder.imm_u64(0)
             }
-            kw::Pop => {
-                // pop() decrements length and clears the last element
-                // Storage layout:
-                // - Length at slot
-                // - Elements at keccak256(slot) + index
-
-                // 1. Load current length and decrement
-                let length = builder.sload(slot_val);
+            Builtin::ArrayPop => {
+                let length = builder.sload(slot);
+                self.emit_panic_if_zero(builder, length, PanicCode::PopEmptyArray);
                 let one = builder.imm_u64(1);
                 let new_length = builder.sub(length, one);
 
-                // 2. Store decremented length back
-                let slot_val2 = builder.imm_u64(slot);
-                builder.sstore(slot_val2, new_length);
-
-                // 3. Compute data slot: keccak256(slot)
-                let slot_val3 = builder.imm_u64(slot);
-                let mem_0 = builder.imm_u64(0);
-                builder.mstore(mem_0, slot_val3);
-                let size_32 = builder.imm_u64(32);
-                let data_slot = builder.keccak256(mem_0, size_32);
-
-                // 4. Compute element slot using stored length (already decremented)
-                let slot_val4 = builder.imm_u64(slot);
-                let length2 = builder.sload(slot_val4);
-                let element_slot = builder.add(data_slot, length2);
-
-                // 5. Clear the popped element
-                let zero = builder.imm_u64(0);
-                builder.sstore(element_slot, zero);
+                let scratch = builder.imm_u64(0);
+                builder.mstore(scratch, slot);
+                let word = builder.imm_u64(32);
+                let data_slot = builder.keccak256(scratch, word);
+                let offset = Self::scale_index_by_slots(builder, new_length, element_slots);
+                let element_slot = builder.add(data_slot, offset);
+                self.clear_storage_value_at(builder, element_ty, element_slot);
+                builder.sstore(slot, new_length);
 
                 builder.imm_u64(0)
             }
-            s => unreachable!("{s}"),
+            _ => unreachable!("{builtin:?}"),
         }
     }
 

--- a/crates/codegen/src/lower/index.rs
+++ b/crates/codegen/src/lower/index.rs
@@ -16,6 +16,16 @@ impl<'gcx> Lowerer<'gcx> {
         base: &hir::Expr<'_>,
         index: Option<&hir::Expr<'_>>,
     ) -> ValueId {
+        if let Some((slot_val, fixed_len, elem_slots)) =
+            self.storage_array_slot_of_base(builder, base)
+        {
+            let index_val = self.lower_index_or_zero(builder, index);
+            let element_slot = self.lower_storage_array_element_slot(
+                builder, slot_val, fixed_len, index_val, elem_slots,
+            );
+            return builder.sload(element_slot);
+        }
+
         if let Some(mapping) = self.lower_mapping_element_slot(builder, base, index) {
             if mapping.value_is_mapping {
                 return mapping.slot;
@@ -36,16 +46,6 @@ impl<'gcx> Lowerer<'gcx> {
                 return self.materialize_storage_bytes(builder, mapping.slot);
             }
             return builder.sload(mapping.slot);
-        }
-
-        if let Some((slot_val, fixed_len, elem_slots)) =
-            self.storage_array_slot_of_base(builder, base)
-        {
-            let index_val = self.lower_index_or_zero(builder, index);
-            let element_slot = self.lower_storage_array_element_slot(
-                builder, slot_val, fixed_len, index_val, elem_slots,
-            );
-            return builder.sload(element_slot);
         }
 
         if let Some((slice, is_bytes)) = self.calldata_bytes_source(builder, base) {
@@ -136,6 +136,17 @@ impl<'gcx> Lowerer<'gcx> {
         index: Option<&hir::Expr<'_>>,
         rhs: ValueId,
     ) {
+        if let Some((slot_val, fixed_len, elem_slots)) =
+            self.storage_array_slot_of_base(builder, base)
+        {
+            let index_val = self.lower_index_or_zero(builder, index);
+            let element_slot = self.lower_storage_array_element_slot(
+                builder, slot_val, fixed_len, index_val, elem_slots,
+            );
+            builder.sstore(element_slot, rhs);
+            return;
+        }
+
         if let Some(mapping) = self.lower_mapping_element_slot(builder, base, index) {
             if let Some(ty) = self.get_expr_type(lhs)
                 && let TyKind::Struct(struct_id) = ty.peel_refs().kind
@@ -154,17 +165,6 @@ impl<'gcx> Lowerer<'gcx> {
         {
             let index_val = self.lower_index_or_zero(builder, index);
             self.store_storage_bytes_element(builder, slot, index_val, rhs);
-            return;
-        }
-
-        if let Some((slot_val, fixed_len, elem_slots)) =
-            self.storage_array_slot_of_base(builder, base)
-        {
-            let index_val = self.lower_index_or_zero(builder, index);
-            let element_slot = self.lower_storage_array_element_slot(
-                builder, slot_val, fixed_len, index_val, elem_slots,
-            );
-            builder.sstore(element_slot, rhs);
             return;
         }
 
@@ -204,9 +204,6 @@ impl<'gcx> Lowerer<'gcx> {
         base: &hir::Expr<'_>,
         index: Option<&hir::Expr<'_>>,
     ) -> Option<ValueId> {
-        if let Some(mapping) = self.lower_mapping_element_slot(builder, base, index) {
-            return Some(mapping.slot);
-        }
         if let Some((slot_val, fixed_len, elem_slots)) =
             self.storage_array_slot_of_base(builder, base)
         {
@@ -214,6 +211,9 @@ impl<'gcx> Lowerer<'gcx> {
             return Some(self.lower_storage_array_element_slot(
                 builder, slot_val, fixed_len, index_val, elem_slots,
             ));
+        }
+        if let Some(mapping) = self.lower_mapping_element_slot(builder, base, index) {
+            return Some(mapping.slot);
         }
         None
     }

--- a/crates/codegen/src/lower/storage.rs
+++ b/crates/codegen/src/lower/storage.rs
@@ -1,5 +1,8 @@
 use super::Lowerer;
-use crate::mir::{FunctionBuilder, StorageField, StorageLayout, StorageLayoutRef, ValueId};
+use crate::mir::{
+    FunctionBuilder, MemoryObjectKind, MemoryObjectLayout, StorageField, StorageLayout,
+    StorageLayoutRef, ValueId,
+};
 use alloy_primitives::U256;
 use solar_interface::Span;
 use solar_sema::{
@@ -30,6 +33,121 @@ impl StorageLocation {
 }
 
 impl<'gcx> Lowerer<'gcx> {
+    /// Stores one Solidity value at a runtime-computed storage slot.
+    pub(super) fn store_storage_value_at(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: Ty<'gcx>,
+        slot: ValueId,
+        value: ValueId,
+    ) {
+        match ty.peel_refs().kind {
+            TyKind::Struct(struct_id) => {
+                let field_tys = self.gcx.struct_field_types(struct_id).to_vec();
+                let fields = field_tys.len() as u64;
+                let mut storage_offset = 0;
+                for (index, field_ty) in field_tys.into_iter().enumerate() {
+                    let memory = builder.memory_object_field_addr(
+                        value,
+                        MemoryObjectLayout::structure(fields),
+                        index as u64,
+                    );
+                    let field_value = builder.mload(memory);
+                    let field_slot = self.offset_storage_slot(builder, slot, storage_offset);
+                    self.store_storage_value_at(builder, field_ty, field_slot, field_value);
+                    storage_offset += self.calculate_storage_slots_for_ty(field_ty, Span::DUMMY);
+                }
+            }
+            TyKind::Array(element_ty, len) => {
+                let Ok(len) = u64::try_from(len) else {
+                    self.gcx.dcx().err("fixed-size storage array is too large for codegen").emit();
+                    return;
+                };
+                let element_slots = self.calculate_storage_slots_for_ty(element_ty, Span::DUMMY);
+                for index in 0..len {
+                    let index_value = builder.imm_u64(index);
+                    let memory = builder.memory_object_element_addr(
+                        value,
+                        MemoryObjectLayout::word_fixed_array(len),
+                        index_value,
+                    );
+                    let element_value = builder.mload(memory);
+                    let storage_offset = index.saturating_mul(element_slots);
+                    let element_slot = self.offset_storage_slot(builder, slot, storage_offset);
+                    self.store_storage_value_at(builder, element_ty, element_slot, element_value);
+                }
+            }
+            TyKind::DynArray(_) => {
+                self.gcx
+                    .dcx()
+                    .err("codegen does not support pushing a dynamic array value yet")
+                    .emit();
+            }
+            TyKind::Elementary(ElementaryType::Bytes | ElementaryType::String) => {
+                self.copy_memory_bytes_to_storage(builder, slot, value);
+            }
+            TyKind::Mapping(..) => {}
+            _ => builder.sstore(slot, value),
+        }
+    }
+
+    /// Clears one Solidity value at a runtime-computed storage slot.
+    pub(super) fn clear_storage_value_at(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: Ty<'gcx>,
+        slot: ValueId,
+    ) {
+        match ty.peel_refs().kind {
+            TyKind::Struct(struct_id) => {
+                let field_tys = self.gcx.struct_field_types(struct_id).to_vec();
+                let mut storage_offset = 0;
+                for field_ty in field_tys {
+                    let field_slot = self.offset_storage_slot(builder, slot, storage_offset);
+                    self.clear_storage_value_at(builder, field_ty, field_slot);
+                    storage_offset += self.calculate_storage_slots_for_ty(field_ty, Span::DUMMY);
+                }
+            }
+            TyKind::Array(element_ty, len) => {
+                let Ok(len) = u64::try_from(len) else {
+                    self.gcx.dcx().err("fixed-size storage array is too large for codegen").emit();
+                    return;
+                };
+                let element_slots = self.calculate_storage_slots_for_ty(element_ty, Span::DUMMY);
+                for index in 0..len {
+                    let storage_offset = index.saturating_mul(element_slots);
+                    let element_slot = self.offset_storage_slot(builder, slot, storage_offset);
+                    self.clear_storage_value_at(builder, element_ty, element_slot);
+                }
+            }
+            TyKind::Elementary(ElementaryType::Bytes | ElementaryType::String) => {
+                let empty = self.allocate_memory_object(builder, 32, MemoryObjectKind::Bytes);
+                let zero = builder.imm_u64(0);
+                builder.set_memory_object_len(empty, zero, MemoryObjectKind::Bytes);
+                self.copy_memory_bytes_to_storage(builder, slot, empty);
+            }
+            TyKind::Mapping(..) => {}
+            _ => {
+                let zero = builder.imm_u64(0);
+                builder.sstore(slot, zero);
+            }
+        }
+    }
+
+    fn offset_storage_slot(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        slot: ValueId,
+        offset: u64,
+    ) -> ValueId {
+        if offset == 0 {
+            slot
+        } else {
+            let offset = builder.imm_u64(offset);
+            builder.add(slot, offset)
+        }
+    }
+
     /// Allocates the storage location for a state variable.
     pub(super) fn allocate_storage_location(
         &mut self,

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -209,6 +209,7 @@ fn reference<'gcx>(
             } else {
                 gcx.types.fixed_bytes(1)
             };
+            let value = inner.with_loc_if_ref(gcx, DataLocation::Memory);
             vec![
                 Member::of_builtin(gcx, Builtin::ArrayLength),
                 Member::with_attached_builtin(
@@ -217,7 +218,7 @@ fn reference<'gcx>(
                 ),
                 Member::with_attached_builtin(
                     Builtin::ArrayPush,
-                    gcx.mk_builtin_fn(&[this, inner], SM::NonPayable, &[]),
+                    gcx.mk_builtin_fn(&[this, value], SM::NonPayable, &[]),
                 ),
                 Member::with_attached_builtin(
                     Builtin::ArrayPop,

--- a/tests/ui/codegen/lowering/storage_array_push.sol
+++ b/tests/ui/codegen/lowering/storage_array_push.sol
@@ -1,0 +1,86 @@
+//@ run-call: direct 7 => 7, 1
+//@ run-call: pushResult => 0, 1
+//@ run-call: pushLvalue 11 => 11, 1
+//@ run-call: throughReference 13 => 13, 1
+//@ run-call: nestedLvalue 17 => 17, 1, 1
+//@ run-call: mappingValue 19 => 19, 1
+//@ run-call: structField 23 => 23, 1
+//@ run-call: structLvalue 29 => 29, 1
+//@ run-call: structPopThenPush => 0, 1
+//@ run-call: popThenPush => 0, 1
+//@ run-call-fail: popEmpty() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000031
+
+contract StorageArrayPush {
+    struct Bucket {
+        uint256[] values;
+    }
+
+    struct Pair {
+        uint256 first;
+        uint256 second;
+    }
+
+    uint256[] values;
+    uint256[][] nested;
+    mapping(uint256 => uint256[]) mapped;
+    Bucket bucket;
+    Pair[] pairs;
+
+    function direct(uint256 value) external returns (uint256, uint256) {
+        values.push(value);
+        return (values[0], values.length);
+    }
+
+    function pushResult() external returns (uint256, uint256) {
+        uint256 pushed = values.push();
+        return (pushed, values.length);
+    }
+
+    function pushLvalue(uint256 value) external returns (uint256, uint256) {
+        values.push() = value;
+        return (values[0], values.length);
+    }
+
+    function throughReference(uint256 value) external returns (uint256, uint256) {
+        uint256[] storage arrayRef = values;
+        arrayRef.push(value);
+        return (values[0], values.length);
+    }
+
+    function nestedLvalue(uint256 value) external returns (uint256, uint256, uint256) {
+        nested.push().push() = value;
+        return (nested[0][0], nested.length, nested[0].length);
+    }
+
+    function mappingValue(uint256 value) external returns (uint256, uint256) {
+        mapped[1].push(value);
+        return (mapped[1][0], mapped[1].length);
+    }
+
+    function structField(uint256 value) external returns (uint256, uint256) {
+        bucket.values.push(value);
+        return (bucket.values[0], bucket.values.length);
+    }
+
+    function structLvalue(uint256 value) external returns (uint256, uint256) {
+        pairs.push().first = value;
+        return (pairs[0].first, pairs.length);
+    }
+
+    function structPopThenPush() external returns (uint256, uint256) {
+        pairs.push().first = 31;
+        pairs.pop();
+        return (pairs.push().first, pairs.length);
+    }
+
+    function popThenPush() external returns (uint256, uint256) {
+        values.push(37);
+        values.pop();
+        uint256 pushed = values.push();
+        return (pushed, values.length);
+    }
+
+    function popEmpty() external {
+        values.pop();
+    }
+}

--- a/tests/ui/codegen/lowering/storage_array_push.sol
+++ b/tests/ui/codegen/lowering/storage_array_push.sol
@@ -6,6 +6,8 @@
 //@ run-call: mappingValue 19 => 19, 1
 //@ run-call: structField 23 => 23, 1
 //@ run-call: structLvalue 29 => 29, 1
+//@ run-call: bytesValue => 1
+//@ run-call: structValue 41, 43 => 41, 43, 1
 //@ run-call: structPopThenPush => 0, 1
 //@ run-call: popThenPush => 0, 1
 //@ run-call-fail: popEmpty() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000031
@@ -25,6 +27,7 @@ contract StorageArrayPush {
     mapping(uint256 => uint256[]) mapped;
     Bucket bucket;
     Pair[] pairs;
+    bytes[] byteValues;
 
     function direct(uint256 value) external returns (uint256, uint256) {
         values.push(value);
@@ -65,6 +68,20 @@ contract StorageArrayPush {
     function structLvalue(uint256 value) external returns (uint256, uint256) {
         pairs.push().first = value;
         return (pairs[0].first, pairs.length);
+    }
+
+    function bytesValue() external returns (uint256) {
+        bytes memory value = hex"010203";
+        byteValues.push(value);
+        return byteValues.length;
+    }
+
+    function structValue(uint256 first, uint256 second)
+        external
+        returns (uint256, uint256, uint256)
+    {
+        pairs.push(Pair(first, second));
+        return (pairs[0].first, pairs[0].second, pairs.length);
     }
 
     function structPopThenPush() external returns (uint256, uint256) {


### PR DESCRIPTION
Lower dynamic storage-array push and pop through runtime-computed base slots instead of limiting them to direct state variables. This supports storage references, nested arrays, mapping values, struct fields, zero-argument push lvalues and results, aggregate elements, and correct clearing and panic behavior for pop.

The lowering now resolves storage lvalues recursively and copies or clears compound values at computed slots. A UI runtime test covers direct and indirect receivers, nested and struct cases, zero initialization after pop, and the empty-pop panic.
