### PR TITLE
feat(lsp): add call hierarchy support

### DIFF
--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -1,0 +1,532 @@
+//! Call hierarchy indexing.
+
+use crate::{
+    proto,
+    symbols::{DeclarationSymbol, SymbolId, remap_symbol_id},
+};
+use lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Position, Range, Url,
+};
+use serde::{Deserialize, Serialize};
+use solar_interface::{
+    Span,
+    data_structures::{
+        Never,
+        index::IndexVec,
+        map::{FxHashMap, FxHashSet},
+    },
+};
+use solar_sema::{
+    Gcx,
+    hir::{self, ItemId, Visit},
+};
+use std::{cmp::Ordering, ops::ControlFlow};
+
+const DATA_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CallHierarchyIndex {
+    items_by_symbol: FxHashMap<SymbolId, CallHierarchyItem>,
+    candidate_key_by_symbol: FxHashMap<SymbolId, CallableKey>,
+    body_range_by_symbol: FxHashMap<SymbolId, Range>,
+    direct_calls: Vec<DirectCall>,
+
+    canonical_symbol_by_key: FxHashMap<CallableKey, SymbolId>,
+    key_by_symbol: FxHashMap<SymbolId, CallableKey>,
+    outgoing_by_key: CallRelations,
+    incoming_by_key: CallRelations,
+    incomplete_outgoing: FxHashSet<CallableKey>,
+    call_sites_by_uri: FxHashMap<Url, Vec<CallSite>>,
+    bodies_by_uri: FxHashMap<Url, Vec<CallableBody>>,
+}
+
+type CallRelations = FxHashMap<CallableKey, FxHashMap<CallableKey, Vec<Range>>>;
+
+#[derive(Clone, Copy, Debug)]
+struct DirectCall {
+    caller: SymbolId,
+    callee: SymbolId,
+    from_range: Range,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CallSite {
+    range: Range,
+    callee: CallableKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CallableBody {
+    range: Range,
+    callable: CallableKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CallableKey {
+    uri: Url,
+    selection_range: Range,
+}
+
+impl Ord for CallableKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.uri
+            .as_str()
+            .cmp(other.uri.as_str())
+            .then_with(|| range_key(self.selection_range).cmp(&range_key(other.selection_range)))
+    }
+}
+
+impl PartialOrd for CallableKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CallHierarchyData {
+    version: u8,
+    uri: Url,
+    selection_range: Range,
+}
+
+impl CallHierarchyIndex {
+    pub(crate) fn build(
+        gcx: Gcx<'_>,
+        item_symbols: &FxHashMap<ItemId, SymbolId>,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+    ) -> Self {
+        let mut index = Self::default();
+        for function_id in gcx.hir.function_ids() {
+            let function = gcx.hir.function(function_id);
+            if function.is_yul || function.is_getter() {
+                continue;
+            }
+            let Some(&symbol_id) = item_symbols.get(&ItemId::Function(function_id)) else {
+                continue;
+            };
+            let declaration = &declarations[symbol_id];
+            let key = CallableKey {
+                uri: declaration.location.uri.clone(),
+                selection_range: declaration.name_range,
+            };
+            let data = CallHierarchyData {
+                version: DATA_VERSION,
+                uri: key.uri.clone(),
+                selection_range: key.selection_range,
+            };
+            let detail = declaration.parent.map(|parent| declarations[parent].name.clone());
+            index.items_by_symbol.insert(
+                symbol_id,
+                CallHierarchyItem {
+                    name: declaration.name.clone(),
+                    kind: declaration.kind,
+                    tags: None,
+                    detail,
+                    uri: key.uri.clone(),
+                    range: declaration.location.range,
+                    selection_range: key.selection_range,
+                    data: Some(
+                        serde_json::to_value(data)
+                            .expect("call hierarchy data should be serializable"),
+                    ),
+                },
+            );
+            index.candidate_key_by_symbol.insert(symbol_id, key);
+            if function.body.is_some()
+                && let Some(location) =
+                    proto::span_to_location(gcx.sess.source_map(), function.body_span)
+            {
+                index.body_range_by_symbol.insert(symbol_id, location.range);
+            }
+        }
+
+        if gcx.has_typeck_results() {
+            collect_direct_calls(&mut index, gcx, item_symbols);
+        }
+        index
+    }
+
+    pub(crate) fn extend(&mut self, other: Self, symbol_offset: usize) {
+        self.items_by_symbol.extend(
+            other
+                .items_by_symbol
+                .into_iter()
+                .map(|(symbol, item)| (remap_symbol_id(symbol, symbol_offset), item)),
+        );
+        self.candidate_key_by_symbol.extend(
+            other
+                .candidate_key_by_symbol
+                .into_iter()
+                .map(|(symbol, key)| (remap_symbol_id(symbol, symbol_offset), key)),
+        );
+        self.body_range_by_symbol.extend(
+            other
+                .body_range_by_symbol
+                .into_iter()
+                .map(|(symbol, range)| (remap_symbol_id(symbol, symbol_offset), range)),
+        );
+        self.direct_calls.extend(other.direct_calls.into_iter().map(|call| DirectCall {
+            caller: remap_symbol_id(call.caller, symbol_offset),
+            callee: remap_symbol_id(call.callee, symbol_offset),
+            from_range: call.from_range,
+        }));
+        self.invalidate_query_indexes();
+    }
+
+    pub(crate) fn rebuild(&mut self, conflicting_contents: &FxHashSet<Url>) {
+        self.invalidate_query_indexes();
+
+        let mut outgoing_facts_by_symbol = FxHashMap::<SymbolId, Vec<_>>::default();
+        for call in &self.direct_calls {
+            let Some(callee) = self.candidate_key_by_symbol.get(&call.callee) else {
+                continue;
+            };
+            outgoing_facts_by_symbol
+                .entry(call.caller)
+                .or_default()
+                .push((callee.clone(), range_key(call.from_range)));
+        }
+        for facts in outgoing_facts_by_symbol.values_mut() {
+            facts.sort_unstable();
+            facts.dedup();
+        }
+
+        let mut incompatible_keys = FxHashSet::default();
+        for (&symbol, key) in &self.candidate_key_by_symbol {
+            if conflicting_contents.contains(&key.uri) || incompatible_keys.contains(key) {
+                continue;
+            }
+            if let Some(&existing) = self.canonical_symbol_by_key.get(key) {
+                let facts =
+                    outgoing_facts_by_symbol.get(&symbol).map(Vec::as_slice).unwrap_or_default();
+                let existing_facts =
+                    outgoing_facts_by_symbol.get(&existing).map(Vec::as_slice).unwrap_or_default();
+                if self.items_by_symbol.get(&symbol) != self.items_by_symbol.get(&existing)
+                    || self.body_range_by_symbol.get(&symbol)
+                        != self.body_range_by_symbol.get(&existing)
+                    || facts != existing_facts
+                {
+                    self.canonical_symbol_by_key.remove(key);
+                    incompatible_keys.insert(key.clone());
+                }
+            } else {
+                self.canonical_symbol_by_key.insert(key.clone(), symbol);
+            }
+        }
+        self.canonical_symbol_by_key.retain(|_, symbol| self.items_by_symbol.contains_key(symbol));
+        for (&symbol, key) in &self.candidate_key_by_symbol {
+            if self.items_by_symbol.contains_key(&symbol)
+                && self.canonical_symbol_by_key.contains_key(key)
+            {
+                self.key_by_symbol.insert(symbol, key.clone());
+            }
+        }
+
+        for call in &self.direct_calls {
+            let Some(caller) = self.key_by_symbol.get(&call.caller) else {
+                continue;
+            };
+            let Some(callee) = self.key_by_symbol.get(&call.callee) else {
+                self.incomplete_outgoing.insert(caller.clone());
+                continue;
+            };
+            self.outgoing_by_key
+                .entry(caller.clone())
+                .or_default()
+                .entry(callee.clone())
+                .or_default()
+                .push(call.from_range);
+            self.incoming_by_key
+                .entry(callee.clone())
+                .or_default()
+                .entry(caller.clone())
+                .or_default()
+                .push(call.from_range);
+            self.call_sites_by_uri
+                .entry(caller.uri.clone())
+                .or_default()
+                .push(CallSite { range: call.from_range, callee: callee.clone() });
+        }
+        normalize_relations(&mut self.outgoing_by_key);
+        normalize_relations(&mut self.incoming_by_key);
+        for sites in self.call_sites_by_uri.values_mut() {
+            sites.sort_by(|a, b| {
+                range_key(a.range).cmp(&range_key(b.range)).then_with(|| a.callee.cmp(&b.callee))
+            });
+            sites.dedup();
+        }
+
+        for (key, &symbol) in &self.canonical_symbol_by_key {
+            if let Some(&range) = self.body_range_by_symbol.get(&symbol) {
+                self.bodies_by_uri
+                    .entry(key.uri.clone())
+                    .or_default()
+                    .push(CallableBody { range, callable: key.clone() });
+            }
+        }
+        for bodies in self.bodies_by_uri.values_mut() {
+            bodies.sort_by(|a, b| {
+                range_key(a.range)
+                    .cmp(&range_key(b.range))
+                    .then_with(|| a.callable.cmp(&b.callable))
+            });
+            bodies.dedup();
+        }
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        uri: &Url,
+        position: Position,
+        declaration: Option<SymbolId>,
+    ) -> Option<Vec<CallHierarchyItem>> {
+        if let Some(key) = self.call_site_key(uri, position) {
+            return Some(vec![self.item(key)?.clone()]);
+        }
+        if let Some(key) = declaration.and_then(|symbol| self.key_by_symbol.get(&symbol)) {
+            return Some(vec![self.item(key)?.clone()]);
+        }
+        let key = self.enclosing_body_key(uri, position)?;
+        Some(vec![self.item(key)?.clone()])
+    }
+
+    pub(crate) fn incoming(
+        &self,
+        item: &CallHierarchyItem,
+    ) -> Option<Vec<CallHierarchyIncomingCall>> {
+        let key = self.resolve_item(item)?;
+        let mut callers = self.incoming_by_key.get(&key).into_iter().flatten().collect::<Vec<_>>();
+        callers.sort_by_key(|(caller, _)| *caller);
+        Some(
+            callers
+                .into_iter()
+                .filter_map(|(caller, ranges)| {
+                    Some(CallHierarchyIncomingCall {
+                        from: self.item(caller)?.clone(),
+                        from_ranges: ranges.clone(),
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    pub(crate) fn outgoing(
+        &self,
+        item: &CallHierarchyItem,
+    ) -> Option<Vec<CallHierarchyOutgoingCall>> {
+        let key = self.resolve_item(item)?;
+        if self.incomplete_outgoing.contains(&key) {
+            return None;
+        }
+        let mut callees = self.outgoing_by_key.get(&key).into_iter().flatten().collect::<Vec<_>>();
+        callees.sort_by_key(|(callee, _)| *callee);
+        Some(
+            callees
+                .into_iter()
+                .filter_map(|(callee, ranges)| {
+                    Some(CallHierarchyOutgoingCall {
+                        to: self.item(callee)?.clone(),
+                        from_ranges: ranges.clone(),
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    fn call_site_key(&self, uri: &Url, position: Position) -> Option<&CallableKey> {
+        self.call_sites_by_uri
+            .get(uri)?
+            .iter()
+            .filter(|site| range_contains(site.range, position))
+            .min_by_key(|site| (range_size_key(site.range), range_key(site.range)))
+            .map(|site| &site.callee)
+    }
+
+    fn enclosing_body_key(&self, uri: &Url, position: Position) -> Option<&CallableKey> {
+        self.bodies_by_uri
+            .get(uri)?
+            .iter()
+            .filter(|body| range_contains(body.range, position))
+            .min_by_key(|body| (range_size_key(body.range), range_key(body.range)))
+            .map(|body| &body.callable)
+    }
+
+    fn item(&self, key: &CallableKey) -> Option<&CallHierarchyItem> {
+        self.items_by_symbol.get(self.canonical_symbol_by_key.get(key)?)
+    }
+
+    fn resolve_item(&self, item: &CallHierarchyItem) -> Option<CallableKey> {
+        let data = CallHierarchyData::deserialize(item.data.as_ref()?).ok()?;
+        if data.version != DATA_VERSION {
+            return None;
+        }
+        let key = CallableKey { uri: data.uri, selection_range: data.selection_range };
+        let current = self.item(&key)?;
+        // Name and kind distinguish a declaration replacement at the same source position. The
+        // full range and detail are presentation data that may change while the callable remains.
+        (item.uri == current.uri
+            && item.selection_range == current.selection_range
+            && item.name == current.name
+            && item.kind == current.kind)
+            .then_some(key)
+    }
+
+    fn invalidate_query_indexes(&mut self) {
+        self.canonical_symbol_by_key.clear();
+        self.key_by_symbol.clear();
+        self.outgoing_by_key.clear();
+        self.incoming_by_key.clear();
+        self.incomplete_outgoing.clear();
+        self.call_sites_by_uri.clear();
+        self.bodies_by_uri.clear();
+    }
+}
+
+fn collect_direct_calls<'gcx>(
+    index: &mut CallHierarchyIndex,
+    gcx: Gcx<'gcx>,
+    item_symbols: &FxHashMap<ItemId, SymbolId>,
+) {
+    for caller_id in gcx.hir.function_ids() {
+        let function = gcx.hir.function(caller_id);
+        if !is_source_callable(function) {
+            continue;
+        }
+        let Some(&caller) = item_symbols.get(&ItemId::Function(caller_id)) else {
+            continue;
+        };
+
+        let mut collector = CallCollector { gcx, item_symbols, index, caller };
+        for modifier in function.modifiers {
+            let _ = collector.visit_modifier(modifier);
+        }
+        if let Some(body) = function.body {
+            for statement in body.stmts {
+                let _ = collector.visit_stmt(statement);
+            }
+        }
+    }
+}
+
+struct CallCollector<'a, 'gcx> {
+    gcx: Gcx<'gcx>,
+    item_symbols: &'a FxHashMap<ItemId, SymbolId>,
+    index: &'a mut CallHierarchyIndex,
+    caller: SymbolId,
+}
+
+impl<'gcx> Visit<'gcx> for CallCollector<'_, 'gcx> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'gcx hir::Hir<'gcx> {
+        &self.gcx.hir
+    }
+
+    fn visit_modifier(
+        &mut self,
+        modifier: &'gcx hir::Modifier<'gcx>,
+    ) -> ControlFlow<Self::BreakValue> {
+        if let ItemId::Function(callee) = modifier.id {
+            self.push_call(callee, modifier.name_span);
+        }
+        self.walk_modifier(modifier)
+    }
+
+    fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
+        if let Some((callee, span)) = resolved_source_call(self.gcx, expr) {
+            self.push_call(callee, span);
+        }
+        self.walk_expr(expr)
+    }
+
+    fn visit_stmt(&mut self, stmt: &'gcx hir::Stmt<'gcx>) -> ControlFlow<Self::BreakValue> {
+        if matches!(stmt.kind, hir::StmtKind::AssemblyBlock(_)) {
+            ControlFlow::Continue(())
+        } else {
+            self.walk_stmt(stmt)
+        }
+    }
+
+    fn visit_var(&mut self, variable: &'gcx hir::Variable<'gcx>) -> ControlFlow<Self::BreakValue> {
+        if let Some(initializer) = variable.initializer {
+            self.visit_expr(initializer)?;
+        }
+        ControlFlow::Continue(())
+    }
+}
+
+impl CallCollector<'_, '_> {
+    fn push_call(&mut self, callee_id: hir::FunctionId, span: Span) {
+        if !is_source_callable(self.gcx.hir.function(callee_id)) {
+            return;
+        }
+        let Some(&callee) = self.item_symbols.get(&ItemId::Function(callee_id)) else {
+            return;
+        };
+        let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), span) else {
+            return;
+        };
+        if self
+            .index
+            .candidate_key_by_symbol
+            .get(&self.caller)
+            .is_none_or(|key| key.uri != location.uri)
+        {
+            return;
+        }
+        self.index.direct_calls.push(DirectCall {
+            caller: self.caller,
+            callee,
+            from_range: location.range,
+        });
+    }
+}
+
+fn is_source_callable(function: &hir::Function<'_>) -> bool {
+    !function.is_yul && !function.is_getter()
+}
+
+fn resolved_source_call<'gcx>(
+    gcx: Gcx<'gcx>,
+    expr: &hir::Expr<'gcx>,
+) -> Option<(hir::FunctionId, Span)> {
+    let hir::ExprKind::Call(callee, ..) = expr.kind else {
+        return None;
+    };
+    let callee_id = gcx.resolved_call(expr)?.res.as_function()?;
+    let callee = callee.peel_parens();
+    let span = match callee.kind {
+        hir::ExprKind::Member(_, member) => member.span,
+        _ => callee.span,
+    };
+    Some((callee_id, span))
+}
+
+fn normalize_relations(relations: &mut CallRelations) {
+    for targets in relations.values_mut() {
+        for ranges in targets.values_mut() {
+            ranges.sort_by_key(|&range| range_key(range));
+            ranges.dedup();
+        }
+    }
+}
+
+fn range_contains(range: Range, position: Position) -> bool {
+    if range.start == range.end {
+        position == range.start
+    } else {
+        position >= range.start && position < range.end
+    }
+}
+
+fn range_size_key(range: Range) -> (u32, u32) {
+    (
+        range.end.line.saturating_sub(range.start.line),
+        range.end.character.saturating_sub(range.start.character),
+    )
+}
+
+fn range_key(range: Range) -> (u32, u32, u32, u32) {
+    (range.start.line, range.start.character, range.end.line, range.end.character)
+}

--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -21,17 +21,39 @@ use solar_sema::{
     hir::{self, ItemId, Visit},
     ty::TyKind,
 };
-use std::{cmp::Ordering, ops::ControlFlow};
+use std::{cmp::Ordering, ops::ControlFlow, sync::OnceLock};
 
 const DATA_VERSION: u8 = 1;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct CallHierarchyIndex {
+    facts: CallHierarchyFacts,
+    query: OnceLock<QueryIndex>,
+}
+
+impl Clone for CallHierarchyIndex {
+    fn clone(&self) -> Self {
+        Self { facts: self.facts.clone(), query: OnceLock::new() }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct CallHierarchyFacts {
+    callables: Vec<CallableFact>,
+    direct_calls: Vec<DirectCall>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CallableFact {
+    symbol: SymbolId,
+    body_range: Option<Range>,
+}
+
+#[derive(Debug, Default)]
+struct QueryIndex {
     items_by_symbol: FxHashMap<SymbolId, CallHierarchyItem>,
     candidate_key_by_symbol: FxHashMap<SymbolId, CallableKey>,
     body_range_by_symbol: FxHashMap<SymbolId, Range>,
-    direct_calls: Vec<DirectCall>,
-
     canonical_symbol_by_key: FxHashMap<CallableKey, SymbolId>,
     key_by_symbol: FxHashMap<SymbolId, CallableKey>,
     outgoing_by_key: CallRelations,
@@ -93,6 +115,11 @@ struct CallHierarchyData {
 }
 
 impl CallHierarchyIndex {
+    #[cfg(test)]
+    pub(crate) fn is_query_initialized(&self) -> bool {
+        self.query.get().is_some()
+    }
+
     pub(crate) fn build(
         gcx: Gcx<'_>,
         item_symbols: &FxHashMap<ItemId, SymbolId>,
@@ -107,7 +134,91 @@ impl CallHierarchyIndex {
             let Some(&symbol_id) = item_symbols.get(&ItemId::Function(function_id)) else {
                 continue;
             };
-            let declaration = &declarations[symbol_id];
+            let body_range = if function.body.is_some() {
+                proto::span_to_location(gcx.sess.source_map(), function.body_span)
+                    .map(|location| location.range)
+            } else {
+                None
+            };
+            index.facts.callables.push(CallableFact { symbol: symbol_id, body_range });
+        }
+
+        if gcx.has_typeck_results() {
+            collect_direct_calls(&mut index.facts, gcx, item_symbols, declarations);
+        }
+        index
+    }
+
+    pub(crate) fn extend(&mut self, other: Self, symbol_offset: usize) {
+        let Self { facts, query: _ } = other;
+        self.facts.callables.extend(facts.callables.into_iter().map(|fact| CallableFact {
+            symbol: remap_symbol_id(fact.symbol, symbol_offset),
+            body_range: fact.body_range,
+        }));
+        self.facts.direct_calls.extend(facts.direct_calls.into_iter().map(|call| DirectCall {
+            caller: remap_symbol_id(call.caller, symbol_offset),
+            callee: remap_symbol_id(call.callee, symbol_offset),
+            from_range: call.from_range,
+        }));
+        self.invalidate_query();
+    }
+
+    pub(crate) fn rebuild(&mut self) {
+        self.invalidate_query();
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+        conflicting_contents: &FxHashSet<Url>,
+        uri: &Url,
+        position: Position,
+        declaration: Option<SymbolId>,
+    ) -> Option<Vec<CallHierarchyItem>> {
+        self.query(declarations, conflicting_contents).prepare(uri, position, declaration)
+    }
+
+    pub(crate) fn incoming(
+        &self,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+        conflicting_contents: &FxHashSet<Url>,
+        item: &CallHierarchyItem,
+    ) -> Option<Vec<CallHierarchyIncomingCall>> {
+        self.query(declarations, conflicting_contents).incoming(item)
+    }
+
+    pub(crate) fn outgoing(
+        &self,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+        conflicting_contents: &FxHashSet<Url>,
+        item: &CallHierarchyItem,
+    ) -> Option<Vec<CallHierarchyOutgoingCall>> {
+        self.query(declarations, conflicting_contents).outgoing(item)
+    }
+
+    fn query(
+        &self,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+        conflicting_contents: &FxHashSet<Url>,
+    ) -> &QueryIndex {
+        self.query
+            .get_or_init(|| QueryIndex::build(&self.facts, declarations, conflicting_contents))
+    }
+
+    fn invalidate_query(&mut self) {
+        let _ = self.query.take();
+    }
+}
+
+impl QueryIndex {
+    fn build(
+        facts: &CallHierarchyFacts,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+        conflicting_contents: &FxHashSet<Url>,
+    ) -> Self {
+        let mut index = Self::default();
+        for fact in &facts.callables {
+            let declaration = &declarations[fact.symbol];
             let key = CallableKey {
                 uri: declaration.location.uri.clone(),
                 selection_range: declaration.name_range,
@@ -119,7 +230,7 @@ impl CallHierarchyIndex {
             };
             let detail = declaration.parent.map(|parent| declarations[parent].name.clone());
             index.items_by_symbol.insert(
-                symbol_id,
+                fact.symbol,
                 CallHierarchyItem {
                     name: declaration.name.clone(),
                     kind: declaration.kind,
@@ -134,53 +245,18 @@ impl CallHierarchyIndex {
                     ),
                 },
             );
-            index.candidate_key_by_symbol.insert(symbol_id, key);
-            if function.body.is_some()
-                && let Some(location) =
-                    proto::span_to_location(gcx.sess.source_map(), function.body_span)
-            {
-                index.body_range_by_symbol.insert(symbol_id, location.range);
+            index.candidate_key_by_symbol.insert(fact.symbol, key);
+            if let Some(range) = fact.body_range {
+                index.body_range_by_symbol.insert(fact.symbol, range);
             }
         }
-
-        if gcx.has_typeck_results() {
-            collect_direct_calls(&mut index, gcx, item_symbols);
-        }
+        index.rebuild(&facts.direct_calls, conflicting_contents);
         index
     }
 
-    pub(crate) fn extend(&mut self, other: Self, symbol_offset: usize) {
-        self.items_by_symbol.extend(
-            other
-                .items_by_symbol
-                .into_iter()
-                .map(|(symbol, item)| (remap_symbol_id(symbol, symbol_offset), item)),
-        );
-        self.candidate_key_by_symbol.extend(
-            other
-                .candidate_key_by_symbol
-                .into_iter()
-                .map(|(symbol, key)| (remap_symbol_id(symbol, symbol_offset), key)),
-        );
-        self.body_range_by_symbol.extend(
-            other
-                .body_range_by_symbol
-                .into_iter()
-                .map(|(symbol, range)| (remap_symbol_id(symbol, symbol_offset), range)),
-        );
-        self.direct_calls.extend(other.direct_calls.into_iter().map(|call| DirectCall {
-            caller: remap_symbol_id(call.caller, symbol_offset),
-            callee: remap_symbol_id(call.callee, symbol_offset),
-            from_range: call.from_range,
-        }));
-        self.invalidate_query_indexes();
-    }
-
-    pub(crate) fn rebuild(&mut self, conflicting_contents: &FxHashSet<Url>) {
-        self.invalidate_query_indexes();
-
+    fn rebuild(&mut self, direct_calls: &[DirectCall], conflicting_contents: &FxHashSet<Url>) {
         let mut outgoing_facts_by_symbol = FxHashMap::<SymbolId, Vec<_>>::default();
-        for call in &self.direct_calls {
+        for call in direct_calls {
             let Some(callee) = self.candidate_key_by_symbol.get(&call.callee) else {
                 continue;
             };
@@ -225,7 +301,7 @@ impl CallHierarchyIndex {
             }
         }
 
-        for call in &self.direct_calls {
+        for call in direct_calls {
             let caller = self.key_by_symbol.get(&call.caller);
             let callee = self.key_by_symbol.get(&call.callee);
             let (Some(caller), Some(callee)) = (caller, callee) else {
@@ -380,23 +456,13 @@ impl CallHierarchyIndex {
             && item.kind == current.kind)
             .then_some(key)
     }
-
-    fn invalidate_query_indexes(&mut self) {
-        self.canonical_symbol_by_key.clear();
-        self.key_by_symbol.clear();
-        self.outgoing_by_key.clear();
-        self.incoming_by_key.clear();
-        self.incomplete_outgoing.clear();
-        self.incomplete_incoming.clear();
-        self.call_sites_by_uri.clear();
-        self.bodies_by_uri.clear();
-    }
 }
 
 fn collect_direct_calls<'gcx>(
-    index: &mut CallHierarchyIndex,
+    facts: &mut CallHierarchyFacts,
     gcx: Gcx<'gcx>,
     item_symbols: &FxHashMap<ItemId, SymbolId>,
+    declarations: &IndexVec<SymbolId, DeclarationSymbol>,
 ) {
     for caller_id in gcx.hir.function_ids() {
         let function = gcx.hir.function(caller_id);
@@ -407,7 +473,16 @@ fn collect_direct_calls<'gcx>(
             continue;
         };
 
-        let mut collector = CallCollector { gcx, item_symbols, index, caller };
+        let mut collector = CallCollector { gcx, item_symbols, declarations, facts, caller };
+        if function.is_constructor()
+            && let Some(contract_id) = function.contract
+        {
+            for base in gcx.hir.contract(contract_id).bases_args {
+                if !base.args.is_dummy() {
+                    let _ = collector.visit_modifier(base);
+                }
+            }
+        }
         for modifier in function.modifiers {
             let _ = collector.visit_modifier(modifier);
         }
@@ -422,7 +497,8 @@ fn collect_direct_calls<'gcx>(
 struct CallCollector<'a, 'gcx> {
     gcx: Gcx<'gcx>,
     item_symbols: &'a FxHashMap<ItemId, SymbolId>,
-    index: &'a mut CallHierarchyIndex,
+    declarations: &'a IndexVec<SymbolId, DeclarationSymbol>,
+    facts: &'a mut CallHierarchyFacts,
     caller: SymbolId,
 }
 
@@ -482,15 +558,10 @@ impl CallCollector<'_, '_> {
         let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), span) else {
             return;
         };
-        if self
-            .index
-            .candidate_key_by_symbol
-            .get(&self.caller)
-            .is_none_or(|key| key.uri != location.uri)
-        {
+        if self.declarations[self.caller].location.uri != location.uri {
             return;
         }
-        self.index.direct_calls.push(DirectCall {
+        self.facts.direct_calls.push(DirectCall {
             caller: self.caller,
             callee,
             from_range: location.range,

--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -19,6 +19,7 @@ use solar_interface::{
 use solar_sema::{
     Gcx,
     hir::{self, ItemId, Visit},
+    ty::TyKind,
 };
 use std::{cmp::Ordering, ops::ControlFlow};
 
@@ -36,6 +37,7 @@ pub(crate) struct CallHierarchyIndex {
     outgoing_by_key: CallRelations,
     incoming_by_key: CallRelations,
     incomplete_outgoing: FxHashSet<CallableKey>,
+    incomplete_incoming: FxHashSet<CallableKey>,
     call_sites_by_uri: FxHashMap<Url, Vec<CallSite>>,
     bodies_by_uri: FxHashMap<Url, Vec<CallableBody>>,
 }
@@ -224,11 +226,15 @@ impl CallHierarchyIndex {
         }
 
         for call in &self.direct_calls {
-            let Some(caller) = self.key_by_symbol.get(&call.caller) else {
-                continue;
-            };
-            let Some(callee) = self.key_by_symbol.get(&call.callee) else {
-                self.incomplete_outgoing.insert(caller.clone());
+            let caller = self.key_by_symbol.get(&call.caller);
+            let callee = self.key_by_symbol.get(&call.callee);
+            let (Some(caller), Some(callee)) = (caller, callee) else {
+                if let Some(caller) = caller {
+                    self.incomplete_outgoing.insert(caller.clone());
+                }
+                if let Some(callee) = callee {
+                    self.incomplete_incoming.insert(callee.clone());
+                }
                 continue;
             };
             self.outgoing_by_key
@@ -296,6 +302,9 @@ impl CallHierarchyIndex {
         item: &CallHierarchyItem,
     ) -> Option<Vec<CallHierarchyIncomingCall>> {
         let key = self.resolve_item(item)?;
+        if self.incomplete_incoming.contains(&key) {
+            return None;
+        }
         let mut callers = self.incoming_by_key.get(&key).into_iter().flatten().collect::<Vec<_>>();
         callers.sort_by_key(|(caller, _)| *caller);
         Some(
@@ -378,6 +387,7 @@ impl CallHierarchyIndex {
         self.outgoing_by_key.clear();
         self.incoming_by_key.clear();
         self.incomplete_outgoing.clear();
+        self.incomplete_incoming.clear();
         self.call_sites_by_uri.clear();
         self.bodies_by_uri.clear();
     }
@@ -427,7 +437,12 @@ impl<'gcx> Visit<'gcx> for CallCollector<'_, 'gcx> {
         &mut self,
         modifier: &'gcx hir::Modifier<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
-        if let ItemId::Function(callee) = modifier.id {
+        let callee = match modifier.id {
+            ItemId::Function(callee) => Some(callee),
+            ItemId::Contract(contract) => self.gcx.hir.contract(contract).ctor,
+            _ => None,
+        };
+        if let Some(callee) = callee {
             self.push_call(callee, modifier.name_span);
         }
         self.walk_modifier(modifier)
@@ -494,8 +509,15 @@ fn resolved_source_call<'gcx>(
     let hir::ExprKind::Call(callee, ..) = expr.kind else {
         return None;
     };
-    let callee_id = gcx.resolved_call(expr)?.res.as_function()?;
     let callee = callee.peel_parens();
+    if let hir::ExprKind::New(ty) = &callee.kind
+        && let TyKind::Fn(function) = gcx.type_of_expr(callee.id)?.kind
+        && function.is_creation()
+        && let hir::TypeKind::Custom(ItemId::Contract(contract_id)) = ty.kind
+    {
+        return Some((gcx.hir.contract(contract_id).ctor?, ty.span));
+    }
+    let callee_id = gcx.resolved_call(expr)?.res.as_function()?;
     let span = match callee.kind {
         hir::ExprKind::Member(_, member) => member.span,
         _ => callee.span,

--- a/crates/lsp/src/call_hierarchy.rs
+++ b/crates/lsp/src/call_hierarchy.rs
@@ -28,7 +28,7 @@ const DATA_VERSION: u8 = 1;
 #[derive(Debug, Default)]
 pub(crate) struct CallHierarchyIndex {
     facts: CallHierarchyFacts,
-    query: OnceLock<QueryIndex>,
+    query: OnceLock<Box<QueryIndex>>,
 }
 
 impl Clone for CallHierarchyIndex {
@@ -201,8 +201,9 @@ impl CallHierarchyIndex {
         declarations: &IndexVec<SymbolId, DeclarationSymbol>,
         conflicting_contents: &FxHashSet<Url>,
     ) -> &QueryIndex {
-        self.query
-            .get_or_init(|| QueryIndex::build(&self.facts, declarations, conflicting_contents))
+        self.query.get_or_init(|| {
+            Box::new(QueryIndex::build(&self.facts, declarations, conflicting_contents))
+        })
     }
 
     fn invalidate_query(&mut self) {

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -5,11 +5,11 @@ use crate::{
     workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest},
 };
 use lsp_types::{
-    CompletionOptions, DeclarationCapability, DiagnosticOptions, DiagnosticServerCapabilities,
-    DocumentLinkOptions, ExecuteCommandOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, ImplementationProviderCapability, InitializeParams, OneOf,
-    RenameOptions, SaveOptions, SelectionRangeProviderCapability, ServerCapabilities,
-    SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
+    CallHierarchyServerCapability, CompletionOptions, DeclarationCapability, DiagnosticOptions,
+    DiagnosticServerCapabilities, DocumentLinkOptions, ExecuteCommandOptions,
+    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
+    InitializeParams, OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
+    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability,
     WorkDoneProgressOptions,
 };
@@ -307,6 +307,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             inlay_hint_provider: Some(OneOf::Left(true)),
             references_provider: Some(OneOf::Left(true)),
+            call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
             selection_range_provider: Some(SelectionRangeProviderCapability::Simple(true)),
             rename_provider: Some(OneOf::Right(RenameOptions {
                 prepare_provider: Some(true),
@@ -350,7 +351,7 @@ mod tests {
     use super::*;
     use crate::{test_support::TestProject, workspace::WorkspaceKind};
     use lsp_types::{
-        CompletionClientCapabilities, CompletionItemCapability,
+        CallHierarchyServerCapability, CompletionClientCapabilities, CompletionItemCapability,
         DidChangeWatchedFilesClientCapabilities, DocumentSymbolClientCapabilities, MarkupKind,
         OneOf, ParameterInformationSettings, RenameOptions, SignatureHelpClientCapabilities,
         SignatureInformationSettings, TextDocumentClientCapabilities, TextDocumentSyncCapability,
@@ -445,6 +446,10 @@ mod tests {
         assert_eq!(capabilities.inlay_hint_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.document_highlight_provider, Some(OneOf::Left(true)));
         assert_eq!(capabilities.references_provider, Some(OneOf::Left(true)));
+        assert_eq!(
+            capabilities.call_hierarchy_provider,
+            Some(CallHierarchyServerCapability::Simple(true))
+        );
         assert_eq!(
             capabilities.selection_range_provider,
             Some(SelectionRangeProviderCapability::Simple(true))

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -9,6 +9,8 @@ use crate::{
 use async_lsp::{ErrorCode, ResponseError};
 use crop::Rope;
 use lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
+    CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     CompletionParams, CompletionResponse, DocumentChanges, DocumentDiagnosticParams,
     DocumentDiagnosticReport, DocumentDiagnosticReportResult, DocumentFormattingParams,
     DocumentHighlight, DocumentHighlightParams, DocumentLink, DocumentLinkParams,
@@ -369,6 +371,49 @@ pub(crate) fn goto_implementation(
         let symbol_tables = latest_analysis.await?;
         let response =
             symbol_tables.read().goto_implementation(&params.text_document.uri, params.position);
+        Ok(response)
+    }
+}
+
+pub(crate) fn prepare_call_hierarchy(
+    state: &mut GlobalState,
+    params: CallHierarchyPrepareParams,
+) -> impl Future<Output = Result<Option<Vec<CallHierarchyItem>>, ResponseError>> + use<> {
+    let params = params.text_document_position_params;
+    let latest_analysis = latest_analysis_for_uri(state, &params.text_document.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response =
+            symbol_tables.read().prepare_call_hierarchy(&params.text_document.uri, params.position);
+        Ok(response)
+    }
+}
+
+pub(crate) fn call_hierarchy_incoming(
+    state: &mut GlobalState,
+    params: CallHierarchyIncomingCallsParams,
+) -> impl Future<Output = Result<Option<Vec<CallHierarchyIncomingCall>>, ResponseError>> + use<> {
+    let item = params.item;
+    let latest_analysis = latest_analysis_for_uri(state, &item.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response = symbol_tables.read().call_hierarchy_incoming(&item);
+        Ok(response)
+    }
+}
+
+pub(crate) fn call_hierarchy_outgoing(
+    state: &mut GlobalState,
+    params: CallHierarchyOutgoingCallsParams,
+) -> impl Future<Output = Result<Option<Vec<CallHierarchyOutgoingCall>>, ResponseError>> + use<> {
+    let item = params.item;
+    let latest_analysis = latest_analysis_for_uri(state, &item.uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(None) };
+        let symbol_tables = latest_analysis.await?;
+        let response = symbol_tables.read().call_hierarchy_outgoing(&item);
         Ok(response)
     }
 }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -18,6 +18,7 @@ use solar_config::LspArgs;
 use std::ops::ControlFlow;
 use tower::ServiceBuilder;
 
+mod call_hierarchy;
 mod commands;
 mod config;
 mod diagnostics;
@@ -94,6 +95,9 @@ fn new_router_with_state(this: GlobalState) -> Router<GlobalState> {
         .request::<req::GotoDeclaration, _>(handlers::goto_declaration)
         .request::<req::GotoImplementation, _>(handlers::goto_implementation)
         .request::<req::References, _>(handlers::references)
+        .request::<req::CallHierarchyPrepare, _>(handlers::prepare_call_hierarchy)
+        .request::<req::CallHierarchyIncomingCalls, _>(handlers::call_hierarchy_incoming)
+        .request::<req::CallHierarchyOutgoingCalls, _>(handlers::call_hierarchy_outgoing)
         .request::<req::DocumentHighlightRequest, _>(handlers::document_highlight)
         .request::<req::HoverRequest, _>(handlers::hover)
         .request::<req::PrepareRenameRequest, _>(handlers::prepare_rename)
@@ -165,13 +169,14 @@ mod tests {
         router::Router,
     };
     use lsp_types::{
-        CancelParams, CompletionParams, CompletionResponse,
+        CallHierarchyIncomingCallsParams, CallHierarchyItem, CallHierarchyOutgoingCallsParams,
+        CallHierarchyPrepareParams, CancelParams, CompletionParams, CompletionResponse,
         DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesParams,
         DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlightParams,
         DocumentLinkParams, DocumentSymbolParams, ExecuteCommandParams, FileChangeType, FileEvent,
         FoldingRangeParams, FormattingOptions, HoverParams, InitializeParams, InitializedParams,
         NumberOrString, PartialResultParams, Position, ProgressParams, ProgressParamsValue,
-        PublishDiagnosticsParams, SelectionRangeParams, SignatureHelpParams,
+        PublishDiagnosticsParams, Range, SelectionRangeParams, SignatureHelpParams, SymbolKind,
         TextDocumentIdentifier, TextDocumentPositionParams, TextDocumentSaveReason,
         WillSaveTextDocumentParams, WindowClientCapabilities, WorkDoneProgress,
         WorkDoneProgressCancelParams, WorkDoneProgressCreateParams, WorkDoneProgressParams,
@@ -515,6 +520,60 @@ mod tests {
         let response = router.call(request).await.unwrap();
 
         assert_eq!(response, serde_json::Value::Null);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_call_hierarchy_requests() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let uri = lsp_types::Url::parse("file:///workspace/src/Test.sol").unwrap();
+        let range = Range::new(Position::new(0, 0), Position::new(0, 1));
+        let item = CallHierarchyItem {
+            name: "f".into(),
+            kind: SymbolKind::FUNCTION,
+            tags: None,
+            detail: None,
+            uri: uri.clone(),
+            range,
+            selection_range: range,
+            data: None,
+        };
+        let requests = [
+            serde_json::json!({
+                "id": 1,
+                "method": request::CallHierarchyPrepare::METHOD,
+                "params": CallHierarchyPrepareParams {
+                    text_document_position_params: TextDocumentPositionParams {
+                        text_document: TextDocumentIdentifier { uri },
+                        position: Position::new(0, 0),
+                    },
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                },
+            }),
+            serde_json::json!({
+                "id": 2,
+                "method": request::CallHierarchyIncomingCalls::METHOD,
+                "params": CallHierarchyIncomingCallsParams {
+                    item: item.clone(),
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                },
+            }),
+            serde_json::json!({
+                "id": 3,
+                "method": request::CallHierarchyOutgoingCalls::METHOD,
+                "params": CallHierarchyOutgoingCallsParams {
+                    item,
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                },
+            }),
+        ];
+
+        for request in requests {
+            let request = serde_json::from_value::<AnyRequest>(request).unwrap();
+            let response = router.call(request).await.unwrap();
+            assert_eq!(response, serde_json::Value::Null);
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -29,6 +29,7 @@ use std::{
 };
 
 use crate::{
+    call_hierarchy::CallHierarchyIndex,
     document_links::DocumentLinkIndex,
     inlay_hints::InlayHintIndex,
     natspec_completion::{DeclarationKey, NatSpecCompletionIndex, NatSpecTargetSemantics},
@@ -64,6 +65,7 @@ pub(crate) struct SymbolTables {
     inlay_hints: InlayHintIndex,
     natspec_completion: NatSpecCompletionIndex,
     signature_help: SignatureHelpIndex,
+    call_hierarchy: CallHierarchyIndex,
 }
 
 newtype_index! {
@@ -274,6 +276,7 @@ impl SymbolTables {
         }
 
         tables.build_type_definitions(gcx, &item_symbols);
+        tables.call_hierarchy = CallHierarchyIndex::build(gcx, &item_symbols, &tables.declarations);
 
         // Public state-variable getters are compiler-generated functions, but source member calls
         // such as `this.value()` still name the state variable. Point getter resolutions back to
@@ -325,6 +328,7 @@ impl SymbolTables {
         self.signature_help.extend(other.signature_help);
 
         let symbol_offset = self.declarations.len();
+        self.call_hierarchy.extend(other.call_hierarchy, symbol_offset);
         self.override_families.extend(other.override_families, symbol_offset);
         let scope_offset = self.scopes.len();
         for declaration in &mut other.declarations {
@@ -598,6 +602,28 @@ impl SymbolTables {
         sort_locations(&mut locations);
         locations.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
         Some(locations)
+    }
+
+    pub(crate) fn prepare_call_hierarchy(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Vec<lsp_types::CallHierarchyItem>> {
+        self.call_hierarchy.prepare(uri, position, self.declaration_at_position(uri, position))
+    }
+
+    pub(crate) fn call_hierarchy_incoming(
+        &self,
+        item: &lsp_types::CallHierarchyItem,
+    ) -> Option<Vec<lsp_types::CallHierarchyIncomingCall>> {
+        self.call_hierarchy.incoming(item)
+    }
+
+    pub(crate) fn call_hierarchy_outgoing(
+        &self,
+        item: &lsp_types::CallHierarchyItem,
+    ) -> Option<Vec<lsp_types::CallHierarchyOutgoingCall>> {
+        self.call_hierarchy.outgoing(item)
     }
 
     pub(crate) fn document_highlights(
@@ -1215,10 +1241,11 @@ impl SymbolTables {
         }
         self.override_families.rebuild(&self.declarations, self.rename.conflicting_contents());
         self.rename.rebuild(&self.override_families);
+        self.call_hierarchy.rebuild(self.rename.conflicting_contents());
     }
 }
 
-fn remap_symbol_id(symbol_id: SymbolId, offset: usize) -> SymbolId {
+pub(crate) fn remap_symbol_id(symbol_id: SymbolId, offset: usize) -> SymbolId {
     SymbolId::from_usize(symbol_id.index() + offset)
 }
 

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -609,21 +609,32 @@ impl SymbolTables {
         uri: &Url,
         position: Position,
     ) -> Option<Vec<lsp_types::CallHierarchyItem>> {
-        self.call_hierarchy.prepare(uri, position, self.declaration_at_position(uri, position))
+        self.call_hierarchy.prepare(
+            &self.declarations,
+            self.rename.conflicting_contents(),
+            uri,
+            position,
+            self.declaration_at_position(uri, position),
+        )
     }
 
     pub(crate) fn call_hierarchy_incoming(
         &self,
         item: &lsp_types::CallHierarchyItem,
     ) -> Option<Vec<lsp_types::CallHierarchyIncomingCall>> {
-        self.call_hierarchy.incoming(item)
+        self.call_hierarchy.incoming(&self.declarations, self.rename.conflicting_contents(), item)
     }
 
     pub(crate) fn call_hierarchy_outgoing(
         &self,
         item: &lsp_types::CallHierarchyItem,
     ) -> Option<Vec<lsp_types::CallHierarchyOutgoingCall>> {
-        self.call_hierarchy.outgoing(item)
+        self.call_hierarchy.outgoing(&self.declarations, self.rename.conflicting_contents(), item)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn call_hierarchy_is_initialized(&self) -> bool {
+        self.call_hierarchy.is_query_initialized()
     }
 
     pub(crate) fn document_highlights(
@@ -1241,7 +1252,7 @@ impl SymbolTables {
         }
         self.override_families.rebuild(&self.declarations, self.rename.conflicting_contents());
         self.rename.rebuild(&self.override_families);
-        self.call_hierarchy.rebuild(self.rename.conflicting_contents());
+        self.call_hierarchy.rebuild();
     }
 }
 

--- a/crates/lsp/src/tests/call_hierarchy.rs
+++ b/crates/lsp/src/tests/call_hierarchy.rs
@@ -381,11 +381,99 @@ fn resolves_parenthesized_direct_calls() {
 }
 
 #[test]
+fn indexes_contract_creation_calls() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Creation.sol
+        contract Target {
+            $1constructor(uint256 value) {}
+        }
+
+        contract C {
+            function $2deploy() external {
+                new $3Target(1);
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Creation.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Creation.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let constructor =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let deploy =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$3").position()),
+        Some(vec![constructor.clone()])
+    );
+    let outgoing = tables.call_hierarchy_outgoing(&deploy).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, constructor);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 6)]);
+    let incoming = tables.call_hierarchy_incoming(&outgoing[0].to).unwrap();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].from, deploy);
+    assert_eq!(incoming[0].from_ranges, outgoing[0].from_ranges);
+}
+
+#[test]
+fn indexes_base_constructor_invocations() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Inheritance.sol
+        contract Base {
+            $1constructor(uint256 value) {}
+        }
+
+        contract Derived is Base {
+            $2constructor() $3Base(1) {}
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Inheritance.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Inheritance.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let base =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let derived =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$3").position()),
+        Some(vec![base.clone()])
+    );
+    let outgoing = tables.call_hierarchy_outgoing(&derived).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, base);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 4)]);
+    let incoming = tables.call_hierarchy_incoming(&outgoing[0].to).unwrap();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].from, derived);
+    assert_eq!(incoming[0].from_ranges, outgoing[0].from_ranges);
+}
+
+#[test]
 fn excludes_non_direct_and_non_source_calls() {
     let marked = MarkedProject::from_fixture(
         r#"
         //- /Excluded.sol
         contract Created {}
+
+        abstract contract AbstractCreated {
+            constructor() {}
+        }
 
         contract C {
             uint256 public value;
@@ -401,6 +489,7 @@ fn excludes_non_direct_and_non_source_calls() {
                 address(this).call("");
                 this.value();
                 new Created();
+                new AbstractCreated();
                 emit Called();
                 $3target();
                 assembly {
@@ -676,6 +765,65 @@ fn isolates_identical_callers_with_conflicting_outgoing_facts() {
 
     assert_eq!(tables.prepare_call_hierarchy(&caller_uri, marked.marker("$1").position()), None);
     assert_eq!(tables.call_hierarchy_outgoing(&caller), None);
+}
+
+#[test]
+fn rejects_partial_incoming_results_for_conflicting_callers() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Target.sol
+        library Target {
+            function $1target() internal pure {}
+        }
+        //- /Caller.sol
+        import {Target} from "./Target.sol";
+
+        contract C {
+            function $2caller() external {
+                Target.target();
+            }
+        }
+        //- /RootA.sol
+        import "./Caller.sol";
+        //- /RootB.sol
+        import "./Caller.sol";
+        "#,
+    );
+    let project = marked.project();
+    let caller_contents = project.read_file("/Caller.sol");
+    let mut tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/RootA.sol"), project.read_file("/RootA.sol"))],
+    ))
+    .symbol_tables;
+    let target_uri = Url::from_file_path(project.path("/Target.sol")).unwrap();
+    let target = tables
+        .prepare_call_hierarchy(&target_uri, marked.marker("$1").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    let caller_uri = Url::from_file_path(project.path("/Caller.sol")).unwrap();
+    let caller = tables
+        .prepare_call_hierarchy(&caller_uri, marked.marker("$2").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    let changed_caller = caller_contents.replace(
+        "        Target.target();",
+        "        uint256 value = 1;\n        Target.target();",
+    );
+    project.write_file("/Caller.sol", &changed_caller);
+    let conflicting = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/RootB.sol"), project.read_file("/RootB.sol"))],
+    ))
+    .symbol_tables;
+
+    tables.extend(conflicting);
+
+    assert_eq!(tables.prepare_call_hierarchy(&caller_uri, marked.marker("$2").position()), None);
+    assert_eq!(tables.call_hierarchy_outgoing(&caller), None);
+    assert_eq!(tables.call_hierarchy_incoming(&target), None);
 }
 
 #[test]

--- a/crates/lsp/src/tests/call_hierarchy.rs
+++ b/crates/lsp/src/tests/call_hierarchy.rs
@@ -465,6 +465,52 @@ fn indexes_base_constructor_invocations() {
 }
 
 #[test]
+fn indexes_inheritance_list_constructor_invocations_and_arguments() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /InheritanceList.sol
+        function $1argument() pure returns (uint256) { return 1; }
+
+        contract Base {
+            $2constructor(uint256 value) {}
+        }
+
+        contract Derived is $4Base($5argument()) {
+            $3constructor() {}
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/InheritanceList.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/InheritanceList.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let item = |marker: &str| {
+        tables
+            .prepare_call_hierarchy(&uri, marked.marker(marker).position())
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    };
+    let argument = item("$1");
+    let base = item("$2");
+    let derived = item("$3");
+
+    assert_eq!(item("$4"), base);
+    assert_eq!(item("$5"), argument);
+    let outgoing = tables.call_hierarchy_outgoing(&derived).unwrap();
+    assert_eq!(outgoing.len(), 2);
+    let base_call = outgoing.iter().find(|call| call.to == base).unwrap();
+    assert_eq!(base_call.from_ranges, [marker_range(&marked, "$4", 4)]);
+    let argument_call = outgoing.iter().find(|call| call.to == argument).unwrap();
+    assert_eq!(argument_call.from_ranges, [marker_range(&marked, "$5", 8)]);
+}
+
+#[test]
 fn excludes_non_direct_and_non_source_calls() {
     let marked = MarkedProject::from_fixture(
         r#"
@@ -569,18 +615,24 @@ fn merges_identical_analysis_contexts_without_duplicate_edges() {
         [(path.clone(), contents.clone())],
     ))
     .symbol_tables;
+    assert!(!tables.call_hierarchy_is_initialized());
     let uri = Url::from_file_path(&path).unwrap();
     let caller =
         tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+    assert!(tables.call_hierarchy_is_initialized());
+    assert!(!tables.clone().call_hierarchy_is_initialized());
     let duplicate = analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, contents)]))
         .symbol_tables;
+    assert!(!duplicate.call_hierarchy_is_initialized());
 
     tables.extend(duplicate);
+    assert!(!tables.call_hierarchy_is_initialized());
 
     assert_eq!(
         tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()),
         Some(vec![caller.clone()])
     );
+    assert!(tables.call_hierarchy_is_initialized());
     let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
     assert_eq!(outgoing.len(), 1);
     assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 6)]);

--- a/crates/lsp/src/tests/call_hierarchy.rs
+++ b/crates/lsp/src/tests/call_hierarchy.rs
@@ -1,0 +1,739 @@
+use super::{AnalysisBatch, analyze};
+use crate::test_support::MarkedProject;
+use lsp_types::{Position, Range, Url};
+use solar_config::CompileOpts;
+
+#[test]
+fn basic_direct_call_hierarchy() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Calls.sol
+        contract C {
+            function $1callee() internal {}
+            function $2caller() external {
+                $3callee();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Calls.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Calls.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+
+    let callee =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$3").position()),
+        Some(vec![callee.clone()])
+    );
+
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, callee);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 6)]);
+
+    let incoming = tables.call_hierarchy_incoming(&outgoing[0].to).unwrap();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].from, caller);
+    assert_eq!(incoming[0].from_ranges, outgoing[0].from_ranges);
+}
+
+#[test]
+fn prepares_enclosing_callable_bodies_only() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Prepare.sol
+        $5contract C {
+            modifier $1guarded() {
+                $2_;
+            }
+
+            function $3f() external {
+                uint256 $4value = 1;
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Prepare.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Prepare.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+
+    let modifier =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let function =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$3").position()).unwrap().pop().unwrap();
+
+    assert_eq!(modifier.name, "guarded");
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()),
+        Some(vec![modifier])
+    );
+    assert_eq!(function.name, "f");
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$4").position()),
+        Some(vec![function])
+    );
+    assert_eq!(tables.prepare_call_hierarchy(&uri, marked.marker("$5").position()), None);
+}
+
+#[test]
+fn groups_repeated_calls_and_preserves_recursion() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Repeated.sol
+        contract C {
+            function $1callee() internal {}
+            function $2caller() external {
+                $3callee();
+                $4callee();
+                $5caller();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Repeated.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Repeated.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let callee =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    let repeated = outgoing.iter().find(|call| call.to == callee).unwrap();
+    assert_eq!(
+        repeated.from_ranges,
+        [marker_range(&marked, "$3", 6), marker_range(&marked, "$4", 6)]
+    );
+    let recursive = outgoing.iter().find(|call| call.to == caller).unwrap();
+    assert_eq!(recursive.from_ranges, [marker_range(&marked, "$5", 6)]);
+
+    let incoming = tables.call_hierarchy_incoming(&callee).unwrap();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].from, caller);
+    assert_eq!(incoming[0].from_ranges, repeated.from_ranges);
+}
+
+#[test]
+fn indexes_modifier_applications_and_arguments() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Modifiers.sol
+        contract C {
+            function $1argument() internal pure returns (uint256) { return 1; }
+            modifier $2guarded(uint256) { _; }
+
+            function $3caller() external $4guarded($5argument()) {}
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Modifiers.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Modifiers.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let argument =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let modifier =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$3").position()).unwrap().pop().unwrap();
+
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$4").position()),
+        Some(vec![modifier.clone()])
+    );
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    let modifier_call = outgoing.iter().find(|call| call.to == modifier).unwrap();
+    assert_eq!(modifier_call.from_ranges, [marker_range(&marked, "$4", 7)]);
+    let argument_call = outgoing.iter().find(|call| call.to == argument).unwrap();
+    assert_eq!(argument_call.from_ranges, [marker_range(&marked, "$5", 8)]);
+}
+
+#[test]
+fn uses_exact_qualified_modifier_name_range() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /QualifiedModifier.sol
+        contract Base {
+            modifier $1guarded() { _; }
+        }
+
+        contract C is Base {
+            function $2caller() external Base.$3guarded /* gap */ () {}
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/QualifiedModifier.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/QualifiedModifier.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let modifier =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$3").position()),
+        Some(vec![modifier.clone()])
+    );
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, modifier);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 7)]);
+}
+
+#[test]
+fn preserves_cross_file_call_identity() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Lib.sol
+        library Lib {
+            function $1target(uint256) internal pure {}
+        }
+        //- /Caller.sol
+        import "./Lib.sol";
+
+        contract C {
+            function $2caller() external {
+                Lib.$3target(1);
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let lib_path = project.path("/Lib.sol");
+    let caller_path = project.path("/Caller.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [
+            (lib_path.clone(), project.read_file("/Lib.sol")),
+            (caller_path.clone(), project.read_file("/Caller.sol")),
+        ],
+    ))
+    .symbol_tables;
+    let lib_uri = Url::from_file_path(lib_path).unwrap();
+    let caller_uri = Url::from_file_path(caller_path).unwrap();
+    let target = tables
+        .prepare_call_hierarchy(&lib_uri, marked.marker("$1").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    let caller = tables
+        .prepare_call_hierarchy(&caller_uri, marked.marker("$2").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, target);
+    assert_eq!(outgoing[0].to.uri, lib_uri);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 6)]);
+    let incoming = tables.call_hierarchy_incoming(&outgoing[0].to).unwrap();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].from, caller);
+    assert_eq!(incoming[0].from.uri, caller_uri);
+}
+
+#[test]
+fn uses_typed_targets_for_call_sites() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Typed.sol
+        library Lib {
+            function $1attached(uint256) internal pure {}
+        }
+
+        contract Base {
+            function $2inherited(uint256) internal virtual {}
+        }
+
+        contract C is Base {
+            using Lib for uint256;
+
+            function $3overloaded(uint256) internal {}
+            function $4overloaded(address) internal {}
+            function $5inherited(uint256) internal override {}
+            function $6externalCall() external {}
+
+            function $7caller(uint256 value) external {
+                $8overloaded(value);
+                $9overloaded(address(this));
+                value.$10attached();
+                this.$11externalCall();
+                super.$12inherited(value);
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Typed.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Typed.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let item = |marker: &str| {
+        tables
+            .prepare_call_hierarchy(&uri, marked.marker(marker).position())
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    };
+    let attached = item("$1");
+    let base_inherited = item("$2");
+    let integer_overload = item("$3");
+    let address_overload = item("$4");
+    let override_inherited = item("$5");
+    let external_call = item("$6");
+    let caller = item("$7");
+
+    assert_eq!(item("$8"), integer_overload);
+    assert_eq!(item("$9"), address_overload);
+    assert_eq!(item("$10"), attached);
+    assert_eq!(item("$11"), external_call);
+    assert_eq!(item("$12"), base_inherited);
+    assert_ne!(item("$12"), override_inherited);
+
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 5);
+    assert!(outgoing.iter().any(|call| call.to == integer_overload));
+    assert!(outgoing.iter().any(|call| call.to == address_overload));
+    assert!(outgoing.iter().any(|call| call.to == attached));
+    assert!(outgoing.iter().any(|call| call.to == external_call));
+    assert!(outgoing.iter().any(|call| call.to == base_inherited));
+    assert!(!outgoing.iter().any(|call| call.to == override_inherited));
+}
+
+#[test]
+fn resolves_parenthesized_direct_calls() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Parenthesized.sol
+        contract Base {
+            function $1inherited() internal virtual {}
+        }
+
+        contract C is Base {
+            function $2direct() internal {}
+            function inherited() internal override {}
+
+            function $3caller() external {
+                ($4direct)();
+                ((super).$5inherited)();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Parenthesized.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Parenthesized.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let item = |marker: &str| {
+        tables
+            .prepare_call_hierarchy(&uri, marked.marker(marker).position())
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    };
+    let inherited = item("$1");
+    let direct = item("$2");
+    let caller = item("$3");
+
+    assert_eq!(item("$4"), direct);
+    assert_eq!(item("$5"), inherited);
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 2);
+    assert!(outgoing.iter().any(|call| call.to == direct));
+    assert!(outgoing.iter().any(|call| call.to == inherited));
+}
+
+#[test]
+fn excludes_non_direct_and_non_source_calls() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Excluded.sol
+        contract Created {}
+
+        contract C {
+            uint256 public value;
+            event Called();
+            error Failed();
+
+            function $1target() internal {}
+
+            function $2caller() external {
+                function() internal pointer = target;
+                pointer();
+                require(true);
+                address(this).call("");
+                this.value();
+                new Created();
+                emit Called();
+                $3target();
+                assembly {
+                    function yulTarget() {}
+                    yulTarget()
+                }
+                revert Failed();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Excluded.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Excluded.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let target =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, target);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 6)]);
+}
+
+#[test]
+fn excludes_calls_without_typed_resolution() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Unresolved.sol
+        contract C {
+            function target() internal pure returns (uint256) { return 1; }
+
+            function $1caller() external {
+                require(true, target(), "extra");
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Unresolved.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), project.read_file("/Unresolved.sol"))],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(path).unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+
+    assert_eq!(tables.call_hierarchy_outgoing(&caller), Some(Vec::new()));
+}
+
+#[test]
+fn merges_identical_analysis_contexts_without_duplicate_edges() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Merged.sol
+        contract C {
+            function $1callee() internal {}
+            function $2caller() external {
+                $3callee();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Merged.sol");
+    let contents = project.read_file("/Merged.sol");
+    let mut tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), contents.clone())],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(&path).unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()).unwrap().pop().unwrap();
+    let duplicate = analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, contents)]))
+        .symbol_tables;
+
+    tables.extend(duplicate);
+
+    assert_eq!(
+        tables.prepare_call_hierarchy(&uri, marked.marker("$2").position()),
+        Some(vec![caller.clone()])
+    );
+    let outgoing = tables.call_hierarchy_outgoing(&caller).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].from_ranges, [marker_range(&marked, "$3", 6)]);
+    let incoming = tables.call_hierarchy_incoming(&outgoing[0].to).unwrap();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].from, caller);
+}
+
+#[test]
+fn stable_items_follow_body_only_reanalysis() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Fresh.sol
+        contract C {
+            function $1calleeA() internal {}
+            function $2calleeB() internal {}
+            function $3caller() external {
+                calleeA();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Fresh.sol");
+    let old_contents = project.read_file("/Fresh.sol");
+    let old_tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), old_contents.clone())],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(&path).unwrap();
+    let old_caller = old_tables
+        .prepare_call_hierarchy(&uri, marked.marker("$3").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let new_contents = old_contents
+        .replace("        calleeA();", "        uint256 value = 1;\n        calleeB();");
+    let new_tables =
+        analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, new_contents)]))
+            .symbol_tables;
+    let new_caller = new_tables
+        .prepare_call_hierarchy(&uri, marked.marker("$3").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    let new_callee = new_tables
+        .prepare_call_hierarchy(&uri, marked.marker("$2").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    assert_eq!(old_caller.selection_range, new_caller.selection_range);
+    assert_ne!(old_caller.range, new_caller.range);
+    let outgoing = new_tables.call_hierarchy_outgoing(&old_caller).unwrap();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(outgoing[0].to, new_callee);
+}
+
+#[test]
+fn rejects_invalid_or_moved_items() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Stale.sol
+        contract C {
+            function callee() internal {}
+            function $1caller() external {
+                callee();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Stale.sol");
+    let contents = project.read_file("/Stale.sol");
+    let tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), contents.clone())],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(&path).unwrap();
+    let item =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+
+    let mut missing_data = item.clone();
+    missing_data.data = None;
+    assert_eq!(tables.call_hierarchy_outgoing(&missing_data), None);
+    let mut malformed_data = item.clone();
+    malformed_data.data = Some(serde_json::json!({ "version": "invalid" }));
+    assert_eq!(tables.call_hierarchy_outgoing(&malformed_data), None);
+    let mut renamed = item.clone();
+    renamed.name = "other".into();
+    assert_eq!(tables.call_hierarchy_outgoing(&renamed), None);
+
+    let moved_contents = contents.replace("    function caller", "\n    function caller");
+    let moved_tables =
+        analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, moved_contents)]))
+            .symbol_tables;
+    assert_eq!(moved_tables.call_hierarchy_outgoing(&item), None);
+}
+
+#[test]
+fn isolates_conflicting_source_snapshots() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Conflict.sol
+        contract C {
+            function callee() internal {}
+            function $1caller() external {
+                callee();
+            }
+        }
+        "#,
+    );
+    let project = marked.project();
+    let path = project.path("/Conflict.sol");
+    let contents = project.read_file("/Conflict.sol");
+    let mut tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(path.clone(), contents.clone())],
+    ))
+    .symbol_tables;
+    let uri = Url::from_file_path(&path).unwrap();
+    let caller =
+        tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()).unwrap().pop().unwrap();
+    let conflicting_contents = contents.replace("        callee();", "        uint256 value = 1;");
+    let conflicting =
+        analyze(AnalysisBatch::from_files(CompileOpts::default(), [(path, conflicting_contents)]))
+            .symbol_tables;
+
+    tables.extend(conflicting);
+
+    assert_eq!(tables.prepare_call_hierarchy(&uri, marked.marker("$1").position()), None);
+    assert_eq!(tables.call_hierarchy_outgoing(&caller), None);
+}
+
+#[test]
+fn isolates_identical_callers_with_conflicting_outgoing_facts() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Target.sol
+        library Target {
+            function target() internal pure {}
+        }
+        //- /Caller.sol
+        import {Target} from "./Target.sol";
+
+        contract C {
+            function $1caller() external {
+                Target.target();
+            }
+        }
+        //- /RootA.sol
+        import "./Caller.sol";
+        //- /RootB.sol
+        import "./Caller.sol";
+        "#,
+    );
+    let project = marked.project();
+    let target_contents = project.read_file("/Target.sol");
+    let mut tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/RootA.sol"), project.read_file("/RootA.sol"))],
+    ))
+    .symbol_tables;
+    let caller_uri = Url::from_file_path(project.path("/Caller.sol")).unwrap();
+    let caller = tables
+        .prepare_call_hierarchy(&caller_uri, marked.marker("$1").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    let moved_target = target_contents.replace("    function target()", "\n    function target()");
+    project.write_file("/Target.sol", &moved_target);
+    let conflicting = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/RootB.sol"), project.read_file("/RootB.sol"))],
+    ))
+    .symbol_tables;
+
+    tables.extend(conflicting);
+
+    assert_eq!(tables.prepare_call_hierarchy(&caller_uri, marked.marker("$1").position()), None);
+    assert_eq!(tables.call_hierarchy_outgoing(&caller), None);
+}
+
+#[test]
+fn rejects_partial_outgoing_results_for_conflicting_callees() {
+    let marked = MarkedProject::from_fixture(
+        r#"
+        //- /Target.sol
+        library Target {
+            function target() internal pure {}
+        }
+        //- /Caller.sol
+        import {Target} from "./Target.sol";
+
+        contract C {
+            function $1caller() external {
+                Target.target();
+            }
+        }
+        //- /RootA.sol
+        import "./Caller.sol";
+        //- /RootB.sol
+        import "./Caller.sol";
+        "#,
+    );
+    let project = marked.project();
+    let target_contents = project.read_file("/Target.sol");
+    let mut tables = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/RootA.sol"), project.read_file("/RootA.sol"))],
+    ))
+    .symbol_tables;
+    let caller_uri = Url::from_file_path(project.path("/Caller.sol")).unwrap();
+    let caller = tables
+        .prepare_call_hierarchy(&caller_uri, marked.marker("$1").position())
+        .unwrap()
+        .pop()
+        .unwrap();
+    let changed_target = target_contents.replace(
+        "function target() internal pure {}",
+        "function target() internal pure { uint256 value = 1; }",
+    );
+    project.write_file("/Target.sol", &changed_target);
+    let conflicting = analyze(AnalysisBatch::from_files(
+        CompileOpts::default(),
+        [(project.path("/RootB.sol"), project.read_file("/RootB.sol"))],
+    ))
+    .symbol_tables;
+
+    tables.extend(conflicting);
+
+    assert_eq!(
+        tables.prepare_call_hierarchy(&caller_uri, marked.marker("$1").position()),
+        Some(vec![caller.clone()])
+    );
+    assert_eq!(tables.call_hierarchy_outgoing(&caller), None);
+}
+
+fn marker_range(marked: &MarkedProject, marker: &str, utf16_len: u32) -> Range {
+    let start = marked.marker(marker).position();
+    Range::new(start, Position::new(start.line, start.character + utf16_len))
+}

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -26,6 +26,7 @@ use std::{
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+mod call_hierarchy;
 mod completion;
 mod document_highlight;
 mod document_link;

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -416,7 +416,12 @@ impl<'gcx> ResolveContext<'gcx> {
                         }
                     }
                     let args = self.lower_call_args(&modifier.arguments);
-                    modifiers.push(hir::Modifier { span: modifier.span(), id, args });
+                    modifiers.push(hir::Modifier {
+                        span: modifier.span(),
+                        name_span: modifier.name.last().span,
+                        id,
+                        args,
+                    });
                 }
                 self.arena.alloc_smallvec(modifiers)
             };
@@ -581,6 +586,7 @@ impl<'gcx> ResolveContext<'gcx> {
             std::iter::zip(&*ast_contract.bases, self.hir.contract(c_id).bases).map(
                 |(ast_base, &base_id)| hir::Modifier {
                     span: ast_base.span(),
+                    name_span: ast_base.name.last().span,
                     id: base_id.into(),
                     args: self.lower_call_args(&ast_base.arguments),
                 },

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -966,6 +966,8 @@ pub fn can_receive_ether(contract: &Contract<'_>, gcx: Gcx<'_>) -> bool {
 pub struct Modifier<'hir> {
     /// The span of the modifier or base class call.
     pub span: Span,
+    /// The span of the final name segment.
+    pub name_span: Span,
     /// The modifier or base class ID.
     pub id: ItemId,
     /// The arguments to the modifier or base class call.

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -78,7 +78,7 @@ pub trait Visit<'hir> {
     }
 
     fn visit_modifier(&mut self, modifier: &'hir Modifier<'hir>) -> ControlFlow<Self::BreakValue> {
-        let Modifier { span: _, id: _, args } = modifier;
+        let Modifier { span: _, name_span: _, id: _, args } = modifier;
         self.visit_call_args(args)
     }
 


### PR DESCRIPTION
Adds call hierarchy support to the LSP, so you can inspect incoming and outgoing calls directly in the editor. It covers functions, modifiers, and explicit constructor calls, while avoiding misleading partial results when workspace snapshots conflict.

- In a multi-root workspace, conflicting snapshots of the same caller must not produce a partial incoming call hierarchy. The server should return null , rather than showing only unaffected callers as a complete result. 
<img width="414" height="234" alt="6592ad1e542be4b1d35a96fd0ec0bae0" src="https://github.com/user-attachments/assets/f7fd30c6-88c0-4419-aaf8-b92153f48a75" />
