### PR TITLE
perf(codegen): index instruction results

### DIFF
--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -859,7 +859,7 @@ mod tests {
             Some(MirType::uint256()),
         ));
         func.blocks[header].instructions.insert(0, phi_inst);
-        func.values[phi_val] = crate::mir::Value::Inst(phi_inst);
+        func.set_value(phi_val, crate::mir::Value::Inst(phi_inst));
 
         let liveness = Liveness::compute(&func);
 

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -10,7 +10,7 @@
 //! treated as uses at the phi instruction in the merge block, and the phi result is
 //! defined like any other instruction result.
 
-use crate::mir::{BlockId, Function, InstId, Terminator, Value, ValueId};
+use crate::mir::{BlockId, Function, Terminator, Value, ValueId};
 use smallvec::SmallVec;
 use solar_data_structures::{
     bit_set::{DenseBitSet, GrowableBitSet},
@@ -59,15 +59,6 @@ impl Liveness {
         let num_values = func.values.len();
         let num_blocks = func.blocks.len();
 
-        // Precompute InstId → ValueId mapping.
-        // This replaces the O(n) linear scans that were previously done per-instruction.
-        let mut inst_to_value: FxHashMap<InstId, ValueId> = FxHashMap::default();
-        for (val_id, val) in func.values.iter_enumerated() {
-            if let Value::Inst(inst_id) = val {
-                inst_to_value.insert(*inst_id, val_id);
-            }
-        }
-
         // Initialize per-block liveness
         let mut block_liveness = (0..num_blocks)
             .map(|_| BlockLiveness {
@@ -100,8 +91,7 @@ impl Liveness {
                     }
                 }
 
-                // Record definition using precomputed map (O(1) instead of O(n)).
-                if let Some(&val_id) = inst_to_value.get(&inst_id) {
+                if let Some(val_id) = func.inst_result_value(inst_id) {
                     block_defs[block_id].insert(val_id);
                 }
             }
@@ -278,7 +268,6 @@ impl Liveness {
     #[cfg(test)]
     fn live_at_inst(&self, func: &Function, block_id: BlockId, inst_idx: usize) -> LivenessInfo {
         let block = &func.blocks[block_id];
-        let inst_to_value = func.inst_results();
         let mut live = self.block_liveness[block_id].live_out.clone();
 
         if let Some(term) = &block.terminator {
@@ -292,7 +281,7 @@ impl Liveness {
         let mut operand_buf = SmallVec::<[ValueId; 8]>::new();
         for (idx, &inst_id) in block.instructions.iter().enumerate().rev() {
             let live_after = (idx == inst_idx).then(|| live.clone());
-            if let Some(&value) = inst_to_value.get(&inst_id) {
+            if let Some(value) = func.inst_result_value(inst_id) {
                 live.remove(value);
             }
             operand_buf.clear();

--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -854,12 +854,14 @@ mod tests {
         // Phase 2: insert the phi instruction at the head of `header` and point
         // the placeholder value at its result.
         let phi_val = phi_placeholder;
-        let phi_inst = func.alloc_inst(crate::mir::Instruction::new(
-            crate::mir::InstKind::Phi(vec![(entry, init), (body, updated)]),
-            Some(MirType::uint256()),
-        ));
+        let phi_inst = func.alloc_inst_with_result(
+            crate::mir::Instruction::new(
+                crate::mir::InstKind::Phi(vec![(entry, init), (body, updated)]),
+                Some(MirType::uint256()),
+            ),
+            phi_val,
+        );
         func.blocks[header].instructions.insert(0, phi_inst);
-        func.set_value(phi_val, crate::mir::Value::Inst(phi_inst));
 
         let liveness = Liveness::compute(&func);
 

--- a/crates/codegen/src/analysis/loop_analysis.rs
+++ b/crates/codegen/src/analysis/loop_analysis.rs
@@ -227,7 +227,7 @@ impl LoopAnalyzer {
                 }
 
                 if let (Some(init), Some(step_val)) = (init_value, step_value) {
-                    let phi_value = self.find_result_value(func, inst_id);
+                    let phi_value = func.inst_result_value(inst_id);
                     if let Some(phi_val) = phi_value
                         && let Some(update_inst) =
                             self.find_update_instruction(func, phi_val, step_val)
@@ -330,7 +330,7 @@ impl LoopAnalyzer {
                     let operands = inst.kind.operands();
                     if operands.iter().all(|&op| invariant_values.contains(op)) {
                         loop_info.invariant_insts.insert(inst_id);
-                        if let Some(result) = self.find_result_value(func, inst_id) {
+                        if let Some(result) = func.inst_result_value(inst_id) {
                             invariant_values.insert(result);
                         }
                         changed = true;
@@ -436,17 +436,6 @@ impl LoopAnalyzer {
             }
         }
         bound
-    }
-
-    fn find_result_value(&self, func: &Function, inst_id: InstId) -> Option<ValueId> {
-        for (value_id, value) in func.values.iter_enumerated() {
-            if let Value::Inst(id) = value
-                && *id == inst_id
-            {
-                return Some(value_id);
-            }
-        }
-        None
     }
 }
 

--- a/crates/codegen/src/analysis/phi_elimination.rs
+++ b/crates/codegen/src/analysis/phi_elimination.rs
@@ -9,7 +9,7 @@
 //! 2. Handle cycles by detecting when copies form a cycle and using a temporary.
 //! 3. Remove the phi instructions after copies are inserted.
 
-use crate::mir::{BlockId, Function, InstId, InstKind, MirType, Value, ValueId};
+use crate::mir::{BlockId, Function, InstKind, MirType, ValueId};
 use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
 
 /// Source for a parallel copy - either a regular value or a temporary.
@@ -76,7 +76,7 @@ impl PhiEliminator {
 
                 if let InstKind::Phi(incoming) = &inst.kind {
                     // Find the value defined by this phi
-                    let phi_dst = find_phi_dst(func, inst_id);
+                    let phi_dst = func.inst_result_value(inst_id);
 
                     if let Some(dst) = phi_dst {
                         let ty = func.value(dst).ty();
@@ -104,18 +104,6 @@ impl PhiEliminator {
 
         PhiEliminationResult { block_copies, phis_to_remove }
     }
-}
-
-/// Finds the ValueId that is defined by a phi instruction.
-fn find_phi_dst(func: &Function, inst_id: InstId) -> Option<ValueId> {
-    for (val_id, val) in func.values.iter_enumerated() {
-        if let Value::Inst(def_inst) = val
-            && *def_inst == inst_id
-        {
-            return Some(val_id);
-        }
-    }
-    None
 }
 
 /// Helper to extract ValueId from CopySource if it's a value (not a temp).

--- a/crates/codegen/src/analysis/validator.rs
+++ b/crates/codegen/src/analysis/validator.rs
@@ -107,12 +107,17 @@ impl<'a> Validator<'a> {
         // Count how many Value entries claim to be the result of each InstId.
         let mut inst_def_count: IndexVec<InstId, usize> = index_vec![0; num_insts];
         let mut invalid_inst_def_count: FxHashMap<InstId, usize> = FxHashMap::default();
-        let mut inst_results: IndexVec<InstId, Option<ValueId>> = index_vec![None; num_insts];
         for (value_id, v) in func.values.iter_enumerated() {
             if let Value::Inst(inst_id) = v {
                 if inst_id.index() < num_insts {
                     inst_def_count[*inst_id] += 1;
-                    inst_results[*inst_id] = Some(value_id);
+                    if func.inst_result_value(*inst_id) != Some(value_id) {
+                        self.emit(format_args!(
+                            "value v{} is not the recorded result of instruction inst{}",
+                            value_id.index(),
+                            inst_id.index()
+                        ));
+                    }
                 } else {
                     *invalid_inst_def_count.entry(*inst_id).or_default() += 1;
                 }
@@ -334,7 +339,7 @@ impl<'a> Validator<'a> {
             index_vec![None; num_values];
         for (block_id, block) in func.blocks.iter_enumerated() {
             for (index, &inst_id) in block.instructions.iter().enumerate() {
-                if let Some(result) = inst_results[inst_id] {
+                if let Some(result) = func.inst_result_value(inst_id) {
                     def_location_of[result] = Some((block_id, index));
                 }
             }

--- a/crates/codegen/src/backend/evm/stack/scheduler.rs
+++ b/crates/codegen/src/backend/evm/stack/scheduler.rs
@@ -335,9 +335,8 @@ mod tests {
         let mut func = make_test_func();
         let v0 = ValueId::from_usize(0);
         let v1 = ValueId::from_usize(1);
-        let inst =
-            func.alloc_inst(Instruction::new(InstKind::Add(v0, v1), Some(MirType::uint256())));
-        let deep = func.alloc_value(Value::Inst(inst));
+        let (_, deep) = func
+            .alloc_value_inst(Instruction::new(InstKind::Add(v0, v1), Some(MirType::uint256())));
         let mut scheduler = StackScheduler::new();
 
         scheduler.stack.push(deep);

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -682,40 +682,44 @@ impl<'gcx> Lowerer<'gcx> {
                 builder.make_slice(zero, size, crate::mir::SliceLocation::Calldata)
             }
             Builtin::BlockTimestamp => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::Timestamp,
-                    Some(MirType::uint256()),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::Timestamp,
+                        Some(MirType::uint256()),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::BlockNumber => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::BlockNumber,
-                    Some(MirType::uint256()),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::BlockNumber,
+                        Some(MirType::uint256()),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::TxOrigin => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::Origin,
-                    Some(MirType::Address),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::Origin,
+                        Some(MirType::Address),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::TxGasPrice => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::GasPrice,
-                    Some(MirType::uint256()),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::GasPrice,
+                        Some(MirType::uint256()),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::Gasleft => builder.gas(),
             Builtin::This => builder.address(),

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -85,7 +85,7 @@ impl<'a> FunctionBuilder<'a> {
 
     /// Replaces an allocated value.
     pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
-        self.func.values[id] = value;
+        self.func.set_value(id, value);
     }
 
     fn emit_inst_raw(&mut self, kind: InstKind, result_ty: Option<MirType>) -> InstId {

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -83,30 +83,41 @@ impl<'a> FunctionBuilder<'a> {
         self.func.alloc_value(value)
     }
 
-    /// Replaces an allocated value.
-    pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
-        self.func.set_value(id, value);
-    }
-
-    fn emit_inst_raw(&mut self, kind: InstKind, result_ty: Option<MirType>) -> InstId {
+    fn make_inst(&self, kind: InstKind, result_ty: Option<MirType>) -> Instruction {
         let mut inst = Instruction::new(kind, result_ty);
         inst.metadata.set_effect(Some(inst.kind.effect_kind()));
         inst.metadata.set_memory_region(self.memory_region_for_inst(&inst.kind));
         inst.metadata.set_storage_alias(self.storage_alias_for_inst(&inst.kind));
-        self.append_instruction(inst)
+        inst
     }
 
     /// Appends a fully constructed instruction to the current block.
-    pub(crate) fn append_instruction(&mut self, inst: Instruction) -> InstId {
-        let inst_id = self.func.alloc_inst(inst);
+    pub(crate) fn append_instruction(&mut self, inst: Instruction) -> (InstId, Option<ValueId>) {
+        let (inst_id, result) = if inst.result_ty.is_some() {
+            let (inst_id, result) = self.func.alloc_value_inst(inst);
+            (inst_id, Some(result))
+        } else {
+            (self.func.alloc_inst(inst), None)
+        };
+        self.func.blocks[self.current_block].instructions.push(inst_id);
+        (inst_id, result)
+    }
+
+    /// Appends a fully constructed instruction for a preallocated undefined result value.
+    pub(crate) fn append_instruction_with_result(
+        &mut self,
+        inst: Instruction,
+        result: ValueId,
+    ) -> InstId {
+        let inst_id = self.func.alloc_inst_with_result(inst, result);
         self.func.blocks[self.current_block].instructions.push(inst_id);
         inst_id
     }
 
     fn emit_inst(&mut self, kind: InstKind, result_ty: Option<MirType>) -> ValueId {
         debug_assert!(result_ty.is_some(), "value-producing instructions must have a result type");
-        let inst_id = self.emit_inst_raw(kind, result_ty);
-        self.alloc_value(Value::Inst(inst_id))
+        let inst = self.make_inst(kind, result_ty);
+        self.append_instruction(inst).1.expect("value-producing instruction must have a result")
     }
 
     /// Emits an instruction that produces no value, such as a store or a log.
@@ -114,7 +125,8 @@ impl<'a> FunctionBuilder<'a> {
     /// No result [`Value`] is allocated: only value-producing instructions get
     /// an entry in the function's value table.
     fn emit_void_inst(&mut self, kind: InstKind) {
-        self.emit_inst_raw(kind, None);
+        let inst = self.make_inst(kind, None);
+        self.append_instruction(inst);
     }
 
     fn memory_region_for_inst(&self, kind: &InstKind) -> Option<MemoryRegion> {

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -141,10 +141,7 @@ impl Function {
     /// Returns the value produced by the given instruction, if it has one.
     #[must_use]
     pub(crate) fn inst_result_value(&self, id: InstId) -> Option<ValueId> {
-        self.values
-            .iter_enumerated()
-            .find(|(_, value)| matches!(value, Value::Inst(inst) if *inst == id))
-            .map(|(value_id, _)| value_id)
+        self.instructions[id].result()
     }
 
     /// Returns a map from each instruction to its result value.
@@ -152,9 +149,9 @@ impl Function {
     pub(crate) fn inst_results(&self) -> FxHashMap<InstId, ValueId> {
         let mut results =
             FxHashMap::with_capacity_and_hasher(self.instructions.len(), Default::default());
-        for (value_id, value) in self.values.iter_enumerated() {
-            if let Value::Inst(inst_id) = value {
-                results.insert(*inst_id, value_id);
+        for (inst_id, instruction) in self.instructions.iter_enumerated() {
+            if let Some(value_id) = instruction.result() {
+                results.insert(inst_id, value_id);
             }
         }
         results
@@ -230,11 +227,37 @@ impl Function {
 
     /// Allocates a new value.
     pub(crate) fn alloc_value(&mut self, value: Value) -> ValueId {
-        self.values.push(value)
+        let result = match &value {
+            Value::Inst(inst) => Some(*inst),
+            _ => None,
+        };
+        let value = self.values.push(value);
+        if let Some(inst) = result {
+            let previous = self.instructions[inst].set_result(Some(value));
+            assert!(previous.is_none(), "instruction cannot have multiple result values");
+        }
+        value
+    }
+
+    /// Replaces an allocated value and updates its instruction-result mapping.
+    pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
+        if let Value::Inst(inst) = self.values[id] {
+            self.instructions[inst].set_result(None);
+        }
+        let result = match &value {
+            Value::Inst(inst) => Some(*inst),
+            _ => None,
+        };
+        self.values[id] = value;
+        if let Some(inst) = result {
+            let previous = self.instructions[inst].set_result(Some(id));
+            assert!(previous.is_none(), "instruction cannot have multiple result values");
+        }
     }
 
     /// Allocates a new instruction.
-    pub(crate) fn alloc_inst(&mut self, inst: Instruction) -> InstId {
+    pub(crate) fn alloc_inst(&mut self, mut inst: Instruction) -> InstId {
+        inst.set_result(None);
         self.instructions.push(inst)
     }
 

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -144,19 +144,6 @@ impl Function {
         self.instructions[id].result()
     }
 
-    /// Returns a map from each instruction to its result value.
-    #[must_use]
-    pub(crate) fn inst_results(&self) -> FxHashMap<InstId, ValueId> {
-        let mut results =
-            FxHashMap::with_capacity_and_hasher(self.instructions.len(), Default::default());
-        for (inst_id, instruction) in self.instructions.iter_enumerated() {
-            if let Some(value_id) = instruction.result() {
-                results.insert(inst_id, value_id);
-            }
-        }
-        results
-    }
-
     /// Returns a map from each instruction to the block containing it.
     #[must_use]
     pub(crate) fn inst_blocks(&self) -> FxHashMap<InstId, BlockId> {

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -227,36 +227,50 @@ impl Function {
 
     /// Allocates a new value.
     pub(crate) fn alloc_value(&mut self, value: Value) -> ValueId {
-        let result = match &value {
-            Value::Inst(inst) => Some(*inst),
-            _ => None,
-        };
-        let value = self.values.push(value);
-        if let Some(inst) = result {
-            let previous = self.instructions[inst].set_result(Some(value));
-            assert!(previous.is_none(), "instruction cannot have multiple result values");
-        }
-        value
+        assert!(
+            !matches!(value, Value::Inst(_)),
+            "instruction results must be allocated with their instruction"
+        );
+        self.values.push(value)
     }
 
-    /// Replaces an allocated value and updates its instruction-result mapping.
-    pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
-        if let Value::Inst(inst) = self.values[id] {
-            self.instructions[inst].set_result(None);
-        }
-        let result = match &value {
-            Value::Inst(inst) => Some(*inst),
-            _ => None,
-        };
-        self.values[id] = value;
-        if let Some(inst) = result {
-            let previous = self.instructions[inst].set_result(Some(id));
-            assert!(previous.is_none(), "instruction cannot have multiple result values");
-        }
+    /// Allocates a value-producing instruction and its result value.
+    pub(crate) fn alloc_value_inst(&mut self, mut inst: Instruction) -> (InstId, ValueId) {
+        assert!(inst.result_ty.is_some(), "value-producing instruction must have a result type");
+
+        let inst_id = self.instructions.next_idx();
+        let value_id = self.values.next_idx();
+        assert!(inst.set_result(Some(value_id)).is_none(), "new instruction already has a result");
+        let allocated_inst = self.instructions.push(inst);
+        let allocated_value = self.values.push(Value::Inst(inst_id));
+        debug_assert_eq!(allocated_inst, inst_id);
+        debug_assert_eq!(allocated_value, value_id);
+        (inst_id, value_id)
     }
 
-    /// Allocates a new instruction.
+    /// Allocates a value-producing instruction for a preallocated undefined result value.
+    pub(crate) fn alloc_inst_with_result(
+        &mut self,
+        mut inst: Instruction,
+        result: ValueId,
+    ) -> InstId {
+        assert!(inst.result_ty.is_some(), "value-producing instruction must have a result type");
+        assert!(
+            matches!(self.values[result], Value::Undef(_)),
+            "preallocated instruction result must be undefined"
+        );
+
+        let inst_id = self.instructions.next_idx();
+        assert!(inst.set_result(Some(result)).is_none(), "new instruction already has a result");
+        self.values[result] = Value::Inst(inst_id);
+        let allocated_inst = self.instructions.push(inst);
+        debug_assert_eq!(allocated_inst, inst_id);
+        inst_id
+    }
+
+    /// Allocates an instruction that produces no value.
     pub(crate) fn alloc_inst(&mut self, mut inst: Instruction) -> InstId {
+        assert!(inst.result_ty.is_none(), "value-producing instruction must allocate its result");
         inst.set_result(None);
         self.instructions.push(inst)
     }

--- a/crates/codegen/src/mir/inst.rs
+++ b/crates/codegen/src/mir/inst.rs
@@ -470,6 +470,8 @@ pub(crate) struct Instruction {
     pub(crate) kind: InstKind,
     /// The result type (if any).
     pub(crate) result_ty: Option<MirType>,
+    /// The value allocated for this instruction's result.
+    result: Option<ValueId>,
     /// Metadata produced by lowering or analysis.
     pub(crate) metadata: InstructionMetadata,
 }
@@ -478,7 +480,18 @@ impl Instruction {
     /// Creates a new instruction.
     #[must_use]
     pub(crate) const fn new(kind: InstKind, result_ty: Option<MirType>) -> Self {
-        Self { kind, result_ty, metadata: InstructionMetadata::EMPTY }
+        Self { kind, result_ty, result: None, metadata: InstructionMetadata::EMPTY }
+    }
+
+    /// Returns the value allocated for this instruction's result.
+    #[must_use]
+    pub(super) const fn result(&self) -> Option<ValueId> {
+        self.result
+    }
+
+    /// Replaces the value allocated for this instruction's result.
+    pub(super) fn set_result(&mut self, result: Option<ValueId>) -> Option<ValueId> {
+        std::mem::replace(&mut self.result, result)
     }
 
     /// Returns the operands of this instruction.

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -520,19 +520,15 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         label: u32,
-        inst_id: InstId,
-    ) -> PResult<'sess, ()> {
+    ) -> PResult<'sess, Option<ValueId>> {
         if let Some(value) = self.value_labels.get(&label).copied() {
             if matches!(builder.func().values[value], Value::Undef(_)) {
-                builder.set_value(value, Value::Inst(inst_id));
-                return Ok(());
+                return Ok(Some(value));
             }
             return Err(self.parser.error(format!("duplicate value `v{label}`")));
         }
 
-        let value = builder.alloc_value(Value::Inst(inst_id));
-        self.value_labels.insert(label, value);
-        Ok(())
+        Ok(None)
     }
 
     fn reject_unresolved_value_labels(&self, func: &Function) -> PResult<'sess, ()> {
@@ -930,10 +926,28 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let metadata = self.parse_metadata(builder)?;
         let mut inst = Instruction::new(kind, result_ty);
         inst.metadata = metadata;
-        let inst_id = builder.append_instruction(inst);
+        if result_label.is_some() && result_ty.is_none() {
+            return Err(self
+                .parser
+                .error_at(mnemonic_span, "instruction does not produce a result value"));
+        }
+        let existing_result = match result_label {
+            Some(label) => self.resolve_result_label(builder, label)?,
+            None => None,
+        };
+        let (inst_id, result) = if let Some(result) = existing_result {
+            (builder.append_instruction_with_result(inst, result), Some(result))
+        } else {
+            builder.append_instruction(inst)
+        };
         self.finish_function_ref(FunctionRefTarget::Instruction(inst_id));
-        if let Some(label) = result_label {
-            self.resolve_result_label(builder, label, inst_id)?;
+        if let Some(label) = result_label
+            && existing_result.is_none()
+        {
+            let result = result.ok_or_else(|| {
+                self.parser.error_at(mnemonic_span, "instruction does not produce a result value")
+            })?;
+            self.value_labels.insert(label, result);
         }
         Ok(())
     }

--- a/crates/codegen/src/transform/adce.rs
+++ b/crates/codegen/src/transform/adce.rs
@@ -6,9 +6,7 @@
 //! and values escaping a candidate dead block all prevent rewriting.
 
 use crate::{
-    mir::{
-        BlockId, Function, InstId, Module, Terminator, ValueId, utils::repair_reachability_phis,
-    },
+    mir::{BlockId, Function, Module, Terminator, ValueId, utils::repair_reachability_phis},
     pass::{MirPass, run_function_pass},
 };
 use solar_data_structures::{bit_set::DenseBitSet, map::FxHashMap};
@@ -61,7 +59,6 @@ struct AggressiveDeadCodeEliminator {
 
 #[derive(Debug)]
 struct AdceContext {
-    inst_results: FxHashMap<InstId, ValueId>,
     value_uses: FxHashMap<ValueId, DenseBitSet<BlockId>>,
 }
 
@@ -212,7 +209,7 @@ impl AggressiveDeadCodeEliminator {
 
     fn block_def_escapes(&self, func: &Function, ctx: &AdceContext, block_id: BlockId) -> bool {
         func.blocks[block_id].instructions.iter().any(|&inst_id| {
-            let Some(&value) = ctx.inst_results.get(&inst_id) else {
+            let Some(value) = func.inst_result_value(inst_id) else {
                 return false;
             };
             ctx.value_uses
@@ -241,9 +238,8 @@ impl AggressiveDeadCodeEliminator {
 
 impl AdceContext {
     fn new(func: &Function) -> Self {
-        let inst_results = func.inst_results();
         let value_uses = Self::value_uses(func);
-        Self { inst_results, value_uses }
+        Self { value_uses }
     }
 
     fn value_uses(func: &Function) -> FxHashMap<ValueId, DenseBitSet<BlockId>> {

--- a/crates/codegen/src/transform/cfg_simplify.rs
+++ b/crates/codegen/src/transform/cfg_simplify.rs
@@ -188,16 +188,13 @@ impl CfgSimplifier {
     /// no phis and a terminal block has no successors, so no phi inputs
     /// elsewhere can mention it.
     fn deduplicate_terminal_blocks(&mut self, func: &mut Function) {
-        let inst_results = func.inst_results();
-
         let mut kept: Vec<(BlockId, CanonBlock)> = Vec::new();
         let mut merges: Vec<(BlockId, BlockId)> = Vec::new();
         for block_id in func.blocks.indices() {
             if func.blocks[block_id].predecessors.is_empty() {
                 continue;
             }
-            let Some(canon) = Self::canonicalize_terminal_block(func, block_id, &inst_results)
-            else {
+            let Some(canon) = Self::canonicalize_terminal_block(func, block_id) else {
                 continue;
             };
             if let Some((keep, _)) = kept.iter().find(|(_, existing)| *existing == canon) {
@@ -224,11 +221,7 @@ impl CfgSimplifier {
 
     /// Builds the alpha-equivalence key of a terminal block, or `None` if the
     /// block is not a dedup candidate.
-    fn canonicalize_terminal_block(
-        func: &Function,
-        block_id: BlockId,
-        inst_results: &FxHashMap<crate::mir::InstId, ValueId>,
-    ) -> Option<CanonBlock> {
+    fn canonicalize_terminal_block(func: &Function, block_id: BlockId) -> Option<CanonBlock> {
         let block = &func.blocks[block_id];
         let term = block.terminator.as_ref()?;
         if matches!(term, Terminator::Invalid) || !term.successors().is_empty() {
@@ -237,7 +230,7 @@ impl CfgSimplifier {
 
         let mut local_defs: FxHashMap<ValueId, usize> = FxHashMap::default();
         for (position, &inst_id) in block.instructions.iter().enumerate() {
-            if let Some(&result) = inst_results.get(&inst_id) {
+            if let Some(result) = func.inst_result_value(inst_id) {
                 local_defs.insert(result, position);
             }
         }

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -336,9 +336,8 @@ impl CommonSubexprEliminator {
         let mut inserted_by_block: FxHashMap<BlockId, usize> = FxHashMap::default();
 
         for candidate in candidates {
-            let new_inst =
-                func.alloc_inst(Instruction::new(candidate.kind, Some(candidate.result_ty)));
-            let new_value = func.alloc_value(Value::Inst(new_inst));
+            let (new_inst, new_value) =
+                func.alloc_value_inst(Instruction::new(candidate.kind, Some(candidate.result_ty)));
 
             let phi_count = func.blocks[candidate.block_id]
                 .instructions

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -160,7 +160,6 @@ type MemRangeKey = MemoryLocation;
 
 struct GlobalCseContext<'a> {
     dom_tree: &'a DominatorTree,
-    inst_results: &'a FxHashMap<InstId, ValueId>,
     block_clobbers: &'a FxHashMap<BlockId, Vec<Clobber>>,
     reachability: &'a FxHashMap<BlockId, DenseBitSet<BlockId>>,
     replacements: &'a mut FxHashMap<ValueId, ValueId>,
@@ -196,7 +195,6 @@ struct PhiExpressionCandidate {
 struct PhiSinkContext<'a> {
     dominators: &'a DominatorTree,
     inst_blocks: &'a FxHashMap<InstId, BlockId>,
-    inst_results: &'a FxHashMap<InstId, ValueId>,
     replacements: &'a FxHashMap<ValueId, ValueId>,
 }
 
@@ -226,16 +224,14 @@ impl CommonSubexprEliminator {
         self.refresh_alias(func);
         self.sink_redundant_phi_expressions(func, cfg);
 
-        // Neither the global nor the local pass allocates values, so the map stays valid.
-        let inst_results = func.inst_results();
         self.alias().clear_cached_addresses();
-        self.process_global_pure(func, &inst_results, cfg);
+        self.process_global_pure(func, cfg);
 
         // Process each block independently (local CSE)
         let block_ids: Vec<BlockId> = func.blocks.indices().collect();
         for block_id in block_ids {
             self.alias().clear_cached_addresses();
-            self.process_block(func, block_id, &inst_results);
+            self.process_block(func, block_id);
         }
 
         self.eliminated_count
@@ -255,12 +251,7 @@ impl CommonSubexprEliminator {
         total
     }
 
-    fn process_global_pure(
-        &mut self,
-        func: &mut Function,
-        inst_results: &FxHashMap<InstId, ValueId>,
-        cfg: &CfgInfo,
-    ) {
+    fn process_global_pure(&mut self, func: &mut Function, cfg: &CfgInfo) {
         let has_path_sensitive_expr = func
             .instructions()
             .any(|inst_id| Self::is_path_sensitive_kind(&func.inst(inst_id).kind));
@@ -279,7 +270,6 @@ impl CommonSubexprEliminator {
         let mut dead = DenseBitSet::new_empty(func.num_insts());
         let mut ctx = GlobalCseContext {
             dom_tree,
-            inst_results,
             block_clobbers: &block_clobbers,
             reachability,
             replacements: &mut replacements,
@@ -299,14 +289,12 @@ impl CommonSubexprEliminator {
     }
 
     fn sink_redundant_phi_expressions(&mut self, func: &mut Function, cfg: &CfgInfo) {
-        let inst_results = func.inst_results();
         let inst_blocks = func.inst_blocks();
         let use_counts = Self::value_use_counts(func);
         let replacements = FxHashMap::default();
         let ctx = PhiSinkContext {
             dominators: cfg.dominators(),
             inst_blocks: &inst_blocks,
-            inst_results: &inst_results,
             replacements: &replacements,
         };
         let mut candidates = Vec::new();
@@ -373,7 +361,7 @@ impl CommonSubexprEliminator {
     ) -> Option<PhiExpressionCandidate> {
         let inst = func.inst(phi_inst);
         let result_ty = inst.result_ty?;
-        let phi_result = *ctx.inst_results.get(&phi_inst)?;
+        let phi_result = func.inst_result_value(phi_inst)?;
         let InstKind::Phi(incoming) = &inst.kind else { return None };
         if incoming.len() < 2 {
             return None;
@@ -440,7 +428,7 @@ impl CommonSubexprEliminator {
                     continue;
                 };
 
-                let Some(&result) = ctx.inst_results.get(&inst_id) else {
+                let Some(result) = func.inst_result_value(inst_id) else {
                     continue;
                 };
                 if let Some(cached) = cache.get(&key) {
@@ -542,12 +530,7 @@ impl CommonSubexprEliminator {
     }
 
     /// Processes a single basic block.
-    fn process_block(
-        &mut self,
-        func: &mut Function,
-        block_id: BlockId,
-        inst_results: &FxHashMap<InstId, ValueId>,
-    ) {
+    fn process_block(&mut self, func: &mut Function, block_id: BlockId) {
         // Map from expression key to the ValueId that computed it
         let mut expr_cache: FxHashMap<ExprKey, ValueId> = FxHashMap::default();
 
@@ -576,7 +559,7 @@ impl CommonSubexprEliminator {
 
             // Try to create an expression key
             if let Some(key) = self.make_expr_key(func, inst_id, &kind, &replacements)
-                && let Some(&result) = inst_results.get(&inst_id)
+                && let Some(result) = func.inst_result_value(inst_id)
             {
                 if let Some(&cached_value) = expr_cache.get(&key) {
                     // This expression was already computed - mark for elimination

--- a/crates/codegen/src/transform/dce.rs
+++ b/crates/codegen/src/transform/dce.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     pass::{MirPass, run_function_pass},
 };
-use solar_data_structures::{bit_set::GrowableBitSet, map::FxHashMap};
+use solar_data_structures::bit_set::GrowableBitSet;
 
 /// Function pass for dead code elimination.
 pub(crate) struct Dce;
@@ -58,11 +58,7 @@ impl DeadCodeEliminator {
         Self::default()
     }
 
-    fn run_with_inst_results(
-        &mut self,
-        func: &mut Function,
-        inst_to_value: &FxHashMap<InstId, ValueId>,
-    ) -> usize {
+    fn run_once(&mut self, func: &mut Function) -> usize {
         self.eliminated_count = 0;
 
         // Phase 1: Remove unreachable blocks
@@ -72,7 +68,7 @@ impl DeadCodeEliminator {
         self.collect_used_values(func);
 
         // Phase 3: Find dead instructions
-        self.find_dead_instructions(func, inst_to_value);
+        self.find_dead_instructions(func);
 
         // Remove dead instructions from blocks
         self.eliminated_count += self.dead.len();
@@ -87,9 +83,8 @@ impl DeadCodeEliminator {
     /// Runs dead code elimination iteratively until no more changes.
     pub(crate) fn run_to_fixpoint(&mut self, func: &mut Function) -> usize {
         let mut total_eliminated = 0;
-        let inst_to_value = func.inst_results();
         loop {
-            let eliminated = self.run_with_inst_results(func, &inst_to_value);
+            let eliminated = self.run_once(func);
             if eliminated == 0 {
                 break;
             }
@@ -150,11 +145,7 @@ impl DeadCodeEliminator {
     }
 
     /// Finds instructions that are dead (unused result, no side effects).
-    fn find_dead_instructions(
-        &mut self,
-        func: &Function,
-        inst_to_value: &FxHashMap<InstId, ValueId>,
-    ) {
+    fn find_dead_instructions(&mut self, func: &Function) {
         self.dead.clear();
 
         for (block_id, block) in func.blocks.iter_enumerated() {
@@ -166,8 +157,7 @@ impl DeadCodeEliminator {
                     continue;
                 }
 
-                // O(1) lookup via precomputed map (was O(V) linear scan).
-                if let Some(&result) = inst_to_value.get(&inst_id)
+                if let Some(result) = func.inst_result_value(inst_id)
                     && !self.used_values.contains(result)
                 {
                     self.dead.push((block_id, inst_id));

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -186,7 +186,6 @@ struct PendingPhi {
 struct SlotSsaBuilder<'a> {
     info: &'a SlotAccessInfo,
     cfg: &'a CfgInfo,
-    inst_results: &'a FxHashMap<InstId, ValueId>,
     aa: &'a AliasAnalysis,
     replacements: FxHashMap<ValueId, ValueId>,
     dead: GrowableBitSet<InstId>,
@@ -230,9 +229,7 @@ impl FrameSlotPromoter {
         };
 
         for info in slots {
-            let inst_results = func.inst_results();
-            let mut builder =
-                SlotSsaBuilder::new(&info, &cfg, &inst_results, &aa, func.num_insts());
+            let mut builder = SlotSsaBuilder::new(&info, &cfg, &aa, func.num_insts());
             if builder.run(func) {
                 self.stats.slots_promoted += 1;
                 self.stats.loads_promoted += builder.loads_promoted;
@@ -647,14 +644,12 @@ impl<'a> SlotSsaBuilder<'a> {
     fn new(
         info: &'a SlotAccessInfo,
         cfg: &'a CfgInfo,
-        inst_results: &'a FxHashMap<InstId, ValueId>,
         aa: &'a AliasAnalysis,
         instruction_count: usize,
     ) -> Self {
         Self {
             info,
             cfg,
-            inst_results,
             aa,
             replacements: FxHashMap::default(),
             dead: GrowableBitSet::with_capacity(instruction_count),
@@ -867,7 +862,7 @@ impl<'a> SlotSsaBuilder<'a> {
                         == Some(self.info.slot) =>
                 {
                     let Some(value) = current else { return false };
-                    self.replace_load(inst_id, value);
+                    self.replace_load(func, inst_id, value);
                     changed = true;
                 }
                 InstKind::MStore(addr, value)
@@ -907,7 +902,7 @@ impl<'a> SlotSsaBuilder<'a> {
         }
 
         for load in &self.info.loads {
-            self.replace_load(load.inst, stored_value);
+            self.replace_load(func, load.inst, stored_value);
         }
         self.remove_store(store.inst);
         true
@@ -917,8 +912,8 @@ impl<'a> SlotSsaBuilder<'a> {
         func.blocks[block].instructions.iter().position(|&candidate| candidate == inst)
     }
 
-    fn replace_load(&mut self, inst_id: InstId, value: ValueId) {
-        if let Some(&load_value) = self.inst_results.get(&inst_id) {
+    fn replace_load(&mut self, func: &Function, inst_id: InstId, value: ValueId) {
+        if let Some(load_value) = func.inst_result_value(inst_id) {
             self.replacements
                 .insert(load_value, mir_utils::resolve_replacement(value, &self.replacements));
             self.dead.insert(inst_id);
@@ -951,7 +946,7 @@ impl<'a> SlotSsaBuilder<'a> {
                         self.failed = true;
                         return;
                     };
-                    self.replace_load(inst_id, value);
+                    self.replace_load(func, inst_id, value);
                 }
                 InstKind::MStore(addr, value)
                     if FrameSlotPromoter::promotable_slot(func, self.aa, addr)

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -16,8 +16,7 @@ use crate::{
     analysis::{AliasAnalysis, CfgInfo, LocationSize, MemoryAddress, MemoryLocation},
     memory::EvmMemoryLayout,
     mir::{
-        BlockId, Function, InstId, InstKind, Instruction, MirType, Module, Terminator, Value,
-        ValueId,
+        BlockId, Function, InstId, InstKind, Instruction, MirType, Module, Terminator, ValueId,
         utils::{self as mir_utils, repair_reachability_phis},
     },
     pass::{MirPass, run_function_pass},
@@ -987,9 +986,10 @@ impl<'a> SlotSsaBuilder<'a> {
             return pending.value;
         }
 
-        let inst =
-            func.alloc_inst(Instruction::new(InstKind::Phi(Vec::new()), Some(MirType::uint256())));
-        let value = func.alloc_value(Value::Inst(inst));
+        let (inst, value) = func.alloc_value_inst(Instruction::new(
+            InstKind::Phi(Vec::new()),
+            Some(MirType::uint256()),
+        ));
         self.phis.insert(
             block,
             PendingPhi {

--- a/crates/codegen/src/transform/gvn.rs
+++ b/crates/codegen/src/transform/gvn.rs
@@ -148,7 +148,6 @@ enum ExprKind {
 struct ReplaceCtx<'a> {
     vn: &'a IndexVec<ValueId, ClassId>,
     cfg: &'a CfgInfo,
-    inst_results: &'a FxHashMap<InstId, ValueId>,
     replacements: &'a mut FxHashMap<ValueId, ValueId>,
     dead: &'a mut DenseBitSet<InstId>,
 }
@@ -174,8 +173,7 @@ impl GlobalValueNumberer {
     /// Runs one numbering and replacement round. Returns true if MIR changed.
     fn run_round(&mut self, func: &mut Function) -> bool {
         let cfg = self.cfg.as_ref().map_or_else(|| Rc::new(CfgInfo::new(func)), Rc::clone);
-        let inst_results = func.inst_results();
-        let Some(vn) = Self::compute_value_numbers(func, cfg.rpo(), &inst_results) else {
+        let Some(vn) = Self::compute_value_numbers(func, cfg.rpo()) else {
             return false;
         };
 
@@ -190,13 +188,8 @@ impl GlobalValueNumberer {
 
         let mut replacements = FxHashMap::default();
         let mut dead = DenseBitSet::new_empty(func.num_insts());
-        let mut ctx = ReplaceCtx {
-            vn: &vn,
-            cfg: &cfg,
-            inst_results: &inst_results,
-            replacements: &mut replacements,
-            dead: &mut dead,
-        };
+        let mut ctx =
+            ReplaceCtx { vn: &vn, cfg: &cfg, replacements: &mut replacements, dead: &mut dead };
         self.replace_in_block(func, BlockId::ENTRY, &mut leaders, &mut ctx);
 
         if replacements.is_empty() {
@@ -216,7 +209,6 @@ impl GlobalValueNumberer {
     fn compute_value_numbers(
         func: &Function,
         rpo: &[BlockId],
-        inst_results: &FxHashMap<InstId, ValueId>,
     ) -> Option<IndexVec<ValueId, ClassId>> {
         let mut vn = func.values.indices().collect::<IndexVec<ValueId, _>>();
         let mut immediate_reps: FxHashMap<Immediate, ValueId> = FxHashMap::default();
@@ -238,7 +230,7 @@ impl GlobalValueNumberer {
             let mut changed = false;
             for &block_id in rpo {
                 for &inst_id in &func.blocks[block_id].instructions {
-                    let Some(&result) = inst_results.get(&inst_id) else { continue };
+                    let Some(result) = func.inst_result_value(inst_id) else { continue };
                     let inst = func.inst(inst_id);
                     let Some(ty) = inst.result_ty else { continue };
                     let Some(class) =
@@ -404,7 +396,7 @@ impl GlobalValueNumberer {
         ctx: &mut ReplaceCtx<'_>,
     ) {
         for &inst_id in &func.blocks[block_id].instructions {
-            let Some(&result) = ctx.inst_results.get(&inst_id) else { continue };
+            let Some(result) = func.inst_result_value(inst_id) else { continue };
             let kind = &func.inst(inst_id).kind;
             if !matches!(kind, InstKind::Phi(_)) && Self::expr_kind(kind, ctx.vn).is_none() {
                 continue;

--- a/crates/codegen/src/transform/indvar_simplify.rs
+++ b/crates/codegen/src/transform/indvar_simplify.rs
@@ -113,14 +113,13 @@ impl IndVarSimplifier {
         };
 
         let scev = ScalarEvolution::analyze(func, loop_data);
-        let inst_results = func.inst_results();
         let mut candidates: FxHashMap<AddressKey, Vec<ValueId>> = FxHashMap::default();
 
         let mut blocks: Vec<_> = loop_data.blocks.iter().collect();
         blocks.sort_by_key(|block| block.index());
         for block in blocks {
             for &inst_id in &func.blocks[block].instructions {
-                let Some(&value) = inst_results.get(&inst_id) else { continue };
+                let Some(value) = func.inst_result_value(inst_id) else { continue };
                 if !self.is_reducible_result(func, inst_id) {
                     continue;
                 }

--- a/crates/codegen/src/transform/indvar_simplify.rs
+++ b/crates/codegen/src/transform/indvar_simplify.rs
@@ -213,11 +213,10 @@ impl IndVarSimplifier {
         }
 
         let initial = self.build_base_plus_offset(func, preheader, key.base, init_offset)?;
-        let phi_inst = func.alloc_inst(Instruction::new(
+        let (phi_inst, phi_value) = func.alloc_value_inst(Instruction::new(
             InstKind::Phi(vec![(preheader, initial)]),
             Some(MirType::uint256()),
         ));
-        let phi_value = func.alloc_value(Value::Inst(phi_inst));
         self.insert_header_phi(func, loop_data.header, phi_inst);
 
         let delta = self.offset_value(func, delta)?;
@@ -268,9 +267,9 @@ impl IndVarSimplifier {
         kind: InstKind,
         ty: Option<MirType>,
     ) -> ValueId {
-        let inst = func.alloc_inst(Instruction::new(kind, ty));
+        let (inst, value) = func.alloc_value_inst(Instruction::new(kind, ty));
         func.blocks[block].instructions.push(inst);
-        func.alloc_value(Value::Inst(inst))
+        value
     }
 
     fn insert_header_phi(&self, func: &mut Function, header: BlockId, phi_inst: InstId) {

--- a/crates/codegen/src/transform/inline.rs
+++ b/crates/codegen/src/transform/inline.rs
@@ -770,12 +770,15 @@ impl<'a> InlineCloner<'a> {
             for &inst_id in &block.instructions {
                 let inst = self.callee.inst(inst_id).clone();
                 let kind = self.clone_inst_kind(inst.kind)?;
-                let new_inst = self.caller.alloc_inst(Instruction::new(kind, inst.result_ty));
-                instructions.push(new_inst);
-                if let Some(callee_result) = self.callee.inst_result_value(inst_id) {
-                    let new_result = self.caller.alloc_value(Value::Inst(new_inst));
+                let instruction = Instruction::new(kind, inst.result_ty);
+                let new_inst = if let Some(callee_result) = self.callee.inst_result_value(inst_id) {
+                    let (new_inst, new_result) = self.caller.alloc_value_inst(instruction);
                     self.value_map.insert(callee_result, new_result);
-                }
+                    new_inst
+                } else {
+                    self.caller.alloc_inst(instruction)
+                };
+                instructions.push(new_inst);
             }
             self.caller.blocks[caller_block].instructions = instructions;
         }
@@ -1119,9 +1122,10 @@ fn build_return_values(
             .iter()
             .map(|(block, edge_values)| Some((*block, *edge_values.get(index)?)))
             .collect::<Option<Vec<_>>>()?;
-        let phi = caller.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(ty)));
+        let (phi, value) =
+            caller.alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(ty)));
         caller.blocks[continuation].instructions.insert(index, phi);
-        values.push(caller.alloc_value(Value::Inst(phi)));
+        values.push(value);
     }
     Some(values)
 }
@@ -1138,8 +1142,8 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
         .take_while(|&&inst_id| matches!(caller.inst(inst_id).kind, InstKind::Phi(_)))
         .count();
 
-    let base_load = caller.alloc_inst(Instruction::new(InstKind::Fmp, Some(MirType::MemPtr)));
-    let base = caller.alloc_value(Value::Inst(base_load));
+    let (base_load, base) =
+        caller.alloc_value_inst(Instruction::new(InstKind::Fmp, Some(MirType::MemPtr)));
     let mut insert_at = phi_count;
     caller.blocks[continuation].instructions.insert(insert_at, base_load);
     insert_at += 1;
@@ -1147,9 +1151,10 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
     for (index, &value) in values.iter().enumerate() {
         let offset = caller
             .alloc_value(Value::Immediate(Immediate::uint256(U256::from((index as u64 + 1) * 32))));
-        let addr = caller
-            .alloc_inst(Instruction::new(InstKind::Add(base, offset), Some(MirType::uint256())));
-        let addr_value = caller.alloc_value(Value::Inst(addr));
+        let (addr, addr_value) = caller.alloc_value_inst(Instruction::new(
+            InstKind::Add(base, offset),
+            Some(MirType::uint256()),
+        ));
         let store = caller.alloc_inst(Instruction::new(InstKind::MStore(addr_value, value), None));
         caller.blocks[continuation].instructions.insert(insert_at, addr);
         caller.blocks[continuation].instructions.insert(insert_at + 1, store);

--- a/crates/codegen/src/transform/inst_simplify.rs
+++ b/crates/codegen/src/transform/inst_simplify.rs
@@ -50,18 +50,13 @@ struct InstSimplifier {
 }
 
 struct RunState {
-    inst_results: FxHashMap<InstId, ValueId>,
     replacements: FxHashMap<ValueId, ValueId>,
     dead: DenseBitSet<InstId>,
 }
 
 impl RunState {
     fn new(func: &Function) -> Self {
-        Self {
-            inst_results: func.inst_results(),
-            replacements: FxHashMap::default(),
-            dead: DenseBitSet::new_empty(func.num_insts()),
-        }
+        Self { replacements: FxHashMap::default(), dead: DenseBitSet::new_empty(func.num_insts()) }
     }
 }
 
@@ -112,7 +107,7 @@ impl InstSimplifier {
                         continue;
                     }
 
-                    let Some(&result) = state.inst_results.get(&inst_id) else {
+                    let Some(result) = func.inst_result_value(inst_id) else {
                         break;
                     };
                     let Some(replacement) = self.simplify_inst(func, &kind, &state.replacements)

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -276,7 +276,6 @@ struct Analysis {
     ins: FxHashMap<BlockId, KeySet>,
     /// Availability at block exit.
     outs: FxHashMap<BlockId, KeySet>,
-    inst_results: FxHashMap<InstId, ValueId>,
     inst_blocks: FxHashMap<InstId, BlockId>,
 }
 
@@ -571,7 +570,6 @@ impl LoadRedundancyEliminator {
             kills,
             ins,
             outs,
-            inst_results: func.inst_results(),
             inst_blocks: func.inst_blocks(),
         })
     }
@@ -713,7 +711,6 @@ impl LoadRedundancyEliminator {
     fn same_key_loads_in_target(
         &self,
         func: &Function,
-        analysis: &Analysis,
         target: BlockId,
         first_inst: InstId,
         key: LoadKey,
@@ -746,7 +743,7 @@ impl LoadRedundancyEliminator {
 
             if let Some((load_key, GenSource::LoadResult)) = self.gen_key_value(func, inst_id)
                 && load_key == key
-                && let Some(&value) = analysis.inst_results.get(&inst_id)
+                && let Some(value) = func.inst_result_value(inst_id)
             {
                 loads.push((inst_id, value));
             }
@@ -765,10 +762,10 @@ impl LoadRedundancyEliminator {
         predecessors: &[BlockId],
     ) -> Option<Candidate> {
         let instruction = func.inst(inst);
-        let result = *cx.analysis.inst_results.get(&inst)?;
+        let result = func.inst_result_value(inst)?;
         let result_ty = instruction.result_ty?;
         let key = cx.analysis.keys[key_idx];
-        let loads = self.same_key_loads_in_target(func, cx.analysis, target, inst, key);
+        let loads = self.same_key_loads_in_target(func, target, inst, key);
         if loads.is_empty() {
             return None;
         }
@@ -914,7 +911,7 @@ impl LoadRedundancyEliminator {
                 // A store's exact-key gen wins over its own kill: the slot
                 // holds the stored value from this point on.
                 return match source {
-                    GenSource::LoadResult => cx.analysis.inst_results.get(&inst_id).copied(),
+                    GenSource::LoadResult => func.inst_result_value(inst_id),
                     GenSource::Stored(value) => Some(value),
                 };
             }

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -956,11 +956,9 @@ impl LoadRedundancyEliminator {
 
         let fully_available = insertions.is_empty();
         for block in insertions {
-            let new_inst = func.alloc_inst(Instruction {
-                kind: kind.clone(),
-                result_ty: Some(result_ty),
-                metadata: metadata.clone(),
-            });
+            let mut instruction = Instruction::new(kind.clone(), Some(result_ty));
+            instruction.metadata = metadata.clone();
+            let new_inst = func.alloc_inst(instruction);
             let value = func.alloc_value(Value::Inst(new_inst));
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -958,8 +958,7 @@ impl LoadRedundancyEliminator {
         for block in insertions {
             let mut instruction = Instruction::new(kind.clone(), Some(result_ty));
             instruction.metadata = metadata.clone();
-            let new_inst = func.alloc_inst(instruction);
-            let value = func.alloc_value(Value::Inst(new_inst));
+            let (new_inst, value) = func.alloc_value_inst(instruction);
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));
             inserted_insts.insert(new_inst);
@@ -980,9 +979,8 @@ impl LoadRedundancyEliminator {
                 first
             }
             _ => {
-                let phi_inst =
-                    func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
-                let phi_value = func.alloc_value(Value::Inst(phi_inst));
+                let (phi_inst, phi_value) = func
+                    .alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
                 let phi_count = func.blocks[target]
                     .instructions
                     .iter()

--- a/crates/codegen/src/transform/loop_canonicalize.rs
+++ b/crates/codegen/src/transform/loop_canonicalize.rs
@@ -249,11 +249,11 @@ impl LoopCanonicalizer {
 
         let result_ty =
             func.inst(header_phi).result_ty.expect("header phi should have result type");
-        let preheader_phi =
-            func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
+        let (preheader_phi, result) =
+            func.alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
         func.blocks[preheader].instructions.push(preheader_phi);
         self.stats.preheader_phis_inserted += 1;
-        func.alloc_value(Value::Inst(preheader_phi))
+        result
     }
 
     fn redirect_terminator(

--- a/crates/codegen/src/transform/lower_abi_encode.rs
+++ b/crates/codegen/src/transform/lower_abi_encode.rs
@@ -56,7 +56,6 @@ fn lower_function(func: &mut Function) -> bool {
         return false;
     }
 
-    let inst_results = func.inst_results();
     let mut replacements = FxHashMap::default();
     let blocks: Vec<_> = func.blocks.indices().collect();
     for block in blocks {
@@ -75,7 +74,11 @@ fn lower_function(func: &mut Function) -> bool {
             };
             if let Some((selector, args, layout)) = encode {
                 let replacement = lower_encode(&mut builder, &layout, selector, &args);
-                replacements.insert(inst_results[&inst], replacement);
+                let result = builder
+                    .func()
+                    .inst_result_value(inst)
+                    .expect("ABI encode must produce a value");
+                replacements.insert(result, replacement);
             } else {
                 let current = builder.current_block();
                 builder.func_mut().blocks[current].instructions.push(inst);

--- a/crates/codegen/src/transform/lower_alloc.rs
+++ b/crates/codegen/src/transform/lower_alloc.rs
@@ -57,7 +57,6 @@ fn lower_function(func: &mut Function) -> bool {
         return false;
     }
 
-    let inst_results = func.inst_results();
     let mut changed = false;
     let mut block_index = 0;
     while block_index < func.blocks.len() {
@@ -73,7 +72,8 @@ fn lower_function(func: &mut Function) -> bool {
                 ) && !func.inst(*inst).metadata.deferred_alloc()
             });
         if let Some((position, inst)) = checked {
-            lower_checked_alloc(func, block, position, inst, inst_results[&inst]);
+            let result = func.inst_result_value(inst).expect("allocation must produce a value");
+            lower_checked_alloc(func, block, position, inst, result);
             changed = true;
         }
         block_index += 1;
@@ -103,7 +103,10 @@ fn lower_function(func: &mut Function) -> bool {
                     }
                     debug_assert_eq!(semantics.failure, AllocationFailure::Infallible);
                     changed = true;
-                    let ptr = inst_results[&inst];
+                    let ptr = builder
+                        .func()
+                        .inst_result_value(inst)
+                        .expect("allocation must produce a value");
                     rewrite_as_fmp_load(&mut builder, inst);
                     builder.func_mut().blocks[block].instructions.push(inst);
                     let size = aligned_size(&mut builder, size, semantics.alignment).0;

--- a/crates/codegen/src/transform/lower_mapping_slots.rs
+++ b/crates/codegen/src/transform/lower_mapping_slots.rs
@@ -42,7 +42,6 @@ impl MirPass for LowerMappingSlots {
                 return false;
             }
 
-            let inst_results = func.inst_results();
             let mut replacements = FxHashMap::default();
             let block_ids: Vec<BlockId> = func.blocks.indices().collect();
             for block_id in block_ids {
@@ -66,7 +65,11 @@ impl MirPass for LowerMappingSlots {
                         }
                     };
                     if let Some(replacement) = replacement {
-                        replacements.insert(inst_results[&inst_id], replacement);
+                        let result = builder
+                            .func()
+                            .inst_result_value(inst_id)
+                            .expect("mapping slot must produce a value");
+                        replacements.insert(result, replacement);
                     }
                 }
             }

--- a/crates/codegen/src/transform/lower_memory_objects.rs
+++ b/crates/codegen/src/transform/lower_memory_objects.rs
@@ -80,7 +80,6 @@ fn lower_function<P: MemoryLayoutPolicy>(
         return false;
     }
 
-    let inst_results = func.inst_results();
     let mut replacements = FxHashMap::default();
     let mut removed = FxHashSet::default();
     let blocks: Vec<_> = func.blocks.indices().collect();
@@ -119,7 +118,7 @@ fn lower_function<P: MemoryLayoutPolicy>(
                 InstKind::MemoryObjectData(object, kind) => {
                     let offset = P::object_data_offset(kind);
                     if offset == 0 {
-                        if let Some(&result) = inst_results.get(&inst) {
+                        if let Some(result) = builder.func().inst_result_value(inst) {
                             replacements.insert(result, object);
                         }
                         removed.insert(inst);
@@ -135,7 +134,7 @@ fn lower_function<P: MemoryLayoutPolicy>(
                         continue;
                     };
                     if offset == 0 {
-                        if let Some(&result) = inst_results.get(&inst) {
+                        if let Some(result) = builder.func().inst_result_value(inst) {
                             replacements.insert(result, object);
                         }
                         removed.insert(inst);

--- a/crates/codegen/src/transform/lower_slices.rs
+++ b/crates/codegen/src/transform/lower_slices.rs
@@ -342,7 +342,6 @@ impl LowerSlicesCx {
         }
         builder.func_mut().params = new_params;
 
-        let inst_results = builder.func().inst_results();
         let mut replacements = FxHashMap::default();
         let mut removed = FxHashSet::default();
         for inst_id in builder.func().instructions() {
@@ -352,7 +351,7 @@ impl LowerSlicesCx {
                 _ => None,
             };
             if let Some(replacement) = replacement
-                && let Some(&result) = inst_results.get(&inst_id)
+                && let Some(result) = builder.func().inst_result_value(inst_id)
             {
                 replacements.insert(result, replacement);
                 removed.insert(inst_id);
@@ -374,7 +373,6 @@ impl LowerSlicesCx {
         func: &mut Function,
         raw_heads: &FxHashMap<ValueId, ValueId>,
     ) {
-        let inst_results = func.inst_results();
         let mut replacements = raw_heads.clone();
         let block_ids: Vec<BlockId> = func.blocks.indices().collect();
         for block_id in block_ids {
@@ -402,7 +400,11 @@ impl LowerSlicesCx {
                             builder.calldataload(len_pos)
                         })
                     };
-                    replacements.insert(inst_results[&inst_id], replacement);
+                    let result = builder
+                        .func()
+                        .inst_result_value(inst_id)
+                        .expect("slice projection must produce a value");
+                    replacements.insert(result, replacement);
                     self.stats.projections += 1;
                 } else {
                     builder.func_mut().blocks[block_id].instructions.push(inst_id);
@@ -502,14 +504,11 @@ impl LowerSlicesCx {
     }
 
     fn lower_projections(&mut self, func: &mut Function) -> bool {
-        let inst_results = func.inst_results();
         let live_insts: FxHashSet<_> = func.instructions().collect();
         let mut components = FxHashMap::<ValueId, (ValueId, ValueId, InstId)>::default();
         let mut projections = FxHashMap::<ValueId, (ValueId, InstId, bool)>::default();
-        for (&inst, &result) in &inst_results {
-            if !live_insts.contains(&inst) {
-                continue;
-            }
+        for &inst in &live_insts {
+            let Some(result) = func.inst_result_value(inst) else { continue };
             match func.inst(inst).kind {
                 InstKind::MakeSlice { ptr, len, .. } => {
                     components.insert(result, (ptr, len, inst));

--- a/crates/codegen/src/transform/lower_slices.rs
+++ b/crates/codegen/src/transform/lower_slices.rs
@@ -93,9 +93,7 @@ fn slice_param_ptr_type(location: SliceLocation) -> MirType {
 
 /// Allocates a word-typed instruction and its result value, returning both.
 fn new_word_inst(func: &mut Function, kind: InstKind) -> (InstId, ValueId) {
-    let inst = func.alloc_inst(Instruction::new(kind, Some(MirType::uint256())));
-    let value = func.alloc_value(Value::Inst(inst));
-    (inst, value)
+    func.alloc_value_inst(Instruction::new(kind, Some(MirType::uint256())))
 }
 
 /// Allocates a `make_slice` instruction and its slice-typed result value.
@@ -105,12 +103,10 @@ fn new_slice_inst(
     len: ValueId,
     location: SliceLocation,
 ) -> (InstId, ValueId) {
-    let inst = func.alloc_inst(Instruction::new(
+    func.alloc_value_inst(Instruction::new(
         InstKind::MakeSlice { ptr, len, location },
         Some(MirType::Slice(location)),
-    ));
-    let value = func.alloc_value(Value::Inst(inst));
-    (inst, value)
+    ))
 }
 
 impl LowerSlicesCx {

--- a/crates/codegen/src/transform/memory_dse.rs
+++ b/crates/codegen/src/transform/memory_dse.rs
@@ -184,16 +184,7 @@ impl MemoryStoreEliminator {
             self.alias = Some(Rc::new(AliasAnalysis::new(func)));
         }
 
-        let needs_inst_results = func.instructions().any(|inst_id| {
-            matches!(
-                func.inst(inst_id).kind,
-                InstKind::MLoad(_) | InstKind::MemoryObjectLen(_, _) | InstKind::Keccak256(_, _)
-            )
-        });
-        let inst_results =
-            if needs_inst_results { func.inst_results() } else { FxHashMap::default() };
-
-        self.reuse_redundant_immutable_copies(func, &inst_results);
+        self.reuse_redundant_immutable_copies(func);
         self.alias().clear_cached_addresses();
         self.remove_unused_internal_frame_stores(func);
 
@@ -203,12 +194,12 @@ impl MemoryStoreEliminator {
             .any(|inst_id| Self::constant_range_read(&func.inst(inst_id).kind).is_some());
         if has_precise_reads {
             for block_id in block_ids {
-                self.process_block::<true>(func, block_id, &inst_results, scratch);
+                self.process_block::<true>(func, block_id, scratch);
                 self.alias().clear_cached_addresses();
             }
         } else {
             for block_id in block_ids {
-                self.process_block::<false>(func, block_id, &inst_results, scratch);
+                self.process_block::<false>(func, block_id, scratch);
                 self.alias().clear_cached_addresses();
             }
         }
@@ -441,11 +432,7 @@ impl MemoryStoreEliminator {
         total
     }
 
-    fn reuse_redundant_immutable_copies(
-        &mut self,
-        func: &mut Function,
-        inst_results: &FxHashMap<InstId, ValueId>,
-    ) {
+    fn reuse_redundant_immutable_copies(&mut self, func: &mut Function) {
         let has_candidate = func.blocks.iter().any(|block| {
             block.instructions.windows(2).any(|window| {
                 matches!(func.inst(window[0]).kind, InstKind::CodeCopy(_, _, _))
@@ -482,7 +469,7 @@ impl MemoryStoreEliminator {
                 if self.mem_addr_key(func, dest) != self.mem_addr_key(func, load_addr) {
                     continue;
                 }
-                let Some(&loaded_value) = inst_results.get(&load) else {
+                let Some(loaded_value) = func.inst_result_value(load) else {
                     continue;
                 };
 
@@ -567,7 +554,6 @@ impl MemoryStoreEliminator {
         &mut self,
         func: &mut Function,
         block_id: BlockId,
-        inst_results: &FxHashMap<InstId, ValueId>,
         scratch: &mut BlockScratch,
     ) {
         let mut mstores = 0;
@@ -601,10 +587,10 @@ impl MemoryStoreEliminator {
         }
 
         if has_keccak && mstores != 0 {
-            self.fold_constant_keccak(func, block_id, inst_results, scratch);
+            self.fold_constant_keccak(func, block_id, scratch);
         }
         if has_load && mstores != 0 {
-            self.forward_loads(func, block_id, inst_results, scratch);
+            self.forward_loads(func, block_id, scratch);
         }
         if mstores >= 2 {
             self.remove_equal_stores(func, block_id, scratch);
@@ -978,7 +964,6 @@ impl MemoryStoreEliminator {
         &mut self,
         func: &mut Function,
         block_id: BlockId,
-        inst_results: &FxHashMap<InstId, ValueId>,
         scratch: &mut BlockScratch,
     ) {
         scratch.stored_words.clear();
@@ -1004,7 +989,7 @@ impl MemoryStoreEliminator {
                     else {
                         continue;
                     };
-                    let Some(&result) = inst_results.get(&inst_id) else {
+                    let Some(result) = func.inst_result_value(inst_id) else {
                         continue;
                     };
                     let hash = keccak256(&bytes);
@@ -1075,7 +1060,6 @@ impl MemoryStoreEliminator {
         &mut self,
         func: &mut Function,
         block_id: BlockId,
-        inst_results: &FxHashMap<InstId, ValueId>,
         scratch: &mut BlockScratch,
     ) {
         scratch.stored_values.clear();
@@ -1122,7 +1106,7 @@ impl MemoryStoreEliminator {
                     let Some(&stored_value) = scratch.stored_values.get(&key) else {
                         continue;
                     };
-                    if let Some(&loaded_value) = inst_results.get(&inst_id) {
+                    if let Some(loaded_value) = func.inst_result_value(inst_id) {
                         scratch.replacements.insert(loaded_value, stored_value);
                         scratch.dead.insert(inst_id);
                     }
@@ -1135,7 +1119,7 @@ impl MemoryStoreEliminator {
                     let Some(&stored_value) = scratch.stored_values.get(&key) else {
                         continue;
                     };
-                    if let Some(&loaded_value) = inst_results.get(&inst_id) {
+                    if let Some(loaded_value) = func.inst_result_value(inst_id) {
                         scratch.replacements.insert(loaded_value, stored_value);
                         scratch.dead.insert(inst_id);
                     }

--- a/crates/codegen/src/transform/pre.rs
+++ b/crates/codegen/src/transform/pre.rs
@@ -372,8 +372,7 @@ impl PartialRedundancyEliminator {
             };
             let mut instruction = Instruction::new(kind, Some(result_ty));
             instruction.metadata = metadata.clone();
-            let new_inst = func.alloc_inst(instruction);
-            let value = func.alloc_value(Value::Inst(new_inst));
+            let (new_inst, value) = func.alloc_value_inst(instruction);
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));
             inst_results.insert(new_inst, value);
@@ -395,9 +394,8 @@ impl PartialRedundancyEliminator {
                 first
             }
             _ => {
-                let phi_inst =
-                    func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
-                let phi_value = func.alloc_value(Value::Inst(phi_inst));
+                let (phi_inst, phi_value) = func
+                    .alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
                 let phi_count = func.blocks[target]
                     .instructions
                     .iter()

--- a/crates/codegen/src/transform/pre.rs
+++ b/crates/codegen/src/transform/pre.rs
@@ -151,7 +151,6 @@ impl PartialRedundancyEliminator {
     fn run(&mut self, func: &mut Function) -> PreStats {
         self.stats = PreStats::default();
 
-        let mut inst_results = func.inst_results();
         let mut inst_blocks = func.inst_blocks();
 
         let mut eliminated_keys = FxHashSet::default();
@@ -166,7 +165,6 @@ impl PartialRedundancyEliminator {
             let batch = self.collect_candidates(
                 func,
                 cfg.dominators(),
-                &inst_results,
                 &inst_blocks,
                 &eliminated_keys,
                 &inserted_insts,
@@ -180,7 +178,6 @@ impl PartialRedundancyEliminator {
                 self.apply_candidate(
                     func,
                     candidate,
-                    &mut inst_results,
                     &mut inst_blocks,
                     &mut eliminated_keys,
                     &mut inserted_insts,
@@ -199,7 +196,6 @@ impl PartialRedundancyEliminator {
         &self,
         func: &Function,
         dominators: &DominatorTree,
-        inst_results: &FxHashMap<InstId, ValueId>,
         inst_blocks: &FxHashMap<InstId, BlockId>,
         eliminated_keys: &FxHashSet<(ExprKey, BlockId)>,
         inserted_insts: &GrowableBitSet<InstId>,
@@ -233,7 +229,7 @@ impl PartialRedundancyEliminator {
                 let Some(result_ty) = instruction.result_ty else {
                     continue;
                 };
-                let Some(&result) = inst_results.get(&inst) else {
+                let Some(result) = func.inst_result_value(inst) else {
                     continue;
                 };
 
@@ -245,7 +241,6 @@ impl PartialRedundancyEliminator {
                     result_ty,
                     instruction.metadata.clone(),
                     &predecessors,
-                    inst_results,
                     inst_blocks,
                     dominators,
                     eliminated_keys,
@@ -294,7 +289,6 @@ impl PartialRedundancyEliminator {
         result_ty: MirType,
         metadata: InstructionMetadata,
         predecessors: &[BlockId],
-        inst_results: &FxHashMap<InstId, ValueId>,
         inst_blocks: &FxHashMap<InstId, BlockId>,
         dominators: &DominatorTree,
         eliminated_keys: &FxHashSet<(ExprKey, BlockId)>,
@@ -311,9 +305,7 @@ impl PartialRedundancyEliminator {
                 return None;
             }
             let key = Self::make_expr_key(func, &translated)?;
-            if let Some(value) =
-                Self::available_value_at_end(func, dominators, pred, &key, inst_results)
-            {
+            if let Some(value) = Self::available_value_at_end(func, dominators, pred, &key) {
                 available += 1;
                 incoming.push((pred, value));
                 continue;
@@ -344,7 +336,6 @@ impl PartialRedundancyEliminator {
         &mut self,
         func: &mut Function,
         candidate: PreCandidate,
-        inst_results: &mut FxHashMap<InstId, ValueId>,
         inst_blocks: &mut FxHashMap<InstId, BlockId>,
         eliminated_keys: &mut FxHashSet<(ExprKey, BlockId)>,
         inserted_insts: &mut GrowableBitSet<InstId>,
@@ -375,7 +366,6 @@ impl PartialRedundancyEliminator {
             let (new_inst, value) = func.alloc_value_inst(instruction);
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));
-            inst_results.insert(new_inst, value);
             inst_blocks.insert(new_inst, block);
             inserted_insts.insert(new_inst);
             self.stats.expressions_inserted += 1;
@@ -402,7 +392,6 @@ impl PartialRedundancyEliminator {
                     .take_while(|&&inst_id| matches!(func.inst(inst_id).kind, InstKind::Phi(_)))
                     .count();
                 func.blocks[target].instructions.insert(phi_count, phi_inst);
-                inst_results.insert(phi_inst, phi_value);
                 inst_blocks.insert(phi_inst, target);
                 phi_value
             }
@@ -411,7 +400,6 @@ impl PartialRedundancyEliminator {
         let replacements = FxHashMap::from_iter([(result, replacement)]);
         func.replace_uses(&replacements);
         func.blocks[target].instructions.retain(|&inst_id| inst_id != inst);
-        inst_results.remove(&inst);
         inst_blocks.remove(&inst);
         self.stats.expressions_eliminated += 1;
     }
@@ -495,27 +483,21 @@ impl PartialRedundancyEliminator {
         dominators: &DominatorTree,
         block: BlockId,
         key: &ExprKey,
-        inst_results: &FxHashMap<InstId, ValueId>,
     ) -> Option<ValueId> {
         dominators
             .self_and_dominators(block)
             .into_iter()
-            .find_map(|block| Self::available_value_in_block(func, block, key, inst_results))
+            .find_map(|block| Self::available_value_in_block(func, block, key))
     }
 
-    fn available_value_in_block(
-        func: &Function,
-        block: BlockId,
-        key: &ExprKey,
-        inst_results: &FxHashMap<InstId, ValueId>,
-    ) -> Option<ValueId> {
+    fn available_value_in_block(func: &Function, block: BlockId, key: &ExprKey) -> Option<ValueId> {
         func.blocks[block].instructions.iter().rev().find_map(|&inst| {
             let instruction = func.inst(inst);
             if !Self::is_pre_expression(&instruction.kind) {
                 return None;
             }
             let candidate_key = Self::make_expr_key(func, &instruction.kind)?;
-            (candidate_key == *key).then(|| inst_results.get(&inst).copied()).flatten()
+            (candidate_key == *key).then(|| func.inst_result_value(inst)).flatten()
         })
     }
 

--- a/crates/codegen/src/transform/pre.rs
+++ b/crates/codegen/src/transform/pre.rs
@@ -370,11 +370,9 @@ impl PartialRedundancyEliminator {
                 }
                 _ => split_edge(func, pred, target),
             };
-            let new_inst = func.alloc_inst(Instruction {
-                kind,
-                result_ty: Some(result_ty),
-                metadata: metadata.clone(),
-            });
+            let mut instruction = Instruction::new(kind, Some(result_ty));
+            instruction.metadata = metadata.clone();
+            let new_inst = func.alloc_inst(instruction);
             let value = func.alloc_value(Value::Inst(new_inst));
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -94,7 +94,6 @@ struct SccpStats {
 /// Active instruction and terminator users of each value.
 struct ValueUsers {
     inst_blocks: IndexVec<InstId, BlockId>,
-    inst_results: IndexVec<InstId, Option<ValueId>>,
     instructions: IndexVec<ValueId, Vec<InstId>>,
     terminators: IndexVec<ValueId, Vec<BlockId>>,
 }
@@ -102,14 +101,8 @@ struct ValueUsers {
 impl ValueUsers {
     fn new(func: &Function) -> Self {
         let mut inst_blocks = index_vec![BlockId::MAX; func.num_insts()];
-        let mut inst_results = index_vec![None; func.num_insts()];
         let mut instructions = index_vec![Vec::new(); func.values.len()];
         let mut terminators = index_vec![Vec::new(); func.values.len()];
-        for (value_id, value) in func.values.iter_enumerated() {
-            if let Value::Inst(inst_id) = value {
-                inst_results[*inst_id] = Some(value_id);
-            }
-        }
         for (block_id, block) in func.blocks.iter_enumerated() {
             for &inst_id in &block.instructions {
                 inst_blocks[inst_id] = block_id;
@@ -131,7 +124,7 @@ impl ValueUsers {
             users.sort_unstable();
             users.dedup();
         }
-        Self { inst_blocks, inst_results, instructions, terminators }
+        Self { inst_blocks, instructions, terminators }
     }
 }
 
@@ -190,7 +183,6 @@ impl SccpCx {
         self.evaluate_phis_in_block(
             func,
             BlockId::ENTRY,
-            &users,
             &mut lattice,
             &executable_edges,
             &mut ssa_worklist,
@@ -199,7 +191,6 @@ impl SccpCx {
         self.evaluate_block(
             func,
             BlockId::ENTRY,
-            &users,
             &mut lattice,
             &executable_blocks,
             &executable_edges,
@@ -224,7 +215,6 @@ impl SccpCx {
                 self.evaluate_phis_in_block(
                     func,
                     to,
-                    &users,
                     &mut lattice,
                     &executable_edges,
                     &mut ssa_worklist,
@@ -235,7 +225,6 @@ impl SccpCx {
                     self.evaluate_block(
                         func,
                         to,
-                        &users,
                         &mut lattice,
                         &executable_blocks,
                         &executable_edges,
@@ -267,7 +256,7 @@ impl SccpCx {
         }
 
         // Rewrite phase: apply the lattice results to the function.
-        self.rewrite(func, &users, &lattice, &executable_blocks, &executable_edges)
+        self.rewrite(func, &lattice, &executable_blocks, &executable_edges)
     }
 
     /// Evaluates all instructions in a block.
@@ -276,7 +265,6 @@ impl SccpCx {
         &self,
         func: &Function,
         block_id: BlockId,
-        users: &ValueUsers,
         lattice: &mut IndexVec<ValueId, LatticeValue>,
         _executable_blocks: &DenseBitSet<BlockId>,
         _executable_edges: &FxHashSet<(BlockId, BlockId)>,
@@ -289,7 +277,7 @@ impl SccpCx {
             if matches!(func.inst(inst_id).kind, InstKind::Phi(_)) {
                 continue;
             }
-            if let Some(vid) = users.inst_results[inst_id] {
+            if let Some(vid) = func.inst_result_value(inst_id) {
                 let new_val = self.evaluate_instruction(func, &func.inst(inst_id).kind, lattice);
                 if self.update_lattice(lattice, vid, new_val) {
                     ssa_worklist.push_back(vid);
@@ -308,7 +296,6 @@ impl SccpCx {
         &self,
         func: &Function,
         block_id: BlockId,
-        users: &ValueUsers,
         lattice: &mut IndexVec<ValueId, LatticeValue>,
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
@@ -316,15 +303,7 @@ impl SccpCx {
         let block = &func.blocks[block_id];
         for &inst_id in &block.instructions {
             if matches!(func.inst(inst_id).kind, InstKind::Phi(_)) {
-                self.evaluate_phi(
-                    func,
-                    block_id,
-                    inst_id,
-                    users,
-                    lattice,
-                    executable_edges,
-                    ssa_worklist,
-                );
+                self.evaluate_phi(func, block_id, inst_id, lattice, executable_edges, ssa_worklist);
             }
         }
     }
@@ -335,13 +314,12 @@ impl SccpCx {
         func: &Function,
         block_id: BlockId,
         inst_id: InstId,
-        users: &ValueUsers,
         lattice: &mut IndexVec<ValueId, LatticeValue>,
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
         ssa_worklist: &mut VecDeque<ValueId>,
     ) {
         let InstKind::Phi(incoming) = &func.inst(inst_id).kind else { return };
-        let Some(vid) = users.inst_results[inst_id] else { return };
+        let Some(vid) = func.inst_result_value(inst_id) else { return };
         let mut result = LatticeValue::Top;
         for &(pred, operand) in incoming {
             if executable_edges.contains(&(pred, block_id)) {
@@ -645,16 +623,8 @@ impl SccpCx {
             }
             let inst = func.inst(inst_id);
             if matches!(inst.kind, InstKind::Phi(_)) {
-                self.evaluate_phi(
-                    func,
-                    block_id,
-                    inst_id,
-                    users,
-                    lattice,
-                    executable_edges,
-                    ssa_worklist,
-                );
-            } else if let Some(result_vid) = users.inst_results[inst_id] {
+                self.evaluate_phi(func, block_id, inst_id, lattice, executable_edges, ssa_worklist);
+            } else if let Some(result_vid) = func.inst_result_value(inst_id) {
                 let new_val = self.evaluate_instruction(func, &inst.kind, lattice);
                 if self.update_lattice(lattice, result_vid, new_val) {
                     ssa_worklist.push_back(result_vid);
@@ -675,7 +645,6 @@ impl SccpCx {
     fn rewrite(
         &mut self,
         func: &mut Function,
-        users: &ValueUsers,
         lattice: &IndexVec<ValueId, LatticeValue>,
         executable_blocks: &DenseBitSet<BlockId>,
         executable_edges: &FxHashSet<(BlockId, BlockId)>,
@@ -685,11 +654,11 @@ impl SccpCx {
         let mut const_values: FxHashMap<ValueId, ValueId> = FxHashMap::default();
         let mut dead_insts = DenseBitSet::new_empty(func.num_insts());
 
-        let inst_results = func
+        let value_insts = func
             .instructions()
-            .filter_map(|inst_id| users.inst_results[inst_id].map(|value| (inst_id, value)))
+            .filter_map(|inst_id| func.inst_result_value(inst_id).map(|value| (inst_id, value)))
             .collect::<Vec<_>>();
-        for (inst_id, vid) in inst_results {
+        for (inst_id, vid) in value_insts {
             if let LatticeValue::Constant(c) = &lattice[vid] {
                 // Don't fold side-effecting instructions.
                 if func.inst(inst_id).kind.has_side_effects() {

--- a/crates/codegen/src/transform/sroa.rs
+++ b/crates/codegen/src/transform/sroa.rs
@@ -77,10 +77,9 @@ impl SroaCx {
             return false;
         }
 
-        let inst_results = func.inst_results();
         let mut changed = false;
         for (block_id, object) in allocs {
-            if let Some(plan) = self.plan(func, alias, &inst_results, block_id, object) {
+            if let Some(plan) = self.plan(func, alias, block_id, object) {
                 self.apply(func, block_id, plan);
                 self.eliminated += 1;
                 changed = true;
@@ -95,7 +94,6 @@ impl SroaCx {
         &self,
         func: &Function,
         alias: &AliasAnalysis,
-        inst_results: &FxHashMap<InstId, ValueId>,
         block_id: BlockId,
         object: ValueId,
     ) -> Option<Plan> {
@@ -128,7 +126,7 @@ impl SroaCx {
                 }
             };
             let slot = slot?;
-            let addr = inst_results.get(&inst_id).copied()?;
+            let addr = func.inst_result_value(inst_id)?;
             slot_of.insert(addr, slot);
             address_insts.insert(inst_id);
         }
@@ -180,8 +178,8 @@ impl SroaCx {
                     // A load with no dominating store observes uninitialized or
                     // zeroed memory; keep the allocation rather than guess.
                     let value = *current.get(&slot_of[&addr])?;
-                    if let Some(result) = inst_results.get(&inst_id) {
-                        replacements.insert(*result, value);
+                    if let Some(result) = func.inst_result_value(inst_id) {
+                        replacements.insert(result, value);
                     }
                     dead.insert(inst_id);
                 }

--- a/crates/codegen/src/transform/static_alloc.rs
+++ b/crates/codegen/src/transform/static_alloc.rs
@@ -133,7 +133,6 @@ fn eligible_static_allocations(func: &Function, aa: &AliasAnalysis) -> Vec<Stati
         return Vec::new();
     }
 
-    let inst_results = func.inst_results();
     let cfg = CfgInfo::new(func);
     let mut cyclic = FxHashMap::default();
     let mut candidates = Vec::new();
@@ -154,7 +153,8 @@ fn eligible_static_allocations(func: &Function, aa: &AliasAnalysis) -> Vec<Stati
             {
                 continue;
             }
-            let candidate = StaticAllocCandidate { block, alloc, ptr: inst_results[&alloc], size };
+            let ptr = func.inst_result_value(alloc).expect("allocation must produce a value");
+            let candidate = StaticAllocCandidate { block, alloc, ptr, size };
             if !aa.value_escapes(func, candidate.ptr) && candidate_uses_are_safe(func, &candidate) {
                 candidates.push(candidate);
             }
@@ -187,8 +187,6 @@ fn block_in_cycle(func: &Function, block: BlockId) -> bool {
 
 /// Verifies every use of the pointer stays in bounds and never escapes.
 fn candidate_uses_are_safe(func: &Function, cand: &StaticAllocCandidate) -> bool {
-    let inst_results = func.inst_results();
-
     // In-bounds address derivations from the pointer, to a fixpoint so
     // definition order does not matter.
     let mut derived: FxHashMap<ValueId, u64> = FxHashMap::default();
@@ -197,7 +195,7 @@ fn candidate_uses_are_safe(func: &Function, cand: &StaticAllocCandidate) -> bool
         let mut grew = false;
         for inst_id in func.instructions() {
             if let InstKind::Add(a, b) = func.inst(inst_id).kind
-                && let Some(&result) = inst_results.get(&inst_id)
+                && let Some(result) = func.inst_result_value(inst_id)
                 && !derived.contains_key(&result)
             {
                 let (base, offset) = if derived.contains_key(&a) {
@@ -261,9 +259,9 @@ fn candidate_uses_are_safe(func: &Function, cand: &StaticAllocCandidate) -> bool
                     }
                     // In-bounds derivations were collected above; anything
                     // else consuming an address is an escape.
-                    InstKind::Add(_, _) => {
-                        inst_results.get(&inst_id).is_some_and(|r| derived.contains_key(r))
-                    }
+                    InstKind::Add(_, _) => func
+                        .inst_result_value(inst_id)
+                        .is_some_and(|result| derived.contains_key(&result)),
                     _ => false,
                 };
                 if !ok {

--- a/crates/codegen/src/transform/storage_load_cse.rs
+++ b/crates/codegen/src/transform/storage_load_cse.rs
@@ -72,13 +72,12 @@ impl StorageLoadCseCx {
 
         let mut analyses = AnalysisManager::new();
         let liveness = analyses.get_or_compute(&LivenessAnalysis, func);
-        let inst_results = func.inst_results();
         state.replacements.clear();
         state.dead.clear();
 
         for block_id in func.blocks.indices() {
             state.cached_loads.clear();
-            self.process_block(func, block_id, liveness, &inst_results, state);
+            self.process_block(func, block_id, liveness, state);
         }
 
         if !state.replacements.is_empty() {
@@ -112,7 +111,6 @@ impl StorageLoadCseCx {
         func: &Function,
         block_id: BlockId,
         liveness: &Liveness,
-        inst_results: &FxHashMap<InstId, ValueId>,
         state: &mut RunState,
     ) {
         let aa = self.alias.as_ref().expect("storage-load CSE alias snapshot is initialized");
@@ -125,7 +123,7 @@ impl StorageLoadCseCx {
                         *slot,
                         &state.replacements,
                     );
-                    let Some(&result) = inst_results.get(&inst_id) else {
+                    let Some(result) = func.inst_result_value(inst_id) else {
                         continue;
                     };
                     if let Some(&cached) = state.cached_loads.get(&alias) {

--- a/crates/codegen/src/transform/storage_promotion.rs
+++ b/crates/codegen/src/transform/storage_promotion.rs
@@ -762,9 +762,10 @@ impl StorageScalarPromoter {
         slot_value: ValueId,
         temp_addr: ValueId,
     ) {
-        let load_inst =
-            func.alloc_inst(Instruction::new(InstKind::MLoad(temp_addr), Some(MirType::uint256())));
-        let load_value = func.alloc_value(Value::Inst(load_inst));
+        let (load_inst, load_value) = func.alloc_value_inst(Instruction::new(
+            InstKind::MLoad(temp_addr),
+            Some(MirType::uint256()),
+        ));
         let store_inst =
             func.alloc_inst(Instruction::new(InstKind::SStore(slot_value, load_value), None));
 
@@ -801,9 +802,8 @@ impl StorageScalarPromoter {
         let mut exit_instructions = old_instructions[..split_pos].to_vec();
         let continuation_instructions = old_instructions[split_pos..].to_vec();
 
-        let dirty_load_inst =
-            func.alloc_inst(Instruction::new(InstKind::MLoad(dirty_addr), Some(MirType::Bool)));
-        let dirty_value = func.alloc_value(Value::Inst(dirty_load_inst));
+        let (dirty_load_inst, dirty_value) = func
+            .alloc_value_inst(Instruction::new(InstKind::MLoad(dirty_addr), Some(MirType::Bool)));
         exit_instructions.push(dirty_load_inst);
 
         func.blocks[exit].instructions = exit_instructions;
@@ -813,9 +813,10 @@ impl StorageScalarPromoter {
             else_block: continuation,
         });
 
-        let load_inst =
-            func.alloc_inst(Instruction::new(InstKind::MLoad(temp_addr), Some(MirType::uint256())));
-        let load_value = func.alloc_value(Value::Inst(load_inst));
+        let (load_inst, load_value) = func.alloc_value_inst(Instruction::new(
+            InstKind::MLoad(temp_addr),
+            Some(MirType::uint256()),
+        ));
         let store_inst =
             func.alloc_inst(Instruction::new(InstKind::SStore(slot_value, load_value), None));
 
@@ -881,9 +882,7 @@ impl StorageScalarPromoter {
         kind: InstKind,
         ty: MirType,
     ) -> (InstId, ValueId) {
-        let inst = func.alloc_inst(Instruction::new(kind, Some(ty)));
-        let value = func.alloc_value(Value::Inst(inst));
-        (inst, value)
+        func.alloc_value_inst(Instruction::new(kind, Some(ty)))
     }
 
     /// Allocates an instruction that produces no value, so no result [`Value`]


### PR DESCRIPTION
Store each instruction's result value on the instruction and allocate the instruction/value pair atomically. Value-producing instructions now use `alloc_value_inst`, void instructions use `alloc_inst`, and MIR forward references use a narrow preallocated-result path instead of the general `set_value` mutation API.

Passes and analyses read that stored result directly through `inst_result_value`. This removes the bulk `inst_results` API, all per-pass reverse result maps, and the remaining linear scans for an instruction's result.

On the representation-only commit, CodSpeed measured Seaport codegen at 968.9 ms instead of 1,038.4 ms, a 7.17% improvement, with the other 98 benchmarks unchanged.
