### PR TITLE
fix(codegen): distinguish tail call targets

### DIFF
--- a/crates/codegen/src/transform/cfg_simplify.rs
+++ b/crates/codegen/src/transform/cfg_simplify.rs
@@ -69,6 +69,7 @@ impl MirPass for FunctionDce {
 struct CanonBlock {
     insts: Vec<CanonInst>,
     term_mnemonic: &'static str,
+    term_function: Option<FunctionId>,
     term_operands: Vec<CanonOperand>,
 }
 
@@ -276,8 +277,10 @@ impl CfgSimplifier {
             });
         }
 
+        let term_function =
+            if let Terminator::TailCall { function, .. } = term { Some(*function) } else { None };
         let term_operands = term.operands().into_iter().map(canon_operand).collect();
-        Some(CanonBlock { insts, term_mnemonic: term.mnemonic(), term_operands })
+        Some(CanonBlock { insts, term_mnemonic: term.mnemonic(), term_function, term_operands })
     }
 
     fn simplify_trivial_phis(&mut self, func: &mut Function) {

--- a/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.stdout
@@ -23,25 +23,35 @@ bb0:
   dup1
   push 0x2a5dea89
   eq
-  push bb14
+  push bb15
   jumpi
   jump bb5
 bb5 [cold]:
   push 0
   dup1
   revert
-bb21 [cold]:
+bb24 [cold]:
+  push 0x4e487b71
+  push 224
+  shl
+  push 0
+  mstore
+  push 65
+  jump bb25
+bb25 [cold]:
+  push 4
+  mstore
+  push 36
+  push 0
+  revert
+bb23 [cold]:
   push 0x4e487b71
   push 224
   shl
   push 0
   mstore
   push 50
-  push 4
-  mstore
-  push 36
-  push 0
-  revert
+  jump bb25
 bb6:
   calldatasize
   push 4
@@ -49,42 +59,62 @@ bb6:
   sub
   push 96
   sgt
+  push 36
+  calldataload
+  push 68
+  calldataload
+  push 4
+  calldataload
+  swap3
+  swap1
+  swap2
+  swap1
   push bb5
   jumpi
   push 0
   push 128
   mstore
   push 36
-  push 4
-  calldataload
+  dup4
   add
   dup1
   push 352
   mstore
   push 4
-  push 4
-  calldataload
+  dup5
   add
+  swap4
+  pop
+  dup4
   calldataload
-  push 68
-  calldataload
+  swap4
+  pop
+  dup4
+  dup4
   gt
+  swap4
+  pop
+  pop
+  swap2
+  swap1
+  swap2
+  swap1
+  push bb23
+  jumpi
+  dup2
+  lt
+  push 36
+  calldataload
+  swap1
+  push bb23
+  jumpi
+  dup2
+  sub
+  dup1
+  push 160
+  mstore
   swap1
   pop
-  push bb21
-  jumpi
-  push 36
-  calldataload
-  push 68
-  calldataload
-  lt
-  push bb21
-  jumpi
-  push 36
-  calldataload
-  push 68
-  calldataload
-  sub
   dup1
   push 160
   mstore
@@ -110,7 +140,7 @@ bb6:
   swap2
   pop
   pop
-  push bb21
+  push bb24
   jumpi
   push 31
   not
@@ -153,11 +183,11 @@ bb6:
   gt
   swap1
   pop
-  push bb21
-  jumpi
   push bb24
-  jump bb23
-bb23:
+  jumpi
+  push bb28
+  jump bb27
+bb27:
   push 64
   mload
   dup1
@@ -181,7 +211,7 @@ bb23:
   mstore
   swap1
   jump
-bb14:
+bb15:
   calldatasize
   push 4
   swap1
@@ -210,34 +240,41 @@ bb14:
   mstore
   push 36
   calldataload
-  gt
-  swap1
-  pop
-  push bb21
+  dup2
+  lt
+  push bb23
   jumpi
   push 36
   calldataload
-  push 352
-  mload
+  dup2
   sub
+  dup1
+  push 160
+  mstore
+  swap1
+  pop
   dup1
   push 160
   mstore
   push 36
   calldataload
-  push 320
-  mload
+  dup3
   add
   dup1
   push 192
   mstore
+  swap2
+  pop
+  dup2
+  push 192
+  mstore
   push 31
-  dup3
+  dup2
   add
   dup1
   push 288
   mstore
-  dup3
+  dup2
   dup1
   push 160
   mstore
@@ -245,7 +282,7 @@ bb14:
   swap2
   pop
   pop
-  push bb21
+  push bb24
   jumpi
   push 31
   not
@@ -288,11 +325,11 @@ bb14:
   gt
   swap1
   pop
-  push bb21
+  push bb24
   jumpi
-  push bb25
-  jump bb23
-bb24:
+  push bb29
+  jump bb27
+bb28:
   push 32
   dup2
   add
@@ -350,15 +387,15 @@ bb24:
   sub
   push 288
   mload
-  jump bb22
-bb22:
+  jump bb26
+bb26:
   keccak256
   push 128
   mstore
   push 32
   push 128
   return
-bb25:
+bb29:
   push 32
   dup2
   add
@@ -428,4 +465,4 @@ bb25:
   swap1
   sub
   swap1
-  jump bb22
+  jump bb26

--- a/tests/ui/codegen/lowering/calldata_array_to_memory.stdout
+++ b/tests/ui/codegen/lowering/calldata_array_to_memory.stdout
@@ -18,12 +18,12 @@ bb0:
   dup1
   push 0x2be02e45
   eq
-  push bb21
+  push bb22
   jumpi
   dup1
   push 0x3ce9e381
   eq
-  push bb26
+  push bb27
   jumpi
   dup1
   push 0x7da1365e
@@ -40,25 +40,33 @@ bb7 [cold]:
   push 0
   dup1
   revert
-bb37 [cold]:
+bb40 [cold]:
+  push 0x4e487b71
+  push 224
+  shl
+  push 0
+  mstore
+  push 17
+  jump bb41
+bb41 [cold]:
+  push 4
+  mstore
+  push 36
+  push 0
+  revert
+bb39 [cold]:
   push 0x4e487b71
   push 224
   shl
   push 0
   mstore
   push 65
-  jump bb39
-bb39 [cold]:
-  push 4
-  mstore
-  push 36
-  push 0
-  revert
+  jump bb41
 bb8:
   push 0
   sload
-  jump bb38
-bb38:
+  jump bb42
+bb42:
   push 128
   mstore
   push 32
@@ -82,7 +90,7 @@ bb9:
   add
   calldataload
   dup1
-  push 256
+  push 288
   mstore
   push 36
   push 4
@@ -93,19 +101,15 @@ bb9:
   mstore
   dup2
   dup1
-  push 256
+  push 288
   mstore
   push 251
   shr
-  swap2
-  pop
-  pop
-  push bb37
+  push bb39
   jumpi
-  push 256
-  mload
+  dup2
   dup1
-  push 256
+  push 288
   mstore
   push 5
   shl
@@ -127,26 +131,26 @@ bb9:
   mstore
   swap1
   pop
-  push 256
-  mload
+  dup4
   dup1
-  push 256
+  push 288
   mstore
   dup2
   mstore
+  swap3
+  pop
   push 32
-  dup2
+  dup4
   add
-  dup3
-  push 352
-  mload
+  dup2
+  dup4
   dup1
   push 352
   mstore
   dup3
   calldatacopy
   pop
-  swap1
+  pop
   pop
   push 0
   push 160
@@ -179,7 +183,7 @@ bb14:
   dup1
   push 384
   mstore
-  jump bb38
+  jump bb42
 bb16:
   push 192
   mload
@@ -231,7 +235,7 @@ bb16:
   push 448
   mstore
   gt
-  push bb37
+  push bb40
   jumpi
   push 320
   mload
@@ -249,7 +253,7 @@ bb16:
   mstore
   add
   dup1
-  push 288
+  push 256
   mstore
   dup2
   dup1
@@ -263,19 +267,19 @@ bb16:
   swap2
   pop
   pop
-  push bb37
+  push bb40
   jumpi
-  push 288
+  push 256
   mload
   dup1
-  push 288
+  push 256
   mstore
   push 192
   mstore
-  push 288
+  push 256
   mload
   jump bb14
-bb21:
+bb22:
   calldatasize
   push 4
   swap1
@@ -311,7 +315,7 @@ bb21:
   mstore
   push 251
   shr
-  push bb37
+  push bb39
   jumpi
   dup2
   dup1
@@ -369,8 +373,8 @@ bb21:
   push 224
   mstore
   mload
-  jump bb38
-bb26:
+  jump bb42
+bb27:
   calldatasize
   push 4
   swap1
@@ -421,7 +425,7 @@ bb26:
   pop
   pop
   pop
-  push bb37
+  push bb39
   jumpi
   push 160
   mload
@@ -506,7 +510,7 @@ bb26:
   swap2
   pop
   pop
-  push bb37
+  push bb39
   jumpi
   push 31
   not
@@ -549,7 +553,7 @@ bb26:
   gt
   swap1
   pop
-  push bb37
+  push bb39
   jumpi
   push 64
   mload
@@ -655,7 +659,7 @@ bb26:
   pop
   pop
   iszero
-  push bb37
+  push bb40
   jumpi
   push 448
   mload
@@ -674,7 +678,7 @@ bb26:
   push 256
   mstore
   gt
-  push bb37
+  push bb40
   jumpi
   push 416
   mload
@@ -707,7 +711,7 @@ bb26:
   pop
   pop
   iszero
-  push bb37
+  push bb40
   jumpi
   push 480
   mload
@@ -726,14 +730,14 @@ bb26:
   push 288
   mstore
   gt
-  push bb37
+  push bb40
   jumpi
   push 512
   mload
   dup1
   push 512
   mstore
-  jump bb38
+  jump bb42
 bb20 [cold]:
   push 0x4e487b71
   push 224
@@ -742,4 +746,4 @@ bb20 [cold]:
   mstore
   pop
   push 50
-  jump bb39
+  jump bb41

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir
@@ -1,0 +1,40 @@
+//@compile-flags: --pass cfg-simplify
+//@filecheck:
+@module CfgDedupTailCalls
+
+fn @target_a() {
+  bb0:
+    stop
+}
+
+fn @target_b() {
+  bb0:
+    stop
+}
+
+// Tail calls with different targets must NOT merge.
+// CHECK-LABEL: {{^[ +].*}}fn @keep_distinct_targets{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK: {{^[ +].*}}tail_call @target_a
+// CHECK: {{^[ +].*}}tail_call @target_b
+fn @keep_distinct_targets(arg0: bool) {
+  bb0:
+    jumpi arg0, bb1, bb2
+  bb1:
+    tail_call fn0
+  bb2:
+    tail_call fn1
+}
+
+// Tail calls with the same target still merge.
+// CHECK-LABEL: {{^[ +].*}}fn @dedup_same_target{{[( ]}}
+// CHECK: - jumpi arg0, bb1, bb2
+// CHECK: {{^[ +].*}}tail_call @target_a
+fn @dedup_same_target(arg0: bool) {
+  bb0:
+    jumpi arg0, bb1, bb2
+  bb1:
+    tail_call fn0
+  bb2:
+    tail_call fn0
+}

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.stdout
@@ -1,0 +1,31 @@
+- // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir (before cfg-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir (after cfg-simplify) ===
+  @module CfgDedupTailCalls
+  fn @target_a() {
+    bb0:
+      stop
+  }
+  
+  fn @target_b() {
+    bb0:
+      stop
+  }
+  
+  fn @keep_distinct_targets(arg0: bool) {
+    bb0:
+      jumpi arg0, bb1, bb2
+    bb1:
+      tail_call @target_a
+    bb2:
+      tail_call @target_b
+  }
+  
+  fn @dedup_same_target(arg0: bool) {
+    bb0:
+-     jumpi arg0, bb1, bb2
+-   bb1:
+-     tail_call @target_a
+-   bb2:
+      tail_call @target_a
+  }
+  


### PR DESCRIPTION
Terminal-block deduplication keys tail calls by mnemonic and operands but not by callee. Argumentless calls to different outlined revert helpers can therefore collapse, changing a memory-allocation panic `0x41` into a bounds panic `0x32`.

Include the callee in the canonical block key. A focused MIR fixture checks that distinct targets remain separate while identical targets still deduplicate, and the affected EVM IR snapshots now retain the correct panic helpers.
