### PR TITLE
refactor(codegen): allocate results atomically

### DIFF
--- a/crates/codegen/src/analysis/liveness.rs
+++ b/crates/codegen/src/analysis/liveness.rs
@@ -854,12 +854,14 @@ mod tests {
         // Phase 2: insert the phi instruction at the head of `header` and point
         // the placeholder value at its result.
         let phi_val = phi_placeholder;
-        let phi_inst = func.alloc_inst(crate::mir::Instruction::new(
-            crate::mir::InstKind::Phi(vec![(entry, init), (body, updated)]),
-            Some(MirType::uint256()),
-        ));
+        let phi_inst = func.alloc_inst_with_result(
+            crate::mir::Instruction::new(
+                crate::mir::InstKind::Phi(vec![(entry, init), (body, updated)]),
+                Some(MirType::uint256()),
+            ),
+            phi_val,
+        );
         func.blocks[header].instructions.insert(0, phi_inst);
-        func.set_value(phi_val, crate::mir::Value::Inst(phi_inst));
 
         let liveness = Liveness::compute(&func);
 

--- a/crates/codegen/src/backend/evm/stack/scheduler.rs
+++ b/crates/codegen/src/backend/evm/stack/scheduler.rs
@@ -335,9 +335,8 @@ mod tests {
         let mut func = make_test_func();
         let v0 = ValueId::from_usize(0);
         let v1 = ValueId::from_usize(1);
-        let inst =
-            func.alloc_inst(Instruction::new(InstKind::Add(v0, v1), Some(MirType::uint256())));
-        let deep = func.alloc_value(Value::Inst(inst));
+        let (_, deep) = func
+            .alloc_value_inst(Instruction::new(InstKind::Add(v0, v1), Some(MirType::uint256())));
         let mut scheduler = StackScheduler::new();
 
         scheduler.stack.push(deep);

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -682,40 +682,44 @@ impl<'gcx> Lowerer<'gcx> {
                 builder.make_slice(zero, size, crate::mir::SliceLocation::Calldata)
             }
             Builtin::BlockTimestamp => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::Timestamp,
-                    Some(MirType::uint256()),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::Timestamp,
+                        Some(MirType::uint256()),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::BlockNumber => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::BlockNumber,
-                    Some(MirType::uint256()),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::BlockNumber,
+                        Some(MirType::uint256()),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::TxOrigin => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::Origin,
-                    Some(MirType::Address),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::Origin,
+                        Some(MirType::Address),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::TxGasPrice => {
-                let inst = builder.func_mut().alloc_inst(crate::mir::Instruction::new(
-                    crate::mir::InstKind::GasPrice,
-                    Some(MirType::uint256()),
-                ));
+                let (inst, result) =
+                    builder.func_mut().alloc_value_inst(crate::mir::Instruction::new(
+                        crate::mir::InstKind::GasPrice,
+                        Some(MirType::uint256()),
+                    ));
                 let block = builder.current_block();
                 builder.func_mut().block_mut(block).instructions.push(inst);
-                builder.func_mut().alloc_value(crate::mir::Value::Inst(inst))
+                result
             }
             Builtin::Gasleft => builder.gas(),
             Builtin::This => builder.address(),

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -83,30 +83,41 @@ impl<'a> FunctionBuilder<'a> {
         self.func.alloc_value(value)
     }
 
-    /// Replaces an allocated value.
-    pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
-        self.func.set_value(id, value);
-    }
-
-    fn emit_inst_raw(&mut self, kind: InstKind, result_ty: Option<MirType>) -> InstId {
+    fn make_inst(&self, kind: InstKind, result_ty: Option<MirType>) -> Instruction {
         let mut inst = Instruction::new(kind, result_ty);
         inst.metadata.set_effect(Some(inst.kind.effect_kind()));
         inst.metadata.set_memory_region(self.memory_region_for_inst(&inst.kind));
         inst.metadata.set_storage_alias(self.storage_alias_for_inst(&inst.kind));
-        self.append_instruction(inst)
+        inst
     }
 
     /// Appends a fully constructed instruction to the current block.
-    pub(crate) fn append_instruction(&mut self, inst: Instruction) -> InstId {
-        let inst_id = self.func.alloc_inst(inst);
+    pub(crate) fn append_instruction(&mut self, inst: Instruction) -> (InstId, Option<ValueId>) {
+        let (inst_id, result) = if inst.result_ty.is_some() {
+            let (inst_id, result) = self.func.alloc_value_inst(inst);
+            (inst_id, Some(result))
+        } else {
+            (self.func.alloc_inst(inst), None)
+        };
+        self.func.blocks[self.current_block].instructions.push(inst_id);
+        (inst_id, result)
+    }
+
+    /// Appends a fully constructed instruction for a preallocated undefined result value.
+    pub(crate) fn append_instruction_with_result(
+        &mut self,
+        inst: Instruction,
+        result: ValueId,
+    ) -> InstId {
+        let inst_id = self.func.alloc_inst_with_result(inst, result);
         self.func.blocks[self.current_block].instructions.push(inst_id);
         inst_id
     }
 
     fn emit_inst(&mut self, kind: InstKind, result_ty: Option<MirType>) -> ValueId {
         debug_assert!(result_ty.is_some(), "value-producing instructions must have a result type");
-        let inst_id = self.emit_inst_raw(kind, result_ty);
-        self.alloc_value(Value::Inst(inst_id))
+        let inst = self.make_inst(kind, result_ty);
+        self.append_instruction(inst).1.expect("value-producing instruction must have a result")
     }
 
     /// Emits an instruction that produces no value, such as a store or a log.
@@ -114,7 +125,8 @@ impl<'a> FunctionBuilder<'a> {
     /// No result [`Value`] is allocated: only value-producing instructions get
     /// an entry in the function's value table.
     fn emit_void_inst(&mut self, kind: InstKind) {
-        self.emit_inst_raw(kind, None);
+        let inst = self.make_inst(kind, None);
+        self.append_instruction(inst);
     }
 
     fn memory_region_for_inst(&self, kind: &InstKind) -> Option<MemoryRegion> {

--- a/crates/codegen/src/mir/function.rs
+++ b/crates/codegen/src/mir/function.rs
@@ -227,36 +227,50 @@ impl Function {
 
     /// Allocates a new value.
     pub(crate) fn alloc_value(&mut self, value: Value) -> ValueId {
-        let result = match &value {
-            Value::Inst(inst) => Some(*inst),
-            _ => None,
-        };
-        let value = self.values.push(value);
-        if let Some(inst) = result {
-            let previous = self.instructions[inst].set_result(Some(value));
-            assert!(previous.is_none(), "instruction cannot have multiple result values");
-        }
-        value
+        assert!(
+            !matches!(value, Value::Inst(_)),
+            "instruction results must be allocated with their instruction"
+        );
+        self.values.push(value)
     }
 
-    /// Replaces an allocated value and updates its instruction-result mapping.
-    pub(crate) fn set_value(&mut self, id: ValueId, value: Value) {
-        if let Value::Inst(inst) = self.values[id] {
-            self.instructions[inst].set_result(None);
-        }
-        let result = match &value {
-            Value::Inst(inst) => Some(*inst),
-            _ => None,
-        };
-        self.values[id] = value;
-        if let Some(inst) = result {
-            let previous = self.instructions[inst].set_result(Some(id));
-            assert!(previous.is_none(), "instruction cannot have multiple result values");
-        }
+    /// Allocates a value-producing instruction and its result value.
+    pub(crate) fn alloc_value_inst(&mut self, mut inst: Instruction) -> (InstId, ValueId) {
+        assert!(inst.result_ty.is_some(), "value-producing instruction must have a result type");
+
+        let inst_id = self.instructions.next_idx();
+        let value_id = self.values.next_idx();
+        assert!(inst.set_result(Some(value_id)).is_none(), "new instruction already has a result");
+        let allocated_inst = self.instructions.push(inst);
+        let allocated_value = self.values.push(Value::Inst(inst_id));
+        debug_assert_eq!(allocated_inst, inst_id);
+        debug_assert_eq!(allocated_value, value_id);
+        (inst_id, value_id)
     }
 
-    /// Allocates a new instruction.
+    /// Allocates a value-producing instruction for a preallocated undefined result value.
+    pub(crate) fn alloc_inst_with_result(
+        &mut self,
+        mut inst: Instruction,
+        result: ValueId,
+    ) -> InstId {
+        assert!(inst.result_ty.is_some(), "value-producing instruction must have a result type");
+        assert!(
+            matches!(self.values[result], Value::Undef(_)),
+            "preallocated instruction result must be undefined"
+        );
+
+        let inst_id = self.instructions.next_idx();
+        assert!(inst.set_result(Some(result)).is_none(), "new instruction already has a result");
+        self.values[result] = Value::Inst(inst_id);
+        let allocated_inst = self.instructions.push(inst);
+        debug_assert_eq!(allocated_inst, inst_id);
+        inst_id
+    }
+
+    /// Allocates an instruction that produces no value.
     pub(crate) fn alloc_inst(&mut self, mut inst: Instruction) -> InstId {
+        assert!(inst.result_ty.is_none(), "value-producing instruction must allocate its result");
         inst.set_result(None);
         self.instructions.push(inst)
     }

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -520,19 +520,15 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         label: u32,
-        inst_id: InstId,
-    ) -> PResult<'sess, ()> {
+    ) -> PResult<'sess, Option<ValueId>> {
         if let Some(value) = self.value_labels.get(&label).copied() {
             if matches!(builder.func().values[value], Value::Undef(_)) {
-                builder.set_value(value, Value::Inst(inst_id));
-                return Ok(());
+                return Ok(Some(value));
             }
             return Err(self.parser.error(format!("duplicate value `v{label}`")));
         }
 
-        let value = builder.alloc_value(Value::Inst(inst_id));
-        self.value_labels.insert(label, value);
-        Ok(())
+        Ok(None)
     }
 
     fn reject_unresolved_value_labels(&self, func: &Function) -> PResult<'sess, ()> {
@@ -930,10 +926,28 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
         let metadata = self.parse_metadata(builder)?;
         let mut inst = Instruction::new(kind, result_ty);
         inst.metadata = metadata;
-        let inst_id = builder.append_instruction(inst);
+        if result_label.is_some() && result_ty.is_none() {
+            return Err(self
+                .parser
+                .error_at(mnemonic_span, "instruction does not produce a result value"));
+        }
+        let existing_result = match result_label {
+            Some(label) => self.resolve_result_label(builder, label)?,
+            None => None,
+        };
+        let (inst_id, result) = if let Some(result) = existing_result {
+            (builder.append_instruction_with_result(inst, result), Some(result))
+        } else {
+            builder.append_instruction(inst)
+        };
         self.finish_function_ref(FunctionRefTarget::Instruction(inst_id));
-        if let Some(label) = result_label {
-            self.resolve_result_label(builder, label, inst_id)?;
+        if let Some(label) = result_label
+            && existing_result.is_none()
+        {
+            let result = result.ok_or_else(|| {
+                self.parser.error_at(mnemonic_span, "instruction does not produce a result value")
+            })?;
+            self.value_labels.insert(label, result);
         }
         Ok(())
     }

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -336,9 +336,8 @@ impl CommonSubexprEliminator {
         let mut inserted_by_block: FxHashMap<BlockId, usize> = FxHashMap::default();
 
         for candidate in candidates {
-            let new_inst =
-                func.alloc_inst(Instruction::new(candidate.kind, Some(candidate.result_ty)));
-            let new_value = func.alloc_value(Value::Inst(new_inst));
+            let (new_inst, new_value) =
+                func.alloc_value_inst(Instruction::new(candidate.kind, Some(candidate.result_ty)));
 
             let phi_count = func.blocks[candidate.block_id]
                 .instructions

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -16,8 +16,7 @@ use crate::{
     analysis::{AliasAnalysis, CfgInfo, LocationSize, MemoryAddress, MemoryLocation},
     memory::EvmMemoryLayout,
     mir::{
-        BlockId, Function, InstId, InstKind, Instruction, MirType, Module, Terminator, Value,
-        ValueId,
+        BlockId, Function, InstId, InstKind, Instruction, MirType, Module, Terminator, ValueId,
         utils::{self as mir_utils, repair_reachability_phis},
     },
     pass::{MirPass, run_function_pass},
@@ -987,9 +986,10 @@ impl<'a> SlotSsaBuilder<'a> {
             return pending.value;
         }
 
-        let inst =
-            func.alloc_inst(Instruction::new(InstKind::Phi(Vec::new()), Some(MirType::uint256())));
-        let value = func.alloc_value(Value::Inst(inst));
+        let (inst, value) = func.alloc_value_inst(Instruction::new(
+            InstKind::Phi(Vec::new()),
+            Some(MirType::uint256()),
+        ));
         self.phis.insert(
             block,
             PendingPhi {

--- a/crates/codegen/src/transform/indvar_simplify.rs
+++ b/crates/codegen/src/transform/indvar_simplify.rs
@@ -213,11 +213,10 @@ impl IndVarSimplifier {
         }
 
         let initial = self.build_base_plus_offset(func, preheader, key.base, init_offset)?;
-        let phi_inst = func.alloc_inst(Instruction::new(
+        let (phi_inst, phi_value) = func.alloc_value_inst(Instruction::new(
             InstKind::Phi(vec![(preheader, initial)]),
             Some(MirType::uint256()),
         ));
-        let phi_value = func.alloc_value(Value::Inst(phi_inst));
         self.insert_header_phi(func, loop_data.header, phi_inst);
 
         let delta = self.offset_value(func, delta)?;
@@ -268,9 +267,9 @@ impl IndVarSimplifier {
         kind: InstKind,
         ty: Option<MirType>,
     ) -> ValueId {
-        let inst = func.alloc_inst(Instruction::new(kind, ty));
+        let (inst, value) = func.alloc_value_inst(Instruction::new(kind, ty));
         func.blocks[block].instructions.push(inst);
-        func.alloc_value(Value::Inst(inst))
+        value
     }
 
     fn insert_header_phi(&self, func: &mut Function, header: BlockId, phi_inst: InstId) {

--- a/crates/codegen/src/transform/inline.rs
+++ b/crates/codegen/src/transform/inline.rs
@@ -770,12 +770,15 @@ impl<'a> InlineCloner<'a> {
             for &inst_id in &block.instructions {
                 let inst = self.callee.inst(inst_id).clone();
                 let kind = self.clone_inst_kind(inst.kind)?;
-                let new_inst = self.caller.alloc_inst(Instruction::new(kind, inst.result_ty));
-                instructions.push(new_inst);
-                if let Some(callee_result) = self.callee.inst_result_value(inst_id) {
-                    let new_result = self.caller.alloc_value(Value::Inst(new_inst));
+                let instruction = Instruction::new(kind, inst.result_ty);
+                let new_inst = if let Some(callee_result) = self.callee.inst_result_value(inst_id) {
+                    let (new_inst, new_result) = self.caller.alloc_value_inst(instruction);
                     self.value_map.insert(callee_result, new_result);
-                }
+                    new_inst
+                } else {
+                    self.caller.alloc_inst(instruction)
+                };
+                instructions.push(new_inst);
             }
             self.caller.blocks[caller_block].instructions = instructions;
         }
@@ -1119,9 +1122,10 @@ fn build_return_values(
             .iter()
             .map(|(block, edge_values)| Some((*block, *edge_values.get(index)?)))
             .collect::<Option<Vec<_>>>()?;
-        let phi = caller.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(ty)));
+        let (phi, value) =
+            caller.alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(ty)));
         caller.blocks[continuation].instructions.insert(index, phi);
-        values.push(caller.alloc_value(Value::Inst(phi)));
+        values.push(value);
     }
     Some(values)
 }
@@ -1138,8 +1142,8 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
         .take_while(|&&inst_id| matches!(caller.inst(inst_id).kind, InstKind::Phi(_)))
         .count();
 
-    let base_load = caller.alloc_inst(Instruction::new(InstKind::Fmp, Some(MirType::MemPtr)));
-    let base = caller.alloc_value(Value::Inst(base_load));
+    let (base_load, base) =
+        caller.alloc_value_inst(Instruction::new(InstKind::Fmp, Some(MirType::MemPtr)));
     let mut insert_at = phi_count;
     caller.blocks[continuation].instructions.insert(insert_at, base_load);
     insert_at += 1;
@@ -1147,9 +1151,10 @@ fn insert_extra_return_stores(caller: &mut Function, continuation: BlockId, valu
     for (index, &value) in values.iter().enumerate() {
         let offset = caller
             .alloc_value(Value::Immediate(Immediate::uint256(U256::from((index as u64 + 1) * 32))));
-        let addr = caller
-            .alloc_inst(Instruction::new(InstKind::Add(base, offset), Some(MirType::uint256())));
-        let addr_value = caller.alloc_value(Value::Inst(addr));
+        let (addr, addr_value) = caller.alloc_value_inst(Instruction::new(
+            InstKind::Add(base, offset),
+            Some(MirType::uint256()),
+        ));
         let store = caller.alloc_inst(Instruction::new(InstKind::MStore(addr_value, value), None));
         caller.blocks[continuation].instructions.insert(insert_at, addr);
         caller.blocks[continuation].instructions.insert(insert_at + 1, store);

--- a/crates/codegen/src/transform/load_pre.rs
+++ b/crates/codegen/src/transform/load_pre.rs
@@ -958,8 +958,7 @@ impl LoadRedundancyEliminator {
         for block in insertions {
             let mut instruction = Instruction::new(kind.clone(), Some(result_ty));
             instruction.metadata = metadata.clone();
-            let new_inst = func.alloc_inst(instruction);
-            let value = func.alloc_value(Value::Inst(new_inst));
+            let (new_inst, value) = func.alloc_value_inst(instruction);
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));
             inserted_insts.insert(new_inst);
@@ -980,9 +979,8 @@ impl LoadRedundancyEliminator {
                 first
             }
             _ => {
-                let phi_inst =
-                    func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
-                let phi_value = func.alloc_value(Value::Inst(phi_inst));
+                let (phi_inst, phi_value) = func
+                    .alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
                 let phi_count = func.blocks[target]
                     .instructions
                     .iter()

--- a/crates/codegen/src/transform/loop_canonicalize.rs
+++ b/crates/codegen/src/transform/loop_canonicalize.rs
@@ -249,11 +249,11 @@ impl LoopCanonicalizer {
 
         let result_ty =
             func.inst(header_phi).result_ty.expect("header phi should have result type");
-        let preheader_phi =
-            func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
+        let (preheader_phi, result) =
+            func.alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
         func.blocks[preheader].instructions.push(preheader_phi);
         self.stats.preheader_phis_inserted += 1;
-        func.alloc_value(Value::Inst(preheader_phi))
+        result
     }
 
     fn redirect_terminator(

--- a/crates/codegen/src/transform/lower_slices.rs
+++ b/crates/codegen/src/transform/lower_slices.rs
@@ -93,9 +93,7 @@ fn slice_param_ptr_type(location: SliceLocation) -> MirType {
 
 /// Allocates a word-typed instruction and its result value, returning both.
 fn new_word_inst(func: &mut Function, kind: InstKind) -> (InstId, ValueId) {
-    let inst = func.alloc_inst(Instruction::new(kind, Some(MirType::uint256())));
-    let value = func.alloc_value(Value::Inst(inst));
-    (inst, value)
+    func.alloc_value_inst(Instruction::new(kind, Some(MirType::uint256())))
 }
 
 /// Allocates a `make_slice` instruction and its slice-typed result value.
@@ -105,12 +103,10 @@ fn new_slice_inst(
     len: ValueId,
     location: SliceLocation,
 ) -> (InstId, ValueId) {
-    let inst = func.alloc_inst(Instruction::new(
+    func.alloc_value_inst(Instruction::new(
         InstKind::MakeSlice { ptr, len, location },
         Some(MirType::Slice(location)),
-    ));
-    let value = func.alloc_value(Value::Inst(inst));
-    (inst, value)
+    ))
 }
 
 impl LowerSlicesCx {

--- a/crates/codegen/src/transform/pre.rs
+++ b/crates/codegen/src/transform/pre.rs
@@ -372,8 +372,7 @@ impl PartialRedundancyEliminator {
             };
             let mut instruction = Instruction::new(kind, Some(result_ty));
             instruction.metadata = metadata.clone();
-            let new_inst = func.alloc_inst(instruction);
-            let value = func.alloc_value(Value::Inst(new_inst));
+            let (new_inst, value) = func.alloc_value_inst(instruction);
             func.blocks[block].instructions.push(new_inst);
             incoming.push((block, value));
             inst_results.insert(new_inst, value);
@@ -395,9 +394,8 @@ impl PartialRedundancyEliminator {
                 first
             }
             _ => {
-                let phi_inst =
-                    func.alloc_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
-                let phi_value = func.alloc_value(Value::Inst(phi_inst));
+                let (phi_inst, phi_value) = func
+                    .alloc_value_inst(Instruction::new(InstKind::Phi(incoming), Some(result_ty)));
                 let phi_count = func.blocks[target]
                     .instructions
                     .iter()

--- a/crates/codegen/src/transform/storage_promotion.rs
+++ b/crates/codegen/src/transform/storage_promotion.rs
@@ -762,9 +762,10 @@ impl StorageScalarPromoter {
         slot_value: ValueId,
         temp_addr: ValueId,
     ) {
-        let load_inst =
-            func.alloc_inst(Instruction::new(InstKind::MLoad(temp_addr), Some(MirType::uint256())));
-        let load_value = func.alloc_value(Value::Inst(load_inst));
+        let (load_inst, load_value) = func.alloc_value_inst(Instruction::new(
+            InstKind::MLoad(temp_addr),
+            Some(MirType::uint256()),
+        ));
         let store_inst =
             func.alloc_inst(Instruction::new(InstKind::SStore(slot_value, load_value), None));
 
@@ -801,9 +802,8 @@ impl StorageScalarPromoter {
         let mut exit_instructions = old_instructions[..split_pos].to_vec();
         let continuation_instructions = old_instructions[split_pos..].to_vec();
 
-        let dirty_load_inst =
-            func.alloc_inst(Instruction::new(InstKind::MLoad(dirty_addr), Some(MirType::Bool)));
-        let dirty_value = func.alloc_value(Value::Inst(dirty_load_inst));
+        let (dirty_load_inst, dirty_value) = func
+            .alloc_value_inst(Instruction::new(InstKind::MLoad(dirty_addr), Some(MirType::Bool)));
         exit_instructions.push(dirty_load_inst);
 
         func.blocks[exit].instructions = exit_instructions;
@@ -813,9 +813,10 @@ impl StorageScalarPromoter {
             else_block: continuation,
         });
 
-        let load_inst =
-            func.alloc_inst(Instruction::new(InstKind::MLoad(temp_addr), Some(MirType::uint256())));
-        let load_value = func.alloc_value(Value::Inst(load_inst));
+        let (load_inst, load_value) = func.alloc_value_inst(Instruction::new(
+            InstKind::MLoad(temp_addr),
+            Some(MirType::uint256()),
+        ));
         let store_inst =
             func.alloc_inst(Instruction::new(InstKind::SStore(slot_value, load_value), None));
 
@@ -881,9 +882,7 @@ impl StorageScalarPromoter {
         kind: InstKind,
         ty: MirType,
     ) -> (InstId, ValueId) {
-        let inst = func.alloc_inst(Instruction::new(kind, Some(ty)));
-        let value = func.alloc_value(Value::Inst(inst));
-        (inst, value)
+        func.alloc_value_inst(Instruction::new(kind, Some(ty)))
     }
 
     /// Allocates an instruction that produces no value, so no result [`Value`]


### PR DESCRIPTION
Instruction and result allocation currently happen in separate calls, temporarily leaving `Instruction::result` and `Value::Inst` out of sync and allowing callers to omit the second half.

Allocate value-producing instructions and their result values through one `Function` operation, while reserving `alloc_inst` for void instructions. MIR forward references use a narrow preallocated-result path, which lets us remove the general `set_value` mutation API without giving up the constant-time links in either direction introduced by #1040.
