### PR TITLE
feat(codegen): lower clz and callcode

### DIFF
--- a/crates/codegen/src/analysis/alias.rs
+++ b/crates/codegen/src/analysis/alias.rs
@@ -1729,4 +1729,27 @@ mod tests {
         assert!(effects.reads_space(AddressSpace::Memory));
         assert!(effects.writes_space(AddressSpace::Memory));
     }
+
+    #[test]
+    fn callcode_reads_and_writes_state_and_memory() {
+        let mut func = function();
+        let call = {
+            let mut builder = FunctionBuilder::new(&mut func);
+            let gas = builder.imm_u64(100_000);
+            let address = builder.imm_u64(1);
+            let value = builder.imm_u64(2);
+            let offset = builder.imm_u64(0x80);
+            let size = builder.imm_u64(32);
+            builder.callcode(gas, address, value, offset, size, offset, size);
+            *builder.func().blocks[builder.current_block()].instructions.last().unwrap()
+        };
+        let effects = AliasAnalysis::new(&func).instruction_mod_ref(&func, call);
+
+        assert!(effects.reads_space(AddressSpace::Storage));
+        assert!(effects.writes_space(AddressSpace::Storage));
+        assert!(effects.reads_space(AddressSpace::Transient));
+        assert!(effects.writes_space(AddressSpace::Transient));
+        assert!(effects.reads_space(AddressSpace::Memory));
+        assert!(effects.writes_space(AddressSpace::Memory));
+    }
 }

--- a/crates/codegen/src/analysis/alias.rs
+++ b/crates/codegen/src/analysis/alias.rs
@@ -695,6 +695,7 @@ impl AliasAnalysis {
             | InstKind::Log3(address, _, _, _, _)
             | InstKind::Log4(address, _, _, _, _, _) => operand != *address,
             InstKind::Call { args_offset, ret_offset, .. }
+            | InstKind::CallCode { args_offset, ret_offset, .. }
             | InstKind::StaticCall { args_offset, ret_offset, .. }
             | InstKind::DelegateCall { args_offset, ret_offset, .. } => {
                 operand != *args_offset && operand != *ret_offset
@@ -939,6 +940,7 @@ impl AliasAnalysis {
                 self.storage_alias_after_replacements(func, inst_id, slot, replacements),
             ))),
             InstKind::Call { args_offset, args_size, ret_offset, ret_size, .. }
+            | InstKind::CallCode { args_offset, args_size, ret_offset, ret_size, .. }
             | InstKind::StaticCall { args_offset, args_size, ret_offset, ret_size, .. }
             | InstKind::DelegateCall { args_offset, args_size, ret_offset, ret_size, .. } => {
                 read_memory(&mut effects, args_offset, SizeOperand::Value(args_size));
@@ -1409,6 +1411,7 @@ impl AliasAnalysis {
                 Self::range_may_overlap_fmp(func, dest, func.value_u64(size))
             }
             InstKind::Call { ret_offset, ret_size, .. }
+            | InstKind::CallCode { ret_offset, ret_size, .. }
             | InstKind::StaticCall { ret_offset, ret_size, .. }
             | InstKind::DelegateCall { ret_offset, ret_size, .. } => {
                 Self::range_may_overlap_fmp(func, ret_offset, func.value_u64(ret_size))

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -2507,6 +2507,15 @@ impl<'gcx> EvmCodegen<'gcx> {
                 block,
                 inst_idx,
             ),
+            InstKind::Clz(a) => self.emit_unary_op_with_result(
+                func,
+                *a,
+                op::CLZ,
+                result_value,
+                liveness,
+                block,
+                inst_idx,
+            ),
             InstKind::Shl(shift, val) => self.emit_binary_op_with_result(
                 func,
                 *shift,
@@ -2970,6 +2979,31 @@ impl<'gcx> EvmCodegen<'gcx> {
                 // CALL consumes 7 values and produces 1 (success bool)
                 let push = result_value.map_or(StackPush::Unknown, StackPush::Tracked);
                 self.emit_op_with_effect(op::CALL, StackEffect { pops: 7, pushes: 1 }, push);
+            }
+
+            InstKind::CallCode {
+                gas,
+                addr,
+                value,
+                args_offset,
+                args_size,
+                ret_offset,
+                ret_size,
+            } => {
+                self.prepare_fresh_operands(
+                    func,
+                    &[*gas, *addr, *value, *args_offset, *args_size, *ret_offset, *ret_size],
+                );
+                self.emit_value_fresh(func, *ret_size);
+                self.emit_value_fresh(func, *ret_offset);
+                self.emit_value_fresh(func, *args_size);
+                self.emit_value_fresh(func, *args_offset);
+                self.emit_value_fresh(func, *value);
+                self.emit_value_fresh(func, *addr);
+                self.emit_value_fresh(func, *gas);
+
+                let push = result_value.map_or(StackPush::Unknown, StackPush::Tracked);
+                self.emit_op_with_effect(op::CALLCODE, StackEffect { pops: 7, pushes: 1 }, push);
             }
 
             InstKind::StaticCall { gas, addr, args_offset, args_size, ret_offset, ret_size } => {

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -729,6 +729,20 @@ impl<'gcx> Lowerer<'gcx> {
             Builtin::YulSgt => builder.sgt(arg_vals[0], arg_vals[1]),
             Builtin::YulEq => builder.eq(arg_vals[0], arg_vals[1]),
             Builtin::YulIszero => builder.iszero(arg_vals[0]),
+            Builtin::YulClz => {
+                if self.gcx.sess.opts.evm_version.has_clz() {
+                    builder.clz(arg_vals[0])
+                } else {
+                    let guar = self
+                        .gcx
+                        .dcx()
+                        .err("codegen requires Osaka-compatible EVM for `clz`")
+                        .span(args.span)
+                        .help("compile with `--evm-version osaka` or newer")
+                        .emit();
+                    builder.error_value(guar)
+                }
+            }
             Builtin::YulMload => builder.mload(arg_vals[0]),
             Builtin::YulMstore => {
                 builder.mstore(arg_vals[0], arg_vals[1]);
@@ -795,6 +809,15 @@ impl<'gcx> Lowerer<'gcx> {
             Builtin::YulBlobhash => builder.blobhash(arg_vals[0]),
             Builtin::YulKeccak256 => builder.keccak256(arg_vals[0], arg_vals[1]),
             Builtin::YulCall => builder.call(
+                arg_vals[0],
+                arg_vals[1],
+                arg_vals[2],
+                arg_vals[3],
+                arg_vals[4],
+                arg_vals[5],
+                arg_vals[6],
+            ),
+            Builtin::YulCallcode => builder.callcode(
                 arg_vals[0],
                 arg_vals[1],
                 arg_vals[2],
@@ -872,11 +895,7 @@ impl<'gcx> Lowerer<'gcx> {
                 builder.imm_u64(0)
             }
             Builtin::YulPop => builder.imm_u64(0),
-            Builtin::YulClz
-            | Builtin::YulCallcode
-            | Builtin::YulExtcall
-            | Builtin::YulExtdelegatecall
-            | Builtin::YulExtstaticcall => {
+            Builtin::YulExtcall | Builtin::YulExtdelegatecall | Builtin::YulExtstaticcall => {
                 self.unsupported_yul_builtin(builder, builtin, args.span)
             }
             _ => unreachable!("non-Yul builtin passed to Yul lowering"),

--- a/crates/codegen/src/mir/builder.rs
+++ b/crates/codegen/src/mir/builder.rs
@@ -270,6 +270,11 @@ impl<'a> FunctionBuilder<'a> {
         self.emit_inst(InstKind::Not(a), Some(MirType::uint256()))
     }
 
+    /// Emits a clz instruction.
+    pub(crate) fn clz(&mut self, a: ValueId) -> ValueId {
+        self.emit_inst(InstKind::Clz(a), Some(MirType::uint256()))
+    }
+
     /// Emits a shl instruction.
     pub(crate) fn shl(&mut self, shift: ValueId, value: ValueId) -> ValueId {
         self.emit_inst(InstKind::Shl(shift, value), Some(MirType::uint256()))
@@ -739,6 +744,24 @@ impl<'a> FunctionBuilder<'a> {
     ) -> ValueId {
         self.emit_inst(
             InstKind::Call { gas, addr, value, args_offset, args_size, ret_offset, ret_size },
+            Some(MirType::uint256()),
+        )
+    }
+
+    /// Emits a callcode instruction.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn callcode(
+        &mut self,
+        gas: ValueId,
+        addr: ValueId,
+        value: ValueId,
+        args_offset: ValueId,
+        args_size: ValueId,
+        ret_offset: ValueId,
+        ret_size: ValueId,
+    ) -> ValueId {
+        self.emit_inst(
+            InstKind::CallCode { gas, addr, value, args_offset, args_size, ret_offset, ret_size },
             Some(MirType::uint256()),
         )
     }

--- a/crates/codegen/src/mir/inst.rs
+++ b/crates/codegen/src/mir/inst.rs
@@ -539,6 +539,8 @@ pub(crate) enum InstKind {
     Xor(ValueId, ValueId),
     /// Bitwise NOT: `~a`
     Not(ValueId),
+    /// Count leading zero bits.
+    Clz(ValueId),
     /// Left shift: `a << b`
     Shl(ValueId, ValueId),
     /// Logical right shift: `a >> b`
@@ -777,6 +779,16 @@ pub(crate) enum InstKind {
         ret_offset: ValueId,
         ret_size: ValueId,
     },
+    /// Call code: `callcode(gas, addr, value, argsOffset, argsSize, retOffset, retSize)`
+    CallCode {
+        gas: ValueId,
+        addr: ValueId,
+        value: ValueId,
+        args_offset: ValueId,
+        args_size: ValueId,
+        ret_offset: ValueId,
+        ret_size: ValueId,
+    },
     /// Static call: `staticcall(gas, addr, argsOffset, argsSize, retOffset, retSize)`
     StaticCall {
         gas: ValueId,
@@ -892,6 +904,7 @@ impl InstKind {
 
             // Unary operations
             Self::Not(a)
+            | Self::Clz(a)
             | Self::IsZero(a)
             | Self::MLoad(a)
             | Self::SetFmp(a)
@@ -959,7 +972,8 @@ impl InstKind {
             }
 
             // Call operations
-            Self::Call { gas, addr, value, args_offset, args_size, ret_offset, ret_size } => {
+            Self::Call { gas, addr, value, args_offset, args_size, ret_offset, ret_size }
+            | Self::CallCode { gas, addr, value, args_offset, args_size, ret_offset, ret_size } => {
                 out.push(*gas);
                 out.push(*addr);
                 out.push(*value);
@@ -1093,6 +1107,7 @@ impl InstKind {
             }
 
             Self::Not(a)
+            | Self::Clz(a)
             | Self::IsZero(a)
             | Self::MLoad(a)
             | Self::SetFmp(a)
@@ -1153,7 +1168,8 @@ impl InstKind {
                 f(g);
             }
 
-            Self::Call { gas, addr, value, args_offset, args_size, ret_offset, ret_size } => {
+            Self::Call { gas, addr, value, args_offset, args_size, ret_offset, ret_size }
+            | Self::CallCode { gas, addr, value, args_offset, args_size, ret_offset, ret_size } => {
                 f(gas);
                 f(addr);
                 f(value);
@@ -1226,6 +1242,7 @@ impl InstKind {
             Self::Or(_, _) => "or",
             Self::Xor(_, _) => "xor",
             Self::Not(_) => "not",
+            Self::Clz(_) => "clz",
             Self::Shl(_, _) => "shl",
             Self::Shr(_, _) => "shr",
             Self::Sar(_, _) => "sar",
@@ -1298,6 +1315,7 @@ impl InstKind {
             Self::MappingSlotMemory(_, _) => "mapping_slot_memory",
             Self::MappingSlotCalldata(_, _) => "mapping_slot_calldata",
             Self::Call { .. } => "call",
+            Self::CallCode { .. } => "callcode",
             Self::StaticCall { .. } => "staticcall",
             Self::DelegateCall { .. } => "delegatecall",
             Self::InternalCall { .. } => "internal_call",
@@ -1336,6 +1354,7 @@ impl InstKind {
             | Self::MCopy(_, _, _)
             // External calls
             | Self::Call { .. }
+            | Self::CallCode { .. }
             | Self::StaticCall { .. }
             | Self::DelegateCall { .. }
             | Self::InternalCall { .. }
@@ -1385,9 +1404,10 @@ impl InstKind {
             }
             Self::TLoad(_) => EffectKind::TransientRead,
             Self::TStore(_, _) => EffectKind::TransientWrite,
-            Self::Call { .. } | Self::StaticCall { .. } | Self::DelegateCall { .. } => {
-                EffectKind::ExternalCall
-            }
+            Self::Call { .. }
+            | Self::CallCode { .. }
+            | Self::StaticCall { .. }
+            | Self::DelegateCall { .. } => EffectKind::ExternalCall,
             Self::InternalCall { .. } => EffectKind::InternalCall,
             Self::Create(_, _, _) | Self::Create2(_, _, _, _) => EffectKind::Create,
             Self::Log0(_, _)
@@ -1436,6 +1456,7 @@ impl InstKind {
             | Self::Or(_, _)
             | Self::Xor(_, _)
             | Self::Not(_)
+            | Self::Clz(_)
             | Self::Shl(_, _)
             | Self::Shr(_, _)
             | Self::Sar(_, _)

--- a/crates/codegen/src/mir/parser.rs
+++ b/crates/codegen/src/mir/parser.rs
@@ -1188,6 +1188,7 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
             kw::Or => inst!(Or(a, b) => MirType::uint256()),
             kw::Xor => inst!(Xor(a, b) => MirType::uint256()),
             kw::Not => inst!(Not(a) => MirType::uint256()),
+            kw::Clz => inst!(Clz(a) => MirType::uint256()),
             kw::Shl => inst!(Shl(a, b) => MirType::uint256()),
             kw::Shr => inst!(Shr(a, b) => MirType::uint256()),
             kw::Sar => inst!(Sar(a, b) => MirType::int256()),
@@ -1433,6 +1434,9 @@ impl<'sess, 'ast> Parser<'sess, 'ast> {
 
             // Calls and creation.
             kw::Call => struct_inst!(Call {
+                gas, addr, value, args_offset, args_size, ret_offset, ret_size
+            } => MirType::uint256()),
+            kw::Callcode => struct_inst!(CallCode {
                 gas, addr, value, args_offset, args_size, ret_offset, ret_size
             } => MirType::uint256()),
             kw::Staticcall => struct_inst!(StaticCall {

--- a/crates/codegen/src/transform/cse.rs
+++ b/crates/codegen/src/transform/cse.rs
@@ -125,6 +125,7 @@ enum ExprKey {
     Eq(OperandKey, OperandKey),
     IsZero(OperandKey),
     Not(OperandKey),
+    Clz(OperandKey),
     SignExtend(OperandKey, OperandKey),
     Select(OperandKey, OperandKey, OperandKey),
     MLoad(MemRangeKey),
@@ -664,6 +665,7 @@ impl CommonSubexprEliminator {
             // Unary operations
             InstKind::IsZero(a) => Some(ExprKey::IsZero(operand(*a))),
             InstKind::Not(a) => Some(ExprKey::Not(operand(*a))),
+            InstKind::Clz(a) => Some(ExprKey::Clz(operand(*a))),
             InstKind::CalldataLoad(a) => Some(ExprKey::CalldataLoad(operand(*a))),
             InstKind::ExtCodeSize(a) => Some(ExprKey::ExtCodeSize(operand(*a))),
             InstKind::ExtCodeHash(a) => Some(ExprKey::ExtCodeHash(operand(*a))),
@@ -864,6 +866,7 @@ impl CommonSubexprEliminator {
         matches!(
             kind,
             InstKind::Call { .. }
+                | InstKind::CallCode { .. }
                 | InstKind::DelegateCall { .. }
                 | InstKind::InternalCall { .. }
                 | InstKind::Create(_, _, _)

--- a/crates/codegen/src/transform/frame_promotion.rs
+++ b/crates/codegen/src/transform/frame_promotion.rs
@@ -455,6 +455,7 @@ impl FrameSlotPromoter {
                 slot_offset,
             ),
             InstKind::Call { args_offset, args_size, ret_offset, ret_size, .. }
+            | InstKind::CallCode { args_offset, args_size, ret_offset, ret_size, .. }
             | InstKind::StaticCall { args_offset, args_size, ret_offset, ret_size, .. }
             | InstKind::DelegateCall { args_offset, args_size, ret_offset, ret_size, .. } => {
                 Self::internal_frame_range_may_overlap(
@@ -546,6 +547,7 @@ impl FrameSlotPromoter {
                 Self::memory_range_may_overlap(func, aa, addr, func.value_u64(size), slot_addr)
             }
             InstKind::Call { .. }
+            | InstKind::CallCode { .. }
             | InstKind::StaticCall { .. }
             | InstKind::DelegateCall { .. }
             | InstKind::InternalCall { .. }

--- a/crates/codegen/src/transform/gvn.rs
+++ b/crates/codegen/src/transform/gvn.rs
@@ -120,6 +120,7 @@ enum ExprKind {
     Or(ClassId, ClassId),
     Xor(ClassId, ClassId),
     Not(ClassId),
+    Clz(ClassId),
     Shl(ClassId, ClassId),
     Shr(ClassId, ClassId),
     Sar(ClassId, ClassId),
@@ -357,6 +358,7 @@ impl GlobalValueNumberer {
             InstKind::SGt(a, b) => ExprKind::SLt(class(b), class(a)),
             InstKind::IsZero(a) => ExprKind::IsZero(class(a)),
             InstKind::Not(a) => ExprKind::Not(class(a)),
+            InstKind::Clz(a) => ExprKind::Clz(class(a)),
             InstKind::Select(condition, then_value, else_value) => {
                 ExprKind::Select(class(condition), class(then_value), class(else_value))
             }

--- a/crates/codegen/src/transform/inline.rs
+++ b/crates/codegen/src/transform/inline.rs
@@ -405,6 +405,7 @@ fn summarize_function(func: &Function) -> MirInlineSummary {
                 InstKind::InternalCall { .. } => summary.has_internal_call = true,
                 InstKind::Phi(_) => summary.has_phi = true,
                 InstKind::Call { .. }
+                | InstKind::CallCode { .. }
                 | InstKind::StaticCall { .. }
                 | InstKind::DelegateCall { .. }
                 | InstKind::Create(..)
@@ -533,7 +534,8 @@ fn estimate_inst_cost(kind: &InstKind) -> MirCost {
         | InstKind::Gas
         | InstKind::BaseFee
         | InstKind::BlobBaseFee => (3, 1),
-        InstKind::Mul(..)
+        InstKind::Clz(..)
+        | InstKind::Mul(..)
         | InstKind::Div(..)
         | InstKind::SDiv(..)
         | InstKind::Mod(..)
@@ -562,9 +564,10 @@ fn estimate_inst_cost(kind: &InstKind) -> MirCost {
         InstKind::MappingSlot(..) => (36, 3),
         InstKind::MappingSlotMemory(..) => (60, 8),
         InstKind::MappingSlotCalldata(..) => (63, 9),
-        InstKind::Call { .. } | InstKind::StaticCall { .. } | InstKind::DelegateCall { .. } => {
-            (700, 1)
-        }
+        InstKind::Call { .. }
+        | InstKind::CallCode { .. }
+        | InstKind::StaticCall { .. }
+        | InstKind::DelegateCall { .. } => (700, 1),
         InstKind::InternalCall { args, returns, .. } => {
             let returns = *returns as usize;
             (80 + ((args.len() + returns) as u64) * 20, 16 + (args.len() + returns) * 4)
@@ -874,6 +877,7 @@ impl<'a> InlineCloner<'a> {
             InstKind::Or(a, b) => InstKind::Or(self.clone_value(a)?, self.clone_value(b)?),
             InstKind::Xor(a, b) => InstKind::Xor(self.clone_value(a)?, self.clone_value(b)?),
             InstKind::Not(a) => InstKind::Not(self.clone_value(a)?),
+            InstKind::Clz(a) => InstKind::Clz(self.clone_value(a)?),
             InstKind::Shl(a, b) => InstKind::Shl(self.clone_value(a)?, self.clone_value(b)?),
             InstKind::Shr(a, b) => InstKind::Shr(self.clone_value(a)?, self.clone_value(b)?),
             InstKind::Sar(a, b) => InstKind::Sar(self.clone_value(a)?, self.clone_value(b)?),
@@ -986,6 +990,23 @@ impl<'a> InlineCloner<'a> {
                     ret_size: self.clone_value(ret_size)?,
                 }
             }
+            InstKind::CallCode {
+                gas,
+                addr,
+                value,
+                args_offset,
+                args_size,
+                ret_offset,
+                ret_size,
+            } => InstKind::CallCode {
+                gas: self.clone_value(gas)?,
+                addr: self.clone_value(addr)?,
+                value: self.clone_value(value)?,
+                args_offset: self.clone_value(args_offset)?,
+                args_size: self.clone_value(args_size)?,
+                ret_offset: self.clone_value(ret_offset)?,
+                ret_size: self.clone_value(ret_size)?,
+            },
             InstKind::StaticCall { gas, addr, args_offset, args_size, ret_offset, ret_size } => {
                 InstKind::StaticCall {
                     gas: self.clone_value(gas)?,

--- a/crates/codegen/src/transform/inst_simplify.rs
+++ b/crates/codegen/src/transform/inst_simplify.rs
@@ -383,6 +383,11 @@ impl InstSimplifier {
                 Self::not_operand(func, a)
                     .or_else(|| func.value_u256(a).map(|v| Self::imm_u256(func, !v)))
             }
+            InstKind::Clz(a) => {
+                let a = resolve(*a);
+                func.value_u256(a)
+                    .map(|v| Self::imm_u256(func, U256::from(v.leading_zeros() as u64)))
+            }
             InstKind::IsZero(a) => {
                 let a = resolve(*a);
                 func.value_u256(a).map(|v| Self::imm_bool(func, v.is_zero())).or_else(|| {
@@ -628,6 +633,9 @@ impl InstSimplifier {
                 Some(Self::imm_u256(func, constant(func, a)? ^ constant(func, b)?))
             }
             InstKind::Not(a) => Some(Self::imm_u256(func, !constant(func, a)?)),
+            InstKind::Clz(a) => {
+                Some(Self::imm_u256(func, U256::from(constant(func, a)?.leading_zeros() as u64)))
+            }
             InstKind::Shl(shift, value) => {
                 let shift = constant(func, shift)?;
                 let value = constant(func, value)?;

--- a/crates/codegen/src/transform/loop_opt.rs
+++ b/crates/codegen/src/transform/loop_opt.rs
@@ -393,6 +393,7 @@ impl LoopOptimizer {
                 matches!(
                     func.inst(inst_id).kind,
                     InstKind::Call { .. }
+                        | InstKind::CallCode { .. }
                         | InstKind::StaticCall { .. }
                         | InstKind::DelegateCall { .. }
                         | InstKind::InternalCall { .. }

--- a/crates/codegen/src/transform/loop_opt.rs
+++ b/crates/codegen/src/transform/loop_opt.rs
@@ -423,7 +423,8 @@ impl LoopOptimizer {
             | InstKind::Mod(_, _)
             | InstKind::SMod(_, _)
             | InstKind::AddMod(_, _, _)
-            | InstKind::MulMod(_, _, _) => 5,
+            | InstKind::MulMod(_, _, _)
+            | InstKind::Clz(_) => 5,
             InstKind::MLoad(_) | InstKind::CalldataLoad(_) => 3,
             _ => 0,
         }

--- a/crates/codegen/src/transform/pre.rs
+++ b/crates/codegen/src/transform/pre.rs
@@ -108,6 +108,7 @@ enum ExprKey {
     Or(OperandKey, OperandKey),
     Xor(OperandKey, OperandKey),
     Not(OperandKey),
+    Clz(OperandKey),
     Shl(OperandKey, OperandKey),
     Shr(OperandKey, OperandKey),
     Sar(OperandKey, OperandKey),
@@ -518,6 +519,7 @@ impl PartialRedundancyEliminator {
                 | InstKind::Or(_, _)
                 | InstKind::Xor(_, _)
                 | InstKind::Not(_)
+                | InstKind::Clz(_)
                 | InstKind::Shl(_, _)
                 | InstKind::Shr(_, _)
                 | InstKind::Sar(_, _)
@@ -578,6 +580,7 @@ impl PartialRedundancyEliminator {
             InstKind::SMod(a, b) => Some(ExprKey::SMod(operand(*a), operand(*b))),
             InstKind::Exp(a, b) => Some(ExprKey::Exp(operand(*a), operand(*b))),
             InstKind::Not(a) => Some(ExprKey::Not(operand(*a))),
+            InstKind::Clz(a) => Some(ExprKey::Clz(operand(*a))),
             InstKind::Shl(a, b) => Some(ExprKey::Shl(operand(*a), operand(*b))),
             InstKind::Shr(a, b) => Some(ExprKey::Shr(operand(*a), operand(*b))),
             InstKind::Sar(a, b) => Some(ExprKey::Sar(operand(*a), operand(*b))),

--- a/crates/codegen/src/transform/pure_eval.rs
+++ b/crates/codegen/src/transform/pure_eval.rs
@@ -204,6 +204,7 @@ impl PureEvaluator {
             InstKind::Or(a, b) => get(a)? | get(b)?,
             InstKind::Xor(a, b) => get(a)? ^ get(b)?,
             InstKind::Not(a) => !get(a)?,
+            InstKind::Clz(a) => U256::from(get(a)?.leading_zeros() as u64),
             InstKind::Shl(shift, value) => {
                 let shift = get(shift)?;
                 if shift >= U256::from(256) {

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -443,6 +443,10 @@ impl SccpCx {
                 Some(a) => LatticeValue::Constant(!a),
                 None => self.check_any_bottom(&[*a], lattice),
             },
+            InstKind::Clz(a) => match get_const(*a) {
+                Some(a) => LatticeValue::Constant(U256::from(a.leading_zeros() as u64)),
+                None => self.check_any_bottom(&[*a], lattice),
+            },
             InstKind::Shl(shift, val) => match (get_const(*shift), get_const(*val)) {
                 (Some(s), Some(v)) => {
                     if s >= U256::from(256) {

--- a/crates/codegen/src/transform/storage_promotion.rs
+++ b/crates/codegen/src/transform/storage_promotion.rs
@@ -295,6 +295,7 @@ impl StorageScalarPromoter {
             !matches!(
                 &func.inst(inst_id).kind,
                 InstKind::Call { .. }
+                    | InstKind::CallCode { .. }
                     | InstKind::StaticCall { .. }
                     | InstKind::DelegateCall { .. }
                     | InstKind::InternalCall { .. }
@@ -338,6 +339,7 @@ impl StorageScalarPromoter {
                     InstKind::SLoad(_) | InstKind::SStore(_, _) => {}
                     InstKind::TStore(_, _)
                     | InstKind::Call { .. }
+                    | InstKind::CallCode { .. }
                     | InstKind::StaticCall { .. }
                     | InstKind::DelegateCall { .. }
                     | InstKind::InternalCall { .. }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -116,9 +116,6 @@ impl EvmVersion {
     pub fn has_bitwise_shifting(self) -> bool {
         self >= Self::Constantinople
     }
-    pub fn has_clz(self) -> bool {
-        self >= Self::Osaka
-    }
     pub fn has_create2(self) -> bool {
         self >= Self::Constantinople
     }
@@ -145,6 +142,9 @@ impl EvmVersion {
     }
     pub fn has_mcopy(self) -> bool {
         self >= Self::Cancun
+    }
+    pub fn has_clz(self) -> bool {
+        self >= Self::Osaka
     }
 }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -116,6 +116,9 @@ impl EvmVersion {
     pub fn has_bitwise_shifting(self) -> bool {
         self >= Self::Constantinople
     }
+    pub fn has_clz(self) -> bool {
+        self >= Self::Osaka
+    }
     pub fn has_create2(self) -> bool {
         self >= Self::Constantinople
     }

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.sol
@@ -3,6 +3,22 @@
 //@filecheck:
 
 contract YulLowLevelBuiltins {
+    // CHECK-LABEL: fn @leadingZeros{{[( ]}}
+    // CHECK: {{v[0-9]+}} = clz arg0
+    function leadingZeros(uint256 value) public pure returns (uint256 result) {
+        assembly {
+            result := clz(value)
+        }
+    }
+
+    // CHECK-LABEL: fn @callCode{{[( ]}}
+    // CHECK: {{v[0-9]+}} = callcode {{v[0-9]+}}, arg0, 0, 0, 0, 0, 0
+    function callCode(address target) public returns (uint256 success) {
+        assembly {
+            success := callcode(gas(), target, 0, 0, 0, 0, 0)
+        }
+    }
+
     // CHECK-LABEL: fn @safeCall{{[( ]}}
     // CHECK: [[FMP:v[0-9]+]] = mload 64
     // CHECK: {{v[0-9]+}} = call {{v[0-9]+}}, arg0, 0, 0, 4, 0, 32

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
@@ -1,5 +1,47 @@
 // === ROOT/tests/ui/codegen/lowering/yul_low_level_builtins.sol:YulLowLevelBuiltins ===
 @module YulLowLevelBuiltins
+fn @leadingZeros(arg0: u256) {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    mstore 128, 0
+    v3 = clz arg0
+    mstore 128, v3
+    v4 = mload 128
+    mstore 128, v4
+    returndata 128, 32
+}
+
+fn @callCode(arg0: address) {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    mstore 128, 0
+    v6 = gas
+    v7 = callcode v6, arg0, 0, 0, 0, 0, 0
+    mstore 128, v7
+    v8 = mload 128
+    mstore 128, v8
+    returndata 128, 32
+}
+
 fn @safeCall(arg0: address, arg1: bytes4) {
   bb0:
     v0 = calldatasize

--- a/tests/ui/codegen/lowering/yul_unsupported_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_unsupported_builtins.sol
@@ -1,9 +1,11 @@
 //@compile-flags: -Zcodegen -Zdump=mir
 
 contract YulUnsupportedBuiltins {
-    function unsupportedBuiltin() public pure returns (uint256 result) {
+    function unsupportedBuiltins() public returns (uint256 result) {
         assembly {
-            result := clz(1) //~ ERROR: unsupported Yul builtin `clz`
+            result := extcall(0, 0, 0, 0) //~ ERROR: unsupported Yul builtin `extcall`
+            result := extdelegatecall(0, 0, 0) //~ ERROR: unsupported Yul builtin `extdelegatecall`
+            result := extstaticcall(0, 0, 0) //~ ERROR: unsupported Yul builtin `extstaticcall`
         }
     }
 }

--- a/tests/ui/codegen/lowering/yul_unsupported_builtins.stderr
+++ b/tests/ui/codegen/lowering/yul_unsupported_builtins.stderr
@@ -1,8 +1,20 @@
-error: unsupported Yul builtin `clz`
+error: unsupported Yul builtin `extcall`
    ╭▸ ROOT/tests/ui/codegen/lowering/yul_unsupported_builtins.sol:LL:CC
    │
-LL │             result := clz(1)
-   ╰╴                      ━━━━━━
+LL │             result := extcall(0, 0, 0, 0)
+   ╰╴                      ━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 1 previous error
+error: unsupported Yul builtin `extdelegatecall`
+   ╭▸ ROOT/tests/ui/codegen/lowering/yul_unsupported_builtins.sol:LL:CC
+   │
+LL │             result := extdelegatecall(0, 0, 0)
+   ╰╴                      ━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: unsupported Yul builtin `extstaticcall`
+   ╭▸ ROOT/tests/ui/codegen/lowering/yul_unsupported_builtins.sol:LL:CC
+   │
+LL │             result := extstaticcall(0, 0, 0)
+   ╰╴                      ━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors
 

--- a/tests/ui/codegen/mir/cse/cse_environment.mir
+++ b/tests/ui/codegen/mir/cse/cse_environment.mir
@@ -74,6 +74,23 @@ fn @invalidate_account_reads_after_call(arg0: address) -> u256 {
     ret v9
 }
 
+// CHECK-LABEL: {{^[ +].*}}fn @invalidate_account_reads_after_callcode{{[( ]}}
+// CHECK: {{^[ +].*}}{{v[0-9]+}} = balance arg0
+// CHECK: {{^[ +].*}}{{v[0-9]+}} = balance arg0
+fn @invalidate_account_reads_after_callcode(arg0: address) -> u256 {
+  bb0:
+    v1 = balance arg0
+    v2 = extcodehash arg0
+    v3 = callcode 100000, arg0, 0, 0, 0, 0, 0
+    v4 = balance arg0
+    v5 = extcodehash arg0
+    v6 = add v1, v4
+    v7 = add v2, v5
+    v8 = add v6, v7
+    v9 = add v8, v3
+    ret v9
+}
+
 // CHECK-LABEL: {{^[ +].*}}fn @keep_gas_uncached{{[( ]}}
 // CHECK: {{^[ +].*}}{{v[0-9]+}} = gas
 // CHECK: {{^[ +].*}}{{v[0-9]+}} = gas

--- a/tests/ui/codegen/mir/cse/cse_environment.stdout
+++ b/tests/ui/codegen/mir/cse/cse_environment.stdout
@@ -65,6 +65,20 @@
       ret v8
   }
   
+  fn @invalidate_account_reads_after_callcode(arg0: address) -> u256 {
+    bb0:
+      v0 = balance arg0
+      v1 = extcodehash arg0
+      v2 = callcode 0x186a0, arg0, 0, 0, 0, 0, 0
+      v3 = balance arg0
+      v4 = extcodehash arg0
+      v5 = add v0, v3
+      v6 = add v1, v4
+      v7 = add v5, v6
+      v8 = add v7, v2
+      ret v8
+  }
+  
   fn @keep_gas_uncached() -> u256 {
     bb0:
       v0 = gas

--- a/tests/ui/codegen/mir/cse/cse_extended_ops.mir
+++ b/tests/ui/codegen/mir/cse/cse_extended_ops.mir
@@ -33,3 +33,12 @@ fn @calldata_reads(arg0: u256) -> u256 {
     v2 = calldataload arg0
     ret v2
 }
+
+// CHECK-LABEL: {{^[ +].*}}fn @clz{{[( ]}}
+// CHECK: - {{v[0-9]+}} = clz arg0
+fn @clz(arg0: u256) -> u256 {
+  bb0:
+    v1 = clz arg0
+    v2 = clz arg0
+    ret v2
+}

--- a/tests/ui/codegen/mir/cse/cse_extended_ops.stdout
+++ b/tests/ui/codegen/mir/cse/cse_extended_ops.stdout
@@ -27,3 +27,11 @@
 +     ret v0
   }
   
+  fn @clz(arg0: u256) -> u256 {
+    bb0:
+      v0 = clz arg0
+-     v1 = clz arg0
+-     ret v1
++     ret v0
+  }
+  

--- a/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir
+++ b/tests/ui/codegen/mir/inst-simplify/inst_simplify.mir
@@ -169,3 +169,15 @@ fn @fold_constant_ops() -> (u256, u256, u256, u256, u256, u256, u256, u256, u256
     v23 = mulmod 5, 7, 10
     ret v1, v2, v3, v4, v5, v6, v7, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23
 }
+
+// CHECK-LABEL: {{^[ +].*}}fn @fold_clz_constants{{[( ]}}
+// CHECK: + ret 256, 255, 248, 1, 0
+fn @fold_clz_constants() -> (u256, u256, u256, u256, u256) {
+  bb0:
+    v0 = clz 0
+    v1 = clz 1
+    v2 = clz 255
+    v3 = clz 0x4000000000000000000000000000000000000000000000000000000000000000
+    v4 = clz 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    ret v0, v1, v2, v3, v4
+}

--- a/tests/ui/codegen/mir/inst-simplify/inst_simplify.stdout
+++ b/tests/ui/codegen/mir/inst-simplify/inst_simplify.stdout
@@ -152,3 +152,14 @@
 +     ret 12, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, 42, 8, 0, 2, 256, 2, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe, 1, 1, 15, 17, 12, 256, 16, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc, 255, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 5
   }
   
+  fn @fold_clz_constants() -> (u256, u256, u256, u256, u256) {
+    bb0:
+-     v0 = clz 0
+-     v1 = clz 1
+-     v2 = clz 255
+-     v3 = clz 0x4000000000000000000000000000000000000000000000000000000000000000
+-     v4 = clz 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+-     ret v0, v1, v2, v3, v4
++     ret 256, 255, 248, 1, 0
+  }
+  

--- a/tests/ui/codegen/mir/licm/builder_cases.mir
+++ b/tests/ui/codegen/mir/licm/builder_cases.mir
@@ -21,6 +21,25 @@ fn @hoist_mul(arg0: u256) {
     stop
 }
 
+// CHECK-LABEL: @hoist_clz
+// CHECK: +     [[CLZ:v[0-9]+]] = clz arg0
+// CHECK-NEXT: {{^ +}}jump [[HEADER:bb[0-9]+]]
+// CHECK: {{^ +}}[[HEADER]]:
+// CHECK-NEXT: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: -     [[CLZ]] = clz arg0
+fn @hoist_clz(arg0: u256) {
+  bb0:
+    jump bb1
+  bb1:
+    jumpi true, bb2, bb3
+  bb2:
+    v1 = clz arg0
+    jump bb1
+  bb3:
+    stop
+}
+
 // CHECK-LABEL: @hoist_non_aliasing_sload
 // CHECK: +     [[LOAD:v[0-9]+]] = sload [[SLOT:[0-9]+]]
 // CHECK-NEXT:  jump {{bb[0-9]+}}

--- a/tests/ui/codegen/mir/licm/builder_cases.stdout
+++ b/tests/ui/codegen/mir/licm/builder_cases.stdout
@@ -14,6 +14,19 @@
       stop
   }
   
+  fn @hoist_clz(arg0: u256) {
+    bb0:
++     v0 = clz arg0
+      jump bb1
+    bb1:
+      jumpi 1, bb2, bb3
+    bb2:
+-     v0 = clz arg0
+      jump bb1
+    bb3:
+      stop
+  }
+  
   fn @hoist_non_aliasing_sload() -> u256 {
     bb0:
 +     v0 = sload 0 !metadata(storage=slot(0))

--- a/tests/ui/codegen/mir/licm/licm_env_reads.mir
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.mir
@@ -21,6 +21,25 @@ fn @keep_balance_with_call() -> u256 {
     ret v1
 }
 
+// CALLCODE executes arbitrary code in the current account context, so it can
+// invalidate the queried balance between iterations.
+// CHECK-LABEL: {{^[ +].*}}fn @keep_balance_with_callcode{{[( ]}}
+// CHECK: {{^[ +].*}}[[BALANCE:v[0-9]+]] = balance 0xbeef
+// CHECK: {{^[ +].*[ =]callcode[[:space:]]}}
+fn @keep_balance_with_callcode() -> u256 {
+  bb0:
+    jump bb1
+  bb1:
+    jumpi true, bb2, bb3
+  bb2:
+    v0 = balance 0xbeef
+    v1 = mul v0, 3
+    v2 = callcode 1000, 0xbeef, 1, 0, 0, 0, 0
+    jump bb1
+  bb3:
+    ret v1
+}
+
 // Without any call or create in the loop the balance is loop-invariant for real.
 // CHECK-LABEL: {{^[ +].*}}fn @hoist_balance_without_calls{{[( ]}}
 // CHECK: + [[BALANCE:v[0-9]+]] = balance 0xbeef

--- a/tests/ui/codegen/mir/licm/licm_env_reads.stdout
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.stdout
@@ -15,6 +15,20 @@
       ret v1
   }
   
+  fn @keep_balance_with_callcode() -> u256 {
+    bb0:
+      jump bb1
+    bb1:
+      jumpi 1, bb2, bb3
+    bb2:
+      v0 = balance 0xbeef
+      v1 = mul v0, 3
+      v2 = callcode 0x3e8, 0xbeef, 1, 0, 0, 0, 0
+      jump bb1
+    bb3:
+      ret v1
+  }
+  
   fn @hoist_balance_without_calls() -> u256 {
     bb0:
 +     v0 = balance 0xbeef

--- a/tests/ui/codegen/mir/none/parser.mir
+++ b/tests/ui/codegen/mir/none/parser.mir
@@ -12,6 +12,24 @@ fn @call(arg0: address, arg1: u256) -> u256 {
     ret v0
 }
 
+// CHECK-LABEL: @clz
+// CHECK: {{^ +}}[[COUNT:v[0-9]+]] = clz arg0
+// CHECK: {{^ +}}ret [[COUNT]]
+fn @clz(arg0: u256) -> u256 {
+  bb0:
+    v0 = clz arg0
+    ret v0
+}
+
+// CHECK-LABEL: @callcode
+// CHECK: {{^ +}}[[SUCCESS:v[0-9]+]] = callcode 100, arg0, arg1, 0, 0, 0, 0
+// CHECK: {{^ +}}ret [[SUCCESS]]
+fn @callcode(arg0: address, arg1: u256) -> u256 {
+  bb0:
+    v0 = callcode 100, arg0, arg1, 0, 0, 0, 0
+    ret v0
+}
+
 // CHECK-LABEL: @hash
 // CHECK: {{^ +}}mstore 0, 1
 // CHECK: {{^ +}}mstore 32, 2

--- a/tests/ui/codegen/mir/none/parser.stdout
+++ b/tests/ui/codegen/mir/none/parser.stdout
@@ -7,6 +7,18 @@
       ret v0
   }
   
+  fn @clz(arg0: u256) -> u256 {
+    bb0:
+      v0 = clz arg0
+      ret v0
+  }
+  
+  fn @callcode(arg0: address, arg1: u256) -> u256 {
+    bb0:
+      v0 = callcode 100, arg0, arg1, 0, 0, 0, 0
+      ret v0
+  }
+  
   fn @hash() -> u256 {
     bb0:
       mstore 0, 1

--- a/tests/ui/codegen/run-call/yul_clz_callcode.prague.stderr
+++ b/tests/ui/codegen/run-call/yul_clz_callcode.prague.stderr
@@ -1,0 +1,10 @@
+error: codegen requires Osaka-compatible EVM for `clz`
+   ╭▸ ROOT/tests/ui/codegen/run-call/yul_clz_callcode.sol:LL:CC
+   │
+LL │             result := clz(value)
+   │                       ━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version osaka` or newer
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/codegen/run-call/yul_clz_callcode.sol
+++ b/tests/ui/codegen/run-call/yul_clz_callcode.sol
@@ -1,0 +1,33 @@
+//@ revisions: osaka prague
+//@[osaka] compile-flags: --evm-version osaka
+//@[prague] compile-flags: --evm-version prague
+//@[osaka] run-call: leadingZeros 0 => 256
+//@[osaka] run-call: leadingZeros 1 => 255
+//@[osaka] run-call: leadingZeros 0xff => 248
+//@[osaka] run-call: leadingZeros 0x4000000000000000000000000000000000000000000000000000000000000000 => 1
+//@[osaka] run-call: invokeCallCode => 42
+
+contract YulClzCallCode {
+    function leadingZeros(uint256 value) external pure returns (uint256 result) {
+        assembly {
+            result := clz(value)
+            //~[prague]^ ERROR: codegen requires Osaka-compatible EVM for `clz`
+            //~[prague]| HELP: compile with `--evm-version osaka` or newer
+        }
+    }
+
+    function target() external pure returns (uint256) {
+        return 42;
+    }
+
+    function invokeCallCode() external returns (uint256 result) {
+        bytes4 selector = this.target.selector;
+        assembly {
+            mstore(0, selector)
+            if iszero(callcode(gas(), address(), 0, 0, 4, 0, 32)) {
+                revert(0, 0)
+            }
+            result := mload(0)
+        }
+    }
+}


### PR DESCRIPTION
Lower the Yul `clz` and `callcode` builtins through MIR into their native EVM opcodes. `clz` is gated to Osaka-compatible targets, matching solc, while `callcode` carries the same conservative memory and state effects as other mutating external calls.

The `extcall`, `extdelegatecall`, and `extstaticcall` names remain unsupported because their EOF opcodes are not part of solc's ordinary EVM Yul dialect.
