### PR TITLE
feat(codegen): simplify clz expressions

### DIFF
--- a/crates/codegen/src/transform/inst_simplify.rs
+++ b/crates/codegen/src/transform/inst_simplify.rs
@@ -226,19 +226,72 @@ impl InstSimplifier {
                     Some(InstKind::IsZero(b))
                 } else if a != b && Self::is_zero(func, b) {
                     Some(InstKind::IsZero(a))
+                } else if let Some((_, input, constant)) = Self::clz_const_operand(func, a, b) {
+                    if constant == U256::from(255) {
+                        let one = Self::imm_u256(func, U256::from(1));
+                        Some(InstKind::Eq(input, one))
+                    } else if constant == U256::from(256) {
+                        Some(InstKind::IsZero(input))
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
             }
+            InstKind::IsZero(a) => {
+                let a = resolve(*a);
+                let input = Self::clz_operand(func, a)?;
+                let zero = Self::imm_u256(func, U256::ZERO);
+                Some(InstKind::SLt(input, zero))
+            }
             // `a < 1` is `a == 0` for unsigned comparisons.
             InstKind::Lt(a, b) => {
                 let (a, b) = (resolve(*a), resolve(*b));
-                Self::is_one(func, b).then_some(InstKind::IsZero(a))
+                if let Some(input) = Self::clz_operand(func, a)
+                    && Self::is_const(func, b, U256::from(256))
+                {
+                    let zero = Self::imm_u256(func, U256::ZERO);
+                    Some(InstKind::Gt(input, zero))
+                } else if let Some(input) = Self::clz_operand(func, b)
+                    && Self::is_const(func, a, U256::from(255))
+                {
+                    Some(InstKind::IsZero(input))
+                } else {
+                    Self::is_one(func, b).then_some(InstKind::IsZero(a))
+                }
             }
             // `1 > b` is `b == 0` for unsigned comparisons.
             InstKind::Gt(a, b) => {
                 let (a, b) = (resolve(*a), resolve(*b));
-                Self::is_one(func, a).then_some(InstKind::IsZero(b))
+                if let Some(input) = Self::clz_operand(func, a)
+                    && Self::is_const(func, b, U256::from(255))
+                {
+                    Some(InstKind::IsZero(input))
+                } else if let Some(input) = Self::clz_operand(func, b)
+                    && Self::is_const(func, a, U256::from(256))
+                {
+                    let zero = Self::imm_u256(func, U256::ZERO);
+                    Some(InstKind::Gt(input, zero))
+                } else {
+                    Self::is_one(func, a).then_some(InstKind::IsZero(b))
+                }
+            }
+            InstKind::Shr(shift, value) => {
+                let (shift, value) = (resolve(*shift), resolve(*value));
+                if Self::is_const(func, shift, U256::from(8)) {
+                    Self::clz_operand(func, value).map(InstKind::IsZero)
+                } else {
+                    None
+                }
+            }
+            InstKind::Byte(index, value) => {
+                let (index, value) = (resolve(*index), resolve(*value));
+                if Self::is_const(func, index, U256::from(30)) {
+                    Self::clz_operand(func, value).map(InstKind::IsZero)
+                } else {
+                    None
+                }
             }
             InstKind::Select(condition, then_value, else_value) => {
                 let (condition, then_value, else_value) =
@@ -307,7 +360,11 @@ impl InstSimplifier {
                 let (a, b) = (resolve(*a), resolve(*b));
                 if Self::is_zero(func, a) || Self::is_one(func, b) {
                     Some(a)
-                } else if Self::is_zero(func, b) {
+                } else if Self::is_zero(func, b)
+                    || (matches!(kind, InstKind::Div(_, _))
+                        && Self::clz_operand(func, a).is_some()
+                        && func.value_u256(b).is_some_and(|b| b > U256::from(256)))
+                {
                     Some(Self::imm_u256(func, U256::ZERO))
                 } else {
                     None
@@ -319,6 +376,11 @@ impl InstSimplifier {
                     Some(a)
                 } else if Self::is_zero(func, b) || Self::is_one(func, b) || a == b {
                     Some(Self::imm_u256(func, U256::ZERO))
+                } else if matches!(kind, InstKind::Mod(_, _))
+                    && Self::clz_operand(func, a).is_some()
+                    && func.value_u256(b).is_some_and(|b| b > U256::from(256))
+                {
+                    Some(a)
                 } else {
                     None
                 }
@@ -335,7 +397,11 @@ impl InstSimplifier {
             }
             InstKind::And(a, b) => {
                 let (a, b) = (resolve(*a), resolve(*b));
-                if a == b
+                if let Some((clz, _, mask)) = Self::clz_const_operand(func, a, b)
+                    && mask & U256::from(0x1ff) == U256::from(0x1ff)
+                {
+                    Some(clz)
+                } else if a == b
                     || Self::is_zero(func, a)
                     || Self::is_all_ones(func, b)
                     || (Self::is_uint160_mask(func, b) && Self::is_clean_address(func, a))
@@ -385,8 +451,7 @@ impl InstSimplifier {
             }
             InstKind::Clz(a) => {
                 let a = resolve(*a);
-                func.value_u256(a)
-                    .map(|v| Self::imm_u256(func, U256::from(v.leading_zeros() as u64)))
+                Self::has_known_sign_bit(func, a).then(|| Self::imm_u256(func, U256::ZERO))
             }
             InstKind::IsZero(a) => {
                 let a = resolve(*a);
@@ -399,8 +464,11 @@ impl InstSimplifier {
                 let (shift, value) = (resolve(*a), resolve(*b));
                 if Self::is_zero(func, shift) || Self::is_zero(func, value) {
                     Some(value)
-                } else if !matches!(kind, InstKind::Sar(_, _))
-                    && func.value_u256(shift).is_some_and(|shift| shift >= U256::from(256))
+                } else if (matches!(kind, InstKind::Shr(_, _))
+                    && Self::clz_operand(func, value).is_some()
+                    && func.value_u256(shift).is_some_and(|shift| shift >= U256::from(9)))
+                    || (!matches!(kind, InstKind::Sar(_, _))
+                        && func.value_u256(shift).is_some_and(|shift| shift >= U256::from(256)))
                 {
                     Some(Self::imm_u256(func, U256::ZERO))
                 } else {
@@ -408,15 +476,22 @@ impl InstSimplifier {
                 }
             }
             InstKind::Byte(a, b) => {
-                let (a, value) = (resolve(*a), resolve(*b));
+                let (index, value) = (resolve(*a), resolve(*b));
                 (Self::is_zero(func, value)
-                    || func.value_u256(a).is_some_and(|index| index >= U256::from(32)))
+                    || func.value_u256(index).is_some_and(|index| {
+                        index >= U256::from(32)
+                            || (index < U256::from(30) && Self::clz_operand(func, value).is_some())
+                    }))
                 .then(|| Self::imm_u256(func, U256::ZERO))
             }
             InstKind::Eq(a, b) => {
                 let (a, b) = (resolve(*a), resolve(*b));
                 if a == b {
                     Some(Self::imm_bool(func, true))
+                } else if Self::clz_const_operand(func, a, b)
+                    .is_some_and(|(_, _, constant)| constant > U256::from(256))
+                {
+                    Some(Self::imm_bool(func, false))
                 } else if Self::is_bool_value(func, a) && Self::is_one(func, b) {
                     Some(a)
                 } else if Self::is_bool_value(func, b) && Self::is_one(func, a) {
@@ -427,7 +502,9 @@ impl InstSimplifier {
             }
             InstKind::Lt(a, b) | InstKind::Gt(a, b) | InstKind::SLt(a, b) | InstKind::SGt(a, b) => {
                 let (a, b) = (resolve(*a), resolve(*b));
-                if a == b {
+                if let Some(value) = Self::fold_clz_range_comparison(func, kind, a, b) {
+                    Some(Self::imm_bool(func, value))
+                } else if a == b {
                     Some(Self::imm_bool(func, false))
                 } else {
                     match kind {
@@ -510,6 +587,8 @@ impl InstSimplifier {
                 let (byte, value) = (resolve(*a), resolve(*b));
                 if Self::is_zero(func, value)
                     || func.value_u256(byte).is_some_and(|byte| byte >= U256::from(31))
+                    || (Self::clz_operand(func, value).is_some()
+                        && func.value_u256(byte).is_some_and(|byte| byte >= U256::from(1)))
                 {
                     Some(value)
                 } else {
@@ -804,6 +883,61 @@ impl InstSimplifier {
             Some((a, constant))
         } else {
             func.value_u256(a).map(|constant| (b, constant))
+        }
+    }
+
+    fn clz_const_operand(
+        func: &Function,
+        a: ValueId,
+        b: ValueId,
+    ) -> Option<(ValueId, ValueId, U256)> {
+        let (clz, constant) = Self::const_operand(func, a, b)?;
+        let input = Self::clz_operand(func, clz)?;
+        Some((clz, input, constant))
+    }
+
+    fn clz_operand(func: &Function, value: ValueId) -> Option<ValueId> {
+        let Value::Inst(inst_id) = func.value(value) else { return None };
+        match func.inst(*inst_id).kind {
+            InstKind::Clz(input) => Some(input),
+            _ => None,
+        }
+    }
+
+    fn has_known_sign_bit(func: &Function, value: ValueId) -> bool {
+        if let Some(value) = func.value_u256(value) {
+            return value.bit(255);
+        }
+        let Value::Inst(inst_id) = func.value(value) else { return false };
+        match func.inst(*inst_id).kind {
+            InstKind::Or(a, b) => {
+                Self::has_known_sign_bit(func, a) || Self::has_known_sign_bit(func, b)
+            }
+            InstKind::Sar(_, value) => Self::has_known_sign_bit(func, value),
+            _ => false,
+        }
+    }
+
+    fn fold_clz_range_comparison(
+        func: &Function,
+        kind: &InstKind,
+        a: ValueId,
+        b: ValueId,
+    ) -> Option<bool> {
+        match kind {
+            InstKind::Lt(_, _) if Self::clz_operand(func, a).is_some() => {
+                func.value_u256(b).and_then(|b| (b > U256::from(256)).then_some(true))
+            }
+            InstKind::Lt(_, _) if Self::clz_operand(func, b).is_some() => {
+                func.value_u256(a).and_then(|a| (a >= U256::from(256)).then_some(false))
+            }
+            InstKind::Gt(_, _) if Self::clz_operand(func, a).is_some() => {
+                func.value_u256(b).and_then(|b| (b >= U256::from(256)).then_some(false))
+            }
+            InstKind::Gt(_, _) if Self::clz_operand(func, b).is_some() => {
+                func.value_u256(a).and_then(|a| (a > U256::from(256)).then_some(true))
+            }
+            _ => None,
         }
     }
 

--- a/tests/ui/codegen/mir/inst-simplify/clz.mir
+++ b/tests/ui/codegen/mir/inst-simplify/clz.mir
@@ -1,0 +1,60 @@
+//@compile-flags: --pass inst-simplify
+@module ClzInstSimplify
+
+fn @simplify_clz_predicates(arg0: u256) -> (bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool) {
+  bb0:
+    v1 = clz arg0
+    v2 = iszero v1
+    v3 = eq v1, 0
+    v4 = eq v1, 255
+    v5 = eq 256, v1
+    v6 = eq v1, 257
+    v7 = gt v1, 255
+    v8 = lt 255, v1
+    v9 = lt v1, 256
+    v10 = gt 256, v1
+    v11 = lt v1, 257
+    v12 = gt v1, 256
+    v13 = lt 256, v1
+    v14 = gt 257, v1
+    ret v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14
+}
+
+fn @simplify_clz_range_ops(arg0: u256) -> (u256, u256, u256, u256, i256, u256, u256, u256, u256, u256, u256) {
+  bb0:
+    v1 = clz arg0
+    v2 = shr 8, v1
+    v3 = shr 9, v1
+    v4 = and v1, 511
+    v5 = and 1023, v1
+    v6 = signextend 1, v1
+    v7 = byte 0, v1
+    v8 = byte 29, v1
+    v9 = byte 30, v1
+    v10 = div v1, 256
+    v11 = div v1, 257
+    v12 = mod v1, 257
+    ret v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12
+}
+
+fn @preserve_clz_range_boundaries(arg0: u256) -> (u256, u256, i256, u256, u256) {
+  bb0:
+    v1 = clz arg0
+    v2 = shr 7, v1
+    v3 = and v1, 255
+    v4 = signextend 0, v1
+    v5 = byte 31, v1
+    v6 = mod v1, 256
+    ret v2, v3, v4, v5, v6
+}
+
+fn @fold_clz_known_sign(arg0: u256, arg1: u256) -> (u256, u256, u256) {
+  bb0:
+    v2 = or arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v3 = clz v2
+    v4 = sar arg1, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v5 = clz v4
+    v6 = sar arg1, v2
+    v7 = clz v6
+    ret v3, v5, v7
+}

--- a/tests/ui/codegen/mir/inst-simplify/clz.stdout
+++ b/tests/ui/codegen/mir/inst-simplify/clz.stdout
@@ -1,0 +1,76 @@
+- // === ROOT/tests/ui/codegen/mir/inst-simplify/clz.mir (before inst-simplify) ===
++ // === ROOT/tests/ui/codegen/mir/inst-simplify/clz.mir (after inst-simplify) ===
+  @module ClzInstSimplify
+  fn @simplify_clz_predicates(arg0: u256) -> (bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool) {
+    bb0:
+      v0 = clz arg0
+-     v1 = iszero v0
+-     v2 = eq v0, 0
+-     v3 = eq v0, 255
+-     v4 = eq 256, v0
+-     v5 = eq v0, 257
+-     v6 = gt v0, 255
+-     v7 = lt 255, v0
+-     v8 = lt v0, 256
+-     v9 = gt 256, v0
+-     v10 = lt v0, 257
+-     v11 = gt v0, 256
+-     v12 = lt 256, v0
+-     v13 = gt 257, v0
+-     ret v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13
++     v1 = slt arg0, 0
++     v2 = slt arg0, 0
++     v3 = eq arg0, 1
++     v4 = iszero arg0
++     v6 = iszero arg0
++     v7 = iszero arg0
++     v8 = gt arg0, 0
++     v9 = gt arg0, 0
++     ret v1, v2, v3, v4, 0, v6, v7, v8, v9, 1, 0, 0, 1
+  }
+  
+  fn @simplify_clz_range_ops(arg0: u256) -> (u256, u256, u256, u256, i256, u256, u256, u256, u256, u256, u256) {
+    bb0:
+      v0 = clz arg0
+-     v1 = shr 8, v0
+-     v2 = shr 9, v0
+-     v3 = and v0, 511
+-     v4 = and 0x3ff, v0
+-     v5 = signextend 1, v0
+-     v6 = byte 0, v0
+-     v7 = byte 29, v0
+-     v8 = byte 30, v0
+-     v9 = div v0, 256
+-     v10 = div v0, 257
+-     v11 = mod v0, 257
+-     ret v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11
++     v1 = iszero arg0
++     v8 = iszero arg0
++     v9 = iszero arg0
++     ret v1, 0, v0, v0, v0, 0, 0, v8, v9, 0, v0
+  }
+  
+  fn @preserve_clz_range_boundaries(arg0: u256) -> (u256, u256, i256, u256, u256) {
+    bb0:
+      v0 = clz arg0
+      v1 = shr 7, v0
+      v2 = and v0, 255
+      v3 = signextend 0, v0
+      v4 = byte 31, v0
+-     v5 = mod v0, 256
++     v5 = and v0, 255
+      ret v1, v2, v3, v4, v5
+  }
+  
+  fn @fold_clz_known_sign(arg0: u256, arg1: u256) -> (u256, u256, u256) {
+    bb0:
+      v0 = or arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
+-     v1 = clz v0
+      v2 = sar arg1, 0x8000000000000000000000000000000000000000000000000000000000000000
+-     v3 = clz v2
+      v4 = sar arg1, v0
+-     v5 = clz v4
+-     ret v1, v3, v5
++     ret 0, 0, 0
+  }
+  

--- a/tests/ui/codegen/run-call/yul_clz_simplify.sol
+++ b/tests/ui/codegen/run-call/yul_clz_simplify.sol
@@ -1,0 +1,37 @@
+//@ compile-flags: --evm-version osaka
+//@ run-call: simplify 0 => 0, 0, 1, 1, 0, 256, 1, 0, 256, 0
+//@ run-call: simplify 1 => 0, 1, 0, 0, 0, 255, 0, 0, 255, 0
+//@ run-call: simplify 0x8000000000000000000000000000000000000000000000000000000000000000 => 1, 0, 0, 0, 0, 0, 0, 0, 0, 0
+
+contract YulClzSimplify {
+    function simplify(uint256 value)
+        external
+        pure
+        returns (
+            uint256 isNegative,
+            uint256 isOne,
+            uint256 isZero,
+            uint256 highByte,
+            uint256 shiftedOut,
+            uint256 masked,
+            uint256 nextByte,
+            uint256 quotient,
+            uint256 remainder,
+            uint256 knownNegative
+        )
+    {
+        assembly {
+            isNegative := iszero(clz(value))
+            isOne := eq(clz(value), 255)
+            isZero := eq(clz(value), 256)
+            highByte := shr(8, clz(value))
+            shiftedOut := shr(9, clz(value))
+            masked := and(clz(value), 511)
+            nextByte := byte(30, clz(value))
+            quotient := div(clz(value), 257)
+            remainder := mod(clz(value), 257)
+            knownNegative :=
+                clz(or(value, 0x8000000000000000000000000000000000000000000000000000000000000000))
+        }
+    }
+}


### PR DESCRIPTION
Adds local MIR simplifications for `clz` based on its exact EVM result range of 0 through 256. Predicate, comparison, shift, byte, mask, division, modulo, and sign-extension consumers now collapse to cheaper operations or constants, and `clz` folds to zero when its operand is known to have the sign bit set.

The transforms stay in MIR, allowing the existing optimization pipeline to remove obsolete `clz` instructions before stack scheduling.
