### PR TITLE
feat(lsp): add CodeLens support

### DIFF
--- a/crates/lsp/src/code_lens.rs
+++ b/crates/lsp/src/code_lens.rs
@@ -1,0 +1,190 @@
+//! CodeLens declaration facts and their cross-analysis merge index.
+//!
+//! The semantic analysis context is short-lived, so this module copies only the facts needed to
+//! render CodeLens items. Query-time reference locations remain owned by [`SymbolTables`].
+
+use crate::symbols::{DeclarationSymbol, SymbolId};
+use lsp_types::{Range, Url};
+use solar_interface::data_structures::{
+    index::IndexVec,
+    map::{FxHashMap, FxHashSet},
+};
+use solar_sema::{
+    Gcx,
+    hir::{ItemId, VarKind},
+};
+use std::cmp::Ordering;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CodeLensIndex {
+    candidates: Vec<CodeLensCandidate>,
+    entries_by_uri: FxHashMap<Url, Vec<CodeLensEntry>>,
+}
+
+#[derive(Clone, Debug)]
+struct CodeLensCandidate {
+    symbol_id: SymbolId,
+    key: NodeKey,
+    selector: Option<[u8; 4]>,
+    inheritance: bool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CodeLensEntry {
+    pub(crate) range: Range,
+    pub(crate) symbol_ids: Vec<SymbolId>,
+    pub(crate) selector: Option<[u8; 4]>,
+    pub(crate) inheritance: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct NodeKey {
+    uri: Url,
+    range: Range,
+}
+
+impl CodeLensIndex {
+    pub(crate) fn build(
+        gcx: Gcx<'_>,
+        item_symbols: &FxHashMap<ItemId, SymbolId>,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+    ) -> Self {
+        let mut index = Self::default();
+        for item_id in gcx.hir.item_ids() {
+            let Some(&symbol_id) = item_symbols.get(&item_id) else { continue };
+            if !has_reference_lens(gcx, item_id) {
+                continue;
+            }
+
+            let declaration = &declarations[symbol_id];
+            index.candidates.push(CodeLensCandidate {
+                symbol_id,
+                key: NodeKey {
+                    uri: declaration.location.uri.clone(),
+                    range: declaration.name_range,
+                },
+                selector: selector(gcx, item_id),
+                inheritance: matches!(item_id, ItemId::Contract(_)),
+            });
+        }
+        index
+    }
+
+    pub(crate) fn extend(&mut self, other: Self, symbol_offset: usize) {
+        self.candidates.extend(other.candidates.into_iter().map(|mut candidate| {
+            candidate.symbol_id = candidate.symbol_id.offset_by(symbol_offset);
+            candidate
+        }));
+        self.entries_by_uri.clear();
+    }
+
+    pub(crate) fn rebuild(&mut self, conflicting_contents: &FxHashSet<Url>) {
+        self.entries_by_uri.clear();
+
+        let mut grouped = FxHashMap::<NodeKey, Vec<&CodeLensCandidate>>::default();
+        for candidate in &self.candidates {
+            if !conflicting_contents.contains(&candidate.key.uri) {
+                grouped.entry(candidate.key.clone()).or_default().push(candidate);
+            }
+        }
+
+        for (key, candidates) in grouped {
+            let Some(first) = candidates.first() else { continue };
+            if candidates.iter().any(|candidate| {
+                candidate.selector != first.selector || candidate.inheritance != first.inheritance
+            }) {
+                // A source declaration compiled under incompatible contexts must not expose a
+                // potentially stale or contradictory lens.
+                continue;
+            }
+
+            let mut symbol_ids: Vec<_> =
+                candidates.iter().map(|candidate| candidate.symbol_id).collect();
+            symbol_ids.sort_unstable_by_key(|symbol_id| symbol_id.index());
+            symbol_ids.dedup();
+            self.entries_by_uri.entry(key.uri.clone()).or_default().push(CodeLensEntry {
+                range: key.range,
+                symbol_ids,
+                selector: first.selector,
+                inheritance: first.inheritance,
+            });
+        }
+
+        for entries in self.entries_by_uri.values_mut() {
+            entries.sort_unstable_by(|lhs, rhs| range_cmp(lhs.range, rhs.range));
+        }
+    }
+
+    pub(crate) fn entries(&self, uri: &Url) -> &[CodeLensEntry] {
+        self.entries_by_uri.get(uri).map_or(&[], Vec::as_slice)
+    }
+}
+
+fn has_reference_lens(gcx: Gcx<'_>, item_id: ItemId) -> bool {
+    match item_id {
+        ItemId::Function(id) => !gcx.hir.function(id).is_yul,
+        ItemId::Contract(_)
+        | ItemId::Struct(_)
+        | ItemId::Enum(_)
+        | ItemId::Udvt(_)
+        | ItemId::Error(_)
+        | ItemId::Event(_) => true,
+        ItemId::Variable(id) => {
+            let variable = gcx.hir.variable(id);
+            let yul_parameter = matches!(
+                variable.parent,
+                Some(ItemId::Function(function)) if gcx.hir.function(function).is_yul
+            );
+            !yul_parameter
+                && matches!(
+                    variable.kind,
+                    VarKind::Global
+                        | VarKind::State
+                        | VarKind::Struct
+                        | VarKind::Enum
+                        | VarKind::FunctionParam
+                )
+        }
+    }
+}
+
+fn selector(gcx: Gcx<'_>, item_id: ItemId) -> Option<[u8; 4]> {
+    match item_id {
+        ItemId::Function(id) => {
+            let function = gcx.hir.function(id);
+            (function.is_part_of_external_interface()
+                && !function.is_getter()
+                && !function.is_yul
+                && selector_is_valid(gcx, id))
+            .then(|| gcx.function_selector(id).0)
+        }
+        ItemId::Variable(id) => {
+            let variable = gcx.hir.variable(id);
+            variable
+                .is_state_variable()
+                .then_some(variable.getter)
+                .flatten()
+                .filter(|&getter| selector_is_valid(gcx, getter))
+                .map(|getter| gcx.function_selector(getter).0)
+        }
+        ItemId::Contract(_)
+        | ItemId::Struct(_)
+        | ItemId::Enum(_)
+        | ItemId::Udvt(_)
+        | ItemId::Error(_)
+        | ItemId::Event(_) => None,
+    }
+}
+
+fn selector_is_valid(gcx: Gcx<'_>, id: solar_sema::hir::FunctionId) -> bool {
+    gcx.item_parameter_types(id).iter().copied().all(|ty| ty.can_be_exported(gcx))
+}
+
+fn range_cmp(lhs: Range, rhs: Range) -> Ordering {
+    (lhs.start.line, lhs.start.character, lhs.end.line, lhs.end.character).cmp(&(
+        rhs.start.line,
+        rhs.start.character,
+        rhs.end.line,
+        rhs.end.character,
+    ))
+}

--- a/crates/lsp/src/code_lens.rs
+++ b/crates/lsp/src/code_lens.rs
@@ -8,6 +8,7 @@ use lsp_types::{Range, Url};
 use solar_interface::data_structures::{
     index::IndexVec,
     map::{FxHashMap, FxHashSet},
+    smallvec::SmallVec,
 };
 use solar_sema::{
     Gcx,
@@ -24,7 +25,6 @@ pub(crate) struct CodeLensIndex {
 #[derive(Clone, Debug)]
 struct CodeLensCandidate {
     symbol_id: SymbolId,
-    key: NodeKey,
     selector: Option<[u8; 4]>,
     inheritance: bool,
 }
@@ -32,37 +32,29 @@ struct CodeLensCandidate {
 #[derive(Clone, Debug)]
 pub(crate) struct CodeLensEntry {
     pub(crate) range: Range,
-    pub(crate) symbol_ids: Vec<SymbolId>,
+    pub(crate) symbol_ids: SmallVec<[SymbolId; 1]>,
     pub(crate) selector: Option<[u8; 4]>,
     pub(crate) inheritance: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct NodeKey {
-    uri: Url,
-    range: Range,
+#[derive(Debug)]
+struct CodeLensGroup {
+    symbol_ids: SmallVec<[SymbolId; 1]>,
+    selector: Option<[u8; 4]>,
+    inheritance: bool,
+    compatible: bool,
 }
 
 impl CodeLensIndex {
-    pub(crate) fn build(
-        gcx: Gcx<'_>,
-        item_symbols: &FxHashMap<ItemId, SymbolId>,
-        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
-    ) -> Self {
+    pub(crate) fn build(gcx: Gcx<'_>, item_symbols: &FxHashMap<ItemId, SymbolId>) -> Self {
         let mut index = Self::default();
         for item_id in gcx.hir.item_ids() {
             let Some(&symbol_id) = item_symbols.get(&item_id) else { continue };
             if !has_reference_lens(gcx, item_id) {
                 continue;
             }
-
-            let declaration = &declarations[symbol_id];
             index.candidates.push(CodeLensCandidate {
                 symbol_id,
-                key: NodeKey {
-                    uri: declaration.location.uri.clone(),
-                    range: declaration.name_range,
-                },
                 selector: selector(gcx, item_id),
                 inheritance: matches!(item_id, ItemId::Contract(_)),
             });
@@ -78,40 +70,61 @@ impl CodeLensIndex {
         self.entries_by_uri.clear();
     }
 
-    pub(crate) fn rebuild(&mut self, conflicting_contents: &FxHashSet<Url>) {
+    pub(crate) fn rebuild(
+        &mut self,
+        declarations: &IndexVec<SymbolId, DeclarationSymbol>,
+        conflicting_contents: &FxHashSet<Url>,
+    ) {
         self.entries_by_uri.clear();
 
-        let mut grouped = FxHashMap::<NodeKey, Vec<&CodeLensCandidate>>::default();
+        let mut grouped = FxHashMap::<&Url, FxHashMap<Range, CodeLensGroup>>::default();
         for candidate in &self.candidates {
-            if !conflicting_contents.contains(&candidate.key.uri) {
-                grouped.entry(candidate.key.clone()).or_default().push(candidate);
-            }
-        }
-
-        for (key, candidates) in grouped {
-            let Some(first) = candidates.first() else { continue };
-            if candidates.iter().any(|candidate| {
-                candidate.selector != first.selector || candidate.inheritance != first.inheritance
-            }) {
-                // A source declaration compiled under incompatible contexts must not expose a
-                // potentially stale or contradictory lens.
+            let declaration = &declarations[candidate.symbol_id];
+            if conflicting_contents.contains(&declaration.location.uri) {
                 continue;
             }
 
-            let mut symbol_ids: Vec<_> =
-                candidates.iter().map(|candidate| candidate.symbol_id).collect();
-            symbol_ids.sort_unstable_by_key(|symbol_id| symbol_id.index());
-            symbol_ids.dedup();
-            self.entries_by_uri.entry(key.uri.clone()).or_default().push(CodeLensEntry {
-                range: key.range,
-                symbol_ids,
-                selector: first.selector,
-                inheritance: first.inheritance,
-            });
+            let group = grouped
+                .entry(&declaration.location.uri)
+                .or_default()
+                .entry(declaration.name_range)
+                .or_insert_with(|| CodeLensGroup {
+                    symbol_ids: SmallVec::new(),
+                    selector: candidate.selector,
+                    inheritance: candidate.inheritance,
+                    compatible: true,
+                });
+            if !group.compatible {
+                continue;
+            }
+            if candidate.selector != group.selector || candidate.inheritance != group.inheritance {
+                // A source declaration compiled under incompatible contexts must not expose a
+                // potentially stale or contradictory lens.
+                group.compatible = false;
+                group.symbol_ids.clear();
+            } else {
+                group.symbol_ids.push(candidate.symbol_id);
+            }
         }
 
-        for entries in self.entries_by_uri.values_mut() {
-            entries.sort_unstable_by(|lhs, rhs| range_cmp(lhs.range, rhs.range));
+        for (uri, groups) in grouped {
+            let mut entries = Vec::with_capacity(groups.len());
+            for (range, mut group) in groups {
+                if group.compatible {
+                    group.symbol_ids.sort_unstable_by_key(|symbol_id| symbol_id.index());
+                    group.symbol_ids.dedup();
+                    entries.push(CodeLensEntry {
+                        range,
+                        symbol_ids: group.symbol_ids,
+                        selector: group.selector,
+                        inheritance: group.inheritance,
+                    });
+                }
+            }
+            if !entries.is_empty() {
+                entries.sort_unstable_by(|lhs, rhs| range_cmp(lhs.range, rhs.range));
+                self.entries_by_uri.insert(uri.clone(), entries);
+            }
         }
     }
 

--- a/crates/lsp/src/code_lens.rs
+++ b/crates/lsp/src/code_lens.rs
@@ -1,7 +1,8 @@
 //! CodeLens declaration facts and their cross-analysis merge index.
 //!
 //! The semantic analysis context is short-lived, so this module copies only the facts needed to
-//! render CodeLens items. Query-time reference locations remain owned by [`SymbolTables`].
+//! render CodeLens items. Query-time reference locations remain owned by
+//! [`SymbolTables`](crate::symbols::SymbolTables).
 
 use crate::symbols::{DeclarationSymbol, SymbolId};
 use lsp_types::{Range, Url};

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -5,14 +5,15 @@ use crate::{
     workspace::{Workspace, WorkspacePathIndex, manifest::ProjectManifest},
 };
 use lsp_types::{
-    CallHierarchyServerCapability, CompletionOptions, DeclarationCapability, DiagnosticOptions,
-    DiagnosticServerCapabilities, DocumentLinkOptions, ExecuteCommandOptions,
-    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
-    InitializeParams, OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
-    ServerCapabilities, SignatureHelpOptions, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextDocumentSyncOptions, TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability,
-    WorkDoneProgressOptions,
+    CallHierarchyServerCapability, CodeLensOptions as CodeLensServerOptions, CompletionOptions,
+    DeclarationCapability, DiagnosticOptions, DiagnosticServerCapabilities, DocumentLinkOptions,
+    ExecuteCommandOptions, FoldingRangeProviderCapability, HoverProviderCapability,
+    ImplementationProviderCapability, InitializeParams, OneOf, RenameOptions, SaveOptions,
+    SelectionRangeProviderCapability, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, TypeDefinitionProviderCapability, WorkDoneProgressOptions,
 };
+use serde::Deserialize;
 use solar_interface::data_structures::map::FxHashSet;
 use std::{
     env,
@@ -33,10 +34,12 @@ pub(crate) struct Config {
     flychecks: Vec<FlycheckConfig>,
     watched_file_dynamic_registration: bool,
     workspace_edit_document_changes: bool,
+    code_lens_refresh_support: bool,
     work_done_progress: bool,
     hierarchical_document_symbol_support: bool,
     completion: CompletionClientOptions,
     signature_help: SignatureHelpClientOptions,
+    code_lens: CodeLensConfig,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -51,6 +54,38 @@ pub(crate) struct SignatureHelpClientOptions {
     pub(crate) signature_active_parameter: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct CodeLensConfig {
+    pub(crate) enable: bool,
+    pub(crate) selectors: bool,
+    pub(crate) references: bool,
+    pub(crate) inheritance: bool,
+    pub(crate) client_commands: bool,
+}
+
+impl Default for CodeLensConfig {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            selectors: true,
+            references: true,
+            inheritance: true,
+            client_commands: false,
+        }
+    }
+}
+
+impl CodeLensConfig {
+    fn from_json(value: Option<serde_json::Value>) -> Self {
+        value
+            .and_then(|value| {
+                value.get("codeLens").cloned().and_then(|value| serde_json::from_value(value).ok())
+            })
+            .unwrap_or_default()
+    }
+}
+
 impl Config {
     pub(crate) fn supports_watched_file_dynamic_registration(&self) -> bool {
         self.watched_file_dynamic_registration
@@ -58,6 +93,10 @@ impl Config {
 
     pub(crate) fn supports_workspace_edit_document_changes(&self) -> bool {
         self.workspace_edit_document_changes
+    }
+
+    pub(crate) fn supports_code_lens_refresh(&self) -> bool {
+        self.code_lens_refresh_support
     }
 
     pub(crate) fn supports_work_done_progress(&self) -> bool {
@@ -81,9 +120,18 @@ impl Config {
         self.signature_help
     }
 
+    pub(crate) fn code_lens_options(&self) -> CodeLensConfig {
+        self.code_lens
+    }
+
     #[cfg(test)]
     pub(crate) fn enable_signature_help_label_offsets(&mut self) {
         self.signature_help.label_offsets = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn enable_code_lens_client_commands(&mut self) {
+        self.code_lens.client_commands = true;
     }
 
     pub(crate) fn workspaces(&self) -> &[Workspace] {
@@ -201,7 +249,8 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
     #[allow(deprecated)]
     let root_uri = params.root_uri;
     let workspace_folders = params.workspace_folders;
-    let flycheck_options = FlycheckInitializationOptions::from_json(initialization_options);
+    let flycheck_options = FlycheckInitializationOptions::from_json(initialization_options.clone());
+    let code_lens = CodeLensConfig::from_json(initialization_options);
 
     // todo: make this absolute guaranteed
     let root_path = match root_uri.and_then(|it| it.to_file_path().ok()) {
@@ -226,6 +275,12 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
         .as_ref()
         .and_then(|workspace| workspace.workspace_edit.as_ref())
         .and_then(|capabilities| capabilities.document_changes)
+        .unwrap_or(false);
+    let code_lens_refresh_support = capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.code_lens.as_ref())
+        .and_then(|capabilities| capabilities.refresh_support)
         .unwrap_or(false);
     let work_done_progress =
         capabilities.window.as_ref().and_then(|window| window.work_done_progress).unwrap_or(false);
@@ -303,6 +358,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
                 work_done_progress_options: WorkDoneProgressOptions::default(),
             }),
             document_symbol_provider: Some(OneOf::Left(true)),
+            code_lens_provider: Some(CodeLensServerOptions { resolve_provider: Some(false) }),
             document_highlight_provider: Some(OneOf::Left(true)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             inlay_hint_provider: Some(OneOf::Left(true)),
@@ -337,10 +393,12 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             flycheck_options,
             watched_file_dynamic_registration,
             workspace_edit_document_changes,
+            code_lens_refresh_support,
             work_done_progress,
             hierarchical_document_symbol_support,
             completion,
             signature_help,
+            code_lens,
             ..Default::default()
         },
     )
@@ -351,7 +409,8 @@ mod tests {
     use super::*;
     use crate::{test_support::TestProject, workspace::WorkspaceKind};
     use lsp_types::{
-        CallHierarchyServerCapability, CompletionClientCapabilities, CompletionItemCapability,
+        CallHierarchyServerCapability, CodeLensWorkspaceClientCapabilities,
+        CompletionClientCapabilities, CompletionItemCapability,
         DidChangeWatchedFilesClientCapabilities, DocumentSymbolClientCapabilities, MarkupKind,
         OneOf, ParameterInformationSettings, RenameOptions, SignatureHelpClientCapabilities,
         SignatureInformationSettings, TextDocumentClientCapabilities, TextDocumentSyncCapability,
@@ -416,6 +475,51 @@ mod tests {
     }
 
     #[test]
+    fn negotiate_capabilities_records_code_lens_refresh_support() {
+        let (_, config) = negotiate_capabilities(InitializeParams::default());
+        assert!(!config.supports_code_lens_refresh());
+
+        let mut params = InitializeParams::default();
+        params.capabilities.workspace = Some(WorkspaceClientCapabilities {
+            code_lens: Some(CodeLensWorkspaceClientCapabilities { refresh_support: Some(true) }),
+            ..Default::default()
+        });
+
+        let (_, config) = negotiate_capabilities(params);
+
+        assert!(config.supports_code_lens_refresh());
+    }
+
+    #[test]
+    fn negotiate_capabilities_reads_code_lens_initialization_options() {
+        let params = InitializeParams {
+            initialization_options: Some(serde_json::json!({
+                "codeLens": {
+                    "enable": false,
+                    "selectors": false,
+                    "references": true,
+                    "inheritance": false,
+                    "clientCommands": true,
+                }
+            })),
+            ..Default::default()
+        };
+
+        let (_, config) = negotiate_capabilities(params);
+
+        assert_eq!(
+            config.code_lens_options(),
+            CodeLensConfig {
+                enable: false,
+                selectors: false,
+                references: true,
+                inheritance: false,
+                client_commands: true,
+            }
+        );
+    }
+
+    #[test]
     fn negotiate_capabilities_advertises_symbol_providers() {
         let (capabilities, _) = negotiate_capabilities(InitializeParams::default());
 
@@ -440,6 +544,10 @@ mod tests {
             Some(FoldingRangeProviderCapability::Simple(true))
         );
         assert_eq!(capabilities.document_symbol_provider, Some(OneOf::Left(true)));
+        assert_eq!(
+            capabilities.code_lens_provider,
+            Some(CodeLensServerOptions { resolve_provider: Some(false) })
+        );
         assert_eq!(capabilities.hover_provider, Some(HoverProviderCapability::Simple(true)));
         let document_link_provider = capabilities.document_link_provider.unwrap();
         assert_eq!(document_link_provider.resolve_provider, Some(false));

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -77,6 +77,10 @@ impl Default for CodeLensConfig {
 }
 
 impl CodeLensConfig {
+    pub(crate) fn is_active(self) -> bool {
+        self.enable && (self.selectors || self.references || self.inheritance)
+    }
+
     fn from_json(value: Option<serde_json::Value>) -> Self {
         value
             .and_then(|value| {
@@ -517,6 +521,28 @@ mod tests {
                 client_commands: true,
             }
         );
+    }
+
+    #[test]
+    fn code_lens_activity_requires_an_enabled_lens_kind() {
+        let inactive = CodeLensConfig {
+            enable: true,
+            selectors: false,
+            references: false,
+            inheritance: false,
+            client_commands: false,
+        };
+        assert!(!inactive.is_active());
+        assert!(!CodeLensConfig { enable: false, selectors: true, ..inactive }.is_active());
+        assert!(!CodeLensConfig { client_commands: true, ..inactive }.is_active());
+
+        for active in [
+            CodeLensConfig { selectors: true, ..inactive },
+            CodeLensConfig { references: true, ..inactive },
+            CodeLensConfig { inheritance: true, ..inactive },
+        ] {
+            assert!(active.is_active());
+        }
     }
 
     #[test]

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -181,7 +181,8 @@ impl GlobalState {
     }
 
     pub(crate) fn clear_analysis_cache(&mut self) {
-        let refresh_code_lenses = self.config.supports_code_lens_refresh();
+        let refresh_code_lenses =
+            self.config.supports_code_lens_refresh() && self.config.code_lens_options().is_active();
         let old_symbol_tables = {
             let Self {
                 client,
@@ -754,7 +755,8 @@ impl GlobalStateSnapshot {
     }
 
     fn publish_analysis(&mut self, version: usize, result: AnalysisResult) -> bool {
-        let refresh_code_lenses = self.config.supports_code_lens_refresh();
+        let refresh_code_lenses =
+            self.config.supports_code_lens_refresh() && self.config.code_lens_options().is_active();
         let old_symbol_tables = {
             let analysis_commit = self.analysis_commit.clone();
             let mut commit = analysis_commit.lock();

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -181,6 +181,7 @@ impl GlobalState {
     }
 
     pub(crate) fn clear_analysis_cache(&mut self) {
+        let refresh_code_lenses = self.config.supports_code_lens_refresh();
         let old_symbol_tables = {
             let Self {
                 client,
@@ -214,6 +215,9 @@ impl GlobalState {
             })
         };
         drop(old_symbol_tables);
+        if refresh_code_lenses {
+            request_code_lens_refresh(&self.client);
+        }
     }
 
     #[cfg(test)]
@@ -750,6 +754,7 @@ impl GlobalStateSnapshot {
     }
 
     fn publish_analysis(&mut self, version: usize, result: AnalysisResult) -> bool {
+        let refresh_code_lenses = self.config.supports_code_lens_refresh();
         let old_symbol_tables = {
             let analysis_commit = self.analysis_commit.clone();
             let mut commit = analysis_commit.lock();
@@ -770,6 +775,9 @@ impl GlobalStateSnapshot {
             old_symbol_tables
         };
         drop(old_symbol_tables);
+        if refresh_code_lenses {
+            request_code_lens_refresh(&self.client);
+        }
         true
     }
 
@@ -819,6 +827,16 @@ impl GlobalStateSnapshot {
         };
         publish_diagnostic_batches(&mut self.client, batches);
     }
+}
+
+fn request_code_lens_refresh(client: &ClientSocket) {
+    let mut client = client.clone();
+    let Ok(handle) = tokio::runtime::Handle::try_current() else { return };
+    handle.spawn(async move {
+        if let Err(error) = client.code_lens_refresh(()).await {
+            tracing::debug!(%error, "client does not accept CodeLens refresh");
+        }
+    });
 }
 
 struct AnalysisBatch {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -11,13 +11,13 @@ use crop::Rope;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
-    CompletionParams, CompletionResponse, DocumentChanges, DocumentDiagnosticParams,
-    DocumentDiagnosticReport, DocumentDiagnosticReportResult, DocumentFormattingParams,
-    DocumentHighlight, DocumentHighlightParams, DocumentLink, DocumentLinkParams,
-    DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
-    FullDocumentDiagnosticReport, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
-    InlayHint, InlayHintParams, OneOf, OptionalVersionedTextDocumentIdentifier, Position,
-    PrepareRenameResponse, ReferenceParams, RelatedFullDocumentDiagnosticReport,
+    CodeLens, CodeLensParams, CompletionParams, CompletionResponse, DocumentChanges,
+    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
+    DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams, DocumentLink,
+    DocumentLinkParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
+    FoldingRangeParams, FullDocumentDiagnosticReport, GotoDefinitionParams, GotoDefinitionResponse,
+    Hover, HoverParams, InlayHint, InlayHintParams, OneOf, OptionalVersionedTextDocumentIdentifier,
+    Position, PrepareRenameResponse, ReferenceParams, RelatedFullDocumentDiagnosticReport,
     RelatedUnchangedDocumentDiagnosticReport, RenameParams, SelectionRange, SelectionRangeParams,
     SignatureHelp, SignatureHelpParams, TextDocumentEdit, TextDocumentPositionParams, TextEdit,
     TypeHierarchyItem, TypeHierarchyPrepareParams, TypeHierarchySubtypesParams,
@@ -476,6 +476,21 @@ pub(crate) fn references(
             include_declaration,
         );
         Ok(response)
+    }
+}
+
+pub(crate) fn code_lens(
+    state: &mut GlobalState,
+    params: CodeLensParams,
+) -> impl Future<Output = Result<Option<Vec<CodeLens>>, ResponseError>> + use<> {
+    let uri = params.text_document.uri;
+    let options = state.config.code_lens_options();
+    let latest_analysis = latest_analysis_for_uri(state, &uri);
+    async move {
+        let Some(latest_analysis) = latest_analysis else { return Ok(Some(Vec::new())) };
+        let symbol_tables = latest_analysis.await?;
+        let response = symbol_tables.read().code_lenses(&uri, options);
+        Ok(Some(response))
     }
 }
 

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -485,7 +485,8 @@ pub(crate) fn code_lens(
 ) -> impl Future<Output = Result<Option<Vec<CodeLens>>, ResponseError>> + use<> {
     let uri = params.text_document.uri;
     let options = state.config.code_lens_options();
-    let latest_analysis = latest_analysis_for_uri(state, &uri);
+    let latest_analysis =
+        if options.is_active() { latest_analysis_for_uri(state, &uri) } else { None };
     async move {
         let Some(latest_analysis) = latest_analysis else { return Ok(Some(Vec::new())) };
         let symbol_tables = latest_analysis.await?;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -19,6 +19,7 @@ use std::ops::ControlFlow;
 use tower::ServiceBuilder;
 
 mod call_hierarchy;
+mod code_lens;
 mod commands;
 mod config;
 mod diagnostics;
@@ -96,6 +97,7 @@ fn new_router_with_state(this: GlobalState) -> Router<GlobalState> {
         .request::<req::GotoDeclaration, _>(handlers::goto_declaration)
         .request::<req::GotoImplementation, _>(handlers::goto_implementation)
         .request::<req::References, _>(handlers::references)
+        .request::<req::CodeLensRequest, _>(handlers::code_lens)
         .request::<req::CallHierarchyPrepare, _>(handlers::prepare_call_hierarchy)
         .request::<req::CallHierarchyIncomingCalls, _>(handlers::call_hierarchy_incoming)
         .request::<req::CallHierarchyOutgoingCalls, _>(handlers::call_hierarchy_outgoing)
@@ -378,6 +380,24 @@ mod tests {
         let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
             "id": 1,
             "method": request::DocumentLinkRequest::METHOD,
+            "params": params,
+        }))
+        .unwrap();
+
+        let response = router.call(request).await.unwrap();
+
+        assert_eq!(response, serde_json::json!([]));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_handles_code_lens_requests() {
+        let mut router = new_router(ClientSocket::new_closed());
+        let params = serde_json::json!({
+            "textDocument": { "uri": "file:///workspace/src/Test.sol" },
+        });
+        let request = serde_json::from_value::<AnyRequest>(serde_json::json!({
+            "id": 1,
+            "method": request::CodeLensRequest::METHOD,
             "params": params,
         }))
         .unwrap();
@@ -1003,6 +1023,7 @@ mod tests {
         let response = router.call(request).await.unwrap();
 
         assert_eq!(response["capabilities"]["typeHierarchyProvider"], true);
+        assert_eq!(response["capabilities"]["codeLensProvider"]["resolveProvider"], false);
         assert_eq!(response["capabilities"]["hoverProvider"], true);
         assert_eq!(response["serverInfo"]["name"], "solar");
     }

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -315,7 +315,7 @@ impl SymbolTables {
 
         tables.build_type_definitions(gcx, &item_symbols);
         tables.call_hierarchy = CallHierarchyIndex::build(gcx, &item_symbols, &tables.declarations);
-        tables.code_lens = CodeLensIndex::build(gcx, &item_symbols, &tables.declarations);
+        tables.code_lens = CodeLensIndex::build(gcx, &item_symbols);
 
         // Public state-variable getters are compiler-generated functions, but source member calls
         // such as `this.value()` still name the state variable. Point getter resolutions back to
@@ -428,24 +428,21 @@ impl SymbolTables {
         let mut lenses = Vec::new();
         for entry in self.code_lens.entries(uri) {
             let position = entry.range.start;
-            let location = serde_json::json!({ "uri": uri, "position": position });
 
             if options.references {
                 let count = self.reference_count(&entry.symbol_ids);
-                let command = (count > 0 && options.client_commands).then_some(Command {
-                    title: format_reference_title(count),
-                    command: "solar.showReferences".into(),
-                    arguments: Some(vec![location.clone()]),
-                });
+                let title = format_reference_title(count);
+                let (command, arguments) = if count > 0 && options.client_commands {
+                    (
+                        "solar.showReferences".into(),
+                        Some(vec![serde_json::json!({ "uri": uri, "position": position })]),
+                    )
+                } else {
+                    (String::new(), None)
+                };
                 lenses.push(CodeLens {
                     range: entry.range,
-                    command: command.or_else(|| {
-                        Some(Command {
-                            title: format_reference_title(count),
-                            command: String::new(),
-                            arguments: None,
-                        })
-                    }),
+                    command: Some(Command { title, command, arguments }),
                     data: None,
                 });
             }
@@ -454,15 +451,15 @@ impl SymbolTables {
                 && let Some(selector) = entry.selector
             {
                 let title = format_selector_title(selector);
+                let arguments =
+                    options.client_commands.then(|| vec![serde_json::Value::String(title.clone())]);
                 lenses.push(CodeLens {
                     range: entry.range,
                     command: Some(Command {
                         title,
                         command: if options.client_commands { "solar.copySelector" } else { "" }
                             .into(),
-                        arguments: options
-                            .client_commands
-                            .then_some(vec![serde_json::json!(format_selector_title(selector))]),
+                        arguments,
                     }),
                     data: None,
                 });
@@ -504,13 +501,13 @@ impl SymbolTables {
     }
 
     fn reference_count(&self, targets: &[SymbolId]) -> usize {
-        let mut locations = self
-            .reference_indices_for_targets(targets)
-            .into_iter()
-            .map(|index| self.references[index].location.clone())
-            .collect::<Vec<_>>();
-        sort_locations(&mut locations);
-        locations.dedup_by(|lhs, rhs| lhs.uri == rhs.uri && lhs.range == rhs.range);
+        let mut locations = FxHashSet::default();
+        for &index in
+            targets.iter().filter_map(|target| self.symbol_references.get(target)).flatten()
+        {
+            let location = &self.references[index].location;
+            locations.insert((&location.uri, location.range));
+        }
         locations.len()
     }
 
@@ -1201,6 +1198,9 @@ impl SymbolTables {
         uri: &Url,
         position: Position,
     ) -> Option<ReferenceTargets> {
+        if self.rename.conflicting_contents().contains(uri) {
+            return None;
+        }
         if let Some(reference) = self.reference_at_position(uri, position) {
             return Some(reference.targets.clone());
         }
@@ -1210,8 +1210,7 @@ impl SymbolTables {
         let mut symbol_ids = self
             .file_declaration_positions
             .get(uri)?
-            .iter()
-            .copied()
+            .candidates_at(position, |symbol_id| self.declarations[symbol_id].name_range)
             .filter(|&candidate| {
                 let candidate = &self.declarations[candidate];
                 candidate.name_range == declaration.name_range
@@ -1219,9 +1218,9 @@ impl SymbolTables {
                     && candidate.name == declaration.name
                     && candidate.kind == declaration.kind
             })
-            .collect::<Vec<_>>();
+            .collect::<ReferenceTargets>();
         symbol_ids.sort_unstable_by_key(|symbol_id| symbol_id.index());
-        Some(ReferenceTargets::from_vec(symbol_ids))
+        Some(symbol_ids)
     }
 
     fn reference_indices_for_targets(&self, targets: &[SymbolId]) -> Vec<usize> {
@@ -1455,7 +1454,7 @@ impl SymbolTables {
         self.override_families.rebuild(&self.declarations, self.rename.conflicting_contents());
         self.type_hierarchy.rebuild(self.rename.conflicting_contents());
         self.rename.rebuild(&self.override_families);
-        self.code_lens.rebuild(self.rename.conflicting_contents());
+        self.code_lens.rebuild(&self.declarations, self.rename.conflicting_contents());
         self.call_hierarchy.rebuild();
     }
 }
@@ -2220,15 +2219,19 @@ fn inheritance_command(
     position: Position,
     enabled: bool,
 ) -> Command {
-    Command {
-        title,
-        command: if enabled { "solar.showTypeHierarchy" } else { "" }.into(),
-        arguments: enabled.then_some(vec![serde_json::json!({
-            "uri": uri,
-            "position": position,
-            "direction": direction,
-        })]),
-    }
+    let (command, arguments) = if enabled {
+        (
+            "solar.showTypeHierarchy".into(),
+            Some(vec![serde_json::json!({
+                "uri": uri,
+                "position": position,
+                "direction": direction,
+            })]),
+        )
+    } else {
+        (String::new(), None)
+    };
+    Command { title, command, arguments }
 }
 
 fn sort_completion_items(items: &mut [CompletionItem]) {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1208,7 +1208,17 @@ impl SymbolTables {
             return None;
         }
         if let Some(reference) = self.reference_at_position(uri, position) {
-            return Some(reference.targets.clone());
+            let range = reference.location.range;
+            let mut targets = self
+                .file_references
+                .get(uri)?
+                .candidates_at(position, |index| self.references[index].location.range)
+                .filter(|&index| self.references[index].location.range == range)
+                .flat_map(|index| self.references[index].targets.iter().copied())
+                .collect::<ReferenceTargets>();
+            targets.sort_unstable_by_key(|symbol_id| symbol_id.index());
+            targets.dedup();
+            return Some(targets);
         }
 
         let symbol_id = self.declaration_at_position(uri, position)?;

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -429,8 +429,9 @@ impl SymbolTables {
         for entry in self.code_lens.entries(uri) {
             let position = entry.range.start;
 
-            if options.references {
-                let count = self.reference_count(&entry.symbol_ids);
+            if options.references
+                && let Some(count) = self.reference_count(&entry.symbol_ids)
+            {
                 let title = format_reference_title(count);
                 let (command, arguments) = if count > 0 && options.client_commands {
                     (
@@ -473,8 +474,8 @@ impl SymbolTables {
                     lenses.push(CodeLens {
                         range: entry.range,
                         command: Some(inheritance_command(
-                            format_inheritance_title("base", bases),
-                            "supertypes",
+                            InheritanceLensKind::Base,
+                            bases,
                             uri,
                             position,
                             options.client_commands,
@@ -486,8 +487,8 @@ impl SymbolTables {
                     lenses.push(CodeLens {
                         range: entry.range,
                         command: Some(inheritance_command(
-                            format_inheritance_title("derived", derived),
-                            "subtypes",
+                            InheritanceLensKind::Derived,
+                            derived,
                             uri,
                             position,
                             options.client_commands,
@@ -500,15 +501,13 @@ impl SymbolTables {
         lenses
     }
 
-    fn reference_count(&self, targets: &[SymbolId]) -> usize {
+    fn reference_count(&self, targets: &[SymbolId]) -> Option<usize> {
         let mut locations = FxHashSet::default();
-        for &index in
-            targets.iter().filter_map(|target| self.symbol_references.get(target)).flatten()
-        {
+        for index in self.complete_reference_indices_for_targets(targets)? {
             let location = &self.references[index].location;
             locations.insert((&location.uri, location.range));
         }
-        locations.len()
+        Some(locations.len())
     }
 
     pub(crate) fn document_links(&self, path: &Path) -> Vec<lsp_types::DocumentLink> {
@@ -765,7 +764,7 @@ impl SymbolTables {
         }
 
         locations.extend(
-            self.reference_indices_for_targets(&target)
+            self.complete_reference_indices_for_targets(&target)?
                 .into_iter()
                 .map(|index| self.references[index].location.clone()),
         );
@@ -1223,7 +1222,7 @@ impl SymbolTables {
         Some(symbol_ids)
     }
 
-    fn reference_indices_for_targets(&self, targets: &[SymbolId]) -> Vec<usize> {
+    fn complete_reference_indices_for_targets(&self, targets: &[SymbolId]) -> Option<Vec<usize>> {
         let mut indices = targets
             .iter()
             .filter_map(|target| self.symbol_references.get(target))
@@ -1232,7 +1231,12 @@ impl SymbolTables {
             .collect::<Vec<_>>();
         indices.sort_unstable();
         indices.dedup();
-        indices
+        if indices.iter().any(|&index| {
+            self.rename.conflicting_contents().contains(&self.references[index].location.uri)
+        }) {
+            return None;
+        }
+        Some(indices)
     }
 
     fn reference_at_position(&self, uri: &Url, position: Position) -> Option<&SymbolReference> {
@@ -2201,31 +2205,46 @@ fn format_selector_title(selector: [u8; 4]) -> String {
     title
 }
 
-fn format_inheritance_title(kind: &str, count: usize) -> String {
-    let noun = match (kind, count) {
-        ("base", 1) => "base contract",
-        ("base", _) => "base contracts",
-        ("derived", 1) => "derived contract",
-        ("derived", _) => "derived contracts",
-        _ => unreachable!("unknown inheritance lens kind"),
-    };
-    format!("{count} {noun}")
+#[derive(Clone, Copy, Debug)]
+enum InheritanceLensKind {
+    Base,
+    Derived,
+}
+
+impl InheritanceLensKind {
+    fn title(self, count: usize) -> String {
+        let noun = match (self, count) {
+            (Self::Base, 1) => "base contract",
+            (Self::Base, _) => "base contracts",
+            (Self::Derived, 1) => "derived contract",
+            (Self::Derived, _) => "derived contracts",
+        };
+        format!("{count} {noun}")
+    }
+
+    fn direction(self) -> &'static str {
+        match self {
+            Self::Base => "supertypes",
+            Self::Derived => "subtypes",
+        }
+    }
 }
 
 fn inheritance_command(
-    title: String,
-    direction: &str,
+    kind: InheritanceLensKind,
+    count: usize,
     uri: &Url,
     position: Position,
     enabled: bool,
 ) -> Command {
+    let title = kind.title(count);
     let (command, arguments) = if enabled {
         (
             "solar.showTypeHierarchy".into(),
             Some(vec![serde_json::json!({
                 "uri": uri,
                 "position": position,
-                "direction": direction,
+                "direction": kind.direction(),
             })]),
         )
     } else {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1,8 +1,8 @@
 use lsp_types::{
-    CompletionItem, CompletionItemKind, DocumentHighlight, DocumentHighlightKind, DocumentSymbol,
-    GotoDefinitionResponse, Hover, HoverContents, InlayHint, Location, MarkupContent, OneOf,
-    Position, Range, SymbolInformation, SymbolKind, TypeHierarchyItem, Url, WorkspaceSymbol,
-    request::GotoTypeDefinitionResponse,
+    CodeLens, Command, CompletionItem, CompletionItemKind, DocumentHighlight,
+    DocumentHighlightKind, DocumentSymbol, GotoDefinitionResponse, Hover, HoverContents, InlayHint,
+    Location, MarkupContent, OneOf, Position, Range, SymbolInformation, SymbolKind,
+    TypeHierarchyItem, Url, WorkspaceSymbol, request::GotoTypeDefinitionResponse,
 };
 use solar_interface::{
     Span,
@@ -24,12 +24,15 @@ use solar_sema::{
     ty::{CallableParamSource, Ty, TyKind},
 };
 use std::{
+    fmt::Write as _,
     ops::ControlFlow,
     path::{Path, PathBuf},
 };
 
 use crate::{
     call_hierarchy::CallHierarchyIndex,
+    code_lens::CodeLensIndex,
+    config::CodeLensConfig,
     document_links::DocumentLinkIndex,
     inlay_hints::InlayHintIndex,
     natspec_completion::{DeclarationKey, NatSpecCompletionIndex, NatSpecTargetSemantics},
@@ -68,6 +71,7 @@ pub(crate) struct SymbolTables {
     signature_help: SignatureHelpIndex,
     call_hierarchy: CallHierarchyIndex,
     type_hierarchy: TypeHierarchyIndex,
+    code_lens: CodeLensIndex,
 }
 
 #[derive(Default)]
@@ -311,6 +315,7 @@ impl SymbolTables {
 
         tables.build_type_definitions(gcx, &item_symbols);
         tables.call_hierarchy = CallHierarchyIndex::build(gcx, &item_symbols, &tables.declarations);
+        tables.code_lens = CodeLensIndex::build(gcx, &item_symbols, &tables.declarations);
 
         // Public state-variable getters are compiler-generated functions, but source member calls
         // such as `this.value()` still name the state variable. Point getter resolutions back to
@@ -365,6 +370,7 @@ impl SymbolTables {
         self.signature_help.extend(other.signature_help);
 
         let symbol_offset = self.declarations.len();
+        self.code_lens.extend(other.code_lens, symbol_offset);
         self.call_hierarchy.extend(other.call_hierarchy, symbol_offset);
         self.type_hierarchy.extend(other.type_hierarchy, symbol_offset);
         self.override_families.extend(other.override_families, symbol_offset);
@@ -412,6 +418,100 @@ impl SymbolTables {
 
     pub(crate) fn inlay_hints(&self, uri: &Url, range: Range) -> Vec<InlayHint> {
         self.inlay_hints.hints(uri, range)
+    }
+
+    pub(crate) fn code_lenses(&self, uri: &Url, options: CodeLensConfig) -> Vec<CodeLens> {
+        if !options.enable {
+            return Vec::new();
+        }
+
+        let mut lenses = Vec::new();
+        for entry in self.code_lens.entries(uri) {
+            let position = entry.range.start;
+            let location = serde_json::json!({ "uri": uri, "position": position });
+
+            if options.references {
+                let count = self.reference_count(&entry.symbol_ids);
+                let command = (count > 0 && options.client_commands).then_some(Command {
+                    title: format_reference_title(count),
+                    command: "solar.showReferences".into(),
+                    arguments: Some(vec![location.clone()]),
+                });
+                lenses.push(CodeLens {
+                    range: entry.range,
+                    command: command.or_else(|| {
+                        Some(Command {
+                            title: format_reference_title(count),
+                            command: String::new(),
+                            arguments: None,
+                        })
+                    }),
+                    data: None,
+                });
+            }
+
+            if options.selectors
+                && let Some(selector) = entry.selector
+            {
+                let title = format_selector_title(selector);
+                lenses.push(CodeLens {
+                    range: entry.range,
+                    command: Some(Command {
+                        title,
+                        command: if options.client_commands { "solar.copySelector" } else { "" }
+                            .into(),
+                        arguments: options
+                            .client_commands
+                            .then_some(vec![serde_json::json!(format_selector_title(selector))]),
+                    }),
+                    data: None,
+                });
+            }
+
+            if options.inheritance
+                && entry.inheritance
+                && let Some((bases, derived)) = self.type_hierarchy.direct_counts(&entry.symbol_ids)
+            {
+                if bases > 0 {
+                    lenses.push(CodeLens {
+                        range: entry.range,
+                        command: Some(inheritance_command(
+                            format_inheritance_title("base", bases),
+                            "supertypes",
+                            uri,
+                            position,
+                            options.client_commands,
+                        )),
+                        data: None,
+                    });
+                }
+                if derived > 0 {
+                    lenses.push(CodeLens {
+                        range: entry.range,
+                        command: Some(inheritance_command(
+                            format_inheritance_title("derived", derived),
+                            "subtypes",
+                            uri,
+                            position,
+                            options.client_commands,
+                        )),
+                        data: None,
+                    });
+                }
+            }
+        }
+        lenses
+    }
+
+    fn reference_count(&self, targets: &[SymbolId]) -> usize {
+        let mut locations = self
+            .reference_indices_for_targets(targets)
+            .into_iter()
+            .map(|index| self.references[index].location.clone())
+            .collect::<Vec<_>>();
+        sort_locations(&mut locations);
+        locations.dedup_by(|lhs, rhs| lhs.uri == rhs.uri && lhs.range == rhs.range);
+        locations.len()
     }
 
     pub(crate) fn document_links(&self, path: &Path) -> Vec<lsp_types::DocumentLink> {
@@ -660,7 +760,7 @@ impl SymbolTables {
         position: Position,
         include_declaration: bool,
     ) -> Option<Vec<Location>> {
-        let target = self.symbol_ids_at_position(uri, position)?;
+        let target = self.reference_targets_at_position(uri, position)?;
         let mut locations = Vec::new();
 
         if include_declaration {
@@ -1096,6 +1196,34 @@ impl SymbolTables {
         Some(ReferenceTargets::from_buf([symbol_id]))
     }
 
+    fn reference_targets_at_position(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<ReferenceTargets> {
+        if let Some(reference) = self.reference_at_position(uri, position) {
+            return Some(reference.targets.clone());
+        }
+
+        let symbol_id = self.declaration_at_position(uri, position)?;
+        let declaration = &self.declarations[symbol_id];
+        let mut symbol_ids = self
+            .file_declaration_positions
+            .get(uri)?
+            .iter()
+            .copied()
+            .filter(|&candidate| {
+                let candidate = &self.declarations[candidate];
+                candidate.name_range == declaration.name_range
+                    && candidate.location.range == declaration.location.range
+                    && candidate.name == declaration.name
+                    && candidate.kind == declaration.kind
+            })
+            .collect::<Vec<_>>();
+        symbol_ids.sort_unstable_by_key(|symbol_id| symbol_id.index());
+        Some(ReferenceTargets::from_vec(symbol_ids))
+    }
+
     fn reference_indices_for_targets(&self, targets: &[SymbolId]) -> Vec<usize> {
         let mut indices = targets
             .iter()
@@ -1327,6 +1455,7 @@ impl SymbolTables {
         self.override_families.rebuild(&self.declarations, self.rename.conflicting_contents());
         self.type_hierarchy.rebuild(self.rename.conflicting_contents());
         self.rename.rebuild(&self.override_families);
+        self.code_lens.rebuild(self.rename.conflicting_contents());
         self.call_hierarchy.rebuild();
     }
 }
@@ -2059,6 +2188,47 @@ fn sort_locations(locations: &mut [Location]) {
                 ))
         })
     });
+}
+
+fn format_reference_title(count: usize) -> String {
+    format!("{count} reference{}", if count == 1 { "" } else { "s" })
+}
+
+fn format_selector_title(selector: [u8; 4]) -> String {
+    let mut title = String::from("0x");
+    for byte in selector {
+        write!(title, "{byte:02x}").expect("writing a selector title cannot fail");
+    }
+    title
+}
+
+fn format_inheritance_title(kind: &str, count: usize) -> String {
+    let noun = match (kind, count) {
+        ("base", 1) => "base contract",
+        ("base", _) => "base contracts",
+        ("derived", 1) => "derived contract",
+        ("derived", _) => "derived contracts",
+        _ => unreachable!("unknown inheritance lens kind"),
+    };
+    format!("{count} {noun}")
+}
+
+fn inheritance_command(
+    title: String,
+    direction: &str,
+    uri: &Url,
+    position: Position,
+    enabled: bool,
+) -> Command {
+    Command {
+        title,
+        command: if enabled { "solar.showTypeHierarchy" } else { "" }.into(),
+        arguments: enabled.then_some(vec![serde_json::json!({
+            "uri": uri,
+            "position": position,
+            "direction": direction,
+        })]),
+    }
 }
 
 fn sort_completion_items(items: &mut [CompletionItem]) {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -72,6 +72,7 @@ pub(crate) struct SymbolTables {
     call_hierarchy: CallHierarchyIndex,
     type_hierarchy: TypeHierarchyIndex,
     code_lens: CodeLensIndex,
+    has_merged_batches: bool,
 }
 
 #[derive(Default)]
@@ -358,6 +359,7 @@ impl SymbolTables {
     }
 
     fn extend_unindexed(&mut self, mut other: Self) {
+        self.has_merged_batches = true;
         if self.global_completions.is_empty() {
             self.global_completions = std::mem::take(&mut other.global_completions);
         }
@@ -1197,6 +1199,11 @@ impl SymbolTables {
         uri: &Url,
         position: Position,
     ) -> Option<ReferenceTargets> {
+        if !self.has_merged_batches {
+            // Duplicate declarations and conflicting snapshots can only come from aggregation.
+            debug_assert!(self.rename.conflicting_contents().is_empty());
+            return self.symbol_ids_at_position(uri, position);
+        }
         if self.rename.conflicting_contents().contains(uri) {
             return None;
         }

--- a/crates/lsp/src/tests/code_lens.rs
+++ b/crates/lsp/src/tests/code_lens.rs
@@ -72,6 +72,201 @@ fn shows_direct_inheritance_counts() {
 }
 
 #[test]
+fn snapshots_complete_command_protocol() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Protocol.sol
+        contract Base {}
+        contract Plain is Base {
+            function target() public {}
+            function callTarget() external { target(); }
+        }
+        "#,
+        "/Protocol.sol",
+    );
+
+    fixture.check_code_lenses_json(
+        "/Protocol.sol",
+        str![[r#"
+[
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 9
+      },
+      "end": {
+        "line": 0,
+        "character": 13
+      }
+    },
+    "command": {
+      "title": "1 reference",
+      "command": "solar.showReferences",
+      "arguments": [
+        {
+          "position": {
+            "character": 9,
+            "line": 0
+          },
+          "uri": "file:///Protocol.sol"
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 9
+      },
+      "end": {
+        "line": 0,
+        "character": 13
+      }
+    },
+    "command": {
+      "title": "1 derived contract",
+      "command": "solar.showTypeHierarchy",
+      "arguments": [
+        {
+          "direction": "subtypes",
+          "position": {
+            "character": 9,
+            "line": 0
+          },
+          "uri": "file:///Protocol.sol"
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 9
+      },
+      "end": {
+        "line": 1,
+        "character": 14
+      }
+    },
+    "command": {
+      "title": "0 references",
+      "command": ""
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 9
+      },
+      "end": {
+        "line": 1,
+        "character": 14
+      }
+    },
+    "command": {
+      "title": "1 base contract",
+      "command": "solar.showTypeHierarchy",
+      "arguments": [
+        {
+          "direction": "supertypes",
+          "position": {
+            "character": 9,
+            "line": 1
+          },
+          "uri": "file:///Protocol.sol"
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 13
+      },
+      "end": {
+        "line": 2,
+        "character": 19
+      }
+    },
+    "command": {
+      "title": "1 reference",
+      "command": "solar.showReferences",
+      "arguments": [
+        {
+          "position": {
+            "character": 13,
+            "line": 2
+          },
+          "uri": "file:///Protocol.sol"
+        }
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 13
+      },
+      "end": {
+        "line": 2,
+        "character": 19
+      }
+    },
+    "command": {
+      "title": "0xd4b83992",
+      "command": "solar.copySelector",
+      "arguments": [
+        "0xd4b83992"
+      ]
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 13
+      },
+      "end": {
+        "line": 3,
+        "character": 23
+      }
+    },
+    "command": {
+      "title": "0 references",
+      "command": ""
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 13
+      },
+      "end": {
+        "line": 3,
+        "character": 23
+      }
+    },
+    "command": {
+      "title": "0x2872b1ff",
+      "command": "solar.copySelector",
+      "arguments": [
+        "0x2872b1ff"
+      ]
+    }
+  }
+]
+"#]],
+    );
+}
+
+#[test]
 fn merges_reference_counts_for_imported_declarations() {
     let fixture = RequestFixture::new_in_batches(
         r#"
@@ -128,6 +323,55 @@ fn merges_reference_counts_for_imported_declarations() {
 
 "#]],
     );
+}
+
+#[test]
+fn rejects_references_from_conflicting_source_snapshots() {
+    let source = r#"
+        //- /Target.sol
+        library Target {
+            function $1target() external pure {}
+        }
+
+        //- /Caller.sol open
+        import {Target} from "./Target.sol";
+
+        contract C {
+            function caller() external pure {
+                Target.target();
+            }
+        }
+
+        //- /Root.sol
+        import "./Caller.sol";
+        "#;
+    let disk_contents = r#"import {Target} from "./Target.sol";
+
+contract C {
+    function caller() external pure {
+
+        Target.target();
+    }
+}
+"#;
+
+    for paths in [["/Root.sol", "/Caller.sol"], ["/Caller.sol", "/Root.sol"]] {
+        let fixture = RequestFixture::new_in_batches_with_stale_disk(
+            source,
+            "/Caller.sol",
+            disk_contents,
+            &paths,
+        );
+
+        fixture.check_code_lenses(
+            "/Target.sol",
+            str![[r#"
+1:13 selector=0xd4b83992 command=solar.copySelector
+
+"#]],
+        );
+        fixture.check_references("$1", false, "<none>\n");
+    }
 }
 
 #[test]

--- a/crates/lsp/src/tests/code_lens.rs
+++ b/crates/lsp/src/tests/code_lens.rs
@@ -1,0 +1,253 @@
+use super::support::RequestFixture;
+use snapbox::str;
+
+#[test]
+fn shows_selectors_and_references() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /CodeLens.sol
+        contract Token {
+            uint256 public value;
+
+            function transfer(address to, uint256 amount)
+                public
+                returns (uint256 result)
+            {
+                value = amount;
+                return amount;
+            }
+
+            function callTransfer(address target) external {
+                transfer(target, value);
+            }
+        }
+
+        "#,
+        "/CodeLens.sol",
+    );
+
+    fixture.check_code_lenses(
+        "/CodeLens.sol",
+        str![[r#"
+0:9 references=0 command=<none>
+1:19 references=2 command=solar.showReferences
+1:19 selector=0x3fa4f245 command=solar.copySelector
+2:13 references=1 command=solar.showReferences
+2:13 selector=0xa9059cbb command=solar.copySelector
+2:30 references=0 command=<none>
+2:42 references=2 command=solar.showReferences
+9:13 references=0 command=<none>
+9:13 selector=0xeec990f2 command=solar.copySelector
+9:34 references=1 command=solar.showReferences
+
+"#]],
+    );
+}
+
+#[test]
+fn shows_direct_inheritance_counts() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Hierarchy.sol
+        contract Base {}
+        contract Mid is Base {}
+        contract Leaf is Mid {}
+        "#,
+        "/Hierarchy.sol",
+    );
+
+    fixture.check_code_lenses(
+        "/Hierarchy.sol",
+        str![[r#"
+0:9 references=1 command=solar.showReferences
+0:9 inheritance=1 derived contract command=solar.showTypeHierarchy
+1:9 references=1 command=solar.showReferences
+1:9 inheritance=1 base contract command=solar.showTypeHierarchy
+1:9 inheritance=1 derived contract command=solar.showTypeHierarchy
+2:9 references=0 command=<none>
+2:9 inheritance=1 base contract command=solar.showTypeHierarchy
+
+"#]],
+    );
+}
+
+#[test]
+fn merges_reference_counts_for_imported_declarations() {
+    let fixture = RequestFixture::new_in_batches(
+        r#"
+        //- /Shared.sol
+        contract $1Base {
+            function $2ping() public {}
+        }
+
+        //- /first/Main.sol
+        import "../Shared.sol";
+        contract First {
+            function useBase() external {
+                Base value;
+                value.ping();
+            }
+        }
+
+        //- /second/Main.sol
+        import "../Shared.sol";
+        contract Second {
+            function useBase() external {
+                Base value;
+                value.ping();
+            }
+        }
+        "#,
+        &["/first/Main.sol", "/second/Main.sol"],
+    );
+
+    fixture.check_code_lenses(
+        "/Shared.sol",
+        str![[r#"
+0:9 references=2 command=solar.showReferences
+1:13 references=2 command=solar.showReferences
+1:13 selector=0x5c36b186 command=solar.copySelector
+
+"#]],
+    );
+    fixture.check_references(
+        "$1",
+        false,
+        str![[r#"
+/first/Main.sol:3:8 Base value;
+/second/Main.sol:3:8 Base value;
+
+"#]],
+    );
+    fixture.check_references(
+        "$2",
+        false,
+        str![[r#"
+/first/Main.sol:4:14 value.ping();
+/second/Main.sol:4:14 value.ping();
+
+"#]],
+    );
+}
+
+#[test]
+fn selectors_cover_public_external_functions_and_getters_only() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Selectors.sol
+        contract Selectors {
+            uint256 public value;
+            uint256 private hidden;
+
+            function externalFn(uint256 input) external {}
+            function publicFn() public {}
+            function internalFn() internal {}
+            function privateFn() private {}
+            constructor() {}
+            fallback() external {}
+            receive() external payable {}
+        }
+        "#,
+        "/Selectors.sol",
+    );
+
+    fixture.check_code_lenses(
+        "/Selectors.sol",
+        str![[r#"
+0:9 references=0 command=<none>
+1:19 references=0 command=<none>
+1:19 selector=0x3fa4f245 command=solar.copySelector
+2:20 references=0 command=<none>
+3:13 references=0 command=<none>
+3:13 selector=0x43a389ef command=solar.copySelector
+3:32 references=0 command=<none>
+4:13 references=0 command=<none>
+4:13 selector=0x5e6858dd command=solar.copySelector
+5:13 references=0 command=<none>
+6:13 references=0 command=<none>
+7:4 references=0 command=<none>
+8:4 references=0 command=<none>
+9:4 references=0 command=<none>
+
+"#]],
+    );
+}
+
+#[test]
+fn skips_selectors_for_invalid_signatures() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Invalid.sol
+        contract Invalid {
+            function bad(Unknown value) external {}
+        }
+        "#,
+        "/Invalid.sol",
+    );
+
+    fixture.check_code_lenses(
+        "/Invalid.sol",
+        str![[r#"
+0:9 references=0 command=<none>
+1:13 references=0 command=<none>
+1:25 references=0 command=<none>
+
+"#]],
+    );
+}
+
+#[test]
+fn excludes_yul_declarations_and_solidity_locals_and_returns() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Yul.sol
+        contract Yul {
+            function outer(uint256 input) external pure returns (uint256 output) {
+                uint256 local = input;
+                assembly {
+                    function inner(y) -> z { z := y }
+                    output := inner(local)
+                }
+            }
+        }
+        "#,
+        "/Yul.sol",
+    );
+
+    fixture.check_code_lenses(
+        "/Yul.sol",
+        str![[r#"
+0:9 references=0 command=<none>
+1:13 references=0 command=<none>
+1:13 selector=0x94209e43 command=solar.copySelector
+1:27 references=1 command=solar.showReferences
+
+"#]],
+    );
+}
+
+#[test]
+fn preserves_titles_without_client_commands() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Plain.sol
+        contract Plain {
+            function target() public {}
+            function callTarget() external { target(); }
+        }
+        "#,
+        "/Plain.sol",
+    );
+
+    fixture.check_code_lenses_without_commands(
+        "/Plain.sol",
+        str![[r#"
+0:9 references=0 command=<none>
+1:13 references=1 command=<none>
+1:13 selector=0xd4b83992 command=<none>
+2:13 references=0 command=<none>
+2:13 selector=0x2872b1ff command=<none>
+
+"#]],
+    );
+}

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -232,17 +232,17 @@ fn analysis_result_accumulator_merges_multiple_batches() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn published_analysis_requests_code_lens_refresh_when_supported() {
+async fn analysis_updates_refresh_code_lenses_only_when_active() {
     let (server_main, client) = async_lsp::MainLoop::new_server(|_| {
         let mut router = Router::new(());
         router.notification::<notification::Exit>(|_, ()| ControlFlow::Break(Ok(())));
         router
     });
-    let (refresh_tx, refresh_rx) = oneshot::channel();
+    let (refresh_tx, mut refresh_rx) = mpsc::unbounded_channel();
     let (client_main, server) = async_lsp::MainLoop::new_client(move |_| {
-        let mut router = Router::new(Some(refresh_tx));
+        let mut router = Router::new(refresh_tx);
         router.request::<request::CodeLensRefresh, _>(|state, ()| {
-            state.take().unwrap().send(()).unwrap();
+            state.send(()).unwrap();
             async { Ok(()) }
         });
         router
@@ -261,20 +261,50 @@ async fn published_analysis_requests_code_lens_refresh_when_supported() {
         ..Default::default()
     });
     let (_, config) = negotiate_capabilities(params);
-    let mut snapshot = snapshot_with_config(config, Vfs::default());
-    snapshot.client = client;
+    let mut state = GlobalState::new(client);
+    state.config = Arc::new(config);
 
-    assert!(snapshot.publish_analysis(
+    assert!(state.snapshot().publish_analysis(
+        0,
+        AnalysisResult {
+            diagnostics: DiagnosticMap::default(),
+            symbol_tables: SymbolTables::default(),
+        },
+    ));
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, refresh_rx.recv())
+        .await
+        .expect("CodeLens refresh should arrive")
+        .expect("CodeLens refresh channel should stay open");
+
+    state.clear_analysis_cache();
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, refresh_rx.recv())
+        .await
+        .expect("CodeLens refresh should arrive after clearing analysis")
+        .expect("CodeLens refresh channel should stay open");
+
+    let mut params = InitializeParams::default();
+    params.capabilities.workspace = Some(lsp_types::WorkspaceClientCapabilities {
+        code_lens: Some(CodeLensWorkspaceClientCapabilities { refresh_support: Some(true) }),
+        ..Default::default()
+    });
+    params.initialization_options = Some(serde_json::json!({
+        "codeLens": { "enable": false }
+    }));
+    let (_, config) = negotiate_capabilities(params);
+    state.config = Arc::new(config);
+
+    assert!(state.snapshot().publish_analysis(
         1,
         AnalysisResult {
             diagnostics: DiagnosticMap::default(),
             symbol_tables: SymbolTables::default(),
         },
     ));
-    tokio::time::timeout(ASYNC_TEST_TIMEOUT, refresh_rx)
-        .await
-        .expect("CodeLens refresh should arrive")
-        .expect("CodeLens refresh sender should stay open");
+    state.clear_analysis_cache();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), refresh_rx.recv()).await.is_err(),
+        "inactive CodeLens should not request refresh"
+    );
 
     server.notify::<notification::Exit>(()).unwrap();
     assert!(server_task.await.unwrap().is_ok());

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -7,14 +7,15 @@ use crate::{
 };
 use async_lsp::{ClientSocket, ErrorCode, ResponseError, ServerSocket, router::Router};
 use lsp_types::{
-    Diagnostic, DidChangeConfigurationParams, DidChangeTextDocumentParams,
-    DidChangeWatchedFilesParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
-    DocumentDiagnosticReportResult, DocumentSymbol, FileChangeType, FileEvent, PartialResultParams,
-    Position, ProgressParams, ProgressParamsValue, PublishDiagnosticsParams, Range, SymbolKind,
-    TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentItem,
-    VersionedTextDocumentIdentifier, WatchKind, WorkDoneProgress, WorkDoneProgressCreateParams,
-    WorkDoneProgressParams, WorkspaceSymbol, notification, notification::Notification, request,
+    CodeLensWorkspaceClientCapabilities, Diagnostic, DidChangeConfigurationParams,
+    DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentDiagnosticReportResult, DocumentSymbol, FileChangeType,
+    FileEvent, PartialResultParams, Position, ProgressParams, ProgressParamsValue,
+    PublishDiagnosticsParams, Range, SymbolKind, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, VersionedTextDocumentIdentifier, WatchKind,
+    WorkDoneProgress, WorkDoneProgressCreateParams, WorkDoneProgressParams, WorkspaceSymbol,
+    notification, notification::Notification, request,
 };
 use std::{
     future::Future,
@@ -27,6 +28,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 mod call_hierarchy;
+mod code_lens;
 mod completion;
 mod document_highlight;
 mod document_link;
@@ -227,6 +229,56 @@ fn analysis_result_accumulator_merges_multiple_batches() {
         .collect::<Vec<_>>();
     names.sort_unstable();
     assert_eq!(names, vec!["One".to_owned(), "Two".to_owned()]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn published_analysis_requests_code_lens_refresh_when_supported() {
+    let (server_main, client) = async_lsp::MainLoop::new_server(|_| {
+        let mut router = Router::new(());
+        router.notification::<notification::Exit>(|_, ()| ControlFlow::Break(Ok(())));
+        router
+    });
+    let (refresh_tx, refresh_rx) = oneshot::channel();
+    let (client_main, server) = async_lsp::MainLoop::new_client(move |_| {
+        let mut router = Router::new(Some(refresh_tx));
+        router.request::<request::CodeLensRefresh, _>(|state, ()| {
+            state.take().unwrap().send(()).unwrap();
+            async { Ok(()) }
+        });
+        router
+    });
+    let (server_stream, client_stream) = tokio::io::duplex(64 << 10);
+    let (server_rx, server_tx) = tokio::io::split(server_stream);
+    let server_task =
+        tokio::spawn(server_main.run_buffered(server_rx.compat(), server_tx.compat_write()));
+    let (client_rx, client_tx) = tokio::io::split(client_stream);
+    let client_task =
+        tokio::spawn(client_main.run_buffered(client_rx.compat(), client_tx.compat_write()));
+
+    let mut params = InitializeParams::default();
+    params.capabilities.workspace = Some(lsp_types::WorkspaceClientCapabilities {
+        code_lens: Some(CodeLensWorkspaceClientCapabilities { refresh_support: Some(true) }),
+        ..Default::default()
+    });
+    let (_, config) = negotiate_capabilities(params);
+    let mut snapshot = snapshot_with_config(config, Vfs::default());
+    snapshot.client = client;
+
+    assert!(snapshot.publish_analysis(
+        1,
+        AnalysisResult {
+            diagnostics: DiagnosticMap::default(),
+            symbol_tables: SymbolTables::default(),
+        },
+    ));
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, refresh_rx)
+        .await
+        .expect("CodeLens refresh should arrive")
+        .expect("CodeLens refresh sender should stay open");
+
+    server.notify::<notification::Exit>(()).unwrap();
+    assert!(server_task.await.unwrap().is_ok());
+    assert!(matches!(client_task.await.unwrap(), Err(async_lsp::Error::Eof)));
 }
 
 #[test]

--- a/crates/lsp/src/tests/references.rs
+++ b/crates/lsp/src/tests/references.rs
@@ -203,3 +203,42 @@ fn indexes_using_directive_references() {
 "#]],
     );
 }
+
+#[test]
+fn finds_references_from_shared_dependency_across_batches() {
+    let source = r#"
+        //- /Shared.sol
+        contract Base {}
+        contract Shared {
+            $1Base value;
+        }
+
+        //- /first/Main.sol
+        import "../Shared.sol";
+        contract First {
+            Base value;
+        }
+
+        //- /second/Main.sol
+        import "../Shared.sol";
+        contract Second {
+            Base value;
+        }
+        "#;
+
+    for paths in [["/first/Main.sol", "/second/Main.sol"], ["/second/Main.sol", "/first/Main.sol"]]
+    {
+        let fixture = RequestFixture::new_in_batches(source, &paths);
+
+        fixture.check_references(
+            "$1",
+            false,
+            str![[r#"
+/Shared.sol:2:4 Base value;
+/first/Main.sol:2:4 Base value;
+/second/Main.sol:2:4 Base value;
+
+"#]],
+        );
+    }
+}

--- a/crates/lsp/src/tests/requests.rs
+++ b/crates/lsp/src/tests/requests.rs
@@ -9,11 +9,11 @@ use crate::{
 };
 use async_lsp::ClientSocket;
 use lsp_types::{
-    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    DocumentSymbolClientCapabilities, DocumentSymbolResponse, InitializeParams,
-    PartialResultParams, ReferenceContext, SymbolKind, TextDocumentClientCapabilities,
-    TextDocumentIdentifier, TypeHierarchyItem, Url, WorkDoneProgressParams,
-    WorkspaceSymbolResponse,
+    CodeLensParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentDiagnosticReportResult, DocumentSymbolClientCapabilities, DocumentSymbolResponse,
+    InitializeParams, PartialResultParams, ReferenceContext, SymbolKind,
+    TextDocumentClientCapabilities, TextDocumentIdentifier, TypeHierarchyItem, Url,
+    WorkDoneProgressParams, WorkspaceSymbolResponse,
 };
 use serde_json::json;
 use std::{
@@ -134,7 +134,8 @@ fn semantic_requests_wait_for_latest_analysis() {
     assert_pending(references(&mut state, reference_params(uri.clone())));
     assert_pending(prepare_rename(&mut state, position_params(uri.clone())));
     assert_pending(rename(&mut state, rename_params(uri.clone(), "renamed")));
-    assert_pending(inlay_hints(&mut state, inlay_hint_params(uri)));
+    assert_pending(inlay_hints(&mut state, inlay_hint_params(uri.clone())));
+    assert_pending(code_lens(&mut state, code_lens_params(uri)));
     assert_pending(prepare_type_hierarchy(
         &mut state,
         type_hierarchy_prepare_params(file_uri("Test.sol"), Position::new(0, 0)),
@@ -163,7 +164,8 @@ fn semantic_requests_skip_analysis_for_non_file_uris() {
     assert_ready(references(&mut state, reference_params(uri.clone())));
     assert_ready(prepare_rename(&mut state, position_params(uri.clone())));
     assert_ready(rename(&mut state, rename_params(uri.clone(), "renamed")));
-    assert_ready(inlay_hints(&mut state, inlay_hint_params(uri)));
+    assert_ready(inlay_hints(&mut state, inlay_hint_params(uri.clone())));
+    assert_ready(code_lens(&mut state, code_lens_params(uri)));
     assert_ready(prepare_type_hierarchy(
         &mut state,
         type_hierarchy_prepare_params(parse_uri("untitled:Test.sol"), Position::new(0, 0)),
@@ -286,6 +288,14 @@ fn inlay_hint_params(uri: Url) -> InlayHintParams {
         text_document: TextDocumentIdentifier::new(uri),
         range: lsp_types::Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX)),
         work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn code_lens_params(uri: Url) -> CodeLensParams {
+    CodeLensParams {
+        text_document: TextDocumentIdentifier::new(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
     }
 }
 

--- a/crates/lsp/src/tests/requests.rs
+++ b/crates/lsp/src/tests/requests.rs
@@ -151,6 +151,35 @@ fn semantic_requests_wait_for_latest_analysis() {
 }
 
 #[test]
+fn inactive_code_lens_does_not_wait_for_latest_analysis() {
+    let uri = file_uri("Test.sol");
+    let inactive_options = [
+        json!({ "enable": false }),
+        json!({
+            "enable": true,
+            "selectors": false,
+            "references": false,
+            "inheritance": false,
+            "clientCommands": true,
+        }),
+    ];
+
+    for code_lens_options in inactive_options {
+        let params = InitializeParams {
+            initialization_options: Some(json!({ "codeLens": code_lens_options })),
+            ..Default::default()
+        };
+        let (_, config) = negotiate_capabilities(params);
+        let mut state = pending_analysis_state();
+        state.config = Arc::new(config);
+
+        let response = expect_ready(code_lens(&mut state, code_lens_params(uri.clone()))).unwrap();
+
+        assert!(response.is_some_and(|lenses| lenses.is_empty()));
+    }
+}
+
+#[test]
 fn semantic_requests_skip_analysis_for_non_file_uris() {
     let uri = parse_uri("untitled:Test.sol");
     let mut state = pending_analysis_state();

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -353,6 +353,20 @@ impl RequestFixture {
         self.check_code_lenses_with_commands(path, false, expected);
     }
 
+    pub(super) fn check_code_lenses_json(&self, path: &str, expected: impl IntoData) {
+        let mut state = self.state();
+        Arc::make_mut(&mut state.config).enable_code_lens_client_commands();
+        let uri = Url::from_file_path(self.marked.project().path(path)).unwrap();
+        let response =
+            expect_ready(crate::handlers::code_lens(&mut state, code_lens_params(uri.clone())))
+                .unwrap()
+                .unwrap_or_default();
+        let output = serde_json::to_string_pretty(&response)
+            .unwrap()
+            .replace(uri.as_str(), &format!("file://{path}"));
+        assert_data_eq!(output, expected);
+    }
+
     fn check_code_lenses_with_commands(
         &self,
         path: &str,

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -7,15 +7,16 @@ use crate::test_support::{
 };
 use async_lsp::{ClientSocket, ErrorCode};
 use lsp_types::{
-    CompletionContext, CompletionItem, CompletionParams, CompletionResponse, CompletionTextEdit,
-    CompletionTriggerKind, DocumentHighlight, DocumentHighlightKind, DocumentHighlightParams,
-    DocumentLink, DocumentLinkParams, Documentation, FoldingRange, FoldingRangeKind,
-    FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents,
-    HoverParams, InlayHint, InlayHintKind, InlayHintLabel, InlayHintParams, Location, MarkupKind,
-    ParameterLabel, PartialResultParams, Position, PrepareRenameResponse, Range, ReferenceContext,
-    ReferenceParams, RenameParams, SelectionRange, SelectionRangeParams, SignatureHelp,
-    SignatureHelpParams, TextDocumentIdentifier, TextDocumentPositionParams, TypeHierarchyItem,
-    Url, WorkDoneProgressParams, WorkspaceEdit,
+    CodeLens, CodeLensParams, CompletionContext, CompletionItem, CompletionParams,
+    CompletionResponse, CompletionTextEdit, CompletionTriggerKind, DocumentHighlight,
+    DocumentHighlightKind, DocumentHighlightParams, DocumentLink, DocumentLinkParams,
+    Documentation, FoldingRange, FoldingRangeKind, FoldingRangeParams, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverContents, HoverParams, InlayHint, InlayHintKind,
+    InlayHintLabel, InlayHintParams, Location, MarkupKind, ParameterLabel, PartialResultParams,
+    Position, PrepareRenameResponse, Range, ReferenceContext, ReferenceParams, RenameParams,
+    SelectionRange, SelectionRangeParams, SignatureHelp, SignatureHelpParams,
+    TextDocumentIdentifier, TextDocumentPositionParams, TypeHierarchyItem, Url,
+    WorkDoneProgressParams, WorkspaceEdit,
 };
 use snapbox::{IntoData, assert_data_eq};
 use solar_config::CompileOpts;
@@ -342,6 +343,31 @@ impl RequestFixture {
         ))
         .unwrap();
         assert_data_eq!(self.locations_output(response), expected);
+    }
+
+    pub(super) fn check_code_lenses(&self, path: &str, expected: impl IntoData) {
+        self.check_code_lenses_with_commands(path, true, expected);
+    }
+
+    pub(super) fn check_code_lenses_without_commands(&self, path: &str, expected: impl IntoData) {
+        self.check_code_lenses_with_commands(path, false, expected);
+    }
+
+    fn check_code_lenses_with_commands(
+        &self,
+        path: &str,
+        client_commands: bool,
+        expected: impl IntoData,
+    ) {
+        let mut state = self.state();
+        if client_commands {
+            Arc::make_mut(&mut state.config).enable_code_lens_client_commands();
+        }
+        let uri = Url::from_file_path(self.marked.project().path(path)).unwrap();
+        let response = expect_ready(crate::handlers::code_lens(&mut state, code_lens_params(uri)))
+            .unwrap()
+            .unwrap_or_default();
+        assert_data_eq!(code_lens_output(&response), expected);
     }
 
     pub(super) fn check_document_highlights(&self, marker: &str, expected: impl IntoData) {
@@ -839,6 +865,29 @@ fn completion_output(items: &[CompletionItem]) -> String {
     output
 }
 
+fn code_lens_output(lenses: &[CodeLens]) -> String {
+    let mut output = String::new();
+    for lens in lenses {
+        let command = lens.command.as_ref().expect("eager CodeLens should have a title");
+        let label = if command.title.starts_with("0x") {
+            format!("selector={}", command.title)
+        } else if command.title.ends_with(" reference") || command.title.ends_with(" references") {
+            let count = command.title.split_once(' ').unwrap().0;
+            format!("references={count}")
+        } else {
+            format!("inheritance={}", command.title)
+        };
+        let command = if command.command.is_empty() { "<none>" } else { &command.command };
+        writeln!(
+            output,
+            "{}:{} {label} command={command}",
+            lens.range.start.line, lens.range.start.character
+        )
+        .unwrap();
+    }
+    output
+}
+
 fn completion_details_output(items: &[CompletionItem]) -> String {
     let mut output = String::new();
     for (index, item) in items.iter().enumerate() {
@@ -1123,6 +1172,14 @@ fn reference_params(uri: Url, position: Position, include_declaration: bool) -> 
         work_done_progress_params: WorkDoneProgressParams::default(),
         partial_result_params: PartialResultParams::default(),
         context: ReferenceContext { include_declaration },
+    }
+}
+
+fn code_lens_params(uri: Url) -> CodeLensParams {
+    CodeLensParams {
+        text_document: TextDocumentIdentifier { uri },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
     }
 }
 

--- a/crates/lsp/src/type_hierarchy.rs
+++ b/crates/lsp/src/type_hierarchy.rs
@@ -242,22 +242,16 @@ impl TypeHierarchyIndex {
     }
 
     pub(crate) fn direct_counts(&self, symbol_ids: &[SymbolId]) -> Option<(usize, usize)> {
-        let mut keys = symbol_ids
-            .iter()
-            .filter_map(|symbol_id| self.key_by_symbol.get(symbol_id))
-            .collect::<Vec<_>>();
-        if keys.is_empty() {
-            return None;
-        }
-        sort_and_dedup_keys(&mut keys);
-
-        let mut bases = FxHashSet::default();
-        let mut derived = FxHashSet::default();
-        for key in keys {
-            bases.extend(self.bases_by_key.get(key).into_iter().flatten().cloned());
-            derived.extend(self.children_by_key.get(key).into_iter().flatten().cloned());
-        }
-        Some((bases.len(), derived.len()))
+        let key = symbol_ids.iter().find_map(|symbol_id| self.key_by_symbol.get(symbol_id))?;
+        debug_assert!(
+            symbol_ids
+                .iter()
+                .filter_map(|symbol_id| self.key_by_symbol.get(symbol_id))
+                .all(|candidate| candidate == key)
+        );
+        let bases = self.bases_by_key.get(key).map_or(0, Vec::len);
+        let derived = self.children_by_key.get(key).map_or(0, Vec::len);
+        Some((bases, derived))
     }
 
     fn neighbors(

--- a/crates/lsp/src/type_hierarchy.rs
+++ b/crates/lsp/src/type_hierarchy.rs
@@ -241,6 +241,25 @@ impl TypeHierarchyIndex {
         self.neighbors(item, &self.children_by_key)
     }
 
+    pub(crate) fn direct_counts(&self, symbol_ids: &[SymbolId]) -> Option<(usize, usize)> {
+        let mut keys = symbol_ids
+            .iter()
+            .filter_map(|symbol_id| self.key_by_symbol.get(symbol_id))
+            .collect::<Vec<_>>();
+        if keys.is_empty() {
+            return None;
+        }
+        sort_and_dedup_keys(&mut keys);
+
+        let mut bases = FxHashSet::default();
+        let mut derived = FxHashSet::default();
+        for key in keys {
+            bases.extend(self.bases_by_key.get(key).into_iter().flatten().cloned());
+            derived.extend(self.children_by_key.get(key).into_iter().flatten().cloned());
+        }
+        Some((bases.len(), derived.len()))
+    }
+
     fn neighbors(
         &self,
         item: &TypeHierarchyItem,

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -34,6 +34,19 @@ the local binary:
 Formatting uses `forge fmt`, so install Foundry or disable
 `solarLsp.formatOnSave`.
 
+## CodeLens
+
+CodeLens annotations are enabled by default for function selectors, reference
+counts, and contract inheritance. Select a selector to copy it, a reference
+count to open Peek References, or inheritance information to open Type
+Hierarchy.
+
+Use `solarLsp.codeLens.enable` to disable all annotations, or configure
+`solarLsp.codeLens.selectors`, `solarLsp.codeLens.references`, and
+`solarLsp.codeLens.inheritance` separately. These settings are sent when the
+language server starts, so changing one restarts the client. Lenses refresh
+after the workspace is reanalyzed. Test and run actions are not yet supported.
+
 ## License
 
 Dual licensed under MIT or Apache-2.0.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -83,6 +83,26 @@
           "default": true,
           "description": "Format files on save using Solar LSP"
         },
+        "solarLsp.codeLens.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Solidity CodeLens annotations"
+        },
+        "solarLsp.codeLens.selectors": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show function selector CodeLens annotations"
+        },
+        "solarLsp.codeLens.references": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show reference count CodeLens annotations"
+        },
+        "solarLsp.codeLens.inheritance": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show contract inheritance CodeLens annotations"
+        },
         "solarLsp.flychecks": {
           "type": [
             "array",

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
+  ReferencesRequest,
   ServerOptions,
   State,
   TransportKind,
@@ -9,21 +10,32 @@ import {
 import { spawn } from "child_process";
 
 let client: LanguageClient | undefined;
+let clientLifecycle: Promise<void> = Promise.resolve();
+
+const restartSettings = [
+  "solarLsp.enable",
+  "solarLsp.codeLens.enable",
+  "solarLsp.codeLens.selectors",
+  "solarLsp.codeLens.references",
+  "solarLsp.codeLens.inheritance",
+];
 
 export function activate(context: vscode.ExtensionContext) {
-  const config = vscode.workspace.getConfiguration("solarLsp");
-
-  if (!config.get("enable")) {
-    return;
-  }
+  const fileWatcher = vscode.workspace.createFileSystemWatcher("**/*.sol");
+  context.subscriptions.push(fileWatcher);
 
   // Start the LSP server
-  startLanguageServer(context);
+  void restartLanguageServer(fileWatcher);
 
   // Register format document command
   const formatCommand = vscode.commands.registerCommand(
     "solarLsp.formatDocument",
     async () => {
+      const currentConfig = vscode.workspace.getConfiguration("solarLsp");
+      if (!currentConfig.get<boolean>("enable", true)) {
+        return;
+      }
+
       const editor = vscode.window.activeTextEditor;
       if (!editor || editor.document.languageId !== "solidity") {
         return;
@@ -50,7 +62,8 @@ export function activate(context: vscode.ExtensionContext) {
       .getConfiguration("editor", event.document.uri)
       .get<boolean>("formatOnSave", false);
     if (
-      currentConfig.get("formatOnSave") &&
+      currentConfig.get<boolean>("enable", true) &&
+      currentConfig.get<boolean>("formatOnSave", true) &&
       (!editorFormatOnSave || !serverSupportsDocumentFormatting()) &&
       event.document.languageId === "solidity"
     ) {
@@ -59,16 +72,67 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const configListener = vscode.workspace.onDidChangeConfiguration((event) => {
-    if (event.affectsConfiguration("solarLsp.enable")) {
-      const currentConfig = vscode.workspace.getConfiguration("solarLsp");
-      if (!currentConfig.get("enable") && client) {
-        client.stop();
-        client = undefined;
-      }
+    if (restartSettings.some((setting) => event.affectsConfiguration(setting))) {
+      void restartLanguageServer(fileWatcher);
     }
   });
 
-  context.subscriptions.push(formatCommand, formatOnSave, configListener);
+  const copySelectorCommand = vscode.commands.registerCommand(
+    "solar.copySelector",
+    copySelector,
+  );
+  const showReferencesCommand = vscode.commands.registerCommand(
+    "solar.showReferences",
+    showReferences,
+  );
+  const showTypeHierarchyCommand = vscode.commands.registerCommand(
+    "solar.showTypeHierarchy",
+    showTypeHierarchy,
+  );
+
+  context.subscriptions.push(
+    formatCommand,
+    formatOnSave,
+    configListener,
+    copySelectorCommand,
+    showReferencesCommand,
+    showTypeHierarchyCommand,
+  );
+}
+
+function restartLanguageServer(
+  fileWatcher: vscode.FileSystemWatcher,
+): Promise<void> {
+  clientLifecycle = clientLifecycle
+    .then(async () => {
+      await stopLanguageServer();
+
+      const config = vscode.workspace.getConfiguration("solarLsp");
+      if (config.get<boolean>("enable", true)) {
+        await startLanguageServer(fileWatcher);
+      }
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("Failed to restart LSP client:", error);
+      vscode.window.showErrorMessage(`Failed to restart LSP: ${message}`);
+    });
+  return clientLifecycle;
+}
+
+async function stopLanguageServer(): Promise<void> {
+  const currentClient = client;
+  if (!currentClient) {
+    return;
+  }
+
+  if (currentClient.state === State.Running) {
+    await currentClient.stop();
+  }
+
+  if (client === currentClient) {
+    client = undefined;
+  }
 }
 
 async function checkExecutableExists(command: string): Promise<boolean> {
@@ -83,11 +147,18 @@ async function checkExecutableExists(command: string): Promise<boolean> {
   });
 }
 
-async function startLanguageServer(context: vscode.ExtensionContext) {
+async function startLanguageServer(fileWatcher: vscode.FileSystemWatcher) {
   const config = vscode.workspace.getConfiguration("solarLsp");
   const solarPath = config.get<string>("serverPath", "solar");
   const forgePath = config.get<string>("forgePath", "forge");
   const flychecks = config.get("flychecks");
+  const codeLens = {
+    enable: config.get<boolean>("codeLens.enable", true),
+    selectors: config.get<boolean>("codeLens.selectors", true),
+    references: config.get<boolean>("codeLens.references", true),
+    inheritance: config.get<boolean>("codeLens.inheritance", true),
+    clientCommands: true,
+  };
 
   // Check if solar is available first
   let serverCommand: string;
@@ -126,37 +197,148 @@ async function startLanguageServer(context: vscode.ExtensionContext) {
     initializationOptions: {
       forgePath,
       flychecks,
+      codeLens,
     },
     synchronize: {
-      fileEvents: vscode.workspace.createFileSystemWatcher("**/*.sol"),
+      fileEvents: fileWatcher,
     },
   };
 
   // Create the language client and start it
-  client = new LanguageClient(
+  const nextClient = new LanguageClient(
     "solarLsp",
     "Solar LSP",
     serverOptions,
     clientOptions,
   );
+  client = nextClient;
 
   // Start the client. This will also launch the server
-  client
-    .start()
-    .then(() => {
-      const serverName = solarExists ? "Solar" : "Forge";
-      console.log(`${serverName} LSP client started`);
-      vscode.window.showInformationMessage(
-        `${serverName} LSP started successfully`,
-      );
-    })
-    .catch((error) => {
-      console.error("Failed to start LSP client:", error);
-      vscode.window.showErrorMessage(`Failed to start LSP: ${error.message}`);
-    });
+  try {
+    await nextClient.start();
+    const serverName = solarExists ? "Solar" : "Forge";
+    console.log(`${serverName} LSP client started`);
+    vscode.window.showInformationMessage(
+      `${serverName} LSP started successfully`,
+    );
+  } catch (error) {
+    try {
+      await nextClient.dispose();
+    } catch {
+      // Failed starts can also reject shutdown after scheduling process cleanup.
+    }
+    if (client === nextClient) {
+      client = undefined;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Failed to start LSP client:", error);
+    vscode.window.showErrorMessage(`Failed to start LSP: ${message}`);
+  }
+}
 
-  // Add client to subscriptions so it gets disposed when extension is deactivated
-  context.subscriptions.push(client);
+async function copySelector(selector: unknown): Promise<void> {
+  if (typeof selector !== "string" || selector.length === 0) {
+    return;
+  }
+  await vscode.env.clipboard.writeText(selector);
+}
+
+async function showReferences(argument: unknown): Promise<void> {
+  const location = parseCodeLensLocation(argument);
+  const runningClient = client;
+  if (!location || !runningClient || runningClient.state !== State.Running) {
+    return;
+  }
+
+  try {
+    const result = await runningClient.sendRequest(ReferencesRequest.type, {
+      textDocument: { uri: location.uri.toString() },
+      position: {
+        line: location.position.line,
+        character: location.position.character,
+      },
+      context: { includeDeclaration: false },
+    });
+    const references = await runningClient.protocol2CodeConverter.asReferences(
+      result ?? [],
+    );
+    await vscode.commands.executeCommand(
+      "editor.action.showReferences",
+      location.uri,
+      location.position,
+      references,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Failed to show references:", error);
+    vscode.window.showErrorMessage(`Failed to show references: ${message}`);
+  }
+}
+
+async function showTypeHierarchy(argument: unknown): Promise<void> {
+  const location = parseCodeLensLocation(argument);
+  if (!location || !argument || typeof argument !== "object") {
+    return;
+  }
+
+  const direction = (argument as { direction?: unknown }).direction;
+  if (direction !== "supertypes" && direction !== "subtypes") {
+    return;
+  }
+
+  try {
+    const range = new vscode.Range(location.position, location.position);
+    const editor = await vscode.window.showTextDocument(location.uri, {
+      selection: range,
+    });
+    editor.revealRange(
+      range,
+      vscode.TextEditorRevealType.InCenterIfOutsideViewport,
+    );
+    await vscode.commands.executeCommand("editor.showTypeHierarchy");
+    await vscode.commands.executeCommand(
+      direction === "supertypes"
+        ? "editor.showSupertypes"
+        : "editor.showSubtypes",
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Failed to show type hierarchy:", error);
+    vscode.window.showErrorMessage(`Failed to show type hierarchy: ${message}`);
+  }
+}
+
+function parseCodeLensLocation(
+  argument: unknown,
+): { uri: vscode.Uri; position: vscode.Position } | undefined {
+  if (!argument || typeof argument !== "object") {
+    return undefined;
+  }
+
+  const candidate = argument as {
+    uri?: unknown;
+    position?: { line?: unknown; character?: unknown };
+  };
+  if (
+    typeof candidate.uri !== "string" ||
+    !candidate.position ||
+    typeof candidate.position.line !== "number" ||
+    typeof candidate.position.character !== "number" ||
+    !Number.isInteger(candidate.position.line) ||
+    !Number.isInteger(candidate.position.character) ||
+    candidate.position.line < 0 ||
+    candidate.position.character < 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    uri: vscode.Uri.parse(candidate.uri),
+    position: new vscode.Position(
+      candidate.position.line,
+      candidate.position.character,
+    ),
+  };
 }
 
 async function formatDocument(
@@ -242,8 +424,5 @@ async function formatDocumentWithForge(
 }
 
 export function deactivate(): Thenable<void> | undefined {
-  if (!client) {
-    return undefined;
-  }
-  return client.stop();
+  return clientLifecycle.then(stopLanguageServer);
 }


### PR DESCRIPTION
Add semantic CodeLens annotations for ABI selectors, reference counts, and direct contract inheritance. The language server derives them from merged semantic analysis, deduplicates references across analysis batches, and suppresses results when source snapshots or compile-context-dependent facts disagree. It also negotiates refresh support so active lenses update after analysis is published or the cache is cleared.
<img width="628" height="381" alt="截屏2026-07-27 20 09 20" src="https://github.com/user-attachments/assets/d0c4f49b-d9b0-4f52-9f5b-71bb2f6beeb1" />

- Click selector above and it will copy 4-byte selector automatically 

- Click reference above :
<img width="668" height="577" alt="截屏2026-07-27 20 19 54" src="https://github.com/user-attachments/assets/ea455f94-16be-432c-8a5a-7885720dddef" />

- Click 'base contract ' above : 
<img width="687" height="338" alt="截屏2026-07-27 20 22 16" src="https://github.com/user-attachments/assets/f236ff40-4ea9-4603-8be6-042ac551c4a4" />

- Click 'derive contract 'above :

<img width="671" height="327" alt="截屏2026-07-27 20 22 48" src="https://github.com/user-attachments/assets/5400e630-52b6-4c27-8262-2cbea0258631" />
