### PR TITLE
fix(lsp): debounce workspace analysis

### DIFF
--- a/crates/interface/src/session.rs
+++ b/crates/interface/src/session.rs
@@ -175,7 +175,7 @@ impl SessionBuilder {
             thread_pool: OnceLock::new(),
         };
         sess.reconfigure();
-        debug!(version = %solar_config::version::SHORT_VERSION, "created new session");
+        debug!(version = %solar_config::version::SEMVER_VERSION, "created new session");
         sess
     }
 }

--- a/crates/interface/src/session.rs
+++ b/crates/interface/src/session.rs
@@ -175,7 +175,7 @@ impl SessionBuilder {
             thread_pool: OnceLock::new(),
         };
         sess.reconfigure();
-        debug!(version = %solar_config::version::SEMVER_VERSION, "created new session");
+        debug!(version = %solar_config::version::SHORT_VERSION, "created new session");
         sess
     }
 }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -35,7 +35,7 @@ glob.workspace = true
 lsp-types.workspace = true
 normalize-path.workspace = true
 serde.workspace = true
-serde_json.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true
 toml_edit = { workspace = true, features = ["serde"] }
 tower.workspace = true

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { workspace = true, features = ["rt", "io-std"] }
 criterion.workspace = true
 snapbox.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["io-util", "macros", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "rt", "sync", "test-util", "time"] }
 tokio-util = { workspace = true, features = ["compat"] }
 
 [features]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -57,6 +57,7 @@ impl Default for Config {
             flychecks: Vec::new(),
             watched_file_dynamic_registration: false,
             workspace_edit_document_changes: false,
+            code_lens_refresh_support: false,
             work_done_progress: false,
             hierarchical_document_symbol_support: false,
             completion: CompletionClientOptions::default(),
@@ -66,6 +67,7 @@ impl Default for Config {
             progress_create_timeout: Duration::from_secs(1),
             formatter_timeout: Duration::from_secs(30),
             flycheck_timeout: Duration::from_secs(30),
+            code_lens: CodeLensConfig::default(),
         }
     }
 }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -63,7 +63,7 @@ impl Default for Config {
             completion: CompletionClientOptions::default(),
             signature_help: SignatureHelpClientOptions::default(),
             source_change_debounce: Duration::from_millis(250),
-            progress_delay: Duration::from_millis(100),
+            progress_delay: Duration::from_millis(250),
             progress_create_timeout: Duration::from_secs(1),
             formatter_timeout: Duration::from_secs(30),
             flycheck_timeout: Duration::from_secs(30),

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -17,6 +17,7 @@ use solar_interface::data_structures::map::FxHashSet;
 use std::{
     env,
     path::{Path, PathBuf},
+    time::Duration,
 };
 use tracing::{info, warn};
 
@@ -25,7 +26,7 @@ use tracing::{info, warn};
 /// This struct is internal only and should not be serialized or deserialized. Instead, values in
 /// this struct are the full view of all merged config sources, such as `initialization_opts`,
 /// on-disk config files (e.g. `foundry.toml`).
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Config {
     workspace_roots: Vec<PathBuf>,
     workspaces: Vec<Workspace>,
@@ -37,6 +38,33 @@ pub(crate) struct Config {
     hierarchical_document_symbol_support: bool,
     completion: CompletionClientOptions,
     signature_help: SignatureHelpClientOptions,
+    source_change_debounce: Duration,
+    progress_delay: Duration,
+    progress_create_timeout: Duration,
+    formatter_timeout: Duration,
+    flycheck_timeout: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            workspace_roots: Vec::new(),
+            workspaces: Vec::new(),
+            flycheck_options: FlycheckInitializationOptions::default(),
+            flychecks: Vec::new(),
+            watched_file_dynamic_registration: false,
+            workspace_edit_document_changes: false,
+            work_done_progress: false,
+            hierarchical_document_symbol_support: false,
+            completion: CompletionClientOptions::default(),
+            signature_help: SignatureHelpClientOptions::default(),
+            source_change_debounce: Duration::from_millis(250),
+            progress_delay: Duration::from_millis(100),
+            progress_create_timeout: Duration::from_secs(1),
+            formatter_timeout: Duration::from_secs(30),
+            flycheck_timeout: Duration::from_secs(30),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -66,6 +94,26 @@ impl Config {
 
     pub(crate) fn supports_hierarchical_document_symbols(&self) -> bool {
         self.hierarchical_document_symbol_support
+    }
+
+    pub(crate) fn source_change_debounce(&self) -> Duration {
+        self.source_change_debounce
+    }
+
+    pub(crate) fn progress_delay(&self) -> Duration {
+        self.progress_delay
+    }
+
+    pub(crate) fn progress_create_timeout(&self) -> Duration {
+        self.progress_create_timeout
+    }
+
+    pub(crate) fn formatter_timeout(&self) -> Duration {
+        self.formatter_timeout
+    }
+
+    pub(crate) fn flycheck_timeout(&self) -> Duration {
+        self.flycheck_timeout
     }
 
     pub(crate) fn completion_options(&self) -> CompletionClientOptions {

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -31,10 +31,26 @@ pub(super) fn parse(
             }
         }
         FlycheckOutput::ForgeLintJson => {
-            let stream =
-                serde_json::Deserializer::from_slice(output).into_iter::<JsonEmitterRecord<'_>>();
-            for record in stream {
-                collect_json_emitter(record?, cwd, source, &mut diagnostics, &mut range_cache);
+            let mut stream =
+                serde_json::Deserializer::from_slice(output).into_iter::<serde_json::Value>();
+            let mut record_start = 0;
+            while let Some(value) = stream.next() {
+                let value = value?;
+                let record_end = stream.byte_offset();
+                let record = serde_json::from_slice(&output[record_start..record_end]);
+                record_start = record_end;
+
+                match record {
+                    Ok(record) => collect_json_emitter(
+                        record,
+                        cwd,
+                        source,
+                        &mut diagnostics,
+                        &mut range_cache,
+                    ),
+                    Err(_) if !is_json_emitter_diagnostic(&value) => {}
+                    Err(error) => return Err(error.into()),
+                }
             }
         }
     }
@@ -67,6 +83,11 @@ struct SolcJsonErrors<'a> {
 enum JsonEmitterRecord<'a> {
     Rustc(#[serde(borrow)] JsonDiagnosticMessage<'a>),
     Solc(#[serde(borrow)] SolcDiagnostic<'a>),
+}
+
+fn is_json_emitter_diagnostic(value: &serde_json::Value) -> bool {
+    value.get("$message_type").and_then(serde_json::Value::as_str) == Some("diagnostic")
+        || value.get("severity").is_some() && value.get("message").is_some()
 }
 
 fn collect_solc_json(
@@ -351,6 +372,37 @@ mod tests {
         assert_eq!(diagnostics[0].code, Some(NumberOrString::String("mixed-case-variable".into())));
         assert_eq!(diagnostics[1].message, "function names should use mixedCase");
         assert_eq!(diagnostics[1].code, Some(NumberOrString::String("mixed-case-function".into())));
+    }
+
+    #[test]
+    fn ignores_non_diagnostic_forge_json_records() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {
+                uint256 bad_name;
+            }
+            "#,
+        );
+        let contents = project.read_file("/src/Test.sol");
+        let start = contents.find("bad_name").unwrap();
+        let end = start + "bad_name".len();
+        let diagnostic = serde_json::to_string(&json_diagnostic_fixture(
+            start,
+            end,
+            "mixed-case-variable",
+            "mutable variables should use mixedCase",
+        ))
+        .unwrap();
+        let output =
+            format!("{{\"$message_type\":\"build_finished\",\"success\":true}}\n{diagnostic}\n");
+
+        let diagnostics =
+            parse(output.as_bytes(), project.root(), FlycheckOutput::ForgeLintJson).unwrap();
+
+        let uri = Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        assert_eq!(diagnostics[&uri].len(), 1);
+        assert_eq!(diagnostics[&uri][0].message, "mutable variables should use mixedCase");
     }
 
     #[test]

--- a/crates/lsp/src/flycheck/parser.rs
+++ b/crates/lsp/src/flycheck/parser.rs
@@ -31,14 +31,11 @@ pub(super) fn parse(
             }
         }
         FlycheckOutput::ForgeLintJson => {
-            let mut stream =
-                serde_json::Deserializer::from_slice(output).into_iter::<serde_json::Value>();
-            let mut record_start = 0;
-            while let Some(value) = stream.next() {
-                let value = value?;
-                let record_end = stream.byte_offset();
-                let record = serde_json::from_slice(&output[record_start..record_end]);
-                record_start = record_end;
+            let stream = serde_json::Deserializer::from_slice(output)
+                .into_iter::<&serde_json::value::RawValue>();
+            for raw in stream {
+                let raw = raw?;
+                let record = serde_json::from_str(raw.get());
 
                 match record {
                     Ok(record) => collect_json_emitter(
@@ -48,8 +45,12 @@ pub(super) fn parse(
                         &mut diagnostics,
                         &mut range_cache,
                     ),
-                    Err(_) if !is_json_emitter_diagnostic(&value) => {}
-                    Err(error) => return Err(error.into()),
+                    Err(error) => {
+                        let value = serde_json::from_str(raw.get())?;
+                        if is_json_emitter_diagnostic(&value) {
+                            return Err(error.into());
+                        }
+                    }
                 }
             }
         }

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -46,7 +46,7 @@ fn command_failed(output: &Output) -> FlycheckError {
 }
 
 fn diagnostic_output<'a>(stdout: &'a [u8], stderr: &'a [u8], format: FlycheckOutput) -> &'a [u8] {
-    if format == FlycheckOutput::ForgeLintJson && !stderr.is_empty() { stderr } else { stdout }
+    if format == FlycheckOutput::ForgeLintJson && stdout.is_empty() { stderr } else { stdout }
 }
 
 async fn command_output(
@@ -112,10 +112,22 @@ mod tests {
     use crate::{config::negotiate_capabilities, test_support::TestProject};
 
     #[test]
-    fn forge_lint_json_diagnostics_are_read_from_stderr() {
+    fn forge_lint_json_diagnostics_prefer_stdout() {
         assert_eq!(
-            diagnostic_output(b"", br#"{"message":"stdout"}"#, FlycheckOutput::ForgeLintJson),
+            diagnostic_output(
+                br#"{"message":"stdout"}"#,
+                br#"{"message":"stderr"}"#,
+                FlycheckOutput::ForgeLintJson
+            ),
             br#"{"message":"stdout"}"#
+        );
+    }
+
+    #[test]
+    fn forge_lint_json_diagnostics_fall_back_to_stderr() {
+        assert_eq!(
+            diagnostic_output(b"", br#"{"message":"stderr"}"#, FlycheckOutput::ForgeLintJson),
+            br#"{"message":"stderr"}"#
         );
     }
 

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -49,8 +49,8 @@ fn parse_output(
         return parser::parse(&output.stdout, &config.cwd, config.output);
     }
 
-    let stdout = parse_nonempty(&output.stdout, config);
-    let stderr = parse_nonempty(&output.stderr, config);
+    let stdout = parse_json_records(&output.stdout, config);
+    let stderr = parse_json_records(&output.stderr, config);
     match (stdout, stderr) {
         (None, None) => Ok(DiagnosticMap::default()),
         (Some(result), None) | (None, Some(result)) => result,
@@ -65,15 +65,36 @@ fn parse_output(
     }
 }
 
-fn parse_nonempty(
+fn parse_json_records(
     output: &[u8],
     config: &FlycheckConfig,
 ) -> Option<Result<DiagnosticMap, parser::ParseError>> {
-    if output.iter().all(u8::is_ascii_whitespace) {
-        None
-    } else {
-        Some(parser::parse(output, &config.cwd, config.output))
+    let mut has_json = false;
+    let mut has_plain_text = false;
+    for line in output.split(|byte| *byte == b'\n') {
+        match line.trim_ascii().first() {
+            Some(b'{' | b'[') => has_json = true,
+            Some(_) => has_plain_text = true,
+            None => {}
+        }
     }
+    if !has_json {
+        return None;
+    }
+    if !has_plain_text {
+        return Some(parser::parse(output, &config.cwd, config.output));
+    }
+
+    let mut json = Vec::new();
+    for line in output.split(|byte| *byte == b'\n') {
+        let line = line.trim_ascii();
+        if matches!(line.first(), Some(b'{' | b'[')) {
+            json.extend_from_slice(line);
+            json.push(b'\n');
+        }
+    }
+
+    (!json.is_empty()).then(|| parser::parse(&json, &config.cwd, config.output))
 }
 
 fn merge_diagnostics(into: &mut DiagnosticMap, diagnostics: DiagnosticMap) {
@@ -157,7 +178,8 @@ mod tests {
             "#,
         );
         let stdout = br#"{"$message_type":"build_finished","success":true}"#.to_vec();
-        let stderr = solc_diagnostic("stderr diagnostic");
+        let mut stderr = b"forge warning\n".to_vec();
+        stderr.extend(solc_diagnostic("stderr diagnostic"));
         let output = Output { status: success_status(), stdout, stderr };
         let config = forge_lint_config(&project);
 
@@ -188,6 +210,19 @@ mod tests {
         let uri = lsp_types::Url::from_file_path(project.path("/src/Test.sol")).unwrap();
         assert_eq!(diagnostics[&uri].len(), 1);
         assert_eq!(diagnostics[&uri][0].message, "stdout diagnostic");
+    }
+
+    #[test]
+    fn forge_lint_plain_warnings_without_diagnostics_are_ignored() {
+        let project = TestProject::new();
+        let output = Output {
+            status: success_status(),
+            stdout: Vec::new(),
+            stderr: b"forge warning\nanother warning\n".to_vec(),
+        };
+        let config = forge_lint_config(&project);
+
+        assert!(parse_output(&output, &config).unwrap().is_empty());
     }
 
     fn forge_lint_config(project: &TestProject) -> FlycheckConfig {

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -15,13 +15,12 @@ use tokio::{
     time,
 };
 
-const FLYCHECK_TIMEOUT: Duration = Duration::from_secs(30);
-
 pub(crate) async fn run(
     config: FlycheckConfig,
+    timeout: Duration,
     cancel: oneshot::Receiver<()>,
 ) -> Result<DiagnosticMap, FlycheckError> {
-    let output = command_output(&config, FLYCHECK_TIMEOUT, cancel).await?;
+    let output = command_output(&config, timeout, cancel).await?;
     let diagnostics = match parser::parse(
         diagnostic_output(&output.stdout, &output.stderr, config.output),
         &config.cwd,
@@ -152,7 +151,7 @@ mod tests {
         };
         let (_cancel, cancelled) = oneshot::channel();
 
-        let error = run(config, cancelled).await.unwrap_err();
+        let error = run(config, Duration::from_secs(30), cancelled).await.unwrap_err();
 
         assert!(matches!(
             error,

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -21,11 +21,7 @@ pub(crate) async fn run(
     cancel: oneshot::Receiver<()>,
 ) -> Result<DiagnosticMap, FlycheckError> {
     let output = command_output(&config, timeout, cancel).await?;
-    let diagnostics = match parser::parse(
-        diagnostic_output(&output.stdout, &output.stderr, config.output),
-        &config.cwd,
-        config.output,
-    ) {
+    let diagnostics = match parse_output(&output, &config) {
         Ok(diagnostics) => diagnostics,
         Err(_) if !output.status.success() => return Err(command_failed(&output)),
         Err(error) => return Err(error.into()),
@@ -45,8 +41,45 @@ fn command_failed(output: &Output) -> FlycheckError {
     }
 }
 
-fn diagnostic_output<'a>(stdout: &'a [u8], stderr: &'a [u8], format: FlycheckOutput) -> &'a [u8] {
-    if format == FlycheckOutput::ForgeLintJson && stdout.is_empty() { stderr } else { stdout }
+fn parse_output(
+    output: &Output,
+    config: &FlycheckConfig,
+) -> Result<DiagnosticMap, parser::ParseError> {
+    if config.output != FlycheckOutput::ForgeLintJson {
+        return parser::parse(&output.stdout, &config.cwd, config.output);
+    }
+
+    let stdout = parse_nonempty(&output.stdout, config);
+    let stderr = parse_nonempty(&output.stderr, config);
+    match (stdout, stderr) {
+        (None, None) => Ok(DiagnosticMap::default()),
+        (Some(result), None) | (None, Some(result)) => result,
+        (Some(Ok(mut stdout)), Some(Ok(stderr))) => {
+            merge_diagnostics(&mut stdout, stderr);
+            Ok(stdout)
+        }
+        (Some(Ok(diagnostics)), Some(Err(_))) | (Some(Err(_)), Some(Ok(diagnostics))) => {
+            Ok(diagnostics)
+        }
+        (Some(Err(error)), Some(Err(_))) => Err(error),
+    }
+}
+
+fn parse_nonempty(
+    output: &[u8],
+    config: &FlycheckConfig,
+) -> Option<Result<DiagnosticMap, parser::ParseError>> {
+    if output.iter().all(u8::is_ascii_whitespace) {
+        None
+    } else {
+        Some(parser::parse(output, &config.cwd, config.output))
+    }
+}
+
+fn merge_diagnostics(into: &mut DiagnosticMap, diagnostics: DiagnosticMap) {
+    for (uri, mut diagnostics) in diagnostics {
+        into.entry(uri).or_default().append(&mut diagnostics);
+    }
 }
 
 async fn command_output(
@@ -110,37 +143,90 @@ mod tests {
     #[cfg(unix)]
     use crate::test_support::process_exists;
     use crate::{config::negotiate_capabilities, test_support::TestProject};
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+    #[cfg(windows)]
+    use std::os::windows::process::ExitStatusExt;
 
     #[test]
-    fn forge_lint_json_diagnostics_prefer_stdout() {
-        assert_eq!(
-            diagnostic_output(
-                br#"{"message":"stdout"}"#,
-                br#"{"message":"stderr"}"#,
-                FlycheckOutput::ForgeLintJson
-            ),
-            br#"{"message":"stdout"}"#
+    fn forge_lint_json_diagnostics_are_collected_from_stderr_when_stdout_is_nonempty() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {}
+            "#,
         );
+        let stdout = br#"{"$message_type":"build_finished","success":true}"#.to_vec();
+        let stderr = solc_diagnostic("stderr diagnostic");
+        let output = Output { status: success_status(), stdout, stderr };
+        let config = forge_lint_config(&project);
+
+        let diagnostics = parse_output(&output, &config).unwrap();
+
+        let uri = lsp_types::Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        assert_eq!(diagnostics[&uri].len(), 1);
+        assert_eq!(diagnostics[&uri][0].message, "stderr diagnostic");
     }
 
     #[test]
-    fn forge_lint_json_diagnostics_fall_back_to_stderr() {
-        assert_eq!(
-            diagnostic_output(b"", br#"{"message":"stderr"}"#, FlycheckOutput::ForgeLintJson),
-            br#"{"message":"stderr"}"#
+    fn forge_lint_json_diagnostics_are_collected_from_stdout_with_plain_stderr() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /src/Test.sol
+            contract Test {}
+            "#,
         );
+        let output = Output {
+            status: success_status(),
+            stdout: solc_diagnostic("stdout diagnostic"),
+            stderr: b"forge warning".to_vec(),
+        };
+        let config = forge_lint_config(&project);
+
+        let diagnostics = parse_output(&output, &config).unwrap();
+
+        let uri = lsp_types::Url::from_file_path(project.path("/src/Test.sol")).unwrap();
+        assert_eq!(diagnostics[&uri].len(), 1);
+        assert_eq!(diagnostics[&uri][0].message, "stdout diagnostic");
     }
 
-    #[test]
-    fn solc_json_diagnostics_are_read_from_stdout() {
-        assert_eq!(
-            diagnostic_output(
-                br#"{"message":"stdout"}"#,
-                br#"{"message":"stderr"}"#,
-                FlycheckOutput::SolcJson
-            ),
-            br#"{"message":"stdout"}"#
-        );
+    fn forge_lint_config(project: &TestProject) -> FlycheckConfig {
+        FlycheckConfig {
+            id: "forge-lint".into(),
+            command: "forge".into(),
+            args: Vec::new(),
+            cwd: project.root().to_path_buf(),
+            workspace_root: project.root().to_path_buf(),
+            output: FlycheckOutput::ForgeLintJson,
+        }
+    }
+
+    fn solc_diagnostic(message: &str) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "sourceLocation": {
+                "file": "src/Test.sol",
+                "start": 9,
+                "end": 13,
+            },
+            "secondarySourceLocations": [],
+            "type": "Warning",
+            "component": "general",
+            "severity": "warning",
+            "errorCode": "1234",
+            "message": message,
+            "formattedMessage": null,
+        }))
+        .unwrap()
+    }
+
+    #[cfg(unix)]
+    fn success_status() -> std::process::ExitStatus {
+        std::process::ExitStatus::from_raw(0)
+    }
+
+    #[cfg(windows)]
+    fn success_status() -> std::process::ExitStatus {
+        std::process::ExitStatus::from_raw(0)
     }
 
     #[cfg(unix)]

--- a/crates/lsp/src/formatter.rs
+++ b/crates/lsp/src/formatter.rs
@@ -11,18 +11,22 @@ use std::{
 };
 use tokio::{io::AsyncWriteExt, process::Command, time};
 
-const FORMATTER_TIMEOUT: Duration = Duration::from_secs(30);
-
-pub(crate) async fn run(forge: &Path, root: &Path, source: &str) -> Result<String, FormatterError> {
-    run_with_timeout(forge, root, source, FORMATTER_TIMEOUT).await
+pub(crate) async fn run(
+    forge: &Path,
+    root: &Path,
+    source: &str,
+    timeout: Duration,
+) -> Result<String, FormatterError> {
+    run_with_timeout(forge, root, source, timeout).await
 }
 
 pub(crate) async fn is_ignored(
     forge: &Path,
     path: &Path,
     root: &Path,
+    timeout: Duration,
 ) -> Result<bool, FormatterError> {
-    let ignores = resolved_formatter_ignores(forge, root, FORMATTER_TIMEOUT).await?;
+    let ignores = resolved_formatter_ignores(forge, root, timeout).await?;
     Ok(matches_ignore(path, root, &ignores))
 }
 
@@ -349,7 +353,9 @@ printf 'contract Formatted {}'
 "#,
         );
 
-        let output = run(&forge, project.root(), "contract Unformatted{}").await.unwrap();
+        let output = run(&forge, project.root(), "contract Unformatted{}", Duration::from_secs(30))
+            .await
+            .unwrap();
 
         assert_eq!(output, "contract Formatted {}");
         assert_eq!(project.read_file("/fake-forge.stdin"), "contract Unformatted{}");
@@ -364,7 +370,10 @@ printf 'contract Formatted {}'
     async fn missing_forge_reports_io_error() {
         let project = TestProject::new();
 
-        let error = run(&project.path("/missing-forge"), project.root(), "").await.unwrap_err();
+        let error =
+            run(&project.path("/missing-forge"), project.root(), "", Duration::from_secs(30))
+                .await
+                .unwrap_err();
 
         assert!(
             matches!(error, FormatterError::Io(error) if error.kind() == io::ErrorKind::NotFound)
@@ -380,7 +389,7 @@ printf 'contract Formatted {}'
             "#!/bin/sh\nprintf 'format failed' >&2\nexit 7\n",
         );
 
-        let error = run(&forge, project.root(), "").await.unwrap_err();
+        let error = run(&forge, project.root(), "", Duration::from_secs(30)).await.unwrap_err();
 
         assert!(matches!(
             error,
@@ -393,7 +402,7 @@ printf 'contract Formatted {}'
         let project = TestProject::new();
         let forge = write_executable(&project, "/fake-forge", "#!/bin/sh\nprintf '\\377'\n");
 
-        let error = run(&forge, project.root(), "").await.unwrap_err();
+        let error = run(&forge, project.root(), "", Duration::from_secs(30)).await.unwrap_err();
 
         assert!(matches!(error, FormatterError::InvalidUtf8(_)));
     }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -328,13 +328,14 @@ impl GlobalState {
             let Ok(permit) = task_scheduler.gate.clone().acquire_owned().await else {
                 return;
             };
-            let worker_progress = progress.clone();
             let worker = {
                 let mut tasks = task_scheduler.tasks.lock();
                 if !snapshot.is_current(version) {
                     return;
                 }
 
+                progress.begin();
+                let worker_progress = progress.clone();
                 let worker = tokio::task::spawn_blocking(move || {
                     let _permit = permit;
                     run_analysis(&mut snapshot, version, disk_paths, &worker_progress)
@@ -381,9 +382,10 @@ impl GlobalState {
             let invalidated = mem::take(&mut commit.cache_invalidated);
             let rediscover = matches!(mode, AnalysisMode::Rediscover) || invalidated;
             let version = self.next_analysis_version();
-            // Retarget progress before publishing the epoch so a delayed create response cannot
-            // end the previous wave after the new analysis becomes current.
-            let progress = self.analysis_progress.start(version);
+            // Reserve progress before publishing the epoch so a delayed create response cannot end
+            // the previous wave after the new analysis becomes current. The progress delay is armed
+            // after debounce and scheduler wait complete.
+            let progress = self.analysis_progress.reserve(version);
             self.commit_analysis_epoch(&mut commit, version, changed_paths, rediscover);
             let batches = self.diagnostics.write().clear_uris_and_publish_batches(removed_uris);
             publish_diagnostic_batches(&mut self.client, batches);

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -36,10 +36,11 @@ use std::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
+    time::Duration,
 };
 use tokio::{
-    sync::{oneshot, watch},
-    task::{JoinError, JoinHandle},
+    sync::{Semaphore, oneshot, watch},
+    task::{AbortHandle, JoinError, JoinHandle},
 };
 
 #[derive(Clone, Copy)]
@@ -64,6 +65,38 @@ struct AnalysisCommitState {
     natspec_context_change_version: usize,
 }
 
+/// Serializes compiler analysis while allowing the newest request to replace a pending one.
+///
+/// Tokio cannot abort a blocking worker after it starts, so its permit stays in the worker until
+/// it exits at one of the version checks. Only the newest coordinator waits for that permit.
+struct AnalysisScheduler {
+    gate: Arc<Semaphore>,
+    tasks: Mutex<AnalysisTasks>,
+}
+
+impl Default for AnalysisScheduler {
+    fn default() -> Self {
+        Self { gate: Arc::new(Semaphore::new(1)), tasks: Mutex::new(AnalysisTasks::default()) }
+    }
+}
+
+#[derive(Default)]
+struct AnalysisTasks {
+    coordinator: Option<(usize, AbortHandle)>,
+    worker: Option<(usize, AbortHandle)>,
+}
+
+impl AnalysisTasks {
+    fn cancel(&mut self) {
+        if let Some((_, worker)) = self.worker.take() {
+            worker.abort();
+        }
+        if let Some((_, coordinator)) = self.coordinator.take() {
+            coordinator.abort();
+        }
+    }
+}
+
 pub(crate) struct GlobalState {
     client: ClientSocket,
     pub(crate) sess: Session,
@@ -73,6 +106,7 @@ pub(crate) struct GlobalState {
     published_analysis_version: watch::Sender<usize>,
     analysis_commit: Arc<Mutex<AnalysisCommitState>>,
     analysis_progress: ProgressCoordinator,
+    analysis_scheduler: Arc<AnalysisScheduler>,
     flycheck_versions: Arc<RwLock<FxHashMap<DiagnosticOwner, usize>>>,
     flycheck_cancels: FxHashMap<DiagnosticOwner, oneshot::Sender<()>>,
     pub(crate) symbol_tables: Arc<RwLock<SymbolTables>>,
@@ -82,7 +116,13 @@ pub(crate) struct GlobalState {
 impl GlobalState {
     pub(crate) fn new(client: ClientSocket) -> Self {
         let (published_analysis_version, _) = watch::channel(0);
-        let analysis_progress = ProgressCoordinator::new(client.clone(), false);
+        let config = Arc::new(Config::default());
+        let analysis_progress = ProgressCoordinator::with_timing(
+            client.clone(),
+            false,
+            config.progress_delay(),
+            config.progress_create_timeout(),
+        );
         Self {
             client,
             sess: Session::default(),
@@ -91,11 +131,12 @@ impl GlobalState {
             published_analysis_version,
             analysis_commit: Arc::new(Default::default()),
             analysis_progress,
+            analysis_scheduler: Arc::new(Default::default()),
             flycheck_versions: Arc::new(Default::default()),
             flycheck_cancels: FxHashMap::default(),
             symbol_tables: Arc::new(Default::default()),
             diagnostics: Arc::new(Default::default()),
-            config: Arc::new(Default::default()),
+            config,
         }
     }
 
@@ -153,11 +194,24 @@ impl GlobalState {
     /// [`salsa`]: https://docs.rs/salsa/latest/salsa/
     pub(crate) fn recompute_with_disk_files(&mut self, disk_paths: Vec<PathBuf>) {
         let changed_paths = disk_paths.clone();
-        self.request_analysis(AnalysisMode::Recompute, disk_paths, Vec::new(), changed_paths);
+        self.request_analysis(
+            AnalysisMode::Recompute,
+            disk_paths,
+            Vec::new(),
+            changed_paths,
+            Duration::ZERO,
+        );
     }
 
     pub(crate) fn recompute_after_source_changes(&mut self, changed_paths: Vec<PathBuf>) {
-        self.request_analysis(AnalysisMode::Recompute, Vec::new(), Vec::new(), changed_paths);
+        let delay = self.config.source_change_debounce();
+        self.request_analysis(
+            AnalysisMode::Recompute,
+            Vec::new(),
+            Vec::new(),
+            changed_paths,
+            delay,
+        );
     }
 
     pub(crate) fn recompute_for_file_changes(
@@ -169,15 +223,27 @@ impl GlobalState {
         let changed_paths = disk_paths.clone();
         let mode =
             if force_rediscover { AnalysisMode::Rediscover } else { AnalysisMode::Recompute };
-        self.request_analysis(mode, disk_paths, removed_paths, changed_paths);
+        self.request_analysis(mode, disk_paths, removed_paths, changed_paths, Duration::ZERO);
     }
 
     pub(crate) fn reindex(&mut self) {
-        self.request_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new(), Vec::new());
+        self.request_analysis(
+            AnalysisMode::Rediscover,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Duration::ZERO,
+        );
     }
 
     pub(crate) fn reindex_if_invalidated(&mut self) {
-        self.request_analysis(AnalysisMode::IfInvalidated, Vec::new(), Vec::new(), Vec::new());
+        self.request_analysis(
+            AnalysisMode::IfInvalidated,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Duration::ZERO,
+        );
     }
 
     pub(crate) fn clear_analysis_cache(&mut self) {
@@ -213,6 +279,7 @@ impl GlobalState {
                 old_symbol_tables
             })
         };
+        self.analysis_scheduler.tasks.lock().cancel();
         drop(old_symbol_tables);
     }
 
@@ -227,52 +294,75 @@ impl GlobalState {
         disk_paths: Vec<PathBuf>,
         removed_paths: Vec<PathBuf>,
         changed_paths: Vec<PathBuf>,
+        delay: Duration,
     ) {
         let removed_uris = self.prepare_removed_file_diagnostics(removed_paths);
         let Some((version, progress)) = self.begin_analysis(mode, removed_uris, changed_paths)
         else {
             return;
         };
-        let worker_progress = progress.clone();
-        let task = self.spawn_with_snapshot(move |mut snapshot| {
-            worker_progress.report("Reading workspace sources");
-            if !snapshot.is_current(version) {
-                return AnalysisTaskOutcome::Superseded;
+        self.schedule_analysis(version, disk_paths, progress, delay);
+    }
+
+    fn schedule_analysis(
+        &self,
+        version: usize,
+        disk_paths: Vec<PathBuf>,
+        progress: ProgressTicket,
+        delay: Duration,
+    ) {
+        let scheduler = self.analysis_scheduler.clone();
+        let task_scheduler = scheduler.clone();
+        let mut snapshot = self.snapshot();
+        let analysis_version = self.analysis_version.clone();
+        let published_analysis_version = self.published_analysis_version.clone();
+        let analysis_commit = self.analysis_commit.clone();
+
+        let mut tasks = scheduler.tasks.lock();
+        tasks.cancel();
+        let coordinator = tokio::spawn(async move {
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
             }
 
-            let batches = snapshot.analysis_batches(disk_paths);
-            worker_progress.report("Analyzing workspace");
-            if !snapshot.is_current(version) {
-                return AnalysisTaskOutcome::Superseded;
-            }
-
-            let mut results = AnalysisResultAccumulator::default();
-
-            for batch in batches {
-                if batch.files.is_empty() {
-                    continue;
-                }
-
+            let Ok(permit) = task_scheduler.gate.clone().acquire_owned().await else {
+                return;
+            };
+            let worker_progress = progress.clone();
+            let worker = {
+                let mut tasks = task_scheduler.tasks.lock();
                 if !snapshot.is_current(version) {
-                    return AnalysisTaskOutcome::Superseded;
+                    return;
                 }
 
-                results.push(analyze(batch));
+                let worker = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    run_analysis(&mut snapshot, version, disk_paths, &worker_progress)
+                });
+                tasks.worker = Some((version, worker.abort_handle()));
+                worker
+            };
 
-                if !snapshot.is_current(version) {
-                    return AnalysisTaskOutcome::Superseded;
-                }
+            monitor_analysis_task(
+                version,
+                worker,
+                progress,
+                &analysis_version,
+                &published_analysis_version,
+                &analysis_commit,
+            )
+            .await;
+
+            let mut tasks = task_scheduler.tasks.lock();
+            if tasks.worker.as_ref().is_some_and(|(task_version, _)| *task_version == version) {
+                tasks.worker = None;
             }
-
-            let result = results.finish();
-            worker_progress.report("Publishing workspace index");
-            if snapshot.publish_analysis(version, result) {
-                AnalysisTaskOutcome::Published
-            } else {
-                AnalysisTaskOutcome::Superseded
+            if tasks.coordinator.as_ref().is_some_and(|(task_version, _)| *task_version == version)
+            {
+                tasks.coordinator = None;
             }
         });
-        self.monitor_analysis_task(version, task, progress);
+        tasks.coordinator = Some((version, coordinator.abort_handle()));
     }
 
     fn begin_analysis(
@@ -437,6 +527,7 @@ impl GlobalState {
     }
 
     pub(crate) fn run_flychecks_on_save(&mut self, path: PathBuf) {
+        let timeout = self.config.flycheck_timeout();
         for flycheck in self.config.flychecks_for_path(&path) {
             let owner = flycheck.owner();
             let version = self.begin_flycheck_epoch(&owner);
@@ -445,7 +536,7 @@ impl GlobalState {
             let (cancel, cancelled) = oneshot::channel();
             let task_owner = owner.clone();
             tokio::spawn(async move {
-                let result = flycheck::run(flycheck, cancelled).await;
+                let result = flycheck::run(flycheck, timeout, cancelled).await;
                 if !snapshot.is_current_flycheck(&task_owner, version) {
                     return;
                 }
@@ -535,14 +626,7 @@ impl GlobalState {
         }
     }
 
-    fn spawn_with_snapshot<T: Send + 'static>(
-        &self,
-        f: impl FnOnce(GlobalStateSnapshot) -> T + Send + 'static,
-    ) -> JoinHandle<T> {
-        let snapshot = self.snapshot();
-        tokio::task::spawn_blocking(move || f(snapshot))
-    }
-
+    #[cfg(test)]
     fn monitor_analysis_task(
         &self,
         version: usize,
@@ -553,34 +637,97 @@ impl GlobalState {
         let published_analysis_version = self.published_analysis_version.clone();
         let analysis_commit = self.analysis_commit.clone();
         tokio::spawn(async move {
-            match task.await {
-                Ok(AnalysisTaskOutcome::Published) => finish_analysis_progress_if_current(
-                    version,
-                    &analysis_version,
-                    &analysis_commit,
-                    &progress,
-                    "Workspace index ready",
-                ),
-                Ok(AnalysisTaskOutcome::Superseded) => {}
-                Err(error) => {
-                    if handle_analysis_failure(
-                        version,
-                        error,
-                        &analysis_version,
-                        &published_analysis_version,
-                        &analysis_commit,
-                    ) {
-                        finish_analysis_progress_if_current(
-                            version,
-                            &analysis_version,
-                            &analysis_commit,
-                            &progress,
-                            "Workspace indexing failed",
-                        );
-                    }
-                }
-            }
+            monitor_analysis_task(
+                version,
+                task,
+                progress,
+                &analysis_version,
+                &published_analysis_version,
+                &analysis_commit,
+            )
+            .await;
         });
+    }
+}
+
+fn run_analysis(
+    snapshot: &mut GlobalStateSnapshot,
+    version: usize,
+    disk_paths: Vec<PathBuf>,
+    progress: &ProgressTicket,
+) -> AnalysisTaskOutcome {
+    progress.report("Reading workspace sources");
+    if !snapshot.is_current(version) {
+        return AnalysisTaskOutcome::Superseded;
+    }
+
+    let batches = snapshot.analysis_batches(disk_paths);
+    progress.report("Analyzing workspace");
+    if !snapshot.is_current(version) {
+        return AnalysisTaskOutcome::Superseded;
+    }
+
+    let mut results = AnalysisResultAccumulator::default();
+
+    for batch in batches {
+        if batch.files.is_empty() {
+            continue;
+        }
+
+        if !snapshot.is_current(version) {
+            return AnalysisTaskOutcome::Superseded;
+        }
+
+        results.push(analyze(batch));
+
+        if !snapshot.is_current(version) {
+            return AnalysisTaskOutcome::Superseded;
+        }
+    }
+
+    let result = results.finish();
+    progress.report("Publishing workspace index");
+    if snapshot.publish_analysis(version, result) {
+        AnalysisTaskOutcome::Published
+    } else {
+        AnalysisTaskOutcome::Superseded
+    }
+}
+
+async fn monitor_analysis_task(
+    version: usize,
+    task: JoinHandle<AnalysisTaskOutcome>,
+    progress: ProgressTicket,
+    analysis_version: &Arc<AtomicUsize>,
+    published_analysis_version: &watch::Sender<usize>,
+    analysis_commit: &Arc<Mutex<AnalysisCommitState>>,
+) {
+    match task.await {
+        Ok(AnalysisTaskOutcome::Published) => finish_analysis_progress_if_current(
+            version,
+            analysis_version,
+            analysis_commit,
+            &progress,
+            "Workspace index ready",
+        ),
+        Ok(AnalysisTaskOutcome::Superseded) => {}
+        Err(error) => {
+            if handle_analysis_failure(
+                version,
+                error,
+                analysis_version,
+                published_analysis_version,
+                analysis_commit,
+            ) {
+                finish_analysis_progress_if_current(
+                    version,
+                    analysis_version,
+                    analysis_commit,
+                    &progress,
+                    "Workspace indexing failed",
+                );
+            }
+        }
     }
 }
 

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -129,7 +129,10 @@ pub(crate) fn did_change_watched_files(
     let mut removed_paths = Vec::new();
 
     for event in params.changes {
-        let Ok(path) = event.uri.to_file_path() else {
+        let Some(vfs_path) = proto::vfs_path(&event.uri) else {
+            continue;
+        };
+        let Some(path) = vfs_path.as_path().map(ToOwned::to_owned) else {
             continue;
         };
 
@@ -138,6 +141,11 @@ pub(crate) fn did_change_watched_files(
                 should_rediscover = true;
             }
             Some(_) if path.extension().is_some_and(|ext| ext == "sol") => {
+                // Open documents are sourced from the VFS, and `didChange` already schedules their
+                // analysis. The watched change emitted after saving one is redundant.
+                if event.typ == FileChangeType::CHANGED && state.vfs.read().exists(&vfs_path) {
+                    continue;
+                }
                 if event.typ == FileChangeType::CREATED {
                     Arc::make_mut(&mut state.config).add_source_file(path.clone());
                 } else if event.typ == FileChangeType::DELETED {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -100,17 +100,24 @@ pub(crate) fn formatting(
             let Some(root) = state.config.formatter_root_for_path(&path) else {
                 return Err(request_failed("document has no parent directory"));
             };
-            Ok((VfsPath::from(path.clone()), path, root, state.config.forge_path()))
+            Ok((
+                VfsPath::from(path.clone()),
+                path,
+                root,
+                state.config.forge_path(),
+                state.config.formatter_timeout(),
+            ))
         });
 
     async move {
-        let (vfs_path, path, root, forge) = request?;
-        if formatter::is_ignored(&forge, &path, &root).await.map_err(formatter_failed)? {
+        let (vfs_path, path, root, forge, timeout) = request?;
+        if formatter::is_ignored(&forge, &path, &root, timeout).await.map_err(formatter_failed)? {
             return Ok(None);
         }
         let source =
             document_contents(&vfs, &vfs_path, &path).await.map_err(document_read_failed)?;
-        let formatted = formatter::run(&forge, &root, &source).await.map_err(formatter_failed)?;
+        let formatted =
+            formatter::run(&forge, &root, &source, timeout).await.map_err(formatter_failed)?;
         let is_current = document_is_current(&vfs, &vfs_path, &path, &source)
             .await
             .map_err(document_read_failed)?;

--- a/crates/lsp/src/progress.rs
+++ b/crates/lsp/src/progress.rs
@@ -76,10 +76,9 @@ impl ProgressCoordinator {
 
     /// Starts or joins the progress wave for `version`.
     ///
-    /// A newer version replaces an invisible delayed wave so its progress clock starts over. Once
-    /// token creation has begun, the newer version reuses that wave and reports at most one
-    /// restart. Tickets for older versions remain valid handles but cannot report or finish the
-    /// newer wave.
+    /// A newer version replaces an invisible wave so its progress clock starts over. Once progress
+    /// is visible, the newer version reuses that wave and reports at most one restart. Tickets for
+    /// older versions remain valid handles but cannot report or finish the newer wave.
     #[cfg(test)]
     pub(crate) fn start(&self, version: usize) -> ProgressTicket {
         let ticket = self.reserve(version);
@@ -336,7 +335,7 @@ impl WorkDoneProgressGuard {
             return true;
         }
 
-        if matches!(state.phase, Phase::Pending | Phase::Delayed) {
+        if matches!(state.phase, Phase::Pending | Phase::Delayed | Phase::Creating) {
             state.phase = Phase::Closed;
             state.message = None;
             state.terminal = None;
@@ -947,7 +946,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn replacement_reuses_a_wave_that_finished_while_create_was_pending() {
+    async fn replacement_while_create_is_pending_can_finish_silently() {
         let mut harness = progress_harness();
         let coordinator = ProgressCoordinator::with_timing(
             harness.client.clone(),
@@ -956,46 +955,25 @@ mod tests {
             Duration::from_secs(1),
         );
         let first = coordinator.start(1);
-        let ClientEvent::Create(create) = next_event(&mut harness.events).await else {
+        let ClientEvent::Create(_) = next_event(&mut harness.events).await else {
             panic!("expected create request")
         };
-        let token = create.token;
         first.finish("first finished");
 
         let second = coordinator.start(2);
-        assert!(Arc::ptr_eq(first.guard.as_ref().unwrap(), second.guard.as_ref().unwrap()));
-        harness.acknowledge_create();
-
-        match next_event(&mut harness.events).await {
-            ClientEvent::Progress(ProgressParams {
-                token: actual,
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)),
-            }) => {
-                assert_eq!(actual, token);
-                assert_eq!(begin.message.as_deref(), Some(RESTART_MESSAGE));
-            }
-            event => panic!("expected progress begin, got {event:?}"),
-        }
-        harness.probe().await;
-        assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
-
+        assert!(!Arc::ptr_eq(first.guard.as_ref().unwrap(), second.guard.as_ref().unwrap()));
         second.finish("second finished");
-        match next_event(&mut harness.events).await {
-            ClientEvent::Progress(ProgressParams {
-                token: actual,
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(end)),
-            }) => {
-                assert_eq!(actual, token);
-                assert_eq!(end.message.as_deref(), Some("second finished"));
-            }
-            event => panic!("expected current end, got {event:?}"),
-        }
+        harness.acknowledge_create();
+        harness.probe().await;
+
+        assert!(!coordinator.is_active_for_test(2));
+        assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
 
         harness.shutdown().await;
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn replacement_across_create_ack_emits_one_restart_message() {
+    async fn replacement_after_begin_reuses_the_visible_wave() {
         let mut harness = progress_harness();
         let coordinator = ProgressCoordinator::with_timing(
             harness.client.clone(),
@@ -1009,28 +987,29 @@ mod tests {
             panic!("expected create request")
         };
         let token = create.token;
-        let second = coordinator.start(2);
-        assert!(Arc::ptr_eq(first.guard.as_ref().unwrap(), second.guard.as_ref().unwrap()));
-
         harness.acknowledge_create();
+        assert!(matches!(
+            next_event(&mut harness.events).await,
+            ClientEvent::Progress(ProgressParams {
+                token: actual,
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)),
+            }) if actual == token
+        ));
+
+        let latest = coordinator.start(2);
+        assert!(Arc::ptr_eq(first.guard.as_ref().unwrap(), latest.guard.as_ref().unwrap()));
         match next_event(&mut harness.events).await {
             ClientEvent::Progress(ProgressParams {
                 token: actual,
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(report)),
             }) => {
                 assert_eq!(actual, token);
-                assert_eq!(begin.message.as_deref(), Some(RESTART_MESSAGE));
+                assert_eq!(report.message.as_deref(), Some(RESTART_MESSAGE));
             }
-            event => panic!("expected progress begin, got {event:?}"),
+            event => panic!("expected replacement report, got {event:?}"),
         }
 
-        let latest = coordinator.start(3);
-        assert!(Arc::ptr_eq(first.guard.as_ref().unwrap(), latest.guard.as_ref().unwrap()));
-        harness.probe().await;
-        assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
-
         first.finish("stale");
-        second.finish("stale");
         latest.finish("done");
         match next_event(&mut harness.events).await {
             ClientEvent::Progress(ProgressParams {
@@ -1149,7 +1128,7 @@ mod tests {
         assert!(coordinator.inner.enabled.load(Ordering::Acquire));
 
         let latest = coordinator.start(2);
-        assert!(Arc::ptr_eq(first.guard.as_ref().unwrap(), latest.guard.as_ref().unwrap()));
+        assert!(!Arc::ptr_eq(first.guard.as_ref().unwrap(), latest.guard.as_ref().unwrap()));
         latest.finish("done");
 
         harness.acknowledge_create();

--- a/crates/lsp/src/progress.rs
+++ b/crates/lsp/src/progress.rs
@@ -76,9 +76,10 @@ impl ProgressCoordinator {
 
     /// Starts or joins the progress wave for `version`.
     ///
-    /// A newer version reuses a visible wave and reports at most one restart. If the previous
-    /// wave has already ended or failed, a fresh token is allocated. Tickets for older versions
-    /// remain valid handles but cannot report or finish the newer wave.
+    /// A newer version replaces an invisible delayed wave so its progress clock starts over. Once
+    /// token creation has begun, the newer version reuses that wave and reports at most one
+    /// restart. Tickets for older versions remain valid handles but cannot report or finish the
+    /// newer wave.
     #[cfg(test)]
     pub(crate) fn start(&self, version: usize) -> ProgressTicket {
         let ticket = self.reserve(version);
@@ -335,6 +336,14 @@ impl WorkDoneProgressGuard {
             return true;
         }
 
+        if matches!(state.phase, Phase::Pending | Phase::Delayed) {
+            state.phase = Phase::Closed;
+            state.message = None;
+            state.terminal = None;
+            state.restart_reported = false;
+            return false;
+        }
+
         state.version = version;
         state.terminal = None;
         if state.phase == Phase::Begun {
@@ -354,7 +363,7 @@ impl WorkDoneProgressGuard {
             } else {
                 state.restart_reported = true;
             }
-        } else if state.phase != Phase::Pending && state.message != Some(RESTART_MESSAGE) {
+        } else if state.message != Some(RESTART_MESSAGE) {
             state.message = Some(RESTART_MESSAGE);
         }
         true
@@ -703,6 +712,53 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert!(!coordinator.is_active_for_test(1));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn finishing_just_before_delay_never_creates_progress() {
+        let delay = Duration::from_millis(100);
+        let coordinator = ProgressCoordinator::with_timing(
+            ClientSocket::new_closed(),
+            true,
+            delay,
+            Duration::from_secs(1),
+        );
+        let ticket = coordinator.start(1);
+
+        tokio::time::advance(delay - Duration::from_millis(1)).await;
+        ticket.finish("done");
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+
+        assert!(!coordinator.is_active_for_test(1));
+        assert!(coordinator.inner.enabled.load(Ordering::Acquire));
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn replacement_before_delay_restarts_the_progress_clock() {
+        let delay = Duration::from_millis(100);
+        let coordinator = ProgressCoordinator::with_timing(
+            ClientSocket::new_closed(),
+            true,
+            delay,
+            Duration::from_secs(1),
+        );
+        let first = coordinator.start(1);
+
+        tokio::time::advance(delay / 2).await;
+        let latest = coordinator.start(2);
+        assert!(!Arc::ptr_eq(first.guard.as_ref().unwrap(), latest.guard.as_ref().unwrap()));
+
+        tokio::time::advance(delay / 2).await;
+        tokio::task::yield_now().await;
+        assert!(coordinator.is_active_for_test(2));
+        assert!(coordinator.inner.enabled.load(Ordering::Acquire));
+
+        latest.finish("done");
+        tokio::time::advance(delay / 2).await;
+        tokio::task::yield_now().await;
+        assert!(!coordinator.is_active_for_test(2));
+        assert!(coordinator.inner.enabled.load(Ordering::Acquire));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/progress.rs
+++ b/crates/lsp/src/progress.rs
@@ -79,12 +79,20 @@ impl ProgressCoordinator {
     /// A newer version reuses a visible wave and reports at most one restart. If the previous
     /// wave has already ended or failed, a fresh token is allocated. Tickets for older versions
     /// remain valid handles but cannot report or finish the newer wave.
+    #[cfg(test)]
     pub(crate) fn start(&self, version: usize) -> ProgressTicket {
+        let ticket = self.reserve(version);
+        ticket.begin();
+        ticket
+    }
+
+    /// Reserves a progress wave that starts when its ticket is begun.
+    pub(crate) fn reserve(&self, version: usize) -> ProgressTicket {
         if !self.inner.enabled.load(Ordering::Acquire) {
             return ProgressTicket::disabled(version);
         }
 
-        let (guard, schedule) = {
+        let guard = {
             let mut active = self.inner.active.lock();
             if !self.inner.enabled.load(Ordering::Acquire) {
                 return ProgressTicket::disabled(version);
@@ -96,7 +104,7 @@ impl ProgressCoordinator {
                 if !self.inner.enabled.load(Ordering::Acquire) {
                     return ProgressTicket::disabled(version);
                 }
-                (Arc::clone(guard), false)
+                Arc::clone(guard)
             } else {
                 // `restart` may have waited for a failing guard that disabled the connection.
                 if !self.inner.enabled.load(Ordering::Acquire) {
@@ -110,13 +118,9 @@ impl ProgressCoordinator {
                     self.inner.timing,
                 ));
                 *active = Some(Arc::clone(&guard));
-                (guard, true)
+                guard
             }
         };
-
-        if schedule {
-            guard.schedule();
-        }
 
         ProgressTicket { guard: Some(guard), version }
     }
@@ -161,6 +165,12 @@ impl ProgressTicket {
         self.guard.is_none()
     }
 
+    pub(crate) fn begin(&self) {
+        if let Some(guard) = &self.guard {
+            guard.schedule(self.version);
+        }
+    }
+
     pub(crate) fn report(&self, message: &'static str) {
         if let Some(guard) = &self.guard {
             guard.report(self.version, message);
@@ -176,6 +186,7 @@ impl ProgressTicket {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Phase {
+    Pending,
     Delayed,
     Creating,
     Begun,
@@ -213,7 +224,7 @@ impl WorkDoneProgressGuard {
             timing,
             state: Mutex::new(ProgressState {
                 version,
-                phase: Phase::Delayed,
+                phase: Phase::Pending,
                 message: None,
                 terminal: None,
                 restart_reported: false,
@@ -222,7 +233,18 @@ impl WorkDoneProgressGuard {
         }
     }
 
-    fn schedule(self: &Arc<Self>) {
+    fn schedule(self: &Arc<Self>, version: usize) {
+        {
+            let mut state = self.state.lock();
+            if !self.enabled.load(Ordering::Acquire)
+                || state.version != version
+                || state.phase != Phase::Pending
+            {
+                return;
+            }
+            state.phase = Phase::Delayed;
+        }
+
         let weak = Arc::downgrade(self);
         let delay = self.timing.delay;
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
@@ -332,7 +354,7 @@ impl WorkDoneProgressGuard {
             } else {
                 state.restart_reported = true;
             }
-        } else if state.message != Some(RESTART_MESSAGE) {
+        } else if state.phase != Phase::Pending && state.message != Some(RESTART_MESSAGE) {
             state.message = Some(RESTART_MESSAGE);
         }
         true
@@ -356,7 +378,7 @@ impl WorkDoneProgressGuard {
             ) {
                 self.disable_locked(&mut state, "failed to enqueue progress report");
             }
-        } else if matches!(state.phase, Phase::Delayed | Phase::Creating) {
+        } else if matches!(state.phase, Phase::Pending | Phase::Delayed | Phase::Creating) {
             state.message = Some(message);
         }
     }
@@ -368,7 +390,7 @@ impl WorkDoneProgressGuard {
         }
 
         match state.phase {
-            Phase::Delayed => {
+            Phase::Pending | Phase::Delayed => {
                 state.phase = Phase::Closed;
                 state.message = None;
             }
@@ -401,7 +423,7 @@ impl WorkDoneProgressGuard {
 
         let result = publish();
         match state.phase {
-            Phase::Delayed => {
+            Phase::Pending | Phase::Delayed => {
                 state.phase = Phase::Closed;
                 state.message = None;
             }
@@ -427,6 +449,11 @@ impl WorkDoneProgressGuard {
     fn created(&self) {
         let mut state = self.state.lock();
         if state.phase != Phase::Creating {
+            return;
+        }
+        if state.terminal.take().is_some() {
+            state.phase = Phase::Closed;
+            state.message = None;
             return;
         }
 
@@ -461,7 +488,7 @@ impl WorkDoneProgressGuard {
 
     fn disable(&self, reason: &str) {
         let mut state = self.state.lock();
-        if !matches!(state.phase, Phase::Delayed | Phase::Creating) {
+        if !matches!(state.phase, Phase::Pending | Phase::Delayed | Phase::Creating) {
             return;
         }
         self.disable_locked(&mut state, reason);
@@ -619,6 +646,7 @@ mod tests {
             1,
             Timing { delay: Duration::ZERO, create_timeout: Duration::from_secs(1) },
         );
+        guard.state.lock().phase = Phase::Delayed;
         assert!(guard.mark_creating());
         guard.finish(1, "first");
         guard.report(1, "ignored");
@@ -628,7 +656,7 @@ mod tests {
     }
 
     #[test]
-    fn finishing_delayed_ticket_discards_pending_message() {
+    fn finishing_pending_ticket_discards_pending_message() {
         let guard = WorkDoneProgressGuard::new(
             ClientSocket::new_closed(),
             Arc::new(AtomicBool::new(true)),
@@ -675,6 +703,46 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert!(!coordinator.is_active_for_test(1));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reserved_ticket_does_not_start_progress_until_begun() {
+        let mut harness = progress_harness();
+        let coordinator = ProgressCoordinator::with_timing(
+            harness.client.clone(),
+            true,
+            Duration::ZERO,
+            Duration::from_secs(1),
+        );
+        let ticket = coordinator.reserve(1);
+
+        harness.probe().await;
+        assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+
+        ticket.begin();
+        let ClientEvent::Create(create) = next_event(&mut harness.events).await else {
+            panic!("expected create request")
+        };
+        let token = create.token;
+        harness.acknowledge_create();
+        assert!(matches!(
+            next_event(&mut harness.events).await,
+            ClientEvent::Progress(ProgressParams {
+                token: actual,
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)),
+            }) if actual == token
+        ));
+
+        ticket.finish("done");
+        assert!(matches!(
+            next_event(&mut harness.events).await,
+            ClientEvent::Progress(ProgressParams {
+                token: actual,
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(_)),
+            }) if actual == token
+        ));
+
+        harness.shutdown().await;
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -999,7 +1067,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn create_timeout_keeps_the_request_alive_for_a_late_success() {
+    async fn late_create_response_after_finish_suppresses_progress() {
         let mut harness = progress_harness();
         let coordinator = ProgressCoordinator::with_timing(
             harness.client.clone(),
@@ -1009,10 +1077,9 @@ mod tests {
         );
         let first = coordinator.start(1);
 
-        let ClientEvent::Create(create) = next_event(&mut harness.events).await else {
+        let ClientEvent::Create(_) = next_event(&mut harness.events).await else {
             panic!("expected create request")
         };
-        let token = create.token;
         tokio::time::timeout(Duration::from_secs(1), async {
             while !first.guard.as_ref().unwrap().create_timed_out_for_test() {
                 tokio::task::yield_now().await;
@@ -1027,26 +1094,9 @@ mod tests {
         latest.finish("done");
 
         harness.acknowledge_create();
-        match next_event(&mut harness.events).await {
-            ClientEvent::Progress(ProgressParams {
-                token: actual,
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)),
-            }) => {
-                assert_eq!(actual, token);
-                assert_eq!(begin.message.as_deref(), Some("done"));
-            }
-            event => panic!("expected late progress begin, got {event:?}"),
-        }
-        match next_event(&mut harness.events).await {
-            ClientEvent::Progress(ProgressParams {
-                token: actual,
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(end)),
-            }) => {
-                assert_eq!(actual, token);
-                assert_eq!(end.message.as_deref(), Some("done"));
-            }
-            event => panic!("expected late progress end, got {event:?}"),
-        }
+        harness.probe().await;
+        assert!(!coordinator.is_active_for_test(2));
+        assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
 
         harness.shutdown().await;
     }
@@ -1059,6 +1109,7 @@ mod tests {
             1,
             Timing { delay: Duration::ZERO, create_timeout: Duration::from_secs(1) },
         ));
+        guard.state.lock().phase = Phase::Delayed;
         assert!(guard.mark_creating());
         guard.finish(1, "obsolete completion");
 

--- a/crates/lsp/src/progress.rs
+++ b/crates/lsp/src/progress.rs
@@ -22,8 +22,6 @@ use std::{
 use tokio::time::sleep;
 
 const PROGRESS_TITLE: &str = "Indexing workspace";
-const PROGRESS_DELAY: Duration = Duration::from_millis(250);
-const CREATE_TIMEOUT: Duration = Duration::from_secs(1);
 const RESTART_MESSAGE: &str = "Workspace changed, restarting analysis";
 
 #[derive(Clone, Copy)]
@@ -46,11 +44,7 @@ struct CoordinatorInner {
 }
 
 impl ProgressCoordinator {
-    pub(crate) fn new(client: ClientSocket, enabled: bool) -> Self {
-        Self::with_timing(client, enabled, PROGRESS_DELAY, CREATE_TIMEOUT)
-    }
-
-    /// Builds a coordinator with explicit timing values for deterministic tests.
+    /// Builds a coordinator with explicit timing values.
     pub(crate) fn with_timing(
         client: ClientSocket,
         enabled: bool,
@@ -799,7 +793,12 @@ mod tests {
 
     #[test]
     fn disabled_coordinator_returns_noop_ticket() {
-        let coordinator = ProgressCoordinator::new(ClientSocket::new_closed(), false);
+        let coordinator = ProgressCoordinator::with_timing(
+            ClientSocket::new_closed(),
+            false,
+            Duration::ZERO,
+            Duration::from_secs(1),
+        );
         let ticket = coordinator.start(1);
         assert!(ticket.is_disabled());
         ticket.report("ignored");
@@ -1180,14 +1179,27 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn quick_and_disabled_work_are_silent() {
         let mut harness = progress_harness();
-        let quick = ProgressCoordinator::new(harness.client.clone(), true).start(1);
+        let delay = Duration::from_millis(250);
+        let quick = ProgressCoordinator::with_timing(
+            harness.client.clone(),
+            true,
+            delay,
+            Duration::from_secs(1),
+        )
+        .start(1);
         quick.report("quick");
         quick.finish("done");
-        let disabled = ProgressCoordinator::new(harness.client.clone(), false).start(2);
+        let disabled = ProgressCoordinator::with_timing(
+            harness.client.clone(),
+            false,
+            delay,
+            Duration::from_secs(1),
+        )
+        .start(2);
         disabled.report("ignored");
         disabled.finish("ignored");
 
-        sleep(PROGRESS_DELAY + Duration::from_millis(50)).await;
+        sleep(delay + Duration::from_millis(50)).await;
         harness.probe().await;
         assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
 

--- a/crates/lsp/src/progress.rs
+++ b/crates/lsp/src/progress.rs
@@ -724,6 +724,7 @@ mod tests {
             Duration::from_secs(1),
         );
         let ticket = coordinator.start(1);
+        tokio::task::yield_now().await;
 
         tokio::time::advance(delay - Duration::from_millis(1)).await;
         ticket.finish("done");
@@ -744,10 +745,12 @@ mod tests {
             Duration::from_secs(1),
         );
         let first = coordinator.start(1);
+        tokio::task::yield_now().await;
 
         tokio::time::advance(delay / 2).await;
         let latest = coordinator.start(2);
         assert!(!Arc::ptr_eq(first.guard.as_ref().unwrap(), latest.guard.as_ref().unwrap()));
+        tokio::task::yield_now().await;
 
         tokio::time::advance(delay / 2).await;
         tokio::task::yield_now().await;

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -1342,6 +1342,33 @@ fn watched_solidity_change_tracks_the_source_until_analysis_publishes() {
 }
 
 #[test]
+fn watched_solidity_change_ignores_open_document() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Request.sol open
+        contract Request {}
+        "#,
+    );
+    let path = project.path("/Request.sol");
+    let uri = Url::from_file_path(path).unwrap();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config());
+    state.vfs = Arc::new(RwLock::new(project.vfs()));
+    let version = state.analysis_version.load(Ordering::Acquire);
+
+    let result = crate::handlers::did_change_watched_files(
+        &mut state,
+        DidChangeWatchedFilesParams {
+            changes: vec![FileEvent { uri, typ: FileChangeType::CHANGED }],
+        },
+    );
+
+    assert!(matches!(result, ControlFlow::Continue(())));
+    assert_eq!(state.analysis_version.load(Ordering::Acquire), version);
+    assert!(state.analysis_scheduler.tasks.lock().coordinator.is_none());
+}
+
+#[test]
 fn did_change_tracks_the_request_source_until_analysis_publishes() {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -78,6 +78,10 @@ impl WorkDoneHarness {
         self.create_ack.take().expect("one create acknowledgement").send(()).unwrap();
     }
 
+    async fn probe(&self) {
+        self.client.request::<request::Shutdown>(()).await.unwrap();
+    }
+
     async fn shutdown(self) {
         self.server.notify::<notification::Exit>(()).unwrap();
         assert!(self.server_task.await.unwrap().is_ok());
@@ -106,6 +110,7 @@ fn work_done_harness() -> WorkDoneHarness {
                 Ok(())
             }
         });
+        router.request::<request::Shutdown, _>(|_, ()| async { Ok(()) });
         router.notification::<notification::Progress>(|state, params| {
             state.events.send(WorkDoneEvent::Progress(params)).unwrap();
             ControlFlow::Continue(())
@@ -625,6 +630,7 @@ async fn clearing_analysis_cache_publishes_before_ending_progress() {
 
     let (_, progress) =
         state.begin_analysis(AnalysisMode::Recompute, Vec::new(), Vec::new()).unwrap();
+    progress.begin();
     progress.report("Analyzing workspace");
     let WorkDoneEvent::Create(create) = harness.next_event().await else {
         panic!("expected progress creation")
@@ -666,7 +672,7 @@ async fn clearing_analysis_cache_publishes_before_ending_progress() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn clearing_analysis_cache_supersedes_a_pending_progress_end() {
+async fn clearing_analysis_cache_suppresses_progress_pending_creation() {
     let project = TestProject::from_fixture(
         r#"
         //- /Cleared.sol
@@ -687,10 +693,10 @@ async fn clearing_analysis_cache_supersedes_a_pending_progress_end() {
 
     let (_, progress) =
         state.begin_analysis(AnalysisMode::Recompute, Vec::new(), Vec::new()).unwrap();
-    let WorkDoneEvent::Create(create) = harness.next_event().await else {
+    progress.begin();
+    let WorkDoneEvent::Create(_) = harness.next_event().await else {
         panic!("expected progress creation")
     };
-    let token = create.token;
     progress.report("obsolete analysis");
     progress.finish("obsolete completion");
 
@@ -704,26 +710,8 @@ async fn clearing_analysis_cache_supersedes_a_pending_progress_end() {
         event => panic!("expected cleared diagnostics, got {event:?}"),
     }
     harness.acknowledge_create();
-    match harness.next_event().await {
-        WorkDoneEvent::Progress(ProgressParams {
-            token: actual,
-            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)),
-        }) => {
-            assert_eq!(actual, token);
-            assert_eq!(begin.message.as_deref(), Some("Workspace index cleared"));
-        }
-        event => panic!("expected progress begin, got {event:?}"),
-    }
-    match harness.next_event().await {
-        WorkDoneEvent::Progress(ProgressParams {
-            token: actual,
-            value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(end)),
-        }) => {
-            assert_eq!(actual, token);
-            assert_eq!(end.message.as_deref(), Some("Workspace index cleared"));
-        }
-        event => panic!("expected progress end, got {event:?}"),
-    }
+    harness.probe().await;
+    assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
 
     harness.shutdown().await;
 }
@@ -746,6 +734,7 @@ async fn superseded_analysis_cannot_publish_or_end_latest_progress() {
     let (stale_version, stale_progress) =
         state.begin_analysis(AnalysisMode::Recompute, Vec::new(), Vec::new()).unwrap();
     let mut stale_snapshot = state.snapshot();
+    stale_progress.begin();
     let WorkDoneEvent::Create(create) = harness.next_event().await else {
         panic!("expected progress creation")
     };
@@ -875,31 +864,29 @@ async fn failed_current_analysis_ends_visible_progress() {
         ProgressCoordinator::with_timing(client, true, Duration::ZERO, Duration::from_secs(1));
     let (version, progress) =
         state.begin_analysis(AnalysisMode::Recompute, Vec::new(), Vec::new()).unwrap();
+    progress.begin();
 
     let WorkDoneEvent::Create(create) = harness.next_event().await else {
         panic!("expected progress creation")
     };
     let token = create.token;
+    harness.acknowledge_create();
+    assert!(matches!(
+        harness.next_event().await,
+        WorkDoneEvent::Progress(ProgressParams {
+            token: actual,
+            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(_)),
+        }) if actual == token
+    ));
+
     let task = tokio::spawn(async { panic!("test analysis failure") });
     state.monitor_analysis_task(version, task, progress);
-
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
         .await
         .expect("failed analysis should publish its terminal version")
         .unwrap();
     assert!(state.analysis_cache_invalidated());
-    harness.acknowledge_create();
 
-    match harness.next_event().await {
-        WorkDoneEvent::Progress(ProgressParams {
-            token: actual,
-            value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(begin)),
-        }) => {
-            assert_eq!(actual, token);
-            assert_eq!(begin.message.as_deref(), Some("Workspace indexing failed"));
-        }
-        event => panic!("expected progress begin, got {event:?}"),
-    }
     match harness.next_event().await {
         WorkDoneEvent::Progress(ProgressParams {
             token: actual,
@@ -1365,6 +1352,44 @@ fn configuration_change_invalidates_natspec_context_until_analysis_publishes() {
             .unwrap();
         assert!(state.natspec_semantics_are_usable(&request_uri));
     });
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn source_change_debounce_does_not_count_toward_progress_delay() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Request.sol open
+        contract Before {}
+        "#,
+    );
+    let uri = Url::from_file_path(project.path("/Request.sol")).unwrap();
+    let mut harness = work_done_harness();
+    let client = harness.client.clone();
+    let mut state = GlobalState::new(client.clone());
+    state.config = Arc::new(project.config());
+    state.vfs = Arc::new(RwLock::new(project.vfs()));
+    state.analysis_progress =
+        ProgressCoordinator::with_timing(client, true, Duration::ZERO, Duration::from_secs(1));
+
+    let result = crate::handlers::did_change_text_document(
+        &mut state,
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier::new(uri, 1),
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "contract After {}".into(),
+            }],
+        },
+    );
+    assert!(matches!(result, ControlFlow::Continue(())));
+
+    tokio::time::sleep(state.config.source_change_debounce() / 2).await;
+    harness.probe().await;
+    assert!(matches!(harness.events.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+
+    state.clear_analysis_cache();
+    harness.shutdown().await;
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -1367,6 +1367,70 @@ fn configuration_change_invalidates_natspec_context_until_analysis_publishes() {
     });
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn rapid_did_changes_debounce_to_the_latest_source() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /Request.sol open
+        contract Before {}
+        "#,
+    );
+    let path = project.path("/Request.sol");
+    let uri = Url::from_file_path(&path).unwrap();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(project.config());
+    state.vfs = Arc::new(RwLock::new(project.vfs()));
+
+    let result = crate::handlers::did_change_text_document(
+        &mut state,
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier::new(uri.clone(), 1),
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "contract Intermediate {}".into(),
+            }],
+        },
+    );
+    assert!(matches!(result, ControlFlow::Continue(())));
+    let first_coordinator =
+        state.analysis_scheduler.tasks.lock().coordinator.as_ref().unwrap().1.clone();
+
+    let result = crate::handlers::did_change_text_document(
+        &mut state,
+        DidChangeTextDocumentParams {
+            text_document: VersionedTextDocumentIdentifier::new(uri, 2),
+            content_changes: vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: "contract Latest {}".into(),
+            }],
+        },
+    );
+    assert!(matches!(result, ControlFlow::Continue(())));
+    let debounce = state.config.source_change_debounce();
+
+    assert!(
+        tokio::time::timeout(debounce / 2, state.latest_analysis()).await.is_err(),
+        "analysis should remain pending during the debounce window"
+    );
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, async {
+        while !first_coordinator.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replacement should cancel the first coordinator");
+
+    let tables = tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("latest source analysis should finish")
+        .unwrap();
+    let tables = tables.read();
+    assert!(tables.workspace_symbols("Intermediate").is_empty());
+    assert!(tables.workspace_symbols("Latest").iter().any(|symbol| symbol.name == "Latest"));
+}
+
 #[test]
 fn pending_request_source_defers_to_target_specific_natspec_lookup() {
     let project = TestProject::new();

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -92,7 +92,7 @@ fn find_foundry_toml_in_child_dirs(
 fn is_heavy_dir(path: &Path) -> bool {
     matches!(
         path.file_name().and_then(|name| name.to_str()),
-        Some(".git" | "cache" | "lib" | "node_modules" | "out")
+        Some(".git" | "cache" | "lib" | "node_modules" | "out" | "target")
     )
 }
 


### PR DESCRIPTION
Frequent document changes currently start a full-workspace analysis for every edit, allowing blocking workers to accumulate and saturate the CPU. This makes analysis single-flight, replaces stale pending work with the newest snapshot, and waits 250 ms after source changes before starting another run.

Work-done progress starts only after the current analysis acquires the scheduler and stays silent unless that analysis is still active after 100 ms. Replacing an invisible analysis resets the progress delay, so quick or superseded work does not flash in the editor.

The LSP runtime timings now live in its existing `Config` and are passed to analysis, progress, formatting, and flycheck. The workspace scanner also treats Foundry's `target` directory as expensive so initialization avoids traversing generated artifacts.

Forge lint parsing now accepts non-diagnostic JSON records, collects diagnostics from both output streams, and ignores plain Foundry warnings mixed with JSON output.
