### PR TITLE
fix(lsp): add missing symbol hovers

### DIFF
--- a/crates/codegen/src/lower/abi_packed.rs
+++ b/crates/codegen/src/lower/abi_packed.rs
@@ -453,7 +453,7 @@ impl<'gcx> Lowerer<'gcx> {
         let ExprKind::Member(base, member) = &callee.kind else {
             return None;
         };
-        matches!(self.ident_builtin(base), Some(Builtin::Abi))
+        (self.gcx.resolved_builtin(base) == Some(Builtin::Abi))
             .then_some(args)
             .filter(|_| member.name == name)
     }

--- a/crates/codegen/src/lower/bytes.rs
+++ b/crates/codegen/src/lower/bytes.rs
@@ -281,11 +281,11 @@ impl<'gcx> Lowerer<'gcx> {
 
     /// Whether an assignment target wants a MEMORY dynamic-array value.
     pub(super) fn lhs_expects_memory_dyn_array_value(&self, lhs: &hir::Expr<'_>) -> bool {
-        let ExprKind::Ident(res_slice) = &lhs.kind else { return false };
-        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+        let Some(var_id) = self.gcx.resolved_variable(lhs) else {
             return false;
         };
-        self.var_expects_memory_dyn_array_value(self.gcx.hir.variable(*var_id))
+        let var = self.gcx.hir.variable(var_id);
+        !var.is_struct_member() && self.var_expects_memory_dyn_array_value(var)
     }
 
     /// Lowers an expression whose consumer needs a MEMORY dynamic array: a
@@ -587,9 +587,8 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     pub(super) fn lhs_expects_memory_bytes_value(&self, lhs: &hir::Expr<'_>) -> bool {
-        if let ExprKind::Ident(res_slice) = &lhs.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-            && self.gcx.hir.variable(*var_id).data_location
+        if let Some(var_id) = self.gcx.resolved_variable(lhs)
+            && self.gcx.hir.variable(var_id).data_location
                 == Some(solar_ast::DataLocation::Calldata)
         {
             return false;
@@ -598,11 +597,10 @@ impl<'gcx> Lowerer<'gcx> {
             return true;
         }
 
-        let ExprKind::Ident(res_slice) = &lhs.kind else { return false };
-        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
+        let Some(var_id) = self.gcx.resolved_variable(lhs) else {
             return false;
         };
-        let var = self.gcx.hir.variable(*var_id);
+        let var = self.gcx.hir.variable(var_id);
         self.var_expects_memory_bytes_value(var)
     }
 
@@ -780,12 +778,10 @@ impl<'gcx> Lowerer<'gcx> {
         if !self.is_dynamic_bytes_expr(expr) {
             return false;
         }
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
+        if let Some(var_id) = self.gcx.resolved_variable(expr) {
             // Storage bytes and calldata bytes have dedicated paths.
-            return !self.storage_slots.contains_key(var_id)
-                && self.gcx.hir.variable(*var_id).data_location
+            return !self.storage_slots.contains_key(&var_id)
+                && self.gcx.hir.variable(var_id).data_location
                     != Some(solar_ast::DataLocation::Calldata);
         }
         true
@@ -794,11 +790,9 @@ impl<'gcx> Lowerer<'gcx> {
     /// Whether an expression is a storage `bytes`/`string` state variable, whose value
     /// lowers to a packed `[length][data...]` memory copy.
     pub(super) fn is_storage_bytes_expr(&self, expr: &hir::Expr<'_>) -> bool {
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
-            return self.storage_slots.contains_key(var_id)
+        if let Some(var_id) = self.gcx.resolved_variable(expr) {
+            let var = self.gcx.hir.variable(var_id);
+            return self.storage_slots.contains_key(&var_id)
                 && matches!(
                     var.ty.kind,
                     hir::TypeKind::Elementary(
@@ -924,8 +918,7 @@ impl<'gcx> Lowerer<'gcx> {
         // Handle the abi.encode* family.
         if let ExprKind::Call(callee, args, _) = &expr.kind
             && let ExprKind::Member(base, member) = &callee.kind
-            && let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Builtin(Builtin::Abi)) = res_slice.first()
+            && self.gcx.resolved_builtin(base) == Some(Builtin::Abi)
         {
             match member.name {
                 sym::encodePacked => {
@@ -1076,13 +1069,17 @@ impl<'gcx> Lowerer<'gcx> {
     /// Whether lowering `expr` yields a memory `bytes`/`string` pointer
     /// (`[length][data...]`).
     pub(super) fn expr_yields_memory_bytes(&self, expr: &hir::Expr<'_>) -> bool {
-        // Calldata- and storage-located values lower to their ABI head or
-        // storage slot, not to a memory pointer.
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
-            if var.data_location != Some(solar_ast::DataLocation::Memory) {
+        // Calldata- and storage-located declarations lower to their ABI head
+        // or storage slot, not to a memory pointer. Struct fields inherit their
+        // location from the surrounding expression type.
+        if let Some(var_id) = self.gcx.resolved_variable(expr) {
+            let var = self.gcx.hir.variable(var_id);
+            if var.is_state_variable()
+                || matches!(
+                    var.data_location,
+                    Some(solar_ast::DataLocation::Calldata | solar_ast::DataLocation::Storage)
+                )
+            {
                 return false;
             }
         }

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -38,7 +38,7 @@ impl<'gcx> Lowerer<'gcx> {
         args: &CallArgs<'_>,
         call_opts: Option<&[hir::NamedArg<'_>]>,
     ) -> ValueId {
-        if let Some(builtin) = self.gcx.builtin_callee(callee.id) {
+        if let Some(builtin) = self.gcx.resolved_builtin(callee) {
             // `T.wrap(x)` / `T.unwrap(v)` for a user-defined value type are identity
             // operations at the EVM level: a UDVT value is represented exactly as its
             // underlying type, so no wrapper is added or removed.
@@ -61,9 +61,7 @@ impl<'gcx> Lowerer<'gcx> {
         if let Some(TyKind::Fn(function)) = self.get_expr_type(callee).map(|ty| ty.kind)
             && function.is_internal()
             && function.function_id.is_none()
-            && !self.gcx.resolved_callee(callee.id).is_some_and(|resolved| {
-                matches!(resolved.res, hir::Res::Item(hir::ItemId::Function(_)))
-            })
+            && self.gcx.resolved_function(callee).is_none()
         {
             return self.lower_internal_function_pointer_call(builder, callee, args, function);
         }
@@ -82,10 +80,7 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         // Handle internal function calls: func(args) where func is a function in the same contract
-        if let ExprKind::Ident(_) = &callee.kind
-            && let Some(resolved) = self.gcx.resolved_callee(callee.id)
-            && let hir::Res::Item(item_id) = resolved.res
-        {
+        if let Some(hir::Res::Item(item_id)) = self.gcx.resolved_expr(callee) {
             match item_id {
                 hir::ItemId::Function(func_id) => {
                     return self.lower_internal_call(builder, func_id, args);
@@ -327,9 +322,7 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     fn custom_error_id_from_callee(&self, callee: &hir::Expr<'_>) -> Option<hir::ErrorId> {
-        if let Some(resolved) = self.gcx.resolved_callee(callee.id)
-            && let hir::Res::Item(hir::ItemId::Error(error_id)) = resolved.res
-        {
+        if let Some(hir::Res::Item(hir::ItemId::Error(error_id))) = self.gcx.resolved_expr(callee) {
             return Some(error_id);
         }
 
@@ -1215,7 +1208,7 @@ impl<'gcx> Lowerer<'gcx> {
         call_opts: Option<&[hir::NamedArg<'_>]>,
     ) -> ValueId {
         let resolved = self.gcx.resolved_callee(callee.id);
-        let builtin = self.gcx.builtin_callee(callee.id);
+        let builtin = self.gcx.resolved_builtin(callee);
 
         if let Some(builtin) = builtin
             && Self::builtin_uses_direct_call_lowering(builtin)
@@ -1542,9 +1535,7 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     fn resolved_function_callee(&self, callee: &hir::Expr<'_>) -> Option<hir::FunctionId> {
-        let resolved = self.gcx.resolved_callee(callee.id)?;
-        let hir::Res::Item(hir::ItemId::Function(func_id)) = resolved.res else { return None };
-        Some(func_id)
+        self.gcx.resolved_function(callee)
     }
 
     fn is_library_type_expr(&self, expr: &hir::Expr<'_>) -> bool {
@@ -1632,11 +1623,9 @@ impl<'gcx> Lowerer<'gcx> {
             None
         };
 
-        // Case 1: base is an identifier (variable with contract type)
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
+        // Case 1: base resolves to a variable with contract type.
+        if let Some(var_id) = self.gcx.resolved_variable(base) {
+            let var = self.gcx.hir.variable(var_id);
             let ty = self.gcx.type_of_hir_ty(&var.ty);
             if let solar_sema::ty::TyKind::Contract(contract_id) = ty.kind
                 && let Some(sel) = lookup_in_contract(contract_id)
@@ -1648,25 +1637,24 @@ impl<'gcx> Lowerer<'gcx> {
         // Case 2: base is a type conversion call like ICallee(addr)
         // The call's callee is an Ident resolving to a Contract/Interface
         if let ExprKind::Call(callee, _args, _named) = &base.kind
-            && let ExprKind::Ident(res_slice) = &callee.kind
-            && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) = res_slice.first()
-            && let Some(sel) = lookup_in_contract(*contract_id)
+            && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) =
+                self.gcx.resolved_expr(callee)
+            && let Some(sel) = lookup_in_contract(contract_id)
         {
             return sel;
         }
 
         // Case 2b: base is the contract/interface name itself, e.g.
         // `IERC20Minimal.transfer.selector`.
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) = res_slice.first()
-            && let Some(sel) = lookup_in_contract(*contract_id)
+        if let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) =
+            self.gcx.resolved_expr(base)
+            && let Some(sel) = lookup_in_contract(contract_id)
         {
             return sel;
         }
 
         // Case 3: base is `this` (Builtin::This)
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Builtin(Builtin::This)) = res_slice.first()
+        if self.gcx.resolved_builtin(base) == Some(Builtin::This)
             && let Some(contract_id) = self.current_contract_id
             && let Some(sel) = lookup_in_contract(contract_id)
         {
@@ -1721,11 +1709,9 @@ impl<'gcx> Lowerer<'gcx> {
             None
         };
 
-        // Case 1: base is an identifier (variable with contract type)
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
+        // Case 1: base resolves to a variable with contract type.
+        if let Some(var_id) = self.gcx.resolved_variable(base) {
+            let var = self.gcx.hir.variable(var_id);
             let ty = self.gcx.type_of_hir_ty(&var.ty);
             if let solar_sema::ty::TyKind::Contract(contract_id) = ty.kind
                 && let Some(count) = lookup_in_contract(contract_id)
@@ -1736,17 +1722,15 @@ impl<'gcx> Lowerer<'gcx> {
 
         // Case 2: base is a type conversion call like ICallee(addr)
         if let ExprKind::Call(callee, _args, _named) = &base.kind
-            && let ExprKind::Ident(res_slice) = &callee.kind
-            && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) = res_slice.first()
-            && let Some(count) = lookup_in_contract(*contract_id)
+            && let Some(hir::Res::Item(hir::ItemId::Contract(contract_id))) =
+                self.gcx.resolved_expr(callee)
+            && let Some(count) = lookup_in_contract(contract_id)
         {
             return count;
         }
 
         // Case 3: base is `this` (Builtin::This)
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Builtin(Builtin::This)) = res_slice.first()
-        {
+        if self.gcx.resolved_builtin(base) == Some(Builtin::This) {
             // Look up the function in the current contract
             // We need to find it through the module's functions
             // Search all known contracts because `this` carries the current

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -48,15 +48,10 @@ impl<'gcx> Lowerer<'gcx> {
                 self.lower_literal(builder, lit)
             }
 
-            ExprKind::Ident(res_slice) => {
-                if res_slice.is_empty() {
-                    builder.imm_u64(0)
-                } else if let Some(res) = self.ident_res(expr) {
+            ExprKind::Ident(_) => {
+                if let Some(res) = self.gcx.resolved_expr(expr) {
                     self.lower_ident(builder, &res)
                 } else {
-                    // The raw resolution set is ambiguous (an overloaded
-                    // function or event referenced as a value); the type
-                    // checker records disambiguation only for callees.
                     self.err_value(
                         builder,
                         expr.span,
@@ -185,7 +180,7 @@ impl<'gcx> Lowerer<'gcx> {
             }
 
             ExprKind::Member(base, member) => {
-                if let Some(builtin) = self.resolved_builtin_member(expr) {
+                if let Some(builtin) = self.gcx.resolved_builtin(expr) {
                     match builtin {
                         // Handle address member access: addr.balance
                         Builtin::AddressBalance => {
@@ -267,7 +262,7 @@ impl<'gcx> Lowerer<'gcx> {
                 if let Some(TyKind::Fn(function)) = self.get_expr_type(expr).map(|ty| ty.kind)
                     && function.is_internal()
                     && let Some(hir::Res::Item(hir::ItemId::Function(function_id))) =
-                        self.resolved_member(expr)
+                        self.gcx.resolved_expr(expr)
                 {
                     self.internal_function_pointer_targets.insert(function_id);
                     return builder.imm_u64(Self::internal_function_pointer_id(function_id));
@@ -275,7 +270,7 @@ impl<'gcx> Lowerer<'gcx> {
 
                 // Handle contract/library constants (e.g. MachineLib.NO_RECOVERY_PC).
                 if let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) =
-                    self.resolved_member(expr)
+                    self.gcx.resolved_expr(expr)
                 {
                     let var = self.gcx.hir.variable(var_id);
                     if var.is_constant()
@@ -473,12 +468,12 @@ impl<'gcx> Lowerer<'gcx> {
                 // Deleting a memory fixed-size array zeroes its elements in
                 // place; nulling the pointer would alias scratch memory on the
                 // next access. Storage targets keep the assignment path.
-                if let Some(var_id) = self.ident_variable(target)
-                    && !self.storage_ref_locals.contains(var_id)
-                    && !self.storage_slots.contains_key(&var_id)
-                {
+                if let Some(var_id) = self.gcx.resolved_variable(target) {
                     let var = self.gcx.hir.variable(var_id);
-                    if self.is_fixed_memory_array_type(&var.ty, var.data_location)
+                    if var.is_local_variable()
+                        && !self.storage_ref_locals.contains(var_id)
+                        && !self.storage_slots.contains_key(&var_id)
+                        && self.is_fixed_memory_array_type(&var.ty, var.data_location)
                         && let Some(len) = self.fixed_memory_array_len(&var.ty)
                         && let hir::TypeKind::Array(array) = &var.ty.kind
                     {
@@ -747,7 +742,7 @@ impl<'gcx> Lowerer<'gcx> {
         base: &hir::Expr<'_>,
         member: Ident,
     ) -> ValueId {
-        let Some(var_id) = self.ident_variable(base) else {
+        let Some(var_id) = self.gcx.resolved_variable(base) else {
             return self.err_value(
                 builder,
                 member.span,
@@ -852,8 +847,8 @@ impl<'gcx> Lowerer<'gcx> {
                     let LitKind::Str(_, bytes, _) = &lit.kind else { return None };
                     return Some(bytes.as_byte_str().to_vec());
                 }
-                ExprKind::Ident([hir::Res::Item(hir::ItemId::Variable(var_id))]) => {
-                    let var = self.gcx.hir.variable(*var_id);
+                ExprKind::Ident(_) => {
+                    let var = self.gcx.hir.variable(self.gcx.resolved_variable(expr)?);
                     if !var.is_constant() {
                         return None;
                     }
@@ -861,7 +856,7 @@ impl<'gcx> Lowerer<'gcx> {
                 }
                 ExprKind::Member(..) => {
                     let hir::Res::Item(hir::ItemId::Variable(var_id)) =
-                        self.resolved_member(expr)?
+                        self.gcx.resolved_expr(expr)?
                     else {
                         return None;
                     };
@@ -999,7 +994,7 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     fn lower_resolved_function_selector(&self, expr: &hir::Expr<'_>) -> Option<u32> {
-        let hir::Res::Item(item_id) = self.resolved_member(expr)? else {
+        let hir::Res::Item(item_id) = self.gcx.resolved_expr(expr)? else {
             return None;
         };
         match item_id {
@@ -1010,7 +1005,7 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     fn lower_resolved_event_selector(&self, expr: &hir::Expr<'_>) -> Option<U256> {
-        let hir::Res::Item(hir::ItemId::Event(event_id)) = self.resolved_member(expr)? else {
+        let hir::Res::Item(hir::ItemId::Event(event_id)) = self.gcx.resolved_expr(expr)? else {
             return None;
         };
         Some(U256::from_be_bytes(self.gcx.event_selector(event_id).0))
@@ -1335,24 +1330,24 @@ impl<'gcx> Lowerer<'gcx> {
         rhs: ValueId,
     ) {
         match &lhs.kind {
-            ExprKind::Ident(res_slice) => {
-                if let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() {
-                    let var = self.gcx.hir.variable(*var_id);
+            ExprKind::Ident(_) => {
+                if let Some(var_id) = self.gcx.resolved_variable(lhs) {
+                    let var = self.gcx.hir.variable(var_id);
 
                     // Check if it's a local variable stored in memory
-                    if let Some(offset) = self.get_local_memory_offset(var_id) {
-                        if self.is_slice_slot_local(var_id) {
+                    if let Some(offset) = self.get_local_memory_offset(&var_id) {
+                        if self.is_slice_slot_local(&var_id) {
                             self.store_slice_slot(builder, offset, rhs);
                             return;
                         }
                         let offset_val = self.local_memory_addr(builder, offset);
                         builder.mstore(offset_val, rhs);
-                    } else if self.locals.contains_key(var_id) {
+                    } else if let Some(local) = self.locals.get_mut(&var_id) {
                         // Function parameter - update SSA mapping (shouldn't happen normally)
-                        self.locals.insert(*var_id, rhs);
-                    } else if let Some(&offset) = self.immutable_slots.get(var_id) {
+                        *local = rhs;
+                    } else if let Some(&offset) = self.immutable_slots.get(&var_id) {
                         self.store_immutable_value(builder, offset, rhs);
-                    } else if let Some(&location) = self.storage_locations.get(var_id) {
+                    } else if let Some(&location) = self.storage_locations.get(&var_id) {
                         let base_slot = location.slot;
                         // Check if this is a struct assignment (memory struct -> storage struct)
                         if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &var.ty.kind
@@ -1467,11 +1462,10 @@ impl<'gcx> Lowerer<'gcx> {
                 // is modeled as an SSA slot in `locals`, marked as a storage ref so
                 // later `r.field` access resolves to `sload`/`sstore(slot + off)`.
                 if member.name == sym::slot
-                    && let ExprKind::Ident(res_slice) = &base.kind
-                    && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
+                    && let Some(var_id) = self.gcx.resolved_variable(base)
                 {
-                    self.locals.insert(*var_id, rhs);
-                    self.storage_ref_locals.insert(*var_id);
+                    self.locals.insert(var_id, rhs);
+                    self.storage_ref_locals.insert(var_id);
                     return;
                 }
                 // `d.offset := x` / `d.length := x` on a `bytes`/`string` calldata
@@ -1480,7 +1474,7 @@ impl<'gcx> Lowerer<'gcx> {
                 // the update; this is the `bytes calldata` empty/sub-slice idiom
                 // (`data.length := 0`) used to build calldata slices in assembly.
                 if matches!(member.name, sym::offset | sym::length)
-                    && let Some(var_id) = self.ident_variable(base)
+                    && let Some(var_id) = self.gcx.resolved_variable(base)
                     && Self::calldata_dynamic_var_kind(self.gcx.hir.variable(var_id)).is_some()
                 {
                     // A reassignable slice lives in a two-word slot; a
@@ -1678,15 +1672,13 @@ impl<'gcx> Lowerer<'gcx> {
 
     /// Checks if an expression is a mapping state variable and returns its var_id and storage slot.
     fn get_mapping_base_slot(&self, expr: &hir::Expr<'_>) -> Option<(hir::VariableId, u64)> {
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
+        if let Some(var_id) = self.gcx.resolved_variable(expr) {
+            let var = self.gcx.hir.variable(var_id);
             // Check if this variable has mapping type
             if matches!(var.ty.kind, hir::TypeKind::Mapping(_)) {
                 // Look up the storage slot
-                if let Some(&slot) = self.storage_slots.get(var_id) {
-                    return Some((*var_id, slot));
+                if let Some(&slot) = self.storage_slots.get(&var_id) {
+                    return Some((var_id, slot));
                 }
             }
         }
@@ -1784,7 +1776,7 @@ impl<'gcx> Lowerer<'gcx> {
 
     /// Whether an expression is `msg.data`.
     pub(super) fn expr_is_msg_data(&self, expr: &hir::Expr<'_>) -> bool {
-        matches!(self.resolved_builtin_member(expr), Some(Builtin::MsgData))
+        matches!(self.gcx.resolved_builtin(expr), Some(Builtin::MsgData))
     }
 
     /// Resolves a calldata bytes/array base to its logical slice: an
@@ -1828,21 +1820,18 @@ impl<'gcx> Lowerer<'gcx> {
         builder: &mut FunctionBuilder<'_>,
         expr: &hir::Expr<'_>,
     ) -> Option<(ValueId, bool)> {
-        let ExprKind::Ident(res_slice) = &expr.kind else { return None };
-        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
-            return None;
-        };
-        let var = self.gcx.hir.variable(*var_id);
+        let var_id = self.gcx.resolved_variable(expr)?;
+        let var = self.gcx.hir.variable(var_id);
         if var.data_location != Some(solar_ast::DataLocation::Calldata) {
             return None;
         }
         let is_bytes = Self::calldata_dynamic_var_kind(var)?;
-        if self.is_slice_slot_local(var_id) {
-            let offset = self.get_local_memory_offset(var_id)?;
+        if self.is_slice_slot_local(&var_id) {
+            let offset = self.get_local_memory_offset(&var_id)?;
             let slice = self.load_slice_slot(builder, offset, crate::mir::SliceLocation::Calldata);
             return Some((slice, is_bytes));
         }
-        let slice = self.locals.get(var_id).copied()?;
+        let slice = self.locals.get(&var_id).copied()?;
         Some((slice, is_bytes))
     }
 
@@ -1861,12 +1850,9 @@ impl<'gcx> Lowerer<'gcx> {
 
     /// Returns the constant length of a fixed-size array expression, if its type is known.
     pub(super) fn fixed_array_len_of_expr(&self, expr: &hir::Expr<'_>) -> Option<u64> {
-        // Identifier: use the variable's declared type directly; `get_expr_type` may not
-        // resolve every local.
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
+        // Use the variable's declared type directly; `get_expr_type` may not resolve every local.
+        if let Some(var_id) = self.gcx.resolved_variable(expr) {
+            let var = self.gcx.hir.variable(var_id);
             if let hir::TypeKind::Array(arr) = &var.ty.kind {
                 arr.size.as_ref()?;
                 if let solar_sema::ty::TyKind::Array(_, len) =
@@ -2171,14 +2157,11 @@ impl<'gcx> Lowerer<'gcx> {
         base: &hir::Expr<'_>,
         member: Ident,
     ) -> Option<(u64, hir::StructId, usize)> {
-        // The base must be an identifier resolving to a variable with struct type
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
+        if let Some(var_id) = self.gcx.resolved_variable(base) {
+            let var = self.gcx.hir.variable(var_id);
             // Check if the variable has a struct type and is stored in storage
             if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &var.ty.kind
-                && let Some(&base_slot) = self.struct_storage_base_slots.get(var_id)
+                && let Some(&base_slot) = self.struct_storage_base_slots.get(&var_id)
             {
                 // Find the field index by name
                 let strukt = self.gcx.hir.strukt(*struct_id);
@@ -2202,11 +2185,10 @@ impl<'gcx> Lowerer<'gcx> {
         base: &hir::Expr<'_>,
         member: Ident,
     ) -> Option<(hir::VariableId, hir::StructId, usize)> {
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-            && self.storage_ref_locals.contains(*var_id)
+        if let Some(var_id) = self.gcx.resolved_variable(base)
+            && self.storage_ref_locals.contains(var_id)
             && let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) =
-                &self.gcx.hir.variable(*var_id).ty.kind
+                &self.gcx.hir.variable(var_id).ty.kind
         {
             let strukt = self.gcx.hir.strukt(*struct_id);
             for (i, &field_id) in strukt.fields.iter().enumerate() {
@@ -2214,7 +2196,7 @@ impl<'gcx> Lowerer<'gcx> {
                 if let Some(field_name) = field.name
                     && field_name.name == member.name
                 {
-                    return Some((*var_id, *struct_id, i));
+                    return Some((var_id, *struct_id, i));
                 }
             }
         }
@@ -2222,24 +2204,21 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     /// Resolves the struct type of an expression, for storage struct field
-    /// access. Uses the variable's declared type directly for an identifier and
-    /// the inferred expression type otherwise (e.g. a mapping/array element).
+    /// access. Uses the variable's declared type when available and the inferred
+    /// expression type otherwise (e.g. a mapping/array element).
     pub(super) fn struct_id_of_expr(&self, expr: &hir::Expr<'_>) -> Option<hir::StructId> {
-        // Identifier: use the variable's declared type.
-        if let ExprKind::Ident(res) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(vid))) = res.first()
+        if let Some(vid) = self.gcx.resolved_variable(expr)
             && let hir::TypeKind::Custom(hir::ItemId::Struct(sid)) =
-                &self.gcx.hir.variable(*vid).ty.kind
+                &self.gcx.hir.variable(vid).ty.kind
         {
             return Some(*sid);
         }
         // Indexed element (`items[k]`, `arr[i]`): the mapping value / array
         // element type, resolved from the indexed variable's declared type.
         if let ExprKind::Index(arr, _) = &expr.kind
-            && let ExprKind::Ident(res) = &arr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(vid))) = res.first()
+            && let Some(vid) = self.gcx.resolved_variable(arr)
         {
-            let elem_kind = match &self.gcx.hir.variable(*vid).ty.kind {
+            let elem_kind = match &self.gcx.hir.variable(vid).ty.kind {
                 hir::TypeKind::Mapping(m) => &m.value.kind,
                 hir::TypeKind::Array(a) => &a.element.kind,
                 _ => return None,
@@ -2252,17 +2231,12 @@ impl<'gcx> Lowerer<'gcx> {
         // Call returning a (storage) struct, e.g. an ERC-7201 `_layout()` getter:
         // use the callee's declared return type.
         if let ExprKind::Call(callee, ..) = &expr.kind
-            && let ExprKind::Ident(res) = &callee.kind
+            && let Some(fid) = self.gcx.resolved_function(callee)
+            && let Some(&rid) = self.gcx.hir.function(fid).returns.first()
+            && let hir::TypeKind::Custom(hir::ItemId::Struct(sid)) =
+                &self.gcx.hir.variable(rid).ty.kind
         {
-            for r in res.iter() {
-                if let hir::Res::Item(hir::ItemId::Function(fid)) = r
-                    && let Some(&rid) = self.gcx.hir.function(*fid).returns.first()
-                    && let hir::TypeKind::Custom(hir::ItemId::Struct(sid)) =
-                        &self.gcx.hir.variable(rid).ty.kind
-                {
-                    return Some(*sid);
-                }
-            }
+            return Some(*sid);
         }
         // Fall back to the inferred expression type.
         if let Some(ty) = self.get_expr_type(expr)
@@ -2339,17 +2313,17 @@ impl<'gcx> Lowerer<'gcx> {
         expr: &hir::Expr<'_>,
     ) -> Option<ValueId> {
         match &expr.kind {
-            ExprKind::Ident(res_slice) => {
-                if let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() {
+            ExprKind::Ident(_) => {
+                if let Some(var_id) = self.gcx.resolved_variable(expr) {
                     // Another storage reference: its value is already the slot.
-                    if self.storage_ref_locals.contains(*var_id) {
-                        return self.locals.get(var_id).copied();
+                    if self.storage_ref_locals.contains(var_id) {
+                        return self.locals.get(&var_id).copied();
                     }
                     // A state variable: its base slot is known at compile time.
-                    if let Some(&slot) = self.storage_slots.get(var_id) {
+                    if let Some(&slot) = self.storage_slots.get(&var_id) {
                         return Some(builder.imm_u64(slot));
                     }
-                    if let Some(&slot) = self.struct_storage_base_slots.get(var_id) {
+                    if let Some(&slot) = self.struct_storage_base_slots.get(&var_id) {
                         return Some(builder.imm_u64(slot));
                     }
                 }
@@ -2397,7 +2371,7 @@ impl<'gcx> Lowerer<'gcx> {
                 None
             }
             ExprKind::Call(callee, args, _)
-                if self.gcx.builtin_callee(callee.id) == Some(Builtin::ArrayPush0) =>
+                if self.gcx.resolved_builtin(callee) == Some(Builtin::ArrayPush0) =>
             {
                 let ExprKind::Member(base, _) = &callee.kind else { return None };
                 let (slot, element_ty, element_slots) =
@@ -2422,19 +2396,11 @@ impl<'gcx> Lowerer<'gcx> {
     /// Whether `callee` resolves to a function whose first return is a storage
     /// reference, so a call to it yields a storage slot value.
     fn call_returns_storage_ref(&self, callee: &hir::Expr<'_>) -> bool {
-        let ExprKind::Ident(res) = &callee.kind else {
+        let Some(fid) = self.gcx.resolved_function(callee) else {
             return false;
         };
-        res.iter().any(|r| {
-            if let hir::Res::Item(hir::ItemId::Function(fid)) = r {
-                let f = self.gcx.hir.function(*fid);
-                f.returns.first().is_some_and(|&rid| {
-                    self.gcx.hir.variable(rid).data_location
-                        == Some(solar_ast::DataLocation::Storage)
-                })
-            } else {
-                false
-            }
+        self.gcx.hir.function(fid).returns.first().is_some_and(|&rid| {
+            self.gcx.hir.variable(rid).data_location == Some(solar_ast::DataLocation::Storage)
         })
     }
 
@@ -2445,14 +2411,13 @@ impl<'gcx> Lowerer<'gcx> {
         base: &hir::Expr<'_>,
         member: Ident,
     ) -> Option<(hir::StructId, usize)> {
-        // The base is a local variable (memory struct) - check if it's in local_memory_slots
-        if let ExprKind::Ident(res_slice) = &base.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            let var = self.gcx.hir.variable(*var_id);
-            if let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &var.ty.kind {
+        if let Some(var_id) = self.gcx.resolved_variable(base) {
+            let var = self.gcx.hir.variable(var_id);
+            if var.is_local_variable()
+                && let hir::TypeKind::Custom(hir::ItemId::Struct(struct_id)) = &var.ty.kind
+            {
                 // For memory structs, we need to verify this is NOT a storage struct
-                if !self.struct_storage_base_slots.contains_key(var_id) {
+                if !self.struct_storage_base_slots.contains_key(&var_id) {
                     let strukt = self.gcx.hir.strukt(*struct_id);
                     for (i, &field_id) in strukt.fields.iter().enumerate() {
                         let field = self.gcx.hir.variable(field_id);
@@ -2809,15 +2774,12 @@ impl<'gcx> Lowerer<'gcx> {
         &self,
         base: &hir::Expr<'_>,
     ) -> Option<(hir::VariableId, ValueId)> {
-        let ExprKind::Ident(res_slice) = &base.kind else { return None };
-        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
-            return None;
-        };
-        if !matches!(self.gcx.hir.variable(*var_id).ty.kind, hir::TypeKind::Mapping(_)) {
+        let var_id = self.gcx.resolved_variable(base)?;
+        if !matches!(self.gcx.hir.variable(var_id).ty.kind, hir::TypeKind::Mapping(_)) {
             return None;
         }
-        let slot_val = self.locals.get(var_id).copied()?;
-        Some((*var_id, slot_val))
+        let slot_val = self.locals.get(&var_id).copied()?;
+        Some((var_id, slot_val))
     }
 
     /// Computes the storage slot for a nested mapping access.
@@ -2933,12 +2895,7 @@ impl<'gcx> Lowerer<'gcx> {
         while let ExprKind::Index(inner_base, _) = &current.kind {
             current = inner_base;
         }
-        if let ExprKind::Ident(res_slice) = &current.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-        {
-            return Some(*var_id);
-        }
-        None
+        self.gcx.resolved_variable(current)
     }
 
     /// Computes the storage slot for a mapping access: keccak256(abi.encode(key, slot))
@@ -3001,11 +2958,10 @@ impl<'gcx> Lowerer<'gcx> {
     /// Whether `expr` is a storage-reference local of `string`/`bytes` type,
     /// which lowers to its storage slot rather than a memory pointer.
     fn is_storage_ref_bytes_local(&self, expr: &hir::Expr<'_>) -> bool {
-        if let ExprKind::Ident(res_slice) = &expr.kind
-            && let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first()
-            && self.storage_ref_locals.contains(*var_id)
+        if let Some(var_id) = self.gcx.resolved_variable(expr)
+            && self.storage_ref_locals.contains(var_id)
         {
-            let var = self.gcx.hir.variable(*var_id);
+            let var = self.gcx.hir.variable(var_id);
             return Self::is_dynamic_mapping_key(&var.ty.kind);
         }
         false
@@ -3079,16 +3035,13 @@ impl<'gcx> Lowerer<'gcx> {
         let Some(expr) = expr else {
             return false;
         };
-        let ExprKind::Ident(res_slice) = &expr.kind else {
+        let Some(var_id) = self.gcx.resolved_variable(expr) else {
             return false;
         };
-        let Some(hir::Res::Item(hir::ItemId::Variable(var_id))) = res_slice.first() else {
-            return false;
-        };
-        if !self.locals.contains_key(var_id) || self.get_local_memory_offset(var_id).is_some() {
+        if !self.locals.contains_key(&var_id) || self.get_local_memory_offset(&var_id).is_some() {
             return false;
         }
-        let var = self.gcx.hir.variable(*var_id);
+        let var = self.gcx.hir.variable(var_id);
         if var.data_location != Some(solar_ast::DataLocation::Calldata) {
             return false;
         }

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -1763,7 +1763,7 @@ impl<'gcx> Lowerer<'gcx> {
             self.mark_assigned_var(base);
             return;
         }
-        if let Some(var_id) = self.ident_variable(expr) {
+        if let Some(var_id) = self.gcx.resolved_variable(expr) {
             self.assigned_vars.insert(var_id);
         }
     }
@@ -1839,7 +1839,7 @@ impl<'gcx> Lowerer<'gcx> {
     fn is_external_call(&self, callee: &hir::Expr<'_>) -> bool {
         // External calls are Member expressions where the base is a contract
         if let hir::ExprKind::Member(base, _) = &callee.kind
-            && let Some(var_id) = self.ident_variable(base)
+            && let Some(var_id) = self.gcx.resolved_variable(base)
         {
             let var = self.gcx.hir.variable(var_id);
             // Contract type variables are external call targets

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -1842,8 +1842,11 @@ impl<'gcx> Lowerer<'gcx> {
             && let Some(var_id) = self.gcx.resolved_variable(base)
         {
             let var = self.gcx.hir.variable(var_id);
-            // Contract type variables are external call targets
-            if matches!(var.ty.kind, hir::TypeKind::Custom(hir::ItemId::Contract(_))) {
+            // This scan tracks declaration-level contract values; struct fields are lowered as
+            // member expressions.
+            if !var.is_struct_member()
+                && matches!(var.ty.kind, hir::TypeKind::Custom(hir::ItemId::Contract(_)))
+            {
                 return true;
             }
         }

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -58,7 +58,7 @@ impl<'gcx> Lowerer<'gcx> {
         let ExprKind::Call(callee, args, _) = &expr.kind else {
             return false;
         };
-        if !matches!(self.callee_res(callee), Some(hir::Res::Builtin(Builtin::Keccak256))) {
+        if self.gcx.resolved_builtin(callee) != Some(Builtin::Keccak256) {
             return false;
         }
 
@@ -66,11 +66,11 @@ impl<'gcx> Lowerer<'gcx> {
         let Some(arg) = exprs.next() else {
             return false;
         };
-        exprs.next().is_none() && self.is_local_ident(arg, var_id)
+        exprs.next().is_none() && self.resolves_to_variable(arg, var_id)
     }
 
-    fn is_local_ident(&self, expr: &hir::Expr<'_>, var_id: hir::VariableId) -> bool {
-        self.ident_variable(expr) == Some(var_id)
+    fn resolves_to_variable(&self, expr: &hir::Expr<'_>, var_id: hir::VariableId) -> bool {
+        self.gcx.resolved_variable(expr) == Some(var_id)
     }
 
     fn lower_immediate_packed_hash_return(
@@ -1017,7 +1017,8 @@ impl<'gcx> Lowerer<'gcx> {
 
         // Get the event from the callee, using the overload target selected by
         // the type checker: `emit E(...)` may name an overloaded event.
-        let Some(hir::Res::Item(hir::ItemId::Event(event_id))) = self.callee_res(callee) else {
+        let Some(hir::Res::Item(hir::ItemId::Event(event_id))) = self.gcx.resolved_expr(callee)
+        else {
             return;
         };
 

--- a/crates/codegen/src/lower/type_query.rs
+++ b/crates/codegen/src/lower/type_query.rs
@@ -3,7 +3,6 @@
 use super::Lowerer;
 use solar_ast::{DataLocation, LitKind};
 use solar_sema::{
-    builtins::Builtin,
     hir::{self, ElementaryType, ExprKind},
     ty::TyKind,
 };
@@ -23,76 +22,11 @@ impl<'gcx> Lowerer<'gcx> {
         self.gcx.type_of_expr(expr.id)
     }
 
-    /// Gets the non-call member target selected by sema's type checker.
-    pub(super) fn resolved_member(&self, expr: &hir::Expr<'_>) -> Option<hir::Res> {
-        self.gcx.resolved_member(expr.id)
-    }
-
-    /// Returns the resolution of an identifier expression used as a value.
-    ///
-    /// `hir::ExprKind::Ident` carries the raw candidate set from name
-    /// resolution, which does not account for overloading. This mirrors the
-    /// type checker's value-position rule: a single candidate wins, and among
-    /// several candidates the unique variable wins (a public state variable is
-    /// accompanied by its getter function). Anything else, such as an
-    /// overloaded function referenced as a value, is ambiguous and yields
-    /// `None`. Overloaded callees must go through [`Self::callee_res`], which
-    /// uses the target selected by sema's type checker.
-    pub(super) fn ident_res(&self, expr: &hir::Expr<'_>) -> Option<hir::Res> {
-        let ExprKind::Ident(res_slice) = &expr.kind else { return None };
-        match res_slice {
-            [] => None,
-            [res] => Some(*res),
-            _ => {
-                let mut vars = res_slice.iter().filter(|res| res.as_variable().is_some());
-                match (vars.next(), vars.next()) {
-                    (Some(&res), None) => Some(res),
-                    _ => None,
-                }
-            }
-        }
-    }
-
-    /// Returns the variable an identifier expression resolves to.
-    ///
-    /// Variables cannot be overloaded, so a single-entry resolution is the
-    /// only valid form here.
-    pub(super) fn ident_variable(&self, expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
-        match self.ident_res(expr)? {
-            hir::Res::Item(hir::ItemId::Variable(var_id)) => Some(var_id),
-            _ => None,
-        }
-    }
-
-    /// Returns the builtin an identifier expression resolves to.
-    pub(super) fn ident_builtin(&self, expr: &hir::Expr<'_>) -> Option<Builtin> {
-        match self.ident_res(expr)? {
-            hir::Res::Builtin(builtin) => Some(builtin),
-            _ => None,
-        }
-    }
-
-    /// Returns the resolution of a call callee expression.
-    ///
-    /// Prefers the overload target selected by sema's type checker; falls back
-    /// to the callee identifier's single resolution when the type checker did
-    /// not need to disambiguate.
-    pub(super) fn callee_res(&self, callee: &hir::Expr<'_>) -> Option<hir::Res> {
-        if let Some(resolved) = self.gcx.resolved_callee(callee.id) {
-            return Some(resolved.res);
-        }
-        self.ident_res(callee)
-    }
-
-    pub(super) fn resolved_builtin_member(&self, expr: &hir::Expr<'_>) -> Option<Builtin> {
-        self.gcx.builtin_member(expr.id)
-    }
-
     pub(super) fn resolved_struct_field(
         &self,
         expr: &hir::Expr<'_>,
     ) -> Option<(hir::StructId, usize)> {
-        let res = self.resolved_member(expr)?;
+        let res = self.gcx.resolved_expr(expr)?;
         let variable = self.gcx.hir.variable(res.as_variable()?);
         Some((variable.parent?.as_struct()?, res.struct_field_index(&self.gcx.hir)?))
     }
@@ -101,7 +35,7 @@ impl<'gcx> Lowerer<'gcx> {
         &self,
         expr: &hir::Expr<'_>,
     ) -> Option<(hir::EnumId, usize)> {
-        let res = self.resolved_member(expr)?;
+        let res = self.gcx.resolved_expr(expr)?;
         let variable = self.gcx.hir.variable(res.as_variable()?);
         Some((variable.parent?.as_enum()?, res.enum_variant_index(&self.gcx.hir)?))
     }
@@ -141,7 +75,7 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     pub(super) fn expr_struct_id(&self, expr: &hir::Expr<'_>) -> Option<hir::StructId> {
-        if let Some(var_id) = self.ident_variable(expr)
+        if let Some(var_id) = self.gcx.resolved_variable(expr)
             && self.struct_storage_base_slots.contains_key(&var_id)
         {
             return None;

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -7,14 +7,12 @@ use std::fmt::Write;
 
 pub(crate) fn render(gcx: Gcx<'_>, item_id: hir::ItemId) -> Option<MarkupContent> {
     let signature = match item_id {
+        hir::ItemId::Contract(id) => render_contract(gcx, id),
         hir::ItemId::Function(id) => render_function(gcx, id),
         hir::ItemId::Variable(id) => render_variable(gcx, id),
         hir::ItemId::Event(id) => render_event(gcx, id),
         hir::ItemId::Error(id) => render_error(gcx, id),
-        hir::ItemId::Contract(_)
-        | hir::ItemId::Struct(_)
-        | hir::ItemId::Enum(_)
-        | hir::ItemId::Udvt(_) => None,
+        hir::ItemId::Struct(_) | hir::ItemId::Enum(_) | hir::ItemId::Udvt(_) => None,
     }?;
     let mut value = format!("```solidity\n{signature}\n```");
     append_documentation(&mut value, &documentation(gcx, item_id));
@@ -31,6 +29,14 @@ struct Documentation {
 
 fn documentation(gcx: Gcx<'_>, item_id: hir::ItemId) -> Documentation {
     match item_id {
+        hir::ItemId::Contract(id) => {
+            let contract = gcx.hir.contract(id);
+            if contract.doc.is_empty() {
+                Documentation::default()
+            } else {
+                item_documentation(gcx.natspec_view(item_id).items())
+            }
+        }
         hir::ItemId::Function(id) => {
             let function = gcx.hir.function(id);
             callable_documentation(
@@ -50,11 +56,22 @@ fn documentation(gcx: Gcx<'_>, item_id: hir::ItemId) -> Documentation {
             let error = gcx.hir.error(id);
             callable_documentation(gcx, hir::ItemId::Error(id), error.doc, error.parameters, &[])
         }
-        hir::ItemId::Contract(_)
-        | hir::ItemId::Struct(_)
-        | hir::ItemId::Enum(_)
-        | hir::ItemId::Udvt(_) => Documentation::default(),
+        hir::ItemId::Struct(_) | hir::ItemId::Enum(_) | hir::ItemId::Udvt(_) => {
+            Documentation::default()
+        }
     }
+}
+
+fn render_contract(gcx: Gcx<'_>, id: hir::ContractId) -> Option<String> {
+    let contract = gcx.hir.contract(id);
+    let mut output = format!("{} {}", contract.kind, contract.name);
+    if let Some((&first, rest)) = contract.bases.split_first() {
+        write!(output, " is {}", gcx.hir.contract(first).name).ok()?;
+        for &base in rest {
+            write!(output, ", {}", gcx.hir.contract(base).name).ok()?;
+        }
+    }
+    Some(output)
 }
 
 fn callable_documentation(

--- a/crates/lsp/src/inlay_hints.rs
+++ b/crates/lsp/src/inlay_hints.rs
@@ -206,8 +206,7 @@ impl<'gcx> InlayHintCollector<'gcx> {
     /// Returns whether an argument expression already makes the parameter name visible.
     fn argument_name_matches_param(&self, arg: &'gcx hir::Expr<'gcx>, param_name: Symbol) -> bool {
         let arg = arg.peel_parens();
-        if let ExprKind::Ident([res]) = arg.kind
-            && let Some(variable) = res.as_variable()
+        if let Some(variable) = self.gcx.resolved_variable(arg)
             && self.gcx.hir.variable(variable).name.is_some_and(|name| name.name == param_name)
         {
             return true;
@@ -275,7 +274,7 @@ impl<'gcx> Visit<'gcx> for InlayHintCollector<'gcx> {
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         if let ExprKind::Call(callee, ref args, _) = expr.kind {
             let callee_ty = self.gcx.type_of_expr(callee.id);
-            if self.gcx.builtin_callee(callee.id) == Some(Builtin::AbiEncodeCall) {
+            if self.gcx.resolved_builtin(callee) == Some(Builtin::AbiEncodeCall) {
                 self.push_abi_encode_call_parameter_hints(args);
             }
             self.push_parameter_hints(args, self.gcx.call_param_source(callee));

--- a/crates/lsp/src/rename.rs
+++ b/crates/lsp/src/rename.rs
@@ -98,11 +98,18 @@ struct ImportBindingKey {
 pub(crate) struct ImportBindings {
     aliases: FxHashMap<ImportBindingKey, ImportAliasId>,
     symbol_sources: FxHashMap<SymbolId, hir::SourceId>,
+    references: Vec<(Span, Vec<SymbolId>)>,
 }
 
 #[derive(Default)]
 pub(crate) struct MappingBindings {
     params: FxHashMap<VariableId, MappingNameId>,
+}
+
+impl ImportBindings {
+    pub(crate) fn references(&self) -> impl Iterator<Item = (Span, &[SymbolId])> {
+        self.references.iter().map(|(span, symbols)| (*span, symbols.as_slice()))
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -178,9 +185,11 @@ impl RenameIndex {
                             }
 
                             self.push_symbol_occurrence(gcx, imported.span, &symbols);
+                            bindings.references.push((imported.span, symbols.clone()));
                             if let Some(alias) = alias
                                 && let Some(alias_id) = self.add_alias(gcx, alias)
                             {
+                                bindings.references.push((alias.span, symbols.clone()));
                                 for &symbol_id in &symbols {
                                     bindings.aliases.insert(
                                         ImportBindingKey {

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -1726,10 +1726,11 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         resolutions: &[Res],
         kind: DocumentHighlightKind,
     ) {
-        let callee = self.gcx.resolved_callee(expr.id).filter(|callee| !callee.res.is_err());
-        let resolutions =
-            callee.as_ref().map_or(resolutions, |callee| std::slice::from_ref(&callee.res));
-        let targets = self.symbol_ids_for_res(resolutions.iter().copied());
+        let resolved = self.gcx.resolved_expr(expr).filter(|res| !res.is_err());
+        let targets = resolved.map_or_else(
+            || self.symbol_ids_for_res(resolutions.iter().copied()),
+            |res| self.symbol_id_for_res(res).into_iter().collect(),
+        );
         self.push_reference_with_kind(expr.span, targets, kind);
         self.push_namespace_references(expr.span, resolutions);
     }
@@ -1742,7 +1743,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         kind: DocumentHighlightKind,
     ) -> ControlFlow<Never> {
         self.visit_expr(receiver)?;
-        let targets = self.symbol_ids_for_member_expr(expr);
+        let targets = self.symbol_ids_for_expr(expr);
         self.push_reference_with_kind(ident.span, targets, kind);
         ControlFlow::Continue(())
     }
@@ -1790,15 +1791,9 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
         }
     }
 
-    fn symbol_ids_for_member_expr(&self, expr: &hir::Expr<'gcx>) -> ReferenceTargets {
-        if let Some(res) = self.gcx.resolved_member(expr.id)
-            && let Some(symbol_id) = self.symbol_id_for_res(res)
-        {
-            return ReferenceTargets::from_buf([symbol_id]);
-        }
-
-        if let Some(callee) = self.gcx.resolved_callee(expr.id)
-            && let Some(symbol_id) = self.symbol_id_for_res(callee.res)
+    fn symbol_ids_for_expr(&self, expr: &hir::Expr<'gcx>) -> ReferenceTargets {
+        if let Some(symbol_id) =
+            self.gcx.resolved_expr(expr).and_then(|res| self.symbol_id_for_res(res))
         {
             return ReferenceTargets::from_buf([symbol_id]);
         }

--- a/crates/lsp/src/symbols.rs
+++ b/crates/lsp/src/symbols.rs
@@ -867,6 +867,22 @@ impl SymbolTables {
         id
     }
 
+    fn push_reference_entry(
+        &mut self,
+        gcx: Gcx<'_>,
+        span: Span,
+        targets: ReferenceTargets,
+        kind: DocumentHighlightKind,
+    ) {
+        if targets.is_empty() {
+            return;
+        }
+        let Some(location) = proto::span_to_location(gcx.sess.source_map(), span) else {
+            return;
+        };
+        self.references.push(SymbolReference { location, targets, kind });
+    }
+
     #[cfg(test)]
     fn push_test_declaration(&mut self, declaration: DeclarationSymbol) -> SymbolId {
         let id = declaration.id;
@@ -942,6 +958,14 @@ impl SymbolTables {
 
     fn build_references(&mut self, gcx: Gcx<'_>, item_symbols: &FxHashMap<ItemId, SymbolId>) {
         let bindings = self.rename.build_imports(gcx, item_symbols);
+        for (span, targets) in bindings.references() {
+            self.push_reference_entry(
+                gcx,
+                span,
+                targets.iter().copied().collect(),
+                DocumentHighlightKind::READ,
+            );
+        }
         let mapping_bindings = self.rename.build_mapping_names(gcx);
         self.rename.build_natspec(gcx, &bindings, item_symbols, &self.declarations);
         self.rename.build_overrides(
@@ -1711,13 +1735,7 @@ impl<'gcx> ReferenceCollector<'_, 'gcx> {
                 &targets,
             );
         }
-        if targets.is_empty() {
-            return;
-        }
-        let Some(location) = proto::span_to_location(self.gcx.sess.source_map(), span) else {
-            return;
-        };
-        self.tables.references.push(SymbolReference { location, targets, kind });
+        self.tables.push_reference_entry(self.gcx, span, targets, kind);
     }
 
     fn visit_ident_reference(

--- a/crates/lsp/src/tests/hover.rs
+++ b/crates/lsp/src/tests/hover.rs
@@ -451,6 +451,58 @@ address immutable owner
 }
 
 #[test]
+fn shows_public_state_variable_at_internal_references() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Counter.sol open
+        contract Counter {
+            uint256 public $1number;
+
+            function setNumber(uint256 newNumber) public {
+                $2number = newNumber;
+            }
+
+            function increment() public {
+                $3number++;
+            }
+        }
+        "#,
+        "/Counter.sol",
+    );
+
+    fixture.check_hover(
+        "$1",
+        str![[r#"
+1:19-1:25
+```solidity
+uint256 public number
+```
+
+"#]],
+    );
+    fixture.check_hover(
+        "$2",
+        str![[r#"
+3:8-3:14
+```solidity
+uint256 public number
+```
+
+"#]],
+    );
+    fixture.check_hover(
+        "$3",
+        str![[r#"
+6:8-6:14
+```solidity
+uint256 public number
+```
+
+"#]],
+    );
+}
+
+#[test]
 fn uses_the_type_checked_overload() {
     let fixture = RequestFixture::new(
         r#"

--- a/crates/lsp/src/tests/hover.rs
+++ b/crates/lsp/src/tests/hover.rs
@@ -503,6 +503,81 @@ uint256 public number
 }
 
 #[test]
+fn shows_contracts_at_declarations_imports_creation_and_inheritance() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /lib/forge-std/src/Script.sol
+        abstract contract Script {}
+        //- /src/Counter.sol
+        contract Counter {}
+        //- /script/Counter.s.sol open
+        import {$1Script} from "../lib/forge-std/src/Script.sol";
+        import {$2Counter} from "../src/Counter.sol";
+
+        contract $3CounterScript is $4Script {
+            Counter public counter;
+
+            function run() public {
+                counter = new $5Counter();
+            }
+        }
+        "#,
+        "/script/Counter.s.sol",
+    );
+
+    fixture.check_hover(
+        "$1",
+        str![[r#"
+0:8-0:14
+```solidity
+abstract contract Script
+```
+
+"#]],
+    );
+    fixture.check_hover(
+        "$2",
+        str![[r#"
+1:8-1:15
+```solidity
+contract Counter
+```
+
+"#]],
+    );
+    fixture.check_hover(
+        "$3",
+        str![[r#"
+2:9-2:22
+```solidity
+contract CounterScript is Script
+```
+
+"#]],
+    );
+    fixture.check_hover(
+        "$4",
+        str![[r#"
+2:26-2:32
+```solidity
+abstract contract Script
+```
+
+"#]],
+    );
+    fixture.check_hover(
+        "$5",
+        str![[r#"
+5:22-5:29
+```solidity
+contract Counter
+```
+
+"#]],
+    );
+}
+
+#[test]
 fn uses_the_type_checked_overload() {
     let fixture = RequestFixture::new(
         r#"
@@ -1021,7 +1096,17 @@ fn returns_no_hover_for_unsupported_or_non_symbol_positions() {
         "/Unsupported.sol",
     );
 
-    for marker in ["$1", "$2", "$3", "$4", "$5", "$7", "$8"] {
+    fixture.check_hover(
+        "$1",
+        str![[r#"
+0:9-0:10
+```solidity
+contract C
+```
+
+"#]],
+    );
+    for marker in ["$2", "$3", "$4", "$5", "$7", "$8"] {
         fixture.check_hover(marker, "<none>\n");
     }
 }

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1681,13 +1681,23 @@ impl Expr<'_> {
         expr
     }
 
+    /// Returns the resolution if this is an unambiguous identifier expression.
+    ///
+    /// Prefer using [`Gcx::resolved_expr`] instead, since this method does not account for
+    /// overloads.
+    ///
+    /// Parentheses are ignored.
+    pub fn as_res(&self) -> Option<Res> {
+        let ExprKind::Ident([res]) = self.peel_parens().kind else { return None };
+        Some(*res)
+    }
+
     /// Returns the variable ID if this is an unambiguous variable expression.
     ///
     /// Parentheses are ignored, but expressions with multiple resolutions are rejected even if
     /// one of those resolutions is a variable.
     pub fn as_variable(&self) -> Option<VariableId> {
-        let ExprKind::Ident([res]) = self.peel_parens().kind else { return None };
-        res.as_variable()
+        self.as_res()?.as_variable()
     }
 }
 
@@ -2030,12 +2040,14 @@ mod tests {
         let paren_values = [Some(&variable_expr)];
         let paren_expr =
             Expr { id: ExprId::new(2), kind: ExprKind::Tuple(&paren_values), span: Span::DUMMY };
+        assert_eq!(paren_expr.as_res(), Some(Res::Item(ItemId::Variable(variable))));
         assert_eq!(paren_expr.as_variable(), Some(variable));
 
         let ambiguous_res =
             [Res::Item(ItemId::Variable(variable)), Res::Item(ItemId::Function(function))];
         let ambiguous_expr =
             Expr { id: ExprId::new(3), kind: ExprKind::Ident(&ambiguous_res), span: Span::DUMMY };
+        assert_eq!(ambiguous_expr.as_res(), None);
         assert_eq!(ambiguous_expr.as_variable(), None);
     }
 

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -81,8 +81,8 @@ pub struct InterfaceFunctions<'gcx> {
 #[derive(Clone, Debug, Default)]
 pub struct TypeckResults<'gcx> {
     pub(crate) expr_types: FxHashMap<hir::ExprId, Ty<'gcx>>,
+    pub(crate) resolved_exprs: FxHashMap<hir::ExprId, hir::Res>,
     pub(crate) resolved_callees: FxHashMap<hir::ExprId, ResolvedCallee>,
-    pub(crate) resolved_members: FxHashMap<hir::ExprId, hir::Res>,
     pub(crate) unsupported_udvt_operators: GrowableBitSet<hir::ExprId>,
 }
 
@@ -147,22 +147,20 @@ impl<'gcx> TypeckResults<'gcx> {
         self.expr_types.get(&id).copied()
     }
 
+    /// Returns the target selected for an expression, if available.
+    #[inline]
+    pub fn resolved_expr(&self, expr: &hir::Expr<'_>) -> Option<hir::Res> {
+        let expr = expr.peel_parens();
+        self.resolved_callee(expr.id)
+            .map(|callee| callee.res)
+            .or_else(|| self.resolved_exprs.get(&expr.id).copied())
+            .or_else(|| expr.as_res())
+    }
+
     /// Returns the overload/member target selected for a call callee expression, if available.
     #[inline]
     pub fn resolved_callee(&self, id: hir::ExprId) -> Option<ResolvedCallee> {
         self.resolved_callees.get(&id).copied()
-    }
-
-    /// Returns the target selected for a non-call member access expression, if available.
-    #[inline]
-    pub fn resolved_member(&self, id: hir::ExprId) -> Option<hir::Res> {
-        self.resolved_members.get(&id).copied()
-    }
-
-    /// Returns the selected builtin target for a non-call member access expression, if available.
-    #[inline]
-    pub fn builtin_member(&self, id: hir::ExprId) -> Option<Builtin> {
-        self.resolved_member(id)?.as_builtin()
     }
 
     /// Returns the selected builtin target for a call callee expression, if available.
@@ -513,6 +511,36 @@ impl<'gcx> Gcx<'gcx> {
         self.typeck_results.get()?.type_of_expr(id)
     }
 
+    /// Returns the target selected for an expression, if available.
+    ///
+    /// This uses the type checker's selection for overloaded identifiers, member accesses, and
+    /// call callees. Identifier expressions with a single name-resolution candidate do not need a
+    /// type-checker entry and resolve directly from HIR.
+    pub fn resolved_expr(self, expr: &hir::Expr<'_>) -> Option<hir::Res> {
+        if let Some(results) = self.typeck_results.get() {
+            return results.resolved_expr(expr);
+        }
+        expr.as_res()
+    }
+
+    /// Returns the variable selected for an expression, if available.
+    #[inline]
+    pub fn resolved_variable(self, expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
+        self.resolved_expr(expr)?.as_variable()
+    }
+
+    /// Returns the function selected for an expression, if available.
+    #[inline]
+    pub fn resolved_function(self, expr: &hir::Expr<'_>) -> Option<hir::FunctionId> {
+        self.resolved_expr(expr)?.as_function()
+    }
+
+    /// Returns the builtin selected for an expression, if available.
+    #[inline]
+    pub fn resolved_builtin(self, expr: &hir::Expr<'_>) -> Option<Builtin> {
+        self.resolved_expr(expr)?.as_builtin()
+    }
+
     /// Returns the source argument at the given visible parameter index.
     ///
     /// Named arguments are reordered into the selected callable's declaration order. For an
@@ -572,15 +600,7 @@ impl<'gcx> Gcx<'gcx> {
             return Some(source);
         }
 
-        if let hir::ExprKind::Ident([res]) = callee.kind
-            && let Some(id) = res.as_variable()
-            && matches!(self.hir.variable(id).ty.kind, hir::TypeKind::Function(_))
-        {
-            return Some(CallableParamSource::FunctionType(id));
-        }
-        if let hir::ExprKind::Member(..) = callee.kind
-            && let Some(id) =
-                self.resolved_callee(callee.id).and_then(|callee| callee.res.as_variable())
+        if let Some(id) = self.resolved_variable(callee)
             && matches!(self.hir.variable(id).ty.kind, hir::TypeKind::Function(_))
         {
             return Some(CallableParamSource::FunctionType(id));
@@ -591,7 +611,7 @@ impl<'gcx> Gcx<'gcx> {
         {
             return Some(CallableParamSource::Function { id, skips_receiver: false });
         }
-        if let Some(builtin) = self.builtin_callee(callee.id)
+        if let Some(builtin) = self.resolved_builtin(callee)
             && matches!(builtin, Builtin::AbiDecode)
         {
             return Some(CallableParamSource::Builtin(builtin));
@@ -615,12 +635,6 @@ impl<'gcx> Gcx<'gcx> {
         self.resolved_callee(callee.id)
     }
 
-    /// Returns the target selected for a non-call member access expression, if available.
-    #[inline]
-    pub fn resolved_member(self, id: hir::ExprId) -> Option<hir::Res> {
-        self.typeck_results.get()?.resolved_member(id)
-    }
-
     /// Resolves every segment of a source path in its source and contract scopes.
     pub fn source_path_resolutions(
         self,
@@ -642,18 +656,6 @@ impl<'gcx> Gcx<'gcx> {
     /// when documentation must be associated with the current item's parameter or return positions.
     pub fn natspec_doc_comments(self, id: hir::DocId) -> &'gcx [hir::NatSpecItem] {
         if id.is_empty() { &[] } else { self.natspec_resolution(self.hir.doc(id).item).items() }
-    }
-
-    /// Returns the selected builtin target for a non-call member access expression, if available.
-    #[inline]
-    pub fn builtin_member(self, id: hir::ExprId) -> Option<Builtin> {
-        self.typeck_results.get()?.builtin_member(id)
-    }
-
-    /// Returns the selected builtin target for a call callee expression, if available.
-    #[inline]
-    pub fn builtin_callee(self, id: hir::ExprId) -> Option<Builtin> {
-        self.typeck_results.get()?.builtin_callee(id)
     }
 
     /// Returns whether codegen cannot lower the user-defined operator used by this expression.

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -385,8 +385,8 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.gcx.mk_ty_err(err.emit())
                 }
             }
-            hir::ExprKind::Ident(res) => {
-                let res = self.resolve_overloads(res, expr.span);
+            hir::ExprKind::Ident(resolutions) => {
+                let res = self.resolve_value(expr, resolutions);
                 if let Some(reason) = self.res_not_lvalue_reason(res) {
                     self.try_set_not_lvalue(reason);
                 }
@@ -812,23 +812,16 @@ impl<'gcx> TypeChecker<'gcx> {
 
     /// Returns true if the expression refers to a local or return variable.
     fn is_local_or_return_variable(&self, expr: &'gcx hir::Expr<'gcx>) -> bool {
-        if let hir::ExprKind::Ident(res_slice) = &expr.kind {
-            let res = self.resolve_overloads(res_slice, expr.span);
-            if let hir::Res::Item(hir::ItemId::Variable(var_id)) = res {
-                let var = self.gcx.hir.variable(var_id);
-                return var.is_local_or_return();
-            }
+        if let Some(var_id) = self.results.resolved_expr(expr).and_then(|res| res.as_variable()) {
+            return self.gcx.hir.variable(var_id).is_local_or_return();
         }
         false
     }
 
     /// Returns true if the expression refers to a non-state storage pointer variable.
     fn is_storage_pointer_variable(&self, expr: &'gcx hir::Expr<'gcx>) -> bool {
-        if let hir::ExprKind::Ident(res_slice) = &expr.peel_parens().kind {
-            let res = self.resolve_overloads(res_slice, expr.span);
-            if let hir::Res::Item(hir::ItemId::Variable(var_id)) = res {
-                return !self.gcx.hir.variable(var_id).is_state_variable();
-            }
+        if let Some(var_id) = self.results.resolved_expr(expr).and_then(|res| res.as_variable()) {
+            return self.gcx.hir.variable(var_id).is_local_variable();
         }
         false
     }
@@ -1702,7 +1695,7 @@ impl<'gcx> TypeChecker<'gcx> {
         member: &members::Member<'gcx>,
     ) {
         if let Some(res) = member.res {
-            self.results.resolved_members.insert(expr.id, res);
+            self.results.resolved_exprs.insert(expr.id, res);
         }
     }
 
@@ -2426,17 +2419,21 @@ impl<'gcx> TypeChecker<'gcx> {
         res_not_lvalue_reason(self.gcx, res, self.in_constructor_context())
     }
 
-    fn resolve_overloads(&self, res: &[hir::Res], span: Span) -> hir::Res {
-        match self.try_resolve_overloads(res) {
+    fn resolve_value(&mut self, expr: &'gcx hir::Expr<'gcx>, resolutions: &[hir::Res]) -> hir::Res {
+        let res = match self.try_resolve_overloads(resolutions) {
             Ok(res) => res,
             Err(e) => {
                 let msg = match e {
                     OverloadError::NotFound => "no matching declarations found",
                     OverloadError::Ambiguous => "no unique declarations found",
                 };
-                hir::Res::Err(self.dcx().emit_err(span, msg))
+                hir::Res::Err(self.dcx().emit_err(expr.span, msg))
             }
+        };
+        if resolutions.len() > 1 {
+            self.results.resolved_exprs.insert(expr.id, res);
         }
+        res
     }
 
     fn try_resolve_overloads(&self, res: &[hir::Res]) -> Result<hir::Res, OverloadError> {

--- a/crates/sema/src/typeck/checker/yul.rs
+++ b/crates/sema/src/typeck/checker/yul.rs
@@ -186,8 +186,8 @@ impl<'gcx> TypeChecker<'gcx> {
         &mut self,
         expr: &'gcx hir::Expr<'gcx>,
     ) -> (Ty<'gcx>, Option<hir::Res>) {
-        if let hir::ExprKind::Ident(res) = expr.kind {
-            let res = self.resolve_overloads(res, expr.span);
+        if let hir::ExprKind::Ident(resolutions) = expr.kind {
+            let res = self.resolve_value(expr, resolutions);
             if let Some(reason) = self.res_not_lvalue_reason(res) {
                 self.try_set_not_lvalue(reason);
             }

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -73,21 +73,21 @@ fn merge_typeck_results<'gcx>(
         }
     }
 
-    for (id, res) in new_results.resolved_callees {
-        if let Some(prev_res) = results.resolved_callees.insert(id, res) {
+    for (id, res) in new_results.resolved_exprs {
+        if let Some(prev_res) = results.resolved_exprs.insert(id, res) {
             gcx.dcx()
                 .bug(format!(
-                    "expression {id:?} already has resolved callee {prev_res:?}; tried to register {res:?}",
+                    "expression {id:?} already has resolution {prev_res:?}; tried to register {res:?}",
                 ))
                 .emit();
         }
     }
 
-    for (id, member) in new_results.resolved_members {
-        if let Some(prev_member) = results.resolved_members.insert(id, member) {
+    for (id, res) in new_results.resolved_callees {
+        if let Some(prev_res) = results.resolved_callees.insert(id, res) {
             gcx.dcx()
                 .bug(format!(
-                    "expression {id:?} already has resolved member {prev_member:?}; tried to register {member:?}",
+                    "expression {id:?} already has resolved callee {prev_res:?}; tried to register {res:?}",
                 ))
                 .emit();
         }
@@ -649,6 +649,19 @@ contract C {
     }
 }
 "#;
+    const PUBLIC_STATE_VARIABLE_SOURCE: &str = r#"
+contract C {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}
+"#;
 
     struct FirstBinaryExpr<'hir> {
         hir: &'hir hir::Hir<'hir>,
@@ -686,6 +699,24 @@ contract C {
             if matches!(expr.kind, ExprKind::Call(..)) {
                 self.calls.push(expr);
             }
+            self.walk_expr(expr)
+        }
+    }
+
+    struct Exprs<'hir> {
+        hir: &'hir hir::Hir<'hir>,
+        exprs: Vec<&'hir hir::Expr<'hir>>,
+    }
+
+    impl<'hir> Visit<'hir> for Exprs<'hir> {
+        type BreakValue = Never;
+
+        fn hir(&self) -> &'hir hir::Hir<'hir> {
+            self.hir
+        }
+
+        fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+            self.exprs.push(expr);
             self.walk_expr(expr)
         }
     }
@@ -817,6 +848,46 @@ contract C {
             let ExprKind::Call(callee, ..) = call.kind else { unreachable!() };
             assert!(gcx.resolved_callee(callee.id).is_some_and(|resolved| resolved.res.is_err()));
             assert!(gcx.resolved_call(call).is_some_and(|resolved| resolved.res.is_err()));
+        });
+    }
+
+    #[test]
+    fn resolved_expr_uses_typechecked_value_overload() {
+        let sess = Session::builder().opts(CompileOpts::default()).with_test_emitter().build();
+        let mut compiler = Compiler::new(sess);
+
+        compiler.enter_mut(|c| {
+            let mut pcx = c.parse();
+            let file = c
+                .sess()
+                .source_map()
+                .new_source_file(PathBuf::from("state-variable.sol"), PUBLIC_STATE_VARIABLE_SOURCE)
+                .unwrap();
+            pcx.add_file(file);
+            pcx.parse();
+
+            assert_eq!(c.lower_asts(), Ok(ControlFlow::Continue(())));
+            assert_eq!(c.analysis(), Ok(ControlFlow::Continue(())));
+        });
+
+        compiler.enter(|c| {
+            let gcx = c.gcx();
+            let mut visitor = Exprs { hir: &gcx.hir, exprs: Vec::new() };
+            let source = gcx.hir.source_ids().next().unwrap();
+            assert_eq!(visitor.visit_nested_source(source), ControlFlow::Continue(()));
+
+            let source_map = gcx.sess.source_map();
+            let number_resolutions = visitor
+                .exprs
+                .into_iter()
+                .filter(|expr| source_map.span_to_snippet(expr.span).as_deref() == Ok("number"))
+                .map(|expr| gcx.resolved_variable(expr))
+                .collect::<Vec<_>>();
+            let [Some(assignment), Some(increment)] = number_resolutions.as_slice() else {
+                panic!("expected two resolved references, got {number_resolutions:?}")
+            };
+            assert_eq!(assignment, increment);
+            assert!(gcx.hir.variable(*assignment).getter.is_some());
         });
     }
 }

--- a/crates/sema/src/typeck/view_pure_checker.rs
+++ b/crates/sema/src/typeck/view_pure_checker.rs
@@ -162,11 +162,8 @@ impl<'gcx, 'a> ViewPureChecker<'gcx, 'a> {
     }
 
     fn report_call_expr(&mut self, expr: &'gcx hir::Expr<'gcx>, callee: &'gcx hir::Expr<'gcx>) {
-        let yul_function = self
-            .gcx
-            .resolved_callee(callee.id)
-            .and_then(|callee| callee.res.as_function())
-            .filter(|&id| self.gcx.hir.function(id).is_yul);
+        let yul_function =
+            self.gcx.resolved_function(callee).filter(|&id| self.gcx.hir.function(id).is_yul);
         if let Some(id) = yul_function {
             if self.current_function.is_some() {
                 if self.mark_yul_function_visited(id) {
@@ -178,7 +175,7 @@ impl<'gcx, 'a> ViewPureChecker<'gcx, 'a> {
             }
             return;
         }
-        if let Some(builtin) = self.gcx.builtin_callee(callee.id) {
+        if let Some(builtin) = self.gcx.resolved_builtin(callee) {
             if builtin.is_yul() {
                 return;
             }
@@ -197,9 +194,7 @@ impl<'gcx, 'a> ViewPureChecker<'gcx, 'a> {
     }
 
     fn report_operator_call(&mut self, expr: &'gcx hir::Expr<'gcx>) {
-        if let Some(callee) = self.gcx.resolved_callee(expr.id)
-            && let Some(id) = callee.res.as_function()
-        {
+        if let Some(id) = self.gcx.resolved_function(expr) {
             self.report_call(self.gcx.hir.function(id).state_mutability, expr.span);
         }
     }
@@ -232,7 +227,7 @@ impl<'gcx, 'a> ViewPureChecker<'gcx, 'a> {
         receiver: &'gcx hir::Expr<'gcx>,
         writing: bool,
     ) {
-        let Some(res) = self.gcx.resolved_member(expr.id) else {
+        let Some(res) = self.gcx.resolved_expr(expr) else {
             if self.in_storage(receiver) {
                 self.report(read_or_write(writing), expr.span, None);
             }
@@ -379,12 +374,12 @@ impl<'gcx, 'a> ViewPureChecker<'gcx, 'a> {
     }
 
     fn is_this_function_selector(&self, expr: &hir::Expr<'_>) -> bool {
-        if self.gcx.builtin_member(expr.id) != Some(Builtin::FunctionSelector) {
+        if self.gcx.resolved_builtin(expr) != Some(Builtin::FunctionSelector) {
             return false;
         }
         let ExprKind::Member(receiver, _) = expr.kind else { return false };
         let ExprKind::Member(base, _) = receiver.peel_parens().kind else { return false };
-        matches!(base.peel_parens().kind, ExprKind::Ident([hir::Res::Builtin(Builtin::This)]))
+        self.gcx.resolved_builtin(base) == Some(Builtin::This)
     }
 }
 
@@ -426,7 +421,7 @@ impl<'gcx, 'a> Visit<'gcx> for ViewPureChecker<'gcx, 'a> {
     fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         let writing = std::mem::replace(&mut self.writing, false);
         let yul_builtin = if let ExprKind::Call(callee, _, _) = expr.kind {
-            self.gcx.builtin_callee(callee.id).filter(|builtin| builtin.is_yul())
+            self.gcx.resolved_builtin(callee).filter(|builtin| builtin.is_yul())
         } else {
             None
         };
@@ -467,14 +462,9 @@ impl<'gcx, 'a> Visit<'gcx> for ViewPureChecker<'gcx, 'a> {
         match expr.kind {
             ExprKind::Binary(_, _, _) | ExprKind::Unary(_, _) => self.report_operator_call(expr),
             ExprKind::Call(callee, _, _) => self.report_call_expr(expr, callee),
-            ExprKind::Ident(resolutions) => {
-                let mut variables = resolutions.iter().filter(|res| res.as_variable().is_some());
-                if let Some(variable) = variables.next()
-                    && variables.next().is_none()
-                {
-                    self.report_res(*variable, expr.span, writing);
-                } else if let [res] = resolutions {
-                    self.report_res(*res, expr.span, writing);
+            ExprKind::Ident(_) => {
+                if let Some(res) = self.gcx.resolved_expr(expr) {
+                    self.report_res(res, expr.span, writing);
                 }
             }
             ExprKind::Index(base, _) | ExprKind::Slice(base, _, _) if self.in_storage(base) => {


### PR DESCRIPTION
Hover was missing in two cases. Public state variables share name-resolution candidates with their generated getters, so value references such as `number = newNumber` appeared ambiguous. Contract items had no hover payload, and named imports existed only in the rename index, so contract names in imports, declarations, inheritance lists, and creation expressions returned no hover.

This records the type checker's selected target for value expressions and exposes it through `Gcx::resolved_expr`. LSP, semantic checks, and codegen now read that shared expression resolution. Contract signatures are rendered as hover content, and named imports are published to the shared reference index.

Codegen's lowering model stays the same. Declaration-only paths remain restricted by HIR variable kind, while overload-sensitive paths use the type checker's selected target.
