### PR TITLE
refactor(lsp): share HIR printer for hovers

### DIFF
--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -10,8 +10,7 @@ use solar_sema::{
 use std::fmt::Write;
 
 pub(crate) fn render(gcx: Gcx<'_>, item_id: hir::ItemId) -> Option<MarkupContent> {
-    let printer = HirPrinter::new(gcx);
-    let mut value = format!("```solidity\n{}\n```", printer.display(item_id));
+    let mut value = format!("```solidity\n{}\n```", HirPrinter::display(gcx, item_id));
     append_documentation(&mut value, &documentation(gcx, item_id));
     Some(MarkupContent { kind: MarkupKind::Markdown, value })
 }

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -2,17 +2,11 @@
 
 use lsp_types::{MarkupContent, MarkupKind};
 use solar_interface::Symbol;
-use solar_sema::{
-    Gcx,
-    hir::{self, HirDisplayPrinter},
-    ty::NatSpecView,
-};
+use solar_sema::{Gcx, hir, ty::NatSpecView};
 use std::fmt::Write;
 
 pub(crate) fn render(gcx: Gcx<'_>, item_id: hir::ItemId) -> Option<MarkupContent> {
-    let mut signature = String::new();
-    HirDisplayPrinter::new(gcx, &mut signature).print(item_id).ok()?;
-    let mut value = format!("```solidity\n{signature}\n```");
+    let mut value = format!("```solidity\n{}\n```", item_id.display(gcx));
     append_documentation(&mut value, &documentation(gcx, item_id));
     Some(MarkupContent { kind: MarkupKind::Markdown, value })
 }

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -2,11 +2,16 @@
 
 use lsp_types::{MarkupContent, MarkupKind};
 use solar_interface::Symbol;
-use solar_sema::{Gcx, hir, ty::NatSpecView};
+use solar_sema::{
+    Gcx,
+    hir::{self, HirPrinter},
+    ty::NatSpecView,
+};
 use std::fmt::Write;
 
 pub(crate) fn render(gcx: Gcx<'_>, item_id: hir::ItemId) -> Option<MarkupContent> {
-    let mut value = format!("```solidity\n{}\n```", item_id.display(gcx));
+    let printer = HirPrinter::new(gcx);
+    let mut value = format!("```solidity\n{}\n```", printer.display(item_id));
     append_documentation(&mut value, &documentation(gcx, item_id));
     Some(MarkupContent { kind: MarkupKind::Markdown, value })
 }

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -1,19 +1,17 @@
-//! Renders Solidity declarations and resolved NatSpec for LSP hover responses.
+//! Renders resolved NatSpec for LSP hover responses.
 
 use lsp_types::{MarkupContent, MarkupKind};
 use solar_interface::Symbol;
-use solar_sema::{Gcx, hir, ty::NatSpecView};
+use solar_sema::{
+    Gcx,
+    hir::{self, HirDisplayPrinter},
+    ty::NatSpecView,
+};
 use std::fmt::Write;
 
 pub(crate) fn render(gcx: Gcx<'_>, item_id: hir::ItemId) -> Option<MarkupContent> {
-    let signature = match item_id {
-        hir::ItemId::Contract(id) => render_contract(gcx, id),
-        hir::ItemId::Function(id) => render_function(gcx, id),
-        hir::ItemId::Variable(id) => render_variable(gcx, id),
-        hir::ItemId::Event(id) => render_event(gcx, id),
-        hir::ItemId::Error(id) => render_error(gcx, id),
-        hir::ItemId::Struct(_) | hir::ItemId::Enum(_) | hir::ItemId::Udvt(_) => None,
-    }?;
+    let mut signature = String::new();
+    HirDisplayPrinter::new(gcx, &mut signature).print(item_id).ok()?;
     let mut value = format!("```solidity\n{signature}\n```");
     append_documentation(&mut value, &documentation(gcx, item_id));
     Some(MarkupContent { kind: MarkupKind::Markdown, value })
@@ -57,21 +55,14 @@ fn documentation(gcx: Gcx<'_>, item_id: hir::ItemId) -> Documentation {
             callable_documentation(gcx, hir::ItemId::Error(id), error.doc, error.parameters, &[])
         }
         hir::ItemId::Struct(_) | hir::ItemId::Enum(_) | hir::ItemId::Udvt(_) => {
-            Documentation::default()
+            let doc = gcx.hir.item(item_id).doc();
+            if doc.is_empty() {
+                Documentation::default()
+            } else {
+                item_documentation(gcx.natspec_view(item_id).items())
+            }
         }
     }
-}
-
-fn render_contract(gcx: Gcx<'_>, id: hir::ContractId) -> Option<String> {
-    let contract = gcx.hir.contract(id);
-    let mut output = format!("{} {}", contract.kind, contract.name);
-    if let Some((&first, rest)) = contract.bases.split_first() {
-        write!(output, " is {}", gcx.hir.contract(first).name).ok()?;
-        for &base in rest {
-            write!(output, ", {}", gcx.hir.contract(base).name).ok()?;
-        }
-    }
-    Some(output)
 }
 
 fn callable_documentation(
@@ -300,201 +291,4 @@ fn append_list<'a>(
             output.push_str(line);
         }
     }
-}
-
-fn render_function(gcx: Gcx<'_>, id: hir::FunctionId) -> Option<String> {
-    let function = gcx.hir.function(id);
-    if function.is_yul {
-        return None;
-    }
-
-    let mut signature = function.kind.to_string();
-    if let Some(name) = function.name {
-        write!(signature, " {name}").ok()?;
-    }
-    signature.push('(');
-    render_variables(gcx, function.parameters, &mut signature)?;
-    signature.push(')');
-
-    match function.kind {
-        hir::FunctionKind::Function => {
-            write!(signature, " {}", function.visibility).ok()?;
-            render_state_mutability(function.state_mutability, &mut signature)?;
-        }
-        hir::FunctionKind::Constructor => {
-            if function.state_mutability == hir::StateMutability::Payable {
-                signature.push_str(" payable");
-            }
-        }
-        hir::FunctionKind::Fallback | hir::FunctionKind::Receive => {
-            write!(signature, " {}", function.visibility).ok()?;
-            render_state_mutability(function.state_mutability, &mut signature)?;
-        }
-        hir::FunctionKind::Modifier => {}
-    }
-
-    if function.marked_virtual {
-        signature.push_str(" virtual");
-    }
-    if function.override_ {
-        signature.push_str(" override");
-        render_override_list(gcx, function.overrides, &mut signature)?;
-    }
-    for modifier in function.modifiers {
-        let name = gcx.item_name_opt(modifier.id)?;
-        write!(signature, " {name}").ok()?;
-        if !modifier.args.is_dummy() {
-            let args = gcx.sess.source_map().span_to_snippet(modifier.args.span).ok()?;
-            signature.push_str(args.trim());
-        }
-    }
-    if !function.returns.is_empty() {
-        signature.push_str(" returns (");
-        render_variables(gcx, function.returns, &mut signature)?;
-        signature.push(')');
-    }
-    Some(signature)
-}
-
-fn render_variable(gcx: Gcx<'_>, id: hir::VariableId) -> Option<String> {
-    let variable = gcx.hir.variable(id);
-    let mut signature = String::new();
-    render_type(gcx, &variable.ty, &mut signature)?;
-    if let Some(visibility) = variable.visibility {
-        write!(signature, " {visibility}").ok()?;
-    }
-    if let Some(mutability) = variable.mutability {
-        write!(signature, " {mutability}").ok()?;
-    }
-    if variable.override_ {
-        signature.push_str(" override");
-        render_override_list(gcx, variable.overrides, &mut signature)?;
-    }
-    if let Some(data_location) = variable.data_location {
-        write!(signature, " {data_location}").ok()?;
-    }
-    if variable.indexed {
-        signature.push_str(" indexed");
-    }
-    let name = variable.name?;
-    write!(signature, " {name}").ok()?;
-    Some(signature)
-}
-
-fn render_event(gcx: Gcx<'_>, id: hir::EventId) -> Option<String> {
-    let event = gcx.hir.event(id);
-    let mut signature = format!("event {}(", event.name);
-    render_variables(gcx, event.parameters, &mut signature)?;
-    signature.push(')');
-    if event.anonymous {
-        signature.push_str(" anonymous");
-    }
-    Some(signature)
-}
-
-fn render_error(gcx: Gcx<'_>, id: hir::ErrorId) -> Option<String> {
-    let error = gcx.hir.error(id);
-    let mut signature = format!("error {}(", error.name);
-    render_variables(gcx, error.parameters, &mut signature)?;
-    signature.push(')');
-    Some(signature)
-}
-
-fn render_variables(
-    gcx: Gcx<'_>,
-    variables: &[hir::VariableId],
-    output: &mut String,
-) -> Option<()> {
-    for (index, &id) in variables.iter().enumerate() {
-        if index != 0 {
-            output.push_str(", ");
-        }
-        let variable = gcx.hir.variable(id);
-        render_type(gcx, &variable.ty, output)?;
-        if let Some(data_location) = variable.data_location {
-            write!(output, " {data_location}").ok()?;
-        }
-        if variable.indexed {
-            output.push_str(" indexed");
-        }
-        if let Some(name) = variable.name {
-            write!(output, " {name}").ok()?;
-        }
-    }
-    Some(())
-}
-
-fn render_type(gcx: Gcx<'_>, ty: &hir::Type<'_>, output: &mut String) -> Option<()> {
-    match &ty.kind {
-        hir::TypeKind::Elementary(elementary) => write!(output, "{elementary}").ok()?,
-        hir::TypeKind::Array(array) => {
-            render_type(gcx, &array.element, output)?;
-            output.push('[');
-            if let Some(size) = array.size {
-                let size = gcx.sess.source_map().span_to_snippet(size.span).ok()?;
-                output.push_str(size.trim());
-            }
-            output.push(']');
-        }
-        hir::TypeKind::Function(function) => {
-            output.push_str("function(");
-            render_variables(gcx, function.parameters, output)?;
-            write!(output, ") {}", function.visibility).ok()?;
-            render_state_mutability(function.state_mutability, output)?;
-            if !function.returns.is_empty() {
-                output.push_str(" returns (");
-                render_variables(gcx, function.returns, output)?;
-                output.push(')');
-            }
-        }
-        hir::TypeKind::Mapping(mapping) => {
-            output.push_str("mapping(");
-            render_type(gcx, &mapping.key, output)?;
-            if let Some(name) = mapping.key_name {
-                write!(output, " {name}").ok()?;
-            }
-            output.push_str(" => ");
-            render_type(gcx, &mapping.value, output)?;
-            if let Some(name) = mapping.value_name {
-                write!(output, " {name}").ok()?;
-            }
-            output.push(')');
-        }
-        hir::TypeKind::Custom(item_id) => {
-            let name = gcx.item_name_opt(*item_id)?;
-            write!(output, "{name}").ok()?;
-        }
-        hir::TypeKind::Err(_) => return None,
-    }
-    Some(())
-}
-
-fn render_state_mutability(
-    state_mutability: hir::StateMutability,
-    output: &mut String,
-) -> Option<()> {
-    if state_mutability != hir::StateMutability::NonPayable {
-        write!(output, " {state_mutability}").ok()?;
-    }
-    Some(())
-}
-
-fn render_override_list(
-    gcx: Gcx<'_>,
-    overrides: &[hir::ContractId],
-    output: &mut String,
-) -> Option<()> {
-    if overrides.is_empty() {
-        return Some(());
-    }
-    output.push('(');
-    for (index, &contract) in overrides.iter().enumerate() {
-        if index != 0 {
-            output.push_str(", ");
-        }
-        let name = gcx.item_name_opt(contract)?;
-        write!(output, "{name}").ok()?;
-    }
-    output.push(')');
-    Some(())
 }

--- a/crates/lsp/src/tests/hover.rs
+++ b/crates/lsp/src/tests/hover.rs
@@ -1076,12 +1076,16 @@ function read(uint256 leafValue) public pure override returns (uint256 leafResul
 }
 
 #[test]
-fn returns_no_hover_for_unsupported_or_non_symbol_positions() {
+fn shows_all_hir_items_and_skips_non_symbol_positions() {
     let fixture = RequestFixture::new_allowing_diagnostics(
         r#"
         //- /Unsupported.sol open
         contract $1C {
+            /// A user ID.
+            type $6UserId is uint256;
+            /// Stored data.
             struct $2Data {}
+            /// An available kind.
             enum $3Kind { A }
 
             function use() public returns (uint256) {
@@ -1106,7 +1110,43 @@ contract C
 
 "#]],
     );
-    for marker in ["$2", "$3", "$4", "$5", "$7", "$8"] {
+    fixture.check_hover(
+        "$2",
+        str![[r#"
+4:11-4:15
+```solidity
+struct Data
+```
+
+Stored data.
+
+"#]],
+    );
+    fixture.check_hover(
+        "$3",
+        str![[r#"
+6:9-6:13
+```solidity
+enum Kind
+```
+
+An available kind.
+
+"#]],
+    );
+    fixture.check_hover(
+        "$6",
+        str![[r#"
+2:9-2:15
+```solidity
+type UserId is uint256
+```
+
+A user ID.
+
+"#]],
+    );
+    for marker in ["$4", "$5", "$7", "$8"] {
         fixture.check_hover(marker, "<none>\n");
     }
 }

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -20,7 +20,7 @@ pub use ast::{
 };
 
 mod print;
-pub use print::HirPrinter;
+pub use print::{HirDisplayPrinter, HirPrinter};
 
 mod visit;
 pub use visit::Visit;

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -20,7 +20,7 @@ pub use ast::{
 };
 
 mod print;
-pub use print::{HirDisplayPrinter, HirPrinter};
+pub use print::HirPrinter;
 
 mod visit;
 pub use visit::Visit;

--- a/crates/sema/src/hir/print.rs
+++ b/crates/sema/src/hir/print.rs
@@ -744,260 +744,257 @@ fn builtin_name(builtin: Builtin) -> impl fmt::Display {
     solar_data_structures::fmt::from_fn(move |f| f.write_str(builtin.name().as_str()))
 }
 
-/// Prints individual HIR declaration headers in Solidity syntax.
-pub struct HirDisplayPrinter<'gcx, W> {
-    gcx: Gcx<'gcx>,
-    buf: W,
+impl ItemId {
+    /// Displays this item's declaration header in Solidity syntax.
+    pub fn display<'gcx>(self, gcx: Gcx<'gcx>) -> impl fmt::Display + use<'gcx> {
+        fmt::from_fn(move |f| HirPrinter::new(gcx).fmt_item(self, f))
+    }
 }
 
-impl<'gcx, W: fmt::Write> HirDisplayPrinter<'gcx, W> {
-    /// Creates a new HIR display printer.
-    pub fn new(gcx: Gcx<'gcx>, buf: W) -> Self {
-        Self { gcx, buf }
-    }
-
-    /// Returns a mutable reference to the underlying buffer.
-    pub fn buf(&mut self) -> &mut W {
-        &mut self.buf
-    }
-
-    /// Consumes the printer and returns the underlying buffer.
-    pub fn into_buf(self) -> W {
-        self.buf
-    }
-
-    /// Prints the declaration header for `item_id`.
-    pub fn print(&mut self, item_id: ItemId) -> fmt::Result {
+impl HirPrinter<'_> {
+    fn fmt_item<W: fmt::Write>(&self, item_id: ItemId, buf: &mut W) -> fmt::Result {
         match item_id {
-            ItemId::Contract(id) => self.print_contract(id),
-            ItemId::Function(id) => self.print_function(id),
-            ItemId::Variable(id) => self.print_variable(id),
-            ItemId::Struct(id) => self.print_struct(id),
-            ItemId::Enum(id) => self.print_enum(id),
-            ItemId::Udvt(id) => self.print_udvt(id),
-            ItemId::Error(id) => self.print_error(id),
-            ItemId::Event(id) => self.print_event(id),
+            ItemId::Contract(id) => self.fmt_contract(id, buf),
+            ItemId::Function(id) => self.fmt_function(id, buf),
+            ItemId::Variable(id) => self.fmt_variable(id, buf),
+            ItemId::Struct(id) => self.fmt_struct(id, buf),
+            ItemId::Enum(id) => self.fmt_enum(id, buf),
+            ItemId::Udvt(id) => self.fmt_udvt(id, buf),
+            ItemId::Error(id) => self.fmt_error(id, buf),
+            ItemId::Event(id) => self.fmt_event(id, buf),
         }
     }
 
-    fn print_contract(&mut self, id: hir::ContractId) -> fmt::Result {
+    fn fmt_contract<W: fmt::Write>(&self, id: hir::ContractId, buf: &mut W) -> fmt::Result {
         let contract = self.gcx.hir.contract(id);
-        write!(self.buf, "{} {}", contract.kind, contract.name)?;
+        write!(buf, "{} {}", contract.kind, contract.name)?;
         if let Some((&first, rest)) = contract.bases.split_first() {
-            write!(self.buf, " is {}", self.gcx.hir.contract(first).name)?;
+            write!(buf, " is {}", self.gcx.hir.contract(first).name)?;
             for &base in rest {
-                write!(self.buf, ", {}", self.gcx.hir.contract(base).name)?;
+                write!(buf, ", {}", self.gcx.hir.contract(base).name)?;
             }
         }
         Ok(())
     }
 
-    fn print_function(&mut self, id: hir::FunctionId) -> fmt::Result {
+    fn fmt_function<W: fmt::Write>(&self, id: hir::FunctionId, buf: &mut W) -> fmt::Result {
         let function = self.gcx.hir.function(id);
         if function.is_yul {
-            self.buf.write_str("yul ")?;
+            buf.write_str("yul ")?;
         }
 
-        write!(self.buf, "{}", function.kind)?;
+        write!(buf, "{}", function.kind)?;
         if let Some(name) = function.name {
-            write!(self.buf, " {name}")?;
+            write!(buf, " {name}")?;
         }
-        self.buf.write_char('(')?;
-        self.print_variables(function.parameters)?;
-        self.buf.write_char(')')?;
+        buf.write_char('(')?;
+        self.fmt_variables(function.parameters, buf)?;
+        buf.write_char(')')?;
 
         match function.kind {
             hir::FunctionKind::Function if !function.is_yul => {
-                write!(self.buf, " {}", function.visibility)?;
-                self.print_state_mutability(function.state_mutability)?;
+                write!(buf, " {}", function.visibility)?;
+                self.fmt_state_mutability(function.state_mutability, buf)?;
             }
             hir::FunctionKind::Function => {}
             hir::FunctionKind::Constructor => {
                 if function.state_mutability == hir::StateMutability::Payable {
-                    self.buf.write_str(" payable")?;
+                    buf.write_str(" payable")?;
                 }
             }
             hir::FunctionKind::Fallback | hir::FunctionKind::Receive => {
-                write!(self.buf, " {}", function.visibility)?;
-                self.print_state_mutability(function.state_mutability)?;
+                write!(buf, " {}", function.visibility)?;
+                self.fmt_state_mutability(function.state_mutability, buf)?;
             }
             hir::FunctionKind::Modifier => {}
         }
 
         if function.marked_virtual {
-            self.buf.write_str(" virtual")?;
+            buf.write_str(" virtual")?;
         }
         if function.override_ {
-            self.buf.write_str(" override")?;
-            self.print_override_list(function.overrides)?;
+            buf.write_str(" override")?;
+            self.fmt_override_list(function.overrides, buf)?;
         }
         for modifier in function.modifiers {
-            self.buf.write_char(' ')?;
-            self.print_item_name(modifier.id)?;
+            buf.write_char(' ')?;
+            self.fmt_item_name(modifier.id, buf)?;
             if !modifier.args.is_dummy() {
                 if let Ok(args) = self.gcx.sess.source_map().span_to_snippet(modifier.args.span) {
-                    self.buf.write_str(args.trim())?;
+                    buf.write_str(args.trim())?;
                 } else {
-                    self.buf.write_str("(...)")?;
+                    buf.write_str("(...)")?;
                 }
             }
         }
         if !function.returns.is_empty() {
-            self.buf.write_str(" returns (")?;
-            self.print_variables(function.returns)?;
-            self.buf.write_char(')')?;
+            buf.write_str(" returns (")?;
+            self.fmt_variables(function.returns, buf)?;
+            buf.write_char(')')?;
         }
         Ok(())
     }
 
-    fn print_variable(&mut self, id: hir::VariableId) -> fmt::Result {
+    fn fmt_variable<W: fmt::Write>(&self, id: hir::VariableId, buf: &mut W) -> fmt::Result {
         let variable = self.gcx.hir.variable(id);
-        self.print_ty(&variable.ty)?;
+        self.fmt_ty(&variable.ty, buf)?;
         if let Some(visibility) = variable.visibility {
-            write!(self.buf, " {visibility}")?;
+            write!(buf, " {visibility}")?;
         }
         if let Some(mutability) = variable.mutability {
-            write!(self.buf, " {mutability}")?;
+            write!(buf, " {mutability}")?;
         }
         if variable.override_ {
-            self.buf.write_str(" override")?;
-            self.print_override_list(variable.overrides)?;
+            buf.write_str(" override")?;
+            self.fmt_override_list(variable.overrides, buf)?;
         }
         if let Some(data_location) = variable.data_location {
-            write!(self.buf, " {data_location}")?;
+            write!(buf, " {data_location}")?;
         }
         if variable.indexed {
-            self.buf.write_str(" indexed")?;
+            buf.write_str(" indexed")?;
         }
         if let Some(name) = variable.name {
-            write!(self.buf, " {name}")?;
+            write!(buf, " {name}")?;
         }
         Ok(())
     }
 
-    fn print_struct(&mut self, id: hir::StructId) -> fmt::Result {
-        write!(self.buf, "struct {}", self.gcx.hir.strukt(id).name)
+    fn fmt_struct<W: fmt::Write>(&self, id: hir::StructId, buf: &mut W) -> fmt::Result {
+        write!(buf, "struct {}", self.gcx.hir.strukt(id).name)
     }
 
-    fn print_enum(&mut self, id: hir::EnumId) -> fmt::Result {
-        write!(self.buf, "enum {}", self.gcx.hir.enumm(id).name)
+    fn fmt_enum<W: fmt::Write>(&self, id: hir::EnumId, buf: &mut W) -> fmt::Result {
+        write!(buf, "enum {}", self.gcx.hir.enumm(id).name)
     }
 
-    fn print_udvt(&mut self, id: hir::UdvtId) -> fmt::Result {
+    fn fmt_udvt<W: fmt::Write>(&self, id: hir::UdvtId, buf: &mut W) -> fmt::Result {
         let udvt = self.gcx.hir.udvt(id);
-        write!(self.buf, "type {} is ", udvt.name)?;
-        self.print_ty(&udvt.ty)
+        write!(buf, "type {} is ", udvt.name)?;
+        self.fmt_ty(&udvt.ty, buf)
     }
 
-    fn print_event(&mut self, id: hir::EventId) -> fmt::Result {
+    fn fmt_event<W: fmt::Write>(&self, id: hir::EventId, buf: &mut W) -> fmt::Result {
         let event = self.gcx.hir.event(id);
-        write!(self.buf, "event {}(", event.name)?;
-        self.print_variables(event.parameters)?;
-        self.buf.write_char(')')?;
+        write!(buf, "event {}(", event.name)?;
+        self.fmt_variables(event.parameters, buf)?;
+        buf.write_char(')')?;
         if event.anonymous {
-            self.buf.write_str(" anonymous")?;
+            buf.write_str(" anonymous")?;
         }
         Ok(())
     }
 
-    fn print_error(&mut self, id: hir::ErrorId) -> fmt::Result {
+    fn fmt_error<W: fmt::Write>(&self, id: hir::ErrorId, buf: &mut W) -> fmt::Result {
         let error = self.gcx.hir.error(id);
-        write!(self.buf, "error {}(", error.name)?;
-        self.print_variables(error.parameters)?;
-        self.buf.write_char(')')
+        write!(buf, "error {}(", error.name)?;
+        self.fmt_variables(error.parameters, buf)?;
+        buf.write_char(')')
     }
 
-    fn print_variables(&mut self, variables: &[hir::VariableId]) -> fmt::Result {
+    fn fmt_variables<W: fmt::Write>(
+        &self,
+        variables: &[hir::VariableId],
+        buf: &mut W,
+    ) -> fmt::Result {
         for (index, &id) in variables.iter().enumerate() {
             if index != 0 {
-                self.buf.write_str(", ")?;
+                buf.write_str(", ")?;
             }
             let variable = self.gcx.hir.variable(id);
-            self.print_ty(&variable.ty)?;
+            self.fmt_ty(&variable.ty, buf)?;
             if let Some(data_location) = variable.data_location {
-                write!(self.buf, " {data_location}")?;
+                write!(buf, " {data_location}")?;
             }
             if variable.indexed {
-                self.buf.write_str(" indexed")?;
+                buf.write_str(" indexed")?;
             }
             if let Some(name) = variable.name {
-                write!(self.buf, " {name}")?;
+                write!(buf, " {name}")?;
             }
         }
         Ok(())
     }
 
-    fn print_ty(&mut self, ty: &hir::Type<'_>) -> fmt::Result {
+    fn fmt_ty<W: fmt::Write>(&self, ty: &hir::Type<'_>, buf: &mut W) -> fmt::Result {
         match &ty.kind {
-            TypeKind::Elementary(elementary) => write!(self.buf, "{elementary}"),
+            TypeKind::Elementary(elementary) => write!(buf, "{elementary}"),
             TypeKind::Array(array) => {
-                self.print_ty(&array.element)?;
-                self.buf.write_char('[')?;
+                self.fmt_ty(&array.element, buf)?;
+                buf.write_char('[')?;
                 if let Some(size) = array.size {
                     if let Ok(size) = self.gcx.sess.source_map().span_to_snippet(size.span) {
-                        self.buf.write_str(size.trim())?;
+                        buf.write_str(size.trim())?;
                     } else {
-                        self.buf.write_str("<error>")?;
+                        buf.write_str("<error>")?;
                     }
                 }
-                self.buf.write_char(']')
+                buf.write_char(']')
             }
             TypeKind::Function(function) => {
-                self.buf.write_str("function(")?;
-                self.print_variables(function.parameters)?;
-                write!(self.buf, ") {}", function.visibility)?;
-                self.print_state_mutability(function.state_mutability)?;
+                buf.write_str("function(")?;
+                self.fmt_variables(function.parameters, buf)?;
+                write!(buf, ") {}", function.visibility)?;
+                self.fmt_state_mutability(function.state_mutability, buf)?;
                 if !function.returns.is_empty() {
-                    self.buf.write_str(" returns (")?;
-                    self.print_variables(function.returns)?;
-                    self.buf.write_char(')')?;
+                    buf.write_str(" returns (")?;
+                    self.fmt_variables(function.returns, buf)?;
+                    buf.write_char(')')?;
                 }
                 Ok(())
             }
             TypeKind::Mapping(mapping) => {
-                self.buf.write_str("mapping(")?;
-                self.print_ty(&mapping.key)?;
+                buf.write_str("mapping(")?;
+                self.fmt_ty(&mapping.key, buf)?;
                 if let Some(name) = mapping.key_name {
-                    write!(self.buf, " {name}")?;
+                    write!(buf, " {name}")?;
                 }
-                self.buf.write_str(" => ")?;
-                self.print_ty(&mapping.value)?;
+                buf.write_str(" => ")?;
+                self.fmt_ty(&mapping.value, buf)?;
                 if let Some(name) = mapping.value_name {
-                    write!(self.buf, " {name}")?;
+                    write!(buf, " {name}")?;
                 }
-                self.buf.write_char(')')
+                buf.write_char(')')
             }
-            TypeKind::Custom(item_id) => self.print_item_name(*item_id),
-            TypeKind::Err(_) => self.buf.write_str("<error>"),
+            TypeKind::Custom(item_id) => self.fmt_item_name(*item_id, buf),
+            TypeKind::Err(_) => buf.write_str("<error>"),
         }
     }
 
-    fn print_state_mutability(&mut self, state_mutability: hir::StateMutability) -> fmt::Result {
+    fn fmt_state_mutability<W: fmt::Write>(
+        &self,
+        state_mutability: hir::StateMutability,
+        buf: &mut W,
+    ) -> fmt::Result {
         if state_mutability != hir::StateMutability::NonPayable {
-            write!(self.buf, " {state_mutability}")?;
+            write!(buf, " {state_mutability}")?;
         }
         Ok(())
     }
 
-    fn print_override_list(&mut self, overrides: &[hir::ContractId]) -> fmt::Result {
+    fn fmt_override_list<W: fmt::Write>(
+        &self,
+        overrides: &[hir::ContractId],
+        buf: &mut W,
+    ) -> fmt::Result {
         if overrides.is_empty() {
             return Ok(());
         }
-        self.buf.write_char('(')?;
+        buf.write_char('(')?;
         for (index, &contract) in overrides.iter().enumerate() {
             if index != 0 {
-                self.buf.write_str(", ")?;
+                buf.write_str(", ")?;
             }
-            self.print_item_name(contract.into())?;
+            self.fmt_item_name(contract.into(), buf)?;
         }
-        self.buf.write_char(')')
+        buf.write_char(')')
     }
 
-    fn print_item_name(&mut self, item_id: ItemId) -> fmt::Result {
+    fn fmt_item_name<W: fmt::Write>(&self, item_id: ItemId, buf: &mut W) -> fmt::Result {
         if let Some(name) = self.gcx.item_name_opt(item_id) {
-            write!(self.buf, "{name}")
+            write!(buf, "{name}")
         } else {
-            self.buf.write_str("<error>")
+            buf.write_str("<error>")
         }
     }
 }

--- a/crates/sema/src/hir/print.rs
+++ b/crates/sema/src/hir/print.rs
@@ -18,6 +18,11 @@ impl<'gcx> HirPrinter<'gcx> {
         Self { gcx, out: String::new(), indent: 0 }
     }
 
+    /// Displays an item's declaration header in Solidity syntax.
+    pub fn display(&self, item_id: ItemId) -> impl fmt::Display + '_ {
+        fmt::from_fn(move |f| self.fmt_item(item_id, f))
+    }
+
     /// Prints all HIR sources and returns the accumulated output.
     pub fn print_all(mut self) -> String {
         for (id, source) in self.gcx.hir.sources_enumerated() {
@@ -742,13 +747,6 @@ enum VarMode {
 
 fn builtin_name(builtin: Builtin) -> impl fmt::Display {
     solar_data_structures::fmt::from_fn(move |f| f.write_str(builtin.name().as_str()))
-}
-
-impl ItemId {
-    /// Displays this item's declaration header in Solidity syntax.
-    pub fn display<'gcx>(self, gcx: Gcx<'gcx>) -> impl fmt::Display + use<'gcx> {
-        fmt::from_fn(move |f| HirPrinter::new(gcx).fmt_item(self, f))
-    }
 }
 
 impl HirPrinter<'_> {

--- a/crates/sema/src/hir/print.rs
+++ b/crates/sema/src/hir/print.rs
@@ -3,24 +3,26 @@ use crate::{
     hir::{self, CallArgsKind, ExprKind, ItemId, Res, StmtKind, TypeKind, UsingEntryKind},
     ty::Gcx,
 };
-use std::fmt::{self, Write};
+use std::fmt;
 
 /// Pretty-prints HIR in a Solidity-like form.
-pub struct HirPrinter<'gcx> {
+pub struct HirPrinter<'gcx, W = String> {
     gcx: Gcx<'gcx>,
-    out: String,
+    out: W,
     indent: usize,
+    mode: PrintMode,
+    ends_with_open: bool,
 }
 
-impl<'gcx> HirPrinter<'gcx> {
+impl<'gcx> HirPrinter<'gcx, String> {
     /// Creates a new HIR printer.
     pub fn new(gcx: Gcx<'gcx>) -> Self {
-        Self { gcx, out: String::new(), indent: 0 }
+        Self::with_mode(gcx, String::new(), PrintMode::Full)
     }
 
     /// Displays an item's declaration header in Solidity syntax.
-    pub fn display(&self, item_id: ItemId) -> impl fmt::Display + '_ {
-        fmt::from_fn(move |f| self.fmt_item(item_id, f))
+    pub fn display(gcx: Gcx<'gcx>, item_id: ItemId) -> impl fmt::Display + use<'gcx> {
+        fmt::from_fn(move |f| HirPrinter::with_mode(gcx, f, PrintMode::Header).print_item(item_id))
     }
 
     /// Prints all HIR sources and returns the accumulated output.
@@ -33,36 +35,55 @@ impl<'gcx> HirPrinter<'gcx> {
 
     /// Prints one HIR source.
     pub fn print_source(&mut self, id: hir::SourceId, source: &'gcx hir::Source<'gcx>) {
-        writeln!(self.out, "source {} \"{}\" {{", id.index(), source.file.name.display()).unwrap();
-        self.indent += 1;
-        self.print_usings(source.usings);
-        self.print_items(source.items);
-        self.indent -= 1;
-        writeln!(self.out, "}}").unwrap();
+        self.print_source_inner(id, source).unwrap();
     }
 
     /// Returns the accumulated output.
     pub fn finish(self) -> String {
         self.out
     }
+}
 
-    fn print_items(&mut self, items: &[ItemId]) {
-        for (i, &item) in items.iter().enumerate() {
-            if i != 0 || !self.ends_with_open_source() {
-                self.out.push('\n');
-            }
-            self.print_item(item);
-        }
+impl<'gcx, W: fmt::Write> HirPrinter<'gcx, W> {
+    fn with_mode(gcx: Gcx<'gcx>, out: W, mode: PrintMode) -> Self {
+        Self { gcx, out, indent: 0, mode, ends_with_open: false }
     }
 
-    fn print_item(&mut self, item: ItemId) {
+    fn print_source_inner(
+        &mut self,
+        id: hir::SourceId,
+        source: &'gcx hir::Source<'gcx>,
+    ) -> fmt::Result {
+        writeln!(self.out, "source {} \"{}\" {{", id.index(), source.file.name.display())?;
+        self.ends_with_open = true;
+        self.indent += 1;
+        self.print_usings(source.usings)?;
+        self.print_items(source.items)?;
+        self.indent -= 1;
+        writeln!(self.out, "}}")
+    }
+
+    fn print_items(&mut self, items: &[ItemId]) -> fmt::Result {
+        for (i, &item) in items.iter().enumerate() {
+            if i != 0 || !self.ends_with_open {
+                self.out.write_char('\n')?;
+            }
+            self.print_item(item)?;
+        }
+        Ok(())
+    }
+
+    fn print_item(&mut self, item: ItemId) -> fmt::Result {
         match item {
             ItemId::Contract(id) => self.print_contract(id),
             ItemId::Function(id) => self.print_function(id),
             ItemId::Variable(id) => {
-                self.write_indent();
-                self.print_variable(id, VarMode::Item);
-                self.out.push_str(";\n");
+                self.write_indent()?;
+                self.print_variable(id, VarMode::Item)?;
+                if self.mode == PrintMode::Full {
+                    self.out.write_str(";\n")?;
+                }
+                Ok(())
             }
             ItemId::Struct(id) => self.print_struct(id),
             ItemId::Enum(id) => self.print_enum(id),
@@ -72,614 +93,716 @@ impl<'gcx> HirPrinter<'gcx> {
         }
     }
 
-    fn print_contract(&mut self, id: hir::ContractId) {
+    fn print_contract(&mut self, id: hir::ContractId) -> fmt::Result {
         let contract = self.gcx.hir.contract(id);
-        self.write_indent();
-        write!(self.out, "{} {}", contract.kind, contract.name).unwrap();
-        if let Some(layout) = contract.layout {
-            self.out.push_str(" layout at ");
-            self.print_expr(layout);
+        self.write_indent()?;
+        write!(self.out, "{} {}", contract.kind, contract.name)?;
+        if self.mode == PrintMode::Full
+            && let Some(layout) = contract.layout
+        {
+            self.out.write_str(" layout at ")?;
+            self.print_expr(layout)?;
         }
-        if !contract.bases_args.is_empty() {
-            self.out.push_str(" is ");
+        if self.mode == PrintMode::Full && !contract.bases_args.is_empty() {
+            self.out.write_str(" is ")?;
             for (i, base) in contract.bases_args.iter().enumerate() {
                 if i != 0 {
-                    self.out.push_str(", ");
+                    self.out.write_str(", ")?;
                 }
-                self.print_modifier(base);
+                self.print_modifier(base)?;
             }
         } else if !contract.bases.is_empty() {
-            self.out.push_str(" is ");
+            self.out.write_str(" is ")?;
             for (i, &base) in contract.bases.iter().enumerate() {
                 if i != 0 {
-                    self.out.push_str(", ");
+                    self.out.write_str(", ")?;
                 }
-                self.out.push_str(self.gcx.hir.contract(base).name.as_str());
+                self.out.write_str(self.gcx.hir.contract(base).name.as_str())?;
             }
         }
-        self.out.push_str(" {\n");
+        if self.mode == PrintMode::Header {
+            return Ok(());
+        }
+        self.out.write_str(" {\n")?;
+        self.ends_with_open = true;
         self.indent += 1;
-        self.print_usings(contract.usings);
-        self.print_items(contract.items);
+        self.print_usings(contract.usings)?;
+        self.print_items(contract.items)?;
         self.indent -= 1;
-        self.write_indent();
-        self.out.push_str("}\n");
+        self.write_indent()?;
+        self.out.write_str("}\n")?;
+        self.ends_with_open = false;
+        Ok(())
     }
 
-    fn print_struct(&mut self, id: hir::StructId) {
+    fn print_struct(&mut self, id: hir::StructId) -> fmt::Result {
         let strukt = self.gcx.hir.strukt(id);
-        self.write_indent();
-        writeln!(self.out, "struct {} {{", strukt.name).unwrap();
+        self.write_indent()?;
+        write!(self.out, "struct {}", strukt.name)?;
+        if self.mode == PrintMode::Header {
+            return Ok(());
+        }
+        self.out.write_str(" {\n")?;
         self.indent += 1;
         for &field in strukt.fields {
-            self.write_indent();
-            self.print_variable(field, VarMode::Parameter);
-            self.out.push_str(";\n");
+            self.write_indent()?;
+            self.print_variable(field, VarMode::Parameter)?;
+            self.out.write_str(";\n")?;
         }
         self.indent -= 1;
-        self.write_indent();
-        self.out.push_str("}\n");
+        self.write_indent()?;
+        self.out.write_str("}\n")
     }
 
-    fn print_enum(&mut self, id: hir::EnumId) {
+    fn print_enum(&mut self, id: hir::EnumId) -> fmt::Result {
         let enumm = self.gcx.hir.enumm(id);
-        self.write_indent();
-        write!(self.out, "enum {} {{", enumm.name).unwrap();
+        self.write_indent()?;
+        write!(self.out, "enum {}", enumm.name)?;
+        if self.mode == PrintMode::Header {
+            return Ok(());
+        }
+        self.out.write_str(" {")?;
         for (i, &variant) in enumm.variants.iter().enumerate() {
             if i != 0 {
-                self.out.push_str(", ");
+                self.out.write_str(", ")?;
             }
-            self.out.push_str(self.gcx.hir.variable(variant).name.unwrap().as_str());
+            self.out.write_str(self.gcx.hir.variable(variant).name.unwrap().as_str())?;
         }
-        self.out.push_str("}\n");
+        self.out.write_str("}\n")
     }
 
-    fn print_udvt(&mut self, id: hir::UdvtId) {
+    fn print_udvt(&mut self, id: hir::UdvtId) -> fmt::Result {
         let udvt = self.gcx.hir.udvt(id);
-        self.write_indent();
-        write!(self.out, "type {} is ", udvt.name).unwrap();
-        self.print_ty(&udvt.ty);
-        self.out.push_str(";\n");
+        self.write_indent()?;
+        write!(self.out, "type {} is ", udvt.name)?;
+        self.print_ty(&udvt.ty)?;
+        if self.mode == PrintMode::Full {
+            self.out.write_str(";\n")?;
+        }
+        Ok(())
     }
 
-    fn print_error(&mut self, id: hir::ErrorId) {
+    fn print_error(&mut self, id: hir::ErrorId) -> fmt::Result {
         let error = self.gcx.hir.error(id);
-        self.write_indent();
-        write!(self.out, "error {}(", error.name).unwrap();
-        self.print_var_list(error.parameters, VarMode::Parameter);
-        self.out.push_str(");\n");
+        self.write_indent()?;
+        write!(self.out, "error {}(", error.name)?;
+        self.print_var_list(error.parameters, VarMode::Parameter)?;
+        self.out.write_char(')')?;
+        if self.mode == PrintMode::Full {
+            self.out.write_str(";\n")?;
+        }
+        Ok(())
     }
 
-    fn print_event(&mut self, id: hir::EventId) {
+    fn print_event(&mut self, id: hir::EventId) -> fmt::Result {
         let event = self.gcx.hir.event(id);
-        self.write_indent();
-        write!(self.out, "event {}(", event.name).unwrap();
-        self.print_var_list(event.parameters, VarMode::Parameter);
-        self.out.push(')');
+        self.write_indent()?;
+        write!(self.out, "event {}(", event.name)?;
+        self.print_var_list(event.parameters, VarMode::Parameter)?;
+        self.out.write_char(')')?;
         if event.anonymous {
-            self.out.push_str(" anonymous");
+            self.out.write_str(" anonymous")?;
         }
-        self.out.push_str(";\n");
+        if self.mode == PrintMode::Full {
+            self.out.write_str(";\n")?;
+        }
+        Ok(())
     }
 
-    fn print_function(&mut self, id: hir::FunctionId) {
+    fn print_function(&mut self, id: hir::FunctionId) -> fmt::Result {
         let func = self.gcx.hir.function(id);
-        if let Some(gettee) = func.gettee {
-            self.write_indent();
-            writeln!(self.out, "// getter for {}", self.var_name(gettee)).unwrap();
+        if self.mode == PrintMode::Full
+            && let Some(gettee) = func.gettee
+        {
+            self.write_indent()?;
+            writeln!(self.out, "// getter for {}", self.var_name(gettee))?;
         }
-        self.write_indent();
+        self.write_indent()?;
         if func.is_yul {
-            self.out.push_str("yul ");
+            self.out.write_str("yul ")?;
         }
-        self.out.push_str(func.kind.to_str());
+        self.out.write_str(func.kind.to_str())?;
         if let Some(name) = func.name {
-            write!(self.out, " {name}").unwrap();
+            write!(self.out, " {name}")?;
         }
-        self.out.push('(');
-        self.print_var_list(func.parameters, VarMode::Parameter);
-        self.out.push(')');
-        write!(self.out, " {}", func.visibility).unwrap();
-        if func.state_mutability != hir::StateMutability::NonPayable {
-            write!(self.out, " {}", func.state_mutability).unwrap();
+        self.out.write_char('(')?;
+        self.print_var_list(func.parameters, VarMode::Parameter)?;
+        self.out.write_char(')')?;
+
+        if self.mode == PrintMode::Full {
+            write!(self.out, " {}", func.visibility)?;
+            self.print_state_mutability(func.state_mutability)?;
+            for modifier in func.modifiers {
+                self.out.write_char(' ')?;
+                self.print_modifier(modifier)?;
+            }
+        } else {
+            match func.kind {
+                hir::FunctionKind::Function if !func.is_yul => {
+                    write!(self.out, " {}", func.visibility)?;
+                    self.print_state_mutability(func.state_mutability)?;
+                }
+                hir::FunctionKind::Function => {}
+                hir::FunctionKind::Constructor => {
+                    if func.state_mutability == hir::StateMutability::Payable {
+                        self.out.write_str(" payable")?;
+                    }
+                }
+                hir::FunctionKind::Fallback | hir::FunctionKind::Receive => {
+                    write!(self.out, " {}", func.visibility)?;
+                    self.print_state_mutability(func.state_mutability)?;
+                }
+                hir::FunctionKind::Modifier => {}
+            }
         }
-        for modifier in func.modifiers {
-            self.out.push(' ');
-            self.print_modifier(modifier);
-        }
+
         if func.marked_virtual {
-            self.out.push_str(" virtual");
+            self.out.write_str(" virtual")?;
         }
         if func.override_ {
-            self.out.push_str(" override");
-            if !func.overrides.is_empty() {
-                self.out.push('(');
-                for (i, &contract) in func.overrides.iter().enumerate() {
-                    if i != 0 {
-                        self.out.push_str(", ");
-                    }
-                    self.out.push_str(self.gcx.hir.contract(contract).name.as_str());
-                }
-                self.out.push(')');
+            self.out.write_str(" override")?;
+            self.print_override_list(func.overrides)?;
+        }
+        if self.mode == PrintMode::Header {
+            for modifier in func.modifiers {
+                self.out.write_char(' ')?;
+                self.print_modifier(modifier)?;
             }
         }
         if !func.returns.is_empty() {
-            self.out.push_str(" returns (");
-            self.print_var_list(func.returns, VarMode::Return);
-            self.out.push(')');
+            self.out.write_str(" returns (")?;
+            self.print_var_list(func.returns, VarMode::Return)?;
+            self.out.write_char(')')?;
+        }
+        if self.mode == PrintMode::Header {
+            return Ok(());
         }
         if let Some(body) = &func.body {
-            self.out.push(' ');
-            self.print_block(body);
+            self.out.write_char(' ')?;
+            self.print_block(body)?;
         } else {
-            self.out.push_str(";\n");
+            self.out.write_str(";\n")?;
         }
+        Ok(())
     }
 
-    fn print_usings(&mut self, usings: &[hir::UsingDirective<'gcx>]) {
+    fn print_usings(&mut self, usings: &[hir::UsingDirective<'gcx>]) -> fmt::Result {
         for using in usings {
-            self.write_indent();
-            self.out.push_str("using ");
+            self.ends_with_open = false;
+            self.write_indent()?;
+            self.out.write_str("using ")?;
             match using.entries {
                 [entry] if matches!(entry.kind, UsingEntryKind::Library(_)) => {
-                    self.print_using_entry(entry);
+                    self.print_using_entry(entry)?;
                 }
                 entries => {
-                    self.out.push('{');
+                    self.out.write_char('{')?;
                     for (i, entry) in entries.iter().enumerate() {
                         if i != 0 {
-                            self.out.push_str(", ");
+                            self.out.write_str(", ")?;
                         }
-                        self.print_using_entry(entry);
+                        self.print_using_entry(entry)?;
                     }
-                    self.out.push('}');
+                    self.out.write_char('}')?;
                 }
             }
-            self.out.push_str(" for ");
+            self.out.write_str(" for ")?;
             if let Some(ty) = &using.ty {
-                self.print_ty(ty);
+                self.print_ty(ty)?;
             } else {
-                self.out.push('*');
+                self.out.write_char('*')?;
             }
             if using.global {
-                self.out.push_str(" global");
+                self.out.write_str(" global")?;
             }
-            self.out.push_str(";\n");
+            self.out.write_str(";\n")?;
         }
+        Ok(())
     }
 
-    fn print_using_entry(&mut self, entry: &hir::UsingEntry<'gcx>) {
+    fn print_using_entry(&mut self, entry: &hir::UsingEntry<'gcx>) -> fmt::Result {
         match entry.kind {
             UsingEntryKind::Library(id) => {
-                self.out.push_str(self.gcx.hir.contract(id).name.as_str());
+                self.out.write_str(self.gcx.hir.contract(id).name.as_str())?;
             }
             UsingEntryKind::Functions(ids) => {
                 for (i, &id) in ids.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(" | ");
+                        self.out.write_str(" | ")?;
                     }
-                    self.out.push_str(self.gcx.hir.function(id).name.unwrap().as_str());
+                    self.out.write_str(self.gcx.hir.function(id).name.unwrap().as_str())?;
                 }
             }
-            UsingEntryKind::Err(_) => self.out.push_str("<error>"),
+            UsingEntryKind::Err(_) => self.out.write_str("<error>")?,
         }
         if let Some(op) = entry.operator {
-            write!(self.out, " as {}", op.to_str()).unwrap();
+            write!(self.out, " as {}", op.to_str())?;
         }
+        Ok(())
     }
 
-    fn print_modifier(&mut self, modifier: &hir::Modifier<'gcx>) {
-        self.out.push_str(&self.item_name(modifier.id));
-        if !modifier.args.is_dummy() || !modifier.args.is_empty() {
-            self.print_call_args(&modifier.args);
+    fn print_modifier(&mut self, modifier: &hir::Modifier<'gcx>) -> fmt::Result {
+        self.out.write_str(&self.item_name(modifier.id))?;
+        if self.mode == PrintMode::Header && !modifier.args.is_dummy() {
+            if let Ok(args) = self.gcx.sess.source_map().span_to_snippet(modifier.args.span) {
+                self.out.write_str(args.trim())?;
+            } else {
+                self.out.write_str("(...)")?;
+            }
+        } else if !modifier.args.is_dummy() || !modifier.args.is_empty() {
+            self.print_call_args(&modifier.args)?;
         }
+        Ok(())
     }
 
-    fn print_variable(&mut self, id: hir::VariableId, mode: VarMode) {
+    fn print_variable(&mut self, id: hir::VariableId, mode: VarMode) -> fmt::Result {
         let var = self.gcx.hir.variable(id);
-        self.print_ty(&var.ty);
-        if let Some(data_location) = var.data_location {
-            write!(self.out, " {data_location}").unwrap();
-        }
-        if mode == VarMode::Item {
+        self.print_ty(&var.ty)?;
+        if self.mode == PrintMode::Header && mode == VarMode::Item {
             if let Some(visibility) = var.visibility {
-                write!(self.out, " {visibility}").unwrap();
+                write!(self.out, " {visibility}")?;
             }
             if let Some(mutability) = var.mutability {
-                write!(self.out, " {mutability}").unwrap();
+                write!(self.out, " {mutability}")?;
             }
             if var.override_ {
-                self.out.push_str(" override");
-                if !var.overrides.is_empty() {
-                    self.out.push('(');
-                    for (i, &contract) in var.overrides.iter().enumerate() {
-                        if i != 0 {
-                            self.out.push_str(", ");
-                        }
-                        self.out.push_str(self.gcx.hir.contract(contract).name.as_str());
-                    }
-                    self.out.push(')');
-                }
+                self.out.write_str(" override")?;
+                self.print_override_list(var.overrides)?;
+            }
+        }
+        if let Some(data_location) = var.data_location {
+            write!(self.out, " {data_location}")?;
+        }
+        if self.mode == PrintMode::Full && mode == VarMode::Item {
+            if let Some(visibility) = var.visibility {
+                write!(self.out, " {visibility}")?;
+            }
+            if let Some(mutability) = var.mutability {
+                write!(self.out, " {mutability}")?;
+            }
+            if var.override_ {
+                self.out.write_str(" override")?;
+                self.print_override_list(var.overrides)?;
             }
         }
         if var.indexed {
-            self.out.push_str(" indexed");
+            self.out.write_str(" indexed")?;
         }
-        write!(self.out, " {}", self.var_name(id)).unwrap();
-        if let Some(initializer) = var.initializer {
-            self.out.push_str(" = ");
-            self.print_expr(initializer);
+        if self.mode == PrintMode::Full {
+            write!(self.out, " {}", self.var_name(id))?;
+        } else if let Some(name) = var.name {
+            write!(self.out, " {name}")?;
         }
+        if self.mode == PrintMode::Full
+            && let Some(initializer) = var.initializer
+        {
+            self.out.write_str(" = ")?;
+            self.print_expr(initializer)?;
+        }
+        Ok(())
     }
 
-    fn print_var_list(&mut self, vars: &[hir::VariableId], mode: VarMode) {
+    fn print_var_list(&mut self, vars: &[hir::VariableId], mode: VarMode) -> fmt::Result {
         for (i, &var) in vars.iter().enumerate() {
             if i != 0 {
-                self.out.push_str(", ");
+                self.out.write_str(", ")?;
             }
-            self.print_variable(var, mode);
+            self.print_variable(var, mode)?;
         }
+        Ok(())
     }
 
-    fn print_block(&mut self, block: &hir::Block<'gcx>) {
-        self.out.push_str("{\n");
+    fn print_block(&mut self, block: &hir::Block<'gcx>) -> fmt::Result {
+        self.out.write_str("{\n")?;
         self.indent += 1;
         for stmt in block.stmts {
-            self.print_stmt(stmt);
+            self.print_stmt(stmt)?;
         }
         self.indent -= 1;
-        self.write_indent();
-        self.out.push_str("}\n");
+        self.write_indent()?;
+        self.out.write_str("}\n")
     }
 
-    fn print_stmt(&mut self, stmt: &hir::Stmt<'gcx>) {
-        self.write_indent();
+    fn print_stmt(&mut self, stmt: &hir::Stmt<'gcx>) -> fmt::Result {
+        self.write_indent()?;
         match &stmt.kind {
             StmtKind::DeclSingle(var) => {
-                self.print_variable(*var, VarMode::Local);
-                self.out.push_str(";\n");
+                self.print_variable(*var, VarMode::Local)?;
+                self.out.write_str(";\n")?;
             }
             StmtKind::DeclMulti(vars, expr) => {
-                self.out.push('(');
+                self.out.write_char('(')?;
                 for (i, var) in vars.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(", ");
+                        self.out.write_str(", ")?;
                     }
                     if let Some(var) = var {
-                        self.print_variable(*var, VarMode::Local);
+                        self.print_variable(*var, VarMode::Local)?;
                     }
                 }
-                self.out.push_str(") = ");
-                self.print_expr(expr);
-                self.out.push_str(";\n");
+                self.out.write_str(") = ")?;
+                self.print_expr(expr)?;
+                self.out.write_str(";\n")?;
             }
-            StmtKind::Block(block) => self.print_block(block),
+            StmtKind::Block(block) => self.print_block(block)?,
             StmtKind::UncheckedBlock(block) => {
-                self.out.push_str("unchecked ");
-                self.print_block(block);
+                self.out.write_str("unchecked ")?;
+                self.print_block(block)?;
             }
             StmtKind::AssemblyBlock(block) => {
-                self.out.push_str("assembly ");
-                self.print_block(block);
+                self.out.write_str("assembly ")?;
+                self.print_block(block)?;
             }
             StmtKind::Emit(expr) => {
-                self.out.push_str("emit ");
-                self.print_expr(expr);
-                self.out.push_str(";\n");
+                self.out.write_str("emit ")?;
+                self.print_expr(expr)?;
+                self.out.write_str(";\n")?;
             }
             StmtKind::Revert(expr) => {
-                self.out.push_str("revert ");
-                self.print_expr(expr);
-                self.out.push_str(";\n");
+                self.out.write_str("revert ")?;
+                self.print_expr(expr)?;
+                self.out.write_str(";\n")?;
             }
             StmtKind::Return(expr) => {
-                self.out.push_str("return");
+                self.out.write_str("return")?;
                 if let Some(expr) = expr {
-                    self.out.push(' ');
-                    self.print_expr(expr);
+                    self.out.write_char(' ')?;
+                    self.print_expr(expr)?;
                 }
-                self.out.push_str(";\n");
+                self.out.write_str(";\n")?;
             }
-            StmtKind::Break => self.out.push_str("break;\n"),
-            StmtKind::Continue => self.out.push_str("continue;\n"),
+            StmtKind::Break => self.out.write_str("break;\n")?,
+            StmtKind::Continue => self.out.write_str("continue;\n")?,
             StmtKind::Loop(block, source) => {
-                write!(self.out, "hir.loop({}) ", source.name()).unwrap();
-                self.print_block(block);
+                write!(self.out, "hir.loop({}) ", source.name())?;
+                self.print_block(block)?;
             }
             StmtKind::If(cond, then, else_) => {
-                self.out.push_str("if (");
-                self.print_condition(cond);
-                self.out.push_str(") ");
-                self.print_stmt_as_block(then);
+                self.out.write_str("if (")?;
+                self.print_condition(cond)?;
+                self.out.write_str(") ")?;
+                self.print_stmt_as_block(then)?;
                 if let Some(else_) = else_ {
-                    self.write_indent();
-                    self.out.push_str("else ");
-                    self.print_stmt_as_block(else_);
+                    self.write_indent()?;
+                    self.out.write_str("else ")?;
+                    self.print_stmt_as_block(else_)?;
                 }
             }
             StmtKind::Switch(switch) => {
-                self.out.push_str("switch ");
-                self.print_expr(switch.selector);
-                self.out.push_str(" {\n");
+                self.out.write_str("switch ")?;
+                self.print_expr(switch.selector)?;
+                self.out.write_str(" {\n")?;
                 self.indent += 1;
                 for case in switch.cases {
-                    self.write_indent();
+                    self.write_indent()?;
                     if let Some(lit) = case.constant {
-                        write!(self.out, "case {lit} ").unwrap();
+                        write!(self.out, "case {lit} ")?;
                     } else {
-                        self.out.push_str("default ");
+                        self.out.write_str("default ")?;
                     }
-                    self.print_block(&case.body);
+                    self.print_block(&case.body)?;
                 }
                 self.indent -= 1;
-                self.write_indent();
-                self.out.push_str("}\n");
+                self.write_indent()?;
+                self.out.write_str("}\n")?;
             }
-            StmtKind::Try(try_) => self.print_try(try_),
+            StmtKind::Try(try_) => self.print_try(try_)?,
             StmtKind::Expr(expr) => {
-                self.print_expr(expr);
-                self.out.push_str(";\n");
+                self.print_expr(expr)?;
+                self.out.write_str(";\n")?;
             }
-            StmtKind::Placeholder => self.out.push_str("_;\n"),
-            StmtKind::Err(_) => self.out.push_str("<error>;\n"),
+            StmtKind::Placeholder => self.out.write_str("_;\n")?,
+            StmtKind::Err(_) => self.out.write_str("<error>;\n")?,
         }
+        Ok(())
     }
 
-    fn print_stmt_as_block(&mut self, stmt: &hir::Stmt<'gcx>) {
+    fn print_stmt_as_block(&mut self, stmt: &hir::Stmt<'gcx>) -> fmt::Result {
         if let StmtKind::Block(block) = &stmt.kind {
-            self.print_block(block);
-            return;
+            return self.print_block(block);
         }
-        self.out.push_str("{\n");
+        self.out.write_str("{\n")?;
         self.indent += 1;
-        self.print_stmt(stmt);
+        self.print_stmt(stmt)?;
         self.indent -= 1;
-        self.write_indent();
-        self.out.push_str("}\n");
+        self.write_indent()?;
+        self.out.write_str("}\n")
     }
 
-    fn print_try(&mut self, try_: &hir::StmtTry<'gcx>) {
-        self.out.push_str("try ");
-        self.print_expr(&try_.expr);
-        self.out.push(' ');
+    fn print_try(&mut self, try_: &hir::StmtTry<'gcx>) -> fmt::Result {
+        self.out.write_str("try ")?;
+        self.print_expr(&try_.expr)?;
+        self.out.write_char(' ')?;
         for (i, clause) in try_.clauses.iter().enumerate() {
             if i != 0 {
-                self.write_indent();
+                self.write_indent()?;
             }
             match clause.name {
-                Some(name) => write!(self.out, "catch {name}(").unwrap(),
-                None if i == 0 => self.out.push_str("returns ("),
-                None => self.out.push_str("catch ("),
+                Some(name) => write!(self.out, "catch {name}(")?,
+                None if i == 0 => self.out.write_str("returns (")?,
+                None => self.out.write_str("catch (")?,
             }
-            self.print_var_list(clause.args, VarMode::Parameter);
-            self.out.push_str(") ");
-            self.print_block(&clause.block);
+            self.print_var_list(clause.args, VarMode::Parameter)?;
+            self.out.write_str(") ")?;
+            self.print_block(&clause.block)?;
         }
+        Ok(())
     }
 
-    fn print_expr(&mut self, expr: &hir::Expr<'gcx>) {
+    fn print_expr(&mut self, expr: &hir::Expr<'gcx>) -> fmt::Result {
         match &expr.kind {
             ExprKind::Array(exprs) => {
-                self.out.push('[');
+                self.out.write_char('[')?;
                 for (i, expr) in exprs.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(", ");
+                        self.out.write_str(", ")?;
                     }
-                    self.print_expr(expr);
+                    self.print_expr(expr)?;
                 }
-                self.out.push(']');
+                self.out.write_char(']')?;
             }
             ExprKind::Assign(lhs, op, rhs) => {
-                self.print_expr(lhs);
-                self.out.push(' ');
+                self.print_expr(lhs)?;
+                self.out.write_char(' ')?;
                 if let Some(op) = op {
-                    self.out.push_str(op.kind.to_str());
+                    self.out.write_str(op.kind.to_str())?;
                 }
-                self.out.push_str("= ");
-                self.print_expr(rhs);
+                self.out.write_str("= ")?;
+                self.print_expr(rhs)?;
             }
             ExprKind::Binary(lhs, op, rhs) => {
-                self.out.push('(');
-                self.print_expr(lhs);
-                write!(self.out, " {} ", op.kind.to_str()).unwrap();
-                self.print_expr(rhs);
-                self.out.push(')');
+                self.out.write_char('(')?;
+                self.print_expr(lhs)?;
+                write!(self.out, " {} ", op.kind.to_str())?;
+                self.print_expr(rhs)?;
+                self.out.write_char(')')?;
             }
             ExprKind::Call(callee, args, opts) => {
-                self.print_expr(callee);
+                self.print_expr(callee)?;
                 if let Some(opts) = opts {
-                    self.out.push_str(" { ");
+                    self.out.write_str(" { ")?;
                     for (i, arg) in opts.args.iter().enumerate() {
                         if i != 0 {
-                            self.out.push_str(", ");
+                            self.out.write_str(", ")?;
                         }
-                        write!(self.out, "{}: ", arg.name).unwrap();
-                        self.print_expr(&arg.value);
+                        write!(self.out, "{}: ", arg.name)?;
+                        self.print_expr(&arg.value)?;
                     }
-                    self.out.push_str(" }");
+                    self.out.write_str(" }")?;
                 }
-                self.print_call_args(args);
+                self.print_call_args(args)?;
             }
             ExprKind::Delete(expr) => {
-                self.out.push_str("delete ");
-                self.print_expr(expr);
+                self.out.write_str("delete ")?;
+                self.print_expr(expr)?;
             }
-            ExprKind::Ident(res) => self.print_res_list(res),
+            ExprKind::Ident(res) => self.print_res_list(res)?,
             ExprKind::Index(expr, index) => {
-                self.print_expr(expr);
-                self.out.push('[');
+                self.print_expr(expr)?;
+                self.out.write_char('[')?;
                 if let Some(index) = index {
-                    self.print_expr(index);
+                    self.print_expr(index)?;
                 }
-                self.out.push(']');
+                self.out.write_char(']')?;
             }
             ExprKind::Slice(expr, start, end) => {
-                self.print_expr(expr);
-                self.out.push('[');
+                self.print_expr(expr)?;
+                self.out.write_char('[')?;
                 if let Some(start) = start {
-                    self.print_expr(start);
+                    self.print_expr(start)?;
                 }
-                self.out.push(':');
+                self.out.write_char(':')?;
                 if let Some(end) = end {
-                    self.print_expr(end);
+                    self.print_expr(end)?;
                 }
-                self.out.push(']');
+                self.out.write_char(']')?;
             }
-            ExprKind::Lit(lit) => write!(self.out, "{lit}").unwrap(),
+            ExprKind::Lit(lit) => write!(self.out, "{lit}")?,
             ExprKind::Member(expr, ident) | ExprKind::YulMember(expr, ident) => {
-                self.print_expr(expr);
-                write!(self.out, ".{ident}").unwrap();
+                self.print_expr(expr)?;
+                write!(self.out, ".{ident}")?;
             }
             ExprKind::New(ty) => {
-                self.out.push_str("new ");
-                self.print_ty(ty);
+                self.out.write_str("new ")?;
+                self.print_ty(ty)?;
             }
             ExprKind::Payable(expr) => {
-                self.out.push_str("payable(");
-                self.print_expr(expr);
-                self.out.push(')');
+                self.out.write_str("payable(")?;
+                self.print_expr(expr)?;
+                self.out.write_char(')')?;
             }
             ExprKind::Ternary(cond, then, else_) => {
-                self.out.push('(');
-                self.print_expr(cond);
-                self.out.push_str(" ? ");
-                self.print_expr(then);
-                self.out.push_str(" : ");
-                self.print_expr(else_);
-                self.out.push(')');
+                self.out.write_char('(')?;
+                self.print_expr(cond)?;
+                self.out.write_str(" ? ")?;
+                self.print_expr(then)?;
+                self.out.write_str(" : ")?;
+                self.print_expr(else_)?;
+                self.out.write_char(')')?;
             }
             ExprKind::Tuple(exprs) => {
-                self.out.push('(');
+                self.out.write_char('(')?;
                 for (i, expr) in exprs.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(", ");
+                        self.out.write_str(", ")?;
                     }
                     if let Some(expr) = expr {
-                        self.print_expr(expr);
+                        self.print_expr(expr)?;
                     }
                 }
-                self.out.push(')');
+                self.out.write_char(')')?;
             }
             ExprKind::TypeCall(ty) => {
-                self.out.push_str("type(");
-                self.print_ty(ty);
-                self.out.push(')');
+                self.out.write_str("type(")?;
+                self.print_ty(ty)?;
+                self.out.write_char(')')?;
             }
-            ExprKind::Type(ty) => self.print_ty(ty),
+            ExprKind::Type(ty) => self.print_ty(ty)?,
             ExprKind::Unary(op, expr) => {
                 if op.kind.is_prefix() {
-                    self.out.push_str(op.kind.to_str());
-                    self.print_expr(expr);
+                    self.out.write_str(op.kind.to_str())?;
+                    self.print_expr(expr)?;
                 } else {
-                    self.print_expr(expr);
-                    self.out.push_str(op.kind.to_str());
+                    self.print_expr(expr)?;
+                    self.out.write_str(op.kind.to_str())?;
                 }
             }
-            ExprKind::Err(_) => self.out.push_str("<error>"),
+            ExprKind::Err(_) => self.out.write_str("<error>")?,
         }
+        Ok(())
     }
 
-    fn print_condition(&mut self, expr: &hir::Expr<'gcx>) {
+    fn print_condition(&mut self, expr: &hir::Expr<'gcx>) -> fmt::Result {
         if let ExprKind::Binary(lhs, op, rhs) = &expr.kind {
-            self.print_expr(lhs);
-            write!(self.out, " {} ", op.kind.to_str()).unwrap();
-            self.print_expr(rhs);
+            self.print_expr(lhs)?;
+            write!(self.out, " {} ", op.kind.to_str())?;
+            self.print_expr(rhs)
         } else {
-            self.print_expr(expr);
+            self.print_expr(expr)
         }
     }
 
-    fn print_call_args(&mut self, args: &hir::CallArgs<'gcx>) {
+    fn print_call_args(&mut self, args: &hir::CallArgs<'gcx>) -> fmt::Result {
         match args.kind {
             CallArgsKind::Unnamed(exprs) => {
-                self.out.push('(');
+                self.out.write_char('(')?;
                 for (i, expr) in exprs.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(", ");
+                        self.out.write_str(", ")?;
                     }
-                    self.print_expr(expr);
+                    self.print_expr(expr)?;
                 }
-                self.out.push(')');
+                self.out.write_char(')')?;
             }
             CallArgsKind::Named(args) => {
-                self.out.push_str("({");
+                self.out.write_str("({")?;
                 for (i, arg) in args.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(", ");
+                        self.out.write_str(", ")?;
                     }
-                    write!(self.out, "{}: ", arg.name).unwrap();
-                    self.print_expr(&arg.value);
+                    write!(self.out, "{}: ", arg.name)?;
+                    self.print_expr(&arg.value)?;
                 }
-                self.out.push_str("})");
+                self.out.write_str("})")?;
             }
         }
+        Ok(())
     }
 
-    fn print_res_list(&mut self, res: &[Res]) {
+    fn print_res_list(&mut self, res: &[Res]) -> fmt::Result {
         match res {
-            [] => self.out.push_str("<unresolved>"),
+            [] => self.out.write_str("<unresolved>")?,
             [res] => {
                 let label = self.res_name(*res);
-                self.out.push_str(&label);
+                self.out.write_str(&label)?;
             }
             many => {
-                self.out.push_str("overload(");
+                self.out.write_str("overload(")?;
                 for (i, &res) in many.iter().enumerate() {
                     if i != 0 {
-                        self.out.push_str(" | ");
+                        self.out.write_str(" | ")?;
                     }
                     let label = self.res_name(res);
-                    self.out.push_str(&label);
+                    self.out.write_str(&label)?;
                 }
-                self.out.push(')');
+                self.out.write_char(')')?;
             }
         }
+        Ok(())
     }
 
-    fn print_ty(&mut self, ty: &hir::Type<'gcx>) {
+    fn print_ty(&mut self, ty: &hir::Type<'gcx>) -> fmt::Result {
         match &ty.kind {
-            TypeKind::Elementary(ty) => write!(self.out, "{ty}").unwrap(),
+            TypeKind::Elementary(ty) => write!(self.out, "{ty}")?,
             TypeKind::Array(arr) => {
-                self.print_ty(&arr.element);
-                self.out.push('[');
+                self.print_ty(&arr.element)?;
+                self.out.write_char('[')?;
                 if let Some(size) = arr.size {
-                    self.print_expr(size);
+                    if self.mode == PrintMode::Header {
+                        if let Ok(size) = self.gcx.sess.source_map().span_to_snippet(size.span) {
+                            self.out.write_str(size.trim())?;
+                        } else {
+                            self.out.write_str("<error>")?;
+                        }
+                    } else {
+                        self.print_expr(size)?;
+                    }
                 }
-                self.out.push(']');
+                self.out.write_char(']')?;
             }
             TypeKind::Function(func) => {
-                self.out.push_str("function(");
-                self.print_var_list(func.parameters, VarMode::Parameter);
-                self.out.push(')');
-                write!(self.out, " {}", func.visibility).unwrap();
-                if func.state_mutability != hir::StateMutability::NonPayable {
-                    write!(self.out, " {}", func.state_mutability).unwrap();
-                }
+                self.out.write_str("function(")?;
+                self.print_var_list(func.parameters, VarMode::Parameter)?;
+                self.out.write_char(')')?;
+                write!(self.out, " {}", func.visibility)?;
+                self.print_state_mutability(func.state_mutability)?;
                 if !func.returns.is_empty() {
-                    self.out.push_str(" returns (");
-                    self.print_var_list(func.returns, VarMode::Return);
-                    self.out.push(')');
+                    self.out.write_str(" returns (")?;
+                    self.print_var_list(func.returns, VarMode::Return)?;
+                    self.out.write_char(')')?;
                 }
             }
             TypeKind::Mapping(map) => {
-                self.out.push_str("mapping(");
-                self.print_ty(&map.key);
+                self.out.write_str("mapping(")?;
+                self.print_ty(&map.key)?;
                 if let Some(name) = map.key_name {
-                    write!(self.out, " {name}").unwrap();
+                    write!(self.out, " {name}")?;
                 }
-                self.out.push_str(" => ");
-                self.print_ty(&map.value);
+                self.out.write_str(" => ")?;
+                self.print_ty(&map.value)?;
                 if let Some(name) = map.value_name {
-                    write!(self.out, " {name}").unwrap();
+                    write!(self.out, " {name}")?;
                 }
-                self.out.push(')');
+                self.out.write_char(')')?;
             }
             TypeKind::Custom(item) => {
                 let label = self.item_name(*item);
-                self.out.push_str(&label);
+                self.out.write_str(&label)?;
             }
-            TypeKind::Err(_) => self.out.push_str("<error>"),
+            TypeKind::Err(_) => self.out.write_str("<error>")?,
         }
+        Ok(())
+    }
+
+    fn print_state_mutability(&mut self, state_mutability: hir::StateMutability) -> fmt::Result {
+        if state_mutability != hir::StateMutability::NonPayable {
+            write!(self.out, " {state_mutability}")?;
+        }
+        Ok(())
+    }
+
+    fn print_override_list(&mut self, overrides: &[hir::ContractId]) -> fmt::Result {
+        if overrides.is_empty() {
+            return Ok(());
+        }
+        self.out.write_char('(')?;
+        for (i, &contract) in overrides.iter().enumerate() {
+            if i != 0 {
+                self.out.write_str(", ")?;
+            }
+            self.out.write_str(self.gcx.hir.contract(contract).name.as_str())?;
+        }
+        self.out.write_char(')')
     }
 
     fn res_name(&self, res: Res) -> String {
@@ -694,10 +817,12 @@ impl<'gcx> HirPrinter<'gcx> {
     }
 
     fn item_name(&self, item: ItemId) -> String {
-        self.gcx
-            .item_name_opt(item)
-            .map(|name| name.to_string())
-            .unwrap_or_else(|| self.synthetic_item_name(item))
+        self.gcx.item_name_opt(item).map(|name| name.to_string()).unwrap_or_else(|| {
+            match self.mode {
+                PrintMode::Full => self.synthetic_item_name(item),
+                PrintMode::Header => "<error>".to_string(),
+            }
+        })
     }
 
     fn synthetic_item_name(&self, item: ItemId) -> String {
@@ -726,15 +851,18 @@ impl<'gcx> HirPrinter<'gcx> {
         format!("_var{}", id.index())
     }
 
-    fn write_indent(&mut self) {
+    fn write_indent(&mut self) -> fmt::Result {
         for _ in 0..self.indent {
-            self.out.push_str("    ");
+            self.out.write_str("    ")?;
         }
+        Ok(())
     }
+}
 
-    fn ends_with_open_source(&self) -> bool {
-        self.out.ends_with("{\n")
-    }
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PrintMode {
+    Full,
+    Header,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -747,252 +875,4 @@ enum VarMode {
 
 fn builtin_name(builtin: Builtin) -> impl fmt::Display {
     solar_data_structures::fmt::from_fn(move |f| f.write_str(builtin.name().as_str()))
-}
-
-impl HirPrinter<'_> {
-    fn fmt_item<W: fmt::Write>(&self, item_id: ItemId, buf: &mut W) -> fmt::Result {
-        match item_id {
-            ItemId::Contract(id) => self.fmt_contract(id, buf),
-            ItemId::Function(id) => self.fmt_function(id, buf),
-            ItemId::Variable(id) => self.fmt_variable(id, buf),
-            ItemId::Struct(id) => self.fmt_struct(id, buf),
-            ItemId::Enum(id) => self.fmt_enum(id, buf),
-            ItemId::Udvt(id) => self.fmt_udvt(id, buf),
-            ItemId::Error(id) => self.fmt_error(id, buf),
-            ItemId::Event(id) => self.fmt_event(id, buf),
-        }
-    }
-
-    fn fmt_contract<W: fmt::Write>(&self, id: hir::ContractId, buf: &mut W) -> fmt::Result {
-        let contract = self.gcx.hir.contract(id);
-        write!(buf, "{} {}", contract.kind, contract.name)?;
-        if let Some((&first, rest)) = contract.bases.split_first() {
-            write!(buf, " is {}", self.gcx.hir.contract(first).name)?;
-            for &base in rest {
-                write!(buf, ", {}", self.gcx.hir.contract(base).name)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn fmt_function<W: fmt::Write>(&self, id: hir::FunctionId, buf: &mut W) -> fmt::Result {
-        let function = self.gcx.hir.function(id);
-        if function.is_yul {
-            buf.write_str("yul ")?;
-        }
-
-        write!(buf, "{}", function.kind)?;
-        if let Some(name) = function.name {
-            write!(buf, " {name}")?;
-        }
-        buf.write_char('(')?;
-        self.fmt_variables(function.parameters, buf)?;
-        buf.write_char(')')?;
-
-        match function.kind {
-            hir::FunctionKind::Function if !function.is_yul => {
-                write!(buf, " {}", function.visibility)?;
-                self.fmt_state_mutability(function.state_mutability, buf)?;
-            }
-            hir::FunctionKind::Function => {}
-            hir::FunctionKind::Constructor => {
-                if function.state_mutability == hir::StateMutability::Payable {
-                    buf.write_str(" payable")?;
-                }
-            }
-            hir::FunctionKind::Fallback | hir::FunctionKind::Receive => {
-                write!(buf, " {}", function.visibility)?;
-                self.fmt_state_mutability(function.state_mutability, buf)?;
-            }
-            hir::FunctionKind::Modifier => {}
-        }
-
-        if function.marked_virtual {
-            buf.write_str(" virtual")?;
-        }
-        if function.override_ {
-            buf.write_str(" override")?;
-            self.fmt_override_list(function.overrides, buf)?;
-        }
-        for modifier in function.modifiers {
-            buf.write_char(' ')?;
-            self.fmt_item_name(modifier.id, buf)?;
-            if !modifier.args.is_dummy() {
-                if let Ok(args) = self.gcx.sess.source_map().span_to_snippet(modifier.args.span) {
-                    buf.write_str(args.trim())?;
-                } else {
-                    buf.write_str("(...)")?;
-                }
-            }
-        }
-        if !function.returns.is_empty() {
-            buf.write_str(" returns (")?;
-            self.fmt_variables(function.returns, buf)?;
-            buf.write_char(')')?;
-        }
-        Ok(())
-    }
-
-    fn fmt_variable<W: fmt::Write>(&self, id: hir::VariableId, buf: &mut W) -> fmt::Result {
-        let variable = self.gcx.hir.variable(id);
-        self.fmt_ty(&variable.ty, buf)?;
-        if let Some(visibility) = variable.visibility {
-            write!(buf, " {visibility}")?;
-        }
-        if let Some(mutability) = variable.mutability {
-            write!(buf, " {mutability}")?;
-        }
-        if variable.override_ {
-            buf.write_str(" override")?;
-            self.fmt_override_list(variable.overrides, buf)?;
-        }
-        if let Some(data_location) = variable.data_location {
-            write!(buf, " {data_location}")?;
-        }
-        if variable.indexed {
-            buf.write_str(" indexed")?;
-        }
-        if let Some(name) = variable.name {
-            write!(buf, " {name}")?;
-        }
-        Ok(())
-    }
-
-    fn fmt_struct<W: fmt::Write>(&self, id: hir::StructId, buf: &mut W) -> fmt::Result {
-        write!(buf, "struct {}", self.gcx.hir.strukt(id).name)
-    }
-
-    fn fmt_enum<W: fmt::Write>(&self, id: hir::EnumId, buf: &mut W) -> fmt::Result {
-        write!(buf, "enum {}", self.gcx.hir.enumm(id).name)
-    }
-
-    fn fmt_udvt<W: fmt::Write>(&self, id: hir::UdvtId, buf: &mut W) -> fmt::Result {
-        let udvt = self.gcx.hir.udvt(id);
-        write!(buf, "type {} is ", udvt.name)?;
-        self.fmt_ty(&udvt.ty, buf)
-    }
-
-    fn fmt_event<W: fmt::Write>(&self, id: hir::EventId, buf: &mut W) -> fmt::Result {
-        let event = self.gcx.hir.event(id);
-        write!(buf, "event {}(", event.name)?;
-        self.fmt_variables(event.parameters, buf)?;
-        buf.write_char(')')?;
-        if event.anonymous {
-            buf.write_str(" anonymous")?;
-        }
-        Ok(())
-    }
-
-    fn fmt_error<W: fmt::Write>(&self, id: hir::ErrorId, buf: &mut W) -> fmt::Result {
-        let error = self.gcx.hir.error(id);
-        write!(buf, "error {}(", error.name)?;
-        self.fmt_variables(error.parameters, buf)?;
-        buf.write_char(')')
-    }
-
-    fn fmt_variables<W: fmt::Write>(
-        &self,
-        variables: &[hir::VariableId],
-        buf: &mut W,
-    ) -> fmt::Result {
-        for (index, &id) in variables.iter().enumerate() {
-            if index != 0 {
-                buf.write_str(", ")?;
-            }
-            let variable = self.gcx.hir.variable(id);
-            self.fmt_ty(&variable.ty, buf)?;
-            if let Some(data_location) = variable.data_location {
-                write!(buf, " {data_location}")?;
-            }
-            if variable.indexed {
-                buf.write_str(" indexed")?;
-            }
-            if let Some(name) = variable.name {
-                write!(buf, " {name}")?;
-            }
-        }
-        Ok(())
-    }
-
-    fn fmt_ty<W: fmt::Write>(&self, ty: &hir::Type<'_>, buf: &mut W) -> fmt::Result {
-        match &ty.kind {
-            TypeKind::Elementary(elementary) => write!(buf, "{elementary}"),
-            TypeKind::Array(array) => {
-                self.fmt_ty(&array.element, buf)?;
-                buf.write_char('[')?;
-                if let Some(size) = array.size {
-                    if let Ok(size) = self.gcx.sess.source_map().span_to_snippet(size.span) {
-                        buf.write_str(size.trim())?;
-                    } else {
-                        buf.write_str("<error>")?;
-                    }
-                }
-                buf.write_char(']')
-            }
-            TypeKind::Function(function) => {
-                buf.write_str("function(")?;
-                self.fmt_variables(function.parameters, buf)?;
-                write!(buf, ") {}", function.visibility)?;
-                self.fmt_state_mutability(function.state_mutability, buf)?;
-                if !function.returns.is_empty() {
-                    buf.write_str(" returns (")?;
-                    self.fmt_variables(function.returns, buf)?;
-                    buf.write_char(')')?;
-                }
-                Ok(())
-            }
-            TypeKind::Mapping(mapping) => {
-                buf.write_str("mapping(")?;
-                self.fmt_ty(&mapping.key, buf)?;
-                if let Some(name) = mapping.key_name {
-                    write!(buf, " {name}")?;
-                }
-                buf.write_str(" => ")?;
-                self.fmt_ty(&mapping.value, buf)?;
-                if let Some(name) = mapping.value_name {
-                    write!(buf, " {name}")?;
-                }
-                buf.write_char(')')
-            }
-            TypeKind::Custom(item_id) => self.fmt_item_name(*item_id, buf),
-            TypeKind::Err(_) => buf.write_str("<error>"),
-        }
-    }
-
-    fn fmt_state_mutability<W: fmt::Write>(
-        &self,
-        state_mutability: hir::StateMutability,
-        buf: &mut W,
-    ) -> fmt::Result {
-        if state_mutability != hir::StateMutability::NonPayable {
-            write!(buf, " {state_mutability}")?;
-        }
-        Ok(())
-    }
-
-    fn fmt_override_list<W: fmt::Write>(
-        &self,
-        overrides: &[hir::ContractId],
-        buf: &mut W,
-    ) -> fmt::Result {
-        if overrides.is_empty() {
-            return Ok(());
-        }
-        buf.write_char('(')?;
-        for (index, &contract) in overrides.iter().enumerate() {
-            if index != 0 {
-                buf.write_str(", ")?;
-            }
-            self.fmt_item_name(contract.into(), buf)?;
-        }
-        buf.write_char(')')
-    }
-
-    fn fmt_item_name<W: fmt::Write>(&self, item_id: ItemId, buf: &mut W) -> fmt::Result {
-        if let Some(name) = self.gcx.item_name_opt(item_id) {
-            write!(buf, "{name}")
-        } else {
-            buf.write_str("<error>")
-        }
-    }
 }

--- a/crates/sema/src/hir/print.rs
+++ b/crates/sema/src/hir/print.rs
@@ -743,3 +743,261 @@ enum VarMode {
 fn builtin_name(builtin: Builtin) -> impl fmt::Display {
     solar_data_structures::fmt::from_fn(move |f| f.write_str(builtin.name().as_str()))
 }
+
+/// Prints individual HIR declaration headers in Solidity syntax.
+pub struct HirDisplayPrinter<'gcx, W> {
+    gcx: Gcx<'gcx>,
+    buf: W,
+}
+
+impl<'gcx, W: fmt::Write> HirDisplayPrinter<'gcx, W> {
+    /// Creates a new HIR display printer.
+    pub fn new(gcx: Gcx<'gcx>, buf: W) -> Self {
+        Self { gcx, buf }
+    }
+
+    /// Returns a mutable reference to the underlying buffer.
+    pub fn buf(&mut self) -> &mut W {
+        &mut self.buf
+    }
+
+    /// Consumes the printer and returns the underlying buffer.
+    pub fn into_buf(self) -> W {
+        self.buf
+    }
+
+    /// Prints the declaration header for `item_id`.
+    pub fn print(&mut self, item_id: ItemId) -> fmt::Result {
+        match item_id {
+            ItemId::Contract(id) => self.print_contract(id),
+            ItemId::Function(id) => self.print_function(id),
+            ItemId::Variable(id) => self.print_variable(id),
+            ItemId::Struct(id) => self.print_struct(id),
+            ItemId::Enum(id) => self.print_enum(id),
+            ItemId::Udvt(id) => self.print_udvt(id),
+            ItemId::Error(id) => self.print_error(id),
+            ItemId::Event(id) => self.print_event(id),
+        }
+    }
+
+    fn print_contract(&mut self, id: hir::ContractId) -> fmt::Result {
+        let contract = self.gcx.hir.contract(id);
+        write!(self.buf, "{} {}", contract.kind, contract.name)?;
+        if let Some((&first, rest)) = contract.bases.split_first() {
+            write!(self.buf, " is {}", self.gcx.hir.contract(first).name)?;
+            for &base in rest {
+                write!(self.buf, ", {}", self.gcx.hir.contract(base).name)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn print_function(&mut self, id: hir::FunctionId) -> fmt::Result {
+        let function = self.gcx.hir.function(id);
+        if function.is_yul {
+            self.buf.write_str("yul ")?;
+        }
+
+        write!(self.buf, "{}", function.kind)?;
+        if let Some(name) = function.name {
+            write!(self.buf, " {name}")?;
+        }
+        self.buf.write_char('(')?;
+        self.print_variables(function.parameters)?;
+        self.buf.write_char(')')?;
+
+        match function.kind {
+            hir::FunctionKind::Function if !function.is_yul => {
+                write!(self.buf, " {}", function.visibility)?;
+                self.print_state_mutability(function.state_mutability)?;
+            }
+            hir::FunctionKind::Function => {}
+            hir::FunctionKind::Constructor => {
+                if function.state_mutability == hir::StateMutability::Payable {
+                    self.buf.write_str(" payable")?;
+                }
+            }
+            hir::FunctionKind::Fallback | hir::FunctionKind::Receive => {
+                write!(self.buf, " {}", function.visibility)?;
+                self.print_state_mutability(function.state_mutability)?;
+            }
+            hir::FunctionKind::Modifier => {}
+        }
+
+        if function.marked_virtual {
+            self.buf.write_str(" virtual")?;
+        }
+        if function.override_ {
+            self.buf.write_str(" override")?;
+            self.print_override_list(function.overrides)?;
+        }
+        for modifier in function.modifiers {
+            self.buf.write_char(' ')?;
+            self.print_item_name(modifier.id)?;
+            if !modifier.args.is_dummy() {
+                if let Ok(args) = self.gcx.sess.source_map().span_to_snippet(modifier.args.span) {
+                    self.buf.write_str(args.trim())?;
+                } else {
+                    self.buf.write_str("(...)")?;
+                }
+            }
+        }
+        if !function.returns.is_empty() {
+            self.buf.write_str(" returns (")?;
+            self.print_variables(function.returns)?;
+            self.buf.write_char(')')?;
+        }
+        Ok(())
+    }
+
+    fn print_variable(&mut self, id: hir::VariableId) -> fmt::Result {
+        let variable = self.gcx.hir.variable(id);
+        self.print_ty(&variable.ty)?;
+        if let Some(visibility) = variable.visibility {
+            write!(self.buf, " {visibility}")?;
+        }
+        if let Some(mutability) = variable.mutability {
+            write!(self.buf, " {mutability}")?;
+        }
+        if variable.override_ {
+            self.buf.write_str(" override")?;
+            self.print_override_list(variable.overrides)?;
+        }
+        if let Some(data_location) = variable.data_location {
+            write!(self.buf, " {data_location}")?;
+        }
+        if variable.indexed {
+            self.buf.write_str(" indexed")?;
+        }
+        if let Some(name) = variable.name {
+            write!(self.buf, " {name}")?;
+        }
+        Ok(())
+    }
+
+    fn print_struct(&mut self, id: hir::StructId) -> fmt::Result {
+        write!(self.buf, "struct {}", self.gcx.hir.strukt(id).name)
+    }
+
+    fn print_enum(&mut self, id: hir::EnumId) -> fmt::Result {
+        write!(self.buf, "enum {}", self.gcx.hir.enumm(id).name)
+    }
+
+    fn print_udvt(&mut self, id: hir::UdvtId) -> fmt::Result {
+        let udvt = self.gcx.hir.udvt(id);
+        write!(self.buf, "type {} is ", udvt.name)?;
+        self.print_ty(&udvt.ty)
+    }
+
+    fn print_event(&mut self, id: hir::EventId) -> fmt::Result {
+        let event = self.gcx.hir.event(id);
+        write!(self.buf, "event {}(", event.name)?;
+        self.print_variables(event.parameters)?;
+        self.buf.write_char(')')?;
+        if event.anonymous {
+            self.buf.write_str(" anonymous")?;
+        }
+        Ok(())
+    }
+
+    fn print_error(&mut self, id: hir::ErrorId) -> fmt::Result {
+        let error = self.gcx.hir.error(id);
+        write!(self.buf, "error {}(", error.name)?;
+        self.print_variables(error.parameters)?;
+        self.buf.write_char(')')
+    }
+
+    fn print_variables(&mut self, variables: &[hir::VariableId]) -> fmt::Result {
+        for (index, &id) in variables.iter().enumerate() {
+            if index != 0 {
+                self.buf.write_str(", ")?;
+            }
+            let variable = self.gcx.hir.variable(id);
+            self.print_ty(&variable.ty)?;
+            if let Some(data_location) = variable.data_location {
+                write!(self.buf, " {data_location}")?;
+            }
+            if variable.indexed {
+                self.buf.write_str(" indexed")?;
+            }
+            if let Some(name) = variable.name {
+                write!(self.buf, " {name}")?;
+            }
+        }
+        Ok(())
+    }
+
+    fn print_ty(&mut self, ty: &hir::Type<'_>) -> fmt::Result {
+        match &ty.kind {
+            TypeKind::Elementary(elementary) => write!(self.buf, "{elementary}"),
+            TypeKind::Array(array) => {
+                self.print_ty(&array.element)?;
+                self.buf.write_char('[')?;
+                if let Some(size) = array.size {
+                    if let Ok(size) = self.gcx.sess.source_map().span_to_snippet(size.span) {
+                        self.buf.write_str(size.trim())?;
+                    } else {
+                        self.buf.write_str("<error>")?;
+                    }
+                }
+                self.buf.write_char(']')
+            }
+            TypeKind::Function(function) => {
+                self.buf.write_str("function(")?;
+                self.print_variables(function.parameters)?;
+                write!(self.buf, ") {}", function.visibility)?;
+                self.print_state_mutability(function.state_mutability)?;
+                if !function.returns.is_empty() {
+                    self.buf.write_str(" returns (")?;
+                    self.print_variables(function.returns)?;
+                    self.buf.write_char(')')?;
+                }
+                Ok(())
+            }
+            TypeKind::Mapping(mapping) => {
+                self.buf.write_str("mapping(")?;
+                self.print_ty(&mapping.key)?;
+                if let Some(name) = mapping.key_name {
+                    write!(self.buf, " {name}")?;
+                }
+                self.buf.write_str(" => ")?;
+                self.print_ty(&mapping.value)?;
+                if let Some(name) = mapping.value_name {
+                    write!(self.buf, " {name}")?;
+                }
+                self.buf.write_char(')')
+            }
+            TypeKind::Custom(item_id) => self.print_item_name(*item_id),
+            TypeKind::Err(_) => self.buf.write_str("<error>"),
+        }
+    }
+
+    fn print_state_mutability(&mut self, state_mutability: hir::StateMutability) -> fmt::Result {
+        if state_mutability != hir::StateMutability::NonPayable {
+            write!(self.buf, " {state_mutability}")?;
+        }
+        Ok(())
+    }
+
+    fn print_override_list(&mut self, overrides: &[hir::ContractId]) -> fmt::Result {
+        if overrides.is_empty() {
+            return Ok(());
+        }
+        self.buf.write_char('(')?;
+        for (index, &contract) in overrides.iter().enumerate() {
+            if index != 0 {
+                self.buf.write_str(", ")?;
+            }
+            self.print_item_name(contract.into())?;
+        }
+        self.buf.write_char(')')
+    }
+
+    fn print_item_name(&mut self, item_id: ItemId) -> fmt::Result {
+        if let Some(name) = self.gcx.item_name_opt(item_id) {
+            write!(self.buf, "{name}")
+        } else {
+            self.buf.write_str("<error>")
+        }
+    }
+}


### PR DESCRIPTION
Moves Solidity declaration rendering out of LSP hover code. A single stateful `HirPrinter` now writes both full HIR dumps and declaration headers through the same methods, with `HirPrinter::display` streaming header output directly into the formatter. The printer covers every HIR item kind, including structs, enums, and user-defined value types.