### PR TITLE
fix(codegen): pack sub-word storage like solc

### DIFF
--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -665,8 +665,17 @@ impl<'gcx> Lowerer<'gcx> {
                             return self.materialize_storage_bytes(builder, slot_val);
                         }
 
-                        // For scalar storage variables, just load the value
-                        return self.load_storage_location_at_slot(builder, location, slot_val);
+                        // For scalar storage variables, load the value and
+                        // sign-extend packed signed integers (the RMW path only
+                        // masks the stored byte window).
+                        let value =
+                            self.load_storage_location_at_slot(builder, location, slot_val);
+                        return self.cleanup_packed_storage_load(
+                            builder,
+                            self.gcx.type_of_hir_ty(&var.ty),
+                            location,
+                            value,
+                        );
                     }
                 }
                 builder.imm_u64(0)
@@ -1638,6 +1647,31 @@ impl<'gcx> Lowerer<'gcx> {
         let mask = U256::MAX << low_bits;
         let mask = builder.imm_u256(mask);
         builder.and(value, mask)
+    }
+
+    /// Restores a packed storage load into a full typed word.
+    ///
+    /// Packed loads only mask the stored byte window. Signed integers need
+    /// sign-extension so later arithmetic and ABI encoding see a proper `intN`.
+    fn cleanup_packed_storage_load(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: Ty<'_>,
+        location: super::storage::StorageLocation,
+        value: ValueId,
+    ) -> ValueId {
+        if !location.is_packed() {
+            return value;
+        }
+        match ty.peel_refs().kind {
+            TyKind::Elementary(ElementaryType::Int(size)) => {
+                self.sign_extend_to_bits(builder, value, size.bits() as u32)
+            }
+            TyKind::Udvt(inner, _) => {
+                self.cleanup_packed_storage_load(builder, inner, location, value)
+            }
+            _ => value,
+        }
     }
 
     pub(super) fn mask_to_bits(

--- a/crates/codegen/src/lower/storage.rs
+++ b/crates/codegen/src/lower/storage.rs
@@ -27,7 +27,7 @@ impl StorageLocation {
         Self { slot, offset: 0, size: Self::WORD_SIZE }
     }
 
-    const fn is_packed(self) -> bool {
+    pub(super) const fn is_packed(self) -> bool {
         self.offset != 0 || self.size != Self::WORD_SIZE
     }
 }
@@ -186,10 +186,33 @@ impl<'gcx> Lowerer<'gcx> {
     }
 
     /// Returns the byte width for scalar types that this lowering can safely pack.
+    ///
+    /// Sizes match the sema storage-layout emitter (`StorageLayoutBuilder::storage_bytes`).
+    /// Left-aligned types (`bytesN`, external function pointers) are excluded until load/store
+    /// learn to shift them into the packed byte window; packing them with a right-aligned mask
+    /// would zero the value.
     fn packed_storage_size(&self, ty: Ty<'gcx>) -> Option<u8> {
         match ty.peel_refs().kind {
-            TyKind::Elementary(ElementaryType::Bool) => Some(1),
+            TyKind::Elementary(elem) => match elem {
+                ElementaryType::Bool => Some(1),
+                ElementaryType::Address(_) => Some(20),
+                ElementaryType::Int(size)
+                | ElementaryType::UInt(size)
+                | ElementaryType::Fixed(size, _)
+                | ElementaryType::UFixed(size, _) => {
+                    let n = size.bytes();
+                    (n < StorageLocation::WORD_SIZE).then_some(n)
+                }
+                // Left-aligned in the EVM word; not packed here yet.
+                ElementaryType::FixedBytes(_) | ElementaryType::String | ElementaryType::Bytes => {
+                    None
+                }
+            },
+            TyKind::Contract(_) => Some(20),
+            TyKind::Enum(_) => Some(1),
             TyKind::Udvt(inner, _) => self.packed_storage_size(inner),
+            // Internal function pointers are right-aligned 8-byte IDs.
+            TyKind::Fn(f) if !f.is_external() => Some(8),
             _ => None,
         }
     }

--- a/tests/ui/codegen/lowering/storage_packed_uint8.sol
+++ b/tests/ui/codegen/lowering/storage_packed_uint8.sol
@@ -1,0 +1,64 @@
+//@ run-call: setAndGet 1, 2 => 1, 2
+//@ run-call: setAKeepsB 255, 2 => 255, 2
+//@ run-call: setBKeepsA 255, 0 => 255, 0
+//@ run-call: spillCheck => 7, 99, 8
+//@ run-call: signedPack -1, 2 => -1, 2
+//@ run-call: addressAndUint96 => 0x0000000000000000000000000000000000000001, 42
+
+// Consecutive sub-word state variables pack into one storage slot like solc.
+// A full-word `uint256` forces alignment to the next slot. RMW stores must not
+// clobber a packed neighbor, and packed `int8` loads must sign-extend.
+
+contract PackedU8 {
+    uint8 public a;
+    uint8 public b;
+
+    function setAndGet(uint8 x, uint8 y) external returns (uint8, uint8) {
+        a = x;
+        b = y;
+        return (a, b);
+    }
+
+    function setAKeepsB(uint8 x, uint8 y) external returns (uint8, uint8) {
+        a = 0;
+        b = y;
+        a = x;
+        return (a, b);
+    }
+
+    function setBKeepsA(uint8 x, uint8 y) external returns (uint8, uint8) {
+        a = x;
+        b = 0;
+        b = y;
+        return (a, b);
+    }
+
+    uint8 public c;
+    uint256 public wide;
+    uint8 public d;
+
+    function spillCheck() external returns (uint8, uint256, uint8) {
+        c = 7;
+        wide = 99;
+        d = 8;
+        return (c, wide, d);
+    }
+
+    int8 public s;
+    uint8 public t;
+
+    function signedPack(int8 x, uint8 y) external returns (int8, uint8) {
+        s = x;
+        t = y;
+        return (s, t);
+    }
+
+    address public addr;
+    uint96 public n;
+
+    function addressAndUint96() external returns (address, uint96) {
+        addr = address(1);
+        n = 42;
+        return (addr, n);
+    }
+}


### PR DESCRIPTION
State variables such as `uint8`, `address`, and `enum` were each given a full storage slot even though the sema storage-layout emitter already packs them the way solc does. That diverges layout for any contract with consecutive sub-word scalars and breaks slot-sensitive code.

This expands right-aligned packing in codegen to those types, keeps left-aligned `bytesN`/external function pointers on the full-slot path until load/store can shift them correctly, and sign-extends packed `intN` loads so ABI and arithmetic see a proper signed word. Runtime `run-call` coverage checks RMW neighbor preservation, full-word spill alignment, signed packing, and `address`+`uint96` sharing a slot.