### PR TITLE
fix(sema): reject internal types in external fn types

### DIFF
--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -2627,12 +2627,23 @@ impl<'gcx> hir::Visit<'gcx> for TypeChecker<'gcx> {
                 // size expression of a fixed-array value type).
                 return self.visit_ty(&mapping.value);
             }
-            // TODO: https://github.com/ethereum/solidity/blob/9d7cc42bc1c12bb43e9dccf8c6c36833fdfcbbca/libsolidity/analysis/TypeChecker.cpp#L713
-            // hir::TypeKind::Function(func) => {
-            //     if func.visibility == hir::Visibility::External {
-
-            //     }
-            // }
+            hir::TypeKind::Function(func) => {
+                if func.visibility == hir::Visibility::External {
+                    for &var_id in func.parameters.iter().chain(func.returns.iter()) {
+                        let var = self.gcx.hir.variable(var_id);
+                        let ty = self.gcx.type_of_item(var_id.into());
+                        if ty.error_reported().is_err() {
+                            continue;
+                        }
+                        if !ty.can_be_exported(self.gcx) {
+                            self.dcx().emit_err(
+                                var.ty.span,
+                                "internal type cannot be used for external function type",
+                            );
+                        }
+                    }
+                }
+            }
             _ => {}
         }
         self.walk_ty(hir_ty)

--- a/tests/ui/typeck/external_fn_type_internal.sol
+++ b/tests/ui/typeck/external_fn_type_internal.sol
@@ -1,0 +1,13 @@
+contract C {
+    // Param is an internal function type.
+    function(function () internal) external x; //~ ERROR: internal type cannot be used for external function type
+
+    // Return is an internal function type.
+    function() external returns (function () internal) y; //~ ERROR: internal type cannot be used for external function type
+
+    // Nested external function type still rejects an internal parameter.
+    function(function(function () internal) external) external nested; //~ ERROR: internal type cannot be used for external function type
+
+    // Valid: external-in-external is OK.
+    function(function () external) external ok;
+}

--- a/tests/ui/typeck/external_fn_type_internal.stderr
+++ b/tests/ui/typeck/external_fn_type_internal.stderr
@@ -1,0 +1,20 @@
+error: internal type cannot be used for external function type
+   ╭▸ ROOT/tests/ui/typeck/external_fn_type_internal.sol:LL:CC
+   │
+LL │     function(function () internal) external x;
+   ╰╴             ━━━━━━━━━━━━━━━━━━━━
+
+error: internal type cannot be used for external function type
+   ╭▸ ROOT/tests/ui/typeck/external_fn_type_internal.sol:LL:CC
+   │
+LL │     function() external returns (function () internal) y;
+   ╰╴                                 ━━━━━━━━━━━━━━━━━━━━
+
+error: internal type cannot be used for external function type
+   ╭▸ ROOT/tests/ui/typeck/external_fn_type_internal.sol:LL:CC
+   │
+LL │     function(function(function () internal) external) external nested;
+   ╰╴                      ━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Solc rejects internal types in the parameter or return list of an external function type (TypeError 2582). We previously accepted programs such as `function(function () internal) external`, which cannot exist at the ABI boundary.

The type checker now walks external `FunctionTypeName` parameters and returns and errors when `can_be_exported` fails, covering nested external function types as well.