### PR TITLE
fix(ast): reject unchecked as bare loop/if body

### DIFF
--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -54,6 +54,12 @@ impl<'sess> AstValidator<'sess, '_> {
                 .help("wrap the statement in a block (`{ ... }`)")
                 .emit();
         }
+        if matches!(stmt.kind, ast::StmtKind::UncheckedBlock(..)) {
+            self.dcx().emit_err(
+                stmt.span,
+                "`unchecked` blocks can only be used inside regular blocks",
+            );
+        }
     }
 
     fn check_underscores_in_number_literals(&self, lit: &ast::Lit<'_>) {

--- a/tests/ui/typeck/unchecked_as_single_statement.sol
+++ b/tests/ui/typeck/unchecked_as_single_statement.sol
@@ -1,0 +1,23 @@
+contract C {
+    function f() public pure {
+        while (true) unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        do unchecked {} while (true); //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        for (;;) unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        if (true) unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        if (true) {} else unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        // Nested inside a regular block is fine.
+        while (true) {
+            unchecked {}
+        }
+        if (true) {
+            unchecked {}
+        } else {
+            unchecked {}
+        }
+    }
+}

--- a/tests/ui/typeck/unchecked_as_single_statement.stderr
+++ b/tests/ui/typeck/unchecked_as_single_statement.stderr
@@ -1,0 +1,32 @@
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         while (true) unchecked {}
+   ╰╴                     ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         do unchecked {} while (true);
+   ╰╴           ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         for (;;) unchecked {}
+   ╰╴                 ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         if (true) unchecked {}
+   ╰╴                  ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         if (true) {} else unchecked {}
+   ╰╴                          ━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
+

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -74,8 +74,6 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "invalid_denomination_no_whitespace"
         // Not actually a broken version, we just don't check "^0 and ^1".
         | "broken_version_1"
-        // TODO: CBA to implement.
-        | "unchecked_while_body"
         // TODO: EVM version-aware parsing.
         | "basefee_pre_london"
         | "basefee_berlin_function"


### PR DESCRIPTION
Solc requires `unchecked` blocks to appear inside a regular block. We accepted them as the sole body of `while`/`do`/`for`/`if`, which is invalid Solidity and was a skipped solc fixture (`unchecked_while_body`).

AST validation now rejects that shape with the same diagnostic family as bare variable declarations, and the corresponding solc skip is removed.