### PR TITLE
fix(ast): reject unchecked as bare loop/if body

### DIFF
--- a/crates/sema/src/ast_passes.rs
+++ b/crates/sema/src/ast_passes.rs
@@ -54,6 +54,10 @@ impl<'sess> AstValidator<'sess, '_> {
                 .help("wrap the statement in a block (`{ ... }`)")
                 .emit();
         }
+        if matches!(stmt.kind, ast::StmtKind::UncheckedBlock(..)) {
+            self.dcx()
+                .emit_err(stmt.span, "`unchecked` blocks can only be used inside regular blocks");
+        }
     }
 
     fn check_underscores_in_number_literals(&self, lit: &ast::Lit<'_>) {

--- a/docs/SOLC_DIVERGENCE.md
+++ b/docs/SOLC_DIVERGENCE.md
@@ -26,7 +26,25 @@ Use the next ID in the relevant phase.
 
 ## Parsing
 
-No intentional divergences documented yet.
+### PARSE-001: Validation stage differences
+
+Status: intentional.
+
+Difference: `solar` and `solc` do not always perform equivalent validation in
+the same compiler stage. As a result, `--stop-after=parsing` may accept input
+that `solc` rejects during parsing even though a normal `solar` compilation
+rejects it in a later frontend stage. For example, `solar` parses an `unchecked`
+block used directly as an `if`, loop, or `else` body and rejects it during AST
+validation, while `solc` rejects it during parsing.
+
+Rationale: the frontend structures parsing and validation differently from
+`solc`; checks live in the earliest `solar` stage with the context and
+responsibility needed to enforce them rather than mirroring solc's internal
+phase boundaries.
+
+Coverage: `tests/ui/typeck/unchecked_as_single_statement.sol`; the upstream
+`unchecked_while_body` parse-only fixture remains excluded from solc parity
+testing.
 
 ## AST Validation
 

--- a/tests/ui/typeck/unchecked_as_single_statement.sol
+++ b/tests/ui/typeck/unchecked_as_single_statement.sol
@@ -1,0 +1,23 @@
+contract C {
+    function f() public pure {
+        while (true) unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        do unchecked {} while (true); //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        for (;;) unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        if (true) unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        if (true) {} else unchecked {} //~ ERROR: `unchecked` blocks can only be used inside regular blocks
+
+        // Nested inside a regular block is fine.
+        while (true) {
+            unchecked {}
+        }
+        if (true) {
+            unchecked {}
+        } else {
+            unchecked {}
+        }
+    }
+}

--- a/tests/ui/typeck/unchecked_as_single_statement.stderr
+++ b/tests/ui/typeck/unchecked_as_single_statement.stderr
@@ -1,0 +1,32 @@
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         while (true) unchecked {}
+   ╰╴                     ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         do unchecked {} while (true);
+   ╰╴           ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         for (;;) unchecked {}
+   ╰╴                 ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         if (true) unchecked {}
+   ╰╴                  ━━━━━━━━━━━━
+
+error: `unchecked` blocks can only be used inside regular blocks
+   ╭▸ ROOT/tests/ui/typeck/unchecked_as_single_statement.sol:LL:CC
+   │
+LL │         if (true) {} else unchecked {}
+   ╰╴                          ━━━━━━━━━━━━
+
+error: aborting due to 5 previous errors
+

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -74,7 +74,7 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "invalid_denomination_no_whitespace"
         // Not actually a broken version, we just don't check "^0 and ^1".
         | "broken_version_1"
-        // TODO: CBA to implement.
+        // Checked during AST validation rather than parsing.
         | "unchecked_while_body"
         // TODO: EVM version-aware parsing.
         | "basefee_pre_london"


### PR DESCRIPTION
Solc requires `unchecked` blocks to appear inside a regular block. Solar enforces the same rule during AST validation, covering bare `while`/`do`/`for`/`if`/`else` bodies.

The parse-only behavior intentionally differs: Solar's parser accepts the statement grammar and AST validation rejects the invalid placement, while solc rejects it during parsing. This keeps the upstream `unchecked_while_body` fixture excluded from parse-only parity testing, removes the stale TODO, and documents the phase difference in `docs/SOLC_DIVERGENCE.md`.

Replaces #1060.

Prompted by: @DaniPopes
