### PR TITLE
feat(codegen): lower crypto precompiles

### DIFF
--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -630,6 +630,10 @@ impl<'gcx> Lowerer<'gcx> {
                 }
                 builder.imm_u64(0)
             }
+            Builtin::Sha256 | Builtin::Ripemd160 => {
+                self.lower_hash_precompile_call(builder, builtin, args)
+            }
+            Builtin::EcRecover => self.lower_ecrecover_call(builder, args),
             Builtin::Erc7201 => self.lower_erc7201_call(builder, args),
             Builtin::Require | Builtin::Assert => {
                 let mut exprs = args.exprs();
@@ -849,6 +853,79 @@ impl<'gcx> Lowerer<'gcx> {
             | Builtin::YulMcopy => self.lower_yul_builtin_call(builder, builtin, args),
             _ => builder.imm_u64(0),
         }
+    }
+
+    fn lower_hash_precompile_call(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        builtin: Builtin,
+        args: &CallArgs<'_>,
+    ) -> ValueId {
+        let Some(input) = args.exprs().next() else {
+            let guar = self
+                .gcx
+                .dcx()
+                .err(format!("wrong number of arguments for builtin `{}`", builtin.name()))
+                .span(args.span)
+                .emit();
+            return builder.error_value(guar);
+        };
+        let input = self.peel_bytes_conversion(input);
+        let (input_ptr, input_len) = self.lower_bytes_arg_to_memory(builder, input);
+
+        let output_ptr = self.allocate_memory(builder, 32);
+        let zero = builder.imm_u64(0);
+        builder.mstore(output_ptr, zero);
+
+        let address = builder.imm_u64(if builtin == Builtin::Sha256 { 2 } else { 3 });
+        let output_size = builder.imm_u64(32);
+        let gas = builder.gas();
+        builder.staticcall(gas, address, input_ptr, input_len, output_ptr, output_size);
+
+        let output = builder.mload(output_ptr);
+        if builtin == Builtin::Ripemd160 {
+            let shift = builder.imm_u64(96);
+            builder.shl(shift, output)
+        } else {
+            output
+        }
+    }
+
+    fn lower_ecrecover_call(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        args: &CallArgs<'_>,
+    ) -> ValueId {
+        let values = args.exprs().map(|arg| self.lower_expr(builder, arg)).collect::<Vec<_>>();
+        let [hash, v, r, s] = values.as_slice() else {
+            let guar = self
+                .gcx
+                .dcx()
+                .err("wrong number of arguments for builtin `ecrecover`")
+                .span(args.span)
+                .emit();
+            return builder.error_value(guar);
+        };
+
+        let input_ptr = self.allocate_memory(builder, 160);
+        builder.mstore(input_ptr, *hash);
+        for (offset, value) in [(32, *v), (64, *r), (96, *s)] {
+            let offset = builder.imm_u64(offset);
+            let ptr = builder.add(input_ptr, offset);
+            builder.mstore(ptr, value);
+        }
+
+        let output_offset = builder.imm_u64(128);
+        let output_ptr = builder.add(input_ptr, output_offset);
+        let zero = builder.imm_u64(0);
+        builder.mstore(output_ptr, zero);
+
+        let gas = builder.gas();
+        let address = builder.imm_u64(1);
+        let input_size = builder.imm_u64(128);
+        let output_size = builder.imm_u64(32);
+        builder.staticcall(gas, address, input_ptr, input_size, output_ptr, output_size);
+        builder.mload(output_ptr)
     }
 
     fn lower_erc7201_call(

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -874,13 +874,13 @@ impl<'gcx> Lowerer<'gcx> {
         let (input_ptr, input_len) = self.lower_bytes_arg_to_memory(builder, input);
 
         let output_ptr = self.allocate_memory(builder, 32);
-        let zero = builder.imm_u64(0);
-        builder.mstore(output_ptr, zero);
 
         let address = builder.imm_u64(if builtin == Builtin::Sha256 { 2 } else { 3 });
         let output_size = builder.imm_u64(32);
         let gas = builder.gas();
-        builder.staticcall(gas, address, input_ptr, input_len, output_ptr, output_size);
+        let success =
+            builder.staticcall(gas, address, input_ptr, input_len, output_ptr, output_size);
+        Self::emit_revert_unless(builder, success);
 
         let output = builder.mload(output_ptr);
         if builtin == Builtin::Ripemd160 {
@@ -924,7 +924,9 @@ impl<'gcx> Lowerer<'gcx> {
         let address = builder.imm_u64(1);
         let input_size = builder.imm_u64(128);
         let output_size = builder.imm_u64(32);
-        builder.staticcall(gas, address, input_ptr, input_size, output_ptr, output_size);
+        let success =
+            builder.staticcall(gas, address, input_ptr, input_size, output_ptr, output_size);
+        Self::emit_revert_unless(builder, success);
         builder.mload(output_ptr)
     }
 

--- a/tests/ui/codegen/lowering/precompile_builtins.sol
+++ b/tests/ui/codegen/lowering/precompile_builtins.sol
@@ -1,0 +1,27 @@
+//@ run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+//@ run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
+//@ run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+//@ run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+
+contract PrecompileBuiltins {
+    function recover() external pure returns (address) {
+        return ecrecover(
+            bytes32(uint256(1)),
+            28,
+            0x6673ffad2147741f04772b6f921f0ba6af0c1e77fc439e65c36dedf4092e8898,
+            0x4c1a971652e0ada880120ef8025e709fff2080c4a39aae068d12eed009b68c89
+        );
+    }
+
+    function recoverInvalid() external pure returns (address) {
+        return ecrecover(bytes32(0), 0, bytes32(0), bytes32(0));
+    }
+
+    function sha() external pure returns (bytes32) {
+        return sha256(bytes("abc"));
+    }
+
+    function ripemd() external pure returns (bytes20) {
+        return ripemd160(bytes("abc"));
+    }
+}


### PR DESCRIPTION
Lower `ecrecover`, `sha256`, and `ripemd160` through their EVM precompiles instead of letting the generic builtin fallback synthesize zero. The lowering materializes dynamic byte inputs, reverts when a precompile call fails, preserves the zero-address result for invalid recovery signatures, and normalizes RIPEMD-160 to Solidity’s left-aligned `bytes20` representation. Runtime coverage includes valid and invalid recovery plus known SHA-256 and RIPEMD-160 vectors.