### PR TITLE
fix(codegen): lower tuple values

### DIFF
--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -418,10 +418,22 @@ impl<'gcx> Lowerer<'gcx> {
             }
 
             ExprKind::Tuple(elements) => {
-                if let Some(Some(expr)) = elements.first() {
-                    return self.lower_expr(builder, expr);
+                let mut values = Vec::with_capacity(elements.len());
+                for &element in *elements {
+                    let Some(element) = element else {
+                        return self.err_value(
+                            builder,
+                            expr.span,
+                            "tuple value contains an omitted element",
+                        );
+                    };
+                    values.push(self.lower_expr(builder, element));
                 }
-                builder.imm_u64(0)
+                let Some(&first) = values.first() else {
+                    return self.err_value(builder, expr.span, "tuple expression has no value");
+                };
+                self.stage_multi_return_tail(builder, &values);
+                first
             }
 
             ExprKind::Array(elements) => {

--- a/tests/ui/codegen/lowering/tuple_value_declaration.sol
+++ b/tests/ui/codegen/lowering/tuple_value_declaration.sol
@@ -1,0 +1,25 @@
+//@ run-call: pair(int256) -7 => 999999999999999993, -7
+//@ run-call: triple(uint256) 11 => 11, 12, 13
+//@ run-call: arrays(uint256,uint256) 17, 29 => 17, 29
+
+contract TupleValueDeclaration {
+    function pair(int256 x) external pure returns (int256, int256) {
+        (int256 wad, int256 p) = (int256(1e18), x);
+        return (wad + p, p);
+    }
+
+    function triple(uint256 x) external pure returns (uint256, uint256, uint256) {
+        (uint256 n, uint256 o, uint256 e) = (x, x + 1, x + 2);
+        return (n, o, e);
+    }
+
+    function arrays(uint256 x, uint256 y) external pure returns (uint256, uint256) {
+        uint256[] memory keys = new uint256[](1);
+        uint256[] memory values = new uint256[](1);
+        keys[0] = x;
+        values[0] = y;
+
+        (uint256[] memory originalKeys, uint256[] memory originalValues) = (keys, values);
+        return (originalKeys[0], originalValues[0]);
+    }
+}


### PR DESCRIPTION
Tuple literal expressions only lowered their first component, while tuple declarations expected the remaining components in the multi-return buffer. Evaluate every tuple component and publish the tail through the existing multi-value convention. Invalid empty or holed value tuples now emit a codegen error, and runtime coverage includes signed scalars, triples, and memory-array pointers.