### PR TITLE
fix(codegen): match precompile targets

### DIFF
--- a/crates/codegen/src/backend/evm/ir/passes/compact_pushes.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/compact_pushes.rs
@@ -101,7 +101,7 @@ fn select(gcx: Gcx<'_>, value: U256) -> CompactPush {
         consider(zero_push_len(gcx) + 1, CompactPush::FullWord);
     }
 
-    if width >= MIN_COMPACT_MASK_WIDTH {
+    if gcx.sess.opts.evm_version.has_bitwise_shifting() && width >= MIN_COMPACT_MASK_WIDTH {
         let bytes = value.to_be_bytes::<EVM_WORD_BYTES>();
         let start = EVM_WORD_BYTES - width as usize;
         if bytes[start..].iter().all(|&byte| byte == 0xff) {
@@ -116,7 +116,10 @@ fn select(gcx: Gcx<'_>, value: U256) -> CompactPush {
     }
 
     let trailing_zero_bytes = value.trailing_zeros() / 8;
-    if trailing_zero_bytes > 0 && trailing_zero_bytes < EVM_WORD_BYTES {
+    if gcx.sess.opts.evm_version.has_bitwise_shifting()
+        && trailing_zero_bytes > 0
+        && trailing_zero_bytes < EVM_WORD_BYTES
+    {
         let shift = trailing_zero_bytes * 8;
         let shifted = value >> shift;
         consider(

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -16,6 +16,9 @@ use solar_sema::{
     ty::{Ty, TyFn, TyKind},
 };
 
+/// Covers Homestead's call and new-account costs plus setup emitted after `GAS`.
+const PRE_TANGERINE_PRECOMPILE_CALL_GAS_RESERVE: u64 = 25_100;
+
 /// How a value travels across a linked-library delegatecall boundary.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum LinkedFieldKind {
@@ -877,7 +880,7 @@ impl<'gcx> Lowerer<'gcx> {
         let address = builder.imm_u64(if builtin == Builtin::Sha256 { 2 } else { 3 });
         let output_ptr = builder.imm_u64(0);
         let output_size = builder.imm_u64(32);
-        let gas = builder.gas();
+        let gas = self.precompile_gas(builder);
         let success = self.emit_precompile_call(
             builder,
             gas,
@@ -936,7 +939,7 @@ impl<'gcx> Lowerer<'gcx> {
         let zero = builder.imm_u64(0);
         builder.mstore(output_ptr, zero);
 
-        let gas = builder.gas();
+        let gas = self.precompile_gas(builder);
         let address = builder.imm_u64(1);
         let input_size = builder.imm_u64(128);
         let output_size = builder.imm_u64(32);
@@ -1001,6 +1004,16 @@ impl<'gcx> Lowerer<'gcx> {
         } else {
             let value = builder.imm_u64(0);
             builder.call(gas, address, value, input_ptr, input_size, output_ptr, output_size)
+        }
+    }
+
+    fn precompile_gas(&self, builder: &mut FunctionBuilder<'_>) -> ValueId {
+        let gas = builder.gas();
+        if self.gcx.sess.opts.evm_version.can_overcharge_gas_for_call() {
+            gas
+        } else {
+            let reserved = builder.imm_u64(PRE_TANGERINE_PRECOMPILE_CALL_GAS_RESERVE);
+            builder.sub(gas, reserved)
         }
     }
 

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -861,7 +861,8 @@ impl<'gcx> Lowerer<'gcx> {
         builtin: Builtin,
         args: &CallArgs<'_>,
     ) -> ValueId {
-        let Some(input) = args.exprs().next() else {
+        let inputs = args.exprs().collect::<Vec<_>>();
+        let [input] = inputs.as_slice() else {
             let guar = self
                 .gcx
                 .dcx()
@@ -871,21 +872,32 @@ impl<'gcx> Lowerer<'gcx> {
             return builder.error_value(guar);
         };
         let input = self.peel_bytes_conversion(input);
-        let (input_ptr, input_len) = self.lower_bytes_arg_to_memory(builder, input);
-
-        let output_ptr = self.allocate_memory(builder, 32);
+        let (input_ptr, input_len) = self.lower_precompile_bytes_input(builder, input);
 
         let address = builder.imm_u64(if builtin == Builtin::Sha256 { 2 } else { 3 });
+        let output_ptr = builder.imm_u64(0);
         let output_size = builder.imm_u64(32);
         let gas = builder.gas();
-        let success =
-            builder.staticcall(gas, address, input_ptr, input_len, output_ptr, output_size);
-        Self::emit_revert_unless(builder, success);
+        let success = self.emit_precompile_call(
+            builder,
+            gas,
+            address,
+            input_ptr,
+            input_len,
+            output_ptr,
+            output_size,
+        );
+        self.emit_forwarding_revert_unless(builder, success);
 
         let output = builder.mload(output_ptr);
         if builtin == Builtin::Ripemd160 {
-            let shift = builder.imm_u64(96);
-            builder.shl(shift, output)
+            if self.gcx.sess.opts.evm_version.has_bitwise_shifting() {
+                let shift = builder.imm_u64(96);
+                builder.shl(shift, output)
+            } else {
+                let factor = builder.imm_u256(U256::from(1) << 96);
+                builder.mul(output, factor)
+            }
         } else {
             output
         }
@@ -896,8 +908,8 @@ impl<'gcx> Lowerer<'gcx> {
         builder: &mut FunctionBuilder<'_>,
         args: &CallArgs<'_>,
     ) -> ValueId {
-        let values = args.exprs().map(|arg| self.lower_expr(builder, arg)).collect::<Vec<_>>();
-        let [hash, v, r, s] = values.as_slice() else {
+        let exprs = args.exprs().collect::<Vec<_>>();
+        let [hash, v, r, s] = exprs.as_slice() else {
             let guar = self
                 .gcx
                 .dcx()
@@ -906,10 +918,12 @@ impl<'gcx> Lowerer<'gcx> {
                 .emit();
             return builder.error_value(guar);
         };
+        let values = [hash, v, r, s].map(|arg| self.lower_expr(builder, arg));
+        let [hash, v, r, s] = values;
 
-        let input_ptr = self.allocate_memory(builder, 160);
-        builder.mstore(input_ptr, *hash);
-        for (offset, value) in [(32, *v), (64, *r), (96, *s)] {
+        let input_ptr = builder.fmp();
+        builder.mstore(input_ptr, hash);
+        for (offset, value) in [(32, v), (64, r), (96, s)] {
             let offset = builder.imm_u64(offset);
             let ptr = builder.add(input_ptr, offset);
             builder.mstore(ptr, value);
@@ -924,10 +938,86 @@ impl<'gcx> Lowerer<'gcx> {
         let address = builder.imm_u64(1);
         let input_size = builder.imm_u64(128);
         let output_size = builder.imm_u64(32);
-        let success =
-            builder.staticcall(gas, address, input_ptr, input_size, output_ptr, output_size);
-        Self::emit_revert_unless(builder, success);
+        let success = self.emit_precompile_call(
+            builder,
+            gas,
+            address,
+            input_ptr,
+            input_size,
+            output_ptr,
+            output_size,
+        );
+        self.emit_forwarding_revert_unless(builder, success);
         builder.mload(output_ptr)
+    }
+
+    fn lower_precompile_bytes_input(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        input: &hir::Expr<'_>,
+    ) -> (ValueId, ValueId) {
+        if let ExprKind::Lit(lit) = &input.kind
+            && let LitKind::Str(_, bytes, _) = &lit.kind
+        {
+            let bytes = bytes.as_byte_str();
+            if bytes.is_empty() {
+                return (builder.imm_u64(0), builder.imm_u64(0));
+            }
+
+            let ptr = builder.fmp();
+            for (i, chunk) in bytes.chunks(32).enumerate() {
+                let mut padded = [0u8; 32];
+                padded[..chunk.len()].copy_from_slice(chunk);
+                let value = builder.imm_u256(U256::from_be_bytes(padded));
+                let dest = if i == 0 {
+                    ptr
+                } else {
+                    let offset = builder.imm_u64((i * 32) as u64);
+                    builder.add(ptr, offset)
+                };
+                builder.mstore(dest, value);
+            }
+            return (ptr, builder.imm_u64(bytes.len() as u64));
+        }
+
+        self.lower_bytes_arg_to_memory(builder, input)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_precompile_call(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        gas: ValueId,
+        address: ValueId,
+        input_ptr: ValueId,
+        input_size: ValueId,
+        output_ptr: ValueId,
+        output_size: ValueId,
+    ) -> ValueId {
+        if self.gcx.sess.opts.evm_version.has_static_call() {
+            builder.staticcall(gas, address, input_ptr, input_size, output_ptr, output_size)
+        } else {
+            let value = builder.imm_u64(0);
+            builder.call(gas, address, value, input_ptr, input_size, output_ptr, output_size)
+        }
+    }
+
+    fn emit_forwarding_revert_unless(&self, builder: &mut FunctionBuilder<'_>, success: ValueId) {
+        let revert_block = builder.create_block();
+        let continue_block = builder.create_block();
+        builder.branch(success, continue_block, revert_block);
+
+        builder.switch_to_block(revert_block);
+        let zero = builder.imm_u64(0);
+        if self.gcx.sess.opts.evm_version.supports_returndata() {
+            let size = builder.returndatasize();
+            builder.returndatacopy(zero, zero, size);
+            builder.revert(zero, size);
+        } else {
+            builder.revert(zero, zero);
+        }
+
+        builder.switch_to_block(continue_block);
     }
 
     fn lower_erc7201_call(

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -861,8 +861,7 @@ impl<'gcx> Lowerer<'gcx> {
         builtin: Builtin,
         args: &CallArgs<'_>,
     ) -> ValueId {
-        let inputs = args.exprs().collect::<Vec<_>>();
-        let [input] = inputs.as_slice() else {
+        if args.len() != 1 {
             let guar = self
                 .gcx
                 .dcx()
@@ -870,7 +869,8 @@ impl<'gcx> Lowerer<'gcx> {
                 .span(args.span)
                 .emit();
             return builder.error_value(guar);
-        };
+        }
+        let input = args.exprs().next().expect("argument count checked");
         let input = self.peel_bytes_conversion(input);
         let (input_ptr, input_len) = self.lower_precompile_bytes_input(builder, input);
 
@@ -908,8 +908,7 @@ impl<'gcx> Lowerer<'gcx> {
         builder: &mut FunctionBuilder<'_>,
         args: &CallArgs<'_>,
     ) -> ValueId {
-        let exprs = args.exprs().collect::<Vec<_>>();
-        let [hash, v, r, s] = exprs.as_slice() else {
+        if args.len() != 4 {
             let guar = self
                 .gcx
                 .dcx()
@@ -917,9 +916,12 @@ impl<'gcx> Lowerer<'gcx> {
                 .span(args.span)
                 .emit();
             return builder.error_value(guar);
-        };
-        let values = [hash, v, r, s].map(|arg| self.lower_expr(builder, arg));
-        let [hash, v, r, s] = values;
+        }
+        let mut exprs = args.exprs();
+        let hash = self.lower_expr(builder, exprs.next().expect("argument count checked"));
+        let v = self.lower_expr(builder, exprs.next().expect("argument count checked"));
+        let r = self.lower_expr(builder, exprs.next().expect("argument count checked"));
+        let s = self.lower_expr(builder, exprs.next().expect("argument count checked"));
 
         let input_ptr = builder.fmp();
         builder.mstore(input_ptr, hash);

--- a/crates/codegen/src/transform/inst_simplify.rs
+++ b/crates/codegen/src/transform/inst_simplify.rs
@@ -32,21 +32,24 @@ impl MirPass for InstSimplify {
 
     fn run_pass(
         &self,
-        _gcx: solar_sema::Gcx<'_>,
+        gcx: solar_sema::Gcx<'_>,
         module: &mut Module,
         analyses: &mut crate::pass::ModuleAnalyses,
     ) -> bool {
         run_function_pass(module, analyses, |func, _| {
-            InstSimplifier::new().run_to_fixpoint(func) != 0
+            InstSimplifier::new(gcx.sess.opts.evm_version.has_bitwise_shifting())
+                .run_to_fixpoint(func)
+                != 0
         })
     }
 }
 
 /// Local MIR instruction simplification pass.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct InstSimplifier {
     /// Number of instructions simplified in the last run.
     simplified_count: usize,
+    has_bitwise_shifting: bool,
 }
 
 struct RunState {
@@ -62,8 +65,8 @@ impl RunState {
 
 impl InstSimplifier {
     /// Creates a new instruction simplifier.
-    fn new() -> Self {
-        Self::default()
+    fn new(has_bitwise_shifting: bool) -> Self {
+        Self { simplified_count: 0, has_bitwise_shifting }
     }
 
     fn run_with_state(&mut self, func: &mut Function, state: &mut RunState) -> usize {
@@ -825,6 +828,9 @@ impl InstSimplifier {
         if func.value_u256(a).is_some() && func.value_u256(b).is_none() {
             return Some(InstKind::Mul(b, a));
         }
+        if !self.has_bitwise_shifting {
+            return None;
+        }
         let (value, constant) = Self::const_operand(func, a, b)?;
         let shift = Self::power_of_two_shift(constant)?;
         if shift.is_zero() {
@@ -835,6 +841,9 @@ impl InstSimplifier {
     }
 
     fn rewrite_div(&self, func: &mut Function, a: ValueId, b: ValueId) -> Option<InstKind> {
+        if !self.has_bitwise_shifting {
+            return None;
+        }
         let shift = Self::power_of_two_shift(func.value_u256(b)?)?;
         if shift.is_zero() {
             return None;

--- a/crates/codegen/src/transform/lower_dispatch.rs
+++ b/crates/codegen/src/transform/lower_dispatch.rs
@@ -4,9 +4,9 @@
 //! makes it an ordinary MIR function named `entry` (the dispatch phase of the
 //! sketch in [`MirPhase`]).
 //!
-//! The synthesized `entry` function loads the 4-byte selector
-//! (`calldataload(0) >> 224`) and switches on it to one argument-free
-//! `internal_call` per external wrapper, defaulting to a `revert`. It is meant
+//! The synthesized `entry` function loads the 4-byte selector from
+//! `calldataload(0)` and switches on it to one argument-free `internal_call`
+//! per external wrapper, defaulting to a `revert`. It is meant
 //! to run after [`super::lower_abi::LowerAbi`], which turns external functions into the
 //! argument-free self-decoding wrappers this switch routes to; that is why it
 //! only routes selector-bearing functions that take no MIR arguments.
@@ -22,6 +22,7 @@ use crate::{
     mir::{Function, FunctionBuilder, FunctionId, MirPhase, Module, ValueId},
     pass::MirPass,
 };
+use alloy_primitives::U256;
 use solar_interface::{Ident, sym};
 
 /// Dispatch phase lowering pass.
@@ -42,11 +43,15 @@ impl MirPass for LowerDispatch {
 
     fn run_pass(
         &self,
-        _gcx: solar_sema::Gcx<'_>,
+        gcx: solar_sema::Gcx<'_>,
         module: &mut Module,
         _analyses: &mut crate::pass::ModuleAnalyses,
     ) -> bool {
-        LowerDispatchCx::default().run(module)
+        LowerDispatchCx {
+            stats: LowerDispatchStats::default(),
+            has_bitwise_shifting: gcx.sess.opts.evm_version.has_bitwise_shifting(),
+        }
+        .run(module)
     }
 }
 
@@ -57,9 +62,10 @@ struct LowerDispatchStats {
     routed: usize,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct LowerDispatchCx {
     stats: LowerDispatchStats,
+    has_bitwise_shifting: bool,
 }
 
 impl LowerDispatchCx {
@@ -209,7 +215,7 @@ impl LowerDispatchCx {
 
             // Selector switch; the default goes to the fallback when present.
             builder.switch_to_block(select_block);
-            let selector = load_selector(&mut builder);
+            let selector = self.load_selector(&mut builder);
             let cases = routes
                 .iter()
                 .zip(&case_blocks)
@@ -262,12 +268,17 @@ impl LowerDispatchCx {
         }
         builder.tail_call(target, Vec::new());
     }
-}
 
-/// Emits `calldataload(0) >> 224`, the 4-byte function selector.
-fn load_selector(builder: &mut FunctionBuilder<'_>) -> ValueId {
-    let zero = builder.imm_u64(0);
-    let word = builder.calldataload(zero);
-    let shift = builder.imm_u64(224);
-    builder.shr(shift, word)
+    /// Loads the 4-byte function selector from the first calldata word.
+    fn load_selector(&self, builder: &mut FunctionBuilder<'_>) -> ValueId {
+        let zero = builder.imm_u64(0);
+        let word = builder.calldataload(zero);
+        if self.has_bitwise_shifting {
+            let shift = builder.imm_u64(224);
+            builder.shr(shift, word)
+        } else {
+            let divisor = builder.imm_u256(U256::from(1) << 224);
+            builder.div(word, divisor)
+        }
+    }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -107,6 +107,9 @@ str_enum! {
 }
 
 impl EvmVersion {
+    pub fn can_overcharge_gas_for_call(self) -> bool {
+        self >= Self::TangerineWhistle
+    }
     pub fn supports_returndata(self) -> bool {
         self >= Self::Byzantium
     }

--- a/tests/ui/codegen/lowering/precompile_builtins.sol
+++ b/tests/ui/codegen/lowering/precompile_builtins.sol
@@ -3,10 +3,10 @@
 //@[byzantium] compile-flags: --evm-version byzantium
 //@[constantinople] compile-flags: --evm-version constantinople
 //@[osaka] compile-flags: --evm-version osaka
-//@[homestead,byzantium,constantinople,osaka] run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
-//@[homestead,byzantium,constantinople,osaka] run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
-//@[homestead,byzantium,constantinople,osaka] run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-//@[homestead,byzantium,constantinople,osaka] run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+//@ run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+//@ run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
+//@ run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+//@ run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
 
 contract PrecompileBuiltins {
     function recover() external pure returns (address) {

--- a/tests/ui/codegen/lowering/precompile_builtins.sol
+++ b/tests/ui/codegen/lowering/precompile_builtins.sol
@@ -1,7 +1,16 @@
-//@ run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
-//@ run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
-//@ run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-//@ run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+//@ revisions: homestead byzantium constantinople osaka
+//@[homestead] compile-flags: --evm-version homestead
+//@[byzantium] compile-flags: --evm-version byzantium
+//@[constantinople] compile-flags: --evm-version constantinople
+//@[osaka] compile-flags: --evm-version osaka
+//@[constantinople] run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+//@[constantinople] run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
+//@[constantinople] run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+//@[constantinople] run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+//@[osaka] run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+//@[osaka] run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
+//@[osaka] run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+//@[osaka] run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
 
 contract PrecompileBuiltins {
     function recover() external pure returns (address) {

--- a/tests/ui/codegen/lowering/precompile_builtins.sol
+++ b/tests/ui/codegen/lowering/precompile_builtins.sol
@@ -3,14 +3,10 @@
 //@[byzantium] compile-flags: --evm-version byzantium
 //@[constantinople] compile-flags: --evm-version constantinople
 //@[osaka] compile-flags: --evm-version osaka
-//@[constantinople] run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
-//@[constantinople] run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
-//@[constantinople] run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-//@[constantinople] run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
-//@[osaka] run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
-//@[osaka] run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
-//@[osaka] run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-//@[osaka] run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
+//@[homestead,byzantium,constantinople,osaka] run-call: recover() => 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+//@[homestead,byzantium,constantinople,osaka] run-call: recoverInvalid() => 0x0000000000000000000000000000000000000000
+//@[homestead,byzantium,constantinople,osaka] run-call: sha() => 0xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+//@[homestead,byzantium,constantinople,osaka] run-call: ripemd() => 0x8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
 
 contract PrecompileBuiltins {
     function recover() external pure returns (address) {


### PR DESCRIPTION
Follow-up to #1065. Select `CALL` or `STATICCALL` from the target EVM revision, use the RIPEMD-160 precompile’s 32-byte output convention, and forward precompile revert data instead of manufacturing a result. The calls use scratch memory without advancing the free-memory pointer.

The runtime cases execute `ecrecover`, invalid `ecrecover`, SHA-256, and RIPEMD-160 under Homestead, Byzantium, Constantinople, and Osaka. The old targets also cover pre-EIP-150 gas forwarding and pre-Constantinople selector and value materialization without shift opcodes.
