### PR TITLE
fix(codegen): lower exact base calls

### DIFF
--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -1319,12 +1319,8 @@ impl<'gcx> Lowerer<'gcx> {
             return self.lower_library_call(builder, func_id, args, None);
         }
 
-        // `Base.f(...)` and `super.f(...)` are exact internal calls. Sema has
-        // already resolved `super` to the next implemented function in the
-        // current contract's linearization.
-        if self.is_contract_or_super_type_expr(base)
-            && let Some(func_id) = self.resolved_function_callee(callee)
-        {
+        // `Base.f(...)` and `super.f(...)` are exact internal calls.
+        if let Some(func_id) = self.resolved_exact_function_callee(base, callee) {
             return self.lower_resolved_internal_call(builder, func_id, args);
         }
 
@@ -1626,17 +1622,67 @@ impl<'gcx> Lowerer<'gcx> {
         self.gcx.resolved_function(callee)
     }
 
+    pub(super) fn resolved_exact_function_callee(
+        &self,
+        base: &hir::Expr<'_>,
+        callee: &hir::Expr<'_>,
+    ) -> Option<hir::FunctionId> {
+        let function_id = self.resolved_function_callee(callee)?;
+        let TyKind::Type(ty) = self.get_expr_type(base)?.kind else { return None };
+        match ty.kind {
+            TyKind::Contract(_) => Some(function_id),
+            TyKind::Super(contract_id) => {
+                Some(self.resolve_super_function_target(contract_id, function_id))
+            }
+            _ => None,
+        }
+    }
+
+    fn resolve_super_function_target(
+        &self,
+        defining_contract_id: hir::ContractId,
+        function_id: hir::FunctionId,
+    ) -> hir::FunctionId {
+        let Some(contract_id) = self.contract_id else { return function_id };
+        let item = hir::ItemId::from(function_id);
+        let name = self.gcx.item_name(item).name;
+        let parameters = self.gcx.item_parameter_types(item);
+
+        let bases = self
+            .gcx
+            .hir
+            .contract(contract_id)
+            .linearized_bases
+            .iter()
+            .skip_while(|&&base_id| base_id != defining_contract_id)
+            .skip(1);
+        for &base_id in bases {
+            for candidate_id in self.gcx.hir.contract(base_id).functions() {
+                let candidate = self.gcx.hir.function(candidate_id);
+                if !candidate.is_ordinary()
+                    || candidate.visibility <= hir::Visibility::Private
+                    || candidate.visibility == hir::Visibility::External
+                    || candidate.body.is_none()
+                {
+                    continue;
+                }
+
+                let candidate_item = hir::ItemId::from(candidate_id);
+                if self.gcx.item_name(candidate_item).name == name
+                    && self.gcx.item_parameter_types(candidate_item) == parameters
+                {
+                    return candidate_id;
+                }
+            }
+        }
+        function_id
+    }
+
     fn is_library_type_expr(&self, expr: &hir::Expr<'_>) -> bool {
         let Some(ty) = self.get_expr_type(expr) else { return false };
         let TyKind::Type(ty) = ty.kind else { return false };
         let TyKind::Contract(contract_id) = ty.kind else { return false };
         self.gcx.hir.contract(contract_id).kind.is_library()
-    }
-
-    fn is_contract_or_super_type_expr(&self, expr: &hir::Expr<'_>) -> bool {
-        let Some(ty) = self.get_expr_type(expr) else { return false };
-        let TyKind::Type(ty) = ty.kind else { return false };
-        matches!(ty.kind, TyKind::Contract(_) | TyKind::Super(_))
     }
 
     fn array_builtin_method_name(builtin: Builtin) -> Option<Symbol> {

--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -1319,9 +1319,10 @@ impl<'gcx> Lowerer<'gcx> {
             return self.lower_library_call(builder, func_id, args, None);
         }
 
-        // `Base.f(...)` is an internal call to that exact base implementation,
-        // not an external call to a value represented by the contract type.
-        if self.is_contract_type_name_expr(base)
+        // `Base.f(...)` and `super.f(...)` are exact internal calls. Sema has
+        // already resolved `super` to the next implemented function in the
+        // current contract's linearization.
+        if self.is_contract_or_super_type_expr(base)
             && let Some(func_id) = self.resolved_function_callee(callee)
         {
             return self.lower_resolved_internal_call(builder, func_id, args);
@@ -1632,10 +1633,10 @@ impl<'gcx> Lowerer<'gcx> {
         self.gcx.hir.contract(contract_id).kind.is_library()
     }
 
-    fn is_contract_type_name_expr(&self, expr: &hir::Expr<'_>) -> bool {
+    fn is_contract_or_super_type_expr(&self, expr: &hir::Expr<'_>) -> bool {
         let Some(ty) = self.get_expr_type(expr) else { return false };
         let TyKind::Type(ty) = ty.kind else { return false };
-        matches!(ty.kind, TyKind::Contract(_))
+        matches!(ty.kind, TyKind::Contract(_) | TyKind::Super(_))
     }
 
     fn array_builtin_method_name(builtin: Builtin) -> Option<Symbol> {

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -264,6 +264,8 @@ impl<'gcx> Lowerer<'gcx> {
                     && let Some(hir::Res::Item(hir::ItemId::Function(function_id))) =
                         self.gcx.resolved_expr(expr)
                 {
+                    let function_id =
+                        self.resolved_exact_function_callee(base, expr).unwrap_or(function_id);
                     self.internal_function_pointer_targets.insert(function_id);
                     return builder.imm_u64(Self::internal_function_pointer_id(function_id));
                 }

--- a/tests/ui/codegen/lowering/base_virtual_calls.sol
+++ b/tests/ui/codegen/lowering/base_virtual_calls.sol
@@ -1,6 +1,15 @@
 //@ run-call: Derived::exact() => 2
+//@ run-call: Derived::exactPointer() => 2
 //@ run-call: Derived::dynamic() => 101
 //@ run-call: Concrete::through() => 7
+//@ run-call: SuperDerived::direct() => 11
+//@ run-call: SuperDerived::parenthesized() => 11
+//@ run-call: SuperDerived::pointer() => 11
+//@ run-call: SuperDerived::dynamic() => 101
+//@ run-call: SkipUnimplemented::callSuper() => 42
+// ported-from: test/libsolidity/semanticTests/various/super.sol
+// ported-from: test/libsolidity/semanticTests/various/super_parentheses.sol
+// ported-from: test/libsolidity/semanticTests/functionCall/inheritance/super_skip_unimplemented_in_abstract_contract.sol
 
 contract Base {
     function value(uint256 x) internal pure virtual returns (uint256) {
@@ -15,6 +24,11 @@ contract Derived is Base {
 
     function exact() external pure returns (uint256) {
         return Base.value(1);
+    }
+
+    function exactPointer() external pure returns (uint256) {
+        function(uint256) internal pure returns (uint256) target = Base.value;
+        return target(1);
     }
 
     function dynamic() external pure returns (uint256) {
@@ -33,5 +47,59 @@ abstract contract Abstract {
 contract Concrete is Abstract {
     function hook() public pure override returns (uint256) {
         return 7;
+    }
+}
+
+contract SuperMiddle is Base {
+    function value(uint256 x) internal pure virtual override returns (uint256) {
+        return x + 10;
+    }
+}
+
+contract SuperDerived is SuperMiddle {
+    function value(uint256 x) internal pure override returns (uint256) {
+        return x + 100;
+    }
+
+    function direct() external pure returns (uint256) {
+        return super.value(1);
+    }
+
+    function parenthesized() external pure returns (uint256) {
+        return ((super).value)(1);
+    }
+
+    function pointer() external pure returns (uint256) {
+        function(uint256) internal pure returns (uint256) target = super.value;
+        return target(1);
+    }
+
+    function dynamic() external pure returns (uint256) {
+        return value(1);
+    }
+}
+
+contract ImplementedBase {
+    function getValue() public pure virtual returns (uint256) {
+        return 42;
+    }
+}
+
+abstract contract UnimplementedBase {
+    function getValue() external pure virtual returns (uint256);
+}
+
+contract SkipUnimplemented is ImplementedBase, UnimplementedBase {
+    function getValue()
+        public
+        pure
+        override(ImplementedBase, UnimplementedBase)
+        returns (uint256)
+    {
+        return super.getValue();
+    }
+
+    function callSuper() external pure returns (uint256) {
+        return super.getValue();
     }
 }

--- a/tests/ui/codegen/lowering/base_virtual_calls.sol
+++ b/tests/ui/codegen/lowering/base_virtual_calls.sol
@@ -1,15 +1,6 @@
 //@ run-call: Derived::exact() => 2
-//@ run-call: Derived::exactPointer() => 2
 //@ run-call: Derived::dynamic() => 101
 //@ run-call: Concrete::through() => 7
-//@ run-call: SuperDerived::direct() => 11
-//@ run-call: SuperDerived::parenthesized() => 11
-//@ run-call: SuperDerived::pointer() => 11
-//@ run-call: SuperDerived::dynamic() => 101
-//@ run-call: SkipUnimplemented::callSuper() => 42
-// ported-from: test/libsolidity/semanticTests/various/super.sol
-// ported-from: test/libsolidity/semanticTests/various/super_parentheses.sol
-// ported-from: test/libsolidity/semanticTests/functionCall/inheritance/super_skip_unimplemented_in_abstract_contract.sol
 
 contract Base {
     function value(uint256 x) internal pure virtual returns (uint256) {
@@ -24,11 +15,6 @@ contract Derived is Base {
 
     function exact() external pure returns (uint256) {
         return Base.value(1);
-    }
-
-    function exactPointer() external pure returns (uint256) {
-        function(uint256) internal pure returns (uint256) target = Base.value;
-        return target(1);
     }
 
     function dynamic() external pure returns (uint256) {
@@ -47,59 +33,5 @@ abstract contract Abstract {
 contract Concrete is Abstract {
     function hook() public pure override returns (uint256) {
         return 7;
-    }
-}
-
-contract SuperMiddle is Base {
-    function value(uint256 x) internal pure virtual override returns (uint256) {
-        return x + 10;
-    }
-}
-
-contract SuperDerived is SuperMiddle {
-    function value(uint256 x) internal pure override returns (uint256) {
-        return x + 100;
-    }
-
-    function direct() external pure returns (uint256) {
-        return super.value(1);
-    }
-
-    function parenthesized() external pure returns (uint256) {
-        return ((super).value)(1);
-    }
-
-    function pointer() external pure returns (uint256) {
-        function(uint256) internal pure returns (uint256) target = super.value;
-        return target(1);
-    }
-
-    function dynamic() external pure returns (uint256) {
-        return value(1);
-    }
-}
-
-contract ImplementedBase {
-    function getValue() public pure virtual returns (uint256) {
-        return 42;
-    }
-}
-
-abstract contract UnimplementedBase {
-    function getValue() external pure virtual returns (uint256);
-}
-
-contract SkipUnimplemented is ImplementedBase, UnimplementedBase {
-    function getValue()
-        public
-        pure
-        override(ImplementedBase, UnimplementedBase)
-        returns (uint256)
-    {
-        return super.getValue();
-    }
-
-    function callSuper() external pure returns (uint256) {
-        return super.getValue();
     }
 }

--- a/tests/ui/codegen/lowering/exact_base_function_pointer.sol
+++ b/tests/ui/codegen/lowering/exact_base_function_pointer.sol
@@ -1,0 +1,18 @@
+//@ run-call: Derived::pointer() => 2
+
+contract Base {
+    function value(uint256 x) internal pure virtual returns (uint256) {
+        return x + 1;
+    }
+}
+
+contract Derived is Base {
+    function value(uint256 x) internal pure override returns (uint256) {
+        return x + 100;
+    }
+
+    function pointer() external pure returns (uint256) {
+        function(uint256) internal pure returns (uint256) target = Base.value;
+        return target(1);
+    }
+}

--- a/tests/ui/codegen/lowering/super_calls.sol
+++ b/tests/ui/codegen/lowering/super_calls.sol
@@ -1,0 +1,26 @@
+//@ run-call: D::f() => 15
+// ported-from: test/libsolidity/semanticTests/various/super.sol
+
+contract A {
+    function f() public virtual returns (uint256) {
+        return 1;
+    }
+}
+
+contract B is A {
+    function f() public virtual override returns (uint256) {
+        return super.f() | 2;
+    }
+}
+
+contract C is A {
+    function f() public virtual override returns (uint256) {
+        return super.f() | 4;
+    }
+}
+
+contract D is B, C {
+    function f() public override(B, C) returns (uint256) {
+        return super.f() | 8;
+    }
+}

--- a/tests/ui/codegen/lowering/super_function_pointer.sol
+++ b/tests/ui/codegen/lowering/super_function_pointer.sol
@@ -1,0 +1,28 @@
+//@ run-call: D::f() => 15
+
+contract A {
+    function f() public virtual returns (uint256) {
+        return 1;
+    }
+}
+
+contract B is A {
+    function f() public virtual override returns (uint256) {
+        function() internal returns (uint256) target = super.f;
+        return target() | 2;
+    }
+}
+
+contract C is A {
+    function f() public virtual override returns (uint256) {
+        function() internal returns (uint256) target = super.f;
+        return target() | 4;
+    }
+}
+
+contract D is B, C {
+    function f() public override(B, C) returns (uint256) {
+        function() internal returns (uint256) target = super.f;
+        return target() | 8;
+    }
+}

--- a/tests/ui/codegen/lowering/super_parenthesized_calls.sol
+++ b/tests/ui/codegen/lowering/super_parenthesized_calls.sol
@@ -1,0 +1,26 @@
+//@ run-call: D::f() => 15
+// ported-from: test/libsolidity/semanticTests/various/super_parentheses.sol
+
+contract A {
+    function f() public virtual returns (uint256) {
+        return 1;
+    }
+}
+
+contract B is A {
+    function f() public virtual override returns (uint256) {
+        return ((super).f)() | 2;
+    }
+}
+
+contract C is A {
+    function f() public virtual override returns (uint256) {
+        return ((super).f)() | 4;
+    }
+}
+
+contract D is B, C {
+    function f() public override(B, C) returns (uint256) {
+        return ((super).f)() | 8;
+    }
+}

--- a/tests/ui/codegen/lowering/super_skip_unimplemented.sol
+++ b/tests/ui/codegen/lowering/super_skip_unimplemented.sol
@@ -1,0 +1,18 @@
+//@ run-call: B::f() => 42
+// ported-from: test/libsolidity/semanticTests/functionCall/inheritance/super_skip_unimplemented_in_abstract_contract.sol
+
+contract A {
+    function f() public virtual returns (uint256) {
+        return 42;
+    }
+}
+
+abstract contract I {
+    function f() external virtual returns (uint256);
+}
+
+contract B is A, I {
+    function f() public override(A, I) returns (uint256) {
+        return super.f();
+    }
+}


### PR DESCRIPTION
Follow-up to #1068. Keep unqualified inherited calls virtual, but resolve `Base.f(...)`, `super.f(...)`, and internal function pointers taken from either form to the exact implementation selected by Solidity’s inheritance rules.

The runtime cases cover direct qualification, parenthesized callees, function pointers, `super` skipping an abstract declaration, and ordinary virtual dispatch as a control.
