### PR TITLE
refactor(codegen): lower tuples directly

### DIFF
--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -418,22 +418,14 @@ impl<'gcx> Lowerer<'gcx> {
             }
 
             ExprKind::Tuple(elements) => {
-                let mut values = Vec::with_capacity(elements.len());
-                for &element in *elements {
-                    let Some(element) = element else {
-                        return self.err_value(
-                            builder,
-                            expr.span,
-                            "tuple value contains an omitted element",
-                        );
-                    };
-                    values.push(self.lower_expr(builder, element));
-                }
-                let Some(&first) = values.first() else {
-                    return self.err_value(builder, expr.span, "tuple expression has no value");
+                let [Some(element)] = *elements else {
+                    return self.err_value(
+                        builder,
+                        expr.span,
+                        "tuple value is not supported in this expression context",
+                    );
                 };
-                self.stage_multi_return_tail(builder, &values);
-                first
+                self.lower_expr(builder, element)
             }
 
             ExprKind::Array(elements) => {

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -449,7 +449,7 @@ impl<'gcx> Lowerer<'gcx> {
         var_ids: &[Option<hir::VariableId>],
         init: &hir::Expr<'_>,
     ) {
-        if let hir::ExprKind::Tuple(elements) = &init.kind {
+        if let hir::ExprKind::Tuple(elements) = &init.peel_parens().kind {
             let Ok(values) = self.lower_tuple_values(builder, elements, init.span) else { return };
             if values.len() != var_ids.len() {
                 self.gcx
@@ -571,7 +571,7 @@ impl<'gcx> Lowerer<'gcx> {
         // Tuple RHS, `(a, b) = (x, y)` (including swaps `(a, b) = (b, a)`):
         // evaluate every RHS element before assigning any, so a swap reads the
         // old values.
-        if let hir::ExprKind::Tuple(rhs_elems) = &rhs.kind {
+        if let hir::ExprKind::Tuple(rhs_elems) = &rhs.peel_parens().kind {
             let Ok(values) = self.lower_tuple_values(builder, rhs_elems, rhs.span) else { return };
             if values.len() != elements.len() {
                 self.gcx

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -6,7 +6,7 @@ use crate::{
     mir::{FunctionBuilder, ValueId},
 };
 use alloy_primitives::U256;
-use solar_interface::{Span, kw};
+use solar_interface::{Span, diagnostics::ErrorGuaranteed, kw};
 use solar_sema::{
     builtins::Builtin,
     hir::{self, ExprKind, StmtKind},
@@ -448,6 +448,25 @@ impl<'gcx> Lowerer<'gcx> {
         var_ids: &[Option<hir::VariableId>],
         init: &hir::Expr<'_>,
     ) {
+        if let hir::ExprKind::Tuple(elements) = &init.kind {
+            let Ok(values) = self.lower_tuple_values(builder, elements, init.span) else { return };
+            if values.len() != var_ids.len() {
+                self.gcx
+                    .dcx()
+                    .err("tuple declaration arity mismatch in codegen")
+                    .span(init.span)
+                    .emit();
+                return;
+            }
+
+            for (&var_id, value) in var_ids.iter().zip(values) {
+                if let Some(var_id) = var_id {
+                    self.bind_local_value(builder, var_id, value);
+                }
+            }
+            return;
+        }
+
         if self.is_low_level_call_expr(init) {
             // `(bool success, bytes memory data) = addr.call(...)`: the call
             // lowering returns the success flag, and the full returndata is
@@ -552,13 +571,18 @@ impl<'gcx> Lowerer<'gcx> {
         // evaluate every RHS element before assigning any, so a swap reads the
         // old values.
         if let hir::ExprKind::Tuple(rhs_elems) = &rhs.kind {
-            let vals: Vec<Option<ValueId>> =
-                rhs_elems.iter().map(|e| e.map(|e| self.lower_expr(builder, e))).collect();
-            for (i, &elem) in elements.iter().enumerate() {
-                if let Some(elem) = elem
-                    && let Some(Some(val)) = vals.get(i)
-                {
-                    self.lower_assign(builder, elem, *val);
+            let Ok(values) = self.lower_tuple_values(builder, rhs_elems, rhs.span) else { return };
+            if values.len() != elements.len() {
+                self.gcx
+                    .dcx()
+                    .err("tuple assignment arity mismatch in codegen")
+                    .span(rhs.span)
+                    .emit();
+                return;
+            }
+            for (&elem, value) in elements.iter().zip(values) {
+                if let Some(elem) = elem {
+                    self.lower_assign(builder, elem, value);
                 }
             }
             return;
@@ -618,6 +642,29 @@ impl<'gcx> Lowerer<'gcx> {
             let Some(elem) = elem else { continue };
             self.lower_assign(builder, elem, val.expect("tuple element has a value"));
         }
+    }
+
+    /// Lowers every component of a tuple value without materializing an
+    /// aggregate or staging values through the multi-return buffer.
+    pub(super) fn lower_tuple_values(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        elements: &[Option<&hir::Expr<'_>>],
+        span: Span,
+    ) -> Result<Vec<ValueId>, ErrorGuaranteed> {
+        let mut values = Vec::with_capacity(elements.len());
+        for &element in elements {
+            let Some(element) = element else {
+                return Err(self
+                    .gcx
+                    .dcx()
+                    .err("tuple value contains an omitted element")
+                    .span(span)
+                    .emit());
+            };
+            values.push(self.lower_expr(builder, element));
+        }
+        Ok(values)
     }
 
     /// Stages return values 2..N at the unbumped free-memory pointer and

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -6,6 +6,7 @@ use crate::{
     mir::{FunctionBuilder, ValueId},
 };
 use alloy_primitives::U256;
+use smallvec::SmallVec;
 use solar_interface::{Span, diagnostics::ErrorGuaranteed, kw};
 use solar_sema::{
     builtins::Builtin,
@@ -651,8 +652,8 @@ impl<'gcx> Lowerer<'gcx> {
         builder: &mut FunctionBuilder<'_>,
         elements: &[Option<&hir::Expr<'_>>],
         span: Span,
-    ) -> Result<Vec<ValueId>, ErrorGuaranteed> {
-        let mut values = Vec::with_capacity(elements.len());
+    ) -> Result<SmallVec<[ValueId; 4]>, ErrorGuaranteed> {
+        let mut values = SmallVec::new();
         for &element in elements {
             let Some(element) = element else {
                 return Err(self

--- a/tests/ui/codegen/lowering/tuple_value_declaration.sol
+++ b/tests/ui/codegen/lowering/tuple_value_declaration.sol
@@ -1,8 +1,11 @@
 //@ run-call: pair(int256) -7 => 999999999999999993, -7
 //@ run-call: triple(uint256) 11 => 11, 12, 13
 //@ run-call: arrays(uint256,uint256) 17, 29 => 17, 29
+//@ run-call: discarded() => 13, 3
 
 contract TupleValueDeclaration {
+    uint256 private count;
+
     function pair(int256 x) external pure returns (int256, int256) {
         (int256 wad, int256 p) = (int256(1e18), x);
         return (wad + p, p);
@@ -21,5 +24,15 @@ contract TupleValueDeclaration {
 
         (uint256[] memory originalKeys, uint256[] memory originalValues) = (keys, values);
         return (originalKeys[0], originalValues[0]);
+    }
+
+    function discarded() external returns (uint256, uint256) {
+        (uint256 first,, uint256 third) = (bump(1), bump(2), bump(3));
+        return (first * 10 + third, count);
+    }
+
+    function bump(uint256 value) internal returns (uint256) {
+        count++;
+        return value;
     }
 }

--- a/tests/ui/codegen/lowering/tuple_value_declaration.sol
+++ b/tests/ui/codegen/lowering/tuple_value_declaration.sol
@@ -2,6 +2,7 @@
 //@ run-call: triple(uint256) 11 => 11, 12, 13
 //@ run-call: arrays(uint256,uint256) 17, 29 => 17, 29
 //@ run-call: discarded() => 13, 3
+//@ run-call: parenthesizedCall() => 7
 
 contract TupleValueDeclaration {
     uint256 private count;
@@ -34,5 +35,15 @@ contract TupleValueDeclaration {
     function bump(uint256 value) internal returns (uint256) {
         count++;
         return value;
+    }
+
+    function parenthesizedCall() external pure returns (uint256) {
+        uint256 first;
+        (first,) = (pairValues());
+        return first;
+    }
+
+    function pairValues() internal pure returns (uint256, uint256) {
+        return (7, 9);
     }
 }


### PR DESCRIPTION
Follow-up to #1071. Tuple literals have no single runtime value, so declarations and assignments now evaluate their components once and bind them directly instead of round-tripping the tail through the multi-return scratch buffer. The buffer remains limited to calls and control-flow joins that genuinely need a multi-value handoff.

The runtime cases cover scalar and memory-pointer tuples plus a discarded component with side effects, which verifies that evaluation order is preserved.
