### PR TITLE
fix(codegen): reassign storage references

### DIFF
--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -4161,18 +4161,18 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         // A computed argument not retained physically survives the drain in
         // its spill slot and is reloaded raw after it; make sure the slot is
-        // written while the value is still reachable.
+        // reloadable on this path or write it while the value is still reachable.
         if let Some(mask) = &stack_mask {
             for (i, &arg) in args.iter().enumerate() {
                 if mask.contains(i)
                     && !retention_plan.as_ref().is_some_and(|plan| plan.retained.contains(i))
                     && matches!(func.value(arg), crate::mir::Value::Inst(_))
-                    && !self.scheduler.spills.is_stored(arg)
+                    && !self.scheduler.spills.is_reloadable(arg)
                 {
                     self.spill_value_if_needed(func, arg);
                     debug_assert!(
-                        self.scheduler.spills.is_stored(arg),
-                        "stack argument neither on the stack nor stored"
+                        self.scheduler.spills.is_reloadable(arg),
+                        "stack argument neither on the stack nor reloadable"
                     );
                 }
             }

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -431,7 +431,20 @@ impl<'gcx> Lowerer<'gcx> {
                         "tuple assignment does not produce a single value",
                     );
                 }
-                let rhs_val = if op.is_none() && self.lhs_expects_memory_bytes_value(lhs) {
+                let rhs_val = if op.is_none()
+                    && self
+                        .gcx
+                        .resolved_variable(lhs)
+                        .is_some_and(|var_id| self.storage_ref_locals.contains(var_id))
+                {
+                    self.lower_lvalue_slot(builder, rhs).unwrap_or_else(|| {
+                        self.err_value(
+                            builder,
+                            rhs.span,
+                            "unsupported storage reference assignment",
+                        )
+                    })
+                } else if op.is_none() && self.lhs_expects_memory_bytes_value(lhs) {
                     self.lower_expr_as_memory_bytes(builder, rhs)
                 } else if op.is_none() && self.lhs_expects_memory_dyn_array_value(lhs) {
                     self.lower_expr_as_memory_dyn_array(builder, rhs)
@@ -1636,12 +1649,17 @@ impl<'gcx> Lowerer<'gcx> {
             }
             ExprKind::YulMember(base, member) => {
                 // `r.slot := x` sets the storage pointer's slot value. The pointer
-                // is modeled as an SSA slot in `locals`, marked as a storage ref so
-                // later `r.field` access resolves to `sload`/`sstore(slot + off)`.
+                // is marked as a storage ref so later `r.field` access resolves to
+                // `sload`/`sstore(slot + off)`.
                 if member.name == sym::slot
                     && let Some(var_id) = self.gcx.resolved_variable(base)
                 {
-                    self.locals.insert(var_id, rhs);
+                    if let Some(offset) = self.get_local_memory_offset(&var_id) {
+                        let addr = self.local_memory_addr(builder, offset);
+                        builder.mstore(addr, rhs);
+                    } else {
+                        self.locals.insert(var_id, rhs);
+                    }
                     self.storage_ref_locals.insert(var_id);
                     return;
                 }
@@ -2484,7 +2502,7 @@ impl<'gcx> Lowerer<'gcx> {
                 if let Some(var_id) = self.gcx.resolved_variable(expr) {
                     // Another storage reference: its value is already the slot.
                     if self.storage_ref_locals.contains(var_id) {
-                        return self.locals.get(&var_id).copied();
+                        return self.load_storage_ref_slot(builder, var_id);
                     }
                     // A state variable: its base slot is known at compile time.
                     if let Some(&slot) = self.storage_slots.get(&var_id) {
@@ -2523,7 +2541,7 @@ impl<'gcx> Lowerer<'gcx> {
                     self.get_storage_ref_struct_field_info(base, *member)
                 {
                     let field_offset = self.get_struct_field_slot_offset(struct_id, field_index);
-                    let base_slot = self.locals.get(&var_id).copied()?;
+                    let base_slot = self.load_storage_ref_slot(builder, var_id)?;
                     return Some(if field_offset == 0 {
                         base_slot
                     } else {
@@ -2555,6 +2573,19 @@ impl<'gcx> Lowerer<'gcx> {
             }
             _ => None,
         }
+    }
+
+    fn load_storage_ref_slot(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        var_id: hir::VariableId,
+    ) -> Option<ValueId> {
+        if let Some(&slot) = self.locals.get(&var_id) {
+            return Some(slot);
+        }
+        let offset = self.get_local_memory_offset(&var_id)?;
+        let addr = self.local_memory_addr(builder, offset);
+        Some(builder.mload(addr))
     }
 
     /// Whether `callee` resolves to a function whose first return is a storage

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -139,9 +139,9 @@ pub(crate) struct Lowerer<'gcx> {
     /// Variables not in this set can be kept as SSA values.
     assigned_vars: GrowableBitSet<VariableId>,
     /// Local variables that are storage references (pointers). Their value in
-    /// `locals` is a storage *slot*, so `r.field` reads `sload(slot + offset)`
-    /// and `r.field = v` writes `sstore(slot + offset, v)`, rather than treating
-    /// the value as a memory pointer.
+    /// `locals` or a local memory slot is a storage *slot*, so `r.field` reads
+    /// `sload(slot + offset)` and `r.field = v` writes `sstore(slot + offset, v)`,
+    /// rather than treating the value as a memory pointer.
     storage_ref_locals: GrowableBitSet<VariableId>,
     /// Stack of function IDs currently being inlined (for cycle detection).
     inline_stack: Vec<HirFunctionId>,
@@ -1221,14 +1221,18 @@ impl<'gcx> Lowerer<'gcx> {
                             abi_param_source,
                         );
                     }
-                    if Self::calldata_dynamic_var_kind(param).is_some()
-                        && self.is_var_assigned(&param_id)
-                    {
+                    let is_reassigned = self.is_var_assigned(&param_id);
+                    let is_storage_ref = self.param_is_storage_ref(param_id);
+                    if Self::calldata_dynamic_var_kind(param).is_some() && is_reassigned {
                         // A rebindable calldata slice needs one representation
                         // on every CFG path: give it a two-word slot instead
                         // of a lexical SSA binding.
                         let offset = self.alloc_local_slice_memory(param_id);
                         self.store_slice_slot(&mut builder, offset, head_or_value);
+                    } else if is_storage_ref && is_reassigned {
+                        let offset = self.alloc_local_memory(param_id);
+                        let addr = self.local_memory_addr(&mut builder, offset);
+                        builder.mstore(addr, head_or_value);
                     } else {
                         self.locals.insert(param_id, head_or_value);
                     }
@@ -1236,7 +1240,7 @@ impl<'gcx> Lowerer<'gcx> {
                     // by slot: its value *is* the base slot, so mark it so mapping
                     // indexing and struct/array reads through it use storage, and
                     // so passing it onward resolves back to the slot.
-                    if self.param_is_storage_ref(param_id) {
+                    if is_storage_ref {
                         self.storage_ref_locals.insert(param_id);
                     }
                 }

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -196,25 +196,35 @@ impl<'gcx> Lowerer<'gcx> {
         // (not the dereferenced value) so `r.field` reads/writes `sload`/`sstore`
         // at `slot + offset` rather than treating the value as a memory pointer.
         if var.data_location == Some(solar_ast::DataLocation::Storage) {
-            if let Some(init) = var.initializer {
+            self.storage_ref_locals.insert(var_id);
+            let slot = if let Some(init) = var.initializer {
                 if let Some(slot) = self.lower_lvalue_slot(builder, init) {
-                    self.locals.insert(var_id, slot);
-                    self.storage_ref_locals.insert(var_id);
+                    Some(slot)
+                } else {
+                    // Unhandled storage-reference initializer: don't silently
+                    // miscompile it as a memory pointer.
+                    self.gcx
+                        .dcx()
+                        .err("unsupported storage reference initializer")
+                        .span(init.span)
+                        .emit();
                     return;
                 }
-                // Unhandled storage-reference initializer: don't silently
-                // miscompile it as a memory pointer.
-                self.gcx
-                    .dcx()
-                    .err("unsupported storage reference initializer")
-                    .span(init.span)
-                    .emit();
-                return;
+            } else {
+                None
+            };
+
+            if self.is_var_assigned(&var_id) {
+                // Reserve a mergeable slot without inventing an initial storage address.
+                // Storage-reference assignment writes the actual address into it.
+                let offset = self.alloc_local_memory(var_id);
+                if let Some(slot) = slot {
+                    let addr = self.local_memory_addr(builder, offset);
+                    builder.mstore(addr, slot);
+                }
+            } else if let Some(slot) = slot {
+                self.locals.insert(var_id, slot);
             }
-            // No initializer (e.g. the slot is set later via `r.slot := ...`).
-            // Keep the value absent until that assignment; reading it first is
-            // an error, not an implicit reference to storage slot zero.
-            self.storage_ref_locals.insert(var_id);
             return;
         }
 
@@ -455,6 +465,11 @@ impl<'gcx> Lowerer<'gcx> {
                 let offset = self.alloc_local_memory(*var_id);
                 let offset_val = self.local_memory_addr(builder, offset);
                 builder.mstore(offset_val, val.expect("bound variable has a value"));
+                if self.gcx.hir.variable(*var_id).data_location
+                    == Some(solar_ast::DataLocation::Storage)
+                {
+                    self.storage_ref_locals.insert(*var_id);
+                }
             }
         }
     }
@@ -469,6 +484,9 @@ impl<'gcx> Lowerer<'gcx> {
         val: ValueId,
     ) {
         let var = self.gcx.hir.variable(var_id);
+        if var.data_location == Some(solar_ast::DataLocation::Storage) {
+            self.storage_ref_locals.insert(var_id);
+        }
         if Self::calldata_dynamic_var_kind(var).is_some() {
             if self.is_var_assigned(&var_id) {
                 let offset = self.alloc_local_slice_memory(var_id);

--- a/tests/ui/codegen/lowering/storage_reference_reassignment.sol
+++ b/tests/ui/codegen/lowering/storage_reference_reassignment.sol
@@ -1,0 +1,67 @@
+//@ run-call: bindAfterDeclaration 7, 11 => 11, 12
+//@ run-call: rebind true, 3, 5, 17 => 0, 17
+//@ run-call: rebind false, 3, 5, 17 => 17, 0
+//@ run-call: rebindParameter 3, 5, 19 => 0, 19
+//@ run-call: swap 3, 5, 23, 29 => 29, 23
+
+contract StorageReferenceReassignment {
+    struct Item {
+        uint256 a;
+        uint256 b;
+    }
+
+    mapping(uint256 => Item) items;
+
+    function bindAfterDeclaration(uint256 key, uint256 value)
+        external
+        returns (uint256, uint256)
+    {
+        Item storage item;
+        item = items[key];
+        item.a = value;
+        item.b = value + 1;
+        return (item.a, readB(item));
+    }
+
+    function rebind(bool useSecond, uint256 first, uint256 second, uint256 value)
+        external
+        returns (uint256, uint256)
+    {
+        Item storage item = items[first];
+        if (useSecond) {
+            item = items[second];
+        }
+        item.a = value;
+        return (items[first].a, items[second].a);
+    }
+
+    function rebindParameter(uint256 first, uint256 second, uint256 value)
+        external
+        returns (uint256, uint256)
+    {
+        Item storage item = items[first];
+        rebindParameterInner(item, second, value);
+        return (items[first].a, items[second].a);
+    }
+
+    function swap(uint256 first, uint256 second, uint256 firstValue, uint256 secondValue)
+        external
+        returns (uint256, uint256)
+    {
+        Item storage firstItem = items[first];
+        Item storage secondItem = items[second];
+        (firstItem, secondItem) = (secondItem, firstItem);
+        firstItem.a = firstValue;
+        secondItem.a = secondValue;
+        return (items[first].a, items[second].a);
+    }
+
+    function readB(Item storage item) internal view returns (uint256) {
+        return item.b;
+    }
+
+    function rebindParameterInner(Item storage item, uint256 key, uint256 value) internal {
+        item = items[key];
+        item.a = value;
+    }
+}


### PR DESCRIPTION
Stacks on #1036.

Reassignable storage pointers now keep their storage slot in a local memory slot, and storage-reference assignment binds the right-hand lvalue's slot instead of copying a struct or dropping the assignment. This covers the delayed binding used by Seaport as well as branch, parameter, and tuple rebindings. Unsupported storage-reference sources still produce a codegen error.

Once Seaport reached backend emission, the static-call stack-argument path exposed an ordering bug: a cross-block spill can be reloadable before its defining block is emitted. Checking reloadability rather than source emission order lets the call load the slot that its runtime predecessor fills.
