### PR TITLE
fix(sema): align project edge cases with solc

### DIFF
--- a/crates/lsp/src/tests/implementation.rs
+++ b/crates/lsp/src/tests/implementation.rs
@@ -497,13 +497,10 @@ fn ignores_conflicting_source_snapshots_across_analysis_batches() {
 fn isolates_conflicting_dependency_implementations_across_analysis_batches() {
     let source = r#"
         //- /Shared.sol open
-        import "./open/OpenImpl.sol";
         abstract contract Base {
             function run(uint256) public virtual {}
         }
 
-        //- /open/OpenImpl.sol
-        import "../Shared.sol";
         contract OpenImpl is Base {
             function run(uint256) public override {}
         }

--- a/crates/parse/src/natspec.rs
+++ b/crates/parse/src/natspec.rs
@@ -5,13 +5,31 @@
 pub fn split_once_ws(content: &str, start: usize, end: usize) -> (&str, usize) {
     let bytes = content.as_bytes();
     if let Some(ws_pos) =
-        memchr::memchr3(b' ', b'\t', b'\r', &bytes[start..end]).map(|offset| start + offset)
+        bytes[start..end].iter().position(|b| b.is_ascii_whitespace()).map(|offset| start + offset)
     {
         let rest = &bytes[ws_pos..end];
         (&content[start..ws_pos], ws_pos + (rest.len() - rest.trim_ascii_start().len()))
     } else {
         (&content[start..end], end)
     }
+}
+
+/// Splits a string slice at the end of its leading identifier.
+///
+/// Returns the identifier prefix and the position of the first following non-blank char; the
+/// prefix is empty when the content does not start with an identifier character. This mirrors
+/// solc, which parses documented parameter names as identifier prefixes, so `@param -` documents
+/// an unnamed parameter.
+#[inline]
+pub fn split_once_ident(content: &str, start: usize, end: usize) -> (&str, usize) {
+    let bytes = content.as_bytes();
+    let ident_len = bytes[start..end]
+        .iter()
+        .position(|&b| !crate::lexer::is_id_continue_byte(b))
+        .unwrap_or(end - start);
+    let ident_end = start + ident_len;
+    let rest = &bytes[ident_end..end];
+    (&content[start..ident_end], ident_end + (rest.len() - rest.trim_ascii_start().len()))
 }
 
 /// Returns the first non-blank word and the position of the first following non-blank char.

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -1136,11 +1136,16 @@ fn parse_natspec(
             // can only be followed by whitespace
             ast::CommentKind::Line => bytes[line_start..at_pos].trim_ascii().is_empty(),
 
-            // can only be followed by whitespaces + ('*') + whitespaces
+            // can only be followed by whitespaces and '*' decorations, which
+            // may repeat (`* * @return` still starts a tag, as in solc, where
+            // the scanner strips one decoration and the parser finds the tag
+            // anywhere in the line).
             ast::CommentKind::Block => {
-                let trimmed = &bytes[line_start..at_pos].trim_ascii_start();
-                trimmed.is_empty()
-                    || (trimmed.starts_with(b"*") && trimmed[1..].trim_ascii_end().is_empty())
+                let mut rest = bytes[line_start..at_pos].trim_ascii_start();
+                while let Some(stripped) = rest.strip_prefix(b"*") {
+                    rest = stripped.trim_ascii_start();
+                }
+                rest.is_empty()
             }
         }
     };
@@ -1152,6 +1157,16 @@ fn parse_natspec(
             && is_line_start(line_start, line_start + tag_offset)
         {
             let tag_start = line_start + tag_offset + 1;
+
+            // The tag name must immediately follow the '@': `@ param` is
+            // plain text continuing the previous tag, matching solc.
+            let (tag, rest_start) = crate::natspec::split_once_ws(content, tag_start, line_end);
+            if tag.is_empty() {
+                prev_line_end = line_end;
+                line_start = line_end + 1;
+                continue;
+            }
+
             flush_item(
                 &mut items,
                 &mut kind,
@@ -1161,15 +1176,8 @@ fn parse_natspec(
                 prev_line_end,
             );
 
-            // Skip leading whitespace after '@'
-            let tag_slice = &bytes[tag_start..line_end];
-            let trimmed = tag_slice.len() - tag_slice.trim_ascii_start().len();
-            let (tag, rest_start) =
-                crate::natspec::split_once_ws(content, tag_start + trimmed, line_end);
-
-            // Calculate span: from first non-whitespace char after '@' to end of tag name.
-            let tag_lo =
-                comment_span.lo().0 + PREFIX_BYTES + 1 + (line_start + tag_offset + trimmed) as u32; // +1 for '@'
+            // Calculate span: from the char after '@' to end of tag name.
+            let tag_lo = comment_span.lo().0 + PREFIX_BYTES + 1 + (line_start + tag_offset) as u32; // +1 for '@'
             let tag_hi = tag_lo + tag.len() as u32;
             span = Some(Span::new(BytePos(tag_lo), BytePos(tag_hi)));
             content_start = rest_start;
@@ -1181,8 +1189,10 @@ fn parse_natspec(
                 "dev" => ast::NatSpecKind::Dev,
                 "param" | "inheritdoc" => {
                     let name_start = rest_start;
+                    // Names are identifier prefixes, mirroring solc: `@param -`
+                    // documents an unnamed parameter with an empty name.
                     let (name, content_start_pos) =
-                        crate::natspec::split_once_ws(content, rest_start, line_end);
+                        crate::natspec::split_once_ident(content, rest_start, line_end);
                     content_start = content_start_pos;
                     let name_lo = comment_span.lo() + PREFIX_BYTES + name_start as u32;
                     let name_span = Span::new(name_lo, name_lo + name.len() as u32);
@@ -1348,7 +1358,9 @@ import * as B from "b.sol";
             let docs = parser.parse_doc_comments();
 
             let natspec_items: Vec<_> = docs.iter().flat_map(|d| d.natspec.iter().map(move |i| (d.symbol, i))).collect();
-            assert_eq!(natspec_items.len(), 12);
+            // `@ notice with space` is not a tag: the name must immediately
+            // follow the `@`, so the line yields no item.
+            assert_eq!(natspec_items.len(), 11);
 
             let check = |i: usize, snip, kind, name, content| {
                 check_natspec_item(sm, natspec_items[i].0, natspec_items[i].1, snip, kind, name, content)
@@ -1367,7 +1379,6 @@ import * as B from "b.sol";
             check(8, "inheritdoc", "inheritdoc", Some("BaseContract"), Some(""));
             check(9, "custom:security", "custom", Some("security"), Some("High priority"));
             check(10, "solidity", "internal", Some("solidity"), Some("memory-safe"));
-            check(11, "notice", "notice", None, Some("with space"));
 
             assert_eq!(sm.span_to_snippet(docs.span()).unwrap(), "/// @title MyContract\n/// @author Alice\n/// @notice This is a notice\n/// that spans multiple lines\n/// and continues here\n/// @dev This is dev documentation\n/// @param x The input parameter\n/// @return result The return value\n/// @inheritdoc BaseContract\n/// @custom:security High priority\n/// @solidity memory-safe\n/// @ notice with space");
         });

--- a/crates/sema/src/builtins/members.rs
+++ b/crates/sema/src/builtins/members.rs
@@ -204,21 +204,28 @@ fn reference<'gcx>(
             TyKind::DynArray(_) | TyKind::Elementary(ElementaryType::Bytes),
             DataLocation::Storage,
         ) => {
-            let inner = if let TyKind::DynArray(inner) = inner.kind {
-                inner.with_loc_if_ref(gcx, loc)
+            let element = if let TyKind::DynArray(element) = inner.kind {
+                element
             } else {
                 gcx.types.fixed_bytes(1)
             };
-            let value = inner.with_loc_if_ref(gcx, DataLocation::Memory);
+            // `push()` returns a reference to the new storage slot, but
+            // `push(x)` takes its argument location-less, like a mapping key:
+            // the value is copied into storage, so any data location converts,
+            // matching solc's direct-storage-reference conversion rule.
             vec![
                 Member::of_builtin(gcx, Builtin::ArrayLength),
                 Member::with_attached_builtin(
                     Builtin::ArrayPush0,
-                    gcx.mk_builtin_fn(&[this], SM::NonPayable, &[inner]),
+                    gcx.mk_builtin_fn(
+                        &[this],
+                        SM::NonPayable,
+                        &[element.with_loc_if_ref(gcx, loc)],
+                    ),
                 ),
                 Member::with_attached_builtin(
                     Builtin::ArrayPush,
-                    gcx.mk_builtin_fn(&[this, value], SM::NonPayable, &[]),
+                    gcx.mk_builtin_fn(&[this, element], SM::NonPayable, &[]),
                 ),
                 Member::with_attached_builtin(
                     Builtin::ArrayPop,

--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use solar_ast as ast;
 use solar_data_structures::{BumpExt, map::FxHashSet, smallvec::SmallVec};
-use solar_interface::{Ident, Span, Symbol};
+use solar_interface::{Ident, Span, Symbol, kw};
 use std::ops::Range;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -282,7 +282,6 @@ impl<'gcx> Resolver<'gcx> {
         #[derive(Default)]
         struct ValidationState {
             seen_tags: SeenTags,
-            seen_params: SmallVec<[(Symbol, Span); 6]>,
             return_count: usize,
         }
 
@@ -350,25 +349,33 @@ impl<'gcx> Resolver<'gcx> {
                             continue;
                         }
 
-                        if let Some(&(_, prev_span)) =
-                            state.seen_params.iter().find(|(sym, _)| *sym == name.name)
-                        {
-                            self.emit_duplicate_param_error(name.name, tag_span, prev_span);
-                            continue;
-                        }
-                        state.seen_params.push((name.name, tag_span));
-
+                        // Valid `@param` targets are the parameter and return
+                        // variable names; unnamed variables contribute the
+                        // empty symbol, which an empty documented name
+                        // (`@param -`) refers to. Duplicates are not
+                        // diagnosed. This matches solc.
                         let params = parameters.get_or_insert_with(|| {
-                            self.gcx.hir.item(item_id).parameters().map_or(
-                                FxHashSet::default(),
-                                |p| {
-                                    p.iter()
-                                        .filter_map(|&id| {
-                                            self.gcx.hir.variable(id).name.map(|ident| ident.name)
-                                        })
-                                        .collect()
-                                },
-                            )
+                            let mut set = FxHashSet::default();
+                            let item = self.gcx.hir.item(item_id);
+                            if let Some(p) = item.parameters() {
+                                set.extend(p.iter().map(|&id| {
+                                    self.gcx
+                                        .hir
+                                        .variable(id)
+                                        .name
+                                        .map_or(kw::Empty, |ident| ident.name)
+                                }));
+                            }
+                            if let hir::ItemId::Function(id) = item_id {
+                                set.extend(self.gcx.hir.function(id).returns.iter().map(|&id| {
+                                    self.gcx
+                                        .hir
+                                        .variable(id)
+                                        .name
+                                        .map_or(kw::Empty, |ident| ident.name)
+                                }));
+                            }
+                            set
                         });
 
                         if params.contains(&name.name) {
@@ -502,16 +509,6 @@ impl<'gcx> Resolver<'gcx> {
     #[cold]
     fn emit_duplicate_tag_error(&self, tag_name: &str, tag_span: Span) {
         self.gcx.dcx().emit_err(tag_span, format!("tag {tag_name} can only be given once"));
-    }
-
-    #[cold]
-    fn emit_duplicate_param_error(&self, param_name: Symbol, tag_span: Span, prev_span: Span) {
-        self.gcx.dcx().emit_err_span_note(
-            tag_span,
-            format!("duplicate documentation for parameter '{param_name}'"),
-            prev_span,
-            "previously documented here",
-        );
     }
 
     /// Helper to validate tags that can only be defined once.

--- a/crates/sema/src/parse.rs
+++ b/crates/sema/src/parse.rs
@@ -595,7 +595,17 @@ impl<'ast> Sources<'ast> {
         let mut map = index_vec![SourceId::MAX; len];
         let mut seen = DenseBitSet::new_empty(len);
         debug_span!("topo_order").in_scope(|| {
-            for id in self.sources.indices() {
+            // Roots in source-name order: for acyclic imports any root order
+            // yields a valid topological order, but cyclic imports are cut at
+            // the first back edge from the root, so the root order decides
+            // whether a base contract's source still precedes its derived
+            // contract's. solc roots its DFS in name order (`m_sources` is an
+            // ordered map); match it so cycles are cut identically.
+            let mut roots: Vec<SourceId> = self.sources.indices().collect();
+            roots.sort_unstable_by(|&a, &b| {
+                self.sources[a].file.name.cmp(&self.sources[b].file.name)
+            });
+            for id in roots {
                 self.topo_order(id, &mut order, &mut map, &mut seen);
             }
         });

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -339,8 +339,7 @@ pub struct GlobalCtxt<'gcx> {
     pub(crate) hir_arenas: ThreadLocal<hir::Arena>,
     interner: Interner<'gcx>,
     cache: Cache<'gcx>,
-    pub(crate) inherited_override_functions:
-        FxOnceMap<hir::ContractId, &'gcx crate::typeck::override_checker::InheritedFunctions<'gcx>>,
+    pub(crate) override_index: OnceLock<crate::typeck::override_checker::OverrideIndex<'gcx>>,
 }
 
 impl fmt::Debug for GlobalCtxt<'_> {
@@ -375,7 +374,7 @@ impl<'gcx> GlobalCtxt<'gcx> {
             hir_arenas,
             interner,
             cache: Cache::default(),
-            inherited_override_functions: FxOnceMap::default(),
+            override_index: OnceLock::new(),
         }
     }
 }

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -706,6 +706,11 @@ impl<'gcx> Ty<'gcx> {
             // See: <https://docs.soliditylang.org/en/latest/types.html#array-slices>
             // `T[] loc slice` -> `T[] loc`
             (Slice(underlying), _) if underlying == other => Ok(()),
+            // `T[] loc slice` -> location-less `T[]`, like any other reference;
+            // this arises for mapping keys, e.g. `m[data[1:]]`.
+            (Slice(underlying), to) if !matches!(to, Ref(..)) => {
+                underlying.try_convert_implicit_to(other, gcx)
+            }
             // `T[] loc slice` -> `T[] memory`
             (Slice(underlying), Ref(other_inner, DataLocation::Memory)) => {
                 if let Ref(self_inner, _) = underlying.kind

--- a/crates/sema/src/ty/ty.rs
+++ b/crates/sema/src/ty/ty.rs
@@ -593,7 +593,7 @@ impl<'gcx> Ty<'gcx> {
     /// Returns `true` if the type can be used for variables.
     pub fn nameable(self) -> bool {
         matches!(
-            self.kind,
+            self.peel_refs().kind,
             TyKind::Elementary(_)
                 | TyKind::Array(..)
                 | TyKind::DynArray(_)

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -2456,10 +2456,47 @@ impl<'gcx> TypeChecker<'gcx> {
         }
 
         match res.iter().filter(|res| res.as_variable().is_some()).collect::<WantOne<_>>() {
-            WantOne::Zero => Err(OverloadError::NotFound),
+            WantOne::Zero => self.resolve_override_chain(res).ok_or(OverloadError::NotFound),
             WantOne::One(var) => Ok(*var),
             WantOne::Many => Err(OverloadError::Ambiguous),
         }
+    }
+
+    /// Resolves a non-call reference to a set of functions that are all one
+    /// override chain, e.g. `onERC1155Received.selector` where the function is
+    /// declared in a base and overridden below it.
+    ///
+    /// An overridden function appears once per level of the inheritance chain
+    /// under name lookup, but overrides share the base's parameter types, so a
+    /// set with a single parameter list is a single function. Resolves to the
+    /// most derived candidate, whose type also carries the tightest state
+    /// mutability.
+    fn resolve_override_chain(&self, res: &[hir::Res]) -> Option<hir::Res> {
+        let function_id = |res: hir::Res| match res {
+            hir::Res::Item(hir::ItemId::Function(id)) => Some(id),
+            _ => None,
+        };
+        let first = function_id(res[0])?;
+        let TyKind::Fn(first_fn) = self.gcx.type_of_item(first.into()).kind else { return None };
+        let mut best = (first, self.gcx.hir.function(first).contract);
+        for &candidate in &res[1..] {
+            let id = function_id(candidate)?;
+            let TyKind::Fn(f) = self.gcx.type_of_item(id.into()).kind else { return None };
+            if f.parameters != first_fn.parameters {
+                return None;
+            }
+            let contract = self.gcx.hir.function(id).contract;
+            if let (Some(current), Some(a), Some(b)) = (self.contract, contract, best.1) {
+                let bases = self.gcx.hir.contract(current).linearized_bases;
+                let position = |c| bases.iter().position(|&base| base == c);
+                if let (Some(pos_a), Some(pos_b)) = (position(a), position(b))
+                    && pos_a < pos_b
+                {
+                    best = (id, contract);
+                }
+            }
+        }
+        Some(hir::ItemId::Function(best.0).into())
     }
 
     fn type_of_res(&self, res: hir::Res) -> Ty<'gcx> {

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -219,8 +219,10 @@ impl<'gcx> TypeChecker<'gcx> {
                                 .emit(),
                         )
                     } else {
+                        // Element types are stored bare; the inferred common
+                        // type of reference elements carries a location.
                         self.gcx
-                            .mk_ty(TyKind::Array(common, U256::from(exprs.len())))
+                            .mk_ty(TyKind::Array(common.peel_refs(), U256::from(exprs.len())))
                             .with_loc(self.gcx, DataLocation::Memory)
                     }
                 } else {

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1226,7 +1226,17 @@ impl<'gcx> TypeChecker<'gcx> {
         }
 
         let hir::ExprKind::Ident(res) = callee.kind else {
+            // Error constructors behind member paths (`Lib.SomeError()`)
+            // resolve through the ordinary call path; admit them exactly like
+            // a revert statement does.
+            let prev_in_revert = std::mem::replace(&mut self.in_revert, true);
             let actual = self.check_expr_once(expr);
+            self.in_revert = prev_in_revert;
+            if let Some(callee_ty) = self.results.expr_types.get(&callee.id)
+                && matches!(callee_ty.kind, TyKind::Error(..))
+            {
+                return Ok(());
+            }
             return self.check_expected(expr, actual, self.gcx.types.string_ref.memory);
         };
         let error_res = res

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -36,12 +36,17 @@ pub(crate) fn check(gcx: Gcx<'_>, contract_id: ContractId) {
     checker.check();
 }
 
-pub(crate) type InheritedFunctions<'gcx> = FxIndexMap<OverrideSignature<'gcx>, Vec<OverrideProxy>>;
+type InheritedFunctions<'gcx> = FxIndexMap<OverrideSignature<'gcx>, Vec<OverrideProxy>>;
+
+pub(crate) struct OverrideIndex<'gcx> {
+    by_signature: InheritedFunctions<'gcx>,
+    by_name: FxHashMap<Ident, Vec<OverrideProxy>>,
+    unimplemented_functions: Vec<FunctionId>,
+}
 
 struct OverrideChecker<'gcx> {
     gcx: Gcx<'gcx>,
     contract_id: ContractId,
-    inherited: &'gcx InheritedFunctions<'gcx>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -304,7 +309,7 @@ impl<'a, 'gcx> CutVertexFinder<'a, 'gcx> {
 
 impl<'gcx> OverrideChecker<'gcx> {
     fn new(gcx: Gcx<'gcx>, contract_id: ContractId) -> Self {
-        Self { gcx, contract_id, inherited: inherited_override_functions(gcx, contract_id) }
+        Self { gcx, contract_id }
     }
 
     fn dcx(&self) -> &'gcx DiagCtxt {
@@ -330,27 +335,8 @@ impl<'gcx> OverrideChecker<'gcx> {
         override_signature(self.gcx, proxy)
     }
 
-    fn inherited_functions(&self) -> &InheritedFunctions<'gcx> {
-        self.inherited
-    }
-
     fn check_illegal_overrides(&self) {
         let contract = self.contract();
-        let inherited = self.inherited_functions();
-
-        let (inherited_modifiers, inherited_functions) = inherited.keys().fold(
-            (FxHashSet::<Ident>::default(), FxHashSet::<Ident>::default()),
-            |(mut modifiers, mut functions), sig| {
-                if let Some(name) = sig.name {
-                    if sig.kind.is_modifier() {
-                        modifiers.insert(name);
-                    } else {
-                        functions.insert(name);
-                    }
-                }
-                (modifiers, functions)
-            },
-        );
 
         for f_id in contract.functions() {
             let f = self.gcx.hir.function(f_id);
@@ -362,14 +348,14 @@ impl<'gcx> OverrideChecker<'gcx> {
 
             if let Some(name) = proxy.name(self.gcx) {
                 if f.kind.is_modifier() {
-                    if inherited_functions.contains(&name) {
+                    if self.has_inherited_name_kind(name, false) {
                         self.dcx()
                             .err("override changes function or public state variable to modifier")
                             .code(error_code!(5631))
                             .span(f.span)
                             .emit();
                     }
-                } else if inherited_modifiers.contains(&name) {
+                } else if self.has_inherited_name_kind(name, true) {
                     self.dcx()
                         .err("override changes modifier to function")
                         .code(error_code!(1469))
@@ -379,8 +365,9 @@ impl<'gcx> OverrideChecker<'gcx> {
             }
 
             let sig = self.signature(proxy);
-            if let Some(bases) = inherited.get(&sig) {
-                self.check_override_list(proxy, bases);
+            let bases = inherited_override_functions(self.gcx, self.contract_id, sig);
+            if !bases.is_empty() {
+                self.check_override_list(proxy, &bases);
             } else if f.override_ {
                 self.dcx()
                     .err(format!(
@@ -410,7 +397,7 @@ impl<'gcx> OverrideChecker<'gcx> {
             let proxy = OverrideProxy::Variable(v_id);
             let name = proxy.name(self.gcx).unwrap();
 
-            if inherited_modifiers.contains(&name) {
+            if self.has_inherited_name_kind(name, true) {
                 self.dcx()
                     .err("override changes modifier to public state variable")
                     .code(error_code!(1456))
@@ -419,8 +406,9 @@ impl<'gcx> OverrideChecker<'gcx> {
             }
 
             let sig = self.signature(proxy);
-            if let Some(bases) = inherited.get(&sig) {
-                self.check_override_list(proxy, bases);
+            let bases = inherited_override_functions(self.gcx, self.contract_id, sig);
+            if !bases.is_empty() {
+                self.check_override_list(proxy, &bases);
             } else if v.override_ {
                 self.dcx()
                     .err("public state variable has override specified but does not override anything")
@@ -429,6 +417,18 @@ impl<'gcx> OverrideChecker<'gcx> {
                     .emit();
             }
         }
+    }
+
+    fn has_inherited_name_kind(&self, name: Ident, modifier: bool) -> bool {
+        let contract = self.contract();
+        override_index(self.gcx).by_name.get(&name).is_some_and(|candidates| {
+            candidates.iter().any(|&candidate| {
+                candidate.is_modifier(self.gcx) == modifier
+                    && candidate.contract(self.gcx).is_some_and(|id| {
+                        id != self.contract_id && contract.linearized_bases[1..].contains(&id)
+                    })
+            })
+        })
     }
 
     fn check_override_list(&self, overriding: OverrideProxy, bases: &[OverrideProxy]) {
@@ -792,7 +792,10 @@ impl<'gcx> OverrideChecker<'gcx> {
 
     fn check_ambiguous_overrides(&self) {
         let contract = self.contract();
-        let inherited = self.inherited_functions();
+        if contract.bases.len() <= 1 {
+            return;
+        }
+        let inherited = compute_inherited_functions(self.gcx, self.contract_id);
 
         let own_signatures: FxHashSet<OverrideSignature<'gcx>> = contract
             .functions()
@@ -812,7 +815,7 @@ impl<'gcx> OverrideChecker<'gcx> {
             }))
             .collect();
 
-        for (sig, bases) in inherited {
+        for (sig, bases) in &inherited {
             if own_signatures.contains(sig) {
                 continue;
             }
@@ -905,31 +908,30 @@ impl<'gcx> OverrideChecker<'gcx> {
 
         let mut unimplemented: Vec<(OverrideProxy, ContractId)> = Vec::new();
 
-        for &base_id in contract.linearized_bases.iter() {
-            let base = self.gcx.hir.contract(base_id);
+        for &f_id in &override_index(self.gcx).unimplemented_functions {
+            let f = self.gcx.hir.function(f_id);
+            let Some(base_id) = f.contract else { continue };
+            if f.kind.is_constructor()
+                || f.name.is_none()
+                || !contract.linearized_bases.contains(&base_id)
+            {
+                continue;
+            }
 
-            for f_id in base.functions() {
-                let f = self.gcx.hir.function(f_id);
-                if f.kind.is_constructor() || f.name.is_none() {
-                    continue;
-                }
-                if f.body.is_none() {
-                    let sig = self.signature(OverrideProxy::Function(f_id));
-                    let is_implemented = contract.linearized_bases.iter().any(|&impl_base_id| {
-                        let impl_base = self.gcx.hir.contract(impl_base_id);
-                        impl_base.functions().any(|impl_f_id| {
-                            let impl_f = self.gcx.hir.function(impl_f_id);
-                            if impl_f.body.is_none() || impl_f.name.is_none() {
-                                return false;
-                            }
-                            let impl_sig = self.signature(OverrideProxy::Function(impl_f_id));
-                            impl_sig == sig
-                        })
-                    });
-                    if !is_implemented {
-                        unimplemented.push((OverrideProxy::Function(f_id), base_id));
+            let sig = self.signature(OverrideProxy::Function(f_id));
+            let is_implemented = contract.linearized_bases.iter().any(|&impl_base_id| {
+                let impl_base = self.gcx.hir.contract(impl_base_id);
+                impl_base.functions().any(|impl_f_id| {
+                    let impl_f = self.gcx.hir.function(impl_f_id);
+                    if impl_f.body.is_none() || impl_f.name.is_none() {
+                        return false;
                     }
-                }
+                    let impl_sig = self.signature(OverrideProxy::Function(impl_f_id));
+                    impl_sig == sig
+                })
+            });
+            if !is_implemented {
+                unimplemented.push((OverrideProxy::Function(f_id), base_id));
             }
         }
 
@@ -972,70 +974,159 @@ impl<'gcx> OverrideChecker<'gcx> {
     }
 }
 
-fn inherited_override_functions<'gcx>(
-    gcx: Gcx<'gcx>,
-    contract_id: ContractId,
-) -> &'gcx InheritedFunctions<'gcx> {
-    gcx.inherited_override_functions.map_insert(
-        contract_id,
-        |&contract_id| {
-            let inherited = compute_inherited_functions(gcx, contract_id);
-            gcx.alloc(inherited)
-        },
-        |_, inherited| *inherited,
-    )
-}
+fn override_index<'gcx>(gcx: Gcx<'gcx>) -> &'gcx OverrideIndex<'gcx> {
+    gcx.override_index.get_or_init(|| {
+        let mut by_signature = InheritedFunctions::default();
+        let mut by_name = FxHashMap::default();
+        let mut unimplemented_functions = Vec::new();
 
-/// Compute inherited functions for a contract.
-///
-/// This matches solc's logic: inherited functions are added unless the direct
-/// base defines a function with the same signature.
-fn compute_inherited_functions<'gcx>(
-    gcx: Gcx<'gcx>,
-    contract_id: ContractId,
-) -> InheritedFunctions<'gcx> {
-    let contract = gcx.hir.contract(contract_id);
-    let mut result: InheritedFunctions<'gcx> = FxIndexMap::default();
-
-    for &base_id in contract.bases.iter() {
-        let base = gcx.hir.contract(base_id);
-
-        // Collect functions/variables defined directly in this base.
-        let mut defined_in_base: FxHashSet<OverrideSignature<'gcx>> = FxHashSet::default();
-
-        for f_id in base.functions() {
+        for f_id in gcx.hir.function_ids() {
             let f = gcx.hir.function(f_id);
+            if f.body.is_none() {
+                unimplemented_functions.push(f_id);
+            }
             if f.kind.is_constructor() {
                 continue;
             }
             let proxy = OverrideProxy::Function(f_id);
-            let sig = override_signature(gcx, proxy);
-
-            result.entry(sig).or_default().push(proxy);
-            defined_in_base.insert(sig);
+            by_signature.entry(override_signature(gcx, proxy)).or_insert_with(Vec::new).push(proxy);
+            if let Some(name) = proxy.name(gcx) {
+                by_name.entry(name).or_insert_with(Vec::new).push(proxy);
+            }
         }
 
-        for v_id in base.variables() {
+        for v_id in gcx.hir.variable_ids() {
             let v = gcx.hir.variable(v_id);
             if !v.is_public() {
                 continue;
             }
             let proxy = OverrideProxy::Variable(v_id);
-            let sig = override_signature(gcx, proxy);
-
-            result.entry(sig).or_default().push(proxy);
-            defined_in_base.insert(sig);
+            by_signature.entry(override_signature(gcx, proxy)).or_insert_with(Vec::new).push(proxy);
+            by_name.entry(proxy.name(gcx).unwrap()).or_insert_with(Vec::new).push(proxy);
         }
 
-        // Get inherited functions from ancestors and add those NOT defined in base.
-        let inherited = inherited_override_functions(gcx, base_id);
-        for (&sig, proxies) in inherited {
-            if !defined_in_base.contains(&sig) {
-                result.entry(sig).or_default().extend(proxies.iter().copied());
+        OverrideIndex { by_signature, by_name, unimplemented_functions }
+    })
+}
+
+/// Returns the definitions of `signature` inherited through the contract's
+/// direct bases.
+///
+/// This preserves the branch-sensitive behavior of solc's override checker: a
+/// definition in a direct base hides that base's ancestors, but definitions
+/// inherited through another direct base remain candidates.
+fn inherited_override_functions<'gcx>(
+    gcx: Gcx<'gcx>,
+    contract_id: ContractId,
+    signature: OverrideSignature<'gcx>,
+) -> Vec<OverrideProxy> {
+    let Some(candidates) = override_index(gcx).by_signature.get(&signature) else {
+        return Vec::new();
+    };
+    let contract = gcx.hir.contract(contract_id);
+    let candidates = candidates
+        .iter()
+        .copied()
+        .filter(|&candidate| {
+            candidate.contract(gcx).is_some_and(|candidate_contract| {
+                candidate_contract != contract_id
+                    && contract.linearized_bases[1..].contains(&candidate_contract)
+            })
+        })
+        .collect::<Vec<_>>();
+    if candidates.is_empty() {
+        return candidates;
+    }
+
+    inherited_override_functions_internal(gcx, contract_id, &candidates)
+}
+
+fn inherited_override_functions_internal(
+    gcx: Gcx<'_>,
+    contract_id: ContractId,
+    candidates: &[OverrideProxy],
+) -> Vec<OverrideProxy> {
+    let mut result = Vec::new();
+
+    for &base_id in gcx.hir.contract(contract_id).bases {
+        let directly_defined = candidates
+            .iter()
+            .copied()
+            .filter(|candidate| candidate.contract(gcx) == Some(base_id))
+            .collect::<Vec<_>>();
+        if directly_defined.is_empty() {
+            result.extend(inherited_override_functions_internal(gcx, base_id, candidates));
+        } else {
+            result.extend(directly_defined);
+        }
+    }
+
+    result
+}
+
+/// Returns the most-derived definitions visible through each direct base.
+fn visible_definitions(
+    gcx: Gcx<'_>,
+    candidates: &[OverrideProxy],
+    direct_base_ancestries: &[DenseBitSet<ContractId>],
+) -> Vec<OverrideProxy> {
+    let mut result = Vec::new();
+
+    for ancestry in direct_base_ancestries {
+        let visible = candidates.iter().copied().filter(|&candidate| {
+            let Some(candidate_contract) = candidate.contract(gcx) else { return false };
+            if !ancestry.contains(candidate_contract) {
+                return false;
+            }
+            !candidates.iter().copied().any(|other| {
+                let Some(other_contract) = other.contract(gcx) else { return false };
+                other_contract != candidate_contract
+                    && ancestry.contains(other_contract)
+                    && gcx
+                        .hir
+                        .contract(other_contract)
+                        .linearized_bases
+                        .contains(&candidate_contract)
+            })
+        });
+        for candidate in visible {
+            if !result.contains(&candidate) {
+                result.push(candidate);
             }
         }
     }
 
+    result
+}
+
+/// Computes the inherited signatures which have multiple visible definitions.
+///
+/// Only multiple-inheritance contracts need this map. Single-inheritance
+/// contracts cannot introduce a new ambiguity, so avoiding a full inherited
+/// map at every level keeps deep hierarchies linear.
+fn compute_inherited_functions<'gcx>(
+    gcx: Gcx<'gcx>,
+    contract_id: ContractId,
+) -> InheritedFunctions<'gcx> {
+    let contract = gcx.hir.contract(contract_id);
+    let direct_base_ancestries = contract
+        .bases
+        .iter()
+        .map(|&direct_base| {
+            let mut ancestry = DenseBitSet::new_empty(gcx.hir.contract_ids().len());
+            for &id in gcx.hir.contract(direct_base).linearized_bases.iter() {
+                ancestry.insert(id);
+            }
+            ancestry
+        })
+        .collect::<Vec<_>>();
+    let mut result: InheritedFunctions<'gcx> = FxIndexMap::default();
+    for (&signature, candidates) in &override_index(gcx).by_signature {
+        let definitions = visible_definitions(gcx, candidates, &direct_base_ancestries);
+        if definitions.len() > 1 {
+            result.insert(signature, definitions);
+        }
+    }
     result
 }
 
@@ -1057,10 +1148,9 @@ pub(crate) fn base_override_functions<'gcx>(
     proxy: OverrideProxy,
 ) -> &'gcx [OverrideProxy] {
     let Some(contract_id) = proxy.contract(gcx) else { return &[] };
-    let inherited = inherited_override_functions(gcx, contract_id);
     let signature = override_signature(gcx, proxy);
-    let Some(bases) = inherited.get(&signature) else { return &[] };
-    gcx.bump().alloc_from_iter(bases.iter().copied().filter(|base| !base.is_variable()))
+    let inherited = inherited_override_functions(gcx, contract_id, signature);
+    gcx.bump().alloc_from_iter(inherited.into_iter().filter(|base| !base.is_variable()))
 }
 
 fn capitalize(s: &str) -> String {

--- a/scripts/gen_compile_repros.py
+++ b/scripts/gen_compile_repros.py
@@ -34,7 +34,7 @@ def main() -> None:
         generate_large_literals(output_dir, size_name, n_symbols)
         generate_many_storage(output_dir, size_name, n_symbols)
         generate_many_events(output_dir, size_name, n_symbols // 10)
-        generate_complex_inheritance(output_dir, size_name, min(n_depth, 50))
+        generate_complex_inheritance(output_dir, size_name, n_depth)
         generate_many_mappings(output_dir, size_name, n_symbols // 10)
         generate_many_modifiers(output_dir, size_name, n_symbols // 10)
 

--- a/testdata/repros/complex_inheritance_large.sol
+++ b/testdata/repros/complex_inheritance_large.sol
@@ -204,6 +204,606 @@ contract L49 is L48{
 uint public l49;
 function g49()public pure returns(uint r){r=49;}
 }
+contract L50 is L49{
+uint public l50;
+function g50()public pure returns(uint r){r=50;}
+}
+contract L51 is L50{
+uint public l51;
+function g51()public pure returns(uint r){r=51;}
+}
+contract L52 is L51{
+uint public l52;
+function g52()public pure returns(uint r){r=52;}
+}
+contract L53 is L52{
+uint public l53;
+function g53()public pure returns(uint r){r=53;}
+}
+contract L54 is L53{
+uint public l54;
+function g54()public pure returns(uint r){r=54;}
+}
+contract L55 is L54{
+uint public l55;
+function g55()public pure returns(uint r){r=55;}
+}
+contract L56 is L55{
+uint public l56;
+function g56()public pure returns(uint r){r=56;}
+}
+contract L57 is L56{
+uint public l57;
+function g57()public pure returns(uint r){r=57;}
+}
+contract L58 is L57{
+uint public l58;
+function g58()public pure returns(uint r){r=58;}
+}
+contract L59 is L58{
+uint public l59;
+function g59()public pure returns(uint r){r=59;}
+}
+contract L60 is L59{
+uint public l60;
+function g60()public pure returns(uint r){r=60;}
+}
+contract L61 is L60{
+uint public l61;
+function g61()public pure returns(uint r){r=61;}
+}
+contract L62 is L61{
+uint public l62;
+function g62()public pure returns(uint r){r=62;}
+}
+contract L63 is L62{
+uint public l63;
+function g63()public pure returns(uint r){r=63;}
+}
+contract L64 is L63{
+uint public l64;
+function g64()public pure returns(uint r){r=64;}
+}
+contract L65 is L64{
+uint public l65;
+function g65()public pure returns(uint r){r=65;}
+}
+contract L66 is L65{
+uint public l66;
+function g66()public pure returns(uint r){r=66;}
+}
+contract L67 is L66{
+uint public l67;
+function g67()public pure returns(uint r){r=67;}
+}
+contract L68 is L67{
+uint public l68;
+function g68()public pure returns(uint r){r=68;}
+}
+contract L69 is L68{
+uint public l69;
+function g69()public pure returns(uint r){r=69;}
+}
+contract L70 is L69{
+uint public l70;
+function g70()public pure returns(uint r){r=70;}
+}
+contract L71 is L70{
+uint public l71;
+function g71()public pure returns(uint r){r=71;}
+}
+contract L72 is L71{
+uint public l72;
+function g72()public pure returns(uint r){r=72;}
+}
+contract L73 is L72{
+uint public l73;
+function g73()public pure returns(uint r){r=73;}
+}
+contract L74 is L73{
+uint public l74;
+function g74()public pure returns(uint r){r=74;}
+}
+contract L75 is L74{
+uint public l75;
+function g75()public pure returns(uint r){r=75;}
+}
+contract L76 is L75{
+uint public l76;
+function g76()public pure returns(uint r){r=76;}
+}
+contract L77 is L76{
+uint public l77;
+function g77()public pure returns(uint r){r=77;}
+}
+contract L78 is L77{
+uint public l78;
+function g78()public pure returns(uint r){r=78;}
+}
+contract L79 is L78{
+uint public l79;
+function g79()public pure returns(uint r){r=79;}
+}
+contract L80 is L79{
+uint public l80;
+function g80()public pure returns(uint r){r=80;}
+}
+contract L81 is L80{
+uint public l81;
+function g81()public pure returns(uint r){r=81;}
+}
+contract L82 is L81{
+uint public l82;
+function g82()public pure returns(uint r){r=82;}
+}
+contract L83 is L82{
+uint public l83;
+function g83()public pure returns(uint r){r=83;}
+}
+contract L84 is L83{
+uint public l84;
+function g84()public pure returns(uint r){r=84;}
+}
+contract L85 is L84{
+uint public l85;
+function g85()public pure returns(uint r){r=85;}
+}
+contract L86 is L85{
+uint public l86;
+function g86()public pure returns(uint r){r=86;}
+}
+contract L87 is L86{
+uint public l87;
+function g87()public pure returns(uint r){r=87;}
+}
+contract L88 is L87{
+uint public l88;
+function g88()public pure returns(uint r){r=88;}
+}
+contract L89 is L88{
+uint public l89;
+function g89()public pure returns(uint r){r=89;}
+}
+contract L90 is L89{
+uint public l90;
+function g90()public pure returns(uint r){r=90;}
+}
+contract L91 is L90{
+uint public l91;
+function g91()public pure returns(uint r){r=91;}
+}
+contract L92 is L91{
+uint public l92;
+function g92()public pure returns(uint r){r=92;}
+}
+contract L93 is L92{
+uint public l93;
+function g93()public pure returns(uint r){r=93;}
+}
+contract L94 is L93{
+uint public l94;
+function g94()public pure returns(uint r){r=94;}
+}
+contract L95 is L94{
+uint public l95;
+function g95()public pure returns(uint r){r=95;}
+}
+contract L96 is L95{
+uint public l96;
+function g96()public pure returns(uint r){r=96;}
+}
+contract L97 is L96{
+uint public l97;
+function g97()public pure returns(uint r){r=97;}
+}
+contract L98 is L97{
+uint public l98;
+function g98()public pure returns(uint r){r=98;}
+}
+contract L99 is L98{
+uint public l99;
+function g99()public pure returns(uint r){r=99;}
+}
+contract L100 is L99{
+uint public l100;
+function g100()public pure returns(uint r){r=100;}
+}
+contract L101 is L100{
+uint public l101;
+function g101()public pure returns(uint r){r=101;}
+}
+contract L102 is L101{
+uint public l102;
+function g102()public pure returns(uint r){r=102;}
+}
+contract L103 is L102{
+uint public l103;
+function g103()public pure returns(uint r){r=103;}
+}
+contract L104 is L103{
+uint public l104;
+function g104()public pure returns(uint r){r=104;}
+}
+contract L105 is L104{
+uint public l105;
+function g105()public pure returns(uint r){r=105;}
+}
+contract L106 is L105{
+uint public l106;
+function g106()public pure returns(uint r){r=106;}
+}
+contract L107 is L106{
+uint public l107;
+function g107()public pure returns(uint r){r=107;}
+}
+contract L108 is L107{
+uint public l108;
+function g108()public pure returns(uint r){r=108;}
+}
+contract L109 is L108{
+uint public l109;
+function g109()public pure returns(uint r){r=109;}
+}
+contract L110 is L109{
+uint public l110;
+function g110()public pure returns(uint r){r=110;}
+}
+contract L111 is L110{
+uint public l111;
+function g111()public pure returns(uint r){r=111;}
+}
+contract L112 is L111{
+uint public l112;
+function g112()public pure returns(uint r){r=112;}
+}
+contract L113 is L112{
+uint public l113;
+function g113()public pure returns(uint r){r=113;}
+}
+contract L114 is L113{
+uint public l114;
+function g114()public pure returns(uint r){r=114;}
+}
+contract L115 is L114{
+uint public l115;
+function g115()public pure returns(uint r){r=115;}
+}
+contract L116 is L115{
+uint public l116;
+function g116()public pure returns(uint r){r=116;}
+}
+contract L117 is L116{
+uint public l117;
+function g117()public pure returns(uint r){r=117;}
+}
+contract L118 is L117{
+uint public l118;
+function g118()public pure returns(uint r){r=118;}
+}
+contract L119 is L118{
+uint public l119;
+function g119()public pure returns(uint r){r=119;}
+}
+contract L120 is L119{
+uint public l120;
+function g120()public pure returns(uint r){r=120;}
+}
+contract L121 is L120{
+uint public l121;
+function g121()public pure returns(uint r){r=121;}
+}
+contract L122 is L121{
+uint public l122;
+function g122()public pure returns(uint r){r=122;}
+}
+contract L123 is L122{
+uint public l123;
+function g123()public pure returns(uint r){r=123;}
+}
+contract L124 is L123{
+uint public l124;
+function g124()public pure returns(uint r){r=124;}
+}
+contract L125 is L124{
+uint public l125;
+function g125()public pure returns(uint r){r=125;}
+}
+contract L126 is L125{
+uint public l126;
+function g126()public pure returns(uint r){r=126;}
+}
+contract L127 is L126{
+uint public l127;
+function g127()public pure returns(uint r){r=127;}
+}
+contract L128 is L127{
+uint public l128;
+function g128()public pure returns(uint r){r=128;}
+}
+contract L129 is L128{
+uint public l129;
+function g129()public pure returns(uint r){r=129;}
+}
+contract L130 is L129{
+uint public l130;
+function g130()public pure returns(uint r){r=130;}
+}
+contract L131 is L130{
+uint public l131;
+function g131()public pure returns(uint r){r=131;}
+}
+contract L132 is L131{
+uint public l132;
+function g132()public pure returns(uint r){r=132;}
+}
+contract L133 is L132{
+uint public l133;
+function g133()public pure returns(uint r){r=133;}
+}
+contract L134 is L133{
+uint public l134;
+function g134()public pure returns(uint r){r=134;}
+}
+contract L135 is L134{
+uint public l135;
+function g135()public pure returns(uint r){r=135;}
+}
+contract L136 is L135{
+uint public l136;
+function g136()public pure returns(uint r){r=136;}
+}
+contract L137 is L136{
+uint public l137;
+function g137()public pure returns(uint r){r=137;}
+}
+contract L138 is L137{
+uint public l138;
+function g138()public pure returns(uint r){r=138;}
+}
+contract L139 is L138{
+uint public l139;
+function g139()public pure returns(uint r){r=139;}
+}
+contract L140 is L139{
+uint public l140;
+function g140()public pure returns(uint r){r=140;}
+}
+contract L141 is L140{
+uint public l141;
+function g141()public pure returns(uint r){r=141;}
+}
+contract L142 is L141{
+uint public l142;
+function g142()public pure returns(uint r){r=142;}
+}
+contract L143 is L142{
+uint public l143;
+function g143()public pure returns(uint r){r=143;}
+}
+contract L144 is L143{
+uint public l144;
+function g144()public pure returns(uint r){r=144;}
+}
+contract L145 is L144{
+uint public l145;
+function g145()public pure returns(uint r){r=145;}
+}
+contract L146 is L145{
+uint public l146;
+function g146()public pure returns(uint r){r=146;}
+}
+contract L147 is L146{
+uint public l147;
+function g147()public pure returns(uint r){r=147;}
+}
+contract L148 is L147{
+uint public l148;
+function g148()public pure returns(uint r){r=148;}
+}
+contract L149 is L148{
+uint public l149;
+function g149()public pure returns(uint r){r=149;}
+}
+contract L150 is L149{
+uint public l150;
+function g150()public pure returns(uint r){r=150;}
+}
+contract L151 is L150{
+uint public l151;
+function g151()public pure returns(uint r){r=151;}
+}
+contract L152 is L151{
+uint public l152;
+function g152()public pure returns(uint r){r=152;}
+}
+contract L153 is L152{
+uint public l153;
+function g153()public pure returns(uint r){r=153;}
+}
+contract L154 is L153{
+uint public l154;
+function g154()public pure returns(uint r){r=154;}
+}
+contract L155 is L154{
+uint public l155;
+function g155()public pure returns(uint r){r=155;}
+}
+contract L156 is L155{
+uint public l156;
+function g156()public pure returns(uint r){r=156;}
+}
+contract L157 is L156{
+uint public l157;
+function g157()public pure returns(uint r){r=157;}
+}
+contract L158 is L157{
+uint public l158;
+function g158()public pure returns(uint r){r=158;}
+}
+contract L159 is L158{
+uint public l159;
+function g159()public pure returns(uint r){r=159;}
+}
+contract L160 is L159{
+uint public l160;
+function g160()public pure returns(uint r){r=160;}
+}
+contract L161 is L160{
+uint public l161;
+function g161()public pure returns(uint r){r=161;}
+}
+contract L162 is L161{
+uint public l162;
+function g162()public pure returns(uint r){r=162;}
+}
+contract L163 is L162{
+uint public l163;
+function g163()public pure returns(uint r){r=163;}
+}
+contract L164 is L163{
+uint public l164;
+function g164()public pure returns(uint r){r=164;}
+}
+contract L165 is L164{
+uint public l165;
+function g165()public pure returns(uint r){r=165;}
+}
+contract L166 is L165{
+uint public l166;
+function g166()public pure returns(uint r){r=166;}
+}
+contract L167 is L166{
+uint public l167;
+function g167()public pure returns(uint r){r=167;}
+}
+contract L168 is L167{
+uint public l168;
+function g168()public pure returns(uint r){r=168;}
+}
+contract L169 is L168{
+uint public l169;
+function g169()public pure returns(uint r){r=169;}
+}
+contract L170 is L169{
+uint public l170;
+function g170()public pure returns(uint r){r=170;}
+}
+contract L171 is L170{
+uint public l171;
+function g171()public pure returns(uint r){r=171;}
+}
+contract L172 is L171{
+uint public l172;
+function g172()public pure returns(uint r){r=172;}
+}
+contract L173 is L172{
+uint public l173;
+function g173()public pure returns(uint r){r=173;}
+}
+contract L174 is L173{
+uint public l174;
+function g174()public pure returns(uint r){r=174;}
+}
+contract L175 is L174{
+uint public l175;
+function g175()public pure returns(uint r){r=175;}
+}
+contract L176 is L175{
+uint public l176;
+function g176()public pure returns(uint r){r=176;}
+}
+contract L177 is L176{
+uint public l177;
+function g177()public pure returns(uint r){r=177;}
+}
+contract L178 is L177{
+uint public l178;
+function g178()public pure returns(uint r){r=178;}
+}
+contract L179 is L178{
+uint public l179;
+function g179()public pure returns(uint r){r=179;}
+}
+contract L180 is L179{
+uint public l180;
+function g180()public pure returns(uint r){r=180;}
+}
+contract L181 is L180{
+uint public l181;
+function g181()public pure returns(uint r){r=181;}
+}
+contract L182 is L181{
+uint public l182;
+function g182()public pure returns(uint r){r=182;}
+}
+contract L183 is L182{
+uint public l183;
+function g183()public pure returns(uint r){r=183;}
+}
+contract L184 is L183{
+uint public l184;
+function g184()public pure returns(uint r){r=184;}
+}
+contract L185 is L184{
+uint public l185;
+function g185()public pure returns(uint r){r=185;}
+}
+contract L186 is L185{
+uint public l186;
+function g186()public pure returns(uint r){r=186;}
+}
+contract L187 is L186{
+uint public l187;
+function g187()public pure returns(uint r){r=187;}
+}
+contract L188 is L187{
+uint public l188;
+function g188()public pure returns(uint r){r=188;}
+}
+contract L189 is L188{
+uint public l189;
+function g189()public pure returns(uint r){r=189;}
+}
+contract L190 is L189{
+uint public l190;
+function g190()public pure returns(uint r){r=190;}
+}
+contract L191 is L190{
+uint public l191;
+function g191()public pure returns(uint r){r=191;}
+}
+contract L192 is L191{
+uint public l192;
+function g192()public pure returns(uint r){r=192;}
+}
+contract L193 is L192{
+uint public l193;
+function g193()public pure returns(uint r){r=193;}
+}
+contract L194 is L193{
+uint public l194;
+function g194()public pure returns(uint r){r=194;}
+}
+contract L195 is L194{
+uint public l195;
+function g195()public pure returns(uint r){r=195;}
+}
+contract L196 is L195{
+uint public l196;
+function g196()public pure returns(uint r){r=196;}
+}
+contract L197 is L196{
+uint public l197;
+function g197()public pure returns(uint r){r=197;}
+}
+contract L198 is L197{
+uint public l198;
+function g198()public pure returns(uint r){r=198;}
+}
+contract L199 is L198{
+uint public l199;
+function g199()public pure returns(uint r){r=199;}
+}
 contract R0 is B{
 uint public r0;
 function h0()public pure returns(uint r){r=0;}
@@ -404,7 +1004,607 @@ contract R49 is R48{
 uint public r49;
 function h49()public pure returns(uint r){r=49;}
 }
-contract D is L49,R49{
+contract R50 is R49{
+uint public r50;
+function h50()public pure returns(uint r){r=50;}
+}
+contract R51 is R50{
+uint public r51;
+function h51()public pure returns(uint r){r=51;}
+}
+contract R52 is R51{
+uint public r52;
+function h52()public pure returns(uint r){r=52;}
+}
+contract R53 is R52{
+uint public r53;
+function h53()public pure returns(uint r){r=53;}
+}
+contract R54 is R53{
+uint public r54;
+function h54()public pure returns(uint r){r=54;}
+}
+contract R55 is R54{
+uint public r55;
+function h55()public pure returns(uint r){r=55;}
+}
+contract R56 is R55{
+uint public r56;
+function h56()public pure returns(uint r){r=56;}
+}
+contract R57 is R56{
+uint public r57;
+function h57()public pure returns(uint r){r=57;}
+}
+contract R58 is R57{
+uint public r58;
+function h58()public pure returns(uint r){r=58;}
+}
+contract R59 is R58{
+uint public r59;
+function h59()public pure returns(uint r){r=59;}
+}
+contract R60 is R59{
+uint public r60;
+function h60()public pure returns(uint r){r=60;}
+}
+contract R61 is R60{
+uint public r61;
+function h61()public pure returns(uint r){r=61;}
+}
+contract R62 is R61{
+uint public r62;
+function h62()public pure returns(uint r){r=62;}
+}
+contract R63 is R62{
+uint public r63;
+function h63()public pure returns(uint r){r=63;}
+}
+contract R64 is R63{
+uint public r64;
+function h64()public pure returns(uint r){r=64;}
+}
+contract R65 is R64{
+uint public r65;
+function h65()public pure returns(uint r){r=65;}
+}
+contract R66 is R65{
+uint public r66;
+function h66()public pure returns(uint r){r=66;}
+}
+contract R67 is R66{
+uint public r67;
+function h67()public pure returns(uint r){r=67;}
+}
+contract R68 is R67{
+uint public r68;
+function h68()public pure returns(uint r){r=68;}
+}
+contract R69 is R68{
+uint public r69;
+function h69()public pure returns(uint r){r=69;}
+}
+contract R70 is R69{
+uint public r70;
+function h70()public pure returns(uint r){r=70;}
+}
+contract R71 is R70{
+uint public r71;
+function h71()public pure returns(uint r){r=71;}
+}
+contract R72 is R71{
+uint public r72;
+function h72()public pure returns(uint r){r=72;}
+}
+contract R73 is R72{
+uint public r73;
+function h73()public pure returns(uint r){r=73;}
+}
+contract R74 is R73{
+uint public r74;
+function h74()public pure returns(uint r){r=74;}
+}
+contract R75 is R74{
+uint public r75;
+function h75()public pure returns(uint r){r=75;}
+}
+contract R76 is R75{
+uint public r76;
+function h76()public pure returns(uint r){r=76;}
+}
+contract R77 is R76{
+uint public r77;
+function h77()public pure returns(uint r){r=77;}
+}
+contract R78 is R77{
+uint public r78;
+function h78()public pure returns(uint r){r=78;}
+}
+contract R79 is R78{
+uint public r79;
+function h79()public pure returns(uint r){r=79;}
+}
+contract R80 is R79{
+uint public r80;
+function h80()public pure returns(uint r){r=80;}
+}
+contract R81 is R80{
+uint public r81;
+function h81()public pure returns(uint r){r=81;}
+}
+contract R82 is R81{
+uint public r82;
+function h82()public pure returns(uint r){r=82;}
+}
+contract R83 is R82{
+uint public r83;
+function h83()public pure returns(uint r){r=83;}
+}
+contract R84 is R83{
+uint public r84;
+function h84()public pure returns(uint r){r=84;}
+}
+contract R85 is R84{
+uint public r85;
+function h85()public pure returns(uint r){r=85;}
+}
+contract R86 is R85{
+uint public r86;
+function h86()public pure returns(uint r){r=86;}
+}
+contract R87 is R86{
+uint public r87;
+function h87()public pure returns(uint r){r=87;}
+}
+contract R88 is R87{
+uint public r88;
+function h88()public pure returns(uint r){r=88;}
+}
+contract R89 is R88{
+uint public r89;
+function h89()public pure returns(uint r){r=89;}
+}
+contract R90 is R89{
+uint public r90;
+function h90()public pure returns(uint r){r=90;}
+}
+contract R91 is R90{
+uint public r91;
+function h91()public pure returns(uint r){r=91;}
+}
+contract R92 is R91{
+uint public r92;
+function h92()public pure returns(uint r){r=92;}
+}
+contract R93 is R92{
+uint public r93;
+function h93()public pure returns(uint r){r=93;}
+}
+contract R94 is R93{
+uint public r94;
+function h94()public pure returns(uint r){r=94;}
+}
+contract R95 is R94{
+uint public r95;
+function h95()public pure returns(uint r){r=95;}
+}
+contract R96 is R95{
+uint public r96;
+function h96()public pure returns(uint r){r=96;}
+}
+contract R97 is R96{
+uint public r97;
+function h97()public pure returns(uint r){r=97;}
+}
+contract R98 is R97{
+uint public r98;
+function h98()public pure returns(uint r){r=98;}
+}
+contract R99 is R98{
+uint public r99;
+function h99()public pure returns(uint r){r=99;}
+}
+contract R100 is R99{
+uint public r100;
+function h100()public pure returns(uint r){r=100;}
+}
+contract R101 is R100{
+uint public r101;
+function h101()public pure returns(uint r){r=101;}
+}
+contract R102 is R101{
+uint public r102;
+function h102()public pure returns(uint r){r=102;}
+}
+contract R103 is R102{
+uint public r103;
+function h103()public pure returns(uint r){r=103;}
+}
+contract R104 is R103{
+uint public r104;
+function h104()public pure returns(uint r){r=104;}
+}
+contract R105 is R104{
+uint public r105;
+function h105()public pure returns(uint r){r=105;}
+}
+contract R106 is R105{
+uint public r106;
+function h106()public pure returns(uint r){r=106;}
+}
+contract R107 is R106{
+uint public r107;
+function h107()public pure returns(uint r){r=107;}
+}
+contract R108 is R107{
+uint public r108;
+function h108()public pure returns(uint r){r=108;}
+}
+contract R109 is R108{
+uint public r109;
+function h109()public pure returns(uint r){r=109;}
+}
+contract R110 is R109{
+uint public r110;
+function h110()public pure returns(uint r){r=110;}
+}
+contract R111 is R110{
+uint public r111;
+function h111()public pure returns(uint r){r=111;}
+}
+contract R112 is R111{
+uint public r112;
+function h112()public pure returns(uint r){r=112;}
+}
+contract R113 is R112{
+uint public r113;
+function h113()public pure returns(uint r){r=113;}
+}
+contract R114 is R113{
+uint public r114;
+function h114()public pure returns(uint r){r=114;}
+}
+contract R115 is R114{
+uint public r115;
+function h115()public pure returns(uint r){r=115;}
+}
+contract R116 is R115{
+uint public r116;
+function h116()public pure returns(uint r){r=116;}
+}
+contract R117 is R116{
+uint public r117;
+function h117()public pure returns(uint r){r=117;}
+}
+contract R118 is R117{
+uint public r118;
+function h118()public pure returns(uint r){r=118;}
+}
+contract R119 is R118{
+uint public r119;
+function h119()public pure returns(uint r){r=119;}
+}
+contract R120 is R119{
+uint public r120;
+function h120()public pure returns(uint r){r=120;}
+}
+contract R121 is R120{
+uint public r121;
+function h121()public pure returns(uint r){r=121;}
+}
+contract R122 is R121{
+uint public r122;
+function h122()public pure returns(uint r){r=122;}
+}
+contract R123 is R122{
+uint public r123;
+function h123()public pure returns(uint r){r=123;}
+}
+contract R124 is R123{
+uint public r124;
+function h124()public pure returns(uint r){r=124;}
+}
+contract R125 is R124{
+uint public r125;
+function h125()public pure returns(uint r){r=125;}
+}
+contract R126 is R125{
+uint public r126;
+function h126()public pure returns(uint r){r=126;}
+}
+contract R127 is R126{
+uint public r127;
+function h127()public pure returns(uint r){r=127;}
+}
+contract R128 is R127{
+uint public r128;
+function h128()public pure returns(uint r){r=128;}
+}
+contract R129 is R128{
+uint public r129;
+function h129()public pure returns(uint r){r=129;}
+}
+contract R130 is R129{
+uint public r130;
+function h130()public pure returns(uint r){r=130;}
+}
+contract R131 is R130{
+uint public r131;
+function h131()public pure returns(uint r){r=131;}
+}
+contract R132 is R131{
+uint public r132;
+function h132()public pure returns(uint r){r=132;}
+}
+contract R133 is R132{
+uint public r133;
+function h133()public pure returns(uint r){r=133;}
+}
+contract R134 is R133{
+uint public r134;
+function h134()public pure returns(uint r){r=134;}
+}
+contract R135 is R134{
+uint public r135;
+function h135()public pure returns(uint r){r=135;}
+}
+contract R136 is R135{
+uint public r136;
+function h136()public pure returns(uint r){r=136;}
+}
+contract R137 is R136{
+uint public r137;
+function h137()public pure returns(uint r){r=137;}
+}
+contract R138 is R137{
+uint public r138;
+function h138()public pure returns(uint r){r=138;}
+}
+contract R139 is R138{
+uint public r139;
+function h139()public pure returns(uint r){r=139;}
+}
+contract R140 is R139{
+uint public r140;
+function h140()public pure returns(uint r){r=140;}
+}
+contract R141 is R140{
+uint public r141;
+function h141()public pure returns(uint r){r=141;}
+}
+contract R142 is R141{
+uint public r142;
+function h142()public pure returns(uint r){r=142;}
+}
+contract R143 is R142{
+uint public r143;
+function h143()public pure returns(uint r){r=143;}
+}
+contract R144 is R143{
+uint public r144;
+function h144()public pure returns(uint r){r=144;}
+}
+contract R145 is R144{
+uint public r145;
+function h145()public pure returns(uint r){r=145;}
+}
+contract R146 is R145{
+uint public r146;
+function h146()public pure returns(uint r){r=146;}
+}
+contract R147 is R146{
+uint public r147;
+function h147()public pure returns(uint r){r=147;}
+}
+contract R148 is R147{
+uint public r148;
+function h148()public pure returns(uint r){r=148;}
+}
+contract R149 is R148{
+uint public r149;
+function h149()public pure returns(uint r){r=149;}
+}
+contract R150 is R149{
+uint public r150;
+function h150()public pure returns(uint r){r=150;}
+}
+contract R151 is R150{
+uint public r151;
+function h151()public pure returns(uint r){r=151;}
+}
+contract R152 is R151{
+uint public r152;
+function h152()public pure returns(uint r){r=152;}
+}
+contract R153 is R152{
+uint public r153;
+function h153()public pure returns(uint r){r=153;}
+}
+contract R154 is R153{
+uint public r154;
+function h154()public pure returns(uint r){r=154;}
+}
+contract R155 is R154{
+uint public r155;
+function h155()public pure returns(uint r){r=155;}
+}
+contract R156 is R155{
+uint public r156;
+function h156()public pure returns(uint r){r=156;}
+}
+contract R157 is R156{
+uint public r157;
+function h157()public pure returns(uint r){r=157;}
+}
+contract R158 is R157{
+uint public r158;
+function h158()public pure returns(uint r){r=158;}
+}
+contract R159 is R158{
+uint public r159;
+function h159()public pure returns(uint r){r=159;}
+}
+contract R160 is R159{
+uint public r160;
+function h160()public pure returns(uint r){r=160;}
+}
+contract R161 is R160{
+uint public r161;
+function h161()public pure returns(uint r){r=161;}
+}
+contract R162 is R161{
+uint public r162;
+function h162()public pure returns(uint r){r=162;}
+}
+contract R163 is R162{
+uint public r163;
+function h163()public pure returns(uint r){r=163;}
+}
+contract R164 is R163{
+uint public r164;
+function h164()public pure returns(uint r){r=164;}
+}
+contract R165 is R164{
+uint public r165;
+function h165()public pure returns(uint r){r=165;}
+}
+contract R166 is R165{
+uint public r166;
+function h166()public pure returns(uint r){r=166;}
+}
+contract R167 is R166{
+uint public r167;
+function h167()public pure returns(uint r){r=167;}
+}
+contract R168 is R167{
+uint public r168;
+function h168()public pure returns(uint r){r=168;}
+}
+contract R169 is R168{
+uint public r169;
+function h169()public pure returns(uint r){r=169;}
+}
+contract R170 is R169{
+uint public r170;
+function h170()public pure returns(uint r){r=170;}
+}
+contract R171 is R170{
+uint public r171;
+function h171()public pure returns(uint r){r=171;}
+}
+contract R172 is R171{
+uint public r172;
+function h172()public pure returns(uint r){r=172;}
+}
+contract R173 is R172{
+uint public r173;
+function h173()public pure returns(uint r){r=173;}
+}
+contract R174 is R173{
+uint public r174;
+function h174()public pure returns(uint r){r=174;}
+}
+contract R175 is R174{
+uint public r175;
+function h175()public pure returns(uint r){r=175;}
+}
+contract R176 is R175{
+uint public r176;
+function h176()public pure returns(uint r){r=176;}
+}
+contract R177 is R176{
+uint public r177;
+function h177()public pure returns(uint r){r=177;}
+}
+contract R178 is R177{
+uint public r178;
+function h178()public pure returns(uint r){r=178;}
+}
+contract R179 is R178{
+uint public r179;
+function h179()public pure returns(uint r){r=179;}
+}
+contract R180 is R179{
+uint public r180;
+function h180()public pure returns(uint r){r=180;}
+}
+contract R181 is R180{
+uint public r181;
+function h181()public pure returns(uint r){r=181;}
+}
+contract R182 is R181{
+uint public r182;
+function h182()public pure returns(uint r){r=182;}
+}
+contract R183 is R182{
+uint public r183;
+function h183()public pure returns(uint r){r=183;}
+}
+contract R184 is R183{
+uint public r184;
+function h184()public pure returns(uint r){r=184;}
+}
+contract R185 is R184{
+uint public r185;
+function h185()public pure returns(uint r){r=185;}
+}
+contract R186 is R185{
+uint public r186;
+function h186()public pure returns(uint r){r=186;}
+}
+contract R187 is R186{
+uint public r187;
+function h187()public pure returns(uint r){r=187;}
+}
+contract R188 is R187{
+uint public r188;
+function h188()public pure returns(uint r){r=188;}
+}
+contract R189 is R188{
+uint public r189;
+function h189()public pure returns(uint r){r=189;}
+}
+contract R190 is R189{
+uint public r190;
+function h190()public pure returns(uint r){r=190;}
+}
+contract R191 is R190{
+uint public r191;
+function h191()public pure returns(uint r){r=191;}
+}
+contract R192 is R191{
+uint public r192;
+function h192()public pure returns(uint r){r=192;}
+}
+contract R193 is R192{
+uint public r193;
+function h193()public pure returns(uint r){r=193;}
+}
+contract R194 is R193{
+uint public r194;
+function h194()public pure returns(uint r){r=194;}
+}
+contract R195 is R194{
+uint public r195;
+function h195()public pure returns(uint r){r=195;}
+}
+contract R196 is R195{
+uint public r196;
+function h196()public pure returns(uint r){r=196;}
+}
+contract R197 is R196{
+uint public r197;
+function h197()public pure returns(uint r){r=197;}
+}
+contract R198 is R197{
+uint public r198;
+function h198()public pure returns(uint r){r=198;}
+}
+contract R199 is R198{
+uint public r199;
+function h199()public pure returns(uint r){r=199;}
+}
+contract D is L199,R199{
 function f()public pure override returns(uint r){r=42;}
 function d()public pure returns(uint r){
 r+=g0()+h0();

--- a/tests/ui/natspec/solc_parity_shapes.sol
+++ b/tests/ui/natspec/solc_parity_shapes.sol
@@ -1,0 +1,65 @@
+// NatSpec shapes solc accepts and solar must too:
+// - `@param -` documents an unnamed parameter (names parse as identifier
+//   prefixes, so `-` is the empty name, valid while unnamed variables exist).
+// - `@param` may reference return variable names.
+// - Duplicate `@param` tags are not diagnosed.
+// - `@ param` (whitespace after `@`) is continuation text, not a tag.
+// - `* * @return` still starts a tag despite the doubled decoration.
+// - A bare `@return name` at the end of a line keeps the name intact.
+
+contract C {
+    /**
+     * @dev Ratifies that the parties have received the correct items.
+     *
+     * @param context         The context of the order.
+     * @ param orderHashes     The order hashes, unused here.
+     * @ param contractNonce   The contract nonce, unused here.
+     *
+     * @return ratifyOrderMagicValue The magic value to indicate things are OK.
+     */
+    function ratifyOrder(bytes calldata context, bytes32[] calldata, uint256)
+        external
+        pure
+        returns (bytes4 ratifyOrderMagicValue)
+    {
+        context;
+        return 0x12345678;
+    }
+
+    /**
+     * @param -               caller, unused here.
+     * @param -               fulfiller, unused here.
+     * @param named           The named one.
+     * @param named           Documented twice, accepted.
+     * @param result          Return names are valid param targets.
+     */
+    function previewOrder(address, address, uint256 named)
+        public
+        pure
+        returns (uint256 result)
+    {
+        return named;
+    }
+
+    /**
+     * @param a first param.
+     * * @return x The first return.
+     * @return y The second return.
+     */
+    function doubled(uint256 a) public pure returns (uint256 x, uint256 y) {
+        return (a, a);
+    }
+
+    /// @return fulfillments
+    function bare(uint256 a) public pure returns (uint256 fulfillments) {
+        return a;
+    }
+
+    /**
+     * @param nope Not a parameter anywhere.
+     */
+    function bad(uint256 a) public pure returns (uint256) {
+        //~^^^ ERROR: tag `@param` references non-existent parameter 'nope'
+        return a;
+    }
+}

--- a/tests/ui/natspec/solc_parity_shapes.stderr
+++ b/tests/ui/natspec/solc_parity_shapes.stderr
@@ -1,0 +1,8 @@
+error: tag `@param` references non-existent parameter 'nope'
+   ╭▸ ROOT/tests/ui/natspec/solc_parity_shapes.sol:LL:CC
+   │
+LL │      * @param nope Not a parameter anywhere.
+   ╰╴        ━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/natspec/tag_sema.sol
+++ b/tests/ui/natspec/tag_sema.sol
@@ -53,10 +53,9 @@ contract DuplicateAuthor {}
 contract DuplicateTitle {}
 
 contract DuplicateParamBase {
+    // Duplicate `@param` tags are accepted, matching solc.
     /// @param x First documentation
-    //~^ NOTE: previously documented here
     /// @param x Second documentation
-    //~^ ERROR: duplicate documentation for parameter 'x'
     function foo(uint x) public {}
 }
 

--- a/tests/ui/natspec/tag_sema.stderr
+++ b/tests/ui/natspec/tag_sema.stderr
@@ -4,18 +4,6 @@ error: tag @title can only be given once
 LL │ /// @title Second title
    ╰╴     ━━━━━
 
-error: duplicate documentation for parameter 'x'
-   ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
-   │
-LL │     /// @param x Second documentation
-   │          ━━━━━
-   ╰╴
-note: previously documented here
-   ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
-   │
-LL │     /// @param x First documentation
-   ╰╴         ━━━━━
-
 error: tag @inheritdoc can only be given once
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
@@ -64,5 +52,5 @@ error: tag `@inheritdoc` not valid for events
 LL │     /// @inheritdoc InvalidInheritdocBase
    ╰╴         ━━━━━━━━━━
 
-error: aborting due to 10 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/standard-json/import-cycle-inheritance/input.jsonc
+++ b/tests/ui/standard-json/import-cycle-inheritance/input.jsonc
@@ -1,0 +1,24 @@
+// A base contract imported through an import cycle must still linearize
+// before its derived contract. Cycles are cut from DFS roots in source-name
+// order, matching solc, so the insertion order below (base's file first,
+// sorting after the derived's) must not flip the cut.
+// CHECK: "sources": {
+// CHECK: "z_base.sol": {
+// CHECK-NEXT: "id": 0
+// CHECK: "a_derived.sol": {
+// CHECK-NEXT: "id": 1
+// CHECK-NOT: definition of base has to precede definition of derived contract
+{
+  "language": "Solidity",
+  "sources": {
+    "z_base.sol": {
+      "content": "import \"./a_derived.sol\";\ncontract Base {\n    function ping() public pure returns (uint256) {\n        return 1;\n    }\n}\ncontract Holder {\n    Derived d;\n}\n"
+    },
+    "a_derived.sol": {
+      "content": "import \"./z_base.sol\";\ncontract Derived is Base {}\n"
+    }
+  },
+  "settings": {
+    "outputSelection": {}
+  }
+}

--- a/tests/ui/standard-json/import-cycle-inheritance/input.stdout
+++ b/tests/ui/standard-json/import-cycle-inheritance/input.stdout
@@ -1,0 +1,10 @@
+{
+  "sources": {
+    "z_base.sol": {
+      "id": 0
+    },
+    "a_derived.sol": {
+      "id": 1
+    }
+  }
+}

--- a/tests/ui/typeck/array_push_element_locations.sol
+++ b/tests/ui/typeck/array_push_element_locations.sol
@@ -1,0 +1,43 @@
+// Storage-array `push(x)` takes its argument location-less: the value is
+// copied into storage, so structs, strings, bytes, UDVTs, and nested arrays
+// convert from any data location, matching solc's direct-storage-reference
+// conversion rule. `push()` still returns a storage reference.
+
+type Price is uint128;
+
+contract C {
+    struct S {
+        uint256 a;
+        string s;
+    }
+
+    struct T {
+        bytes b;
+    }
+
+    S[] ss;
+    string[] strs;
+    bytes[] bs;
+    Price[] prices;
+    uint256[][] nested;
+
+    function ok(S memory m, S calldata c, string memory str, uint256[] memory arr) public {
+        ss.push(m);
+        ss.push(c);
+        ss.push(ss[0]);
+        strs.push(str);
+        strs.push("literal");
+        bs.push(hex"aa");
+        prices.push(Price.wrap(1));
+        nested.push(arr);
+        S storage r = ss.push();
+        r.a = 1;
+    }
+
+    function bad(T memory t, uint256[] memory m) public {
+        ss.push(5); //~ ERROR: no matching member `push` found on type `struct C.S[] storage`
+        ss.push(t); //~ ERROR: no matching member `push` found on type `struct C.S[] storage`
+        strs.push(true); //~ ERROR: no matching member `push` found on type `string[] storage`
+        m.push(1); //~ ERROR: member `push` not found on type `uint256[] memory`
+    }
+}

--- a/tests/ui/typeck/array_push_element_locations.stderr
+++ b/tests/ui/typeck/array_push_element_locations.stderr
@@ -1,0 +1,26 @@
+error: no matching member `push` found on type `struct C.S[] storage`
+   ╭▸ ROOT/tests/ui/typeck/array_push_element_locations.sol:LL:CC
+   │
+LL │         ss.push(5);
+   ╰╴           ━━━━
+
+error: no matching member `push` found on type `struct C.S[] storage`
+   ╭▸ ROOT/tests/ui/typeck/array_push_element_locations.sol:LL:CC
+   │
+LL │         ss.push(t);
+   ╰╴           ━━━━
+
+error: no matching member `push` found on type `string[] storage`
+   ╭▸ ROOT/tests/ui/typeck/array_push_element_locations.sol:LL:CC
+   │
+LL │         strs.push(true);
+   ╰╴             ━━━━
+
+error: member `push` not found on type `uint256[] memory`
+   ╭▸ ROOT/tests/ui/typeck/array_push_element_locations.sol:LL:CC
+   │
+LL │         m.push(1);
+   ╰╴          ━━━━
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/typeck/inline_array_reference_elements.sol
+++ b/tests/ui/typeck/inline_array_reference_elements.sol
@@ -1,0 +1,24 @@
+// Inline arrays infer reference element types: string literals mobilize to
+// `string memory`, and struct, bytes, and nested-array elements work the
+// same. The inferred element type is nameable despite carrying a location.
+
+contract C {
+    struct S {
+        uint256 a;
+    }
+
+    function ok(string memory v, bytes memory b) public pure {
+        string[3] memory strs = ["lit", v, "x"];
+        bytes[2] memory bs = [b, bytes("y")];
+        S[2] memory ss = [S(1), S(2)];
+        uint256[2][2] memory nested = [[uint256(1), 2], [uint256(3), 4]];
+        strs;
+        bs;
+        ss;
+        nested;
+    }
+
+    function bad() public pure {
+        [1, "a"]; //~ ERROR: cannot infer array element type
+    }
+}

--- a/tests/ui/typeck/inline_array_reference_elements.stderr
+++ b/tests/ui/typeck/inline_array_reference_elements.stderr
@@ -1,0 +1,8 @@
+error: cannot infer array element type
+   ╭▸ ROOT/tests/ui/typeck/inline_array_reference_elements.sol:LL:CC
+   │
+LL │         [1, "a"];
+   ╰╴        ━━━━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/require_error_member_path.sol
+++ b/tests/ui/typeck/require_error_member_path.sol
@@ -1,0 +1,28 @@
+// `require(condition, SomeError(...))` accepts error constructors whose
+// callee is a member path (`Lib.SomeError()`), not only plain identifiers,
+// matching solc 0.8.26.
+
+library Errors {
+    error FailedCall();
+    error InsufficientBalance(uint256 balance, uint256 needed);
+}
+
+error TopLevel(uint256 x);
+
+contract C {
+    error Local();
+
+    function ok(bool cond, uint256 b) public pure {
+        require(cond, Errors.FailedCall());
+        require(cond, Errors.InsufficientBalance(b, 100));
+        require(cond, TopLevel(b));
+        require(cond, Local());
+        require(cond, "plain message");
+        require(cond);
+    }
+
+    function bad(bool cond) public pure {
+        require(cond, Errors.FailedCall); //~ ERROR: mismatched types
+        require(cond, Errors.InsufficientBalance(1)); //~ ERROR: wrong argument count for function call: 1 arguments given but expected 2
+    }
+}

--- a/tests/ui/typeck/require_error_member_path.stderr
+++ b/tests/ui/typeck/require_error_member_path.stderr
@@ -1,0 +1,16 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/require_error_member_path.sol:LL:CC
+   │
+LL │         require(cond, Errors.FailedCall);
+   ╰╴                      ━━━━━━━━━━━━━━━━━ expected `string memory`, found `error Errors.FailedCall()`
+
+error: wrong argument count for function call: 1 arguments given but expected 2
+   ╭▸ ROOT/tests/ui/typeck/require_error_member_path.sol:LL:CC
+   │
+LL │ …     require(cond, Errors.InsufficientBalance(1));
+   │                     ━━━━━━━━━━━━━━━━━━━━━━━━━━┬──
+   │                                               │
+   ╰╴                                              expected 2 arguments, found 1
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/selector_override_chain.sol
+++ b/tests/ui/typeck/selector_override_chain.sol
@@ -1,0 +1,43 @@
+// A non-call reference to a function that appears once per level of the
+// inheritance chain (declaration plus overrides) is a single function, so
+// `f.selector` resolves; the most derived candidate wins, carrying the
+// tightest state mutability. Sets with genuinely different signatures stay
+// unresolvable outside calls.
+
+abstract contract TokenReceiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        virtual
+        returns (bytes4);
+}
+
+contract Recipient is TokenReceiver {
+    function onERC1155Received(address, address, uint256, uint256, bytes calldata)
+        external
+        virtual
+        override
+        returns (bytes4)
+    {
+        return 0xf23a6e61;
+    }
+}
+
+contract T is Recipient {
+    function selectorOfOverridden() public pure returns (bytes4) {
+        return onERC1155Received.selector;
+    }
+}
+
+contract Overloads {
+    function g(uint256 x) public pure returns (uint256) {
+        return x;
+    }
+
+    function g(uint256 x, uint256 y) public pure returns (uint256) {
+        return x + y;
+    }
+
+    function bad() public pure returns (bytes4) {
+        return g.selector; //~ ERROR: no matching declarations found
+    }
+}

--- a/tests/ui/typeck/selector_override_chain.stderr
+++ b/tests/ui/typeck/selector_override_chain.stderr
@@ -1,0 +1,8 @@
+error: no matching declarations found
+   ╭▸ ROOT/tests/ui/typeck/selector_override_chain.sol:LL:CC
+   │
+LL │         return g.selector;
+   ╰╴               ━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/slice_mapping_key.sol
+++ b/tests/ui/typeck/slice_mapping_key.sol
@@ -1,0 +1,19 @@
+// Calldata slices convert to location-less reference types like any other
+// reference, so they can index mappings: `m[data[1:]]`.
+
+contract C {
+    mapping(bytes => uint256) bytesKeyed;
+    mapping(uint256 => uint256) valueKeyed;
+
+    function ok(bytes calldata params) external view returns (uint256) {
+        return bytesKeyed[params[1:]];
+    }
+
+    function bad(uint256[] calldata nums) external view returns (uint256) {
+        return bytesKeyed[nums[1:]]; //~ ERROR: mismatched types
+    }
+
+    function alsoBad(bytes calldata params) external view returns (uint256) {
+        return valueKeyed[params[1:]]; //~ ERROR: mismatched types
+    }
+}

--- a/tests/ui/typeck/slice_mapping_key.stderr
+++ b/tests/ui/typeck/slice_mapping_key.stderr
@@ -1,0 +1,14 @@
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/slice_mapping_key.sol:LL:CC
+   │
+LL │         return bytesKeyed[nums[1:]];
+   ╰╴                          ━━━━━━━━ expected `bytes`, found `uint256[] calldata slice`
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/slice_mapping_key.sol:LL:CC
+   │
+LL │         return valueKeyed[params[1:]];
+   ╰╴                          ━━━━━━━━━━ expected `uint256`, found `bytes calldata slice`
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/var_loc_file_level.sol
+++ b/tests/ui/typeck/var_loc_file_level.sol
@@ -7,4 +7,4 @@ uint[] memory constant b0 = []; //~ ERROR: data locations are not allowed here
 //~^ ERROR: mismatched types
 S memory constant c0 = S(0);    //~ ERROR: data locations are not allowed here
 S[] memory constant d0 = [];    //~ ERROR: data locations are not allowed here
-//~^ ERROR: cannot infer nameable array element type
+//~^ ERROR: mismatched types

--- a/tests/ui/typeck/var_loc_file_level.stderr
+++ b/tests/ui/typeck/var_loc_file_level.stderr
@@ -28,13 +28,11 @@ error: mismatched types
 LL │ uint[] memory constant b0 = [];
    ╰╴                            ━━ expected `uint256[] memory`, found `uint256[0] memory`
 
-error: cannot infer nameable array element type
+error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/var_loc_file_level.sol:LL:CC
    │
 LL │ S[] memory constant d0 = [];
-   │                          ━━
-   │
-   ╰ help: add an explicit type conversion for the first element
+   ╰╴                         ━━ expected `struct S[] memory`, found `struct S[0] memory`
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/typeck/var_loc_state.sol
+++ b/tests/ui/typeck/var_loc_state.sol
@@ -7,5 +7,4 @@ contract C {
     uint[] memory b1 = []; //~ ERROR: invalid data location
     S memory c1 = S(0);    //~ ERROR: invalid data location
     S[] memory d1 = [];    //~ ERROR: invalid data location
-    //~^ ERROR: cannot infer nameable array element type
 }

--- a/tests/ui/typeck/var_loc_state.stderr
+++ b/tests/ui/typeck/var_loc_state.stderr
@@ -28,13 +28,5 @@ LL │     S[] memory d1 = [];
    │
    ╰ note: data location must be `none` or `transient` for state variable, but got `memory`
 
-error: cannot infer nameable array element type
-   ╭▸ ROOT/tests/ui/typeck/var_loc_state.sol:LL:CC
-   │
-LL │     S[] memory d1 = [];
-   │                     ━━
-   │
-   ╰ help: add an explicit type conversion for the first element
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Splits the frontend-only fixes from #1081 into the base of the codegen benchmark stack. It aligns storage-array `push`, `require` error constructors, inline arrays, import cycles, NatSpec, calldata slice conversions, and override-chain references with solc.

It also indexes override candidates, cutting the recorded depth-200 inheritance repro from 366 ms to 171 ms, and fixes the LSP snapshot fixture that became invalid under the corrected import ordering.