### PR TITLE
chore(ci): use Depot runners

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,6 +40,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
   SOLC_VERSION: ${{ inputs.solc_version || '0.8.36' }}
   BENCHMARK_REPOSITORY: walnuthq/solidity-compiler-benchmarks
   DEFAULT_BENCHMARK_REF: 01209d2b8ac81645b92e3ef801b5bcdfd61bfd69
@@ -53,7 +54,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.benchmark == 'all' ||
       inputs.benchmark == 'codegen-runtime'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 45
     permissions:
       actions: read
@@ -90,6 +91,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
+
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
@@ -271,7 +275,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.benchmark == 'all' ||
       inputs.benchmark == 'codspeed'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-latest-4
     permissions:
       contents: read
     steps:
@@ -286,6 +290,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
         with:
@@ -311,7 +317,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.benchmark == 'all' ||
       inputs.benchmark == 'gungraun'
-    runs-on: depot-ubuntu-24.04-32
+    runs-on: depot-ubuntu-latest-4
     permissions:
       contents: read
     env:
@@ -349,6 +355,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Install benchmark runner
         run: |
           package=$(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "gungraun" or .name == "iai-callgrind").name' | head -n1)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -53,7 +53,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.benchmark == 'all' ||
       inputs.benchmark == 'codegen-runtime'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-32
     timeout-minutes: 45
     permissions:
       actions: read
@@ -271,7 +271,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.benchmark == 'all' ||
       inputs.benchmark == 'codspeed'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-32
     permissions:
       contents: read
     steps:
@@ -311,7 +311,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.benchmark == 'all' ||
       inputs.benchmark == 'gungraun'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-32
     permissions:
       contents: read
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   test:
     name: test ${{ matrix.os }} ${{ matrix.rust }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -27,14 +27,19 @@ jobs:
       matrix:
         include:
           - os: "ubuntu-latest"
+            runner: "depot-ubuntu-latest"
             rust: "stable"
           - os: "macos-latest"
+            runner: "macos-latest"
             rust: "stable"
           - os: "windows-latest"
+            runner: "windows-latest"
             rust: "stable"
           - os: "ubuntu-latest"
+            runner: "depot-ubuntu-latest"
             rust: "1.96" # MSRV
           - os: "ubuntu-latest"
+            runner: "depot-ubuntu-latest"
             rust: "nightly"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,7 +94,7 @@ jobs:
 
   fandango:
     name: fandango
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     continue-on-error: true
     permissions:
@@ -134,7 +139,7 @@ jobs:
 
   feature-checks:
     name: features
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -153,7 +158,7 @@ jobs:
         run: cargo hack check --feature-powerset --depth 1
 
   wasm:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -172,7 +177,7 @@ jobs:
         run: node crates/capi/tests/soljson.js
 
   typos:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -181,7 +186,7 @@ jobs:
       - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -199,7 +204,7 @@ jobs:
           RUSTFLAGS: -Dwarnings
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
@@ -217,7 +222,7 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs -D warnings -Zunstable-options --show-type-layout --generate-link-to-definition
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
   SOLC_VERSION: 0.8.36
   FANDANGO_VERSION: 1.1.1
 
@@ -79,9 +80,11 @@ jobs:
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
       - name: build
         run: cargo build
       - name: test
@@ -118,9 +121,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
@@ -151,9 +156,11 @@ jobs:
       - uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
         with:
           tool: cargo-hack
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
       - name: cargo hack
         run: cargo hack check --feature-powerset --depth 1
 
@@ -168,9 +175,11 @@ jobs:
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
       - name: build wasm
         run: scripts/wasm/dist-wasm.sh
       - name: test soljson
@@ -196,9 +205,11 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
       - run: cargo clippy --workspace --all-targets
         env:
           RUSTFLAGS: -Dwarnings
@@ -213,9 +224,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: nightly
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          cache-targets: false
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items
         env:


### PR DESCRIPTION
## Summary

- move Solar’s Linux CI jobs to `depot-ubuntu-latest`

- run benchmarks on `depot-ubuntu-24.04-32`, matching Foundry’s benchmark runner setup

Prompted by: @DaniPopes