### PR TITLE
fix(ci): render benchmark note outside details

### DIFF
--- a/.github/scripts/check_codegen_benchmark.py
+++ b/.github/scripts/check_codegen_benchmark.py
@@ -445,25 +445,24 @@ def branch_is_behind_main() -> bool:
 def format_report(markdown: str, has_changes: bool, behind_main: bool) -> str:
     if has_changes and not behind_main:
         return markdown
+    notices = ""
+    if behind_main:
+        notices += (
+            "> [!WARNING]\n"
+            "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
+        )
     if not has_changes:
-        markdown = (
+        notices += (
             "> [!NOTE]\n"
             "> Codegen benchmark output is unchanged from `main`.\n\n"
-            f"{markdown}"
         )
     details = (
         "<details>\n"
         "<summary>Codegen benchmark output</summary>\n\n"
         f"{markdown}\n\n"
-        "</details>"
+        "</details>\n"
     )
-    if behind_main:
-        return (
-            "> [!WARNING]\n"
-            "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
-            f"{details}"
-        )
-    return details
+    return notices + details
 
 
 def metric(value: int | float, unit: str, statistic: str) -> dict[str, Any]:

--- a/.github/scripts/test_check_codegen_benchmark.py
+++ b/.github/scripts/test_check_codegen_benchmark.py
@@ -27,12 +27,12 @@ class ReportFormattingTests(unittest.TestCase):
         report = benchmark.format_report("## Results", False, False)
         self.assertEqual(
             report,
-            "<details>\n"
-            "<summary>Codegen benchmark output</summary>\n\n"
             "> [!NOTE]\n"
             "> Codegen benchmark output is unchanged from `main`.\n\n"
+            "<details>\n"
+            "<summary>Codegen benchmark output</summary>\n\n"
             "## Results\n\n"
-            "</details>",
+            "</details>\n",
         )
 
     def test_changed_report_has_no_details(self):
@@ -47,7 +47,21 @@ class ReportFormattingTests(unittest.TestCase):
             "<details>\n"
             "<summary>Codegen benchmark output</summary>\n\n"
             "## Results\n\n"
-            "</details>",
+            "</details>\n",
+        )
+
+    def test_unchanged_behind_main_report_has_note_and_warning(self):
+        report = benchmark.format_report("## Results", False, True)
+        self.assertEqual(
+            report,
+            "> [!WARNING]\n"
+            "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
+            "> [!NOTE]\n"
+            "> Codegen benchmark output is unchanged from `main`.\n\n"
+            "<details>\n"
+            "<summary>Codegen benchmark output</summary>\n\n"
+            "## Results\n\n"
+            "</details>\n",
         )
 
     def test_lower_is_better_delta_uses_conventional_sign(self):


### PR DESCRIPTION
## Summary

- render the unchanged benchmark note before the collapsible report
- update the formatting regression test

## Testing

- `uv run --with jsonschema .github/scripts/test_check_codegen_benchmark.py`

Prompted by: @DaniPopes