### PR TITLE
fix(ci): post benchmark comments on fork PRs

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -1,0 +1,65 @@
+name: bench-comment
+
+permissions: {}
+
+on:
+  workflow_run:
+    workflows: [Benchmark]
+    types: [completed]
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Find pull request
+        id: pr
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const head = `${run.head_repository.owner.login}:${run.head_branch}`;
+            const { data: pulls } = await github.rest.pulls.list({
+              ...context.repo,
+              state: "open",
+              head,
+            });
+            const pull = pulls.find((candidate) => candidate.head.sha === run.head_sha);
+            if (!pull) {
+              core.setFailed(`No open pull request found for ${head} at ${run.head_sha}`);
+              return;
+            }
+            core.setOutput("number", pull.number);
+
+      - name: Download benchmark report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: codegen-runtime-results
+          path: target/codegen-bench
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read comment metadata
+        id: metadata
+        run: |
+          value="$(< target/codegen-bench/should-comment)"
+          case "$value" in
+            true|false) echo "should-comment=$value" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Invalid should-comment value: $value" >&2; exit 1 ;;
+          esac
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: codegen-runtime-bench
+          path: target/codegen-bench/report.md
+          number_force: ${{ steps.pr.outputs.number }}
+          only_update: ${{ steps.metadata.outputs.should-comment != 'true' }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -249,6 +249,12 @@ jobs:
           message: ${{ steps.runtime-report.outputs.report }}
           only_update: ${{ steps.runtime-report.outputs.should_comment != 'true' }}
 
+      - name: Save comment metadata
+        if: always() && github.event_name == 'pull_request'
+        env:
+          SHOULD_COMMENT: ${{ steps.runtime-report.outputs.should_comment }}
+        run: echo "$SHOULD_COMMENT" > target/codegen-bench/should-comment
+
       - name: Upload results as artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- keep fork benchmark jobs on read-only tokens
- upload the generated report and comment metadata as an artifact
- post fork PR comments from a trusted `workflow_run` with scoped write permissions

## Validation
- parsed both workflow files with PyYAML
- verified fork head lookup resolves PR #1112 by repository, branch, and SHA
- ran `git diff --check`

Prompted by: @DaniPopes