### PR TITLE
test: run foundry tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
         run: cargo build
       - name: test
         run: cargo nextest run --profile ci --workspace
+      - name: Foundry tests
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: cargo tq foundry
       - name: test C API
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
         run: ./crates/capi/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,6 @@ jobs:
         run: cargo build
       - name: test
         run: cargo nextest run --profile ci --workspace
-      - name: Foundry tests
-        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
-        run: cargo tq foundry
       - name: test C API
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
         run: ./crates/capi/test

--- a/tools/tester/Cargo.toml
+++ b/tools/tester/Cargo.toml
@@ -17,7 +17,6 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-cfg-if.workspace = true
 alloy-consensus.workspace = true
 alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
@@ -27,6 +26,9 @@ regex.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 ui_test = { git = "https://github.com/DaniPopes/ui_test", branch = "fork", version = "0.30.5" }
+
+[dev-dependencies]
+cfg-if.workspace = true
 
 [features]
 nightly = []

--- a/tools/tester/README.md
+++ b/tools/tester/README.md
@@ -7,9 +7,12 @@ MIR, EVM IR, standard JSON, and upstream compatibility test runners. The
 Foundry runner is a separate test in this crate, and runs as part of the
 workspace's default `cargo nextest run`. Run individual suites through the
 `cargo tq` aliases, such as `cargo tq ui` or `cargo tq solc-solidity`.
+It discovers every project under `tests/foundry` that contains a `foundry.toml`.
 
 Run only the Foundry suite with:
 
 ```console
 cargo tq foundry
 ```
+
+Set `SOLAR_FOUNDRY_PROJECT` to run one discovered project while debugging.

--- a/tools/tester/README.md
+++ b/tools/tester/README.md
@@ -3,11 +3,12 @@
 Integration test support for the compiler.
 
 `crates/solar/tests.rs` passes the freshly built `solar` binary to the UI,
-MIR, EVM IR, standard JSON, and upstream compatibility test runners. Run these
+MIR, EVM IR, standard JSON, upstream compatibility, and Foundry test runners.
+Running the test entry point without a mode runs all suites. Run individual
 suites through the `cargo tq` aliases, such as `cargo tq ui` or
 `cargo tq solc-solidity`.
 
-The same entry point runs the Foundry suite when `TESTER_MODE=foundry`. Use:
+Run only the Foundry suite with:
 
 ```console
 cargo tq foundry

--- a/tools/tester/README.md
+++ b/tools/tester/README.md
@@ -3,10 +3,10 @@
 Integration test support for the compiler.
 
 `crates/solar/tests.rs` passes the freshly built `solar` binary to the UI,
-MIR, EVM IR, standard JSON, upstream compatibility, and Foundry test runners.
-Running the test entry point without a mode runs all suites. Run individual
-suites through the `cargo tq` aliases, such as `cargo tq ui` or
-`cargo tq solc-solidity`.
+MIR, EVM IR, standard JSON, and upstream compatibility test runners. The
+Foundry runner is a separate test in this crate, and runs as part of the
+workspace's default `cargo nextest run`. Run individual suites through the
+`cargo tq` aliases, such as `cargo tq ui` or `cargo tq solc-solidity`.
 
 Run only the Foundry suite with:
 

--- a/tools/tester/src/foundry.rs
+++ b/tools/tester/src/foundry.rs
@@ -33,6 +33,8 @@ struct TestConfig {
     contract_filter: Option<String>,
     /// If true, only run with Solar (no solc comparison).
     solar_only: bool,
+    /// If true, defer this project until its compiler failures are fixed.
+    ignored: bool,
 }
 
 impl TestConfig {
@@ -113,6 +115,20 @@ impl ForgeCompiler {
 
 static SOLAR_BINARY: OnceLock<PathBuf> = OnceLock::new();
 
+const TEMPORARILY_IGNORED_PROJECTS: &[&str] = &[
+    "abi-encoding",
+    "equivalence",
+    "erc20-minimal",
+    "erc721-minimal",
+    "multicall",
+    "stress-arrays",
+    "stress-inheritance",
+    "stress-modifiers",
+    "unifap-v2",
+    "unifap-v2-create",
+    "vault-minimal",
+];
+
 fn foundry_root() -> PathBuf {
     workspace_root().join("tests/foundry")
 }
@@ -135,8 +151,16 @@ fn discover_projects() -> Vec<TestConfig> {
                 return None;
             }
             let solar_only = relative == Path::new("stack-deep");
+            let ignored = TEMPORARILY_IGNORED_PROJECTS.contains(&name.as_str());
 
-            Some(TestConfig { name, path, test_filter: None, contract_filter: None, solar_only })
+            Some(TestConfig {
+                name,
+                path,
+                test_filter: None,
+                contract_filter: None,
+                solar_only,
+                ignored,
+            })
         })
         .collect()
 }
@@ -777,6 +801,10 @@ pub(super) fn run_default_suite(solar: &Path) {
 
     let mut failures = Vec::new();
     for config in projects {
+        if config.ignored {
+            eprintln!("[{}] temporarily ignored", config.name);
+            continue;
+        }
         let name = config.name.clone();
         if catch_unwind(AssertUnwindSafe(|| config.run())).is_err() {
             failures.push(name);

--- a/tools/tester/src/foundry.rs
+++ b/tools/tester/src/foundry.rs
@@ -112,6 +112,7 @@ impl ForgeCompiler {
 
 static SOLAR_BINARY: OnceLock<PathBuf> = OnceLock::new();
 
+// Keep the default suite limited to projects that are supported in CI.
 const DEFAULT_PROJECTS: &[&str] = &[
     "arithmetic",
     "control-flow",

--- a/tools/tester/src/foundry.rs
+++ b/tools/tester/src/foundry.rs
@@ -9,6 +9,7 @@
 use std::{
     collections::HashMap,
     fs,
+    panic::{AssertUnwindSafe, catch_unwind},
     path::{Path, PathBuf},
     process::Command,
     sync::OnceLock,
@@ -112,23 +113,6 @@ impl ForgeCompiler {
 
 static SOLAR_BINARY: OnceLock<PathBuf> = OnceLock::new();
 
-// Keep the default suite limited to projects that are supported in CI.
-const DEFAULT_PROJECTS: &[&str] = &[
-    "arithmetic",
-    "control-flow",
-    "storage",
-    "events",
-    "calls",
-    "interfaces",
-    "libraries",
-    "constructor-args",
-    "multi-return",
-    "correctness",
-    "receive-fallback",
-    "inheritance",
-    "stack-deep",
-];
-
 fn foundry_root() -> PathBuf {
     workspace_root().join("tests/foundry")
 }
@@ -136,6 +120,7 @@ fn foundry_root() -> PathBuf {
 fn discover_projects() -> Vec<TestConfig> {
     let root = foundry_root();
     assert!(root.is_dir(), "Foundry test root does not exist: {}", root.display());
+    let selected = std::env::var_os("SOLAR_FOUNDRY_PROJECT");
 
     let mut paths = Vec::new();
     discover_project_paths(&root, &mut paths);
@@ -146,7 +131,7 @@ fn discover_projects() -> Vec<TestConfig> {
         .filter_map(|path| {
             let relative = path.strip_prefix(&root).expect("Foundry project outside root");
             let name = relative.to_string_lossy().replace('\\', "/");
-            if !DEFAULT_PROJECTS.contains(&name.as_str()) {
+            if selected.as_deref().is_some_and(|selected| selected != name.as_str()) {
                 return None;
             }
             let solar_only = relative == Path::new("stack-deep");
@@ -787,37 +772,17 @@ fn run_test_with_comparison(config: &TestConfig) {
 /// Runs the default Foundry suite.
 pub(super) fn run_default_suite(solar: &Path) {
     let _ = SOLAR_BINARY.set(solar.to_path_buf());
-    for config in discover_projects() {
-        config.run();
+    let projects = discover_projects();
+    assert!(!projects.is_empty(), "No Foundry projects found");
+
+    let mut failures = Vec::new();
+    for config in projects {
+        let name = config.name.clone();
+        if catch_unwind(AssertUnwindSafe(|| config.run())).is_err() {
+            failures.push(name);
+        }
     }
-    run_compilation_smoke();
-}
-
-fn run_compilation_smoke() {
-    if !forge_available() {
-        eprintln!("Skipping: forge not found");
-        return;
-    }
-
-    let solar_binary = get_solar_binary();
-    if !solar_binary.exists() {
-        eprintln!("Skipping: Solar binary not found");
-        return;
-    }
-
-    let config = discover_projects()
-        .into_iter()
-        .find(|config| config.name == "arithmetic")
-        .expect("arithmetic Foundry project not found");
-    let project_dir = &config.path;
-    let (test_time, tests, sizes) =
-        run_forge_test(project_dir, "compilation-test", &config, ForgeCompiler::Solar);
-
-    println!("Test time: {:?}", test_time);
-    println!("Tests: {:?}", tests.iter().map(|t| &t.name).collect::<Vec<_>>());
-    println!("Bytecode sizes: {:?}", sizes);
-
-    assert!(!tests.is_empty(), "No tests ran");
+    assert!(failures.is_empty(), "Foundry projects failed: {}", failures.join(", "));
 }
 
 #[cfg(test)]

--- a/tools/tester/src/foundry.rs
+++ b/tools/tester/src/foundry.rs
@@ -24,8 +24,8 @@ use std::{
 struct TestConfig {
     /// Project name (used for display).
     name: String,
-    /// Path to project relative to the workspace root.
-    path: String,
+    /// Foundry project root.
+    path: PathBuf,
     /// Optional filter for test function names (substring match).
     test_filter: Option<String>,
     /// Optional filter for contract names (substring match).
@@ -35,37 +35,6 @@ struct TestConfig {
 }
 
 impl TestConfig {
-    /// Creates a new config with default settings.
-    fn new(name: impl Into<String>, path: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            path: path.into(),
-            test_filter: None,
-            contract_filter: None,
-            solar_only: false,
-        }
-    }
-
-    /// Sets test function filter (substring match on test names).
-    #[allow(dead_code)]
-    fn test_filter(mut self, filter: impl Into<String>) -> Self {
-        self.test_filter = Some(filter.into());
-        self
-    }
-
-    /// Sets contract filter (substring match on contract names).
-    #[allow(dead_code)]
-    fn contract_filter(mut self, filter: impl Into<String>) -> Self {
-        self.contract_filter = Some(filter.into());
-        self
-    }
-
-    /// Sets whether to run Solar-only (no solc comparison).
-    fn solar_only(mut self, value: bool) -> Self {
-        self.solar_only = value;
-        self
-    }
-
     /// Runs the test with this configuration.
     fn run(&self) {
         run_test_with_config(self);
@@ -143,6 +112,70 @@ impl ForgeCompiler {
 
 static SOLAR_BINARY: OnceLock<PathBuf> = OnceLock::new();
 
+const DEFAULT_PROJECTS: &[&str] = &[
+    "arithmetic",
+    "control-flow",
+    "storage",
+    "events",
+    "calls",
+    "interfaces",
+    "libraries",
+    "constructor-args",
+    "multi-return",
+    "correctness",
+    "receive-fallback",
+    "inheritance",
+    "stack-deep",
+];
+
+fn foundry_root() -> PathBuf {
+    workspace_root().join("tests/foundry")
+}
+
+fn discover_projects() -> Vec<TestConfig> {
+    let root = foundry_root();
+    assert!(root.is_dir(), "Foundry test root does not exist: {}", root.display());
+
+    let mut paths = Vec::new();
+    discover_project_paths(&root, &mut paths);
+    paths.sort();
+
+    paths
+        .into_iter()
+        .filter_map(|path| {
+            let relative = path.strip_prefix(&root).expect("Foundry project outside root");
+            let name = relative.to_string_lossy().replace('\\', "/");
+            if !DEFAULT_PROJECTS.contains(&name.as_str()) {
+                return None;
+            }
+            let solar_only = relative == Path::new("stack-deep");
+
+            Some(TestConfig { name, path, test_filter: None, contract_filter: None, solar_only })
+        })
+        .collect()
+}
+
+fn discover_project_paths(dir: &Path, projects: &mut Vec<PathBuf>) {
+    let mut entries: Vec<_> = fs::read_dir(dir)
+        .unwrap_or_else(|error| {
+            panic!("failed to read Foundry test directory {}: {error}", dir.display())
+        })
+        .map(|entry| entry.expect("failed to read Foundry test directory entry").path())
+        .collect();
+    entries.sort();
+
+    if entries.iter().any(|path| path.file_name().is_some_and(|name| name == "foundry.toml")) {
+        projects.push(dir.to_path_buf());
+        return;
+    }
+
+    for path in entries {
+        if path.is_dir() {
+            discover_project_paths(&path, projects);
+        }
+    }
+}
+
 /// Gets the path to the Solar binary.
 ///
 /// Uses the binary supplied by the compiler test runner when available and
@@ -150,6 +183,10 @@ static SOLAR_BINARY: OnceLock<PathBuf> = OnceLock::new();
 fn get_solar_binary() -> PathBuf {
     if let Some(path) = SOLAR_BINARY.get() {
         return path.clone();
+    }
+
+    if let Some(path) = option_env!("CARGO_BIN_EXE_solar") {
+        return PathBuf::from(path);
     }
 
     let workspace_root = workspace_root();
@@ -380,7 +417,7 @@ fn write_runtime_report(
     let report = serde_json::json!({
         "project": {
             "name": config.name.as_str(),
-            "path": config.path.as_str(),
+            "path": config.path.display().to_string(),
             "test_filter": config.test_filter.as_deref(),
             "contract_filter": config.contract_filter.as_deref(),
             "solar_only": config.solar_only,
@@ -536,11 +573,11 @@ fn print_test_diff(solar_tests: &[TestResult], solc_tests: &[TestResult], label:
 
 /// Runs a full comparison between Solar and solc for a project.
 fn run_project_comparison(config: &TestConfig) -> (CompilerRun, CompilerRun) {
-    let project_dir = workspace_root().join(&config.path);
+    let project_dir = &config.path;
 
     // Step 1: Run tests with Solar
     let (solar_test_time, solar_tests, solar_sizes) = run_forge_test(
-        &project_dir,
+        project_dir,
         &format!("{}-solar", config.name),
         config,
         ForgeCompiler::Solar,
@@ -560,7 +597,7 @@ fn run_project_comparison(config: &TestConfig) -> (CompilerRun, CompilerRun) {
 
     // Step 2: Run tests with solc
     let (solc_test_time, solc_tests, solc_sizes) =
-        run_forge_test(&project_dir, &format!("{}-solc", config.name), config, ForgeCompiler::Solc);
+        run_forge_test(project_dir, &format!("{}-solc", config.name), config, ForgeCompiler::Solc);
     let solc_tests = filter_tests(solc_tests, config);
     let solc_passed = solc_tests.iter().filter(|t| t.passed).count();
     let solc_failed = solc_tests.iter().filter(|t| !t.passed).count();
@@ -684,7 +721,7 @@ fn run_test_with_config(config: &TestConfig) {
         return;
     }
 
-    let project_dir = workspace_root().join(&config.path);
+    let project_dir = &config.path;
     if !project_dir.exists() {
         panic!("Project directory not found: {:?}", project_dir);
     }
@@ -698,9 +735,9 @@ fn run_test_with_config(config: &TestConfig) {
 
 /// Runs test with Solar only (no solc comparison).
 fn run_test_solar_only(config: &TestConfig) {
-    let project_dir = workspace_root().join(&config.path);
+    let project_dir = &config.path;
     let (test_time, tests, bytecode_sizes) =
-        run_forge_test(&project_dir, &config.name, config, ForgeCompiler::Solar);
+        run_forge_test(project_dir, &config.name, config, ForgeCompiler::Solar);
     let tests = filter_tests(tests, config);
 
     let total_passed = tests.iter().filter(|t| t.passed).count();
@@ -746,38 +783,12 @@ fn run_test_with_comparison(config: &TestConfig) {
     println!("\n✓ [{}] {} tests passed with Solar", config.name, solar_run.total_passed);
 }
 
-// ============================================================================
-// Legacy API (for backward compatibility)
-// ============================================================================
-
-/// Tests a project with Solar vs solc comparison (legacy API).
-fn test_project_solar(project_name: &str, project_path: &str) {
-    TestConfig::new(project_name, project_path).run();
-}
-
-/// Tests a project where solc can't compile (legacy API).
-fn test_project_solar_only(project_name: &str, project_path: &str) {
-    TestConfig::new(project_name, project_path).solar_only(true).run();
-}
-
 /// Runs the default Foundry suite.
-///
-/// [`crate::run_tests`] calls this when `TESTER_MODE=foundry`.
 pub(super) fn run_default_suite(solar: &Path) {
     let _ = SOLAR_BINARY.set(solar.to_path_buf());
-    test_project_solar("arithmetic", "tests/foundry/arithmetic");
-    test_project_solar("control_flow", "tests/foundry/control-flow");
-    test_project_solar("storage", "tests/foundry/storage");
-    test_project_solar("events", "tests/foundry/events");
-    test_project_solar("calls", "tests/foundry/calls");
-    test_project_solar("interfaces", "tests/foundry/interfaces");
-    test_project_solar("libraries", "tests/foundry/libraries");
-    test_project_solar("constructor_args", "tests/foundry/constructor-args");
-    test_project_solar("multi_return", "tests/foundry/multi-return");
-    test_project_solar("correctness", "tests/foundry/correctness");
-    test_project_solar("receive_fallback", "tests/foundry/receive-fallback");
-    test_project_solar("inheritance", "tests/foundry/inheritance");
-    test_project_solar_only("stack_deep", "tests/foundry/stack-deep");
+    for config in discover_projects() {
+        config.run();
+    }
     run_compilation_smoke();
 }
 
@@ -793,10 +804,13 @@ fn run_compilation_smoke() {
         return;
     }
 
-    let config = TestConfig::new("compilation-test", "tests/foundry/arithmetic");
-    let project_dir = workspace_root().join(&config.path);
+    let config = discover_projects()
+        .into_iter()
+        .find(|config| config.name == "arithmetic")
+        .expect("arithmetic Foundry project not found");
+    let project_dir = &config.path;
     let (test_time, tests, sizes) =
-        run_forge_test(&project_dir, "compilation-test", &config, ForgeCompiler::Solar);
+        run_forge_test(project_dir, "compilation-test", &config, ForgeCompiler::Solar);
 
     println!("Test time: {:?}", test_time);
     println!("Tests: {:?}", tests.iter().map(|t| &t.name).collect::<Vec<_>>());
@@ -810,120 +824,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_arithmetic() {
-        test_project_solar("arithmetic", "tests/foundry/arithmetic");
-    }
-
-    #[test]
-    fn test_control_flow() {
-        test_project_solar("control_flow", "tests/foundry/control-flow");
-    }
-
-    #[test]
-    fn test_storage() {
-        test_project_solar("storage", "tests/foundry/storage");
-    }
-
-    #[test]
-    fn test_events() {
-        test_project_solar("events", "tests/foundry/events");
-    }
-
-    #[test]
-    fn test_calls() {
-        test_project_solar("calls", "tests/foundry/calls");
-    }
-
-    #[test]
-    fn test_interfaces() {
-        test_project_solar("interfaces", "tests/foundry/interfaces");
-    }
-
-    #[test]
-    fn test_libraries() {
-        test_project_solar("libraries", "tests/foundry/libraries");
-    }
-
-    #[test]
-    fn test_constructor_args() {
-        test_project_solar("constructor_args", "tests/foundry/constructor-args");
-    }
-
-    #[test]
-    fn test_multi_return() {
-        test_project_solar("multi_return", "tests/foundry/multi-return");
-    }
-
-    #[test]
-    fn test_correctness() {
-        test_project_solar("correctness", "tests/foundry/correctness");
-    }
-
-    #[test]
-    fn test_receive_fallback() {
-        test_project_solar("receive_fallback", "tests/foundry/receive-fallback");
-    }
-
-    #[test]
-    fn test_inheritance() {
-        test_project_solar("inheritance", "tests/foundry/inheritance");
-    }
-
-    #[test]
-    fn test_stack_deep() {
-        test_project_solar_only("stack_deep", "tests/foundry/stack-deep");
-    }
-
-    #[test]
-    fn test_compilation() {
-        run_compilation_smoke();
-    }
-
-    #[test]
-    #[ignore] // Requires forge-std which is not available in CI
-    fn test_unifap_v2() {
-        test_project_solar("unifap-v2", "tests/foundry/unifap-v2");
-    }
-
-    #[test]
-    #[ignore] // Requires forge-std which is not available in CI
-    fn test_unifap_v2_create() {
-        test_project_solar("unifap-v2-create", "tests/foundry/unifap-v2-create");
-    }
-
-    // Example: run only mint-related tests
-    #[test]
-    #[ignore] // Example - enable when debugging specific tests
-    fn test_unifap_mint_only() {
-        TestConfig::new("unifap-v2-create", "tests/foundry/unifap-v2-create")
-            .test_filter("testMint")
-            .run();
-    }
-
-    // Example: run only tests in a specific contract
-    #[test]
-    #[ignore] // Example - enable when debugging specific contracts
-    fn test_unifap_pair_only() {
-        TestConfig::new("unifap-v2-create", "tests/foundry/unifap-v2-create")
-            .contract_filter("UnifapV2Pair")
-            .run();
-    }
-
-    // Example: combine test + contract filters
-    #[test]
-    #[ignore] // Example - enable when debugging
-    fn test_unifap_pair_swap() {
-        TestConfig::new("unifap-v2-create", "tests/foundry/unifap-v2-create")
-            .contract_filter("UnifapV2Pair")
-            .test_filter("testSwap")
-            .run();
-    }
-
-    // ========== Struct Tests ==========
-
-    #[test]
-    #[ignore] // WIP: 8 struct tests have StackUnderflow issues to fix
-    fn test_structs() {
-        test_project_solar("structs", "tests/foundry/structs");
+    fn foundry() {
+        run_default_suite(&get_solar_binary());
     }
 }

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -4,6 +4,9 @@
 
 #![allow(unreachable_pub)]
 
+#[cfg(test)]
+use cfg_if as _;
+
 use eyre::{Result, eyre};
 use std::{
     ffi::OsString,
@@ -22,6 +25,7 @@ use ui_test::{
 };
 
 mod errors;
+#[cfg(test)]
 mod foundry;
 mod run_call;
 mod solc;
@@ -32,14 +36,6 @@ mod utils;
 ///
 /// `cmd` is the path to the `solar` binary used by all modes.
 pub fn run_tests(cmd: &'static Path) -> Result<()> {
-    if runs_foundry_mode() {
-        if std::env::args_os().any(|arg| arg == "--list") {
-            return Ok(());
-        }
-        foundry::run_default_suite(cmd);
-        return Ok(());
-    }
-
     ui_test::color_eyre::install()?;
 
     let mut args = ui_test::Args::test()?;
@@ -104,15 +100,7 @@ pub fn run_tests(cmd: &'static Path) -> Result<()> {
         status_emitter,
     )?;
 
-    if std::env::var_os("TESTER_MODE").is_none() {
-        foundry::run_default_suite(cmd);
-    }
-
     Ok(())
-}
-
-fn runs_foundry_mode() -> bool {
-    std::env::var("TESTER_MODE").is_ok_and(|mode| mode.trim() == "foundry")
 }
 
 fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Config {

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -104,6 +104,10 @@ pub fn run_tests(cmd: &'static Path) -> Result<()> {
         status_emitter,
     )?;
 
+    if std::env::var_os("TESTER_MODE").is_none() {
+        foundry::run_default_suite(cmd);
+    }
+
     Ok(())
 }
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -19,8 +19,10 @@ fn main() -> anyhow::Result<()> {
         flags::XtaskCmd::Test(flags::Test { bless, test_name, rest }) => {
             let sh = Shell::new()?;
 
+            let use_cargo_test = bless
+                || test_name.as_deref().is_some_and(|name| matches!(name, "foundry" | "runtime"));
             let mut cmd =
-                if bless { cmd!(sh, "cargo test") } else { cmd!(sh, "cargo nextest run") };
+                if use_cargo_test { cmd!(sh, "cargo test") } else { cmd!(sh, "cargo nextest run") };
             if bless && test_name.is_none() {
                 cmd = cmd.args(INT_FLAGS).env("TESTER_MODE", "ui");
             }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -12,6 +12,7 @@ use xshell::{Shell, cmd};
 mod flags;
 
 const INT_FLAGS: &[&str] = &["--package=solar-compiler", "--test=tests"];
+const FOUNDRY_FLAGS: &[&str] = &["--package=solar-tester"];
 
 fn main() -> anyhow::Result<()> {
     let flags = flags::Xtask::from_env_or_exit();
@@ -19,10 +20,19 @@ fn main() -> anyhow::Result<()> {
         flags::XtaskCmd::Test(flags::Test { bless, test_name, rest }) => {
             let sh = Shell::new()?;
 
-            let use_cargo_test = bless
-                || test_name.as_deref().is_some_and(|name| matches!(name, "foundry" | "runtime"));
+            if test_name.as_deref().is_some_and(|name| matches!(name, "foundry" | "runtime")) {
+                cmd!(sh, "cargo build --package=solar-compiler --bin=solar").run()?;
+                let mut cmd = cmd!(sh, "cargo nextest run");
+                cmd = cmd.args(FOUNDRY_FLAGS).arg("foundry::tests::foundry").arg("--");
+                if !rest.is_empty() {
+                    cmd = cmd.args(rest);
+                }
+                cmd.run()?;
+                return Ok(());
+            }
+
             let mut cmd =
-                if use_cargo_test { cmd!(sh, "cargo test") } else { cmd!(sh, "cargo nextest run") };
+                if bless { cmd!(sh, "cargo test") } else { cmd!(sh, "cargo nextest run") };
             if bless && test_name.is_none() {
                 cmd = cmd.args(INT_FLAGS).env("TESTER_MODE", "ui");
             }
@@ -50,7 +60,6 @@ fn main() -> anyhow::Result<()> {
 fn tester_mode(test_name: &str) -> Option<&str> {
     match test_name {
         "ui" | "mir" | "evm-ir" | "standard-json" | "solc-solidity" | "solc-yul" => Some(test_name),
-        "foundry" | "runtime" => Some("foundry"),
         _ => None,
     }
 }


### PR DESCRIPTION
Run Foundry comparisons from the existing workspace test job by registering the runner as a separate Rust test. The runner discovers every project rooted at a foundry.toml and keeps the Solar-only stack-depth suite on the same path.

Projects with known compiler gaps are temporarily skipped in this PR. The stacked follow-up in #1127 enables them as the compiler and fixture fixes land.
