### PR TITLE
fix(codegen): panic on zero modular builtin

### DIFF
--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -1179,6 +1179,7 @@ impl<'gcx> Lowerer<'gcx> {
                 let a = self.lower_value_expr(builder, a);
                 let b = self.lower_value_expr(builder, b);
                 let modulus = self.lower_value_expr(builder, modulus);
+                self.emit_panic_if_zero(builder, modulus, PanicCode::DivisionByZero);
                 let value = if matches!(builtin, Builtin::AddMod) {
                     builder.addmod(a, b, modulus)
                 } else {

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol
@@ -3,12 +3,16 @@
 
 contract AddmodMulmod {
     // CHECK-LABEL: fn @am{{[( ]}}
+    // CHECK: jumpi arg2,
+    // CHECK: mstore 4, 18
     // CHECK: {{v[0-9]+}} = addmod arg0, arg1, arg2
     function am(uint x, uint y, uint n) public pure returns (uint) {
         return addmod(x, y, n);
     }
 
     // CHECK-LABEL: fn @mm{{[( ]}}
+    // CHECK: jumpi arg2,
+    // CHECK: mstore 4, 18
     // CHECK: {{v[0-9]+}} = mulmod arg0, arg1, arg2
     function mm(uint x, uint y, uint n) public pure returns (uint) {
         return mulmod(x, y, n);

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
@@ -9,6 +9,12 @@ fn @am(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
   bb1:
     revert 0, 0
   bb2:
+    jumpi arg2, bb4, bb3
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 18 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
     v3 = addmod arg0, arg1, arg2
     ret v3
 }
@@ -22,6 +28,12 @@ fn @mm(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
   bb1:
     revert 0, 0
   bb2:
+    jumpi arg2, bb4, bb3
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 18 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
     v3 = mulmod arg0, arg1, arg2
     ret v3
 }

--- a/tests/ui/codegen/lowering/equal_immediate_scheduling.gas.stdout
+++ b/tests/ui/codegen/lowering/equal_immediate_scheduling.gas.stdout
@@ -30,6 +30,11 @@ bb0:
   jumpi
   push 4
   calldataload
+  iszero
+  push bb9
+  jumpi
+  push 4
+  calldataload
   push 0x123456789abcde
   push 0x123456789abcde
   addmod
@@ -41,4 +46,16 @@ bb0:
 bb4 [cold]:
   push 0
   dup1
+  revert
+bb9 [cold]:
+  push 0x4e487b71
+  push 224
+  shl
+  push 0
+  mstore
+  push 18
+  push 4
+  mstore
+  push 36
+  push 0
   revert

--- a/tests/ui/codegen/lowering/equal_immediate_scheduling.none.stdout
+++ b/tests/ui/codegen/lowering/equal_immediate_scheduling.none.stdout
@@ -50,6 +50,22 @@ bb6 [cold]:
 bb7:
   push 4
   calldataload
+  push bb9
+  jumpi
+  jump bb8
+bb8 [cold]:
+  push 0x4e487b7100000000000000000000000000000000000000000000000000000000
+  push 0
+  mstore
+  push 18
+  push 4
+  mstore
+  push 36
+  push 0
+  revert
+bb9:
+  push 4
+  calldataload
   push 0x123456789abcde
   push 0x123456789abcde
   addmod

--- a/tests/ui/codegen/lowering/equal_immediate_scheduling.size.stdout
+++ b/tests/ui/codegen/lowering/equal_immediate_scheduling.size.stdout
@@ -30,6 +30,11 @@ bb0:
   jumpi
   push 4
   calldataload
+  iszero
+  push bb9
+  jumpi
+  push 4
+  calldataload
   push 0x123456789abcde
   dup1
   addmod
@@ -41,4 +46,16 @@ bb0:
 bb4 [cold]:
   push 0
   dup1
+  revert
+bb9 [cold]:
+  push 0x4e487b71
+  push 224
+  shl
+  push 0
+  mstore
+  push 18
+  push 4
+  mstore
+  push 36
+  push 0
   revert

--- a/tests/ui/codegen/run-call/addmod_mulmod.sol
+++ b/tests/ui/codegen/run-call/addmod_mulmod.sol
@@ -1,0 +1,29 @@
+//@ run-call: am(uint256,uint256,uint256) 1, 2, 3 => 0
+//@ run-call: am(uint256,uint256,uint256) 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 2, 3 => 2
+//@ run-call-fail: am(uint256,uint256,uint256) 0, 0, 0 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000012
+//@ run-call: mm(uint256,uint256,uint256) 5, 5, 7 => 4
+//@ run-call-fail: mm(uint256,uint256,uint256) 0, 0, 0 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000012
+//@ run-call: yulAm(uint256,uint256,uint256) 0, 0, 0 => 0
+//@ run-call: yulMm(uint256,uint256,uint256) 0, 0, 0 => 0
+
+contract AddmodMulmod {
+    function am(uint256 x, uint256 y, uint256 modulus) external pure returns (uint256) {
+        return addmod(x, y, modulus);
+    }
+
+    function mm(uint256 x, uint256 y, uint256 modulus) external pure returns (uint256) {
+        return mulmod(x, y, modulus);
+    }
+
+    function yulAm(uint256 x, uint256 y, uint256 modulus) external pure returns (uint256 result) {
+        assembly {
+            result := addmod(x, y, modulus)
+        }
+    }
+
+    function yulMm(uint256 x, uint256 y, uint256 modulus) external pure returns (uint256 result) {
+        assembly {
+            result := mulmod(x, y, modulus)
+        }
+    }
+}


### PR DESCRIPTION
Solidity’s high-level `addmod` and `mulmod` builtins must revert with `Panic(0x12)` when their modulus is zero. The backend currently lowers them directly to the raw EVM opcodes, whose native zero-modulus behavior is returning zero, so generated contracts diverge from Solc.

This adds the missing high-level zero guard through the existing panic path and covers the MIR and runtime behavior under each optimizer objective. Raw Yul `addmod` and `mulmod` remain unchanged and continue returning zero for a zero modulus.

The mismatch was found by the symbolic Solc-versus-Solar differential work in #1084 and is split out here so the compiler correction can be reviewed independently.