### PR TITLE
perf(codegen): inline tiny leaf helpers

### DIFF
--- a/crates/codegen/src/pass.rs
+++ b/crates/codegen/src/pass.rs
@@ -39,6 +39,7 @@ pub use crate::pass_manager::{MirPass, pipeline_label, run_passes, run_passes_no
 /// All known MIR passes exposed by `-Zmir-pipeline`.
 pub static ALL_PASSES: &[&dyn MirPass] = &[
     &inline::Inline,
+    &inline::InlineTinyLeaves,
     &inline::SpecializeFunctionPointers,
     &outline_reverts::OutlineReverts,
     &cfg_simplify::FunctionDce,
@@ -178,6 +179,9 @@ pub static DEFAULT_PIPELINE: &[&dyn MirPass] = &[
     // simplified graph in one pass through the pipeline.
     &jump_threading::JumpThreading,
     &cfg_simplify::CfgSimplify,
+    // Trivial leaf helpers cost less to duplicate than even the static internal-call protocol.
+    // Keep this separate from general inlining, whose larger candidates regress measured gas.
+    &GasOnly(inline::InlineTinyLeaves),
     &inline::SpecializeFunctionPointers,
     &cfg_simplify::FunctionDce,
     &sccp::Sccp,

--- a/crates/codegen/src/transform/inline.rs
+++ b/crates/codegen/src/transform/inline.rs
@@ -41,6 +41,25 @@ impl MirPass for Inline {
     }
 }
 
+/// Module pass for inlining only trivial leaf helpers in gas mode.
+pub(crate) struct InlineTinyLeaves;
+
+impl MirPass for InlineTinyLeaves {
+    fn name(&self) -> &'static str {
+        "inline-tiny-leaves"
+    }
+
+    fn run_pass(
+        &self,
+        gcx: Gcx<'_>,
+        module: &mut Module,
+        _analyses: &mut crate::pass::ModuleAnalyses,
+    ) -> bool {
+        let mut inliner = MirInliner::for_tiny_leaves();
+        inliner.run(gcx, module).inlined != 0
+    }
+}
+
 /// Module pass for specializing calls through constant internal function pointers.
 pub(crate) struct SpecializeFunctionPointers;
 
@@ -91,6 +110,8 @@ struct MirInliner {
     /// under the EIP-170 deployable-code limit. Small contracts never reach it
     /// and inline normally.
     max_module_code_size: usize,
+    /// Restrict candidates to single-block leaf helpers with at most four MIR instructions.
+    tiny_leaves_only: bool,
 }
 
 impl Default for MirInliner {
@@ -110,6 +131,7 @@ impl Default for MirInliner {
             // emits 15,225 bytes, so 12,000 units leave a conservative margin
             // below EIP-170's 24,576-byte limit.
             max_module_code_size: 12_000,
+            tiny_leaves_only: false,
         }
     }
 }
@@ -123,6 +145,26 @@ impl MirInliner {
     #[must_use]
     fn for_size() -> Self {
         Self { max_module_code_size: 0, ..Self::default() }
+    }
+
+    /// Creates the gas-focused tiny-leaf inliner. A four-instruction leaf is smaller than the
+    /// static internal-call protocol it replaces, even when shared by several callers. Keeping
+    /// this policy separate avoids the code-growth cascades of general MIR inlining.
+    #[must_use]
+    fn for_tiny_leaves() -> Self {
+        Self {
+            max_instructions: 4,
+            max_single_call_sanity_instructions: 4,
+            max_blocks: 1,
+            max_shared_callee_blocks: 1,
+            inline_single_call: true,
+            max_cold_code_growth: 8,
+            max_hot_code_growth: 8,
+            max_caller_inlined_instructions: 64,
+            min_call_savings: 0,
+            max_module_code_size: usize::MAX,
+            tiny_leaves_only: true,
+        }
     }
 }
 
@@ -373,6 +415,16 @@ impl MirInliner {
             || summary.has_phi
             || summary.has_unsupported_terminator
             || summary.return_count == 0
+        {
+            return false;
+        }
+
+        if self.tiny_leaves_only
+            && (summary.block_count != 1
+                || summary.instruction_count > 4
+                || summary.return_count != 1
+                || summary.has_internal_call
+                || summary.has_control_flow)
         {
             return false;
         }

--- a/tests/ui/codegen/lowering/tuple_assignment.sol
+++ b/tests/ui/codegen/lowering/tuple_assignment.sol
@@ -44,15 +44,16 @@ contract C {
     }
 
     // CHECK: [[MULTI]]:
-    // CHECK: push [[TWO_RET:bb[0-9]+]]
-    // CHECK-NEXT: push 7
-    // CHECK: mstore
-    // CHECK: push 9
-    // CHECK: mstore
-    // CHECK-NEXT: jump
-    // CHECK-NEXT: [[TWO_RET]]:
-    // CHECK: push 448
+    // The tiny-leaf inliner exposes `two()` as constants and removes its call frame.
+    // CHECK: push 64
     // CHECK-NEXT: mload
+    // CHECK: push 9
+    // CHECK-NEXT: swap1
+    // CHECK: mstore
+    // CHECK: push 7
+    // CHECK-NEXT: push 128
+    // CHECK-NEXT: mstore
+    // CHECK-NEXT: push 9
     // CHECK: jump [[PAIR_RETURN]]
     function multi() external pure returns (uint256 x, uint256 y) {
         x = 100;

--- a/tests/ui/codegen/lowering/tuple_assignment.stdout
+++ b/tests/ui/codegen/lowering/tuple_assignment.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/tuple_assignment.sol:C (runtime) ===
 @module runtime
 bb0:
-  push 512
+  push 384
   push 64
   mstore
   callvalue
@@ -193,59 +193,26 @@ bb13:
   mstore
   push 4
   calldataload
-  jump bb18
-bb18:
+  jump bb17
+bb17:
   push 160
   mstore
   push 64
   push 128
   return
 bb16:
-  push 100
-  push 128
-  mstore
-  push 200
-  push 160
-  mstore
-  push bb17
-  push 7
-  push 448
-  mstore
-  push 9
-  push 480
-  mstore
-  jump
-bb17:
-  push 448
-  mload
-  dup1
-  push 256
-  mstore
   push 64
   mload
-  push 32
+  dup1
+  push 192
   mstore
-  push 480
-  mload
-  push 32
-  mload
   push 32
   add
+  push 9
+  swap1
   mstore
-  dup1
-  push 256
-  mstore
-  push 32
-  mload
-  push 32
-  add
-  mload
-  dup2
-  dup1
-  push 256
-  mstore
+  push 7
   push 128
   mstore
-  swap1
-  pop
-  jump bb18
+  push 9
+  jump bb17

--- a/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.mir
+++ b/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.mir
@@ -1,0 +1,41 @@
+//@compile-flags: -Zmir-pipeline=inline-tiny-leaves
+//@filecheck:
+@module InlineTinyLeaves
+
+// CHECK-LABEL: {{^[ +].*}}fn @tiny_caller{{[( ]}}
+// CHECK: - {{.*}}internal_call @tiny
+// CHECK: + {{v[0-9]+}} = add arg0, 1
+// CHECK: + {{v[0-9]+}} = sub {{v[0-9]+}}, 4
+fn @tiny_caller(arg0: u256) -> u256 {
+  bb0:
+    v1 = internal_call @tiny, 1, arg0
+    ret v1
+}
+
+fn @tiny(arg0: u256) -> u256 {
+  bb0:
+    v1 = add arg0, 1
+    v2 = xor v1, 2
+    v3 = mul v2, 3
+    v4 = sub v3, 4
+    ret v4
+}
+
+// Five-instruction leaves stay behind the measured profitability boundary.
+// CHECK-LABEL: {{^[ +].*}}fn @large_caller{{[( ]}}
+// CHECK: {{.*}}internal_call @large
+fn @large_caller(arg0: u256) -> u256 {
+  bb0:
+    v1 = internal_call @large, 1, arg0
+    ret v1
+}
+
+fn @large(arg0: u256) -> u256 {
+  bb0:
+    v1 = add arg0, 1
+    v2 = xor v1, 2
+    v3 = mul v2, 3
+    v4 = sub v3, 4
+    v5 = and v4, 5
+    ret v5
+}

--- a/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.stdout
+++ b/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.stdout
@@ -1,0 +1,44 @@
+- // === ROOT/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.mir (before inline-tiny-leaves) ===
++ // === ROOT/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.mir (after inline-tiny-leaves) ===
+  @module InlineTinyLeaves
+  fn @tiny_caller(arg0: u256) -> u256 {
+    bb0:
+-     v0 = internal_call @tiny, 1, arg0
+-     ret v0
++     jump bb2
++   bb1:
++     v5 = phi [bb2: v4]
++     ret v5
++   bb2:
++     v1 = add arg0, 1
++     v2 = xor v1, 2
++     v3 = mul v2, 3
++     v4 = sub v3, 4
++     jump bb1
+  }
+  
+  fn @tiny(arg0: u256) -> u256 {
+    bb0:
+      v0 = add arg0, 1
+      v1 = xor v0, 2
+      v2 = mul v1, 3
+      v3 = sub v2, 4
+      ret v3
+  }
+  
+  fn @large_caller(arg0: u256) -> u256 {
+    bb0:
+      v0 = internal_call @large, 1, arg0
+      ret v0
+  }
+  
+  fn @large(arg0: u256) -> u256 {
+    bb0:
+      v0 = add arg0, 1
+      v1 = xor v0, 2
+      v2 = mul v1, 3
+      v3 = sub v2, 4
+      v4 = and v3, 5
+      ret v4
+  }
+  


### PR DESCRIPTION
Inline gas-mode leaf helpers with one block, no nested call or control flow, at most four MIR instructions, and at most eight estimated bytes of growth. This isolates the measured profitable subset from the regressive general inliner.