### PR TITLE
fix(codegen): truncate narrow left shifts

### DIFF
--- a/crates/codegen/src/lower/checked_arith.rs
+++ b/crates/codegen/src/lower/checked_arith.rs
@@ -177,7 +177,10 @@ impl<'gcx> Lowerer<'gcx> {
             BinOpKind::BitAnd => builder.and(lhs, rhs),
             BinOpKind::BitOr => builder.or(lhs, rhs),
             BinOpKind::BitXor => builder.xor(lhs, rhs),
-            BinOpKind::Shl => builder.shl(rhs, lhs),
+            BinOpKind::Shl => {
+                let result = builder.shl(rhs, lhs);
+                self.truncate_wrapping_result(builder, result, arithmetic.integer)
+            }
             BinOpKind::Shr => {
                 // For signed types, >> is arithmetic shift (SAR)
                 if arithmetic.is_signed { builder.sar(rhs, lhs) } else { builder.shr(rhs, lhs) }
@@ -223,10 +226,9 @@ impl<'gcx> Lowerer<'gcx> {
         }
     }
 
-    /// Truncates a wrapping result back into its sub-word type. The checked
-    /// paths prove the result in range, but unchecked sub-word arithmetic can
-    /// wrap past the type's width, and the checked shapes (and ABI encoding)
-    /// rely on values of type `uintN`/`intN` being clean.
+    /// Truncates a wrapping result back into its sub-word type. Left shifts and unchecked
+    /// arithmetic can wrap past the type's width, while later operations and ABI encoding rely on
+    /// values of type `uintN`/`intN` being clean.
     fn truncate_wrapping_result(
         &mut self,
         builder: &mut FunctionBuilder<'_>,

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol
@@ -9,6 +9,7 @@
 // - signed add/sub: `xor` of two `slt`/`sgt` comparisons, no constants.
 // - signed mul: division-inverse check plus `and(eq(lhs, MIN), slt(rhs, 0))`.
 // - div/mod: branch directly on the divisor, no `iszero`/`eq` flag.
+// - sub-word left shifts: mask unsigned results and sign-extend signed results.
 contract CheckedArithmeticShapes {
     // CHECK-LABEL: fn @sadd{{[( ]}}
     // CHECK: [[SUM:v[0-9]+]] = add arg0, arg1
@@ -105,5 +106,61 @@ contract CheckedArithmeticShapes {
     // CHECK: gt [[RESULT]], 0xffffffffffffffffffffffffffffffffffffffffffffffff
     function umul192(uint192 a, uint192 b) public pure returns (uint192) {
         return a * b;
+    }
+
+    // CHECK-LABEL: fn @leftU8{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = shl arg1, arg0
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = and [[SHIFTED]], 255
+    // CHECK-NEXT: ret [[CLEAN]]
+    function leftU8(uint8 value, uint8 bits) external pure returns (uint8) {
+        return value << bits;
+    }
+
+    // CHECK-LABEL: fn @leftU16{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = shl arg1, arg0
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = and [[SHIFTED]], 0xffff
+    // CHECK-NEXT: ret [[CLEAN]]
+    function leftU16(uint16 value, uint8 bits) external pure returns (uint16) {
+        return value << bits;
+    }
+
+    // CHECK-LABEL: fn @leftI8{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = shl arg1, arg0
+    // CHECK-NEXT: [[ALIGNED:v[0-9]+]] = shl 248, [[SHIFTED]]
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = sar 248, [[ALIGNED]]
+    // CHECK-NEXT: ret [[CLEAN]]
+    function leftI8(int8 value, uint8 bits) external pure returns (int8) {
+        return value << bits;
+    }
+
+    // CHECK-LABEL: fn @leftI16{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = shl arg1, arg0
+    // CHECK-NEXT: [[ALIGNED:v[0-9]+]] = shl 240, [[SHIFTED]]
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = sar 240, [[ALIGNED]]
+    // CHECK-NEXT: ret [[CLEAN]]
+    function leftI16(int16 value, uint8 bits) external pure returns (int16) {
+        return value << bits;
+    }
+
+    // Full-width and right shifts already have native EVM word semantics.
+    // CHECK-LABEL: fn @leftU256{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = shl arg1, arg0
+    // CHECK-NEXT: ret [[SHIFTED]]
+    function leftU256(uint256 value, uint256 bits) external pure returns (uint256) {
+        return value << bits;
+    }
+
+    // CHECK-LABEL: fn @rightU8{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = shr arg1, arg0
+    // CHECK-NEXT: ret [[SHIFTED]]
+    function rightU8(uint8 value, uint8 bits) external pure returns (uint8) {
+        return value >> bits;
+    }
+
+    // CHECK-LABEL: fn @rightI8{{[( ]}}
+    // CHECK: [[SHIFTED:v[0-9]+]] = sar arg1, arg0
+    // CHECK-NEXT: ret [[SHIFTED]]
+    function rightI8(int8 value, uint8 bits) external pure returns (int8) {
+        return value >> bits;
     }
 }

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
@@ -329,3 +329,184 @@ fn @umul192(arg0: u192, arg1: u192) -> u192 [abi_returns=[word]] {
     ret v9
 }
 
+fn @leftU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 255
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = and v6, 255
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = shl arg1, arg0
+    v10 = and v9, 255
+    ret v10
+}
+
+fn @leftU16(arg0: u16, arg1: u8) -> u16 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 0xffff
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = and v6, 255
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = shl arg1, arg0
+    v10 = and v9, 0xffff
+    ret v10
+}
+
+fn @leftI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = signextend 0, v3
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = and v6, 255
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = shl arg1, arg0
+    v10 = shl 248, v9
+    v11 = sar 248, v10
+    ret v11
+}
+
+fn @leftI16(arg0: i16, arg1: u8) -> i16 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = signextend 1, v3
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = and v6, 255
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = shl arg1, arg0
+    v10 = shl 240, v9
+    v11 = sar 240, v10
+    ret v11
+}
+
+fn @leftU256(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = shl arg1, arg0
+    ret v3
+}
+
+fn @rightU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 255
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = and v6, 255
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = shr arg1, arg0
+    ret v9
+}
+
+fn @rightI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = signextend 0, v3
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = and v6, 255
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = sar arg1, arg0
+    ret v9
+}
+

--- a/tests/ui/codegen/lowering/multi_return_named_init.stdout
+++ b/tests/ui/codegen/lowering/multi_return_named_init.stdout
@@ -17,28 +17,29 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v6 = lt v5, 8
     jumpi v6, bb4, bb5
   bb2:
-    v35 = internal_frame_addr 192
-    v36 = mload v35 !metadata(memory=internal_frame)
-    v37 = internal_frame_addr 224
-    v38 = mload v37 !metadata(memory=internal_frame)
-    ret v36, v38
+    v36 = internal_frame_addr 192
+    v37 = mload v36 !metadata(memory=internal_frame)
+    v38 = internal_frame_addr 224
+    v39 = mload v38 !metadata(memory=internal_frame)
+    ret v37, v39
   bb3:
-    v30 = internal_frame_addr 256
-    v31 = mload v30 !metadata(memory=internal_frame)
-    v32 = add v31, 1
-    v33 = lt v32, v31
-    jumpi v33, bb10, bb11
+    v31 = internal_frame_addr 256
+    v32 = mload v31 !metadata(memory=internal_frame)
+    v33 = add v32, 1
+    v34 = lt v33, v32
+    jumpi v34, bb10, bb11
   bb4:
     v7 = internal_frame_addr 192
     v8 = mload v7 !metadata(memory=internal_frame)
     v9 = shl 8, v8
-    v10 = internal_frame_addr 192
-    mstore v10, v9 !metadata(memory=internal_frame)
-    v11 = internal_frame_addr 224
-    v12 = mload v11 !metadata(memory=internal_frame)
-    v13 = slice_len arg0
-    v14 = lt v12, v13
-    jumpi v14, bb7, bb6
+    v10 = and v9, 0xffffffffffffffff
+    v11 = internal_frame_addr 192
+    mstore v11, v10 !metadata(memory=internal_frame)
+    v12 = internal_frame_addr 224
+    v13 = mload v12 !metadata(memory=internal_frame)
+    v14 = slice_len arg0
+    v15 = lt v13, v14
+    jumpi v15, bb7, bb6
   bb5:
     jump bb2
   bb6:
@@ -46,37 +47,37 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb7:
-    v15 = slice_ptr arg0
-    v16 = add v15, v12
-    v17 = calldataload v16
-    v18 = and v17, 0xff00000000000000000000000000000000000000000000000000000000000000
-    v19 = shr 248, v18
-    v20 = and v19, 255
-    v21 = internal_frame_addr 192
-    v22 = mload v21 !metadata(memory=internal_frame)
-    v23 = or v22, v20
-    v24 = internal_frame_addr 192
-    mstore v24, v23 !metadata(memory=internal_frame)
-    v25 = internal_frame_addr 224
-    v26 = mload v25 !metadata(memory=internal_frame)
-    v27 = add v26, 1
-    v28 = lt v27, v26
-    jumpi v28, bb8, bb9
+    v16 = slice_ptr arg0
+    v17 = add v16, v13
+    v18 = calldataload v17
+    v19 = and v18, 0xff00000000000000000000000000000000000000000000000000000000000000
+    v20 = shr 248, v19
+    v21 = and v20, 255
+    v22 = internal_frame_addr 192
+    v23 = mload v22 !metadata(memory=internal_frame)
+    v24 = or v23, v21
+    v25 = internal_frame_addr 192
+    mstore v25, v24 !metadata(memory=internal_frame)
+    v26 = internal_frame_addr 224
+    v27 = mload v26 !metadata(memory=internal_frame)
+    v28 = add v27, 1
+    v29 = lt v28, v27
+    jumpi v29, bb8, bb9
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb9:
-    v29 = internal_frame_addr 224
-    mstore v29, v27 !metadata(memory=internal_frame)
+    v30 = internal_frame_addr 224
+    mstore v30, v28 !metadata(memory=internal_frame)
     jump bb3
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb11:
-    v34 = internal_frame_addr 256
-    mstore v34, v32 !metadata(memory=internal_frame)
+    v35 = internal_frame_addr 256
+    mstore v35, v33 !metadata(memory=internal_frame)
     jump bb1
 }
 

--- a/tests/ui/codegen/run-call/narrow_left_shift.sol
+++ b/tests/ui/codegen/run-call/narrow_left_shift.sol
@@ -1,0 +1,58 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: leftU8(uint8,uint8) 255, 0 => 255
+//@ run-call: leftU8(uint8,uint8) 255, 1 => 254
+//@ run-call: leftU8(uint8,uint8) 255, 8 => 0
+//@ run-call: leftU8(uint8,uint8) 1, 255 => 0
+//@ run-call: leftU16(uint16,uint8) 32769, 1 => 2
+//@ run-call: leftU16(uint16,uint8) 1, 16 => 0
+//@ run-call: leftI8(int8,uint8) 1, 7 => -128
+//@ run-call: leftI8(int8,uint8) -1, 1 => -2
+//@ run-call: leftI8(int8,uint8) -1, 8 => 0
+//@ run-call: leftI16(int16,uint8) 16384, 1 => -32768
+//@ run-call: leftI16(int16,uint8) -1, 1 => -2
+//@ run-call: leftI16(int16,uint8) -1, 16 => 0
+//@ run-call: uncheckedU8(uint8,uint8) 255, 1 => 254
+//@ run-call: uncheckedU8(uint8,uint8) 255, 8 => 0
+//@ run-call: leftU256(uint256,uint256) 1, 255 => 0x8000000000000000000000000000000000000000000000000000000000000000
+//@ run-call: leftU256(uint256,uint256) 1, 256 => 0
+//@ run-call: rightU8(uint8,uint8) 128, 7 => 1
+//@ run-call: rightI8(int8,uint8) -128, 7 => -1
+
+contract NarrowLeftShift {
+    function leftU8(uint8 value, uint8 bits) external pure returns (uint8) {
+        return value << bits;
+    }
+
+    function leftU16(uint16 value, uint8 bits) external pure returns (uint16) {
+        return value << bits;
+    }
+
+    function leftI8(int8 value, uint8 bits) external pure returns (int8) {
+        return value << bits;
+    }
+
+    function leftI16(int16 value, uint8 bits) external pure returns (int16) {
+        return value << bits;
+    }
+
+    function uncheckedU8(uint8 value, uint8 bits) external pure returns (uint8 result) {
+        unchecked {
+            result = value << bits;
+        }
+    }
+
+    function leftU256(uint256 value, uint256 bits) external pure returns (uint256) {
+        return value << bits;
+    }
+
+    function rightU8(uint8 value, uint8 bits) external pure returns (uint8) {
+        return value >> bits;
+    }
+
+    function rightI8(int8 value, uint8 bits) external pure returns (int8) {
+        return value >> bits;
+    }
+}


### PR DESCRIPTION
High-level left shifts currently preserve the full 256-bit EVM `SHL` result even when the expression type is `uintN` or `intN`. Bits outside the declared width can therefore affect later control flow and escape through ABI output.

This restores the typed-value invariant after `SHL`: unsigned sub-word results are masked and signed results are truncated and sign-extended. Full-width shifts, right shifts, and raw Yul retain their existing EVM semantics.

The benchmark corpus has one expected output-size change: Nitro's runtime grows from 14,341 to 14,357 bytes and deployment gas grows by 3,446. Disassembly accounts for all 16 bytes as the three required width-normalization sequences for its `uint16`, `uint32`, and `uint64` `ret <<= 8` loops. Hot runtime gas, all 149 CodSpeed cases, and all 25 Gungraun instruction benchmarks are unchanged.

### How this was found

The automatic differential in #1084 compiled the same `pure` fixture with solc and this compiler, then used Foundry's symbolic EVM to search for calldata that changed the exact result. It found `uint8ShiftControl(1, 8)`, which returned `true` under solc and `false` under this compiler; Foundry replay and a separate fresh-Anvil replay both confirmed the witness.