### PR TITLE
fix(codegen): clean narrow bitwise not

### DIFF
--- a/crates/codegen/src/lower/checked_arith.rs
+++ b/crates/codegen/src/lower/checked_arith.rs
@@ -986,17 +986,31 @@ impl<'gcx> Lowerer<'gcx> {
         op: hir::UnOp,
         operand: ValueId,
         int_info: Option<IntegerInfo>,
-        span: Span,
+        expr: &hir::Expr<'_>,
     ) -> ValueId {
         use hir::UnOpKind;
 
         match op.kind {
             UnOpKind::Not => builder.iszero(operand),
-            UnOpKind::BitNot => builder.not(operand),
+            UnOpKind::BitNot => {
+                let result = builder.not(operand);
+                if let Some(width) = self.fixed_bytes_width_of_expr(expr) {
+                    return self.clean_fixed_bytes(builder, result, TypeSize::new_fb_bytes(width));
+                }
+                if let Some(info) = int_info
+                    && !info.signed
+                    && self.get_expr_type(expr).is_some_and(|ty| {
+                        matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::UInt(_)))
+                    })
+                {
+                    return self.mask_to_bits(builder, result, info.size);
+                }
+                result
+            }
             UnOpKind::Neg => {
                 let zero = builder.imm_u256(U256::ZERO);
                 if !self.in_unchecked_block {
-                    let int_info = self.require_checked_arithmetic_info(int_info, span);
+                    let int_info = self.require_checked_arithmetic_info(int_info, expr.span);
                     if let Some(info) = int_info
                         && info.signed
                     {

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -255,29 +255,7 @@ impl<'gcx> Lowerer<'gcx> {
                             let guar = self.emit_unsupported_udvt_operator(expr.span);
                             return builder.error_value(guar);
                         }
-                        let result =
-                            self.lower_unary_op(builder, *op, operand_val, int_info, expr.span);
-                        if op.kind == UnOpKind::BitNot {
-                            if let Some(width) = self.fixed_bytes_width_of_expr(expr) {
-                                return self.clean_fixed_bytes(
-                                    builder,
-                                    result,
-                                    TypeSize::new_fb_bytes(width),
-                                );
-                            }
-                            if let Some(info) = int_info
-                                && !info.signed
-                                && self.get_expr_type(expr).is_some_and(|ty| {
-                                    matches!(
-                                        ty.peel_refs().kind,
-                                        TyKind::Elementary(ElementaryType::UInt(_))
-                                    )
-                                })
-                            {
-                                return self.mask_to_bits(builder, result, info.size);
-                            }
-                        }
-                        result
+                        self.lower_unary_op(builder, *op, operand_val, int_info, expr)
                     }
                 }
             }

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -267,6 +267,12 @@ impl<'gcx> Lowerer<'gcx> {
                             }
                             if let Some(info) = int_info
                                 && !info.signed
+                                && self.get_expr_type(expr).is_some_and(|ty| {
+                                    matches!(
+                                        ty.peel_refs().kind,
+                                        TyKind::Elementary(ElementaryType::UInt(_))
+                                    )
+                                })
                             {
                                 return self.mask_to_bits(builder, result, info.size);
                             }

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -255,7 +255,23 @@ impl<'gcx> Lowerer<'gcx> {
                             let guar = self.emit_unsupported_udvt_operator(expr.span);
                             return builder.error_value(guar);
                         }
-                        self.lower_unary_op(builder, *op, operand_val, int_info, expr.span)
+                        let result =
+                            self.lower_unary_op(builder, *op, operand_val, int_info, expr.span);
+                        if op.kind == UnOpKind::BitNot {
+                            if let Some(width) = self.fixed_bytes_width_of_expr(expr) {
+                                return self.clean_fixed_bytes(
+                                    builder,
+                                    result,
+                                    TypeSize::new_fb_bytes(width),
+                                );
+                            }
+                            if let Some(info) = int_info
+                                && !info.signed
+                            {
+                                return self.mask_to_bits(builder, result, info.size);
+                            }
+                        }
+                        result
                     }
                 }
             }

--- a/tests/ui/codegen/lowering/narrow_bitwise_not.sol
+++ b/tests/ui/codegen/lowering/narrow_bitwise_not.sol
@@ -1,0 +1,58 @@
+//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ filecheck:
+//@ normalize-stdout-test: "\n(\n)$" -> "$1"
+
+contract NarrowBitwiseNot {
+    // CHECK-LABEL: fn @notUint8{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = and [[NOT]], 255
+    // CHECK-NEXT: ret [[CLEAN]]
+    function notUint8(uint8 value) external pure returns (uint8) {
+        return ~value;
+    }
+
+    // CHECK-LABEL: fn @notUint16{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = and [[NOT]], 0xffff
+    // CHECK-NEXT: ret [[CLEAN]]
+    function notUint16(uint16 value) external pure returns (uint16) {
+        return ~value;
+    }
+
+    // CHECK-LABEL: fn @notUint256{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: ret [[NOT]]
+    function notUint256(uint256 value) external pure returns (uint256) {
+        return ~value;
+    }
+
+    // CHECK-LABEL: fn @notInt8{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: ret [[NOT]]
+    function notInt8(int8 value) external pure returns (int8) {
+        return ~value;
+    }
+
+    // CHECK-LABEL: fn @notBytes1{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = and [[NOT]], 0xff00000000000000000000000000000000000000000000000000000000000000
+    // CHECK-NEXT: ret [[CLEAN]]
+    function notBytes1(bytes1 value) external pure returns (bytes1) {
+        return ~value;
+    }
+
+    // CHECK-LABEL: fn @notBytes2{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: [[CLEAN:v[0-9]+]] = and [[NOT]], 0xffff000000000000000000000000000000000000000000000000000000000000
+    // CHECK-NEXT: ret [[CLEAN]]
+    function notBytes2(bytes2 value) external pure returns (bytes2) {
+        return ~value;
+    }
+
+    // CHECK-LABEL: fn @notBytes32{{[( ]}}
+    // CHECK: [[NOT:v[0-9]+]] = not arg0
+    // CHECK-NEXT: ret [[NOT]]
+    function notBytes32(bytes32 value) external pure returns (bytes32) {
+        return ~value;
+    }
+}

--- a/tests/ui/codegen/lowering/narrow_bitwise_not.stdout
+++ b/tests/ui/codegen/lowering/narrow_bitwise_not.stdout
@@ -1,0 +1,131 @@
+// === ROOT/tests/ui/codegen/lowering/narrow_bitwise_not.sol:NarrowBitwiseNot ===
+@module NarrowBitwiseNot
+fn @notUint8(arg0: u8) -> u8 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 255
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = not arg0
+    v7 = and v6, 255
+    ret v7
+}
+
+fn @notUint16(arg0: u16) -> u16 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 0xffff
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = not arg0
+    v7 = and v6, 0xffff
+    ret v7
+}
+
+fn @notUint256(arg0: u256) -> u256 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = not arg0
+    ret v3
+}
+
+fn @notInt8(arg0: i8) -> i8 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = signextend 0, v3
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = not arg0
+    ret v6
+}
+
+fn @notBytes1(arg0: bytes1) -> bytes1 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 0xff00000000000000000000000000000000000000000000000000000000000000
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = not arg0
+    v7 = and v6, 0xff00000000000000000000000000000000000000000000000000000000000000
+    ret v7
+}
+
+fn @notBytes2(arg0: bytes2) -> bytes2 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 0xffff000000000000000000000000000000000000000000000000000000000000
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = not arg0
+    v7 = and v6, 0xffff000000000000000000000000000000000000000000000000000000000000
+    ret v7
+}
+
+fn @notBytes32(arg0: bytes32) -> bytes32 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = not arg0
+    ret v3
+}

--- a/tests/ui/codegen/run-call/narrow_bitwise_not.sol
+++ b/tests/ui/codegen/run-call/narrow_bitwise_not.sol
@@ -15,6 +15,8 @@
 //@ run-call: notBytes2(bytes2) 0x0000 => 0xffff
 //@ run-call: notBytes2(bytes2) 0xa55a => 0x5aa5
 //@ run-call: notBytes32(bytes32) 0x0000000000000000000000000000000000000000000000000000000000000000 => 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+//@ run-call: notLiteral() => -1
+//@ run-call: notLiteralEqualsNegativeOne() => true
 
 contract NarrowBitwiseNot {
     function notUint8(uint8 value) external pure returns (uint8) {
@@ -47,5 +49,13 @@ contract NarrowBitwiseNot {
 
     function notBytes32(bytes32 value) external pure returns (bytes32) {
         return ~value;
+    }
+
+    function notLiteral() external pure returns (int256) {
+        return ~0;
+    }
+
+    function notLiteralEqualsNegativeOne() external pure returns (bool) {
+        return ~0 == -1;
     }
 }

--- a/tests/ui/codegen/run-call/narrow_bitwise_not.sol
+++ b/tests/ui/codegen/run-call/narrow_bitwise_not.sol
@@ -1,0 +1,51 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: notUint8(uint8) 0 => 255
+//@ run-call: notUint8(uint8) 0xa5 => 90
+//@ run-call: notUint16(uint16) 0 => 65535
+//@ run-call: notUint16(uint16) 0xa55a => 23205
+//@ run-call: notUint256(uint256) 0 => 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+//@ run-call: notInt8(int8) 0 => -1
+//@ run-call: notInt8(int8) -128 => 127
+//@ run-call: notInt16(int16) 4660 => -4661
+//@ run-call: notBytes1(bytes1) 0x00 => 0xff
+//@ run-call: notBytes1(bytes1) 0xa5 => 0x5a
+//@ run-call: notBytes2(bytes2) 0x0000 => 0xffff
+//@ run-call: notBytes2(bytes2) 0xa55a => 0x5aa5
+//@ run-call: notBytes32(bytes32) 0x0000000000000000000000000000000000000000000000000000000000000000 => 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+contract NarrowBitwiseNot {
+    function notUint8(uint8 value) external pure returns (uint8) {
+        return ~value;
+    }
+
+    function notUint16(uint16 value) external pure returns (uint16) {
+        return ~value;
+    }
+
+    function notUint256(uint256 value) external pure returns (uint256) {
+        return ~value;
+    }
+
+    function notInt8(int8 value) external pure returns (int8) {
+        return ~value;
+    }
+
+    function notInt16(int16 value) external pure returns (int16) {
+        return ~value;
+    }
+
+    function notBytes1(bytes1 value) external pure returns (bytes1) {
+        return ~value;
+    }
+
+    function notBytes2(bytes2 value) external pure returns (bytes2) {
+        return ~value;
+    }
+
+    function notBytes32(bytes32 value) external pure returns (bytes32) {
+        return ~value;
+    }
+}


### PR DESCRIPTION
Unary bitwise-not currently leaves a full-word complement for `uintN` and `bytesN`. That makes expressions such as `~uint8(0) == type(uint8).max` evaluate incorrectly, rather than only producing a noncanonical ABI word.

This cleans the result according to the expression type while preserving signed integers, untyped integer literals such as `~0`, full-width values, and raw Yul behavior.

### How this was found

The automatic differential in #1084 compiled the same `pure` fixture with solc and this compiler, then used Foundry's symbolic EVM to search for calldata that changed the exact result. It found `uint8NotControl(0)`, which returned `true` under solc and `false` under this compiler; Foundry replay and a separate fresh-Anvil replay both confirmed the witness.