### PR TITLE
fix(codegen): lower function modifiers

### DIFF
--- a/crates/codegen/src/lower/call.rs
+++ b/crates/codegen/src/lower/call.rs
@@ -2081,7 +2081,7 @@ impl<'gcx> Lowerer<'gcx> {
             && !self.function_is_recursive(func_id)
             && self.try_enter_inline(func_id)
         {
-            let values = self.inline_slice_return_body(builder, func, &body, &arg_vals);
+            let values = self.inline_slice_return_body(builder, func, body, &arg_vals);
             self.exit_inline();
             let Some(first) = values.first().copied() else {
                 return self.err_value(
@@ -2115,8 +2115,8 @@ impl<'gcx> Lowerer<'gcx> {
     fn inline_slice_return_body(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
-        func: &hir::Function<'_>,
-        body: &hir::Block<'_>,
+        func: &'gcx hir::Function<'gcx>,
+        body: hir::Block<'gcx>,
         arg_vals: &[ValueId],
     ) -> Vec<ValueId> {
         let saved_locals = std::mem::take(&mut self.locals);
@@ -2125,8 +2125,10 @@ impl<'gcx> Lowerer<'gcx> {
         let saved_slice_slot_locals = std::mem::take(&mut self.slice_slot_locals);
         let saved_inline_returns = self.inline_returns.take();
         let saved_pending = self.pending_inline_returns.take();
+        let saved_modifier_continuation = self.modifier_continuation.take();
 
-        self.collect_assigned_vars_block(body);
+        self.collect_assigned_vars_block(&body);
+        self.collect_modifier_assigned_vars(func.modifiers);
 
         for &ret_id in func.returns {
             if Self::calldata_dynamic_var_kind(self.gcx.hir.variable(ret_id)).is_some() {
@@ -2152,7 +2154,11 @@ impl<'gcx> Lowerer<'gcx> {
 
         let saved_in_unchecked_block = self.in_unchecked_block;
         self.in_unchecked_block = false;
-        self.lower_block(builder, body);
+        if func.modifiers.iter().any(|modifier| modifier.id.as_function().is_some()) {
+            self.lower_modifier_chain(builder, func.modifiers, body, func.returns);
+        } else {
+            self.lower_block(builder, &body);
+        }
         self.in_unchecked_block = saved_in_unchecked_block;
 
         // Implicit fallthrough joins the explicit returns at the exit block.
@@ -2195,6 +2201,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.slice_slot_locals = saved_slice_slot_locals;
         self.inline_returns = saved_inline_returns;
         self.pending_inline_returns = saved_pending;
+        self.modifier_continuation = saved_modifier_continuation;
 
         values
     }
@@ -2274,10 +2281,12 @@ impl<'gcx> Lowerer<'gcx> {
         let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
         let saved_inline_returns = self.inline_returns.take();
         let saved_pending = self.pending_inline_returns.take();
+        let saved_modifier_continuation = self.modifier_continuation.take();
 
         if let Some(body) = body {
             self.collect_assigned_vars_block(&body);
         }
+        self.collect_modifier_assigned_vars(func.modifiers);
 
         for (i, &param_id) in parameters.iter().enumerate() {
             if let Some(&arg_val) = arg_vals.get(i) {
@@ -2291,7 +2300,11 @@ impl<'gcx> Lowerer<'gcx> {
                 Some(crate::lower::InlineReturnCtx { exit_block, return_vars: Vec::new() });
             let saved_in_unchecked_block = self.in_unchecked_block;
             self.in_unchecked_block = false;
-            self.lower_block(builder, &body);
+            if func.modifiers.iter().any(|modifier| modifier.id.as_function().is_some()) {
+                self.lower_modifier_chain(builder, func.modifiers, body, func.returns);
+            } else {
+                self.lower_block(builder, &body);
+            }
             self.in_unchecked_block = saved_in_unchecked_block;
             if !builder.func().block(builder.current_block()).is_terminated() {
                 builder.jump(exit_block);
@@ -2309,6 +2322,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.assigned_vars = saved_assigned_vars;
         self.inline_returns = saved_inline_returns;
         self.pending_inline_returns = saved_pending;
+        self.modifier_continuation = saved_modifier_continuation;
         self.exit_inline();
     }
 

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -137,6 +137,27 @@ struct InlineReturnCtx {
     return_vars: Vec<VariableId>,
 }
 
+/// The code substituted at a modifier placeholder: the remaining modifier
+/// invocations, followed by the function body.
+#[derive(Clone, Copy)]
+struct ModifierContinuation<'hir> {
+    modifiers: &'hir [hir::Modifier<'hir>],
+    body: hir::Block<'hir>,
+    return_vars: &'hir [VariableId],
+}
+
+/// A snapshot of lexical local bindings around an inlined modifier or function
+/// body. Runtime writes remain in their allocated slots; restoring this map only
+/// prevents repeated substitutions of the same HIR variables from shadowing an
+/// enclosing invocation during lowering.
+#[derive(Clone)]
+struct LocalBindings {
+    locals: FxHashMap<VariableId, ValueId>,
+    local_memory_slots: FxHashMap<VariableId, u64>,
+    slice_slot_locals: FxHashSet<VariableId>,
+    storage_ref_locals: GrowableBitSet<VariableId>,
+}
+
 type InternalFunctionPointerShape = (Vec<MirType>, Vec<MirType>);
 
 /// Lowering context for converting HIR to MIR.
@@ -179,6 +200,8 @@ pub(crate) struct Lowerer<'gcx> {
     /// returns cannot ride the one-word-per-value multi-return buffer
     /// (calldata slices). Destructuring consumes them directly.
     pending_inline_returns: Option<Vec<ValueId>>,
+    /// Continuation substituted at `_` while lowering a modifier body.
+    modifier_continuation: Option<ModifierContinuation<'gcx>>,
     /// Next available memory offset for locals.
     next_local_memory_offset: u64,
     /// Bytecodes of other contracts (for `new` expressions).
@@ -297,6 +320,7 @@ impl<'gcx> Lowerer<'gcx> {
             slice_slot_locals: FxHashSet::default(),
             inline_returns: None,
             pending_inline_returns: None,
+            modifier_continuation: None,
             next_local_memory_offset: EvmMemoryLayout::HEAP_START,
             contract_bytecodes: FxHashMap::default(),
             loop_stack: Vec::new(),
@@ -369,6 +393,22 @@ impl<'gcx> Lowerer<'gcx> {
         debug_assert!(popped.is_some());
         self.check_expr_errors = self.inline_expr_error_checks & 1 != 0;
         self.inline_expr_error_checks >>= 1;
+    }
+
+    fn local_bindings(&self) -> LocalBindings {
+        LocalBindings {
+            locals: self.locals.clone(),
+            local_memory_slots: self.local_memory_slots.clone(),
+            slice_slot_locals: self.slice_slot_locals.clone(),
+            storage_ref_locals: self.storage_ref_locals.clone(),
+        }
+    }
+
+    fn restore_local_bindings(&mut self, bindings: LocalBindings) {
+        self.locals = bindings.locals;
+        self.local_memory_slots = bindings.local_memory_slots;
+        self.slice_slot_locals = bindings.slice_slot_locals;
+        self.storage_ref_locals = bindings.storage_ref_locals;
     }
 
     /// Allocates a memory slot for a local variable.
@@ -661,6 +701,7 @@ impl<'gcx> Lowerer<'gcx> {
             let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
             let saved_inline_returns = self.inline_returns.take();
             let saved_pending_inline_returns = self.pending_inline_returns.take();
+            let saved_modifier_continuation = self.modifier_continuation.take();
             let saved_lowering_constructor = self.lowering_constructor;
             let saved_constructor_args_base = self.constructor_args_base;
             let saved_lowering_internal_function = self.lowering_internal_function;
@@ -683,6 +724,7 @@ impl<'gcx> Lowerer<'gcx> {
             self.assigned_vars = saved_assigned_vars;
             self.inline_returns = saved_inline_returns;
             self.pending_inline_returns = saved_pending_inline_returns;
+            self.modifier_continuation = saved_modifier_continuation;
             self.lowering_constructor = saved_lowering_constructor;
             self.constructor_args_base = saved_constructor_args_base;
             self.lowering_internal_function = saved_lowering_internal_function;
@@ -838,6 +880,7 @@ impl<'gcx> Lowerer<'gcx> {
         let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
         let saved_inline_returns = self.inline_returns.take();
         let saved_pending_inline_returns = self.pending_inline_returns.take();
+        let saved_modifier_continuation = self.modifier_continuation.take();
         let saved_current_contract_id = self.current_contract_id;
         let saved_lowering_constructor = self.lowering_constructor;
         let saved_constructor_args_base = self.constructor_args_base;
@@ -858,6 +901,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.assigned_vars = saved_assigned_vars;
         self.inline_returns = saved_inline_returns;
         self.pending_inline_returns = saved_pending_inline_returns;
+        self.modifier_continuation = saved_modifier_continuation;
         self.current_contract_id = saved_current_contract_id;
         self.lowering_constructor = saved_lowering_constructor;
         self.constructor_args_base = saved_constructor_args_base;
@@ -945,6 +989,7 @@ impl<'gcx> Lowerer<'gcx> {
         let saved_assigned_vars = std::mem::take(&mut self.assigned_vars);
         let saved_inline_returns = self.inline_returns.take();
         let saved_pending_inline_returns = self.pending_inline_returns.take();
+        let saved_modifier_continuation = self.modifier_continuation.take();
         let saved_current_contract_id = self.current_contract_id;
         let saved_lowering_constructor = self.lowering_constructor;
         let saved_constructor_args_base = self.constructor_args_base;
@@ -963,6 +1008,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.assigned_vars = saved_assigned_vars;
         self.inline_returns = saved_inline_returns;
         self.pending_inline_returns = saved_pending_inline_returns;
+        self.modifier_continuation = saved_modifier_continuation;
         self.current_contract_id = saved_current_contract_id;
         self.lowering_constructor = saved_lowering_constructor;
         self.constructor_args_base = saved_constructor_args_base;
@@ -1014,6 +1060,8 @@ impl<'gcx> Lowerer<'gcx> {
             mir_func.selector = Some(self.function_selector(func_id));
         }
         let uses_internal_frame = !uses_external_abi && !is_special;
+        let has_modifiers =
+            hir_func.modifiers.iter().any(|modifier| modifier.id.as_function().is_some());
         let current_return_tys =
             hir_func.returns.iter().map(|&id| self.gcx.type_of_item(id.into())).collect::<Vec<_>>();
 
@@ -1072,6 +1120,7 @@ impl<'gcx> Lowerer<'gcx> {
         if let Some(body) = &hir_func.body {
             self.collect_assigned_vars_block(body);
         }
+        self.collect_modifier_assigned_vars(hir_func.modifiers);
 
         {
             let mut builder = FunctionBuilder::new(&mut mir_func);
@@ -1435,7 +1484,7 @@ impl<'gcx> Lowerer<'gcx> {
                 // An unnamed return cannot be assigned or read by the body.
                 // Keep it absent and materialize its default only if control
                 // actually reaches the implicit-return epilogue.
-                if ret_var.name.is_none() {
+                if ret_var.name.is_none() && !has_modifiers {
                     continue;
                 }
                 // Allocate memory for return variables so they can be assigned to
@@ -1463,7 +1512,16 @@ impl<'gcx> Lowerer<'gcx> {
             }
 
             if let Some(body) = &hir_func.body {
-                self.lower_block(&mut builder, body);
+                if has_modifiers {
+                    self.lower_modifier_chain(
+                        &mut builder,
+                        hir_func.modifiers,
+                        *body,
+                        hir_func.returns,
+                    );
+                } else {
+                    self.lower_block(&mut builder, body);
+                }
             }
 
             if !builder.func().block(builder.current_block()).is_terminated() {
@@ -1514,6 +1572,187 @@ impl<'gcx> Lowerer<'gcx> {
         *self.module.function_mut(mir_id) = mir_func;
         self.check_expr_errors = check_expr_errors;
         mir_id
+    }
+
+    /// Includes assignments from modifier arguments and bodies in the function's
+    /// local-slot analysis. Modifier arguments execute in the caller's scope,
+    /// while a modifier body's own parameters and locals are bound when the
+    /// invocation is expanded.
+    fn collect_modifier_assigned_vars(&mut self, modifiers: &[hir::Modifier<'gcx>]) {
+        for modifier in modifiers {
+            for arg in modifier.args.kind.exprs() {
+                self.collect_assigned_vars_expr(arg);
+            }
+            let Some(source_id) = modifier.id.as_function() else { continue };
+            let target_id = self.virtual_function_target(source_id);
+            if let Some(body) = self.gcx.hir.function(target_id).body {
+                self.collect_assigned_vars_block(&body);
+            }
+        }
+    }
+
+    /// Lowers the nested modifier expansion represented by `modifiers`. Each
+    /// `_` invokes this continuation again, so conditional, repeated, and absent
+    /// placeholders naturally retain Solidity's control-flow semantics.
+    fn lower_modifier_chain(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        modifiers: &'gcx [hir::Modifier<'gcx>],
+        body: hir::Block<'gcx>,
+        return_vars: &'gcx [VariableId],
+    ) {
+        let Some((modifier, rest)) = modifiers.split_first() else {
+            self.lower_modifier_function_body(builder, body, return_vars);
+            return;
+        };
+        let Some(source_id) = modifier.id.as_function() else {
+            self.lower_modifier_chain(builder, rest, body, return_vars);
+            return;
+        };
+
+        let target_id = self.virtual_function_target(source_id);
+        let target = self.gcx.hir.function(target_id);
+        let parameters = target.parameters;
+        let Some(modifier_body) = target.body else {
+            let guar = self
+                .gcx
+                .dcx()
+                .err("codegen cannot lower an unimplemented modifier")
+                .span(modifier.span)
+                .emit();
+            builder.error_value(guar);
+            builder.invalid();
+            return;
+        };
+
+        let args = match self.ordered_args_for(
+            &modifier.args,
+            Some(CallableParamSource::Function { id: source_id, skips_receiver: false }),
+        ) {
+            Ok(args) => args,
+            Err(guar) => {
+                builder.error_value(guar);
+                builder.invalid();
+                return;
+            }
+        };
+        if args.len() != parameters.len() {
+            let guar = self
+                .gcx
+                .dcx()
+                .err("wrong number of modifier arguments in codegen")
+                .span(modifier.span)
+                .emit();
+            builder.error_value(guar);
+            builder.invalid();
+            return;
+        }
+
+        // Evaluate every invocation argument in the enclosing scope before the
+        // modifier parameters with potentially identical HIR IDs are rebound.
+        let values = args
+            .into_iter()
+            .zip(parameters)
+            .map(|(arg, &param_id)| {
+                if self.param_is_storage_ref(param_id)
+                    && let Some(slot) = self.lower_lvalue_slot(builder, arg)
+                {
+                    slot
+                } else {
+                    let param = self.gcx.hir.variable(param_id);
+                    let value = if self.var_expects_memory_bytes_value(param) {
+                        self.lower_expr_as_memory_bytes(builder, arg)
+                    } else if self.var_expects_memory_dyn_array_value(param) {
+                        self.lower_expr_as_memory_dyn_array(builder, arg)
+                    } else {
+                        self.lower_value_expr(builder, arg)
+                    };
+                    self.coerce_arg_for_param(builder, param_id, arg, value)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let saved_bindings = self.local_bindings();
+        for (&param_id, value) in parameters.iter().zip(values) {
+            let param = self.gcx.hir.variable(param_id);
+            if Self::calldata_dynamic_var_kind(param).is_some() && self.is_var_assigned(&param_id) {
+                let offset = self.alloc_local_slice_memory(param_id);
+                self.store_slice_slot(builder, offset, value);
+            } else {
+                self.bind_param_value(builder, param_id, value);
+            }
+            if self.param_is_storage_ref(param_id) {
+                self.storage_ref_locals.insert(param_id);
+            }
+        }
+
+        let exit_block = builder.create_block();
+        let saved_inline_returns = self.inline_returns.take();
+        let saved_pending_inline_returns = self.pending_inline_returns.take();
+        let saved_continuation = self.modifier_continuation.replace(ModifierContinuation {
+            modifiers: rest,
+            body,
+            return_vars,
+        });
+        let saved_in_unchecked_block = self.in_unchecked_block;
+        self.inline_returns = Some(InlineReturnCtx { exit_block, return_vars: Vec::new() });
+        self.in_unchecked_block = false;
+
+        self.lower_block(builder, &modifier_body);
+        if !builder.func().block(builder.current_block()).is_terminated() {
+            builder.jump(exit_block);
+        }
+        builder.switch_to_block(exit_block);
+
+        self.in_unchecked_block = saved_in_unchecked_block;
+        self.modifier_continuation = saved_continuation;
+        self.inline_returns = saved_inline_returns;
+        self.pending_inline_returns = saved_pending_inline_returns;
+        self.restore_local_bindings(saved_bindings);
+    }
+
+    /// Lowers one substitution of the function body. Returns join back into the
+    /// enclosing modifier so code after `_` still executes before the function's
+    /// final return is emitted.
+    fn lower_modifier_function_body(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        body: hir::Block<'gcx>,
+        return_vars: &'gcx [VariableId],
+    ) {
+        let saved_bindings = self.local_bindings();
+        let exit_block = builder.create_block();
+        let saved_inline_returns = self.inline_returns.take();
+        let saved_pending_inline_returns = self.pending_inline_returns.take();
+        let saved_continuation = self.modifier_continuation.take();
+        let saved_in_unchecked_block = self.in_unchecked_block;
+        self.inline_returns =
+            Some(InlineReturnCtx { exit_block, return_vars: return_vars.to_vec() });
+        self.in_unchecked_block = false;
+
+        self.lower_block(builder, &body);
+        if !builder.func().block(builder.current_block()).is_terminated() {
+            builder.jump(exit_block);
+        }
+        builder.switch_to_block(exit_block);
+
+        self.in_unchecked_block = saved_in_unchecked_block;
+        self.modifier_continuation = saved_continuation;
+        self.inline_returns = saved_inline_returns;
+        self.pending_inline_returns = saved_pending_inline_returns;
+        self.restore_local_bindings(saved_bindings);
+    }
+
+    /// Substitutes the active continuation at a modifier placeholder.
+    pub(super) fn lower_modifier_placeholder(&mut self, builder: &mut FunctionBuilder<'_>) {
+        if let Some(continuation) = self.modifier_continuation {
+            self.lower_modifier_chain(
+                builder,
+                continuation.modifiers,
+                continuation.body,
+                continuation.return_vars,
+            );
+        }
     }
 
     /// Reverts when calldata does not contain the complete ABI head.

--- a/crates/codegen/src/lower/stmt.rs
+++ b/crates/codegen/src/lower/stmt.rs
@@ -82,7 +82,10 @@ impl<'gcx> Lowerer<'gcx> {
         builder: &mut FunctionBuilder<'_>,
         args: &hir::CallArgs<'_>,
     ) -> bool {
-        if self.current_return_tys.len() != 1 {
+        // An inlined return must jump through its join so modifier suffixes (or
+        // the surrounding inline call) resume before the enclosing function
+        // returns. The normal declaration/return path handles that control flow.
+        if self.inline_returns.is_some() || self.current_return_tys.len() != 1 {
             return false;
         }
         let ty = self.current_return_tys[0];
@@ -160,7 +163,7 @@ impl<'gcx> Lowerer<'gcx> {
                 }
             }
 
-            StmtKind::Placeholder => {}
+            StmtKind::Placeholder => self.lower_modifier_placeholder(builder),
 
             StmtKind::UncheckedBlock(block) => self.lower_unchecked_block(builder, block),
 
@@ -882,9 +885,11 @@ impl<'gcx> Lowerer<'gcx> {
         let mut values = Vec::with_capacity(n);
         if let Some(expr) = value {
             if let hir::ExprKind::Tuple(elements) = &expr.kind {
-                for elem in elements.iter().flatten() {
-                    values.push(self.lower_value_expr(builder, elem));
+                for (elem, &ret_id) in elements.iter().flatten().zip(&ctx.return_vars) {
+                    values.push(self.lower_inline_return_value(builder, elem, ret_id));
                 }
+            } else if let [ret_id] = ctx.return_vars.as_slice() {
+                values.push(self.lower_inline_return_value(builder, expr, *ret_id));
             } else {
                 self.pending_inline_returns = None;
                 let first = self.lower_value_expr(builder, expr);
@@ -920,6 +925,25 @@ impl<'gcx> Lowerer<'gcx> {
             }
         }
         builder.jump(ctx.exit_block);
+    }
+
+    /// Lowers a value stored into an inlined return slot. Calldata slices stay
+    /// logical slices for the specialized inline-call path; every other return
+    /// uses the function-return coercions, including materializing byte-string
+    /// literals before a modifier suffix resumes.
+    fn lower_inline_return_value(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        expr: &hir::Expr<'_>,
+        ret_id: hir::VariableId,
+    ) -> ValueId {
+        let ret = self.gcx.hir.variable(ret_id);
+        if Self::calldata_dynamic_var_kind(ret).is_some() {
+            self.lower_value_expr(builder, expr)
+        } else {
+            let ty = self.gcx.type_of_item(ret_id.into());
+            self.lower_return_value_for_ty(builder, expr, ty)
+        }
     }
 
     /// Gets the tuple arity if this is a ternary expression with tuple branches.

--- a/tests/ui/codegen/lowering/modifiers.sol
+++ b/tests/ui/codegen/lowering/modifiers.sol
@@ -1,5 +1,6 @@
 //@ compile-flags: -Zcodegen -O none -Zdump=mir
 //@ filecheck:
+//@ normalize-stdout-test: "\n(\n)$" -> "$1"
 
 contract ModifierLowering {
     uint256 private value;

--- a/tests/ui/codegen/lowering/modifiers.sol
+++ b/tests/ui/codegen/lowering/modifiers.sol
@@ -1,0 +1,35 @@
+//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ filecheck:
+
+contract ModifierLowering {
+    uint256 private value;
+
+    modifier outer(uint256 argument) {
+        require(argument != 0);
+        value = 1;
+        _;
+        value = 5;
+    }
+
+    modifier inner() {
+        value = 2;
+        _;
+        value = 4;
+    }
+
+    // CHECK-LABEL: fn @run{{[(]}}
+    // CHECK: sstore 0, 1
+    // CHECK-NEXT: sstore 0, 2
+    // CHECK-NEXT: sstore 0, 3
+    // CHECK: mstore 128,
+    // CHECK-NEXT: jump [[INNER_SUFFIX:bb[0-9]+]]
+    // CHECK: [[OUTER_SUFFIX:bb[0-9]+]]:
+    // CHECK-NEXT: sstore 0, 5
+    // CHECK: [[INNER_SUFFIX]]:
+    // CHECK-NEXT: sstore 0, 4
+    // CHECK-NEXT: jump [[OUTER_SUFFIX]]
+    function run(uint256 argument) external outer(argument) inner returns (uint256) {
+        value = 3;
+        return value;
+    }
+}

--- a/tests/ui/codegen/lowering/modifiers.stdout
+++ b/tests/ui/codegen/lowering/modifiers.stdout
@@ -1,0 +1,56 @@
+// === ROOT/tests/ui/codegen/lowering/modifiers.sol:ModifierLowering ===
+@module ModifierLowering
+fn @outer(arg0: u256) {
+  bb0:
+    v0 = eq arg0, 0
+    v1 = iszero v0
+    v2 = iszero v1
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    sstore 0, 1 !metadata(storage=slot(0))
+    sstore 0, 5 !metadata(storage=slot(0))
+    stop
+}
+
+fn @inner() {
+  bb0:
+    sstore 0, 2 !metadata(storage=slot(0))
+    sstore 0, 4 !metadata(storage=slot(0))
+    stop
+}
+
+fn @run(arg0: u256) -> u256 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    mstore 128, 0
+    v3 = eq arg0, 0
+    v4 = iszero v3
+    v5 = iszero v4
+    jumpi v5, bb4, bb5
+  bb3:
+    v7 = mload 128
+    ret v7
+  bb4:
+    revert 0, 0
+  bb5:
+    sstore 0, 1 !metadata(storage=slot(0))
+    sstore 0, 2 !metadata(storage=slot(0))
+    sstore 0, 3 !metadata(storage=slot(0))
+    v6 = sload 0 !metadata(storage=slot(0))
+    mstore 128, v6
+    jump bb7
+  bb6:
+    sstore 0, 5 !metadata(storage=slot(0))
+    jump bb3
+  bb7:
+    sstore 0, 4 !metadata(storage=slot(0))
+    jump bb6
+}

--- a/tests/ui/codegen/run-call/modifier_calldata_return.sol
+++ b/tests/ui/codegen/run-call/modifier_calldata_return.sol
@@ -1,0 +1,27 @@
+//@ revisions: gas size
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: ModifierCalldataReturn::run(bytes) 0x0102 => 0x22ae6da6b482f9b1b19b0b897c3fd43884180a1c5ee361e1107a1bc635649dda, 7, 19
+
+contract ModifierCalldataReturn {
+    uint256 private trace;
+
+    modifier afterReturn() {
+        _;
+        trace = trace * 10 + 9;
+    }
+
+    function target(bytes calldata input)
+        internal
+        afterReturn
+        returns (bytes calldata, uint256)
+    {
+        trace = 1;
+        return (input, 7);
+    }
+
+    function run(bytes calldata input) external returns (bytes32, uint256, uint256) {
+        (bytes calldata result, uint256 value) = target(input);
+        return (keccak256(result), value, trace);
+    }
+}

--- a/tests/ui/codegen/run-call/modifiers.sol
+++ b/tests/ui/codegen/run-call/modifiers.sol
@@ -1,0 +1,393 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: ModifierRuntime::runOne() => 123
+//@ run-call: ModifierRuntime::runPublicTarget() => 123
+//@ run-call: ModifierRuntime::runTwo() => 12345
+//@ run-call: ModifierRuntime::runThree() => 1234567
+//@ run-call: ModifierRuntime::runRepeated() => 12367
+//@ run-call: ModifierRuntime::runArguments() => 123
+//@ run-call: ModifierRuntime::runArgumentTiming() => 12345
+//@ run-call: ModifierRuntime::runMutations() => 234
+//@ run-call: ModifierRuntime::runMemoryArgument() => 23
+//@ run-call: ModifierRuntime::runStorageArgument() => 12
+//@ run-call: ModifierRuntime::runTwice() => 12325
+//@ run-call: ModifierRuntime::runMaybe(bool) false => 13
+//@ run-call: ModifierRuntime::runMaybe(bool) true => 123
+//@ run-call: ModifierRuntime::runReturn() => 7, 19
+//@ run-call: ModifierRuntime::runReturnPair() => 7, 8, 19
+//@ run-call: ModifierRuntime::runMemoryReturn() => 0x22ae6da6b482f9b1b19b0b897c3fd43884180a1c5ee361e1107a1bc635649dda, 19
+//@ run-call: ModifierRuntime::runPackedHashReturn() => 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6, 19
+//@ run-call: ModifierRuntime::runSkip() => 1
+//@ run-call: ModifierRuntime::runNestedSkip() => 19
+//@ run-call-fail: ModifierRuntime::reject(uint256) 0
+//@ run-call: ModifierRuntime::reject(uint256) 1 => 1
+//@ run-call-fail: ModifierRuntime::returnThroughRejectingSuffix()
+//@ run-call: ModifiedConstructor::trace(); constructor=[1] => 123
+//@ run-call: ModifiedDerivedConstructor::trace() => 123
+//@ run-call: DerivedModifier::run() => 327
+//@ run-call: SpecialFunctionModifiers::runFallback() => 123
+//@ run-call: SpecialFunctionModifiers::runReceive(); value=1 => 123
+
+contract ModifierRuntime {
+    uint256 private trace;
+    uint256 private counter;
+    uint256[] private values;
+
+    modifier around(uint256 before_, uint256 after_) {
+        mark(before_);
+        _;
+        mark(after_);
+    }
+
+    modifier capture(uint256 first, uint256 second) {
+        mark(first);
+        mark(second);
+        _;
+    }
+
+    modifier prefix(uint256, uint256 digit) {
+        mark(digit);
+        _;
+    }
+
+    modifier mutate(uint256 value) {
+        value++;
+        mark(value);
+        uint256 local = 3;
+        local++;
+        _;
+        mark(local);
+    }
+
+    modifier memoryLength(bytes memory data) {
+        mark(data.length);
+        _;
+    }
+
+    modifier storageFirst(uint256[] storage data) {
+        mark(data[0]);
+        _;
+    }
+
+    modifier twice() {
+        mark(1);
+        _;
+        mark(3);
+        _;
+        mark(5);
+    }
+
+    modifier maybe(bool run) {
+        mark(1);
+        if (run) {
+            _;
+        }
+        mark(3);
+    }
+
+    modifier afterReturn() {
+        _;
+        mark(9);
+    }
+
+    modifier skip() {
+        mark(1);
+        return;
+        _;
+    }
+
+    modifier nonzero(uint256 value) {
+        require(value != 0);
+        _;
+    }
+
+    modifier rejectingSuffix() {
+        _;
+        revert();
+    }
+
+    function mark(uint256 value) internal {
+        trace = trace * 10 + value;
+    }
+
+    function next() internal returns (uint256) {
+        counter++;
+        return counter;
+    }
+
+    function markArgument(uint256 value) internal returns (uint256) {
+        mark(value);
+        return value;
+    }
+
+    function targetOne() internal around(1, 3) {
+        mark(2);
+    }
+
+    function runOne() external returns (uint256) {
+        targetOne();
+        return trace;
+    }
+
+    function publicTarget() public around(1, 3) {
+        mark(2);
+    }
+
+    function runPublicTarget() external returns (uint256) {
+        publicTarget();
+        return trace;
+    }
+
+    function targetTwo() internal around(1, 5) around(2, 4) {
+        mark(3);
+    }
+
+    function runTwo() external returns (uint256) {
+        targetTwo();
+        return trace;
+    }
+
+    function targetThree() internal around(1, 7) around(2, 6) around(3, 5) {
+        mark(4);
+    }
+
+    function runThree() external returns (uint256) {
+        targetThree();
+        return trace;
+    }
+
+    function targetRepeated() internal around(1, 7) around(2, 6) {
+        mark(3);
+    }
+
+    function runRepeated() external returns (uint256) {
+        targetRepeated();
+        return trace;
+    }
+
+    function targetArguments() internal capture(next(), next()) {
+        mark(3);
+    }
+
+    function runArguments() external returns (uint256) {
+        targetArguments();
+        return trace;
+    }
+
+    function targetArgumentTiming()
+        internal
+        prefix(markArgument(1), 2)
+        prefix(markArgument(3), 4)
+    {
+        mark(5);
+    }
+
+    function runArgumentTiming() external returns (uint256) {
+        targetArgumentTiming();
+        return trace;
+    }
+
+    function targetMutations() internal mutate(1) {
+        mark(3);
+    }
+
+    function runMutations() external returns (uint256) {
+        targetMutations();
+        return trace;
+    }
+
+    function targetMemoryArgument() internal memoryLength(hex"0102") {
+        mark(3);
+    }
+
+    function runMemoryArgument() external returns (uint256) {
+        targetMemoryArgument();
+        return trace;
+    }
+
+    function targetStorageArgument() internal storageFirst(values) {
+        mark(2);
+    }
+
+    function runStorageArgument() external returns (uint256) {
+        values.push(1);
+        targetStorageArgument();
+        return trace;
+    }
+
+    function targetTwice() internal twice {
+        mark(2);
+    }
+
+    function runTwice() external returns (uint256) {
+        targetTwice();
+        return trace;
+    }
+
+    function targetMaybe(bool run) internal maybe(run) {
+        mark(2);
+    }
+
+    function runMaybe(bool run) external returns (uint256) {
+        targetMaybe(run);
+        return trace;
+    }
+
+    function targetReturn() internal afterReturn returns (uint256) {
+        mark(1);
+        return 7;
+    }
+
+    function runReturn() external returns (uint256, uint256) {
+        uint256 value = targetReturn();
+        return (value, trace);
+    }
+
+    function targetReturnPair() internal afterReturn returns (uint256, uint256) {
+        mark(1);
+        return (7, 8);
+    }
+
+    function runReturnPair() external returns (uint256, uint256, uint256) {
+        (uint256 first, uint256 second) = targetReturnPair();
+        return (first, second, trace);
+    }
+
+    function targetMemoryReturn() internal afterReturn returns (bytes memory) {
+        mark(1);
+        return hex"0102";
+    }
+
+    function runMemoryReturn() external returns (bytes32, uint256) {
+        bytes memory result = targetMemoryReturn();
+        return (keccak256(result), trace);
+    }
+
+    function targetPackedHashReturn() internal afterReturn returns (bytes32) {
+        mark(1);
+        bytes memory encoded = abi.encodePacked(uint256(1));
+        return keccak256(encoded);
+    }
+
+    function runPackedHashReturn() external returns (bytes32, uint256) {
+        bytes32 result = targetPackedHashReturn();
+        return (result, trace);
+    }
+
+    function targetSkip() internal skip {
+        mark(2);
+    }
+
+    function runSkip() external returns (uint256) {
+        targetSkip();
+        return trace;
+    }
+
+    function targetNestedSkip() internal afterReturn skip {
+        mark(2);
+    }
+
+    function runNestedSkip() external returns (uint256) {
+        targetNestedSkip();
+        return trace;
+    }
+
+    function reject(uint256 value) external pure nonzero(value) returns (uint256) {
+        return value;
+    }
+
+    function returnThroughRejectingSuffix() external pure rejectingSuffix returns (uint256) {
+        return 1;
+    }
+}
+
+contract ModifiedConstructor {
+    uint256 public trace;
+
+    modifier aroundConstruction(uint256 start) {
+        trace = start;
+        _;
+        trace = trace * 10 + 3;
+    }
+
+    constructor(uint256 start) aroundConstruction(start) {
+        trace = trace * 10 + 2;
+    }
+}
+
+contract ModifiedBaseConstructor {
+    uint256 public trace;
+
+    modifier aroundConstruction(uint256 start) {
+        trace = start;
+        _;
+        trace = trace * 10 + 3;
+    }
+
+    constructor(uint256 start) aroundConstruction(start) {
+        trace = trace * 10 + 2;
+    }
+}
+
+contract ModifiedDerivedConstructor is ModifiedBaseConstructor {
+    constructor() ModifiedBaseConstructor(1) {}
+}
+
+contract BaseModifier {
+    uint256 internal trace;
+
+    modifier decorated() virtual {
+        trace = 1;
+        _;
+        trace = trace * 10 + 9;
+    }
+
+    function target() internal decorated {
+        trace = trace * 10 + 2;
+    }
+}
+
+contract DerivedModifier is BaseModifier {
+    modifier decorated() override {
+        trace = 3;
+        _;
+        trace = trace * 10 + 7;
+    }
+
+    function run() external returns (uint256) {
+        target();
+        return trace;
+    }
+}
+
+contract SpecialFunctionModifiers {
+    uint256 private trace;
+
+    modifier aroundCall() {
+        trace = 1;
+        _;
+        trace = trace * 10 + 3;
+    }
+
+    fallback() external aroundCall {
+        trace = trace * 10 + 2;
+    }
+
+    receive() external payable aroundCall {
+        trace = trace * 10 + 2;
+    }
+
+    function runFallback() external returns (uint256) {
+        (bool success,) = address(this).call(hex"deadbeef");
+        require(success);
+        return trace;
+    }
+
+    function runReceive() external payable returns (uint256) {
+        (bool success,) = address(this).call{value: msg.value}("");
+        require(success);
+        return trace;
+    }
+}


### PR DESCRIPTION
Function modifier invocations are present in HIR, but codegen currently lowers only the function body and treats each `_` placeholder as a no-op. Guards, prefixes, and suffixes can therefore be silently skipped while compilation still succeeds.

This expands modifier invocations as nested MIR continuations, preserving argument timing, lexical bindings across repeated substitutions, explicit-return joins, conditional and multiple placeholders, constructors, virtual overrides, public internal copies, and calldata-slice returns.

CodSpeed flags only the synthetic `many_modifiers_small/codegen` case; the other 148 measured benchmarks are unchanged. Exact local Criterion measurement is 124.83 µs on the base and 255.72 µs on this branch. The base emits only 90 bytes because it omits all ten `require` paths, while this branch emits 368 bytes; writing the same checks inline emits byte-for-byte identical code in 233.89 µs. Raw source-to-MIR work moves only from 56.83 to 60.41 µs, attributing almost all of the increase to optimizing the restored control flow rather than modifier bookkeeping. The runtime corpus's size increases are likewise modifier-bearing paths that were previously absent, and all 15 measured hot-gas workloads are unchanged.

### How this was found

The automatic differential in #1084 compiled the same `pure` fixture with solc and this compiler, then used Foundry's symbolic EVM to search for a success/revert or exact-result difference. It found `one(0)`, which reverted with `Error("zero")` under solc but returned `0` under this compiler because the modifier guard was skipped; Foundry replay and a separate fresh-Anvil replay both confirmed the witness.