### PR TITLE
fix(codegen): mask packed signed fields

### DIFF
--- a/crates/codegen/src/lower/abi_packed.rs
+++ b/crates/codegen/src/lower/abi_packed.rs
@@ -6,7 +6,7 @@ use crate::{
     mir::{FunctionBuilder, MemoryObjectKind, Value, ValueId},
 };
 use alloy_primitives::U256;
-use solar_ast::{ElementaryType, LitKind};
+use solar_ast::{ElementaryType, LitKind, TypeSize};
 use solar_interface::{Symbol, diagnostics::ErrorGuaranteed, sym};
 use solar_sema::{
     builtins::Builtin,
@@ -18,7 +18,7 @@ enum PackedAbiArg {
     /// Compile-time literal bytes, packed without padding.
     Bytes(Vec<u8>),
     /// A single value occupying the top `size` bytes of its word.
-    Value { value: ValueId, size: usize, left_aligned: bool },
+    Value { value: ValueId, size: usize, left_aligned: bool, signed: bool },
     /// A memory `bytes`/`string` pointer (`[length][data...]`) whose data is
     /// copied without padding.
     DynamicBytes(ValueId),
@@ -214,8 +214,9 @@ impl<'gcx> Lowerer<'gcx> {
 
             let size = self.get_packed_size_from_expr(arg, ty);
             let left_aligned = self.expr_is_fixed_bytes(arg);
+            let signed = ty.is_signed();
             let value = self.lower_value_expr(builder, arg);
-            packed_args.push(PackedAbiArg::Value { value, size, left_aligned });
+            packed_args.push(PackedAbiArg::Value { value, size, left_aligned, signed });
         }
 
         Ok(packed_args)
@@ -314,7 +315,7 @@ impl<'gcx> Lowerer<'gcx> {
                     builder.mstore(dest, value);
                     offset += size as u64;
                 }
-                &PackedAbiArg::Value { value, size, left_aligned } => {
+                &PackedAbiArg::Value { value, size, left_aligned, .. } => {
                     // Less than 32 bytes: the word's top `size` bytes are
                     // written. Fixed-bytes values are already left-aligned;
                     // every other value type is right-aligned and shifts up.
@@ -394,7 +395,7 @@ impl<'gcx> Lowerer<'gcx> {
                     len += bytes.len();
                     consumed += 1;
                 }
-                &PackedAbiArg::Value { value, size, left_aligned: false } if size < 32 => {
+                &PackedAbiArg::Value { value, size, left_aligned: false, signed } if size < 32 => {
                     if size == 0 {
                         consumed += 1;
                         continue;
@@ -403,7 +404,7 @@ impl<'gcx> Lowerer<'gcx> {
                         break;
                     }
                     let shift = (32 - len - size) * 8;
-                    terms.push((value, shift));
+                    terms.push((value, shift, size, signed));
                     len += size;
                     consumed += 1;
                 }
@@ -416,7 +417,12 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         let mut value = builder.imm_u256(const_word);
-        for (term, shift) in terms {
+        for (term, shift, size, signed) in terms {
+            let term = if signed {
+                self.mask_to_bits(builder, term, TypeSize::new_int_bits((size * 8) as u16))
+            } else {
+                term
+            };
             let shifted = if shift == 0 {
                 term
             } else {

--- a/crates/codegen/src/lower/abi_packed.rs
+++ b/crates/codegen/src/lower/abi_packed.rs
@@ -214,7 +214,7 @@ impl<'gcx> Lowerer<'gcx> {
 
             let size = self.get_packed_size_from_expr(arg, ty);
             let left_aligned = self.expr_is_fixed_bytes(arg);
-            let signed = ty.is_signed();
+            let signed = matches!(self.lower_type_from_ty(ty), crate::mir::MirType::Int(_));
             let value = self.lower_value_expr(builder, arg);
             packed_args.push(PackedAbiArg::Value { value, size, left_aligned, signed });
         }

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol
@@ -29,4 +29,19 @@ contract AbiEncodePackedMixed {
     function materialized(uint16 a, bytes memory mid, bool b) external pure returns (bytes memory) {
         return abi.encodePacked(a, mid, b);
     }
+
+    // Signed packed values are sign-extended words. Coalescing them with a
+    // preceding field must mask the sign extension before shifting, or the
+    // high bits overwrite that field.
+    // CHECK-LABEL: fn @signedStaticRun{{[( ]}}
+    // CHECK: [[CLEAN:v[0-9]+]] = and arg1, 0xffff
+    // CHECK: [[SIGNED:v[0-9]+]] = shl 232, [[CLEAN]]
+    // CHECK: keccak256 0, 6
+    function signedStaticRun(uint8 prefix, int16 value, bytes3 suffix)
+        external
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(prefix, value, suffix));
+    }
 }

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
@@ -124,3 +124,44 @@ fn @materialized(arg0: u16, arg1: memorybytes, arg2: bool) -> memorybytes [abi_r
     ret v19
 }
 
+fn @signedStaticRun(arg0: u8, arg1: i16, arg2: bytes3) -> bytes32 [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 96
+    jumpi v2, bb1, bb2
+  bb1:
+    revert 0, 0
+  bb2:
+    v3 = calldataload 4
+    v4 = and v3, 255
+    v5 = eq v3, v4
+    jumpi v5, bb4, bb3
+  bb3:
+    revert 0, 0
+  bb4:
+    v6 = calldataload 36
+    v7 = signextend 1, v6
+    v8 = eq v6, v7
+    jumpi v8, bb6, bb5
+  bb5:
+    revert 0, 0
+  bb6:
+    v9 = calldataload 68
+    v10 = and v9, 0xffffff0000000000000000000000000000000000000000000000000000000000
+    v11 = eq v9, v10
+    jumpi v11, bb8, bb7
+  bb7:
+    revert 0, 0
+  bb8:
+    v12 = shl 248, arg0
+    v13 = or 0, v12
+    v14 = and arg1, 0xffff
+    v15 = shl 232, v14
+    v16 = or v13, v15
+    mstore 0, v16 !metadata(memory=scratch)
+    mstore 3, arg2 !metadata(memory=scratch)
+    v17 = keccak256 0, 6 !metadata(memory=scratch)
+    ret v17
+}
+

--- a/tests/ui/codegen/run-call/abi_encode_packed_signed.sol
+++ b/tests/ui/codegen/run-call/abi_encode_packed_signed.sol
@@ -1,7 +1,10 @@
 //@ run-call: firstByteInt8(uint8,int8) 0, -1 => 0x00
 //@ run-call: firstByteInt16(uint8,int16) 0, -1 => 0x00
 //@ run-call: firstByteInt32(uint8,int32) 0, -1 => 0x00
+//@ run-call: firstByteSigned16() => 0x00
 //@ run-call: packedHash(uint8,int16,bytes3) 0, -1, 0x000000 => 0xb6a3d3257d6e2bc9006a983edcb917248decccd41807b311f1d9317609a2bb05
+
+type Signed16 is int16;
 
 contract AbiEncodePackedSigned {
     function firstByteInt8(uint8 prefix, int8 value) external pure returns (bytes1) {
@@ -16,6 +19,11 @@ contract AbiEncodePackedSigned {
 
     function firstByteInt32(uint8 prefix, int32 value) external pure returns (bytes1) {
         bytes memory encoded = abi.encodePacked(prefix, value);
+        return encoded[0];
+    }
+
+    function firstByteSigned16() external pure returns (bytes1) {
+        bytes memory encoded = abi.encodePacked(uint8(0), Signed16.wrap(int16(-1)));
         return encoded[0];
     }
 

--- a/tests/ui/codegen/run-call/abi_encode_packed_signed.sol
+++ b/tests/ui/codegen/run-call/abi_encode_packed_signed.sol
@@ -1,0 +1,29 @@
+//@ run-call: firstByteInt8(uint8,int8) 0, -1 => 0x00
+//@ run-call: firstByteInt16(uint8,int16) 0, -1 => 0x00
+//@ run-call: firstByteInt32(uint8,int32) 0, -1 => 0x00
+//@ run-call: packedHash(uint8,int16,bytes3) 0, -1, 0x000000 => 0xb6a3d3257d6e2bc9006a983edcb917248decccd41807b311f1d9317609a2bb05
+
+contract AbiEncodePackedSigned {
+    function firstByteInt8(uint8 prefix, int8 value) external pure returns (bytes1) {
+        bytes memory encoded = abi.encodePacked(prefix, value);
+        return encoded[0];
+    }
+
+    function firstByteInt16(uint8 prefix, int16 value) external pure returns (bytes1) {
+        bytes memory encoded = abi.encodePacked(prefix, value);
+        return encoded[0];
+    }
+
+    function firstByteInt32(uint8 prefix, int32 value) external pure returns (bytes1) {
+        bytes memory encoded = abi.encodePacked(prefix, value);
+        return encoded[0];
+    }
+
+    function packedHash(uint8 prefix, int16 value, bytes3 suffix)
+        external
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(prefix, value, suffix));
+    }
+}


### PR DESCRIPTION
Static `abi.encodePacked` runs are coalesced into one word before being stored or hashed. Signed sub-word values arrive sign-extended; shifting them without first masking to their declared width lets the extension overwrite bytes belonging to earlier fields. For example, `abi.encodePacked(uint8(0), int16(-1), bytes3(0))` produced `ffffff000000` instead of `00ffff000000`, and the same contamination changed packed hashes.

This tracks signed packed arguments and masks only those terms before coalescing, leaving unsigned packing unchanged. The runtime regressions cover int8, int16, and int32 materialization and the in-place hash path.

The bug was found by the symbolic Solc-versus-Solar differential in #1084. Foundry produced a concrete witness, then its durable replay and an independent fresh-Anvil replay both confirmed the exact byte difference. Re-running the affected symbolic campaigns on this branch completed 21 of 21 functions with bounded agreement.

This PR was developed with AI assistance; the implementation, minimized reproduction, symbolic replays, and regression coverage were reviewed and executed by the author.
