### PR TITLE
fix(ci): remove benchmark concurrency

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,10 +2,6 @@ name: Benchmark
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Removes workflow-level concurrency from the Benchmark workflow so a newer push does not cancel benchmarks already in progress.

Validation: YAML syntax parsed successfully; `git diff --check` passed.

Prompted by: @DaniPopes