### PR TITLE
perf(codegen): aggregate checked add carries

### DIFF
--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -47,6 +47,76 @@ pub(super) enum DecodeStrategy<'gcx> {
 }
 
 impl<'gcx> Lowerer<'gcx> {
+    /// Collects the leaves of a checked `uint256` addition tree.
+    ///
+    /// This deliberately accepts only identifiers: reassociating an addition tree is
+    /// semantically valid for unsigned values, but lowering all leaves before checking the
+    /// aggregate carry must not move side effects across an arithmetic panic.
+    fn collect_checked_uint256_add_leaves<'hir>(
+        &self,
+        expr: &'hir hir::Expr<'hir>,
+        leaves: &mut Vec<&'hir hir::Expr<'hir>>,
+    ) -> bool {
+        let ExprKind::Binary(lhs, op, rhs) = &expr.kind else {
+            if matches!(expr.kind, ExprKind::Ident(_)) {
+                leaves.push(expr);
+                return true;
+            }
+            return false;
+        };
+        let Some(info) = self.integer_info_for_expr(expr) else { return false };
+        if op.kind != hir::BinOpKind::Add
+            || info.signed
+            || info.size.bits() != 256
+            || self.gcx.user_operator(expr.id).is_some()
+            || self.gcx.unsupported_udvt_operator(expr.id)
+        {
+            return false;
+        }
+        self.collect_checked_uint256_add_leaves(lhs, leaves)
+            && self.collect_checked_uint256_add_leaves(rhs, leaves)
+    }
+
+    /// Lowers a checked `uint256` addition tree with one aggregate overflow branch.
+    fn lower_checked_uint256_add_tree(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        expr: &hir::Expr<'_>,
+    ) -> Option<ValueId> {
+        if self.in_unchecked_block {
+            return None;
+        }
+        let mut leaves = Vec::new();
+        if !self.collect_checked_uint256_add_leaves(expr, &mut leaves) || leaves.len() < 3 {
+            return None;
+        }
+        if leaves.iter().enumerate().any(|(index, leaf)| {
+            let Some(res) = self.gcx.resolved_expr(leaf) else { return true };
+            leaves[..index].iter().any(|previous| self.gcx.resolved_expr(previous) == Some(res))
+        }) {
+            return None;
+        }
+
+        // Resolve leaves in source order, then consume them in reverse order. Locals are commonly
+        // produced in source order, so this gives the stack scheduler shallow operands while
+        // preserving expression evaluation order.
+        let mut values =
+            leaves.into_iter().map(|leaf| self.lower_value_expr(builder, leaf)).collect::<Vec<_>>();
+        let mut sum = values.pop().unwrap();
+        let next = values.pop().unwrap();
+        let new_sum = builder.add(sum, next);
+        let mut overflow = builder.lt(new_sum, sum);
+        sum = new_sum;
+        while let Some(next) = values.pop() {
+            let new_sum = builder.add(sum, next);
+            let carry = builder.lt(new_sum, sum);
+            overflow = builder.or(overflow, carry);
+            sum = new_sum;
+        }
+        self.emit_panic_if(builder, overflow, PanicCode::ArithmeticOverflowUnderflow);
+        Some(sum)
+    }
+
     /// Lowers an expression, preserving whether it produces one MIR value.
     pub(super) fn lower_expr(
         &mut self,
@@ -124,6 +194,11 @@ impl<'gcx> Lowerer<'gcx> {
             }
 
             ExprKind::Binary(lhs, op, rhs) => {
+                if op.kind == hir::BinOpKind::Add
+                    && let Some(result) = self.lower_checked_uint256_add_tree(builder, expr)
+                {
+                    return result;
+                }
                 // Constant operations are not special-cased here: lowering
                 // emits the plain instruction and the MIR pass pipeline folds
                 // it uniformly, with checked-arithmetic semantics intact.

--- a/crates/codegen/src/lower/expr.rs
+++ b/crates/codegen/src/lower/expr.rs
@@ -90,12 +90,6 @@ impl<'gcx> Lowerer<'gcx> {
         if !self.collect_checked_uint256_add_leaves(expr, &mut leaves) || leaves.len() < 3 {
             return None;
         }
-        if leaves.iter().enumerate().any(|(index, leaf)| {
-            let Some(res) = self.gcx.resolved_expr(leaf) else { return true };
-            leaves[..index].iter().any(|previous| self.gcx.resolved_expr(previous) == Some(res))
-        }) {
-            return None;
-        }
 
         // Resolve leaves in source order, then consume them in reverse order. Locals are commonly
         // produced in source order, so this gives the stack scheduler shallow operands while

--- a/tests/ui/codegen/lowering/checked_add_tree.sol
+++ b/tests/ui/codegen/lowering/checked_add_tree.sol
@@ -1,0 +1,14 @@
+//@ run-call: left 1, 2, 3, 4 => 10
+//@ run-call: right 1, 2, 3, 4 => 10
+//@ run-call-fail: left 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0, 1, 0 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
+//@ run-call-fail: right 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 0 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
+
+contract CheckedAddTree {
+    function left(uint256 a, uint256 b, uint256 c, uint256 d) external pure returns (uint256) {
+        return a + b + c + d;
+    }
+
+    function right(uint256 a, uint256 b, uint256 c, uint256 d) external pure returns (uint256) {
+        return a + (b + (c + d));
+    }
+}

--- a/tests/ui/codegen/lowering/multi_return.stdout
+++ b/tests/ui/codegen/lowering/multi_return.stdout
@@ -62,20 +62,15 @@ fn @triple(arg0: u256) -> (u256, u256, u256) [abi_returns=[word, word, word]] {
   bb4:
     v5 = add arg0, arg0
     v6 = lt v5, arg0
-    jumpi v6, bb5, bb6
+    v7 = add v5, arg0
+    v8 = lt v7, v5
+    v9 = or v6, v8
+    jumpi v9, bb5, bb6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb6:
-    v7 = add v5, arg0
-    v8 = lt v7, v5
-    jumpi v8, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb8:
     ret arg0, v3, v7
 }
 

--- a/tests/ui/codegen/lowering/stack-too-deep/call_args.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/call_args.sol
@@ -6,9 +6,7 @@ pragma solidity ^0.8.0;
 contract StackTooDeepCall {
     // CHECK-LABEL: @module runtime
     // CHECK: push 0x2b096926
-    // CHECK: eq
-    // CHECK-NEXT: push [[BODY:bb[0-9]+]]
-    // CHECK: [[BODY]]:
+    // CHECK: sub
     // CHECK: push 1{{$}}
     // CHECK-NEXT: push 4
     // CHECK-NEXT: calldataload

--- a/tests/ui/codegen/lowering/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/call_args.stdout
@@ -2,7 +2,7 @@
 // === deployment ===
 @module deployment
 bb0:
-  push 863
+  push 680
   dup1
   push 10
   push 0
@@ -13,7 +13,7 @@ bb0:
 // === runtime ===
 @module runtime
 bb0:
-  push 0x600
+  push 0x5e0
   push 64
   mstore
   callvalue
@@ -25,27 +25,9 @@ bb0:
   shr
   dup1
   push 0x2b096926
-  eq
-  push bb4
+  sub
+  push bb3
   jumpi
-  jump bb3
-bb3 [cold]:
-  push 0
-  dup1
-  revert
-bb49 [cold]:
-  push 0x4e487b71
-  push 224
-  shl
-  push 0
-  mstore
-  push 17
-  push 4
-  mstore
-  push 36
-  push 0
-  revert
-bb4:
   calldatasize
   push 4
   swap1
@@ -64,7 +46,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 2
   push 4
@@ -76,7 +58,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 3
   push 4
@@ -88,7 +70,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 4
   dup1
@@ -100,7 +82,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 5
   push 4
@@ -112,7 +94,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 6
   push 4
@@ -124,7 +106,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 7
   push 4
@@ -136,7 +118,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 8
   push 4
@@ -148,7 +130,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 9
   push 4
@@ -160,7 +142,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 10
   push 4
@@ -172,7 +154,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 11
   push 4
@@ -184,7 +166,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 12
   push 4
@@ -196,7 +178,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 13
   push 4
@@ -208,7 +190,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 14
   push 4
@@ -220,7 +202,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 15
   push 4
@@ -232,7 +214,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 16
   push 4
@@ -244,7 +226,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 17
   push 4
@@ -256,7 +238,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 18
   push 4
@@ -268,7 +250,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 19
   push 4
@@ -280,266 +262,195 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
-  push 4
-  calldataload
-  push 800
-  mstore
-  push 608
-  push 160
-  push 832
+  push 384
+  dup1
+  push 0x420
   mcopy
   push bb25
-  push 832
+  push 4
+  calldataload
+  push 160
   mload
-  push 800
+  push 192
   mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 800
+  push 224
   mload
-  gt
-  push bb49
-  jumpi
-  push 864
+  push 256
   mload
-  push 0x5c0
+  push 288
   mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
+  push 320
   mload
-  gt
-  push bb49
-  jumpi
-  push 896
+  push 352
   mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 928
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 960
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 992
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x400
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x420
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x440
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x460
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x480
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x4a0
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x4c0
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x4e0
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x500
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x520
-  mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x540
-  mload
-  push 0x5e0
-  mload
-  add
-  dup1
-  push 0x5c0
-  mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
-  jumpi
   push 0x560
   mload
-  push 0x5c0
-  mload
-  add
-  dup1
-  push 0x5e0
-  mstore
-  push 0x5c0
-  mload
-  gt
-  push bb49
-  jumpi
   push 0x580
   mload
-  push 0x5e0
+  add
+  push 0x580
   mload
+  dup2
+  lt
+  push 0x540
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x520
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x500
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x4e0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x4c0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x4a0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x480
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x460
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x440
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x420
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  swap2
+  dup2
   add
   dup1
   push 0x5c0
   mstore
-  push 0x5e0
-  mload
-  gt
-  push bb49
+  swap1
+  dup2
+  lt
+  swap1
+  swap2
+  or
+  push bb30
   jumpi
-  push 0x5c0
-  mload
   push 0x5a0
   mstore
   jump
@@ -554,3 +465,22 @@ bb25:
   push 32
   push 128
   return
+bb30 [cold]:
+  pop
+  jump bb31
+bb31 [cold]:
+  push 0x4e487b71
+  push 224
+  shl
+  push 0
+  mstore
+  push 17
+  push 4
+  mstore
+  push 36
+  push 0
+  revert
+bb3 [cold]:
+  push 0
+  dup1
+  revert

--- a/tests/ui/codegen/lowering/stack-too-deep/call_args.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/call_args.stdout
@@ -2,7 +2,7 @@
 // === deployment ===
 @module deployment
 bb0:
-  push 0x3f0
+  push 789
   dup1
   push 10
   push 0
@@ -13,7 +13,7 @@ bb0:
 // === runtime ===
 @module runtime
 bb0:
-  push 0x680
+  push 0x660
   push 64
   mstore
   callvalue
@@ -33,7 +33,7 @@ bb3 [cold]:
   push 0
   dup1
   revert
-bb49 [cold]:
+bb31 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -64,7 +64,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 2
   push 4
@@ -76,7 +76,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 3
   push 4
@@ -88,7 +88,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 4
   push 4
@@ -100,7 +100,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 5
   push 4
@@ -112,7 +112,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 6
   push 4
@@ -124,7 +124,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 7
   push 4
@@ -136,7 +136,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 8
   push 4
@@ -148,7 +148,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 9
   push 4
@@ -160,7 +160,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 10
   push 4
@@ -172,7 +172,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 11
   push 4
@@ -184,7 +184,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 12
   push 4
@@ -196,7 +196,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 13
   push 4
@@ -208,7 +208,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 14
   push 4
@@ -220,7 +220,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 15
   push 4
@@ -232,7 +232,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 16
   push 4
@@ -244,7 +244,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 17
   push 4
@@ -256,7 +256,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 18
   push 4
@@ -268,7 +268,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 19
   push 4
@@ -280,7 +280,7 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb31
   jumpi
   push 4
   calldataload
@@ -363,255 +363,164 @@ bb4:
   push 0x600
   mstore
   push bb25
-  push 960
-  mload
-  push 928
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 928
-  mload
-  gt
-  push bb49
-  jumpi
-  push 992
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x400
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x420
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x440
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x460
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x480
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x4a0
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x4c0
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x4e0
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x500
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x520
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x540
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x560
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x580
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x5a0
-  mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
-  push 0x5c0
-  mload
-  push 0x660
-  mload
-  add
-  dup1
-  push 0x640
-  mstore
-  push 0x660
-  mload
-  gt
-  push bb49
-  jumpi
   push 0x5e0
   mload
-  push 0x640
-  mload
-  add
-  dup1
-  push 0x660
-  mstore
-  push 0x640
-  mload
-  gt
-  push bb49
-  jumpi
   push 0x600
   mload
-  push 0x660
+  add
+  push 0x600
   mload
+  dup2
+  lt
+  push 0x5c0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x5a0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x580
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x560
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x540
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x520
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x500
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x4e0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x4c0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x4a0
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x480
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x460
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x440
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x420
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 0x400
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 992
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 960
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 928
+  mload
+  dup3
   add
   dup1
   push 0x640
   mstore
-  push 0x660
-  mload
-  gt
-  push bb49
+  swap2
+  dup3
+  lt
+  or
+  push bb31
   jumpi
-  push 0x640
-  mload
   push 0x620
   mstore
   jump

--- a/tests/ui/codegen/lowering/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/locals.stdout
@@ -2,7 +2,7 @@
 // === deployment ===
 @module deployment
 bb0:
-  push 842
+  push 665
   dup1
   push 10
   push 0
@@ -33,7 +33,7 @@ bb3 [cold]:
   push 0
   dup1
   revert
-bb49 [cold]:
+bb29 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -64,520 +64,423 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 2
   push 4
   calldataload
   add
   dup1
-  push 192
+  push 224
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 3
   push 4
   calldataload
   add
   dup1
-  push 224
+  push 256
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 4
   dup1
   calldataload
   add
   dup1
-  push 256
+  push 288
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 5
   push 4
   calldataload
   add
   dup1
-  push 288
+  push 320
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 6
   push 4
   calldataload
   add
   dup1
-  push 320
+  push 352
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 7
   push 4
   calldataload
   add
   dup1
-  push 352
+  push 384
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 8
   push 4
   calldataload
   add
   dup1
-  push 384
+  push 416
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 9
   push 4
   calldataload
   add
   dup1
-  push 416
+  push 448
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 10
   push 4
   calldataload
   add
   dup1
-  push 448
+  push 480
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 11
   push 4
   calldataload
   add
   dup1
-  push 480
+  push 512
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 12
   push 4
   calldataload
   add
   dup1
-  push 512
+  push 544
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 13
   push 4
   calldataload
   add
   dup1
-  push 544
+  push 576
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 14
   push 4
   calldataload
   add
   dup1
-  push 576
+  push 608
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 15
   push 4
   calldataload
   add
   dup1
-  push 608
+  push 640
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 16
   push 4
   calldataload
   add
   dup1
-  push 640
+  push 672
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 17
   push 4
   calldataload
   add
   dup1
-  push 672
+  push 704
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 18
   push 4
   calldataload
   add
   dup1
-  push 704
+  push 736
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 19
   push 4
   calldataload
   add
   dup1
-  push 736
+  push 768
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 20
   push 4
   calldataload
   add
   dup1
-  push 768
+  push 800
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 21
   push 4
   calldataload
   add
   dup1
+  push 192
+  mstore
+  push 4
+  calldataload
+  gt
+  push bb29
+  jumpi
   push 800
-  mstore
-  push 4
-  calldataload
-  gt
-  push bb49
-  jumpi
-  push 160
-  mload
-  push 4
-  calldataload
-  add
-  dup1
-  push 160
-  mstore
-  push 4
-  calldataload
-  gt
-  push bb49
-  jumpi
-  push 192
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 224
   mload
   push 192
   mload
   add
-  dup1
-  push 160
-  mstore
   push 192
   mload
-  gt
-  push bb49
-  jumpi
-  push 256
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 288
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 320
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 352
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 384
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 416
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 448
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 480
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 512
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 544
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 576
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 608
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 640
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 672
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 704
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 736
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
+  dup2
+  lt
   push 768
   mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 736
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 704
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 672
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 640
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 608
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 576
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 544
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 512
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 480
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 448
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 416
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 384
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 352
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 320
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 288
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 256
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 224
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
   push 160
   mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 4
+  calldataload
+  dup3
   add
   dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 800
-  mload
-  push 192
-  mload
-  add
-  dup1
   push 160
   mstore
-  push 192
-  mload
-  gt
-  push bb49
+  swap2
+  dup3
+  lt
+  or
+  swap1
+  pop
+  push bb29
   jumpi
   push 160
   mload

--- a/tests/ui/codegen/lowering/stack-too-deep/locals.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/locals.stdout
@@ -2,7 +2,7 @@
 // === deployment ===
 @module deployment
 bb0:
-  push 843
+  push 666
   dup1
   push 10
   push 0
@@ -33,7 +33,7 @@ bb3 [cold]:
   push 0
   dup1
   revert
-bb49 [cold]:
+bb29 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -64,520 +64,423 @@ bb4:
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 2
   push 4
   calldataload
   add
   dup1
-  push 192
+  push 224
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 3
   push 4
   calldataload
   add
   dup1
-  push 224
+  push 256
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 4
   push 4
   calldataload
   add
   dup1
-  push 256
+  push 288
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 5
   push 4
   calldataload
   add
   dup1
-  push 288
+  push 320
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 6
   push 4
   calldataload
   add
   dup1
-  push 320
+  push 352
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 7
   push 4
   calldataload
   add
   dup1
-  push 352
+  push 384
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 8
   push 4
   calldataload
   add
   dup1
-  push 384
+  push 416
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 9
   push 4
   calldataload
   add
   dup1
-  push 416
+  push 448
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 10
   push 4
   calldataload
   add
   dup1
-  push 448
+  push 480
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 11
   push 4
   calldataload
   add
   dup1
-  push 480
+  push 512
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 12
   push 4
   calldataload
   add
   dup1
-  push 512
+  push 544
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 13
   push 4
   calldataload
   add
   dup1
-  push 544
+  push 576
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 14
   push 4
   calldataload
   add
   dup1
-  push 576
+  push 608
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 15
   push 4
   calldataload
   add
   dup1
-  push 608
+  push 640
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 16
   push 4
   calldataload
   add
   dup1
-  push 640
+  push 672
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 17
   push 4
   calldataload
   add
   dup1
-  push 672
+  push 704
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 18
   push 4
   calldataload
   add
   dup1
-  push 704
+  push 736
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 19
   push 4
   calldataload
   add
   dup1
-  push 736
+  push 768
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 20
   push 4
   calldataload
   add
   dup1
-  push 768
+  push 800
   mstore
   push 4
   calldataload
   gt
-  push bb49
+  push bb29
   jumpi
   push 21
   push 4
   calldataload
   add
   dup1
+  push 192
+  mstore
+  push 4
+  calldataload
+  gt
+  push bb29
+  jumpi
   push 800
-  mstore
-  push 4
-  calldataload
-  gt
-  push bb49
-  jumpi
-  push 160
-  mload
-  push 4
-  calldataload
-  add
-  dup1
-  push 160
-  mstore
-  push 4
-  calldataload
-  gt
-  push bb49
-  jumpi
-  push 192
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 224
   mload
   push 192
   mload
   add
-  dup1
-  push 160
-  mstore
   push 192
   mload
-  gt
-  push bb49
-  jumpi
-  push 256
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 288
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 320
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 352
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 384
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 416
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 448
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 480
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 512
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 544
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 576
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 608
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 640
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 672
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
-  push 704
-  mload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 736
-  mload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb49
-  jumpi
+  dup2
+  lt
   push 768
   mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 736
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 704
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 672
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 640
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 608
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 576
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 544
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 512
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 480
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 448
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 416
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 384
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 352
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 320
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 288
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 256
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 224
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
   push 160
   mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 4
+  calldataload
+  dup3
   add
   dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb49
-  jumpi
-  push 800
-  mload
-  push 192
-  mload
-  add
-  dup1
   push 160
   mstore
-  push 192
-  mload
-  gt
-  push bb49
+  swap2
+  dup3
+  lt
+  or
+  swap1
+  pop
+  push bb29
   jumpi
   push 160
   mload

--- a/tests/ui/codegen/lowering/stack-too-deep/params.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/params.sol
@@ -6,16 +6,21 @@ pragma solidity ^0.8.0;
 contract StackTooDeepParams {
     // CHECK-LABEL: @module runtime
     // CHECK: push 0x8c4ee692
-    // CHECK: eq
-    // CHECK-NEXT: push [[BODY:bb[0-9]+]]
-    // CHECK: [[BODY]]:
+    // CHECK: sub
+    // CHECK-NEXT: push bb
+    // CHECK-NEXT: jumpi
+    // CHECK-NEXT: calldatasize
     // CHECK: push 640
     // CHECK-NEXT: sgt
-    // CHECK: push 36
+    // CHECK: push 580
     // CHECK-NEXT: calldataload
     // CHECK: push 612
     // CHECK-NEXT: calldataload
     // CHECK: add
+    // CHECK: push 36
+    // CHECK-NEXT: calldataload
+    // CHECK: or
+    // CHECK: jumpi
     // CHECK: return
     function sum(
         uint256 a0,

--- a/tests/ui/codegen/lowering/stack-too-deep/params.stdout
+++ b/tests/ui/codegen/lowering/stack-too-deep/params.stdout
@@ -2,7 +2,7 @@
 // === deployment ===
 @module deployment
 bb0:
-  push 426
+  push 266
   dup1
   push 10
   push 0
@@ -13,7 +13,7 @@ bb0:
 // === runtime ===
 @module runtime
 bb0:
-  push 224
+  push 192
   push 64
   mstore
   callvalue
@@ -25,15 +25,188 @@ bb0:
   shr
   dup1
   push 0x8c4ee692
-  eq
-  push bb4
+  sub
+  push bb3
   jumpi
-  jump bb3
+  calldatasize
+  push 4
+  swap1
+  sub
+  push 640
+  sgt
+  push bb3
+  jumpi
+  push 580
+  calldataload
+  push 612
+  calldataload
+  add
+  push 612
+  calldataload
+  dup2
+  lt
+  push 548
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 516
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 484
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 452
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 420
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 388
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 356
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 324
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 292
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 260
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 228
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 196
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 164
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 132
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 100
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 68
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 36
+  calldataload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 4
+  calldataload
+  dup3
+  add
+  dup1
+  push 160
+  mstore
+  swap2
+  dup3
+  lt
+  or
+  push bb8
+  jumpi
+  dup1
+  push 160
+  mstore
+  push 128
+  mstore
+  push 32
+  push 128
+  return
 bb3 [cold]:
   push 0
   dup1
   revert
-bb26 [cold]:
+bb8 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -45,266 +218,3 @@ bb26 [cold]:
   push 36
   push 0
   revert
-bb4:
-  calldatasize
-  push 4
-  swap1
-  sub
-  push 640
-  sgt
-  push bb3
-  jumpi
-  push 36
-  calldataload
-  push 4
-  calldataload
-  add
-  dup1
-  push 160
-  mstore
-  push 4
-  calldataload
-  gt
-  push bb26
-  jumpi
-  push 68
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 100
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 132
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 164
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 196
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 228
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 260
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 292
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 324
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 356
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 388
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 420
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 452
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 484
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 516
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 548
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 580
-  calldataload
-  push 160
-  mload
-  add
-  dup1
-  push 192
-  mstore
-  push 160
-  mload
-  gt
-  push bb26
-  jumpi
-  push 612
-  calldataload
-  push 192
-  mload
-  add
-  dup1
-  push 160
-  mstore
-  push 192
-  mload
-  gt
-  push bb26
-  jumpi
-  push 160
-  mload
-  push 128
-  mstore
-  push 32
-  push 128
-  return

--- a/tests/ui/codegen/lowering/static_frames.stdout
+++ b/tests/ui/codegen/lowering/static_frames.stdout
@@ -26,7 +26,7 @@ bb4 [cold]:
   push 0
   dup1
   revert
-bb70 [cold]:
+bb68 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -41,8 +41,8 @@ bb70 [cold]:
 bb5:
   push 0
   sload
-  jump bb72
-bb72:
+  jump bb70
+bb70:
   push 128
   mstore
   push 32
@@ -62,7 +62,7 @@ bb6:
   calldataload
   mul
   dup1
-  push 256
+  push 224
   mstore
   push 3
   dup2
@@ -73,7 +73,7 @@ bb6:
   swap1
   pop
   iszero
-  push bb70
+  push bb68
   jumpi
   push 4
   calldataload
@@ -90,7 +90,7 @@ bb6:
   push 448
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 512
   mload
@@ -100,7 +100,7 @@ bb6:
   mload
   push 704
   mstore
-  push bb20
+  push bb18
   push 704
   mload
   push 672
@@ -111,7 +111,7 @@ bb6:
   mstore
   push 960
   mstore
-  push bb25
+  push bb23
   push 0
   sload
   push 1
@@ -121,7 +121,7 @@ bb6:
   push 0x420
   mstore
   lt
-  push bb70
+  push bb68
   jumpi
   push 0x420
   mload
@@ -138,7 +138,7 @@ bb6:
   push 0x420
   mstore
   lt
-  push bb70
+  push bb68
   jumpi
   push 5
   push 960
@@ -157,7 +157,7 @@ bb9:
   push 480
   mload
   dup1
-  push 224
+  push 320
   mstore
   push 7
   push 4
@@ -192,8 +192,8 @@ bb9:
   pop
   pop
   push bb10
-  jump bb35
-bb35:
+  jump bb33
+bb33:
   push 160
   mload
   push 64
@@ -223,7 +223,7 @@ bb35:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 160
   mload
@@ -232,9 +232,9 @@ bb35:
   mload
   push 448
   mstore
-  push bb37
-  jump bb46
-bb46:
+  push bb35
+  jump bb44
+bb44:
   push 448
   mload
   push 1
@@ -251,7 +251,7 @@ bb46:
   swap1
   pop
   iszero
-  push bb70
+  push bb68
   jumpi
   push 1
   push 512
@@ -263,7 +263,7 @@ bb46:
   push 512
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 0
   sload
@@ -274,8 +274,8 @@ bb46:
   sstore
   push 0x3e8
   push 544
-  jump bb71
-bb71:
+  jump bb69
+bb69:
   mload
   mod
   push 480
@@ -288,11 +288,11 @@ bb10:
   add
   mload
   dup1
-  push 320
+  push 352
   mstore
-  push bb79
-  jump bb78
-bb78:
+  push bb77
+  jump bb76
+bb76:
   push 160
   mload
   push 64
@@ -312,11 +312,11 @@ bb11:
   add
   mload
   dup1
-  push 352
+  push 256
   mstore
-  push bb80
-  jump bb78
-bb20:
+  push bb78
+  jump bb76
+bb18:
   push 736
   mload
   dup1
@@ -339,7 +339,7 @@ bb20:
   pop
   pop
   iszero
-  push bb70
+  push bb68
   jumpi
   push 544
   mload
@@ -352,14 +352,14 @@ bb20:
   push 576
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 512
   mload
   push 480
   mstore
   jump
-bb25:
+bb23:
   push 992
   mload
   dup1
@@ -399,7 +399,7 @@ bb25:
   swap2
   pop
   pop
-  push bb70
+  push bb68
   jumpi
   push 864
   mload
@@ -421,7 +421,7 @@ bb25:
   swap1
   pop
   iszero
-  push bb70
+  push bb68
   jumpi
   push 864
   mload
@@ -434,7 +434,7 @@ bb25:
   push 768
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 832
   mload
@@ -447,14 +447,14 @@ bb25:
   push 800
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 768
   mload
   push 736
   mstore
   jump
-bb37:
+bb35:
   push 480
   mload
   dup1
@@ -475,15 +475,15 @@ bb37:
   push 64
   add
   mload
-  push bb40
-  jump bb74
-bb74:
+  push bb38
+  jump bb72
+bb72:
   jumpi
   push 160
   mload
   push 160
-  jump bb73
-bb73:
+  jump bb71
+bb71:
   add
   mload
   push 160
@@ -492,10 +492,10 @@ bb73:
   add
   mstore
   jump
-bb40:
-  push bb82
-  jump bb77
-bb77:
+bb38:
+  push bb80
+  jump bb75
+bb75:
   push 1
   push 160
   mload
@@ -517,7 +517,7 @@ bb77:
   mstore
   swap1
   jump
-bb42:
+bb40:
   push 160
   mload
   push 128
@@ -529,9 +529,9 @@ bb42:
   push 192
   add
   mstore
-  push bb83
-  jump bb78
-bb44:
+  push bb81
+  jump bb76
+bb42:
   push 480
   mload
   dup1
@@ -570,9 +570,9 @@ bb44:
   add
   mload
   gt
-  push bb70
-  jump bb74
-bb52:
+  push bb68
+  jump bb72
+bb50:
   push 480
   mload
   dup1
@@ -588,8 +588,8 @@ bb52:
   add
   mstore
   push 7
-  jump bb75
-bb75:
+  jump bb73
+bb73:
   dup2
   add
   dup1
@@ -605,9 +605,9 @@ bb75:
   add
   mstore
   lt
-  push bb70
-  jump bb74
-bb54:
+  push bb68
+  jump bb72
+bb52:
   push 160
   mload
   push 96
@@ -615,9 +615,9 @@ bb54:
   mload
   push 448
   mstore
-  push bb55
-  jump bb60
-bb60:
+  push bb53
+  jump bb58
+bb58:
   push 3
   push 448
   mload
@@ -633,7 +633,7 @@ bb60:
   swap1
   dup2
   lt
-  push bb70
+  push bb68
   jumpi
   dup1
   push 512
@@ -642,8 +642,8 @@ bb60:
   sstore
   push 97
   push 448
-  jump bb71
-bb55:
+  jump bb69
+bb53:
   push 480
   mload
   dup1
@@ -658,9 +658,9 @@ bb55:
   push 160
   add
   mstore
-  push bb85
-  jump bb77
-bb57:
+  push bb83
+  jump bb75
+bb55:
   push 160
   mload
   push 128
@@ -672,9 +672,9 @@ bb57:
   push 256
   add
   mstore
-  push bb86
-  jump bb78
-bb66:
+  push bb84
+  jump bb76
+bb64:
   push 160
   mload
   push 128
@@ -686,9 +686,9 @@ bb66:
   push 224
   add
   mstore
-  push bb87
-  jump bb78
-bb68:
+  push bb85
+  jump bb76
+bb66:
   push 13
   push 160
   mload
@@ -704,9 +704,9 @@ bb68:
   mstore
   pop
   jump
-bb79:
+bb77:
   dup1
-  push 320
+  push 352
   mstore
   push 5
   push 4
@@ -741,14 +741,14 @@ bb79:
   pop
   pop
   push bb11
-  jump bb50
-bb50:
+  jump bb48
+bb48:
   push 160
   mload
   push 64
   add
   mload
-  push bb54
+  push bb52
   jumpi
   push 160
   mload
@@ -757,15 +757,15 @@ bb50:
   mload
   push 448
   mstore
-  push bb52
-  jump bb60
-bb80:
+  push bb50
+  jump bb58
+bb78:
   dup1
-  push 352
+  push 256
   mstore
   push 0
   sload
-  push 256
+  push 224
   mload
   dup2
   add
@@ -775,62 +775,55 @@ bb80:
   lt
   swap1
   pop
-  push bb70
+  push bb68
   jumpi
   push 288
   mload
   push 0
   sstore
-  push 224
-  mload
-  push 256
-  mload
-  add
-  dup1
-  push 224
-  mstore
-  push 256
-  mload
-  gt
-  push bb70
-  jumpi
-  push 320
-  mload
-  push 224
-  mload
-  add
-  dup1
-  push 256
-  mstore
-  push 224
-  mload
-  gt
-  push bb70
-  jumpi
   push 352
   mload
   push 256
   mload
   add
+  push 256
+  mload
+  dup2
+  lt
+  push 320
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 224
+  mload
+  dup3
+  add
   dup1
   push 224
   mstore
-  push 256
-  mload
-  gt
-  push bb70
+  swap2
+  dup3
+  lt
+  or
+  swap1
+  pop
+  push bb68
   jumpi
   push 224
   mload
-  jump bb72
-bb81:
+  jump bb70
+bb79:
   push 288
   add
   push 64
   mstore
-  push bb42
-  jump bb35
-bb82:
+  push bb40
+  jump bb33
+bb80:
   push 1
   push 160
   mload
@@ -858,11 +851,11 @@ bb82:
   gt
   swap1
   pop
-  push bb70
+  push bb68
   jumpi
-  push bb81
-  jump bb76
-bb76:
+  push bb79
+  jump bb74
+bb74:
   push 64
   mload
   push 160
@@ -894,7 +887,7 @@ bb76:
   mstore
   swap1
   jump
-bb83:
+bb81:
   dup1
   push 160
   mload
@@ -928,7 +921,7 @@ bb83:
   gt
   swap1
   pop
-  push bb70
+  push bb68
   jumpi
   push 160
   mload
@@ -937,21 +930,21 @@ bb83:
   mload
   push 448
   mstore
-  push bb44
-  jump bb46
-bb84:
+  push bb42
+  jump bb44
+bb82:
   push 256
   add
   push 64
   mstore
-  push bb57
+  push bb55
   push 160
   mload
   push 64
   add
   mload
   iszero
-  push bb68
+  push bb66
   jumpi
   push 1
   push 160
@@ -999,7 +992,7 @@ bb84:
   gt
   swap1
   pop
-  push bb70
+  push bb68
   jumpi
   push 64
   mload
@@ -1034,9 +1027,9 @@ bb84:
   add
   push 64
   mstore
-  push bb66
-  jump bb50
-bb85:
+  push bb64
+  jump bb48
+bb83:
   push 3
   push 160
   mload
@@ -1065,11 +1058,11 @@ bb85:
   swap2
   pop
   pop
-  push bb70
+  push bb68
   jumpi
-  push bb84
-  jump bb76
-bb86:
+  push bb82
+  jump bb74
+bb84:
   dup1
   push 160
   mload
@@ -1100,13 +1093,13 @@ bb86:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 160
   mload
   push 192
-  jump bb73
-bb87:
+  jump bb71
+bb85:
   dup1
   push 160
   mload
@@ -1114,4 +1107,4 @@ bb87:
   add
   mstore
   push 1
-  jump bb75
+  jump bb73

--- a/tests/ui/codegen/lowering/static_frames.stdout
+++ b/tests/ui/codegen/lowering/static_frames.stdout
@@ -26,7 +26,7 @@ bb4 [cold]:
   push 0
   dup1
   revert
-bb70 [cold]:
+bb68 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -41,8 +41,8 @@ bb70 [cold]:
 bb5:
   push 0
   sload
-  jump bb72
-bb72:
+  jump bb70
+bb70:
   push 128
   mstore
   push 32
@@ -62,7 +62,7 @@ bb6:
   calldataload
   mul
   dup1
-  push 256
+  push 224
   mstore
   push 3
   dup2
@@ -73,7 +73,7 @@ bb6:
   swap1
   pop
   iszero
-  push bb70
+  push bb68
   jumpi
   push 4
   calldataload
@@ -90,9 +90,9 @@ bb6:
   push 384
   mload
   gt
-  push bb70
+  push bb68
   jumpi
-  push bb20
+  push bb18
   push 448
   mload
   push 384
@@ -103,7 +103,7 @@ bb6:
   mstore
   push 768
   mstore
-  push bb25
+  push bb23
   push 0
   sload
   push 1
@@ -113,7 +113,7 @@ bb6:
   push 864
   mstore
   lt
-  push bb70
+  push bb68
   jumpi
   push 864
   mload
@@ -130,7 +130,7 @@ bb6:
   push 864
   mstore
   lt
-  push bb70
+  push bb68
   jumpi
   push 5
   push 768
@@ -148,7 +148,7 @@ bb6:
 bb9:
   push 416
   mload
-  push 224
+  push 320
   mstore
   push 7
   push 4
@@ -182,8 +182,8 @@ bb9:
   mstore
   pop
   push bb10
-  jump bb35
-bb35:
+  jump bb33
+bb33:
   push 160
   mload
   push 64
@@ -213,16 +213,16 @@ bb35:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
-  push bb37
+  push bb35
   push 160
   mload
   push 160
   add
   mload
-  jump bb46
-bb46:
+  jump bb44
+bb44:
   dup1
   push 384
   mstore
@@ -237,7 +237,7 @@ bb46:
   mload
   eq
   iszero
-  push bb70
+  push bb68
   jumpi
   push 1
   push 448
@@ -249,7 +249,7 @@ bb46:
   push 448
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 0
   sload
@@ -260,8 +260,8 @@ bb46:
   sstore
   push 0x3e8
   push 480
-  jump bb71
-bb71:
+  jump bb69
+bb69:
   mload
   mod
   push 416
@@ -274,7 +274,7 @@ bb10:
   add
   mload
   dup1
-  push 320
+  push 352
   mstore
   push 160
   mload
@@ -287,7 +287,7 @@ bb10:
   mload
   push 160
   mstore
-  push 320
+  push 352
   mstore
   push 5
   push 4
@@ -321,14 +321,14 @@ bb10:
   mstore
   pop
   push bb11
-  jump bb50
-bb50:
+  jump bb48
+bb48:
   push 160
   mload
   push 64
   add
   mload
-  push bb54
+  push bb52
   jumpi
   push 160
   mload
@@ -337,9 +337,9 @@ bb50:
   mload
   push 384
   mstore
-  push bb52
-  jump bb60
-bb60:
+  push bb50
+  jump bb58
+bb58:
   push 3
   push 384
   mload
@@ -355,7 +355,7 @@ bb60:
   swap1
   dup2
   lt
-  push bb70
+  push bb68
   jumpi
   dup1
   push 448
@@ -364,7 +364,7 @@ bb60:
   sstore
   push 97
   push 384
-  jump bb71
+  jump bb69
 bb11:
   push 160
   mload
@@ -372,7 +372,7 @@ bb11:
   add
   mload
   dup1
-  push 352
+  push 256
   mstore
   push 160
   mload
@@ -385,11 +385,11 @@ bb11:
   mload
   push 160
   mstore
-  push 352
+  push 256
   mstore
   push 0
   sload
-  push 256
+  push 224
   mload
   dup2
   add
@@ -397,55 +397,48 @@ bb11:
   push 288
   mstore
   lt
-  push bb70
+  push bb68
   jumpi
   push 288
   mload
   push 0
   sstore
-  push 224
-  mload
-  push 256
-  mload
-  add
-  dup1
-  push 224
-  mstore
-  push 256
-  mload
-  gt
-  push bb70
-  jumpi
-  push 320
-  mload
-  push 224
-  mload
-  add
-  dup1
-  push 256
-  mstore
-  push 224
-  mload
-  gt
-  push bb70
-  jumpi
   push 352
   mload
   push 256
   mload
   add
+  push 256
+  mload
+  dup2
+  lt
+  push 320
+  mload
+  dup3
+  add
+  swap2
+  dup3
+  lt
+  or
+  push 224
+  mload
+  dup3
+  add
   dup1
   push 224
   mstore
-  push 256
-  mload
-  gt
-  push bb70
+  swap2
+  dup3
+  lt
+  or
+  swap1
+  pop
+  push bb68
   jumpi
   push 224
   mload
-  jump bb72
-bb20:
+  jump bb70
+bb18:
   push 608
   mload
   push 480
@@ -463,7 +456,7 @@ bb20:
   mload
   eq
   iszero
-  push bb70
+  push bb68
   jumpi
   push 480
   mload
@@ -476,14 +469,14 @@ bb20:
   push 512
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 448
   mload
   push 416
   mstore
   jump
-bb25:
+bb23:
   push 800
   mload
   dup1
@@ -521,7 +514,7 @@ bb25:
   lt
   swap1
   pop
-  push bb70
+  push bb68
   jumpi
   push 736
   mload
@@ -540,7 +533,7 @@ bb25:
   mload
   eq
   iszero
-  push bb70
+  push bb68
   jumpi
   push 736
   mload
@@ -553,7 +546,7 @@ bb25:
   push 640
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 704
   mload
@@ -566,14 +559,14 @@ bb25:
   push 672
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 640
   mload
   push 608
   mstore
   jump
-bb37:
+bb35:
   push 416
   mload
   dup1
@@ -592,15 +585,15 @@ bb37:
   push 64
   add
   mload
-  push bb40
-  jump bb74
-bb74:
+  push bb38
+  jump bb72
+bb72:
   jumpi
   push 160
   mload
   push 160
-  jump bb73
-bb73:
+  jump bb71
+bb71:
   add
   mload
   push 160
@@ -609,7 +602,7 @@ bb73:
   add
   mstore
   jump
-bb40:
+bb38:
   push 1
   push 160
   mload
@@ -653,7 +646,7 @@ bb40:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 64
   mload
@@ -688,9 +681,9 @@ bb40:
   add
   push 64
   mstore
-  push bb42
-  jump bb35
-bb42:
+  push bb40
+  jump bb33
+bb40:
   push 160
   mload
   push 128
@@ -743,16 +736,16 @@ bb42:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
-  push bb44
+  push bb42
   push 160
   mload
   push 192
   add
   mload
-  jump bb46
-bb44:
+  jump bb44
+bb42:
   push 416
   mload
   dup1
@@ -791,9 +784,9 @@ bb44:
   add
   mload
   gt
-  push bb70
-  jump bb74
-bb52:
+  push bb68
+  jump bb72
+bb50:
   push 416
   mload
   dup1
@@ -809,8 +802,8 @@ bb52:
   add
   mstore
   push 7
-  jump bb75
-bb75:
+  jump bb73
+bb73:
   dup2
   add
   dup1
@@ -826,9 +819,9 @@ bb75:
   add
   mstore
   lt
-  push bb70
-  jump bb74
-bb54:
+  push bb68
+  jump bb72
+bb52:
   push 160
   mload
   push 96
@@ -836,9 +829,9 @@ bb54:
   mload
   push 384
   mstore
-  push bb55
-  jump bb60
-bb55:
+  push bb53
+  jump bb58
+bb53:
   push 416
   mload
   dup1
@@ -895,7 +888,7 @@ bb55:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 64
   mload
@@ -930,14 +923,14 @@ bb55:
   add
   push 64
   mstore
-  push bb57
+  push bb55
   push 160
   mload
   push 64
   add
   mload
   iszero
-  push bb68
+  push bb66
   jumpi
   push 1
   push 160
@@ -982,7 +975,7 @@ bb55:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 64
   mload
@@ -1017,9 +1010,9 @@ bb55:
   add
   push 64
   mstore
-  push bb66
-  jump bb50
-bb57:
+  push bb64
+  jump bb48
+bb55:
   push 160
   mload
   push 128
@@ -1072,13 +1065,13 @@ bb57:
   add
   mload
   gt
-  push bb70
+  push bb68
   jumpi
   push 160
   mload
   push 192
-  jump bb73
-bb66:
+  jump bb71
+bb64:
   push 160
   mload
   push 128
@@ -1108,8 +1101,8 @@ bb66:
   add
   mstore
   push 1
-  jump bb75
-bb68:
+  jump bb73
+bb66:
   push 13
   push 160
   mload

--- a/tests/ui/codegen/lowering/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/lowering/tuple_assign_branch_leak.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol:TupleAssignBranchLeak (runtime) ===
 @module runtime
 bb0:
-  push 512
+  push 480
   push 64
   mstore
   callvalue
@@ -21,7 +21,7 @@ bb3 [cold]:
   push 0
   dup1
   revert
-bb22 [cold]:
+bb21 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -74,53 +74,53 @@ bb4:
   push 224
   mstore
   lt
-  push bb22
+  push bb21
   jumpi
   push bb14
   push 224
   mload
-  jump bb18
-bb18:
+  jump bb17
+bb17:
   dup1
-  push 352
+  push 320
   mstore
   push 1
   add
   dup1
-  push 448
+  push 416
   mstore
-  push 352
+  push 320
   mload
   gt
-  push bb22
+  push bb21
   jumpi
   push 2
-  push 352
+  push 320
   mload
   add
   dup1
-  push 480
+  push 448
   mstore
-  push 352
+  push 320
   mload
   gt
-  push bb22
+  push bb21
   jumpi
   push 64
-  push 448
-  push 384
+  push 416
+  push 352
   mcopy
   jump
 bb8:
   push bb9
   push 36
   calldataload
-  jump bb18
+  jump bb17
 bb9:
-  push bb25
-  jump bb24
-bb24:
-  push 384
+  push bb24
+  jump bb23
+bb23:
+  push 352
   mload
   dup1
   push 256
@@ -129,7 +129,7 @@ bb24:
   mload
   push 32
   mstore
-  push 416
+  push 384
   mload
   push 32
   mload
@@ -142,9 +142,9 @@ bb24:
   swap1
   jump
 bb14:
-  push bb26
-  jump bb24
-bb25:
+  push bb25
+  jump bb23
+bb24:
   push 32
   mload
   push 32
@@ -157,11 +157,11 @@ bb25:
   push 160
   mstore
   dup1
-  push 320
+  push 288
   mstore
   push 192
   mstore
-  push 320
+  push 288
   mload
   dup2
   add
@@ -169,11 +169,11 @@ bb25:
   push 224
   mstore
   lt
-  push bb22
+  jump bb22
+bb22:
+  push bb21
   jumpi
   push 224
-  jump bb23
-bb23:
   mload
   dup1
   push 128
@@ -183,32 +183,32 @@ bb23:
   push 32
   push 128
   return
-bb26:
+bb25:
   push 32
   mload
   push 32
   add
   mload
+  push 192
+  mload
+  swap1
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap2
   dup2
   add
   dup1
   push 224
   mstore
+  swap1
+  dup2
   lt
-  push bb22
-  jumpi
-  push 192
-  mload
-  push 224
-  mload
-  add
-  dup1
-  push 288
-  mstore
-  push 224
-  mload
-  gt
-  push bb22
-  jumpi
-  push 288
-  jump bb23
+  swap1
+  swap2
+  or
+  swap1
+  pop
+  jump bb22

--- a/tests/ui/codegen/lowering/tuple_assign_branch_leak.stdout
+++ b/tests/ui/codegen/lowering/tuple_assign_branch_leak.stdout
@@ -1,7 +1,7 @@
 // === ROOT/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol:TupleAssignBranchLeak (runtime) ===
 @module runtime
 bb0:
-  push 640
+  push 608
   push 64
   mstore
   callvalue
@@ -21,7 +21,7 @@ bb3 [cold]:
   push 0
   dup1
   revert
-bb22 [cold]:
+bb21 [cold]:
   push 0x4e487b71
   push 224
   shl
@@ -74,58 +74,58 @@ bb4:
   push 288
   mstore
   lt
-  push bb22
+  push bb21
   jumpi
   push bb14
   push 288
   mload
-  jump bb18
-bb18:
-  push 480
+  jump bb17
+bb17:
+  push 448
   mstore
   push 1
-  push 480
+  push 448
+  mload
+  add
+  dup1
+  push 544
+  mstore
+  push 448
+  mload
+  gt
+  push bb21
+  jumpi
+  push 2
+  push 448
   mload
   add
   dup1
   push 576
   mstore
-  push 480
+  push 448
   mload
   gt
-  push bb22
+  push bb21
   jumpi
-  push 2
-  push 480
+  push 544
   mload
-  add
-  dup1
-  push 608
+  push 480
   mstore
-  push 480
-  mload
-  gt
-  push bb22
-  jumpi
   push 576
   mload
   push 512
-  mstore
-  push 608
-  mload
-  push 544
   mstore
   jump
 bb8:
   push bb9
   push 36
   calldataload
-  jump bb18
+  jump bb17
 bb9:
-  push bb25
-  jump bb24
-bb24:
-  push 512
+  push bb24
+  jump bb23
+bb23:
+  push 480
   mload
   dup1
   push 320
@@ -134,7 +134,7 @@ bb24:
   mload
   push 32
   mstore
-  push 544
+  push 512
   mload
   push 32
   mload
@@ -147,9 +147,9 @@ bb24:
   swap1
   jump
 bb14:
-  push bb26
-  jump bb24
-bb25:
+  push bb25
+  jump bb23
+bb24:
   push 32
   mload
   push 32
@@ -162,11 +162,11 @@ bb25:
   push 160
   mstore
   dup1
-  push 384
+  push 352
   mstore
   push 192
   mstore
-  push 384
+  push 352
   mload
   dup2
   add
@@ -174,11 +174,11 @@ bb25:
   push 288
   mstore
   lt
-  push bb22
+  jump bb22
+bb22:
+  push bb21
   jumpi
   push 288
-  jump bb23
-bb23:
   mload
   dup1
   push 128
@@ -188,32 +188,32 @@ bb23:
   push 32
   push 128
   return
-bb26:
+bb25:
   push 32
   mload
   push 32
   add
   mload
+  push 192
+  mload
+  swap1
+  dup2
+  add
+  swap1
+  dup2
+  lt
+  swap2
   dup2
   add
   dup1
   push 288
   mstore
+  swap1
+  dup2
   lt
-  push bb22
-  jumpi
-  push 192
-  mload
-  push 288
-  mload
-  add
-  dup1
-  push 352
-  mstore
-  push 288
-  mload
-  gt
-  push bb22
-  jumpi
-  push 352
-  jump bb23
+  swap1
+  swap2
+  or
+  swap1
+  pop
+  jump bb22


### PR DESCRIPTION
Checked `uint256` addition trees currently lower each addition with its own immediate overflow branch. Besides duplicating control flow, that keeps intermediate values live and can force expensive stack arrangements or spills for large expressions.

This change recognizes builtin checked `uint256` addition trees whose leaves are distinct resolved identifiers. It evaluates those leaves in source order, accumulates the modular sums and carry bits in a stack-friendly order, then emits one arithmetic panic branch for the combined carry condition. Signed and narrow integers, unchecked expressions, user-defined operators, side-effecting leaves, and repeated operands retain the existing lowering.

The largest affected UI fixtures shrink from 431 to 272 runtime bytes for `params` under `-Ogas`, from 907 to 673 bytes for `locals` under `-Osize`, and from 1,013 to 794 bytes for `call_args` under `-Ogas`. Deployment gas falls by as much as 47,371, while affected runtime calls improve by as much as 432 gas. Runtime coverage exercises left- and right-associated trees plus overflow panics, and the affected EVM IR fixtures pin the aggregate carry chain.
