### PR TITLE
fix(ci): compare benches with base branch

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,6 +48,8 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+    env:
+      BASE_BRANCH: ${{ github.base_ref || 'main' }}
     steps:
       - name: Checkout Solar
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -90,7 +92,7 @@ jobs:
       - name: Build Solar
         run: cargo build -p solar-compiler --bin solar
 
-      - name: Download baseline (main branch)
+      - name: Download baseline (${{ env.BASE_BRANCH }} branch)
         id: baseline
         env:
           GH_TOKEN: ${{ github.token }}
@@ -98,27 +100,37 @@ jobs:
           set -euo pipefail
           mkdir -p target/codegen-bench/baseline
 
-          run_id="$(
+          run_ids="$(
             gh run list \
               --workflow bench.yml \
-              --branch main \
-              --event push \
+              --branch "$BASE_BRANCH" \
               --status success \
-              --limit 1 \
+              --limit 20 \
               --json databaseId \
-              --jq '.[0].databaseId // ""' \
+              --jq '.[].databaseId' \
               2>/dev/null || true
           )"
-          if [[ -z "$run_id" ]]; then
-            echo "::warning::No successful main benchmark run was found for baseline comparison"
+          if [[ -z "$run_ids" ]]; then
+            echo "::warning::No successful $BASE_BRANCH benchmark run was found for baseline comparison"
             exit 0
           fi
 
-          if ! gh run download "$run_id" \
-            --name codegen-runtime-baseline \
-            --dir target/codegen-bench/baseline; then
-            echo "::warning::No main baseline artifact was available for comparison"
-          fi
+          for run_id in $run_ids; do
+            if gh run download "$run_id" \
+              --name codegen-runtime-baseline \
+              --dir target/codegen-bench/baseline \
+              2>/dev/null && [[ -f target/codegen-bench/baseline/results.json ]]; then
+              exit 0
+            fi
+            if gh run download "$run_id" \
+              --name codegen-runtime-results \
+              --dir target/codegen-bench/baseline \
+              2>/dev/null && [[ -f target/codegen-bench/baseline/results.json ]]; then
+              exit 0
+            fi
+          done
+
+          echo "::warning::No $BASE_BRANCH baseline artifact was available for comparison"
 
       - name: Run codegen benchmark
         id: codegen-bench
@@ -143,6 +155,7 @@ jobs:
         env:
           BENCHMARK_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BENCHMARK_PR_NUMBER: ${{ github.event.pull_request.number }}
+          BENCHMARK_BASE_REF: ${{ env.BASE_BRANCH }}
         run: |
           set -euo pipefail
           mkdir -p target/codegen-bench

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -386,6 +386,7 @@ def report_section(
     title: str,
     results: list[dict[str, Any]],
     baseline_results: list[dict[str, Any]],
+    baseline_ref: str = "main",
 ) -> str:
     lines = [f"## {title}", ""]
     if not results:
@@ -393,12 +394,15 @@ def report_section(
         return "\n".join(lines)
 
     baseline = by_test_id(baseline_results)
+    baseline_label = markdown_cell(baseline_ref)
     if not baseline:
-        lines.extend(["No `main` baseline artifact was available for comparison.", ""])
+        lines.extend(
+            [f"No `{baseline_ref}` baseline artifact was available for comparison.", ""]
+        )
 
     lines.extend(
         [
-            "| bench | gas (vs main) | solc | size (vs main) | solc |",
+            f"| bench | gas (vs {baseline_label}) | solc | size (vs {baseline_label}) | solc |",
             "| ----- | ------------- | ---- | -------------- | ---- |",
             *benchmark_rows(results, baseline),
             "",
@@ -411,8 +415,9 @@ def report_section(
 def codegen_report(
     results: list[dict[str, Any]],
     baseline_results: list[dict[str, Any]],
+    baseline_ref: str = "main",
 ) -> str:
-    return report_section("Codegen benchmark", results, baseline_results)
+    return report_section("Codegen benchmark", results, baseline_results, baseline_ref)
 
 
 def emit_warnings(results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]) -> None:
@@ -442,35 +447,37 @@ def append_github_output(name: str, value: str) -> None:
         f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
 
 
-def branch_is_behind_main() -> bool:
+def branch_is_behind(base_ref: str = "main") -> bool:
     head_sha = os.environ.get("BENCHMARK_PR_HEAD_SHA")
     if not head_sha:
         return False
     try:
         count = subprocess.check_output(
-            ["git", "rev-list", "--count", f"{head_sha}..origin/main"],
+            ["git", "rev-list", "--count", f"{head_sha}..origin/{base_ref}"],
             text=True,
             stderr=subprocess.DEVNULL,
         )
     except (OSError, subprocess.CalledProcessError):
-        warning("could not determine whether the branch is behind main")
+        warning(f"could not determine whether the branch is behind {base_ref}")
         return False
     return int(count) > 0
 
 
-def format_report(markdown: str, has_changes: bool, behind_main: bool) -> str:
-    if has_changes and not behind_main:
+def format_report(
+    markdown: str, has_changes: bool, behind_base: bool, base_ref: str = "main"
+) -> str:
+    if has_changes and not behind_base:
         return markdown
     notices = ""
-    if behind_main:
+    if behind_base:
         notices += (
             "> [!WARNING]\n"
-            "> This branch is behind `main`, so these benchmark results may be incorrect.\n\n"
+            f"> This branch is behind `{base_ref}`, so these benchmark results may be incorrect.\n\n"
         )
     if not has_changes:
         notices += (
             "> [!NOTE]\n"
-            "> Codegen benchmark output is unchanged from `main`.\n\n"
+            f"> Codegen benchmark output is unchanged from `{base_ref}`.\n\n"
         )
     details = (
         "<details>\n"
@@ -615,16 +622,17 @@ def main() -> int:
     baseline_document = load_document(args.baseline, "baseline")
     results = document["results"]
     baseline_results = baseline_document["results"]
+    base_ref = os.environ.get("BENCHMARK_BASE_REF") or "main"
 
     emit_warnings(results, baseline_results)
 
     if args.results is not None:
-        report = codegen_report(results, baseline_results)
+        report = codegen_report(results, baseline_results, base_ref)
     else:
         report = "## Codegen benchmark\n\nNo benchmark inputs were configured.\n"
 
     should_comment = has_baseline_changes(results, baseline_results)
-    markdown = format_report(report, should_comment, branch_is_behind_main())
+    markdown = format_report(report, should_comment, branch_is_behind(base_ref), base_ref)
     print(markdown)
     append_step_summary(markdown)
     append_github_output("report", markdown)

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -37,6 +37,18 @@ class ReportFormattingTests(unittest.TestCase):
     def test_changed_report_has_no_details(self):
         self.assertEqual(benchmark.format_report("## Results", True, False), "## Results")
 
+    def test_unchanged_report_uses_base_branch(self):
+        report = benchmark.format_report("## Results", False, False, "feat/base")
+        self.assertEqual(
+            report,
+            "> [!NOTE]\n"
+            "> Codegen benchmark output is unchanged from `feat/base`.\n\n"
+            "<details>\n"
+            "<summary>Codegen benchmark output</summary>\n\n"
+            "## Results\n\n"
+            "</details>\n",
+        )
+
     def test_behind_main_report_has_warning(self):
         report = benchmark.format_report("## Results", True, True)
         self.assertEqual(
@@ -123,6 +135,17 @@ class ReportFormattingTests(unittest.TestCase):
             "| micro | 10 (~0%) | n/a (n/a) | 20B (~0%) | n/a (n/a) |\n"
             "| repository | 30 (~0%) | n/a (n/a) | 40B (~0%) | n/a (n/a) |\n"
             "| large | 50 (~0%) | n/a (n/a) | 60B (~0%) | n/a (n/a) |\n"
+        )
+
+    def test_codegen_report_uses_base_branch(self):
+        micro = result("micro", suite="micro", status="ok", total_gas=10, runtime_size=20)
+        self.assertEqual(
+            benchmark.codegen_report([micro], [micro], "feat/base"),
+            "## Codegen benchmark\n"
+            "\n"
+            "| bench | gas (vs feat/base) | solc | size (vs feat/base) | solc |\n"
+            "| ----- | ------------- | ---- | -------------- | ---- |\n"
+            "| micro | 10 (~0%) | n/a (n/a) | 20B (~0%) | n/a (n/a) |\n",
         )
 
 


### PR DESCRIPTION
Codegen runtime benchmark CI always downloaded the latest successful `main` baseline, so stacked pull requests compared against unrelated code. Resolve the pull request base branch from `github.base_ref`, use its latest successful benchmark artifact, and pass that ref through the report so the comparison labels and stale-branch warning match the actual base. Pushes and manual runs continue to use `main` by default.
