### PR TITLE
refactor(codegen): clean transform passes

### DIFF
--- a/crates/codegen/src/transform/indvar_simplify.rs
+++ b/crates/codegen/src/transform/indvar_simplify.rs
@@ -20,7 +20,7 @@
 //! - preserve the original address value when it is still used outside the loop
 
 use crate::{
-    analysis::{AffineExpr, Loop, LoopAnalyzer, ScalarEvolution},
+    analysis::{Loop, LoopAnalyzer, ScalarEvolution},
     mir::{
         BlockId, Function, Immediate, InstId, InstKind, Instruction, MirType, Module, Value,
         ValueId, utils as mir_utils,
@@ -183,16 +183,16 @@ impl IndVarSimplifier {
         value: ValueId,
         iv_value: ValueId,
     ) -> Option<AddressKey> {
-        let AffineExpr { base, constant, terms } = scev.get(value)?.clone();
-        let base = base?;
-        let [term] = terms.as_slice() else { return None };
+        let expr = scev.get(value)?;
+        let base = expr.base?;
+        let [term] = expr.terms.as_slice() else { return None };
         if term.value != iv_value || term.scale <= 0 {
             return None;
         }
-        if constant < 0 {
+        if expr.constant < 0 {
             return None;
         }
-        Some(AddressKey { base, iv: iv_value, scale: term.scale, constant })
+        Some(AddressKey { base, iv: iv_value, scale: term.scale, constant: expr.constant })
     }
 
     fn materialize_pointer_phi(

--- a/crates/codegen/src/transform/lower_abi.rs
+++ b/crates/codegen/src/transform/lower_abi.rs
@@ -274,13 +274,16 @@ fn encode_live_returns(func: &mut Function) -> usize {
     let block_ids: Vec<_> = func.blocks.indices().collect();
     let mut encoded_returns = 0;
     for block_id in block_ids {
-        let Some(Terminator::Return { values }) = &func.blocks[block_id].terminator else {
-            continue;
+        let values = match func.blocks[block_id].terminator.take() {
+            Some(Terminator::Return { values }) if !values.is_empty() => {
+                values.into_vec().into_boxed_slice()
+            }
+            Some(terminator) => {
+                func.blocks[block_id].terminator = Some(terminator);
+                continue;
+            }
+            None => continue,
         };
-        if values.is_empty() {
-            continue;
-        }
-        let values = values.clone().into_vec().into_boxed_slice();
         let mut builder = FunctionBuilder::new(func);
         builder.switch_to_block(block_id);
         if layout.types.iter().any(crate::mir::AbiType::is_dynamic) {

--- a/crates/codegen/src/transform/lower_slices.rs
+++ b/crates/codegen/src/transform/lower_slices.rs
@@ -150,7 +150,7 @@ impl LowerSlicesCx {
             let block_id = *block_id;
             // Collect the leading slice phis before mutating, since forming the
             // paired words allocates instructions and values.
-            type SlicePhi = (InstId, Vec<(BlockId, ValueId)>, SliceLocation);
+            type SlicePhi = (InstId, SliceLocation);
             let mut slice_phis: Vec<SlicePhi> = Vec::new();
             for &inst_id in &func.blocks[block_id].instructions {
                 match &func.inst(inst_id).kind {
@@ -159,14 +159,18 @@ impl LowerSlicesCx {
                             .first()
                             .and_then(|(_, value)| value_slice_location(func, *value))
                         {
-                            slice_phis.push((inst_id, incoming.clone(), location));
+                            slice_phis.push((inst_id, location));
                         }
                     }
                     _ => break,
                 }
             }
             let mut splits: Vec<(InstId, InstId, InstId, InstId)> = Vec::new();
-            for (inst_id, incoming, location) in slice_phis {
+            for (inst_id, location) in slice_phis {
+                let incoming = match &mut func.inst_mut(inst_id).kind {
+                    InstKind::Phi(incoming) => std::mem::take(incoming),
+                    _ => unreachable!(),
+                };
                 let mut ptr_incoming = Vec::with_capacity(incoming.len());
                 let mut len_incoming = Vec::with_capacity(incoming.len());
                 for (pred, value) in incoming {
@@ -279,7 +283,7 @@ impl LowerSlicesCx {
             return false;
         }
 
-        let old_params = func.params.clone();
+        let old_params = std::mem::take(&mut func.params);
         let mut physical_indices = IndexVec::<ArgIdx, ArgIdx>::with_capacity(old_params.len());
         let mut new_params = IndexVec::<ArgIdx, MirType>::with_capacity(old_params.len() + 1);
         for (index, &ty) in old_params.iter_enumerated() {

--- a/crates/codegen/src/transform/pure_eval.rs
+++ b/crates/codegen/src/transform/pure_eval.rs
@@ -213,14 +213,15 @@ impl PureEvaluator {
             }
         }
 
-        let returns = func.returns.clone();
+        let returns = std::mem::take(&mut func.returns);
         let values = values
             .iter()
-            .zip(returns)
+            .zip(&returns)
             .map(|(&value, ty)| {
-                func.alloc_value(Value::Immediate(Immediate::for_type(Some(ty), value)))
+                func.alloc_value(Value::Immediate(Immediate::for_type(Some(*ty), value)))
             })
             .collect();
+        func.returns = returns;
         func.blocks[entry].terminator = Some(Terminator::Return { values });
     }
 }

--- a/crates/codegen/src/transform/sccp.rs
+++ b/crates/codegen/src/transform/sccp.rs
@@ -49,7 +49,7 @@ impl MirPass for Sccp {
 }
 
 /// Lattice element for a single SSA value.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum LatticeValue {
     /// Not yet evaluated.
     Top,
@@ -64,7 +64,7 @@ impl LatticeValue {
     /// Top ∧ x = x, Bottom ∧ x = Bottom, Const(a) ∧ Const(b) = if a==b Const(a) else Bottom.
     fn meet(&self, other: &Self) -> Self {
         match (self, other) {
-            (Self::Top, x) | (x, Self::Top) => x.clone(),
+            (Self::Top, x) | (x, Self::Top) => *x,
             (Self::Bottom, _) | (_, Self::Bottom) => Self::Bottom,
             (Self::Constant(a), Self::Constant(b)) => {
                 if a == b {
@@ -349,7 +349,7 @@ impl SccpCx {
             return match lattice[condition] {
                 LatticeValue::Constant(condition) => {
                     let chosen = if condition.is_zero() { else_value } else { then_value };
-                    lattice[chosen].clone()
+                    lattice[chosen]
                 }
                 LatticeValue::Bottom => lattice[then_value].meet(&lattice[else_value]),
                 LatticeValue::Top => match (get_const(then_value), get_const(else_value)) {

--- a/crates/codegen/src/transform/sroa.rs
+++ b/crates/codegen/src/transform/sroa.rs
@@ -196,8 +196,9 @@ impl SroaCx {
         let mut dead: FxHashSet<InstId> = FxHashSet::default();
         for &inst_id in &block.instructions {
             match func.inst(inst_id).kind {
-                InstKind::MStore(addr, value) if slot_of.contains_key(&addr) => {
-                    current.insert(slot_of[&addr], Some(value));
+                InstKind::MStore(addr, value) => {
+                    let Some(&slot) = slot_of.get(&addr) else { continue };
+                    current.insert(slot, Some(value));
                     dead.insert(inst_id);
                 }
                 InstKind::MemoryZero(base, _) if base == object => {
@@ -205,10 +206,11 @@ impl SroaCx {
                     current.extend((0..words).map(|slot| (slot, None)));
                     dead.insert(inst_id);
                 }
-                InstKind::MLoad(addr) if slot_of.contains_key(&addr) => {
+                InstKind::MLoad(addr) => {
+                    let Some(&slot) = slot_of.get(&addr) else { continue };
                     // A load with no dominating store observes uninitialized or
                     // zeroed memory; keep the allocation rather than guess.
-                    let value = current.get(&slot_of[&addr]).copied()?;
+                    let value = current.get(&slot).copied()?;
                     if let Some(result) = func.inst_result_value(inst_id) {
                         replacements.insert(result, value);
                     }


### PR DESCRIPTION
Moves the transform-only ownership and allocation cleanups into a standalone change. The pass behavior stays the same; the changes reduce temporary clones and make mutation ownership explicit.