### PR TITLE
feat(cli): warn instead of -Zcodegen

### DIFF
--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -242,7 +242,7 @@ def compile_case(spec: CompilerSpec, test_case: TestCase) -> Dict[str, object]:
 
     cmd = [str(spec.path)]
     if spec.kind != "solc":
-        # Solar gates its experimental code generator behind `-Zcodegen`.
+        # Keep the legacy flag to acknowledge the experimental code generator.
         cmd.append("-Zcodegen")
     cmd.append("--standard-json")
     started = time.monotonic()

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -240,11 +240,7 @@ def compile_case(spec: CompilerSpec, test_case: TestCase) -> Dict[str, object]:
         input_text = standard_json_input(test_case)
         timeout = 120
 
-    cmd = [str(spec.path)]
-    if spec.kind != "solc":
-        # Keep the legacy flag to acknowledge the experimental code generator.
-        cmd.append("-Zcodegen")
-    cmd.append("--standard-json")
+    cmd = [str(spec.path), "--standard-json"]
     started = time.monotonic()
     proc = run(
         cmd,

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -447,11 +447,7 @@ impl Compiler for Solar {
 fn session(source: &Source) -> Session {
     let mut opts = solar::config::CompileOpts {
         threads: solar::config::Threads::resolve(1),
-        unstable: solar::config::UnstableOpts {
-            codegen: true,
-            codegen_all_functions: true,
-            ..Default::default()
-        },
+        unstable: solar::config::UnstableOpts { codegen_all_functions: true, ..Default::default() },
         ..Default::default()
     };
     opts.import_remappings =

--- a/crates/cli/src/commands/compile.rs
+++ b/crates/cli/src/commands/compile.rs
@@ -1,6 +1,6 @@
 use solar_codegen::ContractSelection;
 use solar_config::CompileOpts;
-use solar_interface::{Result, Session};
+use solar_interface::{Result, Session, error_code};
 use solar_sema::{CompilerRef, ParsingContext};
 use std::{ops::ControlFlow, process::ExitCode};
 
@@ -96,19 +96,17 @@ pub(crate) fn run_pipeline(
         return Ok(ControlFlow::Break(()));
     };
 
-    // Code generation (MIR, EVM IR, and bytecode) is experimental and not part of the
-    // stable, solc-compatible pipeline yet, so it is gated behind `-Zcodegen`.
     let needs_codegen = sess.opts.emit.iter().any(|e| e.is_codegen())
         || sess.opts.unstable.dump.as_ref().is_some_and(|dump| dump.needs_codegen());
-    if needs_codegen && !sess.opts.unstable.codegen {
-        return Err(sess
-            .dcx
-            .err("code generation is experimental")
-            .help("pass `-Zcodegen` to emit bytecode or dump MIR, EVM IR, or disassembly")
-            .emit());
-    }
+    warn_experimental_codegen(sess, needs_codegen);
 
     Ok(ControlFlow::Continue(()))
+}
+
+pub(crate) fn warn_experimental_codegen(sess: &Session, needs_codegen: bool) {
+    if needs_codegen && !sess.opts.unstable.codegen {
+        sess.dcx.warn("code generation is experimental").code(error_code!(2264)).emit();
+    }
 }
 
 pub(crate) fn run_compiler_with(

--- a/crates/cli/src/commands/compile.rs
+++ b/crates/cli/src/commands/compile.rs
@@ -104,7 +104,7 @@ pub(crate) fn run_pipeline(
 }
 
 pub(crate) fn warn_experimental_codegen(sess: &Session, needs_codegen: bool) {
-    if needs_codegen && !sess.opts.unstable.codegen {
+    if needs_codegen {
         sess.dcx.warn("code generation is experimental").code(error_code!(2264)).emit();
     }
 }

--- a/crates/cli/src/standard_json/compile.rs
+++ b/crates/cli/src/standard_json/compile.rs
@@ -212,13 +212,11 @@ fn compile(
 
             let gcx = compiler.gcx();
 
-            // Code generation is experimental and gated behind `-Zcodegen`;
-            // without it, no bytecode is produced even when requested.
-            let bytecode_contracts = if gcx.sess.opts.unstable.codegen {
-                requested_bytecode_contracts(gcx, &output_selection)
-            } else {
-                ContractSelection::empty(gcx)
-            };
+            let bytecode_contracts = requested_bytecode_contracts(gcx, &output_selection);
+            crate::commands::compile::warn_experimental_codegen(
+                gcx.sess,
+                !bytecode_contracts.is_empty(),
+            );
             let bytecodes = crate::emit::emit_requested(compiler, bytecode_contracts)?;
 
             gcx.dcx().has_errors()?;

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -276,10 +276,7 @@ impl<'gcx> Lowerer<'gcx> {
     /// Creates a new lowerer.
     pub(crate) fn new(gcx: Gcx<'gcx>, name: Ident) -> Self {
         if !gcx.has_typeck_results() {
-            gcx.dcx().emit_err(
-                name.span,
-                "tried to lower contract without typeck results; likely missing -Zcodegen",
-            );
+            gcx.dcx().emit_err(name.span, "tried to lower contract without typeck results");
         }
         let hir_has_errors = gcx.dcx().has_errors().is_err();
         Self {

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -386,15 +386,6 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub time_passes: bool,
 
-    /// Legacy acknowledgement for the experimental EVM code generator (MIR lowering and backend).
-    ///
-    /// Codegen runs whenever bytecode or IR output is requested. This flag only suppresses the
-    /// experimental warning and is retained for compatibility.
-    ///
-    /// TODO(codegen): Remove this compatibility flag once downstream callers stop passing it.
-    #[cfg_attr(feature = "clap", arg(long, hide = true))]
-    pub codegen: bool,
-
     /// Lower all contract functions instead of only reachable ones. This is intended for
     /// benchmarks and compiler debugging.
     #[cfg_attr(feature = "clap", arg(long))]

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -386,11 +386,10 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub time_passes: bool,
 
-    /// Enable the experimental EVM code generator (MIR lowering and backend).
+    /// Acknowledge the experimental EVM code generator (MIR lowering and backend).
     ///
-    /// Off by default: MIR, EVM IR, disassembly, and bytecode output are only
-    /// produced when this is set. Codegen is a work in progress and not yet part
-    /// of the compiler's stable, solc-compatible behavior.
+    /// Codegen runs whenever bytecode or IR output is requested. This flag preserves the
+    /// old opt-in behavior and suppresses the experimental warning.
     #[cfg_attr(feature = "clap", arg(long))]
     pub codegen: bool,
 

--- a/crates/config/src/opts.rs
+++ b/crates/config/src/opts.rs
@@ -386,11 +386,13 @@ pub struct UnstableOpts {
     #[cfg_attr(feature = "clap", arg(long))]
     pub time_passes: bool,
 
-    /// Acknowledge the experimental EVM code generator (MIR lowering and backend).
+    /// Legacy acknowledgement for the experimental EVM code generator (MIR lowering and backend).
     ///
-    /// Codegen runs whenever bytecode or IR output is requested. This flag preserves the
-    /// old opt-in behavior and suppresses the experimental warning.
-    #[cfg_attr(feature = "clap", arg(long))]
+    /// Codegen runs whenever bytecode or IR output is requested. This flag only suppresses the
+    /// experimental warning and is retained for compatibility.
+    ///
+    /// TODO(codegen): Remove this compatibility flag once downstream callers stop passing it.
+    #[cfg_attr(feature = "clap", arg(long, hide = true))]
     pub codegen: bool,
 
     /// Lower all contract functions instead of only reachable ones. This is intended for

--- a/fuzz/fandango/evm_runtime.py
+++ b/fuzz/fandango/evm_runtime.py
@@ -49,7 +49,7 @@ def compile_solc(solc: str, source: pathlib.Path, contract: str, timeout: float)
 
 def compile_solar(solar: str, source: pathlib.Path, contract: str, timeout: float) -> str:
     result = subprocess.run(
-        [solar, "-Zcodegen", "--emit=bin-runtime", "--pretty-json", str(source)],
+        [solar, "--emit=bin-runtime", "--pretty-json", str(source)],
         check=True,
         text=True,
         stdout=subprocess.PIPE,

--- a/fuzz/fandango/run_solidity_sources.py
+++ b/fuzz/fandango/run_solidity_sources.py
@@ -88,7 +88,7 @@ def _check_source(
     if args.verbose:
         print(f"  solc:  {solc_result['status']}", file=sys.stderr)
         print(
-            f"  solar: {args.solar} -Zcodegen --emit=bin-runtime {path}",
+            f"  solar: {args.solar} --emit=bin-runtime {path}",
             file=sys.stderr,
         )
 
@@ -162,7 +162,6 @@ def _compile_solc(solc: str, source: pathlib.Path, timeout: float) -> dict[str, 
 def _compile_solar(solar: str, source: pathlib.Path, timeout: float) -> dict[str, Any]:
     return _run([
         solar,
-        "-Zcodegen",
         "--emit=bin-runtime",
         str(source),
     ], timeout)

--- a/scripts/bench_switch_lowering.py
+++ b/scripts/bench_switch_lowering.py
@@ -750,7 +750,6 @@ def run_ui_case(
     for spec in specs:
         command = [
             str(spec.path),
-            "-Zcodegen",
             "--emit",
             "bin,bin-runtime",
             "--base-path",

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -58,9 +58,9 @@ Options:
           Print the time spent in each MIR and EVM IR pass
 
       -Zcodegen
-          Enable the experimental EVM code generator (MIR lowering and backend).
+          Acknowledge the experimental EVM code generator (MIR lowering and backend).
           
-          Off by default: MIR, EVM IR, disassembly, and bytecode output are only produced when this is set. Codegen is a work in progress and not yet part of the compiler's stable, solc-compatible behavior.
+          Codegen runs whenever bytecode or IR output is requested. This flag preserves the old opt-in behavior and suppresses the experimental warning.
 
       -Zcodegen-all-functions
           Lower all contract functions instead of only reachable ones. This is intended for benchmarks and compiler debugging

--- a/tests/ui/cli/Zhelp.stdout
+++ b/tests/ui/cli/Zhelp.stdout
@@ -57,11 +57,6 @@ Options:
       -Ztime-passes
           Print the time spent in each MIR and EVM IR pass
 
-      -Zcodegen
-          Acknowledge the experimental EVM code generator (MIR lowering and backend).
-          
-          Codegen runs whenever bytecode or IR output is requested. This flag preserves the old opt-in behavior and suppresses the experimental warning.
-
       -Zcodegen-all-functions
           Lower all contract functions instead of only reachable ones. This is intended for benchmarks and compiler debugging
 

--- a/tests/ui/cli/codegen.sol
+++ b/tests/ui/cli/codegen.sol
@@ -1,0 +1,11 @@
+//@ compile-flags: --emit=bin --pretty-json
+//@ filecheck:
+//~? WARN: code generation is experimental
+
+// CHECK-LABEL: "ROOT/tests/ui/cli/codegen.sol:C":
+// CHECK: "bin":
+// CHECK: "version":
+
+contract C {
+    function f() external {}
+}

--- a/tests/ui/cli/codegen.stderr
+++ b/tests/ui/cli/codegen.stderr
@@ -1,0 +1,2 @@
+warning[2264]: code generation is experimental
+

--- a/tests/ui/cli/codegen.stdout
+++ b/tests/ui/cli/codegen.stdout
@@ -1,0 +1,8 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/cli/codegen.sol:C": {
+      "bin": "601d8060095f395ff36080604052346019575f3560e01c806326121ff003601957005b5f80fd"
+    }
+  },
+  "version": "VERSION"
+}

--- a/tests/ui/codegen/disasm/cold_fallthrough.evmir
+++ b/tests/ui/codegen/disasm/cold_fallthrough.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
 //@ filecheck: --implicit-check-not=JUMPDEST
 
 @module cold_fallthrough

--- a/tests/ui/codegen/disasm/cold_layout.evmir
+++ b/tests/ui/codegen/disasm/cold_layout.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
 //@ filecheck:
 
 @module cold_layout

--- a/tests/ui/codegen/disasm/compact_pushes.evmir
+++ b/tests/ui/codegen/disasm/compact_pushes.evmir
@@ -1,11 +1,11 @@
 //@ revisions: size gas none berlin
-//@[size] compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O size --evm-version shanghai -Zdump=disasm-runtime
+//@[size] compile-flags: -Zevm-ir-pipeline=default -O size --evm-version shanghai -Zdump=disasm-runtime
 //@[size] filecheck: --check-prefix=COMPACT
-//@[gas] compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O gas --evm-version shanghai -Zdump=disasm-runtime
+//@[gas] compile-flags: -Zevm-ir-pipeline=default -O gas --evm-version shanghai -Zdump=disasm-runtime
 //@[gas] filecheck: --check-prefix=COMPACT
-//@[none] compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none --evm-version shanghai -Zdump=disasm-runtime
+//@[none] compile-flags: -Zevm-ir-pipeline=default -O none --evm-version shanghai -Zdump=disasm-runtime
 //@[none] filecheck: --check-prefix=NONE --implicit-check-not=NOT
-//@[berlin] compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O size --evm-version berlin -Zdump=disasm-runtime
+//@[berlin] compile-flags: -Zevm-ir-pipeline=default -O size --evm-version berlin -Zdump=disasm-runtime
 //@[berlin] filecheck: --check-prefix=BERLIN --implicit-check-not=PUSH0
 
 @module compact_pushes

--- a/tests/ui/codegen/disasm/dump.sol
+++ b/tests/ui/codegen/disasm/dump.sol
@@ -1,7 +1,7 @@
 //@ revisions: deploy runtime
-//@[deploy] compile-flags: -Zcodegen -O none -Zdump=disasm-deploy
+//@[deploy] compile-flags: -O none -Zdump=disasm-deploy
 //@[deploy] filecheck: --check-prefix=DEPLOY --implicit-check-not=CALLDATALOAD
-//@[runtime] compile-flags: -Zcodegen -O none -Zdump=disasm-runtime
+//@[runtime] compile-flags: -O none -Zdump=disasm-runtime
 //@[runtime] filecheck: --check-prefix=RUNTIME
 
 contract C {

--- a/tests/ui/codegen/disasm/jumpi_layout.evmir
+++ b/tests/ui/codegen/disasm/jumpi_layout.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
 //@ filecheck:
 
 @module jumpi_layout

--- a/tests/ui/codegen/disasm/label_relaxation.evmir
+++ b/tests/ui/codegen/disasm/label_relaxation.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module label_relaxation

--- a/tests/ui/codegen/disasm/label_resolution.evmir
+++ b/tests/ui/codegen/disasm/label_resolution.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module label_resolution

--- a/tests/ui/codegen/disasm/program_data.evmir
+++ b/tests/ui/codegen/disasm/program_data.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module program_data

--- a/tests/ui/codegen/disasm/push_widths.evmir
+++ b/tests/ui/codegen/disasm/push_widths.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module push_widths

--- a/tests/ui/codegen/disasm/push_zero.evmir
+++ b/tests/ui/codegen/disasm/push_zero.evmir
@@ -1,7 +1,7 @@
 //@ revisions: shanghai berlin
-//@[shanghai] compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none --evm-version shanghai -Zdump=disasm-runtime
+//@[shanghai] compile-flags: -Zevm-ir-pipeline=default -O none --evm-version shanghai -Zdump=disasm-runtime
 //@[shanghai] filecheck: --check-prefix=SHANGHAI --implicit-check-not=PUSH1
-//@[berlin] compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none --evm-version berlin -Zdump=disasm-runtime
+//@[berlin] compile-flags: -Zevm-ir-pipeline=default -O none --evm-version berlin -Zdump=disasm-runtime
 //@[berlin] filecheck: --check-prefix=BERLIN --implicit-check-not=PUSH0
 
 @module push_zero

--- a/tests/ui/codegen/disasm/simple.evmir
+++ b/tests/ui/codegen/disasm/simple.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module simple

--- a/tests/ui/codegen/disasm/sparse_label.evmir
+++ b/tests/ui/codegen/disasm/sparse_label.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module sparse_label

--- a/tests/ui/codegen/disasm/terminal_dedup.evmir
+++ b/tests/ui/codegen/disasm/terminal_dedup.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O gas -Zdump=disasm-runtime
 //@ filecheck: --implicit-check-not=JUMPDEST
 
 @module terminal_dedup

--- a/tests/ui/codegen/disasm/unresolved_deferred.evmir
+++ b/tests/ui/codegen/disasm/unresolved_deferred.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -Zdump=disasm-runtime
 
 @module unresolved_deferred
 

--- a/tests/ui/codegen/lowering/abi_decode_calldata_slice.sol
+++ b/tests/ui/codegen/lowering/abi_decode_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract AbiDecodeCalldataSlice {

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_arrays.sol
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_arrays.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=ADDA
 
 // `abi.decode` into dynamic arrays of elementary types: the head offset and

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.sol
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract AbiDecodeDynamicTuple {

--- a/tests/ui/codegen/lowering/abi_decode_static_tuple.sol
+++ b/tests/ui/codegen/lowering/abi_decode_static_tuple.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract AbiDecodeStaticTuple {

--- a/tests/ui/codegen/lowering/abi_decode_structs.sol
+++ b/tests/ui/codegen/lowering/abi_decode_structs.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=ADS
 
 // `abi.decode` into structs, struct arrays, and mixed tuples routes through

--- a/tests/ui/codegen/lowering/abi_dynamic_return.sol
+++ b/tests/ui/codegen/lowering/abi_dynamic_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract AbiDynamicReturn {

--- a/tests/ui/codegen/lowering/abi_encode_bytes.sol
+++ b/tests/ui/codegen/lowering/abi_encode_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // `abi.encode(...)` allocates a fresh `bytes memory` `[length][data...]` from

--- a/tests/ui/codegen/lowering/abi_encode_call.sol
+++ b/tests/ui/codegen/lowering/abi_encode_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=AEC
 
 // `abi.encodeCall(F, (args))` takes the selector from the function reference

--- a/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // `abi.encodePacked(...)` may include a slice of a `bytes`/`string` calldata

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Packed encoding writes each value's top `size` bytes: fixed-bytes values

--- a/tests/ui/codegen/lowering/abi_encode_packed_static_hash.sol
+++ b/tests/ui/codegen/lowering/abi_encode_packed_static_hash.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Nitro-style compact hashes should stage small all-static packed data in

--- a/tests/ui/codegen/lowering/abi_encode_semantic.sol
+++ b/tests/ui/codegen/lowering/abi_encode_semantic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck: --implicit-check-not=set_fmp
 
 interface Sink {

--- a/tests/ui/codegen/lowering/abi_encode_with_signature_dynamic.sol
+++ b/tests/ui/codegen/lowering/abi_encode_with_signature_dynamic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: test/utils/mocks/MockReentrancyGuard.sol
 
 // `abi.encodeWithSignature` with a signature that is not a string literal.

--- a/tests/ui/codegen/lowering/abi_head_size_overflow.sol
+++ b/tests/ui/codegen/lowering/abi_head_size_overflow.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 
 contract AbiHeadSizeOverflow {
     function oversized(

--- a/tests/ui/codegen/lowering/abi_nested_return.sol
+++ b/tests/ui/codegen/lowering/abi_nested_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract AbiNestedReturn {

--- a/tests/ui/codegen/lowering/abi_packed_calldata_bytes.sol
+++ b/tests/ui/codegen/lowering/abi_packed_calldata_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // `abi.encodePacked(...)` may include a `bytes`/`string` calldata argument,

--- a/tests/ui/codegen/lowering/abi_packed_calldata_struct_field.sol
+++ b/tests/ui/codegen/lowering/abi_packed_calldata_struct_field.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: contracts/metatx/ERC2771Forwarder.sol
 
 // Packing a dynamic field of a calldata struct. The prologue decodes the

--- a/tests/ui/codegen/lowering/acyclic_stack_phi.sol
+++ b/tests/ui/codegen/lowering/acyclic_stack_phi.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@ compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 contract AcyclicStackPhi {

--- a/tests/ui/codegen/lowering/array_bounds_panic.sol
+++ b/tests/ui/codegen/lowering/array_bounds_panic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Array indexing emits a bounds check that reverts with Panic(0x32)

--- a/tests/ui/codegen/lowering/assembler_block_dedup.sol
+++ b/tests/ui/codegen/lowering/assembler_block_dedup.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime --pretty-json
+//@compile-flags: -Zdump=evm-ir-runtime --pretty-json
 //@ filecheck:
 contract AssemblerBlockDedup {
     // CHECK: push 0xdbe671f

--- a/tests/ui/codegen/lowering/backend_control_flow.sol
+++ b/tests/ui/codegen/lowering/backend_control_flow.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck: --enable-var-scope
 
 contract BackendControlFlow {

--- a/tests/ui/codegen/lowering/base_constructor.sol
+++ b/tests/ui/codegen/lowering/base_constructor.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Base {

--- a/tests/ui/codegen/lowering/branch.sol
+++ b/tests/ui/codegen/lowering/branch.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Branch {

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract AddmodMulmod {

--- a/tests/ui/codegen/lowering/bytes_memory_elements.sol
+++ b/tests/ui/codegen/lowering/bytes_memory_elements.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Memory `bytes` uses the packed `[length][data...]` layout: `new bytes(n)`

--- a/tests/ui/codegen/lowering/calldata_array_subslice.sol
+++ b/tests/ui/codegen/lowering/calldata_array_subslice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract CalldataArraySubslice {

--- a/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.sol
+++ b/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 
 contract CalldataArraySubsliceDynamic {
     // A sub-slice of a dynamic-element array keeps element offsets relative to

--- a/tests/ui/codegen/lowering/calldata_array_to_memory.sol
+++ b/tests/ui/codegen/lowering/calldata_array_to_memory.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // A calldata dynamic array converted to memory (declaration initializer,

--- a/tests/ui/codegen/lowering/calldata_nested_forward.sol
+++ b/tests/ui/codegen/lowering/calldata_nested_forward.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 struct NestedItem {

--- a/tests/ui/codegen/lowering/calldata_slice_bounds_revert.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_bounds_revert.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zdump=mir
+//@ compile-flags: -Zdump=mir
 
 // Unlike an array index, invalid calldata slice bounds revert with empty data.
 // This covers both an end past the source length and a start after the end.

--- a/tests/ui/codegen/lowering/calldata_slice_call_stack.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_call_stack.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 interface SliceToken {
     function balanceOf(address account) external view returns (uint256);

--- a/tests/ui/codegen/lowering/calldata_slice_control_flow.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_control_flow.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // A calldata slice built or trimmed under control flow, then read back or passed

--- a/tests/ui/codegen/lowering/calldata_slice_encode.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_encode.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 interface SliceSink {

--- a/tests/ui/codegen/lowering/calldata_slice_named_return.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_named_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=CSNR
 
 // A calldata-slice named return (`returns (bytes calldata result)`) that is

--- a/tests/ui/codegen/lowering/calldata_slice_param_helper.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_param_helper.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=CDPARAM
 
 // An internal helper taking a `bytes calldata` parameter used only through its

--- a/tests/ui/codegen/lowering/calldata_slice_param_large_helper.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_param_large_helper.sol
@@ -1,4 +1,3 @@
-//@compile-flags: -Zcodegen
 
 contract CalldataSliceParamLargeHelper {
     function lastWord(bytes calldata data) external pure returns (uint256) {

--- a/tests/ui/codegen/lowering/calldata_slice_rebind.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_rebind.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Rebinding calldata bytes keeps a lazy `(ptr, len)` slice. A later external

--- a/tests/ui/codegen/lowering/calldata_slice_return.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 contract CalldataSliceReturn {
     function whole(bytes calldata data) external pure returns (bytes calldata) {

--- a/tests/ui/codegen/lowering/calldata_slice_return_unsupported.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_return_unsupported.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 contract CalldataSliceReturnUnsupported {
     // A calldata slice returned from an internal function is inlined at the

--- a/tests/ui/codegen/lowering/calldata_slice_ternary.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_ternary.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract CalldataSliceTernary {

--- a/tests/ui/codegen/lowering/calldata_slice_yul_bounds.sol
+++ b/tests/ui/codegen/lowering/calldata_slice_yul_bounds.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract CalldataSliceYulBounds {

--- a/tests/ui/codegen/lowering/calldata_struct_field_slice.sol
+++ b/tests/ui/codegen/lowering/calldata_struct_field_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=CDSFS
 
 // Slicing a dynamic field of a calldata struct, the ERC-4337

--- a/tests/ui/codegen/lowering/calldata_struct_member_index.sol
+++ b/tests/ui/codegen/lowering/calldata_struct_member_index.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=CDSMI
 
 // Indexing a calldata array whose elements are wider than a word. The elements

--- a/tests/ui/codegen/lowering/calldata_validation.sol
+++ b/tests/ui/codegen/lowering/calldata_validation.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Pins the calldata lower-bound check and validators emitted for value-type

--- a/tests/ui/codegen/lowering/chained_calldata_slice.sol
+++ b/tests/ui/codegen/lowering/chained_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract ChainedCalldataSlice {

--- a/tests/ui/codegen/lowering/checked_arithmetic_panic.sol
+++ b/tests/ui/codegen/lowering/checked_arithmetic_panic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract CheckedArithmeticPanic {

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Pins the per-op checked-arithmetic check shapes so they stay at or below

--- a/tests/ui/codegen/lowering/checked_pow_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Pins the checked exponentiation shapes ported from solc's `checked_exp_*`

--- a/tests/ui/codegen/lowering/cold_call_fallthrough.sol
+++ b/tests/ui/codegen/lowering/cold_call_fallthrough.sol
@@ -1,7 +1,7 @@
 //@ revisions: none size
-//@[none] compile-flags: -Zcodegen -O none -Zdump=evm-ir-runtime
+//@[none] compile-flags: -O none -Zdump=evm-ir-runtime
 //@[none] filecheck: --check-prefix=NONE --enable-var-scope
-//@[size] compile-flags: -Zcodegen -O size -Zdump=evm-ir-runtime --pretty-json
+//@[size] compile-flags: -O size -Zdump=evm-ir-runtime --pretty-json
 //@[size] filecheck: --check-prefix=SIZE --enable-var-scope
 
 // Calls to the non-returning helper make their blocks cold. The backend should

--- a/tests/ui/codegen/lowering/comparison.sol
+++ b/tests/ui/codegen/lowering/comparison.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Comparison {

--- a/tests/ui/codegen/lowering/compound_assign.sol
+++ b/tests/ui/codegen/lowering/compound_assign.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract CompoundAssign {

--- a/tests/ui/codegen/lowering/constructor_abi_validation.sol
+++ b/tests/ui/codegen/lowering/constructor_abi_validation.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract ConstructorAbiValidation {

--- a/tests/ui/codegen/lowering/constructor_internal_call.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_call.sol
@@ -1,7 +1,7 @@
 //@ revisions: mir evmir
-//@[mir] compile-flags: -Zcodegen -O none -Zdump=mir
+//@[mir] compile-flags: -O none -Zdump=mir
 //@[mir] filecheck: --check-prefix=MIR
-//@[evmir] compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
+//@[evmir] compile-flags: -Zdump=evm-ir --pretty-json
 //@[evmir] filecheck: --check-prefix=EVMIR
 
 contract ConstructorInternalCall {

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 library ConstructorLibrary {

--- a/tests/ui/codegen/lowering/constructor_success_postlude.sol
+++ b/tests/ui/codegen/lowering/constructor_success_postlude.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir
+//@compile-flags: -Zdump=evm-ir
 //@filecheck: --enable-var-scope
 
 contract ConstructorSuccessPostlude {

--- a/tests/ui/codegen/lowering/contract_creation_self_cycle.sol
+++ b/tests/ui/codegen/lowering/contract_creation_self_cycle.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen --emit=bin
+//@ compile-flags: --emit=bin
 
 contract SelfCycle { //~ ERROR: recursive contract creation bytecode dependency
     function create() external {

--- a/tests/ui/codegen/lowering/custom_error_payloads.sol
+++ b/tests/ui/codegen/lowering/custom_error_payloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract CustomErrorPayloads {

--- a/tests/ui/codegen/lowering/dynamic_struct_param.sol
+++ b/tests/ui/codegen/lowering/dynamic_struct_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 struct InitInput {

--- a/tests/ui/codegen/lowering/emit_abi_bin.sol
+++ b/tests/ui/codegen/lowering/emit_abi_bin.sol
@@ -1,7 +1,7 @@
 //@ revisions: evmir bin
-//@[evmir] compile-flags: -Zcodegen --emit=abi -Zdump=evm-ir,evm-ir-runtime --pretty-json
+//@[evmir] compile-flags: --emit=abi -Zdump=evm-ir,evm-ir-runtime --pretty-json
 //@[evmir] filecheck: --check-prefix=EVMIR
-//@[bin] compile-flags: -Zcodegen --emit=abi,bin,bin-runtime --pretty-json
+//@[bin] compile-flags: --emit=abi,bin,bin-runtime --pretty-json
 //@[bin] filecheck: --check-prefix=BIN
 
 // EVMIR: "type": "constructor"

--- a/tests/ui/codegen/lowering/empty_external_return.sol
+++ b/tests/ui/codegen/lowering/empty_external_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@filecheck: --enable-var-scope
 
 contract EmptyExternalReturn {

--- a/tests/ui/codegen/lowering/enum_conversion_qualified.sol
+++ b/tests/ui/codegen/lowering/enum_conversion_qualified.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // Integer-to-enum conversions must check the actual variant count rather than

--- a/tests/ui/codegen/lowering/equal_immediate_scheduling.sol
+++ b/tests/ui/codegen/lowering/equal_immediate_scheduling.sol
@@ -1,9 +1,9 @@
 //@ revisions: none gas size
-//@[none] compile-flags: -Zcodegen -O none -Zdump=evm-ir-runtime
+//@[none] compile-flags: -O none -Zdump=evm-ir-runtime
 //@[none] filecheck: --check-prefix=NONE
-//@[gas] compile-flags: -Zcodegen -O gas -Zdump=evm-ir-runtime
+//@[gas] compile-flags: -O gas -Zdump=evm-ir-runtime
 //@[gas] filecheck: --check-prefix=GAS
-//@[size] compile-flags: -Zcodegen -O size -Zdump=evm-ir-runtime
+//@[size] compile-flags: -O size -Zdump=evm-ir-runtime
 //@[size] filecheck: --check-prefix=SIZE
 
 contract EqualImmediateScheduling {

--- a/tests/ui/codegen/lowering/event_dynamic_data.sol
+++ b/tests/ui/codegen/lowering/event_dynamic_data.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract EventDynamicData {

--- a/tests/ui/codegen/lowering/event_encoding.sol
+++ b/tests/ui/codegen/lowering/event_encoding.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract EventEncoding {

--- a/tests/ui/codegen/lowering/event_indexed_aggregate.sol
+++ b/tests/ui/codegen/lowering/event_indexed_aggregate.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 
 contract EventIndexedAggregate {
     event IndexedArray(uint256[2] indexed values);

--- a/tests/ui/codegen/lowering/event_overloads.sol
+++ b/tests/ui/codegen/lowering/event_overloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Emitting an overloaded event must use the overload selected by the type

--- a/tests/ui/codegen/lowering/event_topic_limit.sol
+++ b/tests/ui/codegen/lowering/event_topic_limit.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 
 contract EventTopicLimit {
     event Named( //~ ERROR: event cannot have more than 3 indexed parameters

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.sol
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.sol
@@ -1,7 +1,7 @@
 //@revisions: homestead byzantium
-//@[homestead] compile-flags: -Zcodegen -O none --evm-version homestead -Zdump=mir
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
 //@[homestead] filecheck: --check-prefix=HOMESTEAD
-//@[byzantium] compile-flags: -Zcodegen -O none --evm-version byzantium -Zdump=mir
+//@[byzantium] compile-flags: -O none --evm-version byzantium -Zdump=mir
 //@[byzantium] filecheck: --check-prefix=BYZANTIUM
 
 interface Target {

--- a/tests/ui/codegen/lowering/fallback_bytes_unsupported.sol
+++ b/tests/ui/codegen/lowering/fallback_bytes_unsupported.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen --emit=bin-runtime
+//@ compile-flags: --emit=bin-runtime
 
 contract FallbackBytesUnsupported { //~ ERROR: codegen does not support `fallback(bytes) returns (bytes)` yet
     fallback(bytes calldata input) external returns (bytes memory) {

--- a/tests/ui/codegen/lowering/fixed_bytes_canonical.sol
+++ b/tests/ui/codegen/lowering/fixed_bytes_canonical.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract FixedBytesCanonical {

--- a/tests/ui/codegen/lowering/fmp_reload_across_blocks.sol
+++ b/tests/ui/codegen/lowering/fmp_reload_across_blocks.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: contracts/test/ExcessReturnDataRecipient.sol
 
 // A free-memory-pointer load whose only reload path is its spill slot: the

--- a/tests/ui/codegen/lowering/function_call.sol
+++ b/tests/ui/codegen/lowering/function_call.sol
@@ -1,7 +1,7 @@
 //@ revisions: mir size
-//@[mir] compile-flags: -Zcodegen -O none -Zdump=mir
+//@[mir] compile-flags: -O none -Zdump=mir
 //@[mir] filecheck:
-//@[size] compile-flags: -Zcodegen -O size -Zdump=evm-ir-runtime
+//@[size] compile-flags: -O size -Zdump=evm-ir-runtime
 
 contract FunctionCall {
     // CHECK-LABEL: fn @double{{[( ]}}

--- a/tests/ui/codegen/lowering/global_stack_calldata_alias.sol
+++ b/tests/ui/codegen/lowering/global_stack_calldata_alias.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 contract Test {

--- a/tests/ui/codegen/lowering/immutable_byte_patches.sol
+++ b/tests/ui/codegen/lowering/immutable_byte_patches.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O size -Zdump=evm-ir
+//@ compile-flags: -O size -Zdump=evm-ir
 //@ filecheck:
 
 contract ImmutableBytePatches {

--- a/tests/ui/codegen/lowering/immutable_getter.sol
+++ b/tests/ui/codegen/lowering/immutable_getter.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract C {

--- a/tests/ui/codegen/lowering/immutable_keccak_literal.sol
+++ b/tests/ui/codegen/lowering/immutable_keccak_literal.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract ImmutableKeccakLiteral {

--- a/tests/ui/codegen/lowering/immutable_name_conflicts.sol
+++ b/tests/ui/codegen/lowering/immutable_name_conflicts.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 contract Base {

--- a/tests/ui/codegen/lowering/immutable_reads.sol
+++ b/tests/ui/codegen/lowering/immutable_reads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract C {

--- a/tests/ui/codegen/lowering/immutable_widths.sol
+++ b/tests/ui/codegen/lowering/immutable_widths.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir
+//@compile-flags: -Zdump=evm-ir
 //@filecheck:
 
 type Tiny is uint16;

--- a/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 // ported-from: test/libsolidity/semanticTests/constructor/store_internal_unused_function_in_constructor.sol

--- a/tests/ui/codegen/lowering/internal-function-pointer/higher_order_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/higher_order_mir.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 // ported-from: test/libsolidity/semanticTests/functionCall/call_function_returning_function.sol

--- a/tests/ui/codegen/lowering/internal-function-pointer/inheritance_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/inheritance_mir.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 // ported-from: test/libsolidity/semanticTests/inheritance/inherited_function_through_dispatch.sol

--- a/tests/ui/codegen/lowering/internal-function-pointer/memory_array_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/memory_array_mir.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 // ported-from: test/libsolidity/semanticTests/array/function_memory_array.sol

--- a/tests/ui/codegen/lowering/internal-function-pointer/selection_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/selection_mir.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 contract FunctionPointerSelection {

--- a/tests/ui/codegen/lowering/internal-function-pointer/signatures_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/signatures_mir.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 // CHECK-LABEL: fn @constructor(

--- a/tests/ui/codegen/lowering/internal_call_frame_dealloc.sol
+++ b/tests/ui/codegen/lowering/internal_call_frame_dealloc.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime --pretty-json
+//@compile-flags: -Zdump=evm-ir-runtime --pretty-json
 //@ filecheck:
 
 contract InternalCallFrameDealloc {

--- a/tests/ui/codegen/lowering/internal_loop_call.sol
+++ b/tests/ui/codegen/lowering/internal_loop_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // A same-contract internal function whose body contains a loop, called by bare

--- a/tests/ui/codegen/lowering/internal_void_call.sol
+++ b/tests/ui/codegen/lowering/internal_void_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract InternalVoidCall {

--- a/tests/ui/codegen/lowering/library_call.sol
+++ b/tests/ui/codegen/lowering/library_call.sol
@@ -1,7 +1,7 @@
 //@ revisions: unlinked linked
-//@[unlinked] compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@[unlinked] compile-flags: -Zdump=evm-ir-runtime
 //@[unlinked] filecheck: --check-prefixes=COMMON,UNLINKED --implicit-check-not=delegatecall
-//@[linked] compile-flags: -Zcodegen --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=evm-ir-runtime
+//@[linked] compile-flags: --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=evm-ir-runtime
 //@[linked] filecheck: --check-prefixes=COMMON,LINKED
 
 // A `public`/`external` library function called from another contract is

--- a/tests/ui/codegen/lowering/library_mapping_storage_param.sol
+++ b/tests/ui/codegen/lowering/library_mapping_storage_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // A `library` function may take a `mapping`/`storage` reference parameter and

--- a/tests/ui/codegen/lowering/library_wrapper_storage_param.sol
+++ b/tests/ui/codegen/lowering/library_wrapper_storage_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // The external wrapper of a public library function must decode a

--- a/tests/ui/codegen/lowering/linear.sol
+++ b/tests/ui/codegen/lowering/linear.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Linear {

--- a/tests/ui/codegen/lowering/linked_library_chain.sol
+++ b/tests/ui/codegen/lowering/linked_library_chain.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries Inner=0x1000000000000000000000000000000000000001,Outer=0x1000000000000000000000000000000000000002 -Zdump=evm-ir-runtime
+//@compile-flags: --libraries Inner=0x1000000000000000000000000000000000000001,Outer=0x1000000000000000000000000000000000000002 -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // A linked library may itself call another linked library, forwarding a

--- a/tests/ui/codegen/lowering/linked_library_dynamic_fields.sol
+++ b/tests/ui/codegen/lowering/linked_library_dynamic_fields.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --libraries L=0x1000000000000000000000000000000000000001 -Zdump=evm-ir-runtime
+//@compile-flags: --libraries L=0x1000000000000000000000000000000000000001 -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // A linked library call whose struct parameter carries dynamic fields:

--- a/tests/ui/codegen/lowering/linked_library_multi_return.sol
+++ b/tests/ui/codegen/lowering/linked_library_multi_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
+//@compile-flags: -O none --libraries Lib=0x1111111111111111111111111111111111111111 -Zdump=mir
 //@filecheck:
 
 library Lib {

--- a/tests/ui/codegen/lowering/log_topic_reuse.sol
+++ b/tests/ui/codegen/lowering/log_topic_reuse.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // A value used as a `LOG` topic and then used again *later in the same block*

--- a/tests/ui/codegen/lowering/loop_simple.sol
+++ b/tests/ui/codegen/lowering/loop_simple.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract LoopSimple {

--- a/tests/ui/codegen/lowering/low_level_call_calldata_bytes.sol
+++ b/tests/ui/codegen/lowering/low_level_call_calldata_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // A low-level call may take a `bytes calldata` value as its call data, e.g. a

--- a/tests/ui/codegen/lowering/low_level_call_returndata.sol
+++ b/tests/ui/codegen/lowering/low_level_call_returndata.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 interface IERC20Minimal {

--- a/tests/ui/codegen/lowering/low_level_call_storage_bytes.sol
+++ b/tests/ui/codegen/lowering/low_level_call_storage_bytes.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: contracts/test/Reenterer.sol
 
 // A storage `bytes` used directly as low-level call data. A call reads its

--- a/tests/ui/codegen/lowering/low_level_staticcall_evm_version.sol
+++ b/tests/ui/codegen/lowering/low_level_staticcall_evm_version.sol
@@ -1,6 +1,6 @@
 //@revisions: homestead byzantium
-//@[homestead] compile-flags: -Zcodegen -O none --evm-version homestead -Zdump=mir
-//@[byzantium] compile-flags: -Zcodegen -O none --evm-version byzantium -Zdump=mir
+//@[homestead] compile-flags: -O none --evm-version homestead -Zdump=mir
+//@[byzantium] compile-flags: -O none --evm-version byzantium -Zdump=mir
 //@[byzantium] filecheck:
 
 contract Caller {

--- a/tests/ui/codegen/lowering/lowering_error_sentinel.sol
+++ b/tests/ui/codegen/lowering/lowering_error_sentinel.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 
 // Unsupported constructs reported during lowering produce an error sentinel
 // value instead of panicking or silently lowering to zero. This used to ICE.

--- a/tests/ui/codegen/lowering/mapping.sol
+++ b/tests/ui/codegen/lowering/mapping.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Mapping {

--- a/tests/ui/codegen/lowering/mapping_bytes_values.sol
+++ b/tests/ui/codegen/lowering/mapping_bytes_values.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract MappingBytesValues {

--- a/tests/ui/codegen/lowering/mapping_dynamic_key.sol
+++ b/tests/ui/codegen/lowering/mapping_dynamic_key.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract MappingDynamicKey {

--- a/tests/ui/codegen/lowering/mapping_nested_struct_copy.sol
+++ b/tests/ui/codegen/lowering/mapping_nested_struct_copy.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Mapping values that are structs use a runtime-computed base slot. Copy the

--- a/tests/ui/codegen/lowering/mapping_struct_getter.sol
+++ b/tests/ui/codegen/lowering/mapping_struct_getter.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // The auto-generated getter for a `mapping(K => Struct) public` must read the

--- a/tests/ui/codegen/lowering/mcopy_evm_version.sol
+++ b/tests/ui/codegen/lowering/mcopy_evm_version.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none --evm-version shanghai -Zdump=mir
+//@compile-flags: -O none --evm-version shanghai -Zdump=mir
 
 contract McopyEvmVersion {
     function copy() external pure {

--- a/tests/ui/codegen/lowering/mcopy_precancun.sol
+++ b/tests/ui/codegen/lowering/mcopy_precancun.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --evm-version paris -Zdump=disasm-runtime
+//@compile-flags: --evm-version paris -Zdump=disasm-runtime
 //@filecheck:
 
 // On pre-Cancun targets there is no MCOPY; memory copy lowers to the identity

--- a/tests/ui/codegen/lowering/member_call_unresolved.sol
+++ b/tests/ui/codegen/lowering/member_call_unresolved.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir
+//@compile-flags: -Zdump=evm-ir
 // Calls with an erroneous receiver or builtin argument must reuse that error,
 // not emit another diagnostic or ICE in codegen.
 import {Missing} from "./does-not-exist.sol"; //~ ERROR: file

--- a/tests/ui/codegen/lowering/memory_allocation_panic.sol
+++ b/tests/ui/codegen/lowering/memory_allocation_panic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Dynamic memory allocations must revert with Panic(0x41) when the requested

--- a/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol
+++ b/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract MemoryFixedArrayAlloc {

--- a/tests/ui/codegen/lowering/mir_alloc_ops.sol
+++ b/tests/ui/codegen/lowering/mir_alloc_ops.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract MirAllocOps {

--- a/tests/ui/codegen/lowering/msg_data.sol
+++ b/tests/ui/codegen/lowering/msg_data.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract MsgData {

--- a/tests/ui/codegen/lowering/multi_return.sol
+++ b/tests/ui/codegen/lowering/multi_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract MultiReturn {

--- a/tests/ui/codegen/lowering/multi_return_call.sol
+++ b/tests/ui/codegen/lowering/multi_return_call.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Multi-value returns from internal *calls* must propagate all N values, not

--- a/tests/ui/codegen/lowering/multi_return_named_init.sol
+++ b/tests/ui/codegen/lowering/multi_return_named_init.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Finalize the complete return prefix before initializing named return

--- a/tests/ui/codegen/lowering/multi_return_scratch.sol
+++ b/tests/ui/codegen/lowering/multi_return_scratch.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 // Multi-return tails live at the free-memory pointer, and every tail word is
 // loaded before the first tuple lvalue is evaluated. Computing `stored[key]`

--- a/tests/ui/codegen/lowering/narrow_bitwise_not.sol
+++ b/tests/ui/codegen/lowering/narrow_bitwise_not.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 //@ normalize-stdout-test: "\n(\n)$" -> "$1"
 

--- a/tests/ui/codegen/lowering/nested_loops.sol
+++ b/tests/ui/codegen/lowering/nested_loops.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract NestedLoops {

--- a/tests/ui/codegen/lowering/nested_static_struct_param.sol
+++ b/tests/ui/codegen/lowering/nested_static_struct_param.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 struct Inner {

--- a/tests/ui/codegen/lowering/packed_calldata_slice.sol
+++ b/tests/ui/codegen/lowering/packed_calldata_slice.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract PackedCalldataSlice {

--- a/tests/ui/codegen/lowering/param_reassigned_across_control_flow.sol
+++ b/tests/ui/codegen/lowering/param_reassigned_across_control_flow.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 // A parameter reassigned under control flow must merge through its frame slot
 // like a reassigned local: a plain SSA binding only updates within a block, so

--- a/tests/ui/codegen/lowering/recursive.sol
+++ b/tests/ui/codegen/lowering/recursive.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Recursive functions. A recursive call can't be inlined (the inline path's

--- a/tests/ui/codegen/lowering/recursive_memory_return.sol
+++ b/tests/ui/codegen/lowering/recursive_memory_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Functions returning a memory reference can now recurse: the return is a

--- a/tests/ui/codegen/lowering/revert_error_helper.sol
+++ b/tests/ui/codegen/lowering/revert_error_helper.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // Constant short revert messages share one synthesized `__revert_error`

--- a/tests/ui/codegen/lowering/revert_payloads.sol
+++ b/tests/ui/codegen/lowering/revert_payloads.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract RevertPayloads {

--- a/tests/ui/codegen/lowering/selector_on_bare_overload_set.sol
+++ b/tests/ui/codegen/lowering/selector_on_bare_overload_set.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: test/foundry/utils/TestTokenMinter.sol
 
 // `.selector` on a bare function name inherited through an override chain.

--- a/tests/ui/codegen/lowering/signed_constant_ops.sol
+++ b/tests/ui/codegen/lowering/signed_constant_ops.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract SignedConstantOps {

--- a/tests/ui/codegen/lowering/stack-too-deep/call_args.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/call_args.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
+//@compile-flags: -Zdump=evm-ir --pretty-json
 //@ filecheck:
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;

--- a/tests/ui/codegen/lowering/stack-too-deep/locals.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/locals.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
+//@compile-flags: -Zdump=evm-ir --pretty-json
 //@ filecheck:
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;

--- a/tests/ui/codegen/lowering/stack-too-deep/params.sol
+++ b/tests/ui/codegen/lowering/stack-too-deep/params.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir --pretty-json
+//@compile-flags: -Zdump=evm-ir --pretty-json
 //@ filecheck:
 // solc 0.8.30 without --via-ir reports `Stack too deep` for this contract.
 pragma solidity ^0.8.0;

--- a/tests/ui/codegen/lowering/stack_arg_rotation.sol
+++ b/tests/ui/codegen/lowering/stack_arg_rotation.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 contract StackArgRotation {
     uint256 public sink;

--- a/tests/ui/codegen/lowering/stack_phi_loop.sol
+++ b/tests/ui/codegen/lowering/stack_phi_loop.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime --pretty-json
+//@compile-flags: -Zdump=evm-ir-runtime --pretty-json
 //@ filecheck:
 
 contract StackPhiLoop {

--- a/tests/ui/codegen/lowering/static_frames.sol
+++ b/tests/ui/codegen/lowering/static_frames.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // Static frame overlays use compile-time-fixed frame addresses, while recursive

--- a/tests/ui/codegen/lowering/storage.sol
+++ b/tests/ui/codegen/lowering/storage.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Storage {

--- a/tests/ui/codegen/lowering/storage_bytes_array_push.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_array_push.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=SBAP
 
 // Storage arrays with `bytes`/`string` elements support push, pop, and

--- a/tests/ui/codegen/lowering/storage_bytes_elements.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract StorageBytesElements {

--- a/tests/ui/codegen/lowering/storage_bytes_from_calldata.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_from_calldata.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract StorageBytesFromCalldata {

--- a/tests/ui/codegen/lowering/storage_bytes_member.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_member.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime -Zswitch-lowering=perfect
+//@compile-flags: -Zdump=evm-ir-runtime -Zswitch-lowering=perfect
 //@ filecheck:
 
 // A `bytes` struct field reached through a storage reference bound from a

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract StorageBytesPushPop {

--- a/tests/ui/codegen/lowering/storage_checked_arithmetic.sol
+++ b/tests/ui/codegen/lowering/storage_checked_arithmetic.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract StorageCheckedArithmetic {

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.sol
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract StorageLongBytesReturn {

--- a/tests/ui/codegen/lowering/storage_packed_bool.sol
+++ b/tests/ui/codegen/lowering/storage_packed_bool.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir
+//@ compile-flags: -O none -Zdump=mir
 //@ filecheck:
 
 contract PackedBool {

--- a/tests/ui/codegen/lowering/storage_ref_parenthesized_init.sol
+++ b/tests/ui/codegen/lowering/storage_ref_parenthesized_init.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: test/foundry/new/helpers/CriteriaResolverHelper.sol
 
 // A parenthesized storage-reference initializer. Parentheses reach HIR as a

--- a/tests/ui/codegen/lowering/storage_reference.sol
+++ b/tests/ui/codegen/lowering/storage_reference.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // Storage references are modeled as slot values: `Item storage r = items[k]`

--- a/tests/ui/codegen/lowering/storage_slots_beyond_u64.sol
+++ b/tests/ui/codegen/lowering/storage_slots_beyond_u64.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 // EVM storage slots span the full 2^256 space, and a fixed array like
 // solady's `uint8[0xffffffffffffffff]` map walks the layout cursor past

--- a/tests/ui/codegen/lowering/storage_struct_array.sol
+++ b/tests/ui/codegen/lowering/storage_struct_array.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 // Fixed storage arrays of multi-slot elements stride by the element's slot
 // count: arr[i].a lives at base + i*2 and arr[i].b one slot above, so

--- a/tests/ui/codegen/lowering/storage_struct_deep_copy.sol
+++ b/tests/ui/codegen/lowering/storage_struct_deep_copy.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=SDC
 
 // Copying a memory struct with dynamic fields (bytes/string/dynamic arrays)

--- a/tests/ui/codegen/lowering/store_immutable_requires_lowering.sol
+++ b/tests/ui/codegen/lowering/store_immutable_requires_lowering.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen --emit=bin-runtime -Zmir-pipeline=lower-abi,lower-abi-encode,lower-aggregates,lower-slices,lower-dispatch,lower-memory-objects,lower-alloc,lower-evm-shaped
+//@ compile-flags: --emit=bin-runtime -Zmir-pipeline=lower-abi,lower-abi-encode,lower-aggregates,lower-slices,lower-dispatch,lower-memory-objects,lower-alloc,lower-evm-shaped
 
 contract StoreImmutableRequiresLowering { //~ ERROR: immutable assignments must be lowered before EVM codegen
     uint256 immutable value;

--- a/tests/ui/codegen/lowering/switch/bucket_dispatch.sol
+++ b/tests/ui/codegen/lowering/switch/bucket_dispatch.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zdump=evm-ir-runtime -Zswitch-lowering=buckets
+//@ compile-flags: -Zdump=evm-ir-runtime -Zswitch-lowering=buckets
 //@ filecheck: --check-prefix=TABLE
 
 // TABLE: indexed_jump

--- a/tests/ui/codegen/lowering/switch/common.sol
+++ b/tests/ui/codegen/lowering/switch/common.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O gas -Zdump=evm-ir-runtime
+//@ compile-flags: -O gas -Zdump=evm-ir-runtime
 //@ filecheck:
 
 contract ProxyResult {

--- a/tests/ui/codegen/lowering/switch/dense_table.sol
+++ b/tests/ui/codegen/lowering/switch/dense_table.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O size -Zdump=evm-ir-runtime
+//@ compile-flags: -O size -Zdump=evm-ir-runtime
 //@ filecheck: --check-prefix=TABLE
 
 // TABLE: push 10

--- a/tests/ui/codegen/lowering/switch/indexed_jump.evmir
+++ b/tests/ui/codegen/lowering/switch/indexed_jump.evmir
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
+//@ compile-flags: -Zevm-ir-pipeline=default -O none -Zdump=disasm-runtime
 //@ filecheck:
 
 @module indexed_jump

--- a/tests/ui/codegen/lowering/switch/lowerings.sol
+++ b/tests/ui/codegen/lowering/switch/lowerings.sol
@@ -1,24 +1,24 @@
 //@ revisions: linear_gas linear_size binary_gas binary_size buckets_gas buckets_size dense_gas dense_size perfect_gas perfect_size
 
-//@[linear_gas] compile-flags: -Zcodegen -O gas -Zswitch-lowering=linear -Zdump=evm-ir-runtime,disasm-runtime
+//@[linear_gas] compile-flags: -O gas -Zswitch-lowering=linear -Zdump=evm-ir-runtime,disasm-runtime
 //@[linear_gas] filecheck: --check-prefix=LINEAR
-//@[linear_size] compile-flags: -Zcodegen -O size -Zswitch-lowering=linear -Zdump=evm-ir-runtime,disasm-runtime
+//@[linear_size] compile-flags: -O size -Zswitch-lowering=linear -Zdump=evm-ir-runtime,disasm-runtime
 //@[linear_size] filecheck: --check-prefix=LINEAR
-//@[binary_gas] compile-flags: -Zcodegen -O gas -Zswitch-lowering=binary -Zdump=evm-ir-runtime,disasm-runtime
+//@[binary_gas] compile-flags: -O gas -Zswitch-lowering=binary -Zdump=evm-ir-runtime,disasm-runtime
 //@[binary_gas] filecheck: --check-prefix=BINARY
-//@[binary_size] compile-flags: -Zcodegen -O size -Zswitch-lowering=binary -Zdump=evm-ir-runtime,disasm-runtime
+//@[binary_size] compile-flags: -O size -Zswitch-lowering=binary -Zdump=evm-ir-runtime,disasm-runtime
 //@[binary_size] filecheck: --check-prefix=BINARY
-//@[buckets_gas] compile-flags: -Zcodegen -O gas -Zswitch-lowering=buckets -Zdump=evm-ir-runtime,disasm-runtime
+//@[buckets_gas] compile-flags: -O gas -Zswitch-lowering=buckets -Zdump=evm-ir-runtime,disasm-runtime
 //@[buckets_gas] filecheck: --check-prefix=BUCKETSGAS
-//@[buckets_size] compile-flags: -Zcodegen -O size -Zswitch-lowering=buckets -Zdump=evm-ir-runtime,disasm-runtime
+//@[buckets_size] compile-flags: -O size -Zswitch-lowering=buckets -Zdump=evm-ir-runtime,disasm-runtime
 //@[buckets_size] filecheck: --check-prefix=BUCKETSSIZE
-//@[dense_gas] compile-flags: -Zcodegen -O gas -Zswitch-lowering=dense -Zdump=evm-ir-runtime,disasm-runtime
+//@[dense_gas] compile-flags: -O gas -Zswitch-lowering=dense -Zdump=evm-ir-runtime,disasm-runtime
 //@[dense_gas] filecheck: --check-prefix=DENSE
-//@[dense_size] compile-flags: -Zcodegen -O size -Zswitch-lowering=dense -Zdump=evm-ir-runtime,disasm-runtime
+//@[dense_size] compile-flags: -O size -Zswitch-lowering=dense -Zdump=evm-ir-runtime,disasm-runtime
 //@[dense_size] filecheck: --check-prefix=DENSE
-//@[perfect_gas] compile-flags: -Zcodegen -O gas -Zswitch-lowering=perfect -Zdump=evm-ir-runtime,disasm-runtime
+//@[perfect_gas] compile-flags: -O gas -Zswitch-lowering=perfect -Zdump=evm-ir-runtime,disasm-runtime
 //@[perfect_gas] filecheck: --check-prefix=PERFECTGAS
-//@[perfect_size] compile-flags: -Zcodegen -O size -Zswitch-lowering=perfect -Zdump=evm-ir-runtime,disasm-runtime
+//@[perfect_size] compile-flags: -O size -Zswitch-lowering=perfect -Zdump=evm-ir-runtime,disasm-runtime
 //@[perfect_size] filecheck: --check-prefix=PERFECTSIZE
 
 contract SwitchLowerings {

--- a/tests/ui/codegen/lowering/switch/shared_growth_budget.sol
+++ b/tests/ui/codegen/lowering/switch/shared_growth_budget.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O gas -Zdump=evm-ir -Zswitch-max-gas-code-growth=100 -Zswitch-max-bit-slice-gas-code-growth=63
+//@ compile-flags: -O gas -Zdump=evm-ir -Zswitch-max-gas-code-growth=100 -Zswitch-max-bit-slice-gas-code-growth=63
 //@ filecheck:
 
 contract SwitchSharedGrowthBudget {

--- a/tests/ui/codegen/lowering/ternary.sol
+++ b/tests/ui/codegen/lowering/ternary.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract Ternary {

--- a/tests/ui/codegen/lowering/ternary_operand_reuse.sol
+++ b/tests/ui/codegen/lowering/ternary_operand_reuse.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 
 contract TernaryOperandReuse {
     // `caller()` is not rematerializable: consuming it as the modulus and then

--- a/tests/ui/codegen/lowering/time_passes.sol
+++ b/tests/ui/codegen/lowering/time_passes.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Ztime-passes -Zcodegen -O none --emit=bin
+//@ compile-flags: -Ztime-passes -O none --emit=bin
 //@ normalize-stderr-test: "time: +[0-9]+\.[0-9]{3}" -> "time: <TIME>"
 
 contract TimePasses {

--- a/tests/ui/codegen/lowering/try_catch_full.sol
+++ b/tests/ui/codegen/lowering/try_catch_full.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=TCF
 
 // Full try/catch shape: return bindings decode the successful call's

--- a/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol
+++ b/tests/ui/codegen/lowering/tuple_assign_branch_leak.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@ compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 // A multi-return tuple assignment inside one branch arm must not leak its
 // values into the sibling arm: `off` below is reassigned only in the `then`

--- a/tests/ui/codegen/lowering/tuple_assignment.sol
+++ b/tests/ui/codegen/lowering/tuple_assignment.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // Tuple assignment to EXISTING lvalues, `(a, b) = rhs`. `lower_assign` had no

--- a/tests/ui/codegen/lowering/type_conversion.sol
+++ b/tests/ui/codegen/lowering/type_conversion.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract TypeConversion {

--- a/tests/ui/codegen/lowering/udvt_selector.sol
+++ b/tests/ui/codegen/lowering/udvt_selector.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=hashes -Zdump=evm-ir-runtime --pretty-json
+//@compile-flags: --emit=hashes -Zdump=evm-ir-runtime --pretty-json
 //@ filecheck:
 
 type Wad is uint256;

--- a/tests/ui/codegen/lowering/user_defined_operators.sol
+++ b/tests/ui/codegen/lowering/user_defined_operators.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=mir
+//@compile-flags: -Zdump=mir
 //@filecheck: --check-prefix=UDO
 
 // User-defined operators on a value type (`using {add as +, neg as -} for T`)

--- a/tests/ui/codegen/lowering/using_for_struct.sol
+++ b/tests/ui/codegen/lowering/using_for_struct.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // `using L for S` attached calls on a struct (a reference type) must resolve to

--- a/tests/ui/codegen/lowering/while_empty_body.sol
+++ b/tests/ui/codegen/lowering/while_empty_body.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir
+//@compile-flags: -Zdump=evm-ir
 //@ filecheck:
 
 contract WhileEmptyBody {

--- a/tests/ui/codegen/lowering/while_loop.sol
+++ b/tests/ui/codegen/lowering/while_loop.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract WhileLoop {

--- a/tests/ui/codegen/lowering/yul_call_errors.sol
+++ b/tests/ui/codegen/lowering/yul_call_errors.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 
 contract YulCallErrors {
     function unknownCall() public pure returns (uint256 result) {

--- a/tests/ui/codegen/lowering/yul_calldata_array.sol
+++ b/tests/ui/codegen/lowering/yul_calldata_array.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 // `.length`/`.offset` on a calldata array in inline assembly. The array

--- a/tests/ui/codegen/lowering/yul_local_phi.sol
+++ b/tests/ui/codegen/lowering/yul_local_phi.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract YulLocalPhi {

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 //@filecheck:
 
 contract YulLowLevelBuiltins {

--- a/tests/ui/codegen/lowering/yul_param_reassignment.sol
+++ b/tests/ui/codegen/lowering/yul_param_reassignment.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen --emit=bin-runtime
+//@compile-flags: --emit=bin-runtime
 // ported-from: src/utils/LibBytes.sol
 
 // A parameter reassigned in inline assembly, the solady `LibBytes.indexOf`

--- a/tests/ui/codegen/lowering/yul_return.sol
+++ b/tests/ui/codegen/lowering/yul_return.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -Zdump=evm-ir-runtime
+//@compile-flags: -Zdump=evm-ir-runtime
 //@ filecheck:
 
 // The Yul `return(offset, size)` builtin halts execution and returns `size`

--- a/tests/ui/codegen/lowering/yul_unsupported_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_unsupported_builtins.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 
 contract YulUnsupportedBuiltins {
     function unsupportedBuiltins() public returns (uint256 result) {

--- a/tests/ui/codegen/mir/dump_cfg.sol
+++ b/tests/ui/codegen/mir/dump_cfg.sol
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zcodegen -O none -Zdump=mir-cfg
+//@ compile-flags: -O none -Zdump=mir-cfg
 //@ filecheck: --enable-var-scope
 
 contract DumpCfg {

--- a/tests/ui/codegen/mir/dump_phase.sol
+++ b/tests/ui/codegen/mir/dump_phase.sol
@@ -1,13 +1,13 @@
 //@ revisions: none gas pipeline substitute evm-substitute
-//@[none] compile-flags: -Zcodegen -O none -Zdump=mir
+//@[none] compile-flags: -O none -Zdump=mir
 //@[none] filecheck: --check-prefix=NONE
-//@[gas] compile-flags: -Zcodegen -O gas -Zdump=mir
+//@[gas] compile-flags: -O gas -Zdump=mir
 //@[gas] filecheck: --check-prefix=GAS
 //@[pipeline] compile-flags: -Zmir-pipeline=none
 //@[pipeline] filecheck: --check-prefix=PIPELINE
-//@[substitute] compile-flags: -Zcodegen -O gas -Zdump=mir -Zmir-pipeline=none
+//@[substitute] compile-flags: -O gas -Zdump=mir -Zmir-pipeline=none
 //@[substitute] filecheck: --check-prefix=SUBSTITUTE
-//@[evm-substitute] compile-flags: -Zcodegen -Zdump=evm-ir-runtime -Zevm-ir-pipeline=none
+//@[evm-substitute] compile-flags: -Zdump=evm-ir-runtime -Zevm-ir-pipeline=none
 //@[evm-substitute] filecheck: --check-prefix=EVM-SUBSTITUTE
 
 // NONE: @module DumpPhase

--- a/tests/ui/erc7201/codegen.sol
+++ b/tests/ui/erc7201/codegen.sol
@@ -1,4 +1,4 @@
-//@compile-flags: -Zcodegen -O none -Zdump=mir
+//@compile-flags: -O none -Zdump=mir
 // ported-from: test/cmdlineTests/yul_optimizer_erc7201_literal_comptime_evaluation/input.sol
 // ported-from: test/cmdlineTests/yul_optimizer_erc7201_param_memory/input.sol
 // ported-from: test/cmdlineTests/yul_optimizer_erc7201_param_calldata/input.sol

--- a/tests/ui/standard-json/basic.jsonc
+++ b/tests/ui/standard-json/basic.jsonc
@@ -1,4 +1,3 @@
-//@ compile-flags: -Zcodegen
 // CHECK: "sources": {
 // CHECK: "A.sol": {
 // CHECK: "id": 0

--- a/tests/ui/standard-json/basic.stdout
+++ b/tests/ui/standard-json/basic.stdout
@@ -1,4 +1,16 @@
 {
+  "errors": [
+    {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    }
+  ],
   "sources": {
     "A.sol": {
       "id": 0

--- a/tests/ui/standard-json/codegen-selected-contract.jsonc
+++ b/tests/ui/standard-json/codegen-selected-contract.jsonc
@@ -1,6 +1,7 @@
-//@ compile-flags: -Zcodegen
 //@ filecheck:
-// CHECK-NOT: "errors"
+// CHECK: "errors": [
+// CHECK: "errorCode": "2264"
+// CHECK: "message": "code generation is experimental"
 // CHECK: "contracts": {
 // CHECK: "Selected": {
 // CHECK: "bytecode": {

--- a/tests/ui/standard-json/codegen-selected-contract.stdout
+++ b/tests/ui/standard-json/codegen-selected-contract.stdout
@@ -1,4 +1,16 @@
 {
+  "errors": [
+    {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    }
+  ],
   "sources": {
     "A.sol": {
       "id": 0

--- a/tests/ui/standard-json/codegen-unsupported.jsonc
+++ b/tests/ui/standard-json/codegen-unsupported.jsonc
@@ -1,4 +1,3 @@
-//@ compile-flags: -Zcodegen
 //@ filecheck:
 // CHECK: "errors": [
 // CHECK: "severity": "error"

--- a/tests/ui/standard-json/codegen-unsupported.stdout
+++ b/tests/ui/standard-json/codegen-unsupported.stdout
@@ -1,6 +1,16 @@
 {
   "errors": [
     {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    },
+    {
       "sourceLocation": {
         "file": "Fallback.sol",
         "start": 9,

--- a/tests/ui/standard-json/immutable-references/input.jsonc
+++ b/tests/ui/standard-json/immutable-references/input.jsonc
@@ -1,4 +1,3 @@
-//@ compile-flags: -Zcodegen
 //@ filecheck:
 // CHECK-LABEL: "Widths": {
 // CHECK: "deployedBytecode": {

--- a/tests/ui/standard-json/immutable-references/input.stdout
+++ b/tests/ui/standard-json/immutable-references/input.stdout
@@ -1,4 +1,16 @@
 {
+  "errors": [
+    {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    }
+  ],
   "sources": {
     "A.sol": {
       "id": 0

--- a/tests/ui/standard-json/libraries/input.jsonc
+++ b/tests/ui/standard-json/libraries/input.jsonc
@@ -1,6 +1,6 @@
-//@ compile-flags: -Zcodegen
 //@ filecheck:
-// CHECK-NOT: "errors"
+// CHECK: "errors": [
+// CHECK: "errorCode": "2264"
 // CHECK: "deployedBytecode": {
 // CHECK-NEXT: "opcodes":
 // CHECK-SAME: PUSH20 0x1111111111111111111111111111111111111111

--- a/tests/ui/standard-json/libraries/input.stdout
+++ b/tests/ui/standard-json/libraries/input.stdout
@@ -1,4 +1,16 @@
 {
+  "errors": [
+    {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    }
+  ],
   "sources": {
     "A.sol": {
       "id": 0

--- a/tests/ui/standard-json/link-references/input.jsonc
+++ b/tests/ui/standard-json/link-references/input.jsonc
@@ -1,4 +1,3 @@
-//@ compile-flags: -Zcodegen
 //@ filecheck:
 // CHECK-LABEL: "bytecode": {
 // CHECK-NEXT: "linkReferences": {}

--- a/tests/ui/standard-json/link-references/input.stdout
+++ b/tests/ui/standard-json/link-references/input.stdout
@@ -1,4 +1,16 @@
 {
+  "errors": [
+    {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    }
+  ],
   "sources": {
     "A.sol": {
       "id": 0

--- a/tests/ui/standard-json/opcodes/input.jsonc
+++ b/tests/ui/standard-json/opcodes/input.jsonc
@@ -1,4 +1,3 @@
-//@ compile-flags: -Zcodegen
 //@ filecheck:
 // CHECK-LABEL: "bytecode": {
 // CHECK-NEXT: "opcodes":

--- a/tests/ui/standard-json/opcodes/input.stdout
+++ b/tests/ui/standard-json/opcodes/input.stdout
@@ -1,4 +1,16 @@
 {
+  "errors": [
+    {
+      "sourceLocation": null,
+      "secondarySourceLocations": [],
+      "type": "Warning",
+      "component": "general",
+      "severity": "warning",
+      "errorCode": "2264",
+      "message": "code generation is experimental",
+      "formattedMessage": "warning[2264]: code generation is experimental\n\n"
+    }
+  ],
   "sources": {
     "A.sol": {
       "id": 0

--- a/tools/tester/src/foundry.rs
+++ b/tools/tester/src/foundry.rs
@@ -71,7 +71,6 @@ struct CompilerRun {
 
 struct FoundrySolc {
     path: PathBuf,
-    _temp_dir: tempfile::TempDir,
 }
 
 impl FoundrySolc {
@@ -212,47 +211,9 @@ fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).parent().unwrap().parent().unwrap().to_path_buf()
 }
 
-/// A `solc`-compatible executable for `FOUNDRY_SOLC` that enables Solar's
-/// experimental code generator.
-///
-/// Code generation is gated behind `-Zcodegen`, but Forge invokes
-/// `FOUNDRY_SOLC` with solc-style arguments and cannot pass that flag itself.
-/// We therefore point it at a tiny wrapper script that forwards every call to
-/// Solar with `-Zcodegen` prepended; otherwise Forge would receive empty
-/// bytecode.
+/// A `solc`-compatible executable for `FOUNDRY_SOLC`.
 fn foundry_solc() -> FoundrySolc {
-    let solar = get_solar_binary();
-    let temp_dir = tempfile::Builder::new()
-        .prefix("solar-zcodegen-")
-        .tempdir()
-        .expect("failed to create Solar codegen wrapper directory");
-
-    cfg_if::cfg_if! {
-        if #[cfg(unix)] {
-            use std::os::unix::fs::PermissionsExt;
-
-            let path = temp_dir.path().join("solar-zcodegen.sh");
-            let script = format!(
-                "#!/bin/sh\nexec \"{}\" -Zcodegen \"$@\"\n",
-                solar.display()
-            );
-            fs::write(&path, script).expect("failed to write solar codegen wrapper");
-            let mut perms = fs::metadata(&path).unwrap().permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&path, perms).unwrap();
-            FoundrySolc { path, _temp_dir: temp_dir }
-        } else if #[cfg(windows)] {
-            let path = temp_dir.path().join("solar-zcodegen.cmd");
-            let script = format!(
-                "@echo off\r\n\"{}\" -Zcodegen %*\r\nexit /b %ERRORLEVEL%\r\n",
-                solar.display()
-            );
-            fs::write(&path, script).expect("failed to write Solar codegen wrapper");
-            FoundrySolc { path, _temp_dir: temp_dir }
-        } else {
-            FoundrySolc { path: solar, _temp_dir: temp_dir }
-        }
-    }
+    FoundrySolc { path: get_solar_binary() }
 }
 
 /// Checks if forge is available.

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -9,7 +9,7 @@ use cfg_if as _;
 
 use eyre::{Result, eyre};
 use std::{
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     io,
     path::{Path, PathBuf},
     process::{Command, Stdio},
@@ -329,8 +329,16 @@ fn per_file_config(config: &mut ui_test::Config, file: &Spanned<Vec<u8>>, cfg: M
     }
 
     assert_eq!(config.comment_start, "//");
+    let is_codegen_test = path.components().any(|component| component.as_os_str() == "codegen")
+        || path.file_stem().is_some_and(|stem| {
+            stem == "codegen" && path.parent().and_then(Path::file_name) != Some(OsStr::new("cli"))
+        });
+    // Codegen fixtures exercise generated output; the warning is tested separately by CLI fixtures.
+    if is_codegen_test {
+        config.program.args.push("--allow=2264".into());
+    }
     if matches!(cfg.mode, Mode::Ui) && src.lines().any(run_call::is_directive) {
-        config.program.args.extend(["-Zcodegen".into(), "--emit=abi,bin".into()]);
+        config.program.args.push("--emit=abi,bin".into());
         config.stdout_filter(r"(?s).+", "");
     }
     if src.lines().any(|line| {


### PR DESCRIPTION
Codegen now runs whenever bytecode or IR output is requested, so solc-compatible callers no longer need an unstable opt-in. The compiler emits warning 2264 to mark codegen as experimental. This removes `-Zcodegen` from the compiler configuration and all callers, tests, benchmarks, and fuzzers; Standard JSON follows the same behavior, and Foundry can invoke Solar directly.