### PR TITLE
fix(lsp): complete unterminated imports

### DIFF
--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -4,7 +4,10 @@ use crate::{
     document_links::solidity_string_contents,
     formatter::{self, FormatterError},
     global_state::GlobalState,
-    import_resolution::{ImportCandidateKind, ImportResolver, decode_import_path, import_path_at},
+    import_resolution::{
+        ImportCandidateKind, ImportResolver, decode_import_path, import_path_at,
+        import_path_at_for_completion,
+    },
     natspec_completion::{self, NatSpecCompletionResult},
     progress::send_progress,
     symbols::{CompletionContext, CompletionItemData, SymbolTables},
@@ -921,7 +924,7 @@ fn import_completion(
         crate::proto::checked_text_range(contents, lsp_types::Range::new(position, position))?
             .start;
     let source = contents.to_string();
-    let import = import_path_at(&source, cursor_offset)?;
+    let import = import_path_at_for_completion(&source, cursor_offset)?;
     let prefix_end = cursor_offset.max(import.content_range.start);
     let raw_path_prefix = source.get(import.content_range.start..prefix_end).map(str::to_owned)?;
     let replacement = import.content_range;

--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -9,9 +9,12 @@ use solar_interface::{
     source_map::{FileName, FileResolver, SourceMap},
 };
 use solar_parse::{
-    Parser,
+    Cursor, Parser,
     ast::{self, StrKind},
-    lexer::unescape::try_parse_string_literal,
+    lexer::{
+        token::{RawLiteralKind, RawTokenKind},
+        unescape::try_parse_string_literal,
+    },
 };
 use std::{
     collections::BTreeMap,
@@ -36,6 +39,19 @@ pub(crate) fn import_path_at(source: &str, cursor: usize) -> Option<ImportPathAt
         return None;
     }
 
+    parse_import_path(source, cursor)
+}
+
+/// Finds an import path for completion, recovering a plain string left open at `cursor`.
+pub(crate) fn import_path_at_for_completion(source: &str, cursor: usize) -> Option<ImportPathAt> {
+    if cursor > source.len() || !source.is_char_boundary(cursor) {
+        return None;
+    }
+
+    import_path_at(source, cursor).or_else(|| recover_unterminated_import_path(source, cursor))
+}
+
+fn parse_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
     let mut opts = CompileOpts::default();
     opts.unstable.recover_incomplete_input = true;
     let sess = Session::builder().opts(opts).with_silent_emitter(None).single_threaded().build();
@@ -79,6 +95,66 @@ pub(crate) fn import_path_at(source: &str, cursor: usize) -> Option<ImportPathAt
         source.get(content_range.clone())?;
         Some(ImportPathAt { raw_path: raw_path.to_owned(), content_range, delimiter })
     })
+}
+
+fn recover_unterminated_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
+    let delimiter = unterminated_string_delimiter_at(source, cursor)?;
+    let mut recovered = String::with_capacity(cursor + 2);
+    recovered.push_str(&source[..cursor]);
+    recovered.push(char::from(delimiter));
+    recovered.push(';');
+
+    let import = parse_import_path(&recovered, cursor)?;
+    (import.delimiter == delimiter && import.content_range.end == cursor).then_some(import)
+}
+
+fn unterminated_string_delimiter_at(source: &str, cursor: usize) -> Option<u8> {
+    for (start, token) in Cursor::new(source).with_position() {
+        let end = start + token.len as usize;
+        let RawTokenKind::Literal { kind: RawLiteralKind::Str { kind: StrKind::Str, terminated } } =
+            token.kind
+        else {
+            continue;
+        };
+        let content_start = start + 1;
+        let content_end = if terminated { end - 1 } else { end };
+        if !(content_start..=content_end).contains(&cursor) {
+            continue;
+        }
+
+        let line_break = first_unescaped_line_break(&source.as_bytes()[content_start..content_end]);
+        if terminated && line_break.is_none() {
+            return None;
+        }
+        if line_break.is_some_and(|offset| cursor > content_start + offset) {
+            return None;
+        }
+        return source
+            .as_bytes()
+            .get(start)
+            .copied()
+            .filter(|delimiter| matches!(delimiter, b'\'' | b'"'));
+    }
+    None
+}
+
+fn first_unescaped_line_break(bytes: &[u8]) -> Option<usize> {
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' if bytes.get(index + 1) == Some(&b'\n') => index += 2,
+            b'\\'
+                if bytes.get(index + 1) == Some(&b'\r') && bytes.get(index + 2) == Some(&b'\n') =>
+            {
+                index += 3;
+            }
+            b'\\' if bytes.get(index + 1) == Some(&b'\r') => return Some(index + 1),
+            b'\\' => index += 2,
+            b'\r' | b'\n' => return Some(index),
+            _ => index += 1,
+        }
+    }
+    None
 }
 
 pub(crate) fn decode_import_path(path: &str) -> Option<String> {

--- a/crates/lsp/src/import_resolution/tests/mod.rs
+++ b/crates/lsp/src/import_resolution/tests/mod.rs
@@ -1,2 +1,3 @@
 mod context;
+mod path;
 mod resolver;

--- a/crates/lsp/src/import_resolution/tests/path.rs
+++ b/crates/lsp/src/import_resolution/tests/path.rs
@@ -1,0 +1,40 @@
+use super::super::{import_path_at, import_path_at_for_completion};
+
+#[test]
+fn completion_recovers_an_unterminated_import_before_an_unrelated_string() {
+    let source = "import \"./Dep\ncontract Main { string value = \"ordinary\"; }";
+    let cursor = source.find('\n').unwrap();
+
+    assert!(import_path_at(source, cursor).is_none());
+    let import = import_path_at_for_completion(source, cursor).unwrap();
+
+    assert_eq!(import.raw_path, "./Dep");
+    assert_eq!(import.content_range, 8..13);
+    assert_eq!(import.delimiter, b'"');
+}
+
+#[test]
+fn completion_recovers_a_single_quoted_named_import() {
+    let source = "import { Dependency } from './Dep";
+    let cursor = source.len();
+    let import = import_path_at_for_completion(source, cursor).unwrap();
+
+    assert_eq!(import.raw_path, "./Dep");
+    assert_eq!(&source[import.content_range], "./Dep");
+    assert_eq!(import.delimiter, b'\'');
+}
+
+#[test]
+fn completion_does_not_recover_an_unterminated_ordinary_string() {
+    let source = "contract Main { string value = \"./Dep";
+
+    assert!(import_path_at_for_completion(source, source.len()).is_none());
+}
+
+#[test]
+fn completion_does_not_recover_past_an_unescaped_line_break() {
+    let source = "import \"./Dep\ncontract Main { string value = \"ordinary\"; }";
+    let cursor = source.find("contract").unwrap() + "contract".len();
+
+    assert!(import_path_at_for_completion(source, cursor).is_none());
+}

--- a/crates/lsp/src/tests/import_completion.rs
+++ b/crates/lsp/src/tests/import_completion.rs
@@ -478,7 +478,7 @@ fn opening_quote_completion_does_not_return_an_out_of_range_edit() {
 }
 
 #[test]
-fn unterminated_import_completion_requires_an_import_ast() {
+fn unterminated_import_completion_does_not_replace_the_next_line() {
     let fixture = RequestFixture::new_allowing_diagnostics(
         r#"
         //- /foundry.toml
@@ -493,7 +493,20 @@ fn unterminated_import_completion_requires_an_import_ast() {
         "/src/Main.sol",
     );
 
-    fixture.check_completion_details("$1", str![""]);
+    fixture.check_completion_details(
+        "$1",
+        str![[r#"
+label=./Dependency.sol
+kind=File
+detail=<none>
+sort_text=<none>
+text_edit=edit 0:8-0:13
+insert_text_format=<none>
+new_text:
+./Dependency.sol
+
+"#]],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Import completion only accepted paths present in a successfully parsed source AST. Unterminated string literals therefore produced no candidates, which breaks editors that do not automatically close quotes.

This recovers plain-string import prefixes only for completion by detecting lexically incomplete literals, closing a truncated prefix, and validating it through the parser AST. Completed imports and import-definition lookup retain their existing behavior, and replacement edits remain confined to the incomplete path. Regression coverage includes later unrelated strings, single-quoted named imports, and false-positive guards.