### PR TITLE
fix(lsp): harden import completion

### DIFF
--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -4,7 +4,10 @@ use crate::{
     document_links::solidity_string_contents,
     formatter::{self, FormatterError},
     global_state::GlobalState,
-    import_resolution::{ImportCandidateKind, ImportResolver, decode_import_path, import_path_at},
+    import_resolution::{
+        ImportCandidateKind, ImportResolver, decode_import_path, import_path_at,
+        import_path_at_for_completion,
+    },
     natspec_completion::{self, NatSpecCompletionResult},
     progress::send_progress,
     symbols::{CompletionContext, CompletionItemData, SymbolTables},
@@ -921,7 +924,7 @@ fn import_completion(
         crate::proto::checked_text_range(contents, lsp_types::Range::new(position, position))?
             .start;
     let source = contents.to_string();
-    let import = import_path_at(&source, cursor_offset)?;
+    let import = import_path_at_for_completion(&source, cursor_offset)?;
     let prefix_end = cursor_offset.max(import.content_range.start);
     let raw_path_prefix = source.get(import.content_range.start..prefix_end).map(str::to_owned)?;
     let replacement = import.content_range;

--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -9,9 +9,12 @@ use solar_interface::{
     source_map::{FileName, FileResolver, SourceMap},
 };
 use solar_parse::{
-    Parser,
+    Cursor, Parser,
     ast::{self, StrKind},
-    lexer::unescape::try_parse_string_literal,
+    lexer::{
+        token::{RawLiteralKind, RawTokenKind},
+        unescape::try_parse_string_literal,
+    },
 };
 use std::{
     collections::BTreeMap,
@@ -36,6 +39,19 @@ pub(crate) fn import_path_at(source: &str, cursor: usize) -> Option<ImportPathAt
         return None;
     }
 
+    parse_import_path(source, cursor)
+}
+
+/// Finds an import path for completion, recovering a plain string left open at `cursor`.
+pub(crate) fn import_path_at_for_completion(source: &str, cursor: usize) -> Option<ImportPathAt> {
+    if cursor > source.len() || !source.is_char_boundary(cursor) {
+        return None;
+    }
+
+    import_path_at(source, cursor).or_else(|| recover_unterminated_import_path(source, cursor))
+}
+
+fn parse_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
     let mut opts = CompileOpts::default();
     opts.unstable.recover_incomplete_input = true;
     let sess = Session::builder().opts(opts).with_silent_emitter(None).single_threaded().build();
@@ -79,6 +95,66 @@ pub(crate) fn import_path_at(source: &str, cursor: usize) -> Option<ImportPathAt
         source.get(content_range.clone())?;
         Some(ImportPathAt { raw_path: raw_path.to_owned(), content_range, delimiter })
     })
+}
+
+fn recover_unterminated_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
+    let delimiter = unterminated_string_delimiter_at(source, cursor)?;
+    let mut recovered = String::with_capacity(cursor + 2);
+    recovered.push_str(&source[..cursor]);
+    recovered.push(char::from(delimiter));
+    recovered.push(';');
+
+    let import = parse_import_path(&recovered, cursor)?;
+    (import.delimiter == delimiter && import.content_range.end == cursor).then_some(import)
+}
+
+fn unterminated_string_delimiter_at(source: &str, cursor: usize) -> Option<u8> {
+    for (start, token) in Cursor::new(source).with_position() {
+        let end = start + token.len as usize;
+        let RawTokenKind::Literal { kind: RawLiteralKind::Str { kind: StrKind::Str, terminated } } =
+            token.kind
+        else {
+            continue;
+        };
+        let content_start = start + 1;
+        let content_end = if terminated { end - 1 } else { end };
+        if !(content_start..=content_end).contains(&cursor) {
+            continue;
+        }
+
+        let line_break = first_unescaped_line_break(&source.as_bytes()[content_start..content_end]);
+        if terminated && line_break.is_none() {
+            return None;
+        }
+        if line_break.is_some_and(|offset| cursor > content_start + offset) {
+            return None;
+        }
+        return source
+            .as_bytes()
+            .get(start)
+            .copied()
+            .filter(|delimiter| matches!(delimiter, b'\'' | b'"'));
+    }
+    None
+}
+
+fn first_unescaped_line_break(bytes: &[u8]) -> Option<usize> {
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' if bytes.get(index + 1) == Some(&b'\n') => index += 2,
+            b'\\'
+                if bytes.get(index + 1) == Some(&b'\r') && bytes.get(index + 2) == Some(&b'\n') =>
+            {
+                index += 3;
+            }
+            b'\\' if bytes.get(index + 1) == Some(&b'\r') => return Some(index + 1),
+            b'\\' => index += 2,
+            b'\r' | b'\n' => return Some(index),
+            _ => index += 1,
+        }
+    }
+    None
 }
 
 pub(crate) fn decode_import_path(path: &str) -> Option<String> {

--- a/crates/lsp/src/import_resolution.rs
+++ b/crates/lsp/src/import_resolution.rs
@@ -48,7 +48,19 @@ pub(crate) fn import_path_at_for_completion(source: &str, cursor: usize) -> Opti
         return None;
     }
 
-    import_path_at(source, cursor).or_else(|| recover_unterminated_import_path(source, cursor))
+    let Some(string) = plain_string_at(source, cursor) else {
+        return parse_import_path(source, cursor);
+    };
+    if string.first_unescaped_line_break.is_some_and(|line_break| cursor > line_break) {
+        return None;
+    }
+    if string.terminated && string.first_unescaped_line_break.is_none() {
+        return parse_import_path(source, cursor);
+    }
+    if string.terminated && parse_import_path(source, cursor).is_some() {
+        return None;
+    }
+    recover_unterminated_import_path(source, cursor, string)
 }
 
 fn parse_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
@@ -97,18 +109,35 @@ fn parse_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
     })
 }
 
-fn recover_unterminated_import_path(source: &str, cursor: usize) -> Option<ImportPathAt> {
-    let delimiter = unterminated_string_delimiter_at(source, cursor)?;
+fn recover_unterminated_import_path(
+    source: &str,
+    cursor: usize,
+    string: PlainStringAt,
+) -> Option<ImportPathAt> {
     let mut recovered = String::with_capacity(cursor + 2);
     recovered.push_str(&source[..cursor]);
-    recovered.push(char::from(delimiter));
+    recovered.push(char::from(string.delimiter));
     recovered.push(';');
 
-    let import = parse_import_path(&recovered, cursor)?;
-    (import.delimiter == delimiter && import.content_range.end == cursor).then_some(import)
+    let mut import = parse_import_path(&recovered, cursor)?;
+    if import.delimiter != string.delimiter
+        || import.content_range != (string.content_range.start..cursor)
+    {
+        return None;
+    }
+    import.content_range.end =
+        string.first_unescaped_line_break.unwrap_or(string.content_range.end);
+    Some(import)
 }
 
-fn unterminated_string_delimiter_at(source: &str, cursor: usize) -> Option<u8> {
+struct PlainStringAt {
+    content_range: Range<usize>,
+    delimiter: u8,
+    terminated: bool,
+    first_unescaped_line_break: Option<usize>,
+}
+
+fn plain_string_at(source: &str, cursor: usize) -> Option<PlainStringAt> {
     for (start, token) in Cursor::new(source).with_position() {
         let end = start + token.len as usize;
         let RawTokenKind::Literal { kind: RawLiteralKind::Str { kind: StrKind::Str, terminated } } =
@@ -122,18 +151,20 @@ fn unterminated_string_delimiter_at(source: &str, cursor: usize) -> Option<u8> {
             continue;
         }
 
-        let line_break = first_unescaped_line_break(&source.as_bytes()[content_start..content_end]);
-        if terminated && line_break.is_none() {
-            return None;
-        }
-        if line_break.is_some_and(|offset| cursor > content_start + offset) {
-            return None;
-        }
-        return source
+        let delimiter = source
             .as_bytes()
             .get(start)
             .copied()
-            .filter(|delimiter| matches!(delimiter, b'\'' | b'"'));
+            .filter(|delimiter| matches!(delimiter, b'\'' | b'"'))?;
+        let first_unescaped_line_break =
+            first_unescaped_line_break(&source.as_bytes()[content_start..content_end])
+                .map(|offset| content_start + offset);
+        return Some(PlainStringAt {
+            content_range: content_start..content_end,
+            delimiter,
+            terminated,
+            first_unescaped_line_break,
+        });
     }
     None
 }

--- a/crates/lsp/src/import_resolution/tests/mod.rs
+++ b/crates/lsp/src/import_resolution/tests/mod.rs
@@ -1,2 +1,3 @@
 mod context;
+mod path;
 mod resolver;

--- a/crates/lsp/src/import_resolution/tests/path.rs
+++ b/crates/lsp/src/import_resolution/tests/path.rs
@@ -1,0 +1,40 @@
+use super::super::{import_path_at, import_path_at_for_completion};
+
+#[test]
+fn completion_recovers_an_unterminated_import_before_an_unrelated_string() {
+    let source = "import \"./Dep\ncontract Main { string value = \"ordinary\"; }";
+    let cursor = source.find('\n').unwrap();
+
+    assert!(import_path_at(source, cursor).is_none());
+    let import = import_path_at_for_completion(source, cursor).unwrap();
+
+    assert_eq!(import.raw_path, "./Dep");
+    assert_eq!(import.content_range, 8..13);
+    assert_eq!(import.delimiter, b'"');
+}
+
+#[test]
+fn completion_recovers_a_single_quoted_named_import() {
+    let source = "import { Dependency } from './Dep";
+    let cursor = source.len();
+    let import = import_path_at_for_completion(source, cursor).unwrap();
+
+    assert_eq!(import.raw_path, "./Dep");
+    assert_eq!(&source[import.content_range], "./Dep");
+    assert_eq!(import.delimiter, b'\'');
+}
+
+#[test]
+fn completion_does_not_recover_an_unterminated_ordinary_string() {
+    let source = "contract Main { string value = \"./Dep";
+
+    assert!(import_path_at_for_completion(source, source.len()).is_none());
+}
+
+#[test]
+fn completion_does_not_recover_past_an_unescaped_line_break() {
+    let source = "import \"./Dep\ncontract Main { string value = \"ordinary\"; }";
+    let cursor = source.find("contract").unwrap() + "contract".len();
+
+    assert!(import_path_at_for_completion(source, cursor).is_none());
+}

--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -109,22 +109,7 @@ pub(crate) fn vfs_path(url: &lsp_types::Url) -> Option<vfs::VfsPath> {
 ///
 /// [`Range`]: std::ops::Range
 pub(crate) fn text_range(rope: &Rope, range: lsp_types::Range) -> std::ops::Range<usize> {
-    let start_line_byte = if range.start.line > rope.line_len() as u32 {
-        0usize
-    } else {
-        rope.byte_of_line(range.start.line as usize)
-    };
-    let start_line_utf16 = rope.utf16_code_unit_of_byte(start_line_byte);
-    let start = rope.byte_of_utf16_code_unit(start_line_utf16 + range.start.character as usize);
-    let end_line_byte = if range.end.line > rope.line_len() as u32 {
-        0usize
-    } else {
-        rope.byte_of_line(range.end.line as usize)
-    };
-    let end_line_utf16 = rope.utf16_code_unit_of_byte(end_line_byte);
-    let end = rope.byte_of_utf16_code_unit(end_line_utf16 + range.end.character as usize);
-
-    start..end
+    LspPositionIndex::new(rope).text_range(range)
 }
 
 /// Maps between byte offsets and LSP UTF-16 positions for one document.
@@ -167,6 +152,25 @@ impl<'a> LspPositionIndex<'a> {
         let start = self.byte_position(range.start)?;
         let end = self.byte_position(range.end)?;
         (start <= end).then_some(start..end)
+    }
+
+    fn text_range(&self, range: lsp_types::Range) -> std::ops::Range<usize> {
+        let start = self.byte_position_clamped(range.start);
+        let end = self.byte_position_clamped(range.end);
+        start..end
+    }
+
+    fn byte_position_clamped(&self, position: lsp_types::Position) -> usize {
+        let line = usize::try_from(position.line).unwrap_or(usize::MAX);
+        let start = self.line_starts.get(line).copied().unwrap_or_else(|| {
+            if position.line > self.rope.line_len() as u32 {
+                0
+            } else {
+                self.rope.byte_of_line(line)
+            }
+        });
+        let start_utf16 = self.rope.utf16_code_unit_of_byte(start);
+        self.rope.byte_of_utf16_code_unit(start_utf16 + position.character as usize)
     }
 
     fn byte_position(&self, position: lsp_types::Position) -> Option<usize> {
@@ -228,50 +232,12 @@ pub(crate) fn checked_text_range(
     rope: &Rope,
     range: lsp_types::Range,
 ) -> Option<std::ops::Range<usize>> {
-    let start = checked_byte_position(rope, range.start)?;
-    let end = checked_byte_position(rope, range.end)?;
-    (start <= end).then_some(start..end)
-}
-
-fn checked_byte_position(rope: &Rope, position: lsp_types::Position) -> Option<usize> {
-    let line_index = usize::try_from(position.line).ok()?;
-    if line_index >= rope.line_len() {
-        let is_trailing_line = line_index == rope.line_len()
-            && position.character == 0
-            && (rope.byte_len() == 0 || rope.byte(rope.byte_len() - 1) == b'\n');
-        return is_trailing_line.then_some(rope.byte_len());
-    }
-
-    let line_start = rope.byte_of_line(line_index);
-    let line = rope.line(line_index);
-    let target = usize::try_from(position.character).ok()?;
-    let mut utf16 = 0;
-    let mut byte = 0;
-    for ch in line.chars() {
-        if utf16 == target {
-            return Some(line_start + byte);
-        }
-        let next = utf16 + ch.len_utf16();
-        if target < next {
-            return None;
-        }
-        utf16 = next;
-        byte += ch.len_utf8();
-    }
-    Some(line_start + byte)
+    LspPositionIndex::new(rope).checked_text_range(range)
 }
 
 /// Converts a byte offset into an LSP UTF-16 position.
 pub(crate) fn position_at_byte(rope: &Rope, byte: usize) -> Option<lsp_types::Position> {
-    if byte > rope.byte_len() || !rope.is_char_boundary(byte) {
-        return None;
-    }
-    let line = rope.line_of_byte(byte);
-    let line_start = rope.byte_of_line(line);
-    let character = rope.utf16_code_unit_of_byte(byte) - rope.utf16_code_unit_of_byte(line_start);
-    let position =
-        lsp_types::Position::new(u32::try_from(line).ok()?, u32::try_from(character).ok()?);
-    (checked_byte_position(rope, position) == Some(byte)).then_some(position)
+    LspPositionIndex::new(rope).position_at_byte(byte)
 }
 
 // TODO: track `None`s here as they shouldn't happen?
@@ -397,7 +363,7 @@ fn severity(level: Level) -> lsp_types::DiagnosticSeverity {
 
 #[cfg(test)]
 mod tests {
-    use super::{checked_text_range, position_at_byte};
+    use super::{checked_text_range, position_at_byte, text_range};
     use crop::Rope;
     use lsp_types::{Position, Range, request::Request};
     use solar_interface::{
@@ -604,6 +570,37 @@ mod tests {
             Some(rope.byte_len()..rope.byte_len())
         );
         assert_eq!(index.position_at_byte(rope.byte_len()), Some(position));
+    }
+
+    #[test]
+    fn position_conversions_support_standalone_carriage_returns() {
+        let rope = Rope::from("a😀\rvalue");
+        for (position, byte) in
+            [(Position::new(0, 3), 5), (Position::new(1, 0), 6), (Position::new(1, 5), 11)]
+        {
+            let range = Range::new(position, position);
+            assert_eq!(checked_text_range(&rope, range), Some(byte..byte));
+            assert_eq!(position_at_byte(&rope, byte), Some(position));
+        }
+        assert!(position_at_byte(&rope, 2).is_none());
+    }
+
+    #[test]
+    fn position_conversions_accept_trailing_carriage_return_line() {
+        let rope = Rope::from("value\r");
+        let position = Position::new(1, 0);
+        assert_eq!(
+            checked_text_range(&rope, Range::new(position, position)),
+            Some(rope.byte_len()..rope.byte_len())
+        );
+        assert_eq!(position_at_byte(&rope, rope.byte_len()), Some(position));
+    }
+
+    #[test]
+    fn text_range_uses_standalone_carriage_return_lines() {
+        let rope = Rope::from("first\rsecond");
+        let range = text_range(&rope, Range::new(Position::new(1, 0), Position::new(1, 6)));
+        assert_eq!(rope.byte_slice(range).to_string(), "second");
     }
 
     #[test]

--- a/crates/lsp/src/tests/import_completion.rs
+++ b/crates/lsp/src/tests/import_completion.rs
@@ -478,7 +478,7 @@ fn opening_quote_completion_does_not_return_an_out_of_range_edit() {
 }
 
 #[test]
-fn unterminated_import_completion_requires_an_import_ast() {
+fn unterminated_import_completion_does_not_replace_the_next_line() {
     let fixture = RequestFixture::new_allowing_diagnostics(
         r#"
         //- /foundry.toml
@@ -493,7 +493,20 @@ fn unterminated_import_completion_requires_an_import_ast() {
         "/src/Main.sol",
     );
 
-    fixture.check_completion_details("$1", str![""]);
+    fixture.check_completion_details(
+        "$1",
+        str![[r#"
+label=./Dependency.sol
+kind=File
+detail=<none>
+sort_text=<none>
+text_edit=edit 0:8-0:13
+insert_text_format=<none>
+new_text:
+./Dependency.sol
+
+"#]],
+    );
 }
 
 #[test]

--- a/crates/lsp/src/tests/import_completion.rs
+++ b/crates/lsp/src/tests/import_completion.rs
@@ -1,8 +1,8 @@
 use super::{GlobalState, support::RequestFixture};
 use lsp_types::{
-    CompletionParams, CompletionResponse, DidChangeWatchedFilesParams, FileChangeType, FileEvent,
-    PartialResultParams, Position, TextDocumentIdentifier, TextDocumentPositionParams, Url,
-    WorkDoneProgressParams,
+    CompletionParams, CompletionResponse, CompletionTextEdit, DidChangeWatchedFilesParams,
+    FileChangeType, FileEvent, PartialResultParams, Position, TextDocumentIdentifier,
+    TextDocumentPositionParams, Url, WorkDoneProgressParams,
 };
 use snapbox::{IntoData, str};
 use std::time::Duration;
@@ -82,6 +82,94 @@ async fn import_completion_items(
         CompletionResponse::Array(items) => items,
         CompletionResponse::List(list) => list.items,
     }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn recovered_import_completion_replaces_the_cursor_suffix() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /foundry.toml
+
+        //- /src/Main.sol open
+        import "./De$1p
+
+        //- /src/Dependency.sol
+        contract Dependency {}
+        "#,
+        "/src/Main.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+
+    let item = import_completion_items(&mut state, uri, position)
+        .await
+        .into_iter()
+        .find(|item| item.label == "./Dependency.sol")
+        .unwrap();
+    let Some(CompletionTextEdit::Edit(edit)) = item.text_edit else {
+        panic!("expected a plain text edit")
+    };
+
+    assert_eq!(edit.range, lsp_types::Range::new(Position::new(0, 8), Position::new(0, 13)));
+    assert_eq!(edit.new_text, "./Dependency.sol");
+    assert!(item.additional_text_edits.is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn import_completion_does_not_delete_source_after_an_unescaped_newline() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /foundry.toml
+
+        //- /src/Main.sol open
+        import "./Dep$1
+        contract Victim {}
+        ";
+
+        //- /src/Dependency.sol
+        contract Dependency {}
+        "#,
+        "/src/Main.sol",
+    );
+    let mut state = fixture.state();
+    let (uri, position) = fixture.marker_location("$1");
+
+    let items = import_completion_items(&mut state, uri, position).await;
+
+    assert!(!items.iter().any(|item| item.label == "./Dependency.sol"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn import_completion_uses_lsp_lines_after_a_standalone_carriage_return() {
+    let mut fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /foundry.toml
+
+        //- /src/Main.sol open
+        contract C {}
+
+        //- /src/Dependency.sol
+        contract Dependency {}
+        "#,
+        "/src/Main.sol",
+    );
+    fixture.set_open_file_contents("/src/Main.sol", "\rcontract C {}\nimport \"./Dep");
+    let mut state = fixture.state();
+    let uri = Url::from_file_path(fixture.project_path("/src/Main.sol")).unwrap();
+
+    let contract_items =
+        import_completion_items(&mut state, uri.clone(), Position::new(1, 13)).await;
+    assert!(!contract_items.iter().any(|item| item.label == "./Dependency.sol"));
+
+    let item = import_completion_items(&mut state, uri, Position::new(2, 13))
+        .await
+        .into_iter()
+        .find(|item| item.label == "./Dependency.sol")
+        .unwrap();
+    let Some(CompletionTextEdit::Edit(edit)) = item.text_edit else {
+        panic!("expected a plain text edit")
+    };
+    assert_eq!(edit.range, lsp_types::Range::new(Position::new(2, 8), Position::new(2, 13)));
 }
 
 #[test]

--- a/crates/parse/src/lexer/unescape/mod.rs
+++ b/crates/parse/src/lexer/unescape/mod.rs
@@ -263,18 +263,19 @@ where
     let mut tail = chars.as_str();
     start += 1;
 
-    while tail.starts_with(|c: char| c.is_ascii_whitespace()) {
+    loop {
         let first_non_space =
             tail.bytes().position(|b| !matches!(b, b' ' | b'\t')).unwrap_or(tail.len());
         tail = &tail[first_non_space..];
         start += first_non_space;
 
-        if let Some(tail2) = tail.strip_prefix('\n').or_else(|| tail.strip_prefix("\r\n")) {
-            let skipped = tail.len() - tail2.len();
-            tail = tail2;
-            callback(start..start + skipped, Err(EscapeError::CannotSkipMultipleLines));
-            start += skipped;
-        }
+        let Some(tail2) = tail.strip_prefix('\n').or_else(|| tail.strip_prefix("\r\n")) else {
+            break;
+        };
+        let skipped = tail.len() - tail2.len();
+        tail = tail2;
+        callback(start..start + skipped, Err(EscapeError::CannotSkipMultipleLines));
+        start += skipped;
     }
     *chars = tail.chars();
 }
@@ -455,6 +456,22 @@ mod tests {
         check_parse(StrKind::Unicode, r"\u00e8", "è".as_bytes());
         check_parse(StrKind::Str, r"\xE8\u00e8", b"\xE8\xc3\xa8");
         check_parse(StrKind::Unicode, r"\xE8\u00e8", b"\xE8\xc3\xa8");
+    }
+
+    #[test]
+    fn line_continuation_before_form_feed() {
+        check(StrKind::Str, "\\\n\x0cafter", "\x0cafter", &[]);
+        check(StrKind::Str, "\\\r\n \t\x0cafter", "\x0cafter", &[]);
+    }
+
+    #[test]
+    fn line_continuation_before_vertical_tab() {
+        check(StrKind::Str, "\\\n\x0bafter", "\x0bafter", &[]);
+    }
+
+    #[test]
+    fn line_continuation_before_bare_carriage_return() {
+        check(StrKind::Str, "\\\n\rafter", "after", &[(2..3, BareCarriageReturn)]);
     }
 
     #[test]


### PR DESCRIPTION
This supersedes #1170 and includes @mattsse's original parser-validated recovery for unterminated import strings. It is meant to replace that PR, not stack on top of it.

The follow-up addresses all four actionable findings from the [Cyclops review](https://github.com/paradigmxyz/solar/pull/1170#pullrequestreview-4912538282). Recovered edits now replace the rest of the original same-line token without crossing an unescaped line break, so they neither leave suffix text behind nor delete later source. String unescaping now always consumes input or exits after a continuation, and the LSP byte/position helpers share one CR-aware index, preventing the form-feed hang and lone-CR range mismatch.

Complete imports and go-to-definition still use the normal AST path. When the lexer already proves the import string is open, completion skips the parse that is guaranteed to fail and validates only the recovered prefix.
