### PR TITLE
fix(codegen): clean unchecked signed negation

### DIFF
--- a/crates/codegen/src/lower/checked_arith.rs
+++ b/crates/codegen/src/lower/checked_arith.rs
@@ -1025,7 +1025,12 @@ impl<'gcx> Lowerer<'gcx> {
                         );
                     }
                 }
-                builder.sub(zero, operand)
+                let result = builder.sub(zero, operand);
+                if self.in_unchecked_block {
+                    self.truncate_wrapping_result(builder, result, int_info)
+                } else {
+                    result
+                }
             }
             UnOpKind::PreInc | UnOpKind::PostInc => {
                 let one = builder.imm_u64(1);

--- a/tests/ui/codegen/run-call/narrow_signed_negation.sol
+++ b/tests/ui/codegen/run-call/narrow_signed_negation.sol
@@ -1,0 +1,65 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: uncheckedI8(int8) -128 => -128
+//@ run-call: uncheckedI8(int8) -127 => 127
+//@ run-call: uncheckedI8(int8) 1 => -1
+//@ run-call: uncheckedI8(int8) 0 => 0
+//@ run-call: uncheckedI24(int24) -8388608 => -8388608
+//@ run-call: uncheckedI24(int24) 1 => -1
+//@ run-call: uncheckedI128(int128) -170141183460469231731687303715884105728 => -170141183460469231731687303715884105728
+//@ run-call: uncheckedI128(int128) 1 => -1
+//@ run-call: uncheckedI256(int256) -0x8000000000000000000000000000000000000000000000000000000000000000 => -0x8000000000000000000000000000000000000000000000000000000000000000
+//@ run-call: checkedI8(int8) -127 => 127
+//@ run-call-fail: checkedI8(int8) -128 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
+//@ run-call: upcastI8(int8) -128 => -128
+//@ run-call: internalI8(int8) -128 => -128
+
+contract NarrowSignedNegation {
+    function uncheckedI8(int8 value) external pure returns (int8) {
+        unchecked {
+            return -value;
+        }
+    }
+
+    function uncheckedI24(int24 value) external pure returns (int24) {
+        unchecked {
+            return -value;
+        }
+    }
+
+    function uncheckedI128(int128 value) external pure returns (int128) {
+        unchecked {
+            return -value;
+        }
+    }
+
+    function uncheckedI256(int256 value) external pure returns (int256) {
+        unchecked {
+            return -value;
+        }
+    }
+
+    function checkedI8(int8 value) external pure returns (int8) {
+        return -value;
+    }
+
+    function upcastI8(int8 value) external pure returns (int256 result) {
+        int8 negated;
+        unchecked {
+            negated = -value;
+        }
+        result = negated;
+    }
+
+    function internalI8(int8 value) external pure returns (int8) {
+        return negateI8(value);
+    }
+
+    function negateI8(int8 value) private pure returns (int8) {
+        unchecked {
+            return -value;
+        }
+    }
+}


### PR DESCRIPTION
Unchecked unary negation of a sub-word signed integer left the wrapped result as a dirty, zero-extended 256-bit word. This made values such as `unchecked { -type(int8).min; }` return `0x80` instead of the canonical sign-extended representation.

Normalize unchecked unary negation with the same typed-width cleanup already used for wrapping binary arithmetic. The runtime regression covers narrow and full-width boundaries, checked overflow behavior, and values crossing assignment and internal-call boundaries.

The Solc-vs-Solar symbolic differential harness in #1084 found this discrepancy and independently replayed it against both deployed runtimes.