### PR TITLE
fix(codegen): clean unchecked signed division

### DIFF
--- a/crates/codegen/src/lower/checked_arith.rs
+++ b/crates/codegen/src/lower/checked_arith.rs
@@ -142,7 +142,7 @@ impl<'gcx> Lowerer<'gcx> {
                     self.require_checked_arithmetic_info(arithmetic.integer, arithmetic.span);
                 let is_signed = int_info.map_or(arithmetic.is_signed, |info| info.signed);
                 self.emit_panic_if_zero(builder, rhs, PanicCode::DivisionByZero);
-                if is_signed {
+                let result = if is_signed {
                     if !self.in_unchecked_block
                         && let Some(info) = int_info
                         && info.signed
@@ -152,6 +152,11 @@ impl<'gcx> Lowerer<'gcx> {
                     builder.sdiv(lhs, rhs)
                 } else {
                     builder.div(lhs, rhs)
+                };
+                if self.in_unchecked_block && is_signed {
+                    self.truncate_wrapping_result(builder, result, int_info)
+                } else {
+                    result
                 }
             }
             BinOpKind::Rem => {

--- a/tests/ui/codegen/run-call/unchecked_signed_division.sol
+++ b/tests/ui/codegen/run-call/unchecked_signed_division.sol
@@ -1,0 +1,75 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: uncheckedI8(int8,int8) -128, -1 => -128
+//@ run-call: uncheckedI8(int8,int8) -128, 1 => -128
+//@ run-call: uncheckedI8(int8,int8) -128, -2 => 64
+//@ run-call: uncheckedI8(int8,int8) -127, -1 => 127
+//@ run-call: uncheckedI8(int8,int8) -10, 3 => -3
+//@ run-call: uncheckedI8(int8,int8) -10, -3 => 3
+//@ run-call: uncheckedI24(int24,int24) -8388608, -1 => -8388608
+//@ run-call: uncheckedI128(int128,int128) -170141183460469231731687303715884105728, -1 => -170141183460469231731687303715884105728
+//@ run-call: uncheckedI256(int256,int256) -0x8000000000000000000000000000000000000000000000000000000000000000, -1 => -0x8000000000000000000000000000000000000000000000000000000000000000
+//@ run-call-fail: uncheckedI8(int8,int8) 1, 0 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000012
+//@ run-call: checkedI8(int8,int8) -127, -1 => 127
+//@ run-call-fail: checkedI8(int8,int8) -128, -1 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
+//@ run-call: upcastI8(int8,int8) -128, -1 => -128
+//@ run-call: internalI8(int8,int8) -128, -1 => -128
+//@ run-call: isNegativeI8(int8,int8) -128, -1 => true
+
+contract UncheckedSignedDivision {
+    function uncheckedI8(int8 lhs, int8 rhs) external pure returns (int8) {
+        unchecked {
+            return lhs / rhs;
+        }
+    }
+
+    function uncheckedI24(int24 lhs, int24 rhs) external pure returns (int24) {
+        unchecked {
+            return lhs / rhs;
+        }
+    }
+
+    function uncheckedI128(int128 lhs, int128 rhs) external pure returns (int128) {
+        unchecked {
+            return lhs / rhs;
+        }
+    }
+
+    function uncheckedI256(int256 lhs, int256 rhs) external pure returns (int256) {
+        unchecked {
+            return lhs / rhs;
+        }
+    }
+
+    function checkedI8(int8 lhs, int8 rhs) external pure returns (int8) {
+        return lhs / rhs;
+    }
+
+    function upcastI8(int8 lhs, int8 rhs) external pure returns (int256 result) {
+        int8 quotient;
+        unchecked {
+            quotient = lhs / rhs;
+        }
+        result = quotient;
+    }
+
+    function internalI8(int8 lhs, int8 rhs) external pure returns (int8) {
+        return divideI8(lhs, rhs);
+    }
+
+    function isNegativeI8(int8 lhs, int8 rhs) external pure returns (bool) {
+        int8 quotient;
+        unchecked {
+            quotient = lhs / rhs;
+        }
+        return quotient < 0;
+    }
+
+    function divideI8(int8 lhs, int8 rhs) private pure returns (int8) {
+        unchecked {
+            return lhs / rhs;
+        }
+    }
+}


### PR DESCRIPTION
Unchecked signed division of a sub-word minimum by `-1` left the wrapped quotient as a dirty, positive 256-bit word. For `int8`, Solar returned `0x80` where Solidity wrapping semantics require the canonical sign-extended `-128`; the dirty value could also change internal comparisons and upcasts.

Normalize unchecked signed `SDIV` with the existing typed-width cleanup. Checked overflow and divide-by-zero behavior remain unchanged, and the runtime regression covers narrow/full-width boundaries, normal quotients, both panic codes, and internal value use.

The Solc-vs-Solar symbolic differential harness in #1084 found the `(-128, -1)` witness and independently replayed it against both deployed runtimes.