### PR TITLE
chore(ci): update Cyclops action refs

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -19,7 +19,7 @@ jobs:
       )
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@af809bfc35e4dd023bd52f6cc45e09809612a8cf # tempoxyz/gh-actions#40
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@dd1014bf8244fded7a501e701cafab240a4f9f0e
     with:
       required-labels: |
         cyclops
@@ -44,7 +44,7 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@af809bfc35e4dd023bd52f6cc45e09809612a8cf # tempoxyz/gh-actions#40
+      - uses: tempoxyz/gh-actions/actions/pr-audit-comment@dd1014bf8244fded7a501e701cafab240a4f9f0e
         with:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
           permission-check-mode: association


### PR DESCRIPTION
Updates both Cyclops workflow references to the latest commit on `tempoxyz/gh-actions` main (`dd1014bf8244fded7a501e701cafab240a4f9f0e`).

Prompted by: @DaniPopes