### PR TITLE
fix(ci): grant Cyclops workflow permissions

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -19,6 +19,8 @@ jobs:
       )
     permissions:
       contents: read
+      pull-requests: read
+      statuses: write
     uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@dd1014bf8244fded7a501e701cafab240a4f9f0e
     with:
       required-labels: |


### PR DESCRIPTION
The latest reusable Cyclops workflow includes audit-gate jobs that request `pull-requests: read` and `statuses: write`. GitHub validates those requested permissions at workflow startup, even when the caller job condition is false, so issue-comment runs failed before creating any jobs.

This grants the caller the full permission ceiling required by the reusable workflow, matching the working configuration in `tempoxyz/tempo`.

Validation:
- Compared the caller permission set with `tempoxyz/tempo/.github/workflows/pr-audit.yml`.
- Confirmed the referenced reusable workflow requests these permissions.
- `git diff --check` passes.

Prompted by: @DaniPopes