### PR TITLE
fix(ci): allow Cyclops PR comments

### DIFF
--- a/.github/workflows/cyclops-audit.yml
+++ b/.github/workflows/cyclops-audit.yml
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: tempoxyz/gh-actions/actions/pr-audit-comment@dd1014bf8244fded7a501e701cafab240a4f9f0e
         with:


### PR DESCRIPTION
Cyclops audit events are publishing successfully, but acknowledgement reactions and status comments on pull requests return `403 Resource not accessible by integration`.

Issue-comment API calls targeting pull requests require write access to pull requests. This upgrades the comment handler from `pull-requests: read` to `pull-requests: write`; `issues: write` remains for issue-comment operations.

Validation:
- Confirmed the audit event completed successfully in run `31713115184`.
- Confirmed both warnings are GitHub REST writes against pull request #1139.
- `git diff --check` passes.

Prompted by: @DaniPopes