### PR TITLE
fix(codegen): clean integer conversions

### DIFF
--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -2846,8 +2846,16 @@ impl<'gcx> EvmCodegen<'gcx> {
         };
         let cfg = CfgInfo::new(func);
         let reachable = cfg.reachable();
+        let mut reachable_values = DenseBitSet::new_empty(func.num_values());
+        for block_id in reachable {
+            for &inst_id in &func.blocks[block_id].instructions {
+                if let Some(value) = func.inst_result_value(inst_id) {
+                    reachable_values.insert(value);
+                }
+            }
+        }
         for value in values.iter().collect::<Vec<_>>() {
-            if !Self::value_defined_in_reachable_block(func, value, reachable) {
+            if !reachable_values.contains(value) {
                 values.remove(value);
             }
         }
@@ -2857,7 +2865,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         // load a stable slot so a call operand can always recover the value even when block
         // layout emits its use before the defining block.
         for val in Self::fmp_load_values(func) {
-            if !Self::value_defined_in_reachable_block(func, val, reachable) {
+            if !reachable_values.contains(val) {
                 continue;
             }
             self.scheduler.spills.reserve(val);
@@ -2872,26 +2880,13 @@ impl<'gcx> EvmCodegen<'gcx> {
         for inst_id in func.instructions() {
             if func.inst(inst_id).metadata.deferred_alloc()
                 && let Some(value) = func.inst_result_value(inst_id)
-                && Self::value_defined_in_reachable_block(func, value, reachable)
+                && reachable_values.contains(value)
             {
                 self.scheduler.spills.reserve(value);
                 self.scheduler.spills.require_store(value);
                 self.scheduler.spills.mark_reloadable(value);
             }
         }
-    }
-
-    fn value_defined_in_reachable_block(
-        func: &Function,
-        value: ValueId,
-        reachable: &DenseBitSet<BlockId>,
-    ) -> bool {
-        reachable.iter().any(|block_id| {
-            func.blocks[block_id]
-                .instructions
-                .iter()
-                .any(|&inst_id| func.inst_result_value(inst_id) == Some(value))
-        })
     }
 
     fn preallocate_spill_metadata(&mut self, func: &Function, values: &DenseBitSet<ValueId>) {

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -2802,7 +2802,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         // Coloring minimizes the local frame, which reduces memory expansion in gas mode. It is
         // deliberately disabled in size mode because renumbering spill addresses disturbed
         // downstream block sharing and regressed aggregate CI bytecode despite smaller frames.
-        let values = if self.gcx.sess.opts.optimization.is_gas() {
+        let mut values = if self.gcx.sess.opts.optimization.is_gas() {
             let (values, colorable) = Self::cross_block_spill_values_and_colorable(func, liveness);
             if !colorable.is_empty() {
                 let ranges = Self::spill_live_ranges(func, liveness, &colorable);
@@ -2844,12 +2844,22 @@ impl<'gcx> EvmCodegen<'gcx> {
             }
             values
         };
+        let cfg = CfgInfo::new(func);
+        let reachable = cfg.reachable();
+        for value in values.iter().collect::<Vec<_>>() {
+            if !Self::value_defined_in_reachable_block(func, value, &reachable) {
+                values.remove(value);
+            }
+        }
         self.preallocate_spill_metadata(func, &values);
 
         // A free-memory-pointer load cannot be recomputed after the pointer moves. Give every
         // load a stable slot so a call operand can always recover the value even when block
         // layout emits its use before the defining block.
         for val in Self::fmp_load_values(func) {
+            if !Self::value_defined_in_reachable_block(func, val, &reachable) {
+                continue;
+            }
             self.scheduler.spills.reserve(val);
             self.scheduler.spills.require_store(val);
             self.scheduler.spills.mark_reloadable(val);
@@ -2862,12 +2872,26 @@ impl<'gcx> EvmCodegen<'gcx> {
         for inst_id in func.instructions() {
             if func.inst(inst_id).metadata.deferred_alloc()
                 && let Some(value) = func.inst_result_value(inst_id)
+                && Self::value_defined_in_reachable_block(func, value, &reachable)
             {
                 self.scheduler.spills.reserve(value);
                 self.scheduler.spills.require_store(value);
                 self.scheduler.spills.mark_reloadable(value);
             }
         }
+    }
+
+    fn value_defined_in_reachable_block(
+        func: &Function,
+        value: ValueId,
+        reachable: &DenseBitSet<BlockId>,
+    ) -> bool {
+        reachable.iter().any(|block_id| {
+            func.blocks[block_id]
+                .instructions
+                .iter()
+                .any(|&inst_id| func.inst_result_value(inst_id) == Some(value))
+        })
     }
 
     fn preallocate_spill_metadata(&mut self, func: &Function, values: &DenseBitSet<ValueId>) {

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -2847,7 +2847,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         let cfg = CfgInfo::new(func);
         let reachable = cfg.reachable();
         for value in values.iter().collect::<Vec<_>>() {
-            if !Self::value_defined_in_reachable_block(func, value, &reachable) {
+            if !Self::value_defined_in_reachable_block(func, value, reachable) {
                 values.remove(value);
             }
         }
@@ -2857,7 +2857,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         // load a stable slot so a call operand can always recover the value even when block
         // layout emits its use before the defining block.
         for val in Self::fmp_load_values(func) {
-            if !Self::value_defined_in_reachable_block(func, val, &reachable) {
+            if !Self::value_defined_in_reachable_block(func, val, reachable) {
                 continue;
             }
             self.scheduler.spills.reserve(val);
@@ -2872,7 +2872,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         for inst_id in func.instructions() {
             if func.inst(inst_id).metadata.deferred_alloc()
                 && let Some(value) = func.inst_result_value(inst_id)
-                && Self::value_defined_in_reachable_block(func, value, &reachable)
+                && Self::value_defined_in_reachable_block(func, value, reachable)
             {
                 self.scheduler.spills.reserve(value);
                 self.scheduler.spills.require_store(value);

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -562,6 +562,28 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         } else {
             value
         };
+        let integer_conversion_needs_cleanup = match (from.peel_refs().kind, to.peel_refs().kind) {
+            (
+                TyKind::Elementary(solar_sema::hir::ElementaryType::UInt(from_size)),
+                TyKind::Elementary(solar_sema::hir::ElementaryType::UInt(to_size)),
+            )
+            | (
+                TyKind::Elementary(solar_sema::hir::ElementaryType::Int(from_size)),
+                TyKind::Elementary(solar_sema::hir::ElementaryType::Int(to_size)),
+            ) => to_size.bits() < from_size.bits(),
+            (
+                TyKind::Elementary(solar_sema::hir::ElementaryType::UInt(from_size)),
+                TyKind::Elementary(solar_sema::hir::ElementaryType::Int(to_size)),
+            )
+            | (
+                TyKind::Elementary(solar_sema::hir::ElementaryType::Int(from_size)),
+                TyKind::Elementary(solar_sema::hir::ElementaryType::UInt(to_size)),
+            ) => to_size.bits() <= from_size.bits(),
+            _ => false,
+        };
+        if integer_conversion_needs_cleanup {
+            return self.normalize_abi_scalar(value, to);
+        }
         if let TyKind::Enum(id) = to.peel_refs().kind {
             if !matches!(from.peel_refs().kind, TyKind::Enum(from_id) if from_id == id) {
                 let limit = self.gcx.hir.enumm(id).variants.len() as u64;

--- a/tests/ui/codegen/lowering/calldata_validation.abi.stdout
+++ b/tests/ui/codegen/lowering/calldata_validation.abi.stdout
@@ -144,34 +144,35 @@ fn @vEnum() [selector=0x5aa5e60a, pure] {
 
 fn @vMulti() [selector=0x403ecab4, pure] {
   bb0:
-    v2 = calldatasize
-    v3 = lt v2, 68
-    jumpi v3, bb4, bb5
+    v3 = calldatasize
+    v4 = lt v3, 68
+    jumpi v4, bb4, bb5
   bb1:
-    v0 = add arg0, arg1
-    v1 = lt v0, arg0
-    jumpi v1, bb2, bb3
+    v0 = and arg1, 255
+    v1 = add arg0, v0
+    v2 = lt v1, arg0
+    jumpi v2, bb2, bb3
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb3:
-    mstore 128, v0
-    v10 = add 128, 32
-    v11 = sub v10, 128
-    returndata 128, v11
+    mstore 128, v1
+    v11 = add 128, 32
+    v12 = sub v11, 128
+    returndata 128, v12
   bb4:
     revert 0, 0
   bb5:
-    v4 = calldataload 4
-    v5 = and v4, 0xffffffff
-    v6 = eq v4, v5
-    jumpi v6, bb6, bb4
+    v5 = calldataload 4
+    v6 = and v5, 0xffffffff
+    v7 = eq v5, v6
+    jumpi v7, bb6, bb4
   bb6:
-    v7 = calldataload 36
-    v8 = signextend 0, v7
-    v9 = eq v7, v8
-    jumpi v9, bb7, bb4
+    v8 = calldataload 36
+    v9 = signextend 0, v8
+    v10 = eq v8, v9
+    jumpi v10, bb7, bb4
   bb7:
     jump bb1
 }

--- a/tests/ui/codegen/lowering/calldata_validation.built.stdout
+++ b/tests/ui/codegen/lowering/calldata_validation.built.stdout
@@ -32,15 +32,16 @@ fn @vEnum(arg0: u8) -> u8 [selector=0x5aa5e60a, pure, abi_args=lazy, abi_params=
 
 fn @vMulti(arg0: u32, arg1: i8) -> u256 [selector=0x403ecab4, pure, abi_args=lazy, abi_params=[u32, i8], abi_returns=[word]] {
   bb0:
-    v0 = add arg0, arg1
-    v1 = lt v0, arg0
-    jumpi v1, bb1, bb2
+    v0 = and arg1, 255
+    v1 = add arg0, v0
+    v2 = lt v1, arg0
+    jumpi v2, bb1, bb2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb2:
-    ret v0
+    ret v1
 }
 
 fn @vFull(arg0: u256, arg1: bytes32, arg2: i256) -> u256 [selector=0x76fef307, pure, abi_args=lazy, abi_params=[u256, bytes32, i256], abi_returns=[word]] {

--- a/tests/ui/codegen/lowering/type_conversion.sol
+++ b/tests/ui/codegen/lowering/type_conversion.sol
@@ -3,20 +3,49 @@
 
 contract TypeConversion {
     // CHECK-LABEL: fn @narrowAddress{{[( ]}}
-    // CHECK: ret arg0
+    // CHECK: [[NARROW:v[0-9]+]] = and arg0, 0xffff
+    // CHECK: ret [[NARROW]]
     function narrowAddress(address asset) public pure returns (uint16) {
         return uint16(uint160(asset));
     }
 
     // CHECK-LABEL: fn @narrowUint{{[( ]}}
-    // CHECK: ret arg0
+    // CHECK: [[NARROW:v[0-9]+]] = and arg0, 0xffff
+    // CHECK: ret [[NARROW]]
     function narrowUint(uint256 value) public pure returns (uint16) {
         return uint16(value);
     }
 
     // CHECK-LABEL: fn @narrowSigned{{[( ]}}
-    // CHECK: ret arg0
+    // CHECK: [[NARROW:v[0-9]+]] = signextend 0, arg0
+    // CHECK: ret [[NARROW]]
     function narrowSigned(int256 value) public pure returns (int8) {
+        return int8(value);
+    }
+
+    // CHECK-LABEL: fn @widenUnsigned{{[( ]}}
+    // CHECK: ret arg0
+    function widenUnsigned(uint8 value) public pure returns (uint256) {
+        return uint256(value);
+    }
+
+    // CHECK-LABEL: fn @widenSigned{{[( ]}}
+    // CHECK: ret arg0
+    function widenSigned(int8 value) public pure returns (int256) {
+        return int256(value);
+    }
+
+    // CHECK-LABEL: fn @reinterpretUnsigned{{[( ]}}
+    // CHECK: [[CLEAN:v[0-9]+]] = and arg0, 255
+    // CHECK: ret [[CLEAN]]
+    function reinterpretUnsigned(int8 value) public pure returns (uint8) {
+        return uint8(value);
+    }
+
+    // CHECK-LABEL: fn @reinterpretSigned{{[( ]}}
+    // CHECK: [[CLEAN:v[0-9]+]] = signextend 0, arg0
+    // CHECK: ret [[CLEAN]]
+    function reinterpretSigned(uint8 value) public pure returns (int8) {
         return int8(value);
     }
 }

--- a/tests/ui/codegen/lowering/type_conversion.stdout
+++ b/tests/ui/codegen/lowering/type_conversion.stdout
@@ -2,16 +2,41 @@
 @module TypeConversion
 fn @narrowAddress(arg0: address) -> u16 [selector=0xaf290423, pure, abi_args=lazy, abi_params=[address], abi_returns=[word]] {
   bb0:
-    ret arg0
+    v0 = and arg0, 0xffff
+    ret v0
 }
 
 fn @narrowUint(arg0: u256) -> u16 [selector=0xf6938387, pure, abi_args=lazy, abi_params=[u256], abi_returns=[word]] {
   bb0:
-    ret arg0
+    v0 = and arg0, 0xffff
+    ret v0
 }
 
 fn @narrowSigned(arg0: i256) -> i8 [selector=0x195777d9, pure, abi_args=lazy, abi_params=[i256], abi_returns=[word]] {
   bb0:
+    v0 = signextend 0, arg0
+    ret v0
+}
+
+fn @widenUnsigned(arg0: u8) -> u256 [selector=0x8db66a41, pure, abi_args=lazy, abi_params=[u8], abi_returns=[word]] {
+  bb0:
     ret arg0
+}
+
+fn @widenSigned(arg0: i8) -> i256 [selector=0x697f65b8, pure, abi_args=lazy, abi_params=[i8], abi_returns=[word]] {
+  bb0:
+    ret arg0
+}
+
+fn @reinterpretUnsigned(arg0: i8) -> u8 [selector=0x51282c33, pure, abi_args=lazy, abi_params=[i8], abi_returns=[word]] {
+  bb0:
+    v0 = and arg0, 255
+    ret v0
+}
+
+fn @reinterpretSigned(arg0: u8) -> i8 [selector=0x55c3e2bc, pure, abi_args=lazy, abi_params=[u8], abi_returns=[word]] {
+  bb0:
+    v0 = signextend 0, arg0
+    ret v0
 }
 

--- a/tests/ui/codegen/run-call/integer_conversions.sol
+++ b/tests/ui/codegen/run-call/integer_conversions.sol
@@ -1,0 +1,54 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: int8ToUint256(int8) -1 => 255
+//@ run-call: int8ToUint256(int8) -128 => 128
+//@ run-call: int8ToUint256(int8) 127 => 127
+//@ run-call: int24ToUint256(int24) -1 => 16777215
+//@ run-call: int24ToUint256(int24) -8388608 => 8388608
+//@ run-call: int24ToUint256(int24) 8388607 => 8388607
+//@ run-call: uint8ToInt256(uint8) 255 => -1
+//@ run-call: uint8ToInt256(uint8) 128 => -128
+//@ run-call: uint8ToInt256(uint8) 127 => 127
+//@ run-call: uint24ToInt256(uint24) 16777215 => -1
+//@ run-call: narrowInt24(int24) -129 => 127
+//@ run-call: narrowInt24(int24) 128 => -128
+//@ run-call: directXor(int8,uint24) -1, 256 => 511
+//@ run-call: isUint8Max(int8) -1 => true
+//@ run-call: isUint8Max(int8) 1 => false
+//@ run-call: fullWidth(int256) -1 => 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+contract IntegerConversions {
+    function int8ToUint256(int8 value) external pure returns (uint256) {
+        return uint256(uint8(value));
+    }
+
+    function int24ToUint256(int24 value) external pure returns (uint256) {
+        return uint256(uint24(value));
+    }
+
+    function uint8ToInt256(uint8 value) external pure returns (int256) {
+        return int256(int8(value));
+    }
+
+    function uint24ToInt256(uint24 value) external pure returns (int256) {
+        return int256(int24(value));
+    }
+
+    function narrowInt24(int24 value) external pure returns (int256) {
+        return int256(int8(value));
+    }
+
+    function directXor(int8 value, uint24 other) external pure returns (uint256) {
+        return uint256(other) ^ uint256(uint8(value));
+    }
+
+    function isUint8Max(int8 value) external pure returns (bool) {
+        return uint8(value) == type(uint8).max;
+    }
+
+    function fullWidth(int256 value) external pure returns (uint256) {
+        return uint256(value);
+    }
+}


### PR DESCRIPTION
PR #1161 can carry the source word through integer conversions without cleaning it to the destination type. A negative int8 converted through uint8 could therefore remain an all-ones word, changing later widening, comparisons, and bitwise operations.

Normalize only conversions that change the 256-bit representation: narrowing conversions and same- or narrower-width signedness changes. Ordinary widening remains zero-cost, and the MIR tests pin both behaviors. Runtime coverage exercises int8/int24 boundaries, signed and unsigned directions, internal use, comparisons, and the full-width boundary across all optimizer modes.

The Solc-vs-Solar differential harness found this on #1161 in a stateful campaign, then reduced it to pure valid calldata. Independent EVM replay now matches Solc; a 1,024-case generated corpus and the full Foundry integration suite also pass.