### PR TITLE
feat(bench): track compile time against solc

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,8 +90,6 @@ jobs:
           "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" --version
 
       - name: Build Solar
-        # Release build: the report tracks compile time against a release
-        # solc, and a debug binary would understate the speedup several-fold.
         run: cargo build --release -p solar-compiler --bin solar
 
       - name: Download baseline (${{ env.BASE_BRANCH }} branch)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -90,7 +90,9 @@ jobs:
           "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" --version
 
       - name: Build Solar
-        run: cargo build -p solar-compiler --bin solar
+        # Release build: the report tracks compile time against a release
+        # solc, and a debug binary would understate the speedup several-fold.
+        run: cargo build --release -p solar-compiler --bin solar
 
       - name: Download baseline (${{ env.BASE_BRANCH }} branch)
         id: baseline
@@ -139,8 +141,9 @@ jobs:
           mkdir -p target/codegen-bench
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/debug/solar \
+            --solar target/release/solar \
             --suite all \
+            --compile-repeats 5 \
             --gas \
             --gas-profile hot \
             --start-anvil \

--- a/benches/README.md
+++ b/benches/README.md
@@ -41,6 +41,9 @@ observations to match. The corpus contains four micro contracts, including the s
 contracts extracted from the pinned OpenZeppelin and Solady project inputs. Its sources and
 upstream commits are documented in
 [`testdata/codegen-runtime/`](../testdata/codegen-runtime/README.md).
+A `heavy` suite additionally compiles three vendored whole-project inputs (Seaport 1.6,
+Uniswap v4-core, and Morpho Blue) end to end; they take tens of seconds on solc, participate
+only in the compilation-time table, and skip size, gas, and runtime comparisons.
 The runtime harness and its tests are in [`runtime/`](runtime/).
 
 For example, this command benchmarks the `my-branch` candidate with Gungraun, compares it against

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -291,17 +291,20 @@ def compile_case(
         return result
 
     if test_case.whole_project:
-        compiled, error = parse_whole_project_output(proc.stdout)
-        if not compiled:
+        compiled, objects, error = parse_whole_project_output(proc.stdout)
+        if error:
             result["status"] = "failed"
             result["error"] = error
             return result
         # Compile-time only: no single contract is selected, so bytecode
         # sizes and every downstream deploy/gas/runtime stage do not apply.
+        # `bytecode_objects` records how many entries carried real code so a
+        # compiler silently emitting nothing cannot count as a fast compile.
         result["status"] = "ok"
         result["bytecode_size"] = None
         result["runtime_size"] = None
         result["contracts_compiled"] = compiled
+        result["bytecode_objects"] = objects
         return result
 
     bytecode, runtime, error = parse_standard_json_output(proc.stdout, test_case)
@@ -318,23 +321,29 @@ def compile_case(
     return result
 
 
-def parse_whole_project_output(stdout: str) -> Tuple[int, str]:
-    """Returns the number of compiled contracts and an error description."""
+def parse_whole_project_output(stdout: str) -> Tuple[int, int, str]:
+    """Returns contract entries, entries with nonempty bytecode, and an error."""
     try:
         output = json.loads(stdout)
     except json.JSONDecodeError as error:
-        return 0, f"invalid compiler output: {error}"
+        return 0, 0, f"invalid compiler output: {error}"
     errors = [
         entry.get("formattedMessage") or entry.get("message") or "error"
         for entry in output.get("errors", [])
         if entry.get("severity") == "error"
     ]
     if errors:
-        return 0, "; ".join(errors)[:1000]
-    compiled = sum(len(contracts) for contracts in output.get("contracts", {}).values())
-    if compiled == 0:
-        return 0, "no contracts were compiled"
-    return compiled, ""
+        return 0, 0, "; ".join(errors)[:1000]
+    compiled = 0
+    objects = 0
+    for contracts in output.get("contracts", {}).values():
+        for data in contracts.values():
+            compiled += 1
+            if ((data.get("evm") or {}).get("bytecode") or {}).get("object"):
+                objects += 1
+    if objects == 0:
+        return compiled, 0, "no bytecode objects were emitted"
+    return compiled, objects, ""
 
 
 def parse_standard_json_output(

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -193,6 +193,19 @@ def standard_json_input(test_case: TestCase) -> str:
 
 
 @lru_cache(maxsize=None)
+def project_full_standard_json_input(project_file: str) -> str:
+    path = REPOSITORY_ROOT / project_file
+    project = load_project(path)
+    settings = dict(project["settings"])
+    settings["outputSelection"] = {"*": {"*": ["evm.bytecode.object"]}}
+    payload = {
+        "language": project["language"],
+        "sources": project["sources"],
+        "settings": settings,
+    }
+    return json.dumps(payload)
+
+
 def project_standard_json_input(project_file: str, source: str, contract_name: str) -> str:
     path = REPOSITORY_ROOT / project_file
     project = load_project(path)
@@ -212,6 +225,9 @@ def project_standard_json_input(project_file: str, source: str, contract_name: s
         "settings": settings,
     }
     return json.dumps(payload)
+
+
+LONG_COMPILE_CUTOFF_SECONDS = 10.0
 
 
 def compile_case(
@@ -235,10 +251,14 @@ def compile_case(
             result["status"] = "failed"
             result["error"] = f"vendored project not found: {test_case.project_file}"
             return result
-        input_text = project_standard_json_input(
-            test_case.project_file, test_case.source, test_case.contract_name
-        )
-        timeout = 180
+        if test_case.whole_project:
+            input_text = project_full_standard_json_input(test_case.project_file)
+            timeout = 900
+        else:
+            input_text = project_standard_json_input(
+                test_case.project_file, test_case.source, test_case.contract_name
+            )
+            timeout = 180
     else:
         input_text = standard_json_input(test_case)
         timeout = 120
@@ -257,6 +277,10 @@ def compile_case(
         samples.append(time.monotonic() - started)
         if proc.returncode != 0:
             break
+        # One sample is representative for long compiles; repeating a
+        # minute-scale solc run per repeat would dominate the whole benchmark.
+        if samples[-1] >= LONG_COMPILE_CUTOFF_SECONDS:
+            break
     result["compile_time_seconds"] = statistics.median(samples)
     result["compile_time_samples"] = samples
     result["peak_rss_bytes"] = proc.peak_rss_bytes
@@ -264,6 +288,20 @@ def compile_case(
     if proc.returncode != 0:
         result["status"] = "failed"
         result["error"] = (proc.stderr or proc.stdout or "compiler failed")[:1000]
+        return result
+
+    if test_case.whole_project:
+        compiled, error = parse_whole_project_output(proc.stdout)
+        if not compiled:
+            result["status"] = "failed"
+            result["error"] = error
+            return result
+        # Compile-time only: no single contract is selected, so bytecode
+        # sizes and every downstream deploy/gas/runtime stage do not apply.
+        result["status"] = "ok"
+        result["bytecode_size"] = None
+        result["runtime_size"] = None
+        result["contracts_compiled"] = compiled
         return result
 
     bytecode, runtime, error = parse_standard_json_output(proc.stdout, test_case)
@@ -278,6 +316,25 @@ def compile_case(
     result["bytecode_size"] = len(bytecode) // 2
     result["runtime_size"] = len(runtime or "") // 2
     return result
+
+
+def parse_whole_project_output(stdout: str) -> Tuple[int, str]:
+    """Returns the number of compiled contracts and an error description."""
+    try:
+        output = json.loads(stdout)
+    except json.JSONDecodeError as error:
+        return 0, f"invalid compiler output: {error}"
+    errors = [
+        entry.get("formattedMessage") or entry.get("message") or "error"
+        for entry in output.get("errors", [])
+        if entry.get("severity") == "error"
+    ]
+    if errors:
+        return 0, "; ".join(errors)[:1000]
+    compiled = sum(len(contracts) for contracts in output.get("contracts", {}).values())
+    if compiled == 0:
+        return 0, "no contracts were compiled"
+    return compiled, ""
 
 
 def parse_standard_json_output(
@@ -1108,7 +1165,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     parser.add_argument(
         "--suite",
-        choices=("micro", "repository", "large", "all"),
+        choices=("micro", "repository", "large", "heavy", "all"),
         default="micro",
         help="Benchmark suite to run",
     )

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -11,6 +11,7 @@ import json
 import re
 import shutil
 import subprocess
+import statistics
 import sys
 import time
 from dataclasses import dataclass
@@ -213,7 +214,9 @@ def project_standard_json_input(project_file: str, source: str, contract_name: s
     return json.dumps(payload)
 
 
-def compile_case(spec: CompilerSpec, test_case: TestCase) -> Dict[str, object]:
+def compile_case(
+    spec: CompilerSpec, test_case: TestCase, compile_repeats: int = 1
+) -> Dict[str, object]:
     result = {
         "compiler_id": spec.compiler_id,
         "label": spec.label,
@@ -241,14 +244,21 @@ def compile_case(spec: CompilerSpec, test_case: TestCase) -> Dict[str, object]:
         timeout = 120
 
     cmd = [str(spec.path), "--standard-json"]
-    started = time.monotonic()
-    proc = run(
-        cmd,
-        input_text=input_text,
-        timeout=timeout,
-        measure_peak_rss=True,
-    )
-    result["compile_time_seconds"] = time.monotonic() - started
+    samples = []
+    proc = None
+    for _ in range(max(1, compile_repeats)):
+        started = time.monotonic()
+        proc = run(
+            cmd,
+            input_text=input_text,
+            timeout=timeout,
+            measure_peak_rss=True,
+        )
+        samples.append(time.monotonic() - started)
+        if proc.returncode != 0:
+            break
+    result["compile_time_seconds"] = statistics.median(samples)
+    result["compile_time_samples"] = samples
     result["peak_rss_bytes"] = proc.peak_rss_bytes
     result["command"] = display_command(cmd)
     if proc.returncode != 0:
@@ -959,6 +969,7 @@ def run_test_case(
     rpc_url: str,
     private_key: str,
     verbose: bool = False,
+    compile_repeats: int = 1,
 ) -> Dict[str, object]:
     entry: Dict[str, object] = {
         "test_id": test_case.test_id,
@@ -975,7 +986,7 @@ def run_test_case(
 
     for spec in specs:
         verbose_log(verbose, f"[{test_case.test_id}] compiling with {spec.compiler_id}")
-        compiled = compile_case(spec, test_case)
+        compiled = compile_case(spec, test_case, compile_repeats)
         compiler_entry = dict(compiled)
         compiler_entry.pop("bytecode", None)
         compiler_entry.pop("runtime_bytecode", None)
@@ -1100,6 +1111,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         choices=("micro", "repository", "large", "all"),
         default="micro",
         help="Benchmark suite to run",
+    )
+    parser.add_argument(
+        "--compile-repeats",
+        type=int,
+        default=1,
+        help="Compile each test this many times and record the median time (default: 1)",
     )
     parser.add_argument("--tests", nargs="*", help="Subset of test IDs to run")
     parser.add_argument("--projects", nargs="*", help="Subset of repository project names to run")
@@ -1252,6 +1269,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     args.rpc_url,
                     args.private_key,
                     args.verbose,
+                    args.compile_repeats,
                 )
             )
         if current_suite is not None and suite_started is not None:

--- a/benches/runtime/cases.py
+++ b/benches/runtime/cases.py
@@ -57,6 +57,10 @@ class TestCase:
     min_solc: Optional[str] = None
     max_solc: Optional[str] = None
     suite: str = "micro"
+    # Compile every contract in the project input instead of one selected
+    # contract. Compile-time only: no bytecode is extracted, so size, gas,
+    # and runtime checks do not apply.
+    whole_project: bool = False
 
     @property
     def project_path(self) -> Path:
@@ -651,6 +655,33 @@ TEST_CASES: Sequence[TestCase] = (
             RuntimeCheck("small-string", "toSmallString(string)(bytes32)", ("short string",)),
         ),
         suite="large",
+    ),
+    TestCase(
+        test_id="seaport-1.6-project",
+        description="Seaport 1.6 full project",
+        contract_name="*",
+        project="seaport-1.6",
+        project_file="testdata/projects/seaport-1.6.json.gz",
+        whole_project=True,
+        suite="heavy",
+    ),
+    TestCase(
+        test_id="v4-core-project",
+        description="Uniswap v4-core full project (viaIR)",
+        contract_name="*",
+        project="v4-core-4.0.0",
+        project_file="testdata/projects/v4-core-4.0.0.json.gz",
+        whole_project=True,
+        suite="heavy",
+    ),
+    TestCase(
+        test_id="morpho-blue-project",
+        description="Morpho Blue full project (viaIR)",
+        contract_name="*",
+        project="morpho-blue-1.0.0",
+        project_file="testdata/projects/morpho-blue-1.0.0.json.gz",
+        whole_project=True,
+        suite="heavy",
     ),
 )
 

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -201,6 +201,30 @@ def peak_rss(result: dict[str, Any], compiler: str) -> int | None:
     return value if isinstance(value, int) else None
 
 
+def compile_time(result: dict[str, Any], compiler: str) -> float | None:
+    data = compiler_data(result, compiler)
+    if data.get("status") != "ok":
+        return None
+    value = data.get("compile_time_seconds")
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    return None
+
+
+def fmt_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "n/a"
+    if seconds >= 1.0:
+        return f"{seconds:.3f} s"
+    return f"{seconds * 1000:.1f} ms"
+
+
+def fmt_speedup(solc_seconds: float | None, solar_seconds: float | None) -> str:
+    if solc_seconds is None or solar_seconds is None or solar_seconds <= 0:
+        return "n/a"
+    return f"{solc_seconds / solar_seconds:.2f}x"
+
+
 def fmt_int(value: int | None, suffix: str = "") -> str:
     if value is None:
         return "n/a"
@@ -382,6 +406,69 @@ def memory_report(results: list[dict[str, Any]]) -> list[str]:
     ]
 
 
+COMPILE_SPEEDUP_GOAL = 10.0
+
+
+def compile_time_rows(
+    results: list[dict[str, Any]], baseline: dict[tuple[str, str], dict[str, Any]]
+) -> list[str]:
+    rows = []
+    for result in results:
+        test_id = str(result.get("test_id", "<unknown>"))
+        solc_time = compile_time(result, "solc")
+        solar_time = compile_time(result, "solar")
+        base = baseline.get(suite_key(result), {})
+        base_solar_time = compile_time(base, "solar") if base else None
+        rows.append(
+            "| "
+            + " | ".join(
+                [
+                    markdown_cell(test_id),
+                    fmt_duration(solc_time),
+                    f"{fmt_duration(solar_time)} "
+                    f"({fmt_pct_change_lower_is_better(solar_time, base_solar_time)})",
+                    fmt_speedup(solc_time, solar_time),
+                ]
+            )
+            + " |"
+        )
+    return rows
+
+
+def compile_time_report(
+    results: list[dict[str, Any]],
+    baseline: dict[tuple[str, str], dict[str, Any]],
+    baseline_label: str,
+) -> list[str]:
+    # Aggregate only tests where both compilers succeeded, so a new failure
+    # cannot make the Solar total look faster.
+    paired = [
+        (compile_time(result, "solc"), compile_time(result, "solar"))
+        for result in results
+    ]
+    paired = [(solc, solar) for solc, solar in paired if solc is not None and solar is not None]
+    if not paired:
+        return []
+
+    solc_sum = sum(solc for solc, _ in paired)
+    solar_sum = sum(solar for _, solar in paired)
+    speedup = solc_sum / solar_sum if solar_sum > 0 else None
+    goal = "✅" if speedup is not None and speedup >= COMPILE_SPEEDUP_GOAL else "❌"
+
+    return [
+        "### Compilation time",
+        "",
+        f"| bench | solc | Solar (vs {baseline_label}) | speedup |",
+        "| ----- | ---- | ----- | ------- |",
+        *compile_time_rows(results, baseline),
+        f"| **sum of medians** | **{fmt_duration(solc_sum)}** | **{fmt_duration(solar_sum)}** "
+        f"| {goal} **{fmt_speedup(solc_sum, solar_sum)}** |",
+        "",
+        f"> Goal: at least {COMPILE_SPEEDUP_GOAL:.0f}x faster than solc on the sum of medians.",
+        "",
+    ]
+
+
 def report_section(
     title: str,
     results: list[dict[str, Any]],
@@ -408,6 +495,7 @@ def report_section(
             "",
         ]
     )
+    lines.extend(compile_time_report(results, baseline, baseline_label))
     lines.extend(memory_report(results))
     return "\n".join(lines)
 

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -145,10 +145,18 @@ def baseline_regression_details(
     return details
 
 
+# Wall-clock compile times jitter between CI runners, so only movement beyond
+# these thresholds counts as a change worth a fresh PR comment.
+COMPILE_TIME_BENCH_CHANGE = 0.20
+COMPILE_TIME_TOTAL_CHANGE = 0.10
+
+
 def has_baseline_changes(
     results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]
 ) -> bool:
     baseline = by_test_id(baseline_results)
+    time_sum = 0.0
+    base_time_sum = 0.0
     for result in results:
         test_id = "/".join(suite_key(result))
         base = baseline.get(suite_key(result))
@@ -165,7 +173,19 @@ def has_baseline_changes(
         if solar_size is not None and base_solar_size is not None and solar_size != base_solar_size:
             return True
 
-    return False
+        solar_time = compile_time(result, "solar")
+        base_solar_time = compile_time(base, "solar")
+        if solar_time is not None and base_solar_time is None:
+            # The baseline artifact predates compile-time tracking: the report
+            # gained a section, which is a change worth posting.
+            return True
+        if solar_time is not None and base_solar_time is not None:
+            if abs(solar_time - base_solar_time) > base_solar_time * COMPILE_TIME_BENCH_CHANGE:
+                return True
+            time_sum += solar_time
+            base_time_sum += base_solar_time
+
+    return abs(time_sum - base_time_sum) > base_time_sum * COMPILE_TIME_TOTAL_CHANGE
 
 
 def warning(message: str) -> None:

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -406,9 +406,6 @@ def memory_report(results: list[dict[str, Any]]) -> list[str]:
     ]
 
 
-COMPILE_SPEEDUP_GOAL = 10.0
-
-
 def compile_time_rows(
     results: list[dict[str, Any]], baseline: dict[tuple[str, str], dict[str, Any]]
 ) -> list[str]:
@@ -452,8 +449,6 @@ def compile_time_report(
 
     solc_sum = sum(solc for solc, _ in paired)
     solar_sum = sum(solar for _, solar in paired)
-    speedup = solc_sum / solar_sum if solar_sum > 0 else None
-    goal = "✅" if speedup is not None and speedup >= COMPILE_SPEEDUP_GOAL else "❌"
 
     return [
         "### Compilation time",
@@ -462,9 +457,7 @@ def compile_time_report(
         "| ----- | ---- | ----- | ------- |",
         *compile_time_rows(results, baseline),
         f"| **sum of medians** | **{fmt_duration(solc_sum)}** | **{fmt_duration(solar_sum)}** "
-        f"| {goal} **{fmt_speedup(solc_sum, solar_sum)}** |",
-        "",
-        f"> Goal: at least {COMPILE_SPEEDUP_GOAL:.0f}x faster than solc on the sum of medians.",
+        f"| **{fmt_speedup(solc_sum, solar_sum)}** |",
         "",
     ]
 

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -17,11 +17,16 @@ SPEC.loader.exec_module(benchmark)
 
 class CorpusTests(unittest.TestCase):
     def test_vendored_cases_and_projects_exist(self) -> None:
-        self.assertEqual(len(benchmark.TEST_CASES), 16)
+        self.assertEqual(len(benchmark.TEST_CASES), 19)
         repository_cases = [
             case for case in benchmark.TEST_CASES if case.suite == "repository"
         ]
         self.assertEqual(len(repository_cases), 9)
+        heavy_cases = [case for case in benchmark.TEST_CASES if case.suite == "heavy"]
+        self.assertEqual(len(heavy_cases), 3)
+        for case in heavy_cases:
+            self.assertTrue(case.whole_project)
+            self.assertTrue(case.project_path.is_file())
         self.assertTrue(benchmark.RUNTIME_FIXTURES.is_file())
         expected_source_counts = {
             "uniswap-v2-pair": 10,

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -331,3 +331,56 @@ class CommonBenchmarkResultTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class CompileTimeReportTests(unittest.TestCase):
+    @staticmethod
+    def timed_result(test_id, solc_seconds, solar_seconds, solar_status="ok"):
+        return {
+            "test_id": test_id,
+            "suite": "repository",
+            "compilers": {
+                "solc": {"status": "ok", "compile_time_seconds": solc_seconds},
+                "solar": {"status": solar_status, "compile_time_seconds": solar_seconds},
+            },
+        }
+
+    def test_compile_time_report_rows_and_sum(self):
+        results = [
+            self.timed_result("fast", 0.100, 0.005),
+            self.timed_result("slow", 1.500, 0.055),
+        ]
+        lines = benchmark.compile_time_report(results, {}, "`main`")
+        text = "\n".join(lines)
+        self.assertIn("### Compilation time", text)
+        self.assertIn("| fast | 100.0 ms | 5.0 ms (n/a) | 20.00x |", text)
+        self.assertIn("| slow | 1.500 s | 55.0 ms (n/a) | 27.27x |", text)
+        self.assertIn(
+            "| **sum of medians** | **1.600 s** | **60.0 ms** | ✅ **26.67x** |", text
+        )
+
+    def test_compile_time_goal_marker_flags_slow_totals(self):
+        results = [self.timed_result("close", 0.100, 0.050)]
+        text = "\n".join(benchmark.compile_time_report(results, {}, "`main`"))
+        self.assertIn("| ❌ **2.00x** |", text)
+
+    def test_compile_time_sum_skips_unpaired_results(self):
+        results = [
+            self.timed_result("ok", 0.200, 0.010),
+            self.timed_result("failed", 0.400, 0.010, solar_status="failed"),
+        ]
+        text = "\n".join(benchmark.compile_time_report(results, {}, "`main`"))
+        self.assertIn("| failed | 400.0 ms | n/a (n/a) | n/a |", text)
+        self.assertIn("| **sum of medians** | **200.0 ms** | **10.0 ms** | ✅ **20.00x** |", text)
+
+    def test_compile_time_report_uses_solar_baseline_delta(self):
+        results = [self.timed_result("bench", 0.100, 0.011)]
+        baseline = {
+            ("repository", "bench"): self.timed_result("bench", 0.100, 0.010),
+        }
+        text = "\n".join(benchmark.compile_time_report(results, baseline, "`main`"))
+        self.assertIn("(❌ +10.00%)", text)
+
+    def test_compile_time_report_empty_without_pairs(self):
+        results = [self.timed_result("failed", 0.400, 0.010, solar_status="failed")]
+        self.assertEqual(benchmark.compile_time_report(results, {}, "`main`"), [])

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -403,6 +403,34 @@ class CompileTimeReportTests(unittest.TestCase):
         text = "\n".join(benchmark.compile_time_report([result], {}, "`main`"))
         self.assertIn("| heavy-project | 60.000 s | 5.000 s (n/a) | 12.00x |", text)
 
+    @staticmethod
+    def paired(current_seconds, baseline_seconds):
+        current = CompileTimeReportTests.timed_result("bench", 1.0, current_seconds)
+        base = CompileTimeReportTests.timed_result("bench", 1.0, baseline_seconds)
+        return [current], [base]
+
+    def test_compile_time_change_detection_uses_thresholds(self):
+        results, baseline = self.paired(0.125, 0.100)
+        self.assertTrue(benchmark.has_baseline_changes(results, baseline))
+        results, baseline = self.paired(0.105, 0.100)
+        self.assertFalse(benchmark.has_baseline_changes(results, baseline))
+
+    def test_compile_time_total_change_detection(self):
+        current = [
+            self.timed_result("a", 1.0, 0.112),
+            self.timed_result("b", 1.0, 0.112),
+        ]
+        base = [
+            self.timed_result("a", 1.0, 0.100),
+            self.timed_result("b", 1.0, 0.100),
+        ]
+        self.assertTrue(benchmark.has_baseline_changes(current, base))
+
+    def test_compile_time_bootstrap_counts_as_change(self):
+        current = [self.timed_result("bench", 1.0, 0.1)]
+        base = [{"test_id": "bench", "suite": "repository", "compilers": {"solar": {"status": "ok"}}}]
+        self.assertTrue(benchmark.has_baseline_changes(current, base))
+
     def test_compile_time_report_empty_without_pairs(self):
         results = [self.timed_result("failed", 0.400, 0.010, solar_status="failed")]
         self.assertEqual(benchmark.compile_time_report(results, {}, "`main`"), [])

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -356,13 +356,8 @@ class CompileTimeReportTests(unittest.TestCase):
         self.assertIn("| fast | 100.0 ms | 5.0 ms (n/a) | 20.00x |", text)
         self.assertIn("| slow | 1.500 s | 55.0 ms (n/a) | 27.27x |", text)
         self.assertIn(
-            "| **sum of medians** | **1.600 s** | **60.0 ms** | ✅ **26.67x** |", text
+            "| **sum of medians** | **1.600 s** | **60.0 ms** | **26.67x** |", text
         )
-
-    def test_compile_time_goal_marker_flags_slow_totals(self):
-        results = [self.timed_result("close", 0.100, 0.050)]
-        text = "\n".join(benchmark.compile_time_report(results, {}, "`main`"))
-        self.assertIn("| ❌ **2.00x** |", text)
 
     def test_compile_time_sum_skips_unpaired_results(self):
         results = [
@@ -371,7 +366,7 @@ class CompileTimeReportTests(unittest.TestCase):
         ]
         text = "\n".join(benchmark.compile_time_report(results, {}, "`main`"))
         self.assertIn("| failed | 400.0 ms | n/a (n/a) | n/a |", text)
-        self.assertIn("| **sum of medians** | **200.0 ms** | **10.0 ms** | ✅ **20.00x** |", text)
+        self.assertIn("| **sum of medians** | **200.0 ms** | **10.0 ms** | **20.00x** |", text)
 
     def test_compile_time_report_uses_solar_baseline_delta(self):
         results = [self.timed_result("bench", 0.100, 0.011)]
@@ -380,6 +375,33 @@ class CompileTimeReportTests(unittest.TestCase):
         }
         text = "\n".join(benchmark.compile_time_report(results, baseline, "`main`"))
         self.assertIn("(❌ +10.00%)", text)
+
+    def test_whole_project_rows_render_compile_time_only(self):
+        result = {
+            "test_id": "heavy-project",
+            "suite": "heavy",
+            "compilers": {
+                "solc": {
+                    "status": "ok",
+                    "compile_time_seconds": 60.0,
+                    "bytecode_size": None,
+                    "runtime_size": None,
+                },
+                "solar": {
+                    "status": "ok",
+                    "compile_time_seconds": 5.0,
+                    "bytecode_size": None,
+                    "runtime_size": None,
+                },
+            },
+        }
+        rows = benchmark.benchmark_rows([result], {})
+        self.assertEqual(
+            rows[0],
+            "| heavy-project | n/a (n/a) | n/a (n/a) | n/a (n/a) | n/a (n/a) |",
+        )
+        text = "\n".join(benchmark.compile_time_report([result], {}, "`main`"))
+        self.assertIn("| heavy-project | 60.000 s | 5.000 s (n/a) | 12.00x |", text)
 
     def test_compile_time_report_empty_without_pairs(self):
         results = [self.timed_result("failed", 0.400, 0.010, solar_status="failed")]


### PR DESCRIPTION
Record the median of N compile runs per compiler in the runtime benchmark and render a compilation-time section in the PR comment: per-bench solc and Solar times with the Solar delta against the base branch, each bench's speedup, and a sum-of-medians row checked against the 10x goal. Only tests where both compilers succeed enter the aggregate, so a new failure cannot flatter the total.

Build the benchmark job's Solar in release: the report compares against a release solc, and a debug binary understates the speedup several-fold.