### PR TITLE
fix(codegen): reload reserved spill values

### DIFF
--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -12,12 +12,15 @@ apt-get install -y --no-install-recommends \
     lsb-release wget gnupg ca-certificates
 apt-get install -y --no-install-recommends software-properties-common 2>/dev/null || true
 
+# Pass the codename explicitly because llvm.sh overwrites VERSION from /etc/os-release.
+codename=$(lsb_release -cs)
+
 # Use the official LLVM install script which handles distro detection,
 # GPG key import, and apt source configuration for all Debian/Ubuntu versions.
 llvm_sh=$(mktemp)
 wget -qO "$llvm_sh" https://apt.llvm.org/llvm.sh
 chmod +x "$llvm_sh"
-"$llvm_sh" "$v" all
+"$llvm_sh" "$v" all -n "$codename"
 rm -f "$llvm_sh"
 
 for bin in "${bins[@]}"; do

--- a/.github/scripts/install_llvm_ubuntu.sh
+++ b/.github/scripts/install_llvm_ubuntu.sh
@@ -12,15 +12,12 @@ apt-get install -y --no-install-recommends \
     lsb-release wget gnupg ca-certificates
 apt-get install -y --no-install-recommends software-properties-common 2>/dev/null || true
 
-# Pass the codename explicitly because llvm.sh overwrites VERSION from /etc/os-release.
-codename=$(lsb_release -cs)
-
 # Use the official LLVM install script which handles distro detection,
 # GPG key import, and apt source configuration for all Debian/Ubuntu versions.
 llvm_sh=$(mktemp)
 wget -qO "$llvm_sh" https://apt.llvm.org/llvm.sh
 chmod +x "$llvm_sh"
-"$llvm_sh" "$v" all -n "$codename"
+"$llvm_sh" "$v" all
 rm -f "$llvm_sh"
 
 for bin in "${bins[@]}"; do

--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -7677,9 +7677,7 @@ impl<'gcx> EvmCodegen<'gcx> {
                 }
                 // For instruction results, we need to check if they're spilled
                 // or if they're instruction results that produce fresh values (like GAS, MLOAD)
-                if let Some(slot) = self.scheduler.spills.get(val)
-                    && self.scheduler.spills.is_stored(val)
-                {
+                if let Some(slot) = self.scheduler.reloadable_spill(val) {
                     // Load from spill slot. Reloadable covers slots whose
                     // defining block is emitted later: the definition still
                     // executes before any use at runtime.

--- a/tests/ui/codegen/lowering/fmp_reload_computed_operand.sol
+++ b/tests/ui/codegen/lowering/fmp_reload_computed_operand.sol
@@ -1,4 +1,5 @@
 //@ compile-flags: -O gas --evm-version paris
+//@ run-call-fail: run() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
 
 interface Vm {
     function expectRevert(bytes calldata) external;

--- a/tests/ui/codegen/lowering/fmp_reload_computed_operand.sol
+++ b/tests/ui/codegen/lowering/fmp_reload_computed_operand.sol
@@ -1,0 +1,23 @@
+//@ compile-flags: -O gas --evm-version paris
+
+interface Vm {
+    function expectRevert(bytes calldata) external;
+}
+
+library stdError {
+    bytes public constant arithmeticError = abi.encodeWithSignature("Panic(uint256)", 0x11);
+}
+
+// Dynamic revert data followed by a self-call exercises the stale FMP reload path.
+contract FmpReloadComputedOperand {
+    Vm private constant vm = Vm(address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D));
+
+    function callWithFmp(uint256 a, uint256 b) external pure returns (uint256) {
+        return a + b;
+    }
+
+    function run() external {
+        vm.expectRevert(stdError.arithmeticError);
+        this.callWithFmp(2 ** 256 - 1, 2 ** 256 - 1);
+    }
+}


### PR DESCRIPTION
`emit_value_fresh` skipped reserved spill slots until they were marked stored. That caused it to rematerialize an expression containing a stale free-memory-pointer load when block layout emitted the use before the defining block. Load any runtime-reloadable spill first, preserving the value across memory-pointer updates. Add a regression UI test for dynamic revert-data encoding followed by a self-call.
