### PR TITLE
fix(codegen): lower fixed bytes indexing

### DIFF
--- a/crates/codegen/src/lower/function/indexing.rs
+++ b/crates/codegen/src/lower/function/indexing.rs
@@ -32,6 +32,14 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let index = self.lower_expr(index)?;
         let receiver_ty = self.gcx.type_of_expr(receiver.id)?;
         let object = self.lower_expr(receiver)?;
+        if let TyKind::Elementary(solar_sema::hir::ElementaryType::FixedBytes(size)) =
+            receiver_ty.peel_refs().kind
+        {
+            let length = self.builder.imm_u64(u64::from(size.bytes()));
+            self.bounds_check(index, length);
+            let byte = self.builder.byte(index, object);
+            return Some(self.normalize_byte_value(expr, byte));
+        }
         if let Some(MirType::Slice(location)) = self.builder.func().value_ty(object) {
             let length = self.builder.slice_len(object);
             self.bounds_check(index, length);

--- a/tests/ui/codegen/run-call/fixed_bytes_indexing.sol
+++ b/tests/ui/codegen/run-call/fixed_bytes_indexing.sol
@@ -1,0 +1,23 @@
+//@ run-call: at1(bytes1,uint256) 0xa5, 0 => 0xa5
+//@ run-call-fail: at1(bytes1,uint256) 0xa5, 1 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000032
+//@ run-call: at7(bytes7,uint256) 0x01020304050607, 0 => 0x01
+//@ run-call: at7(bytes7,uint256) 0x01020304050607, 3 => 0x04
+//@ run-call: at7(bytes7,uint256) 0x01020304050607, 6 => 0x07
+//@ run-call-fail: at7(bytes7,uint256) 0x01020304050607, 7 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000032
+//@ run-call: at32(bytes32,uint256) 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f, 0 => 0x00
+//@ run-call: at32(bytes32,uint256) 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f, 31 => 0x1f
+//@ run-call-fail: at32(bytes32,uint256) 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f, 32 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000032
+
+contract C {
+    function at1(bytes1 value, uint256 index) external pure returns (bytes1) {
+        return value[index];
+    }
+
+    function at7(bytes7 value, uint256 index) external pure returns (bytes1) {
+        return value[index];
+    }
+
+    function at32(bytes32 value, uint256 index) external pure returns (bytes1) {
+        return value[index];
+    }
+}


### PR DESCRIPTION
Fixed-size bytes indexing currently falls through memory-object lowering and emits `INVALID`. This lowers it directly with `BYTE` after the Solidity bounds check and preserves the canonical `bytes1` representation.

`solsymdiff` found and replayed the discrepancy on `bytes7` index zero: Solc returned the selected byte while Solar faulted. The regression covers `bytes1`, `bytes7`, and `bytes32` at both endpoint and out-of-bounds indices. This is stacked on #1161.