### PR TITLE
fix(codegen): preserve getter bounds reverts

### DIFF
--- a/crates/codegen/src/lower/checked_arith.rs
+++ b/crates/codegen/src/lower/checked_arith.rs
@@ -903,11 +903,19 @@ impl<'gcx> Lowerer<'gcx> {
                 return;
             }
             let always = builder.imm_bool(true);
-            self.emit_panic_if(builder, always, PanicCode::ArrayOutOfBounds);
+            if self.lowering_getter {
+                Self::emit_revert_if(builder, always);
+            } else {
+                self.emit_panic_if(builder, always, PanicCode::ArrayOutOfBounds);
+            }
             return;
         }
         let in_range = builder.lt(index, len);
-        self.emit_panic_if_zero(builder, in_range, PanicCode::ArrayOutOfBounds);
+        if self.lowering_getter {
+            Self::emit_revert_unless(builder, in_range);
+        } else {
+            self.emit_panic_if_zero(builder, in_range, PanicCode::ArrayOutOfBounds);
+        }
     }
 
     /// Emits the runtime range check required by an explicit integer-to-enum

--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -218,6 +218,8 @@ pub(crate) struct Lowerer<'gcx> {
     internal_function_pointer_dispatchers: FxHashMap<InternalFunctionPointerShape, FunctionId>,
     /// Whether the current function body is constructor code.
     lowering_constructor: bool,
+    /// Whether the current function is a compiler-generated public getter.
+    lowering_getter: bool,
     /// Shared base value for constructor ABI argument accesses.
     constructor_args_base: Option<ValueId>,
     /// Whether local memory slots should be addressed through the internal-call frame.
@@ -311,6 +313,7 @@ impl<'gcx> Lowerer<'gcx> {
             internal_function_pointer_targets: GrowableBitSet::new_empty(),
             internal_function_pointer_dispatchers: FxHashMap::default(),
             lowering_constructor: false,
+            lowering_getter: false,
             constructor_args_base: None,
             lowering_internal_function: false,
             revert_error_helper: None,
@@ -660,12 +663,14 @@ impl<'gcx> Lowerer<'gcx> {
             let saved_inline_returns = self.inline_returns.take();
             let saved_pending_inline_returns = self.pending_inline_returns.take();
             let saved_lowering_constructor = self.lowering_constructor;
+            let saved_lowering_getter = self.lowering_getter;
             let saved_constructor_args_base = self.constructor_args_base;
             let saved_lowering_internal_function = self.lowering_internal_function;
             let saved_in_unchecked_block = self.in_unchecked_block;
             let saved_current_return_tys = std::mem::take(&mut self.current_return_tys);
             self.next_local_memory_offset = EvmMemoryLayout::HEAP_START;
             self.lowering_constructor = true;
+            self.lowering_getter = false;
             self.constructor_args_base = None;
             self.lowering_internal_function = false;
             self.in_unchecked_block = false;
@@ -682,6 +687,7 @@ impl<'gcx> Lowerer<'gcx> {
             self.inline_returns = saved_inline_returns;
             self.pending_inline_returns = saved_pending_inline_returns;
             self.lowering_constructor = saved_lowering_constructor;
+            self.lowering_getter = saved_lowering_getter;
             self.constructor_args_base = saved_constructor_args_base;
             self.lowering_internal_function = saved_lowering_internal_function;
             self.in_unchecked_block = saved_in_unchecked_block;
@@ -838,6 +844,7 @@ impl<'gcx> Lowerer<'gcx> {
         let saved_pending_inline_returns = self.pending_inline_returns.take();
         let saved_current_contract_id = self.current_contract_id;
         let saved_lowering_constructor = self.lowering_constructor;
+        let saved_lowering_getter = self.lowering_getter;
         let saved_constructor_args_base = self.constructor_args_base;
         let saved_lowering_internal_function = self.lowering_internal_function;
         let saved_in_unchecked_block = self.in_unchecked_block;
@@ -858,6 +865,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.pending_inline_returns = saved_pending_inline_returns;
         self.current_contract_id = saved_current_contract_id;
         self.lowering_constructor = saved_lowering_constructor;
+        self.lowering_getter = saved_lowering_getter;
         self.constructor_args_base = saved_constructor_args_base;
         self.lowering_internal_function = saved_lowering_internal_function;
         self.in_unchecked_block = saved_in_unchecked_block;
@@ -945,6 +953,7 @@ impl<'gcx> Lowerer<'gcx> {
         let saved_pending_inline_returns = self.pending_inline_returns.take();
         let saved_current_contract_id = self.current_contract_id;
         let saved_lowering_constructor = self.lowering_constructor;
+        let saved_lowering_getter = self.lowering_getter;
         let saved_constructor_args_base = self.constructor_args_base;
         let saved_lowering_internal_function = self.lowering_internal_function;
         let saved_in_unchecked_block = self.in_unchecked_block;
@@ -963,6 +972,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.pending_inline_returns = saved_pending_inline_returns;
         self.current_contract_id = saved_current_contract_id;
         self.lowering_constructor = saved_lowering_constructor;
+        self.lowering_getter = saved_lowering_getter;
         self.constructor_args_base = saved_constructor_args_base;
         self.lowering_internal_function = saved_lowering_internal_function;
         self.in_unchecked_block = saved_in_unchecked_block;
@@ -1057,6 +1067,7 @@ impl<'gcx> Lowerer<'gcx> {
         self.next_local_memory_offset = EvmMemoryLayout::HEAP_START;
         self.assigned_vars.clear();
         self.lowering_constructor = hir_func.kind == hir::FunctionKind::Constructor;
+        self.lowering_getter = hir_func.is_getter();
         self.constructor_args_base = None;
         self.lowering_internal_function = uses_internal_frame;
         self.in_unchecked_block = false;
@@ -1510,6 +1521,7 @@ impl<'gcx> Lowerer<'gcx> {
         }
 
         self.lowering_constructor = false;
+        self.lowering_getter = false;
         self.lowering_internal_function = false;
         mir_func.internal_frame_size =
             self.next_local_memory_offset.saturating_sub(EvmMemoryLayout::HEAP_START);

--- a/tests/ui/codegen/run-call/public_array_getter_bounds.sol
+++ b/tests/ui/codegen/run-call/public_array_getter_bounds.sol
@@ -1,0 +1,16 @@
+//@ run-call: fixedValues(uint256) 0 => 0
+//@ run-call-fail: fixedValues(uint256) 3
+//@ run-call-fail: dynamicValues(uint256) 0
+//@ run-call: nested(uint256,uint256) 7, 1 => 0
+//@ run-call-fail: nested(uint256,uint256) 7, 2
+//@ run-call-fail: explicitFixed(uint256) 3 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000032
+
+contract C {
+    uint256[3] public fixedValues;
+    uint256[] public dynamicValues;
+    mapping(uint256 => uint256[2]) public nested;
+
+    function explicitFixed(uint256 index) external view returns (uint256) {
+        return fixedValues[index];
+    }
+}


### PR DESCRIPTION
Compiler-generated public array getters revert with empty data on invalid indices in Solc, while explicit array indexing uses panic `0x32`. Solar used the explicit-index panic for both. This tracks getter lowering so fixed, dynamic, and nested public array getters preserve Solc behavior without changing user-written indexing.

`solsymdiff` found and replayed the discrepancy at index three of a three-element public array. It reproduces on current main with optimization and via IR both enabled and disabled; independent Anvil replay confirmed the exact revert-data difference.