### PR TITLE
fix(bench): reduce comment noise

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -164,6 +164,7 @@ jobs:
             --results target/codegen-bench/results.json
             --common-output target/codegen-bench/common.json
             --report-output target/codegen-bench/report.md
+            --ignore-compile-time-changes
           )
           if [[ -f target/codegen-bench/baseline/results.json ]]; then
             args+=(--baseline target/codegen-bench/baseline/results.json)

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -145,20 +145,19 @@ def baseline_regression_details(
     return details
 
 
-# Wall-clock compile times jitter between CI runners, so only movement beyond
-# these thresholds counts as a change worth a fresh PR comment.
+# Wall-clock compile times jitter between CI runners. Require both a relative
+# and absolute change before posting a fresh PR comment.
 COMPILE_TIME_BENCH_CHANGE = 0.20
+COMPILE_TIME_BENCH_ABSOLUTE_CHANGE = 0.010
 COMPILE_TIME_TOTAL_CHANGE = 0.10
+COMPILE_TIME_TOTAL_ABSOLUTE_CHANGE = 1.0
 
 
-def has_baseline_changes(
+def has_codegen_changes(
     results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]
 ) -> bool:
     baseline = by_test_id(baseline_results)
-    time_sum = 0.0
-    base_time_sum = 0.0
     for result in results:
-        test_id = "/".join(suite_key(result))
         base = baseline.get(suite_key(result))
         if base is None:
             continue
@@ -173,19 +172,46 @@ def has_baseline_changes(
         if solar_size is not None and base_solar_size is not None and solar_size != base_solar_size:
             return True
 
+    return False
+
+
+def has_compile_time_changes(
+    results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]
+) -> bool:
+    baseline = by_test_id(baseline_results)
+    time_sum = 0.0
+    base_time_sum = 0.0
+    for result in results:
+        base = baseline.get(suite_key(result))
+        if base is None:
+            continue
+
         solar_time = compile_time(result, "solar")
         base_solar_time = compile_time(base, "solar")
         if solar_time is not None and base_solar_time is None:
-            # The baseline artifact predates compile-time tracking: the report
-            # gained a section, which is a change worth posting.
             return True
         if solar_time is not None and base_solar_time is not None:
-            if abs(solar_time - base_solar_time) > base_solar_time * COMPILE_TIME_BENCH_CHANGE:
+            time_delta = abs(solar_time - base_solar_time)
+            if (
+                time_delta > COMPILE_TIME_BENCH_ABSOLUTE_CHANGE
+                and time_delta > base_solar_time * COMPILE_TIME_BENCH_CHANGE
+            ):
                 return True
             time_sum += solar_time
             base_time_sum += base_solar_time
 
-    return abs(time_sum - base_time_sum) > base_time_sum * COMPILE_TIME_TOTAL_CHANGE
+    return (
+        abs(time_sum - base_time_sum) > COMPILE_TIME_TOTAL_ABSOLUTE_CHANGE
+        and abs(time_sum - base_time_sum) > base_time_sum * COMPILE_TIME_TOTAL_CHANGE
+    )
+
+
+def has_baseline_changes(
+    results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]
+) -> bool:
+    return has_codegen_changes(results, baseline_results) or has_compile_time_changes(
+        results, baseline_results
+    )
 
 
 def warning(message: str) -> None:
@@ -237,12 +263,6 @@ def fmt_duration(seconds: float | None) -> str:
     if seconds >= 1.0:
         return f"{seconds:.3f} s"
     return f"{seconds * 1000:.1f} ms"
-
-
-def fmt_speedup(solc_seconds: float | None, solar_seconds: float | None) -> str:
-    if solc_seconds is None or solar_seconds is None or solar_seconds <= 0:
-        return "n/a"
-    return f"{solc_seconds / solar_seconds:.2f}x"
 
 
 def fmt_int(value: int | None, suffix: str = "") -> str:
@@ -330,6 +350,9 @@ def benchmark_rows(
         solar_size = runtime_size(result, "solar")
         solc_size = runtime_size(result, "solc")
         base_solar_size = runtime_size(base, "solar") if base else None
+
+        if all(value is None for value in (solar_gas, solc_gas, solar_size, solc_size)):
+            continue
 
         rows.append(
             "| "
@@ -441,10 +464,9 @@ def compile_time_rows(
             + " | ".join(
                 [
                     markdown_cell(test_id),
-                    fmt_duration(solc_time),
                     f"{fmt_duration(solar_time)} "
                     f"({fmt_pct_change_lower_is_better(solar_time, base_solar_time)})",
-                    fmt_speedup(solc_time, solar_time),
+                    f"{fmt_duration(solc_time)} ({fmt_pct_vs_current(solar_time, solc_time)})",
                 ]
             )
             + " |"
@@ -473,11 +495,11 @@ def compile_time_report(
     return [
         "### Compilation time",
         "",
-        f"| bench | solc | Solar (vs {baseline_label}) | speedup |",
-        "| ----- | ---- | ----- | ------- |",
+        f"| bench | time (vs {baseline_label}) | solc |",
+        "| ----- | --------------------- | ---- |",
         *compile_time_rows(results, baseline),
-        f"| **sum of medians** | **{fmt_duration(solc_sum)}** | **{fmt_duration(solar_sum)}** "
-        f"| **{fmt_speedup(solc_sum, solar_sum)}** |",
+        f"| **sum of medians** | **{fmt_duration(solar_sum)}** | "
+        f"**{fmt_duration(solc_sum)} ({fmt_pct_vs_current(solar_sum, solc_sum)})** |",
         "",
     ]
 
@@ -500,14 +522,16 @@ def report_section(
             [f"No `{baseline_ref}` baseline artifact was available for comparison.", ""]
         )
 
-    lines.extend(
-        [
-            f"| bench | gas (vs {baseline_label}) | solc | size (vs {baseline_label}) | solc |",
-            "| ----- | ------------- | ---- | -------------- | ---- |",
-            *benchmark_rows(results, baseline),
-            "",
-        ]
-    )
+    rows = benchmark_rows(results, baseline)
+    if rows:
+        lines.extend(
+            [
+                f"| bench | gas (vs {baseline_label}) | solc | size (vs {baseline_label}) | solc |",
+                "| ----- | ------------- | ---- | -------------- | ---- |",
+                *rows,
+                "",
+            ]
+        )
     lines.extend(compile_time_report(results, baseline, baseline_label))
     lines.extend(memory_report(results))
     return "\n".join(lines)
@@ -717,6 +741,7 @@ def main() -> int:
     parser.add_argument("--baseline", type=Path)
     parser.add_argument("--common-output", type=Path)
     parser.add_argument("--report-output", type=Path)
+    parser.add_argument("--ignore-compile-time-changes", action="store_true")
     args = parser.parse_args()
 
     document = load_document(args.results, "benchmark")
@@ -732,7 +757,9 @@ def main() -> int:
     else:
         report = "## Codegen benchmark\n\nNo benchmark inputs were configured.\n"
 
-    should_comment = has_baseline_changes(results, baseline_results)
+    should_comment = has_codegen_changes(results, baseline_results)
+    if not args.ignore_compile_time_changes:
+        should_comment |= has_compile_time_changes(results, baseline_results)
     markdown = format_report(report, should_comment, branch_is_behind(base_ref), base_ref)
     print(markdown)
     append_step_summary(markdown)

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -353,10 +353,10 @@ class CompileTimeReportTests(unittest.TestCase):
         lines = benchmark.compile_time_report(results, {}, "`main`")
         text = "\n".join(lines)
         self.assertIn("### Compilation time", text)
-        self.assertIn("| fast | 100.0 ms | 5.0 ms (n/a) | 20.00x |", text)
-        self.assertIn("| slow | 1.500 s | 55.0 ms (n/a) | 27.27x |", text)
+        self.assertIn("| fast | 5.0 ms (n/a) | 100.0 ms (✅ +1900.00%) |", text)
+        self.assertIn("| slow | 55.0 ms (n/a) | 1.500 s (✅ +2627.27%) |", text)
         self.assertIn(
-            "| **sum of medians** | **1.600 s** | **60.0 ms** | **26.67x** |", text
+            "| **sum of medians** | **60.0 ms** | **1.600 s (✅ +2566.67%)** |", text
         )
 
     def test_compile_time_sum_skips_unpaired_results(self):
@@ -365,8 +365,10 @@ class CompileTimeReportTests(unittest.TestCase):
             self.timed_result("failed", 0.400, 0.010, solar_status="failed"),
         ]
         text = "\n".join(benchmark.compile_time_report(results, {}, "`main`"))
-        self.assertIn("| failed | 400.0 ms | n/a (n/a) | n/a |", text)
-        self.assertIn("| **sum of medians** | **200.0 ms** | **10.0 ms** | **20.00x** |", text)
+        self.assertIn("| failed | n/a (n/a) | 400.0 ms (n/a) |", text)
+        self.assertIn(
+            "| **sum of medians** | **10.0 ms** | **200.0 ms (✅ +1900.00%)** |", text
+        )
 
     def test_compile_time_report_uses_solar_baseline_delta(self):
         results = [self.timed_result("bench", 0.100, 0.011)]
@@ -376,7 +378,7 @@ class CompileTimeReportTests(unittest.TestCase):
         text = "\n".join(benchmark.compile_time_report(results, baseline, "`main`"))
         self.assertIn("(❌ +10.00%)", text)
 
-    def test_whole_project_rows_render_compile_time_only(self):
+    def test_whole_project_rows_skip_missing_codegen(self):
         result = {
             "test_id": "heavy-project",
             "suite": "heavy",
@@ -396,12 +398,11 @@ class CompileTimeReportTests(unittest.TestCase):
             },
         }
         rows = benchmark.benchmark_rows([result], {})
-        self.assertEqual(
-            rows[0],
-            "| heavy-project | n/a (n/a) | n/a (n/a) | n/a (n/a) | n/a (n/a) |",
-        )
+        self.assertEqual(rows, [])
         text = "\n".join(benchmark.compile_time_report([result], {}, "`main`"))
-        self.assertIn("| heavy-project | 60.000 s | 5.000 s (n/a) | 12.00x |", text)
+        self.assertIn(
+            "| heavy-project | 5.000 s (n/a) | 60.000 s (✅ +1100.00%) |", text
+        )
 
     @staticmethod
     def paired(current_seconds, baseline_seconds):
@@ -409,13 +410,14 @@ class CompileTimeReportTests(unittest.TestCase):
         base = CompileTimeReportTests.timed_result("bench", 1.0, baseline_seconds)
         return [current], [base]
 
-    def test_compile_time_change_detection_uses_thresholds(self):
+    def test_compile_time_change_requires_relative_and_absolute_thresholds(self):
         results, baseline = self.paired(0.125, 0.100)
         self.assertTrue(benchmark.has_baseline_changes(results, baseline))
-        results, baseline = self.paired(0.105, 0.100)
+        self.assertFalse(benchmark.has_codegen_changes(results, baseline))
+        results, baseline = self.paired(0.006, 0.003)
         self.assertFalse(benchmark.has_baseline_changes(results, baseline))
 
-    def test_compile_time_total_change_detection(self):
+    def test_compile_time_total_change_requires_relative_and_absolute_thresholds(self):
         current = [
             self.timed_result("a", 1.0, 0.112),
             self.timed_result("b", 1.0, 0.112),
@@ -424,12 +426,20 @@ class CompileTimeReportTests(unittest.TestCase):
             self.timed_result("a", 1.0, 0.100),
             self.timed_result("b", 1.0, 0.100),
         ]
+        self.assertFalse(benchmark.has_baseline_changes(current, base))
+        current = [self.timed_result(str(i), 1.0, 0.056) for i in range(200)]
+        base = [self.timed_result(str(i), 1.0, 0.050) for i in range(200)]
         self.assertTrue(benchmark.has_baseline_changes(current, base))
 
-    def test_compile_time_bootstrap_counts_as_change(self):
+    def test_compile_time_bootstrap_triggers_comments(self):
         current = [self.timed_result("bench", 1.0, 0.1)]
         base = [{"test_id": "bench", "suite": "repository", "compilers": {"solar": {"status": "ok"}}}]
         self.assertTrue(benchmark.has_baseline_changes(current, base))
+
+    def test_codegen_changes_trigger_comments(self):
+        current = [result(status="ok", total_gas=2)]
+        base = [result(status="ok", total_gas=1)]
+        self.assertTrue(benchmark.has_codegen_changes(current, base))
 
     def test_compile_time_report_empty_without_pairs(self):
         results = [self.timed_result("failed", 0.400, 0.010, solar_status="failed")]


### PR DESCRIPTION
Codegen reports now omit benchmarks with no codegen output and present compile times in the same two-column shape as codegen results.\n\nThe reporter retains strict compile-time change detection, but CI ignores it when deciding whether to update benchmark comments until the runners stabilize.