### PR TITLE
fix(codegen): fold wide literal expressions

### DIFF
--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -399,6 +399,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     }
 
     fn lower_expr(&mut self, expr: &hir::Expr<'_>) -> Option<ValueId> {
+        if expr.is_integer_literal_expression()
+            && let Ok(ConstValue::Integer(value)) = self.gcx.try_eval_const_value(expr)
+            && value.bit_len() <= u64::from(solar_ast::TypeSize::MAX)
+        {
+            return Some(self.builder.imm_u256(value.as_evm_word()));
+        }
         match &expr.kind {
             ExprKind::Lit(lit) => self.lower_literal(lit.kind, expr.span),
             ExprKind::Array(elements) => self.lower_array(expr, elements),

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -7,7 +7,9 @@ use solar_interface::{ByteSymbol, Span, diagnostics::ErrorGuaranteed};
 use std::fmt;
 
 const RECURSION_LIMIT: usize = 64;
-const MAX_BITS: u64 = solar_ast::TypeSize::MAX as u64;
+// Keep constant-expression intermediates within the same bound as parsed numeric literals. Their
+// final value is still checked against the destination Solidity type.
+const MAX_BITS: u64 = 4096;
 
 // TODO: `convertType` for truncating and extending correctly: https://github.com/argotorg/solidity/blob/de1a017ccb935d149ed6bcbdb730d89883f8ce02/libsolidity/analysis/ConstantEvaluator.cpp#L234
 
@@ -25,9 +27,12 @@ pub fn erc7201_slot(namespace_id: &[u8]) -> B256 {
 /// Evaluates the given array size expression, emitting an error diagnostic if it fails.
 pub fn eval_array_len(gcx: Gcx<'_>, size: &hir::Expr<'_>) -> Result<U256, ErrorGuaranteed> {
     let int = gcx.eval_const(size)?;
-    let Some(int) = int.as_u256() else {
+    if int.is_negative() {
         let msg = "array length cannot be negative";
         return Err(gcx.dcx().emit_err(size.span, msg));
+    }
+    let Some(int) = int.as_u256() else {
+        return Err(gcx.emit_const_eval_error(size, EE::ArithmeticOverflow.spanned(size.span)));
     };
     if int.is_zero() {
         let msg = "array length must be greater than zero";

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1681,6 +1681,26 @@ impl Expr<'_> {
         expr
     }
 
+    /// Returns whether this expression consists only of integer literals and operators.
+    pub fn is_integer_literal_expression(&self) -> bool {
+        match &self.kind {
+            ExprKind::Lit(lit) => matches!(lit.kind, ast::LitKind::Number(_)),
+            ExprKind::Unary(op, inner)
+                if matches!(op.kind, ast::UnOpKind::Neg | ast::UnOpKind::BitNot) =>
+            {
+                inner.is_integer_literal_expression()
+            }
+            ExprKind::Binary(lhs, op, rhs)
+                if !op.kind.is_cmp()
+                    && !matches!(op.kind, ast::BinOpKind::Or | ast::BinOpKind::And) =>
+            {
+                lhs.is_integer_literal_expression() && rhs.is_integer_literal_expression()
+            }
+            ExprKind::Tuple([Some(inner)]) => inner.is_integer_literal_expression(),
+            _ => false,
+        }
+    }
+
     /// Returns the resolution if this is an unambiguous identifier expression.
     ///
     /// Prefer using [`Gcx::resolved_expr`] instead, since this method does not account for

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use alloy_primitives::U256;
 use solar_ast::{
-    DataLocation, ElementaryType, LitKind, Span, StateMutability, TypeSize, UserDefinableOperator,
+    DataLocation, ElementaryType, Span, StateMutability, TypeSize, UserDefinableOperator,
 };
 use solar_data_structures::{Never, bit_set::DenseBitSet, pluralize, smallvec::SmallVec};
 use solar_interface::{
@@ -689,7 +689,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 // For integer literal negation, don't propagate the expected type to the inner
                 // expression because we'll modify its type by flipping the sign.
                 let propagate_expected = op.kind != hir::UnOpKind::Neg
-                    || (!is_int_literal_expr(inner)
+                    || (!inner.is_integer_literal_expression()
                         && !matches!(expected, Some(ty) if ty.is_signed()));
                 let ty = if op.kind.has_side_effects() {
                     self.require_lvalue(inner)
@@ -2835,25 +2835,6 @@ fn invalid_storage_pointer_return(actual: Ty<'_>, expected: Ty<'_>) -> bool {
         }
         (TyKind::Ref(_, DataLocation::Storage), TyKind::Ref(_, DataLocation::Storage)) => false,
         (_, TyKind::Ref(_, DataLocation::Storage)) => true,
-        _ => false,
-    }
-}
-
-fn is_int_literal_expr(expr: &hir::Expr<'_>) -> bool {
-    match &expr.kind {
-        hir::ExprKind::Lit(lit) => matches!(lit.kind, LitKind::Number(_)),
-        hir::ExprKind::Unary(op, inner)
-            if matches!(op.kind, hir::UnOpKind::Neg | hir::UnOpKind::BitNot) =>
-        {
-            is_int_literal_expr(inner)
-        }
-        hir::ExprKind::Binary(lhs, op, rhs)
-            if !op.kind.is_cmp()
-                && !matches!(op.kind, hir::BinOpKind::Or | hir::BinOpKind::And) =>
-        {
-            is_int_literal_expr(lhs) && is_int_literal_expr(rhs)
-        }
-        hir::ExprKind::Tuple([Some(inner)]) => is_int_literal_expr(inner),
         _ => false,
     }
 }

--- a/tests/ui/codegen/lowering/checked_pow_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.sol
@@ -62,8 +62,8 @@ contract CheckedPowShapes {
     }
 
     // CHECK-LABEL: fn @const_neg2{{[( ]}}
-    // CHECK: [[BASE:v[0-9]+]] = sub 0, 2
-    // CHECK: phi [bb0: [[BASE]]]
+    // CHECK-NOT: sub 0, 2
+    // CHECK: phi [bb0: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe]
     // CHECK: sdiv {{v[0-9]+}}, {{v[0-9]+}}
     // CHECK: mstore 4, 17
     function const_neg2(uint256 b) public pure returns (int256) {

--- a/tests/ui/codegen/lowering/checked_pow_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.stdout
@@ -308,58 +308,57 @@ fn @const10(arg0: u256) -> u256 [selector=0xd325f19a, pure, abi_args=lazy, abi_p
 
 fn @const_neg2(arg0: u256) -> i256 [selector=0xf3adabf1, pure, abi_args=lazy, abi_params=[u256], abi_returns=[word]] {
   bb0:
-    v0 = sub 0, 2
     jump bb1
   bb1:
-    v1 = phi [bb0: 1], [bb7: v21]
-    v2 = phi [bb0: v0], [bb7: v23]
-    v3 = phi [bb0: arg0], [bb7: v22]
-    v4 = gt v3, 0
-    jumpi v4, bb2, bb3
+    v0 = phi [bb0: 1], [bb7: v20]
+    v1 = phi [bb0: 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe], [bb7: v22]
+    v2 = phi [bb0: arg0], [bb7: v21]
+    v3 = gt v2, 0
+    jumpi v3, bb2, bb3
   bb2:
-    v5 = and v3, 1
-    v6 = mul v1, v2
-    v7 = iszero v2
-    v8 = sdiv v6, v2
-    v9 = eq v8, v1
-    v10 = or v7, v9
-    v11 = iszero v10
-    v12 = slt v6, 0x8000000000000000000000000000000000000000000000000000000000000000
-    v13 = sgt v6, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    v14 = or v12, v13
-    v15 = or v11, v14
-    v16 = eq v1, 0x8000000000000000000000000000000000000000000000000000000000000000
-    v17 = eq v2, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    v18 = and v16, v17
-    v19 = or v15, v18
-    v20 = and v5, v19
-    jumpi v20, bb4, bb5
+    v4 = and v2, 1
+    v5 = mul v0, v1
+    v6 = iszero v1
+    v7 = sdiv v5, v1
+    v8 = eq v7, v0
+    v9 = or v6, v8
+    v10 = iszero v9
+    v11 = slt v5, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v12 = sgt v5, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    v13 = or v11, v12
+    v14 = or v10, v13
+    v15 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v16 = eq v1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    v17 = and v15, v16
+    v18 = or v14, v17
+    v19 = and v4, v18
+    jumpi v19, bb4, bb5
   bb3:
-    ret v1
+    ret v0
   bb4:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb5:
-    v21 = select v5, v6, v1
-    v22 = shr 1, v3
-    v23 = mul v2, v2
-    v24 = iszero v2
-    v25 = sdiv v23, v2
-    v26 = eq v25, v2
-    v27 = or v24, v26
-    v28 = iszero v27
-    v29 = slt v23, 0x8000000000000000000000000000000000000000000000000000000000000000
-    v30 = sgt v23, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    v31 = or v29, v30
-    v32 = or v28, v31
-    v33 = eq v2, 0x8000000000000000000000000000000000000000000000000000000000000000
-    v34 = eq v2, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    v35 = and v33, v34
-    v36 = or v32, v35
-    v37 = gt v22, 0
-    v38 = and v37, v36
-    jumpi v38, bb6, bb7
+    v20 = select v4, v5, v0
+    v21 = shr 1, v2
+    v22 = mul v1, v1
+    v23 = iszero v1
+    v24 = sdiv v22, v1
+    v25 = eq v24, v1
+    v26 = or v23, v25
+    v27 = iszero v26
+    v28 = slt v22, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v29 = sgt v22, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    v30 = or v28, v29
+    v31 = or v27, v30
+    v32 = eq v1, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v33 = eq v1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    v34 = and v32, v33
+    v35 = or v31, v34
+    v36 = gt v21, 0
+    v37 = and v36, v35
+    jumpi v37, bb6, bb7
   bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/signed_constant_ops.sol
+++ b/tests/ui/codegen/lowering/signed_constant_ops.sol
@@ -3,22 +3,19 @@
 
 contract SignedConstantOps {
     // CHECK-LABEL: fn @lt{{[( ]}}
-    // CHECK: [[NEG_ONE:v[0-9]+]] = sub 0, 1
-    // CHECK: slt [[NEG_ONE]], 1
+    // CHECK: slt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
     function lt() public pure returns (bool) {
         return int256(-1) < int256(1);
     }
 
     // CHECK-LABEL: fn @div{{[( ]}}
-    // CHECK: [[NEG_SEVEN:v[0-9]+]] = sub 0, 7
-    // CHECK: sdiv [[NEG_SEVEN]], 2
+    // CHECK: sdiv 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 2
     function div() public pure returns (int256) {
         return int256(-7) / int256(2);
     }
 
     // CHECK-LABEL: fn @shr{{[( ]}}
-    // CHECK: [[NEG_EIGHT:v[0-9]+]] = sub 0, 8
-    // CHECK: sar 1, [[NEG_EIGHT]]
+    // CHECK: sar 1, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
     function shr() public pure returns (int256) {
         return int256(-8) >> 1;
     }

--- a/tests/ui/codegen/lowering/signed_constant_ops.stdout
+++ b/tests/ui/codegen/lowering/signed_constant_ops.stdout
@@ -2,37 +2,34 @@
 @module SignedConstantOps
 fn @lt() -> bool [selector=0xa22ca2a6, pure, abi_args=lazy, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = sub 0, 1
-    v1 = slt v0, 1
-    ret v1
+    v0 = slt 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
+    ret v0
 }
 
 fn @div() -> i256 [selector=0xf9fa48c3, pure, abi_args=lazy, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = sub 0, 7
     jumpi 2, bb2, bb1
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 18 !metadata(memory=scratch)
     revert 0, 36
   bb2:
-    v1 = eq v0, 0x8000000000000000000000000000000000000000000000000000000000000000
-    v2 = eq 2, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    v3 = and v1, v2
-    jumpi v3, bb3, bb4
+    v0 = eq 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 0x8000000000000000000000000000000000000000000000000000000000000000
+    v1 = eq 2, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    v2 = and v0, v1
+    jumpi v2, bb3, bb4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb4:
-    v4 = sdiv v0, 2
-    ret v4
+    v3 = sdiv 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff9, 2
+    ret v3
 }
 
 fn @shr() -> i256 [selector=0xb87f777a, pure, abi_args=lazy, abi_params=[], abi_returns=[word]] {
   bb0:
-    v0 = sub 0, 8
-    v1 = sar 1, v0
-    ret v1
+    v0 = sar 1, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
+    ret v0
 }
 

--- a/tests/ui/codegen/run-call/wide_constant_intermediates.sol
+++ b/tests/ui/codegen/run-call/wide_constant_intermediates.sol
@@ -1,0 +1,21 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: uint256Max() => true
+//@ run-call: wideIntermediate() => true
+//@ run-call: cancelledPower() => true
+
+contract WideConstantIntermediates {
+    function uint256Max() external pure returns (bool) {
+        return 2**256 - 1 == type(uint256).max;
+    }
+
+    function wideIntermediate() external pure returns (bool) {
+        return (2**256 + 1) * 2 - 2**256 - 3 == type(uint256).max;
+    }
+
+    function cancelledPower() external pure returns (bool) {
+        return (2**512 - 1) - (2**512 - 2**256) == type(uint256).max;
+    }
+}

--- a/tests/ui/typeck/storage_layout_base_slot_overflow.sol
+++ b/tests/ui/typeck/storage_layout_base_slot_overflow.sol
@@ -3,10 +3,10 @@
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_bitwise_negation_literal.sol
 // ported-from: test/libsolidity/syntaxTests/storageLayoutSpecifier/contract_extends_past_storage_end.sol
 
-contract IntermediateOperationOutOfRange layout at (2**256 + 1) * 2 - 2**256 - 3 {} //~ ERROR: failed to evaluate constant: arithmetic overflow
-contract OverflowAdd layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {} //~ ERROR: failed to evaluate constant: arithmetic overflow
-contract OverflowPow layout at 2**256 {} //~ ERROR: failed to evaluate constant: arithmetic overflow
-contract BitwiseNegationLiteral layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {} //~ ERROR: failed to evaluate constant: arithmetic overflow
+contract IntermediateOperationOutOfRange layout at (2**256 + 1) * 2 - 2**256 - 3 {}
+contract OverflowAdd layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {} //~ ERROR: base slot of storage layout evaluates to a value outside the range of type `uint256`
+contract OverflowPow layout at 2**256 {} //~ ERROR: base slot of storage layout evaluates to a value outside the range of type `uint256`
+contract BitwiseNegationLiteral layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {} //~ ERROR: base slot of storage layout evaluates to a value outside the range of type `uint256`
 
 contract ExtendsPastEnd layout at 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff {
     //~^ ERROR: contract extends past the end of storage when this base slot value is specified

--- a/tests/ui/typeck/storage_layout_base_slot_overflow.stderr
+++ b/tests/ui/typeck/storage_layout_base_slot_overflow.stderr
@@ -1,28 +1,20 @@
-error: failed to evaluate constant: arithmetic overflow
+error: base slot of storage layout evaluates to a value outside the range of type `uint256`
    ╭▸ ROOT/tests/ui/typeck/storage_layout_base_slot_overflow.sol:LL:CC
    │
-LL │ contract IntermediateOperationOutOfRange layout at (2**256 + 1) * 2 - 2**256 - 3 {}
-   │                                                    ━┬─────━━━━━━━━━━━━━━━━━━━━━━
-   │                                                     │
-   ╰╴                                                    evaluation of constant value failed here
+LL │ contract OverflowAdd layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
+   ╰╴                               ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: failed to evaluate constant: arithmetic overflow
-   ╭▸ ROOT/tests/ui/typeck/storage_layout_base_slot_overflow.sol:LL:CC
-   │
-LL │ … layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF + 1 {}
-   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ evaluation of constant value failed here
-
-error: failed to evaluate constant: arithmetic overflow
+error: base slot of storage layout evaluates to a value outside the range of type `uint256`
    ╭▸ ROOT/tests/ui/typeck/storage_layout_base_slot_overflow.sol:LL:CC
    │
 LL │ contract OverflowPow layout at 2**256 {}
-   ╰╴                               ━━━━━━ evaluation of constant value failed here
+   ╰╴                               ━━━━━━
 
-error: failed to evaluate constant: arithmetic overflow
+error: base slot of storage layout evaluates to a value outside the range of type `uint256`
    ╭▸ ROOT/tests/ui/typeck/storage_layout_base_slot_overflow.sol:LL:CC
    │
-LL │ …l layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
-   ╰╴             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ evaluation of constant value failed here
+LL │ contract BitwiseNegationLiteral layout at ~0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE {}
+   ╰╴                                          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 error: contract extends past the end of storage when this base slot value is specified
    ╭▸ ROOT/tests/ui/typeck/storage_layout_base_slot_overflow.sol:LL:CC
@@ -30,5 +22,5 @@ error: contract extends past the end of storage when this base slot value is spe
 LL │ contract ExtendsPastEnd layout at 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff {
    ╰╴                                  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
This fixes integer-literal expressions whose intermediate value exceeds one EVM word while the final value still fits its Solidity type. Solidity evaluates literal expressions with arbitrary precision, but our constant evaluator stopped at 256 bits and codegen then emitted checked runtime arithmetic, making expressions such as `2**256 - 1` revert.

The evaluator now uses the parser's existing 4096-bit numeric bound, codegen folds only syntactic integer-literal expressions whose final value fits an EVM word, and destination-type range checks remain unchanged. The storage-layout diagnostics continue to reject final values outside `uint256`.

`solsymdiff` found this in Solidity's `integer/basic.sol` and `integer/uint.sol` semantic cases. Both now produce bounded agreement with solc. This is based on #1161 because the affected lowering path lives in that rewrite.
