### PR TITLE
fix(codegen): clean exponent operands

### DIFF
--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -204,6 +204,7 @@ struct FunctionLowerer<'gcx, 'ctx> {
     builder: FunctionBuilder<'ctx>,
     types: types::TypeLowerer<'gcx>,
     values: FxHashMap<VariableId, ValueId>,
+    dirty_values: FxHashSet<ValueId>,
     default_bindings: FxHashSet<VariableId>,
     deferred_bindings: FxHashSet<VariableId>,
     storage_refs: FxHashMap<VariableId, StorageAccess>,
@@ -214,6 +215,7 @@ struct FunctionLowerer<'gcx, 'ctx> {
     modifiers: Vec<ModifierContext<'gcx>>,
     return_targets: Vec<ReturnTarget>,
     unchecked: bool,
+    in_inline_assembly: bool,
 }
 
 struct LoopTargets {
@@ -385,6 +387,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             builder: FunctionBuilder::new(function),
             types: types::TypeLowerer::new(gcx),
             values: FxHashMap::default(),
+            dirty_values: FxHashSet::default(),
             default_bindings: FxHashSet::default(),
             deferred_bindings: FxHashSet::default(),
             storage_refs: FxHashMap::default(),
@@ -395,6 +398,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             modifiers: Vec::new(),
             return_targets: Vec::new(),
             unchecked: false,
+            in_inline_assembly: false,
         }
     }
 
@@ -458,6 +462,21 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                         (self.coerce_value(lhs, lhs_ty, rhs_ty), rhs)
                     }
                     _ => (lhs, rhs),
+                };
+                let (lhs, rhs) = if op.kind == BinOpKind::Pow {
+                    let lhs = if self.dirty_values.contains(&lhs) {
+                        lhs_ty.map_or(lhs, |ty| self.normalize_abi_scalar(lhs, ty))
+                    } else {
+                        lhs
+                    };
+                    let rhs = if self.dirty_values.contains(&rhs) {
+                        rhs_ty.map_or(rhs, |ty| self.normalize_abi_scalar(rhs, ty))
+                    } else {
+                        rhs
+                    };
+                    (lhs, rhs)
+                } else {
+                    (lhs, rhs)
                 };
                 let ty = match op.kind {
                     BinOpKind::Lt

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -614,7 +614,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             (true, false) => Some(else_branch.value),
             (false, true) => Some(then_branch.value),
             _ if then_branch.value == else_branch.value => Some(then_branch.value),
-            _ => Some(self.builder.phi(vec![
+            _ => Some(self.merge_value_phi(vec![
                 (then_branch.block, then_branch.value),
                 (else_branch.block, else_branch.value),
             ])),
@@ -711,8 +711,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     if then == else_ {
                         then
                     } else {
-                        self.builder
-                            .phi(vec![(then_branch.block, then), (else_branch.block, else_)])
+                        self.merge_value_phi(vec![
+                            (then_branch.block, then),
+                            (else_branch.block, else_),
+                        ])
                     }
                 })
                 .collect(),
@@ -741,7 +743,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let mut header_values = before_values.clone();
         let mut header_phis = FxHashMap::default();
         for (&id, &value) in &before_values {
-            let phi = self.builder.phi(vec![(preheader, value)]);
+            let phi = self.merge_value_phi(vec![(preheader, value)]);
             header_values.insert(id, phi);
             header_phis.insert(id, phi);
         }
@@ -844,6 +846,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         for (&id, &phi) in header_phis {
             let value = state.values.get(&id).copied().unwrap_or(phi);
             self.builder.add_phi_incoming(phi, state.block, value);
+            if !self.dirty_values.is_empty() && self.dirty_values.contains(&value) {
+                self.dirty_values.insert(phi);
+            }
         }
     }
 
@@ -876,7 +881,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 [value] => Some(*value),
                 [first, rest @ ..] if rest.iter().all(|value| value == first) => Some(*first),
                 _ => Some(
-                    self.builder.phi(
+                    self.merge_value_phi(
                         exits
                             .iter()
                             .filter_map(|state| {
@@ -986,9 +991,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 match (then_branch.terminated, else_branch.terminated, then_value, else_value) {
                     (true, false, _, value) | (false, true, value, _) => value,
                     (_, _, Some(lhs), Some(rhs)) if lhs == rhs => Some(lhs),
-                    (false, false, Some(lhs), Some(rhs)) => Some(
-                        self.builder.phi(vec![(then_branch.block, lhs), (else_branch.block, rhs)]),
-                    ),
+                    (false, false, Some(lhs), Some(rhs)) => {
+                        Some(self.merge_value_phi(vec![
+                            (then_branch.block, lhs),
+                            (else_branch.block, rhs),
+                        ]))
+                    }
                     _ => then_value.or(else_value),
                 };
             if let Some(value) = value {
@@ -1025,13 +1033,23 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 [(_, first), rest @ ..] if rest.iter().all(|(_, value)| value == first) => {
                     Some(*first)
                 }
-                _ => Some(self.builder.phi(incoming)),
+                _ => Some(self.merge_value_phi(incoming)),
             };
             if let Some(value) = value {
                 before.insert(id, value);
             }
         }
         before
+    }
+
+    fn merge_value_phi(&mut self, incoming: Vec<(BlockId, ValueId)>) -> ValueId {
+        let dirty = !self.dirty_values.is_empty()
+            && incoming.iter().any(|(_, value)| self.dirty_values.contains(value));
+        let value = self.builder.phi(incoming);
+        if dirty {
+            self.dirty_values.insert(value);
+        }
+        value
     }
 
     pub(super) fn merge_many_storage_refs(

--- a/crates/codegen/src/lower/function/lvalues.rs
+++ b/crates/codegen/src/lower/function/lvalues.rs
@@ -229,6 +229,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         value: ValueId,
         span: Span,
     ) -> Option<()> {
+        if self.in_inline_assembly {
+            self.dirty_values.insert(value);
+        }
         if let StdEntry::Occupied(mut entry) = self.values.entry(id) {
             entry.insert(value);
             return Some(());

--- a/crates/codegen/src/lower/function/statements.rs
+++ b/crates/codegen/src/lower/function/statements.rs
@@ -230,7 +230,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 }
             }
             StmtKind::Revert(expr) => self.lower_revert_payload(expr)?,
-            StmtKind::AssemblyBlock(block) => self.lower_block(*block)?,
+            StmtKind::AssemblyBlock(block) => {
+                let previous = std::mem::replace(&mut self.in_inline_assembly, true);
+                let result = self.lower_block(*block);
+                self.in_inline_assembly = previous;
+                result?;
+            }
             StmtKind::Placeholder => {
                 self.lower_modifier_placeholder(stmt.span)?;
             }

--- a/tests/ui/codegen/run-call/exponent_operand_cleanup.sol
+++ b/tests/ui/codegen/run-call/exponent_operand_cleanup.sol
@@ -1,0 +1,60 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: checkedDirtyOperands() => 9, -27
+//@ run-call: uncheckedDirtyOperands() => 4
+//@ run-call: copiedDirtyOperand() => 9
+//@ run-call: branchedDirtyOperand(bool) true => -27
+//@ run-call: branchedDirtyOperand(bool) false => 9
+//@ run-call: fullWidthOperands() => 16
+// ported-from: test/libsolidity/semanticTests/exponentiation/signed_base.sol
+// ported-from: test/libsolidity/semanticTests/exponentiation/small_exp.sol
+
+contract ExponentOperandCleanup {
+    function checkedDirtyOperands() external pure returns (int256, int256) {
+        int32 base = -3;
+        uint8 evenExponent;
+        uint8 oddExponent;
+        assembly {
+            evenExponent := 0x102
+            oddExponent := 0x103
+        }
+        return (base**evenExponent, base**oddExponent);
+    }
+
+    function uncheckedDirtyOperands() external pure returns (uint256 result) {
+        uint32 base;
+        uint8 exponent;
+        assembly {
+            base := 0xfffffffffe
+            exponent := 0x102
+        }
+        unchecked {
+            result = base**exponent;
+        }
+    }
+
+    function copiedDirtyOperand() external pure returns (uint256) {
+        uint8 exponent;
+        assembly {
+            exponent := 0x102
+        }
+        uint8 copy = exponent;
+        return 3**copy;
+    }
+
+    function branchedDirtyOperand(bool chooseDirty) external pure returns (int256) {
+        uint8 exponent = 2;
+        if (chooseDirty) {
+            assembly {
+                exponent := 0x103
+            }
+        }
+        return int256(-3)**exponent;
+    }
+
+    function fullWidthOperands() external pure returns (uint256) {
+        return 2**4;
+    }
+}


### PR DESCRIPTION
This fixes high-level exponentiation when a narrow operand carries dirty upper bits from inline assembly. The raw value previously reached `EXP` or the checked power loop without masking or sign extension, so Solidity's declared operand width was ignored and valid operations returned the wrong value or panicked.

Lowering now tracks assembly-derived MIR values through assignments and control-flow merges, then applies the existing scalar normalizer only when such a value reaches `Pow`. Ordinary `uint32 ** uint8` code remains byte-for-byte identical to the baseline at both `-O gas` and `-O size`.

`solsymdiff` found this independently in Solidity's `exponentiation/signed_base.sol` and `exponentiation/small_exp.sol` semantic cases. Both now produce bounded agreement with solc. This is based on #1161 because the affected lowering path lives in that rewrite.
