### PR TITLE
fix(codegen): type literal operands

### DIFF
--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -421,15 +421,32 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 } else {
                     (lhs, rhs)
                 };
-                let ty = match op.kind {
-                    BinOpKind::Lt
-                    | BinOpKind::Gt
-                    | BinOpKind::Le
-                    | BinOpKind::Ge
-                    | BinOpKind::Shl
-                    | BinOpKind::Shr
-                    | BinOpKind::Sar => lhs_ty,
-                    _ => self.context.gcx.type_of_expr(expr.id),
+                let expr_ty = self.context.gcx.type_of_expr(expr.id);
+                let lhs_is_literal =
+                    lhs_ty.is_some_and(|ty| matches!(ty.peel_refs().kind, TyKind::IntLiteral(..)));
+                let rhs_is_literal =
+                    rhs_ty.is_some_and(|ty| matches!(ty.peel_refs().kind, TyKind::IntLiteral(..)));
+                let signed_literal_arithmetic = lhs_is_literal
+                    && rhs_is_literal
+                    && lhs_ty
+                        .zip(rhs_ty)
+                        .is_some_and(|(lhs, rhs)| lhs.is_signed() || rhs.is_signed());
+                let ty = if signed_literal_arithmetic {
+                    Some(self.context.gcx.types.int(256))
+                } else {
+                    match op.kind {
+                        BinOpKind::Lt | BinOpKind::Gt | BinOpKind::Le | BinOpKind::Ge
+                            if lhs_is_literal =>
+                        {
+                            rhs_ty
+                        }
+                        BinOpKind::Lt | BinOpKind::Gt | BinOpKind::Le | BinOpKind::Ge => lhs_ty,
+                        BinOpKind::Shl | BinOpKind::Shr | BinOpKind::Sar if lhs_is_literal => {
+                            expr_ty
+                        }
+                        BinOpKind::Shl | BinOpKind::Shr | BinOpKind::Sar => lhs_ty,
+                        _ => expr_ty,
+                    }
                 };
                 let result = self.binary(op.kind, lhs, rhs, ty);
                 Some(

--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -391,7 +391,13 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                         if matches!(
                             lhs_ty.peel_refs().kind,
                             TyKind::Elementary(solar_sema::hir::ElementaryType::FixedBytes(_))
-                        ) && matches!(rhs_ty.peel_refs().kind, TyKind::StringLiteral(..)) =>
+                        ) && matches!(
+                            rhs_ty.peel_refs().kind,
+                            TyKind::IntLiteral(..) | TyKind::StringLiteral(..)
+                        ) && !matches!(
+                            op.kind,
+                            BinOpKind::Shl | BinOpKind::Shr | BinOpKind::Sar
+                        ) =>
                     {
                         (lhs, self.coerce_value(rhs, rhs_ty, lhs_ty))
                     }

--- a/tests/ui/codegen/run-call/fixed_bytes_literals.sol
+++ b/tests/ui/codegen/run-call/fixed_bytes_literals.sol
@@ -1,0 +1,34 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: equal(bytes1) 0x01 => true
+//@ run-call: equal(bytes1) 0x02 => false
+//@ run-call: notEqual(bytes1) 0x01 => false
+//@ run-call: notEqual(bytes1) 0x02 => true
+//@ run-call: lessThan(bytes1) 0x7f => true
+//@ run-call: lessThan(bytes1) 0x80 => false
+//@ run-call: bitwiseOr(bytes1) 0x80 => 0x81
+//@ run-call: wide(bytes10) 0x0102030405060708090a => true
+
+contract FixedBytesLiterals {
+    function equal(bytes1 value) external pure returns (bool) {
+        return value == 0x01;
+    }
+
+    function notEqual(bytes1 value) external pure returns (bool) {
+        return value != 0x01;
+    }
+
+    function lessThan(bytes1 value) external pure returns (bool) {
+        return value < 0x80;
+    }
+
+    function bitwiseOr(bytes1 value) external pure returns (bytes1) {
+        return value | 0x01;
+    }
+
+    function wide(bytes10 value) external pure returns (bool) {
+        return value == 0x0102030405060708090a;
+    }
+}

--- a/tests/ui/codegen/run-call/signed_integer_literals.sol
+++ b/tests/ui/codegen/run-call/signed_integer_literals.sol
@@ -1,0 +1,90 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: negativeRemainder() => -5
+//@ run-call: mixedRemainder() => -5
+//@ run-call: negativeDivisorRemainder() => 5
+//@ run-call: negativeDivision() => 2
+//@ run-call: mixedDivision() => -2
+//@ run-call: rightShift(uint256) 0 => -16
+//@ run-call: rightShift(uint256) 1 => -8
+//@ run-call: rightShift(uint256) 255 => -1
+//@ run-call: rightShift(uint256) 256 => -1
+//@ run-call: leftShift(uint256) 1 => -2
+//@ run-call: leftShift(uint256) 255 => -0x8000000000000000000000000000000000000000000000000000000000000000
+//@ run-call: leftShift(uint256) 256 => 0
+//@ run-call: lessThan() => true
+//@ run-call: greaterThan() => false
+//@ run-call: literalLessThan(int256) -10 => true
+//@ run-call: literalLessThan(int256) -20 => false
+//@ run-call: parameterLessThan(int256) -20 => true
+//@ run-call: parameterLessThan(int256) -10 => false
+//@ run-call: positiveRemainder() => 5
+//@ run-call: largePositiveDivision() => 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+//@ run-call: largePositiveRightShift(uint256) 1 => 0x4000000000000000000000000000000000000000000000000000000000000000
+//@ run-call: largePositiveGreaterThan() => true
+
+// Adapted from
+// https://github.com/ethereum/solidity/blob/develop/test/libsolidity/semanticTests/operators/userDefined/operator_precendence.sol
+contract SignedIntegerLiterals {
+    function negativeRemainder() external pure returns (int256) {
+        return -15 % -10;
+    }
+
+    function mixedRemainder() external pure returns (int256) {
+        return -15 % 10;
+    }
+
+    function negativeDivisorRemainder() external pure returns (int256) {
+        return 15 % -10;
+    }
+
+    function negativeDivision() external pure returns (int256) {
+        return -20 / -10;
+    }
+
+    function mixedDivision() external pure returns (int256) {
+        return -20 / 10;
+    }
+
+    function rightShift(uint256 shift) external pure returns (int256) {
+        return -16 >> shift;
+    }
+
+    function leftShift(uint256 shift) external pure returns (int256) {
+        return -1 << shift;
+    }
+
+    function lessThan() external pure returns (bool) {
+        return -15 < -10;
+    }
+
+    function greaterThan() external pure returns (bool) {
+        return -15 > -10;
+    }
+
+    function literalLessThan(int256 rhs) external pure returns (bool) {
+        return -15 < rhs;
+    }
+
+    function parameterLessThan(int256 lhs) external pure returns (bool) {
+        return lhs < -15;
+    }
+
+    function positiveRemainder() external pure returns (uint256) {
+        return 15 % 10;
+    }
+
+    function largePositiveDivision() external pure returns (uint256) {
+        return 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff / 2;
+    }
+
+    function largePositiveRightShift(uint256 shift) external pure returns (uint256) {
+        return 0x8000000000000000000000000000000000000000000000000000000000000000 >> shift;
+    }
+
+    function largePositiveGreaterThan() external pure returns (bool) {
+        return 0x8000000000000000000000000000000000000000000000000000000000000000 > 1;
+    }
+}


### PR DESCRIPTION
## summary

- lower integer-literal operations as signed when either literal is negative
- use the resolved full-width type for runtime shifts with literal left operands
- coerce compatible integer literals to fixed bytes for comparisons and bitwise operations, while leaving shift counts numeric

## differential findings

`solsymdiff` first found that Solar selected unsigned EVM operations for negative integer literals. For example, Solc returns `-5`, `-2`, and `-8` for `-15 % 10`, `-20 / 10`, and `-16 >> 1`; Solar returned `1`, a large positive quotient, and `2^255 - 8`.

A stateful sweep of Solidity's `packed_storage_structs_bytes.sol` then found a separate operand-conversion gap. The #1161 head stored the packed fields correctly, but compiled `bytes1Value == 0x01` as a comparison against unshifted `1`, returning `false` where Solc returned `true`. The Standard JSON input hash was `86c075322f07c6b8f9b8299df982840d045440510de55cf038cbffa41d704861`. Foundry replay and a fresh-Anvil call confirmed the exact result; the patched branch reaches bounded agreement.

Both classes reproduce across optimization modes. The focused runtime tests cover signed division, remainder, shifts, mixed comparisons, fixed-bytes equality/order/bitwise operations, multiple byte widths, and the shift-count non-regression.

## tests

- `cargo nextest run -p solar-codegen` (220 passed)
- `FILECHECK=/opt/homebrew/opt/llvm/bin/FileCheck TESTER_MODE=ui cargo nextest run -p solar-compiler --test tests`
- `cargo clippy -p solar-codegen -p solar-compiler --all-targets`
- `cargo +nightly fmt --all -- --check`
- `solsymdiff` replay before/after on both discrepancy classes

AI assistance was used for implementation and validation.
