### PR TITLE
fix(codegen): lower transient state variables

### DIFF
--- a/crates/codegen/src/lower/function/storage_values.rs
+++ b/crates/codegen/src/lower/function/storage_values.rs
@@ -523,8 +523,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 if let TyKind::Mapping(_, value) = ty.kind {
                     let slot = self.mapping_slot(index, index_ty, base.slot);
                     if let Some((size, encoding)) = self.context.storage.packed_encoding(value) {
-                        let location =
-                            StorageLocation { slot: U256::ZERO, offset: 0, size, encoding };
+                        let location = StorageLocation::packed_word(size, encoding);
                         return Some(StorageAccess { slot, location, offset: None });
                     }
                     return Some(StorageAccess {
@@ -825,7 +824,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let index_in_slot = self.builder.mod_(index, per_slot_value);
             let byte_size = self.builder.imm_u64(bytes);
             let offset = self.builder.mul(index_in_slot, byte_size);
-            let location = StorageLocation { slot: U256::ZERO, offset: 0, size, encoding };
+            let location = StorageLocation::packed_word(size, encoding);
             return Some(StorageAccess { slot, location, offset: Some(offset) });
         }
         let element_slots = self.context.storage.element_slots(element, span);

--- a/crates/codegen/src/lower/storage.rs
+++ b/crates/codegen/src/lower/storage.rs
@@ -4,6 +4,7 @@ use std::{cell::RefCell, sync::OnceLock};
 
 use crate::mir::{FunctionBuilder, TypeSize, ValueId};
 use alloy_primitives::U256;
+use solar_ast::DataLocation;
 use solar_data_structures::{index::IndexVec, map::FxHashMap};
 use solar_interface::Span;
 use solar_sema::{
@@ -27,13 +28,24 @@ pub(super) struct StorageLocation {
     pub(super) offset: u8,
     pub(super) size: TypeSize,
     pub(super) encoding: StorageEncoding,
+    transient: bool,
 }
 
 impl StorageLocation {
     const WORD: TypeSize = TypeSize::new_int_bits(256);
 
     pub(super) const fn word(slot: U256) -> Self {
-        Self { slot, offset: 0, size: Self::WORD, encoding: StorageEncoding::Unsigned }
+        Self {
+            slot,
+            offset: 0,
+            size: Self::WORD,
+            encoding: StorageEncoding::Unsigned,
+            transient: false,
+        }
+    }
+
+    pub(super) const fn packed_word(size: TypeSize, encoding: StorageEncoding) -> Self {
+        Self { slot: U256::ZERO, offset: 0, size, encoding, transient: false }
     }
 
     const fn packed(self) -> bool {
@@ -49,6 +61,18 @@ impl StorageLocation {
             U256::MAX
         } else {
             (U256::from(1) << self.size.bits()) - U256::from(1)
+        }
+    }
+
+    fn load(self, builder: &mut FunctionBuilder<'_>, slot: ValueId) -> ValueId {
+        if self.transient { builder.tload(slot) } else { builder.sload(slot) }
+    }
+
+    fn store(self, builder: &mut FunctionBuilder<'_>, slot: ValueId, value: ValueId) {
+        if self.transient {
+            builder.tstore(slot, value);
+        } else {
+            builder.sstore(slot, value);
         }
     }
 }
@@ -149,7 +173,7 @@ impl<'gcx> StorageLayout<'gcx> {
         location: StorageLocation,
         slot: ValueId,
     ) -> ValueId {
-        let word = builder.sload(slot);
+        let word = location.load(builder, slot);
         let shift = (location.offset != 0).then(|| builder.imm_u64(u64::from(location.offset) * 8));
         self.load_word(builder, location, word, shift)
     }
@@ -161,7 +185,7 @@ impl<'gcx> StorageLayout<'gcx> {
         slot: ValueId,
         offset: ValueId,
     ) -> ValueId {
-        let word = builder.sload(slot);
+        let word = location.load(builder, slot);
         if !location.packed() {
             return word;
         }
@@ -205,7 +229,7 @@ impl<'gcx> StorageLayout<'gcx> {
         value: ValueId,
     ) {
         if !location.packed() {
-            builder.sstore(slot, value);
+            location.store(builder, slot, value);
             return;
         }
         let shift = (location.offset != 0).then(|| builder.imm_u64(u64::from(location.offset) * 8));
@@ -221,7 +245,7 @@ impl<'gcx> StorageLayout<'gcx> {
         value: ValueId,
     ) {
         if !location.packed() {
-            builder.sstore(slot, value);
+            location.store(builder, slot, value);
             return;
         }
 
@@ -242,7 +266,7 @@ impl<'gcx> StorageLayout<'gcx> {
         let field_mask_value = builder.imm_u256(field_mask);
         let shifted_mask =
             shift.map_or(field_mask_value, |shift| builder.shl(shift, field_mask_value));
-        let old = builder.sload(slot);
+        let old = location.load(builder, slot);
         let keep_mask = builder.not(shifted_mask);
         let cleared = builder.and(old, keep_mask);
         let value = match location.encoding {
@@ -256,7 +280,7 @@ impl<'gcx> StorageLayout<'gcx> {
         let value = builder.and(value, field_mask_value);
         let value = shift.map_or(value, |shift| builder.shl(shift, value));
         let updated = builder.or(cleared, value);
-        builder.sstore(slot, updated);
+        location.store(builder, slot, updated);
     }
 }
 
@@ -266,7 +290,8 @@ struct StorageBuilder<'gcx> {
     locations: FxHashMap<VariableId, StorageLocation>,
     field_types: IndexVec<StructId, OnceLock<&'gcx [Ty<'gcx>]>>,
     field_locations: RefCell<FxHashMap<StructId, Option<Box<[StorageLocation]>>>>,
-    cursor: StorageCursor,
+    storage_cursor: StorageCursor,
+    transient_cursor: StorageCursor,
 }
 
 /// Walks Solidity's sequential storage layout, including fields packed into a word.
@@ -274,11 +299,12 @@ struct StorageBuilder<'gcx> {
 struct StorageCursor {
     slot: U256,
     offset: u8,
+    transient: bool,
 }
 
 impl StorageCursor {
-    fn new() -> Self {
-        Self { slot: U256::ZERO, offset: 0 }
+    fn new(transient: bool) -> Self {
+        Self { slot: U256::ZERO, offset: 0, transient }
     }
 
     fn take(
@@ -293,7 +319,13 @@ impl StorageCursor {
             if self.offset.checked_add(bytes)? > StorageLocation::word_bytes() {
                 self.finish_word()?;
             }
-            let location = StorageLocation { slot: self.slot, offset: self.offset, size, encoding };
+            let location = StorageLocation {
+                slot: self.slot,
+                offset: self.offset,
+                size,
+                encoding,
+                transient: self.transient,
+            };
             self.offset += bytes;
             if self.offset == StorageLocation::word_bytes() {
                 self.finish_word()?;
@@ -302,7 +334,13 @@ impl StorageCursor {
         }
 
         self.finish_word()?;
-        let location = StorageLocation::word(self.slot);
+        let location = StorageLocation {
+            slot: self.slot,
+            offset: 0,
+            size: StorageLocation::WORD,
+            encoding: StorageEncoding::Unsigned,
+            transient: self.transient,
+        };
         self.slot = self.slot.checked_add(U256::from(slots))?;
         Some(location)
     }
@@ -328,7 +366,8 @@ impl<'gcx> StorageBuilder<'gcx> {
             locations: FxHashMap::default(),
             field_types: gcx.hir.strukt_ids().map(|_| OnceLock::new()).collect(),
             field_locations: RefCell::new(FxHashMap::default()),
-            cursor: StorageCursor::new(),
+            storage_cursor: StorageCursor::new(false),
+            transient_cursor: StorageCursor::new(true),
         }
     }
 
@@ -341,7 +380,8 @@ impl<'gcx> StorageBuilder<'gcx> {
                     continue;
                 }
                 let ty = self.gcx.type_of_item(id.into());
-                if let Some(location) = self.allocate(ty, var.span) {
+                let transient = var.data_location == Some(DataLocation::Transient);
+                if let Some(location) = self.allocate(ty, var.span, transient) {
                     self.locations.insert(id, location);
                 }
             }
@@ -349,10 +389,11 @@ impl<'gcx> StorageBuilder<'gcx> {
         StorageLayout { builder: self }
     }
 
-    fn allocate(&mut self, ty: Ty<'gcx>, span: Span) -> Option<StorageLocation> {
+    fn allocate(&mut self, ty: Ty<'gcx>, span: Span, transient: bool) -> Option<StorageLocation> {
         let encoding = self.packed_encoding(ty);
         let slots = self.storage_slots(ty, span);
-        self.cursor.take(encoding, slots).or_else(|| {
+        let cursor = if transient { &mut self.transient_cursor } else { &mut self.storage_cursor };
+        cursor.take(encoding, slots).or_else(|| {
             self.gcx
                 .dcx()
                 .err("contract storage layout exceeds the addressable storage space")
@@ -367,7 +408,7 @@ impl<'gcx> StorageBuilder<'gcx> {
             return locations.as_ref()?.get(field).copied();
         }
 
-        let mut cursor = StorageCursor::new();
+        let mut cursor = StorageCursor::new(false);
         let locations = self
             .struct_field_types(struct_id)
             .iter()
@@ -459,7 +500,7 @@ impl<'gcx> StorageBuilder<'gcx> {
     }
 
     fn sequence_slots(&self, tys: impl Iterator<Item = Ty<'gcx>>, span: Span) -> Option<u64> {
-        let mut cursor = StorageCursor::new();
+        let mut cursor = StorageCursor::new(false);
         for ty in tys {
             let encoding = self.packed_encoding(ty);
             let slots = self.storage_slots_inner(ty, span)?;

--- a/tests/ui/codegen/run-call/transient_storage.sol
+++ b/tests/ui/codegen/run-call/transient_storage.sol
@@ -1,0 +1,81 @@
+//@ run-call: TransientStorage::separateSpaces(uint256,uint256) 11, 22 => 11, 22, 11, 22, 0, 0
+//@ run-call: TransientStorage::packed() => 4386, 13124, 860098850
+//@ run-call: TransientStorage::signed() => -2
+//@ run-call: TransientStorage::clear() => 0, 0
+//@ run-call: TransientStorage::getter() => 77
+//@ run-call: TransientModifier::run() => 100
+// ported-from: test/libsolidity/semanticTests/operators/compound_assign_transient_storage.sol
+// ported-from: test/libsolidity/semanticTests/modifiers/transient_state_variable_value_type.sol
+
+contract TransientStorage {
+    uint256 persistent;
+    uint256 public transient temporary;
+    uint16 transient low;
+    uint16 transient high;
+    int16 transient signedValue;
+
+    function separateSpaces(uint256 stored, uint256 temporaryValue)
+        external
+        returns (
+            uint256 storedValue,
+            uint256 transientValue,
+            uint256 storedWord,
+            uint256 transientWord,
+            uint256 storedSlot,
+            uint256 transientSlot
+        )
+    {
+        persistent = stored;
+        temporary = temporaryValue;
+        storedValue = persistent;
+        transientValue = temporary;
+        assembly {
+            storedWord := sload(persistent.slot)
+            transientWord := tload(temporary.slot)
+            storedSlot := persistent.slot
+            transientSlot := temporary.slot
+        }
+    }
+
+    function packed() external returns (uint16, uint16, uint256 word) {
+        low = 0x1122;
+        high = 0x3344;
+        assembly {
+            word := tload(low.slot)
+        }
+        return (low, high, word);
+    }
+
+    function signed() external returns (int16) {
+        signedValue = -2;
+        return signedValue;
+    }
+
+    function clear() external returns (uint256 value, uint256 word) {
+        temporary = 42;
+        delete temporary;
+        value = temporary;
+        assembly {
+            word := tload(temporary.slot)
+        }
+    }
+
+    function getter() external returns (uint256) {
+        temporary = 77;
+        return this.temporary();
+    }
+}
+
+contract TransientModifier {
+    uint16 transient value;
+
+    modifier bump(uint16) {
+        value += 10;
+        _;
+    }
+
+    function run() external bump(value) returns (uint16) {
+        value *= 10;
+        return value;
+    }
+}


### PR DESCRIPTION
## summary

- give persistent and transient state variables independent layout cursors
- emit `tload`/`tstore` for transient scalar loads, stores, and packed-word updates
- cover namespace isolation, packed and signed values, deletion, getters, modifiers, and persistent storage controls

## how symbolic differential testing found it

`solsymdiff` compared Solar with Solc on the upstream `compound_assign_transient_storage.sol` and `transient_state_variable_value_type.sol` semantic tests. Both produced replay-confirmed mismatches with identical standard-json inputs.

The minimized case showed Solar lowering a high-level transient variable to `sload`/`sstore`. A fresh Anvil replay returned the same value from both runtimes, but after the transaction Solc left persistent storage empty while Solar had permanently written `7` to slot 1. The mismatch reproduced with optimization on and off, runs 1/200, via-ir on and off, Cancun/Osaka, and BFS/DFS.

After this change, the minimized persistent/transient namespace, packed value, signed value, delete, and getter cases all reach bounded symbolic agreement.

## tests

- `cargo nextest run -p solar-codegen` (220 passed)
- `FILECHECK=/opt/homebrew/opt/llvm/bin/FileCheck TESTER_MODE=ui cargo nextest run -p solar-compiler --test tests`
- `cargo clippy -p solar-codegen -p solar-compiler --all-targets`
- `cargo +nightly fmt --all -- --check`
