### PR TITLE
fix(codegen): preserve loop continue edges

### DIFF
--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -757,13 +757,19 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
 
     pub(super) fn lower_loop(
         &mut self,
-        block: hir::Block<'_>,
+        mut block: hir::Block<'_>,
         source: LoopSource<'_>,
     ) -> Option<()> {
         self.materialize_default_bindings();
         let update_stmt = match source {
             LoopSource::For { update } => update,
-            LoopSource::While | LoopSource::DoWhile => None,
+            LoopSource::While => None,
+            LoopSource::DoWhile => {
+                let (condition, body) =
+                    block.stmts.split_last().expect("do while loop has a condition");
+                block.stmts = body;
+                Some(condition)
+            }
         };
         let preheader = self.builder.current_block();
         let header = self.builder.create_block();
@@ -812,9 +818,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             if let Some(state) = normal_state {
                 update_states.push(state);
             }
-            update_states.extend(
-                self.loops.last().expect("loop target exists").continue_states.iter().cloned(),
-            );
+            update_states.extend(std::mem::take(
+                &mut self.loops.last_mut().expect("loop target exists").continue_states,
+            ));
 
             if update_states.is_empty() {
                 let update = update.expect("for loop update block");
@@ -830,6 +836,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 );
                 self.storage_refs =
                     self.merge_loop_storage_refs(header_storage_refs.clone(), &update_states);
+                if matches!(source, LoopSource::DoWhile) {
+                    self.loops.last_mut().expect("loop target exists").continue_block = header;
+                }
                 self.lower_stmt(update_stmt)?;
                 let update_state = (!self.is_terminated()).then(|| LoopState {
                     block: self.builder.current_block(),
@@ -857,7 +866,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         if let Some(state) = &update_state {
             self.add_loop_phi_incoming(&header_phis, state);
             self.add_loop_storage_phi_incoming(&header_storage_refs, state);
-        } else if update_stmt.is_none() {
+        }
+        if update_stmt.is_none() || matches!(source, LoopSource::DoWhile) {
             for state in &loop_targets.continue_states {
                 self.add_loop_phi_incoming(&header_phis, state);
                 self.add_loop_storage_phi_incoming(&header_storage_refs, state);

--- a/crates/codegen/src/lower/function/control_flow.rs
+++ b/crates/codegen/src/lower/function/control_flow.rs
@@ -823,12 +823,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             ));
 
             if update_states.is_empty() {
-                let update = update.expect("for loop update block");
+                let update = update.expect("loop update block exists");
                 self.builder.switch_to_block(update);
                 self.builder.invalid();
                 None
             } else {
-                self.builder.switch_to_block(update.expect("for loop update block"));
+                self.builder.switch_to_block(update.expect("loop update block exists"));
                 self.values = self.merge_loop_values(
                     header_values.clone(),
                     &update_states,

--- a/tests/ui/codegen/lowering/while_loop.stdout
+++ b/tests/ui/codegen/lowering/while_loop.stdout
@@ -31,26 +31,28 @@ fn @do_at_least_once(arg0: u256) -> u256 [selector=0x0cf92500, pure, abi_args=la
   bb0:
     jump bb1
   bb1:
-    v0 = phi [bb0: arg0], [bb5: v0]
-    v1 = phi [bb0: 0], [bb5: v3]
-    v2 = phi [bb0: 0], [bb5: v2]
+    v0 = phi [bb0: arg0], [bb6: v0]
+    v1 = phi [bb0: 0], [bb6: v3]
+    v2 = phi [bb0: 0], [bb6: v2]
     v3 = add v1, 1
     v4 = lt v3, v1
-    jumpi v4, bb3, bb4
+    jumpi v4, bb4, bb5
   bb2:
     ret v3
   bb3:
+    v5 = lt v3, v0
+    jumpi v5, bb6, bb7
+  bb4:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v5 = lt v3, v0
-    jumpi v5, bb5, bb6
   bb5:
-    jump bb1
+    jump bb3
   bb6:
-    jump bb2
+    jump bb1
   bb7:
+    jump bb2
+  bb8:
     invalid
 }
 

--- a/tests/ui/codegen/run-call/do_while_continue.sol
+++ b/tests/ui/codegen/run-call/do_while_continue.sol
@@ -1,0 +1,75 @@
+//@ run-call: falseCondition() => 42
+//@ run-call: countToThree() => 3
+//@ run-call: conditionSideEffect() => 2, 2
+//@ run-call: skipRemainder() => 20
+//@ run-call: nested() => 6
+//@ run-call: whileControl() => 3
+//@ run-call: whileConditionalContinue() => 22
+// ported-from: test/libsolidity/semanticTests/statements/do_while_loop_continue.sol
+
+contract DoWhileContinue {
+    function falseCondition() external pure returns (uint256) {
+        uint256 i;
+        do {
+            if (i > 0) return 0;
+            ++i;
+            continue;
+        } while (false);
+        return 42;
+    }
+
+    function countToThree() external pure returns (uint256 i) {
+        do {
+            ++i;
+            continue;
+        } while (i < 3);
+    }
+
+    function conditionSideEffect() external pure returns (uint256 i, uint256 checks) {
+        do {
+            ++i;
+            continue;
+        } while (++checks < 2);
+    }
+
+    function skipRemainder() external pure returns (uint256 sum) {
+        uint256 i;
+        do {
+            ++i;
+            if (i < 3) continue;
+            sum += 10;
+        } while (i < 4);
+    }
+
+    function nested() external pure returns (uint256 total) {
+        uint256 outer;
+        do {
+            ++outer;
+            uint256 inner;
+            do {
+                ++inner;
+                ++total;
+                continue;
+            } while (inner < 3);
+        } while (outer < 2);
+    }
+
+    function whileControl() external pure returns (uint256 i) {
+        while (i < 3) {
+            ++i;
+            continue;
+        }
+    }
+
+    function whileConditionalContinue() external pure returns (uint256 sum) {
+        uint256 i;
+        while (i < 4) {
+            ++i;
+            if (i < 3) {
+                ++sum;
+                continue;
+            }
+            sum += 10;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- lower a `do while` condition as the loop update so explicit `continue` statements still evaluate it
- retain conditional `continue` states as loop-header phi inputs
- add upstream-based runtime coverage for do-while, nested loops, condition side effects, and ordinary while-loop controls

## Differential finding

`solsymdiff` found the upstream Solidity test `statements/do_while_loop_continue.sol` disagreeing at the current #1161 head (`825aebac`). With identical Standard JSON input (`sha256: 581631fa2802ea449dd8e58c80ffb9d8bd4b1c5670258eb47277c8789d714c41`), Solc 0.8.35 returned `42` while Solar returned `0` for calldata `0x26121ff0`. Foundry replay and an independent fresh-Anvil call confirmed the same result.

The mismatch reproduced with optimization on/off, optimizer runs 1/200, via-IR on/off, Cancun/Osaka, and BFS/DFS. Solar MIR showed the explicit `continue` jumping directly to the loop header and bypassing the condition. A conditional `continue` also exposed a missing phi predecessor; this change preserves that edge as well.

After the fix, the upstream test and the added boundary cases reach bounded symbolic agreement.

## Tests

- `cargo nextest run -p solar-codegen` (220 passed)
- `FILECHECK=/opt/homebrew/opt/llvm/bin/FileCheck TESTER_MODE=ui cargo nextest run -p solar-compiler --test tests` (1,269 passed)
- `cargo clippy -p solar-codegen -p solar-compiler --all-targets`
- `cargo +nightly fmt --all -- --check`
