### PR TITLE
feat(lsp): expose launch configuration

### DIFF
--- a/crates/cli/src/commands/lsp.rs
+++ b/crates/cli/src/commands/lsp.rs
@@ -6,7 +6,7 @@ pub(super) fn run(args: LspArgs) -> ExitCode {
         .enable_all()
         .build()
         .unwrap()
-        .block_on(solar_lsp::run_server_stdio(args))
+        .block_on(solar_lsp::launch(solar_lsp::LaunchConfig::from(args)))
     {
         Ok(()) => ExitCode::SUCCESS,
         Err(_) => ExitCode::FAILURE,

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -20,13 +20,13 @@ use std::{
 };
 use tracing::{info, warn};
 
-/// The LSP config.
+/// The post-initialize LSP session config.
 ///
 /// This struct is internal only and should not be serialized or deserialized. Instead, values in
 /// this struct are the full view of all merged config sources, such as `initialization_opts`,
 /// on-disk config files (e.g. `foundry.toml`).
 #[derive(Default, Clone, Debug)]
-pub(crate) struct Config {
+pub(crate) struct SessionConfig {
     workspace_roots: Vec<PathBuf>,
     workspaces: Vec<Workspace>,
     flycheck_options: FlycheckInitializationOptions,
@@ -51,7 +51,7 @@ pub(crate) struct SignatureHelpClientOptions {
     pub(crate) signature_active_parameter: bool,
 }
 
-impl Config {
+impl SessionConfig {
     pub(crate) fn supports_watched_file_dynamic_registration(&self) -> bool {
         self.watched_file_dynamic_registration
     }
@@ -195,13 +195,24 @@ fn push_workspace(workspaces: &mut Vec<Workspace>, mut workspace: Workspace) {
     workspaces.push(workspace);
 }
 
-pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabilities, Config) {
+#[cfg(test)]
+pub(crate) fn negotiate_capabilities(
+    params: InitializeParams,
+) -> (ServerCapabilities, SessionConfig) {
+    negotiate_capabilities_with_default_forge_path(params, None)
+}
+
+pub(crate) fn negotiate_capabilities_with_default_forge_path(
+    params: InitializeParams,
+    default_forge_path: Option<&Path>,
+) -> (ServerCapabilities, SessionConfig) {
     let capabilities = params.capabilities;
     let initialization_options = params.initialization_options;
     #[allow(deprecated)]
     let root_uri = params.root_uri;
     let workspace_folders = params.workspace_folders;
-    let flycheck_options = FlycheckInitializationOptions::from_json(initialization_options);
+    let flycheck_options =
+        FlycheckInitializationOptions::from_json(initialization_options, default_forge_path);
 
     // todo: make this absolute guaranteed
     let root_path = match root_uri.and_then(|it| it.to_file_path().ok()) {
@@ -332,7 +343,7 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
             workspace_symbol_provider: Some(OneOf::Left(true)),
             ..Default::default()
         },
-        Config {
+        SessionConfig {
             workspace_roots,
             flycheck_options,
             watched_file_dynamic_registration,
@@ -636,19 +647,25 @@ mod tests {
 
     #[test]
     fn negotiate_capabilities_records_configured_forge_path() {
-        let (_, default_config) = negotiate_capabilities(InitializeParams::default());
-        assert_eq!(default_config.forge_path(), PathBuf::from("forge"));
+        let (_, default_config) = negotiate_capabilities_with_default_forge_path(
+            InitializeParams::default(),
+            Some(Path::new("/embedded/forge")),
+        );
+        assert_eq!(default_config.forge_path(), PathBuf::from("/embedded/forge"));
 
-        let params = InitializeParams {
-            initialization_options: Some(serde_json::json!({
-                "forgePath": "/tools/forge"
-            })),
-            ..Default::default()
-        };
+        let (_, bare_config) = negotiate_capabilities(InitializeParams::default());
+        assert_eq!(bare_config.forge_path(), PathBuf::from("forge"));
 
-        let (_, config) = negotiate_capabilities(params);
-
-        assert_eq!(config.forge_path(), PathBuf::from("/tools/forge"));
+        let (_, client_config) = negotiate_capabilities_with_default_forge_path(
+            InitializeParams {
+                initialization_options: Some(serde_json::json!({
+                    "forgePath": "/client/forge"
+                })),
+                ..Default::default()
+            },
+            Some(Path::new("/embedded/forge")),
+        );
+        assert_eq!(client_config.forge_path(), PathBuf::from("/client/forge"));
     }
 
     #[test]

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -36,8 +36,16 @@ pub(crate) struct FlycheckInitializationOptions {
 }
 
 impl FlycheckInitializationOptions {
-    pub(crate) fn from_json(value: Option<serde_json::Value>) -> Self {
-        value.and_then(|value| serde_json::from_value(value).ok()).unwrap_or_default()
+    pub(crate) fn from_json(
+        value: Option<serde_json::Value>,
+        default_forge_path: Option<&Path>,
+    ) -> Self {
+        let mut options: Self =
+            value.and_then(|value| serde_json::from_value(value).ok()).unwrap_or_default();
+        if options.forge_path.is_none() {
+            options.forge_path = default_forge_path.map(Path::to_path_buf);
+        }
+        options
     }
 
     pub(crate) fn configs(&self, workspaces: &[Workspace]) -> Vec<FlycheckConfig> {

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -1,6 +1,6 @@
 use crate::{
     NotifyResult,
-    config::{Config, negotiate_capabilities},
+    config::{SessionConfig, negotiate_capabilities_with_default_forge_path},
     diagnostics::{DiagnosticMap, DiagnosticOwner, DiagnosticStore, PullReport},
     flycheck,
     progress::{ProgressCoordinator, ProgressTicket},
@@ -68,7 +68,8 @@ pub(crate) struct GlobalState {
     client: ClientSocket,
     pub(crate) sess: Session,
     pub(crate) vfs: Arc<RwLock<Vfs>>,
-    pub(crate) config: Arc<Config>,
+    pub(crate) config: Arc<SessionConfig>,
+    launch_config: crate::LaunchConfig,
     analysis_version: Arc<AtomicUsize>,
     published_analysis_version: watch::Sender<usize>,
     analysis_commit: Arc<Mutex<AnalysisCommitState>>,
@@ -80,7 +81,15 @@ pub(crate) struct GlobalState {
 }
 
 impl GlobalState {
+    #[cfg(test)]
     pub(crate) fn new(client: ClientSocket) -> Self {
+        Self::with_launch_config(client, crate::LaunchConfig::default())
+    }
+
+    pub(crate) fn with_launch_config(
+        client: ClientSocket,
+        launch_config: crate::LaunchConfig,
+    ) -> Self {
         let (published_analysis_version, _) = watch::channel(0);
         let analysis_progress = ProgressCoordinator::new(client.clone(), false);
         Self {
@@ -96,6 +105,7 @@ impl GlobalState {
             symbol_tables: Arc::new(Default::default()),
             diagnostics: Arc::new(Default::default()),
             config: Arc::new(Default::default()),
+            launch_config,
         }
     }
 
@@ -103,7 +113,10 @@ impl GlobalState {
         &mut self,
         params: InitializeParams,
     ) -> impl Future<Output = Result<proto::InitializeResponse, ResponseError>> + use<> {
-        let (capabilities, mut config) = negotiate_capabilities(params);
+        let (capabilities, mut config) = negotiate_capabilities_with_default_forge_path(
+            params,
+            self.launch_config.default_forge_path(),
+        );
 
         config.rediscover_workspaces();
 
@@ -676,7 +689,7 @@ fn publish_diagnostic_batches(
 pub(crate) struct GlobalStateSnapshot {
     client: ClientSocket,
     vfs: Arc<RwLock<Vfs>>,
-    config: Arc<Config>,
+    config: Arc<SessionConfig>,
     analysis_version: Arc<AtomicUsize>,
     published_analysis_version: watch::Sender<usize>,
     analysis_commit: Arc<Mutex<AnalysisCommitState>>,

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -283,6 +283,16 @@ mod tests {
         assert_eq!(config.default_forge_path(), Some(Path::new("/embedded/forge")));
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn initialize_applies_launch_config_default_forge_path() {
+        let config = LaunchConfig::default().with_default_forge_path("/embedded/forge");
+        let mut state = GlobalState::with_launch_config(ClientSocket::new_closed(), config);
+
+        state.on_initialize(InitializeParams::default()).await.unwrap();
+
+        assert_eq!(state.config.forge_path(), Path::new("/embedded/forge"));
+    }
+
     fn start_request<F: Future>(future: F) -> Pin<Box<F>> {
         let mut future = Box::pin(future);
         let mut cx = Context::from_waker(Waker::noop());

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -6,17 +6,46 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use crate::global_state::GlobalState;
+#[cfg(test)]
+use async_lsp::ClientSocket;
 use async_lsp::{
-    ClientSocket, client_monitor::ClientProcessMonitorLayer, router::Router,
-    server::LifecycleLayer, tracing::TracingLayer,
+    client_monitor::ClientProcessMonitorLayer, router::Router, server::LifecycleLayer,
+    tracing::TracingLayer,
 };
 #[cfg(test)]
 use criterion as _;
 use lsp_types::{notification as notif, request as req};
 use serde_json as _;
 use solar_config::LspArgs;
-use std::ops::ControlFlow;
+use std::{
+    ops::ControlFlow,
+    path::{Path, PathBuf},
+};
 use tower::ServiceBuilder;
+
+/// Configuration used to launch the language server before the client initializes it.
+#[derive(Clone, Debug, Default)]
+pub struct LaunchConfig {
+    default_forge_path: Option<PathBuf>,
+}
+
+impl From<LspArgs> for LaunchConfig {
+    fn from(_: LspArgs) -> Self {
+        Self::default()
+    }
+}
+
+impl LaunchConfig {
+    /// Sets the Forge executable to use when the client does not provide one.
+    pub fn with_default_forge_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.default_forge_path = Some(path.into());
+        self
+    }
+
+    pub(crate) fn default_forge_path(&self) -> Option<&Path> {
+        self.default_forge_path.as_deref()
+    }
+}
 
 mod call_hierarchy;
 mod commands;
@@ -71,6 +100,7 @@ mod test_support;
 
 pub(crate) type NotifyResult = ControlFlow<async_lsp::Result<()>>;
 
+#[cfg(test)]
 fn new_router(client: ClientSocket) -> Router<GlobalState> {
     new_router_with_state(GlobalState::new(client))
 }
@@ -139,7 +169,7 @@ fn request_layer() -> request_cancellation::RequestCancellationLayer {
 /// Start the LSP server over stdin/stdout.
 ///
 /// This future is long running and will not stop until the server exits.
-pub async fn run_server_stdio(_args: LspArgs) -> async_lsp::Result<()> {
+pub async fn launch(config: LaunchConfig) -> async_lsp::Result<()> {
     // Prefer truly asynchronous piped stdin/stdout without blocking tasks.
     #[cfg(unix)]
     let (stdin, stdout) =
@@ -158,10 +188,17 @@ pub async fn run_server_stdio(_args: LspArgs) -> async_lsp::Result<()> {
             .layer(LifecycleLayer::default())
             .layer(request_layer())
             .layer(ClientProcessMonitorLayer::new(client.clone()))
-            .service(new_router(client))
+            .service(new_router_with_state(GlobalState::with_launch_config(client, config.clone())))
     });
 
     eloop.run_buffered(stdin, stdout).await
+}
+
+/// Start the LSP server over stdin/stdout with command-line options.
+///
+/// This is retained for callers that previously launched the server with [`LspArgs`].
+pub async fn run_server_stdio(args: LspArgs) -> async_lsp::Result<()> {
+    launch(args.into()).await
 }
 
 #[cfg(test)]
@@ -236,6 +273,14 @@ mod tests {
             panic!("expected request cancellation, got {error:?}");
         };
         assert_eq!(error.code, async_lsp::ErrorCode::REQUEST_CANCELLED);
+    }
+
+    #[test]
+    fn launch_config_converts_lsp_args_and_accepts_a_default_forge_path() {
+        let config =
+            LaunchConfig::from(LspArgs::default()).with_default_forge_path("/embedded/forge");
+
+        assert_eq!(config.default_forge_path(), Some(Path::new("/embedded/forge")));
     }
 
     fn start_request<F: Future>(future: F) -> Pin<Box<F>> {

--- a/crates/lsp/src/test_support.rs
+++ b/crates/lsp/src/test_support.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{Config, negotiate_capabilities},
+    config::{SessionConfig, negotiate_capabilities},
     project_fixture::{FixtureMarker, ProjectFixture},
     vfs::{Vfs, VfsPath},
 };
@@ -155,13 +155,13 @@ impl TestProject {
         }
     }
 
-    pub(crate) fn config(&self) -> Config {
+    pub(crate) fn config(&self) -> SessionConfig {
         let (_, mut config) = negotiate_capabilities(self.initialize_params());
         config.rediscover_workspaces();
         config
     }
 
-    pub(crate) fn config_with_roots(&self, roots: &[&str]) -> Config {
+    pub(crate) fn config_with_roots(&self, roots: &[&str]) -> SessionConfig {
         let (_, mut config) = negotiate_capabilities(self.initialize_params_with_roots(roots));
         config.rediscover_workspaces();
         config

--- a/crates/lsp/src/tests/mod.rs
+++ b/crates/lsp/src/tests/mod.rs
@@ -2,7 +2,7 @@ use super::*;
 #[cfg(unix)]
 use crate::test_support::process_exists;
 use crate::{
-    config::negotiate_capabilities,
+    config::{SessionConfig, negotiate_capabilities},
     test_support::{MarkedProject, TestProject},
 };
 use async_lsp::{ClientSocket, ErrorCode, ResponseError, ServerSocket, router::Router};
@@ -139,7 +139,7 @@ fn snapshot(project: &TestProject) -> GlobalStateSnapshot {
     snapshot_with_config(project.config(), project.vfs())
 }
 
-fn snapshot_with_config(config: Config, vfs: Vfs) -> GlobalStateSnapshot {
+fn snapshot_with_config(config: SessionConfig, vfs: Vfs) -> GlobalStateSnapshot {
     let (published_analysis_version, _) = watch::channel(1);
     GlobalStateSnapshot {
         client: ClientSocket::new_closed(),


### PR DESCRIPTION
Expose a pre-initialize `LaunchConfig` for embedded language-server hosts. Reuse `solar_config::LspArgs`, preserve the client/default/bare Forge executable precedence, and keep the negotiated runtime state private.

This lets Foundry launch the embedded server with its own executable path while standalone `solar lsp` keeps the existing behavior.