### PR TITLE
fix(codegen): lower tuple expression statements

### DIFF
--- a/crates/codegen/src/lower/function/statements.rs
+++ b/crates/codegen/src/lower/function/statements.rs
@@ -140,7 +140,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     self.lower_constant_storage_assignment(lhs, rhs)?;
                     return Some(());
                 }
-                self.lower_expr(expr)?;
+                if self.context.gcx.type_of_expr(expr.id).is_some_and(|ty| ty.is_tuple()) {
+                    self.lower_values(expr)?;
+                } else {
+                    self.lower_expr(expr)?;
+                }
             }
             StmtKind::Block(block) => self.lower_block(*block)?,
             StmtKind::UncheckedBlock(block) => {

--- a/tests/ui/codegen/lowering/internal_void_call.sol
+++ b/tests/ui/codegen/lowering/internal_void_call.sol
@@ -50,7 +50,6 @@ contract InternalVoidCall {
     // CHECK: jumpi arg0,
     // CHECK: internal_call @writeIfNonZero, 0, arg1
     // CHECK: internal_call @clear, 0
-    // CHECK: phi [
     function unitTernary(bool writeValue, uint256 newValue) public {
         writeValue ? writeIfNonZero(newValue) : clear();
     }

--- a/tests/ui/codegen/lowering/internal_void_call.stdout
+++ b/tests/ui/codegen/lowering/internal_void_call.stdout
@@ -60,7 +60,6 @@ fn @unitTernary(arg0: bool, arg1: u256) [selector=0xeb6f9827, abi_args=lazy, abi
     internal_call @clear, 0
     jump bb3
   bb3:
-    v0 = phi [bb1: 0], [bb2: 0]
     stop
 }
 

--- a/tests/ui/codegen/run-call/tuple_expression_statements.sol
+++ b/tests/ui/codegen/run-call/tuple_expression_statements.sol
@@ -1,0 +1,17 @@
+//@ run-call: tupleLiteral() => true
+//@ run-call: tupleTernary() => true, 2
+// ported-from: test/libsolidity/semanticTests/expressions/tuple_from_ternary_expression.sol
+contract C {
+    function tupleLiteral() external pure returns (bool) {
+        bool flag;
+        ((flag = true), 1);
+        return flag;
+    }
+
+    function tupleTernary() external pure returns (bool, uint256) {
+        bool flag;
+        uint256 selected;
+        ((flag = true) ? (selected = 2, 3) : (selected = 4, 5));
+        return (flag, selected);
+    }
+}


### PR DESCRIPTION
Tuple-valued expressions used as statements currently go through scalar lowering. On Solc's tuple_from_ternary_expression semantic test, Solar replaces the function body with INVALID and reverts instead of returning true.

This routes tuple-typed statements through the existing multi-value lowering path, preserving component and ternary side effects without constructing an unsupported tuple object. It also removes the now-dead unit-value phi from the existing void-ternary MIR snapshot.

solsymdiff found and concretely replayed the mismatch for standard input dff2106a45bb43f00f9c8df1d96cc4644570e5c3ce77e966fe974c7c9995a58b. The same input reaches bounded agreement after the fix, including unoptimized non-via-IR, Cancun DFS, and optimizer-runs=1 configurations.