### PR TITLE
fix(codegen): lower Yul literals as words

### DIFF
--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -531,7 +531,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 let lhs_ty = self.type_of_expr_or_variable(lhs)?;
                 let rhs_ty = self.context.gcx.type_of_expr(rhs.id).unwrap_or(lhs_ty);
                 let memory_rhs_ty = rhs_ty.with_loc_if_ref(self.context.gcx, DataLocation::Memory);
-                let rhs_value = if self.types.memory_layout(memory_rhs_ty).is_some()
+                let rhs_value = if self.in_inline_assembly {
+                    self.lower_yul_word_expr(rhs)?
+                } else if self.types.memory_layout(memory_rhs_ty).is_some()
                     && rhs_ty.is_ref_at(DataLocation::Storage)
                 {
                     self.lower_typed_expr(rhs, memory_rhs_ty)?

--- a/crates/codegen/src/lower/function/statements.rs
+++ b/crates/codegen/src/lower/function/statements.rs
@@ -25,7 +25,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     return Some(());
                 }
                 let value = if let Some(expr) = initializer {
-                    let value = self.lower_typed_expr(expr, ty)?;
+                    let value = if self.in_inline_assembly {
+                        self.lower_yul_word_expr(expr)?
+                    } else {
+                        self.lower_typed_expr(expr, ty)?
+                    };
                     self.coerce_value(value, self.context.gcx.type_of_expr(expr.id)?, ty)
                 } else if let Some(value) = self.default_object(ty) {
                     value

--- a/tests/ui/codegen/run-call/yul_word_literals.sol
+++ b/tests/ui/codegen/run-call/yul_word_literals.sol
@@ -1,0 +1,38 @@
+//@ run-call: direct() => 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
+//@ run-call: shortDirect() => 0x1234000000000000000000000000000000000000000000000000000000000000
+//@ run-call: local() => 0x202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f
+//@ run-call: stringDirect() => 0x68656c6c6f000000000000000000000000000000000000000000000000000000
+//@ run-call: builtin() => 0x1234000000000000000000000000000000000000000000000000000000000000
+// ported-from: test/libsolidity/semanticTests/literals/hex_string_with_non_printable_characters.sol
+contract C {
+    function direct() external pure returns (bytes32 result) {
+        assembly {
+            result := hex"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        }
+    }
+
+    function shortDirect() external pure returns (bytes32 result) {
+        assembly {
+            result := hex"1234"
+        }
+    }
+
+    function local() external pure returns (bytes32 result) {
+        assembly {
+            let value := hex"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            result := value
+        }
+    }
+
+    function stringDirect() external pure returns (bytes32 result) {
+        assembly {
+            result := "hello"
+        }
+    }
+
+    function builtin() external pure returns (bytes32 result) {
+        assembly {
+            result := or(hex"1234", 0)
+        }
+    }
+}


### PR DESCRIPTION
Yul string and hex-string literals are word values, but direct assignments and local declarations currently route them through Solidity literal lowering. Solar therefore returns a memory-object pointer where Solc returns the literal word.

This reuses the existing Yul word-expression lowering at the two binding boundaries while leaving Solidity literal materialization unchanged. The regression covers full and short hex literals, local declarations, string literals, and a builtin expression.

solsymdiff found and concretely replayed the mismatch for standard input be398f62cf9cdf3c4d7a31fa2f923cc697fc9ec757590f690b49ef761cef124e. The same input reaches bounded agreement after the fix, including unoptimized non-via-IR, Cancun DFS, and optimizer-runs=1 configurations.