### PR TITLE
feat(codegen): support nested tuple assignments

### DIFF
--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -153,10 +153,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         self.lower_values(expr)
     }
 
-    pub(super) fn lower_tuple_assignment(
+    pub(super) fn lower_tuple_assignment<'hir>(
         &mut self,
-        elements: &[Option<&hir::Expr<'_>>],
-        rhs: &hir::Expr<'_>,
+        elements: &[Option<&'hir hir::Expr<'hir>>],
+        rhs: &'hir hir::Expr<'hir>,
     ) -> Option<()> {
         let rhs = rhs.peel_parens();
         if elements.iter().flatten().any(|element| {
@@ -274,25 +274,9 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     return Some(());
                 }
             }
-            if rhs_elements.len() < elements.len() {
-                return report_unsupported(self.context.gcx, rhs.span, "tuple assignment arity");
-            }
             let mut values = Vec::with_capacity(rhs_elements.len());
-            for (index, value) in rhs_elements.iter().enumerate() {
-                let Some(value) = value else {
-                    if elements.get(index).is_some_and(Option::is_some) {
-                        return report_unsupported(
-                            self.context.gcx,
-                            rhs.span,
-                            "tuple assignment value",
-                        );
-                    }
-                    continue;
-                };
-                values.push((index, value, self.lower_expr(value)?));
-            }
-            for (index, rhs, value) in values {
-                let Some(Some(element)) = elements.get(index) else { continue };
+            self.lower_tuple_assignment_values(elements, rhs_elements, rhs.span, &mut values)?;
+            for (element, rhs, value) in values {
                 let lhs_ty = self.type_of_expr_or_variable(element)?;
                 let rhs_ty = self.context.gcx.type_of_expr(rhs.id).unwrap_or(lhs_ty);
                 let value = if lhs_ty.is_ref_at(DataLocation::Storage) {
@@ -313,6 +297,43 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             if let Some(element) = element {
                 self.store_lvalue(element, value)?;
             }
+        }
+        Some(())
+    }
+
+    fn lower_tuple_assignment_values<'hir>(
+        &mut self,
+        elements: &[Option<&'hir hir::Expr<'hir>>],
+        rhs_elements: &[Option<&'hir hir::Expr<'hir>>],
+        span: Span,
+        values: &mut Vec<(&'hir hir::Expr<'hir>, &'hir hir::Expr<'hir>, ValueId)>,
+    ) -> Option<()> {
+        if rhs_elements.len() < elements.len() {
+            return report_unsupported(self.context.gcx, span, "tuple assignment arity");
+        }
+        for (index, rhs) in rhs_elements.iter().enumerate() {
+            let lhs = elements.get(index).copied().flatten();
+            let Some(rhs) = rhs else {
+                if lhs.is_some() {
+                    return report_unsupported(self.context.gcx, span, "tuple assignment value");
+                }
+                continue;
+            };
+            let ExprKind::Tuple(nested_rhs) = &rhs.peel_parens().kind else {
+                let value = self.lower_expr(rhs)?;
+                if let Some(lhs) = lhs {
+                    values.push((lhs, rhs, value));
+                }
+                continue;
+            };
+            let Some(lhs) = lhs else {
+                self.lower_tuple_assignment_values(&[], nested_rhs, rhs.span, values)?;
+                continue;
+            };
+            let ExprKind::Tuple(nested_lhs) = &lhs.peel_parens().kind else {
+                return report_unsupported(self.context.gcx, lhs.span, "tuple assignment target");
+            };
+            self.lower_tuple_assignment_values(nested_lhs, nested_rhs, rhs.span, values)?;
         }
         Some(())
     }

--- a/tests/ui/codegen/run-call/nested_tuple_assignment.sol
+++ b/tests/ui/codegen/run-call/nested_tuple_assignment.sol
@@ -1,0 +1,22 @@
+// ported-from: tests/libsolidity/semanticTests/types/tuple_assign_multi_slot_grow.sol
+//@ run-call: assign() => 0x30, 0x31, 0x32
+//@ run-call: swap() => 2, 1, 4, 3
+
+contract NestedTupleAssignment {
+    function assign() external pure returns (uint256, uint256, uint256) {
+        bytes memory a;
+        bytes memory b;
+        bytes memory c;
+        (a, (b, c)) = ("0", ("1", "2"));
+        return (uint8(a[0]), uint8(b[0]), uint8(c[0]));
+    }
+
+    function swap() external pure returns (uint256, uint256, uint256, uint256) {
+        uint256 a = 1;
+        uint256 b = 2;
+        uint256 c = 3;
+        uint256 d = 4;
+        (a, (b, (c, d))) = (b, (a, (d, c)));
+        return (a, b, c, d);
+    }
+}


### PR DESCRIPTION
Nested tuple-literal assignments are currently lowered as a flat tuple. Solar tries to lower the nested right-hand side as one unsupported tuple object, emits INVALID, and reverts on Solc's tuple_assign_multi_slot_grow semantic test.

This recursively evaluates tuple-literal leaves, then performs every store only after evaluation is complete. That supports nested assignments while preserving simultaneous assignment semantics; the regression covers both multi-slot memory values and a three-level nested swap.

solsymdiff found and concretely replayed the mismatch for standard input 92f065a09d383d00d715ca07be4f1b6892d1939a0178d2797538b62b94a13e5a. The identical input reaches bounded agreement after the fix, including unoptimized non-via-IR, Cancun DFS, and optimizer-runs=1 configurations.