### PR TITLE
fix(parse): preserve continued string whitespace

### DIFF
--- a/crates/lsp/src/tests/import_completion.rs
+++ b/crates/lsp/src/tests/import_completion.rs
@@ -507,7 +507,7 @@ fn completes_imports_across_escaped_line_continuations() {
 
         //- /src/Main.sol open
         import "./nested/$2\
-            Tar$1get.sol";
+        Tar$1get.sol";
 
         //- /src/nested/Target.sol
         contract Target {}
@@ -522,7 +522,7 @@ label=./nested/Target.sol
 kind=File
 detail=<none>
 sort_text=<none>
-text_edit=edit 1:0-1:14
+text_edit=edit 1:0-1:10
 additional_text_edit=0:8-1:0 new_text=""
 insert_text_format=<none>
 new_text:
@@ -538,7 +538,7 @@ kind=File
 detail=<none>
 sort_text=<none>
 text_edit=edit 0:8-0:18
-additional_text_edit=0:18-1:14 new_text=""
+additional_text_edit=0:18-1:10 new_text=""
 insert_text_format=<none>
 new_text:
 ./nested/Target.sol

--- a/crates/lsp/src/tests/import_definition.rs
+++ b/crates/lsp/src/tests/import_definition.rs
@@ -311,7 +311,7 @@ fn resolves_import_literals_across_escaped_line_continuations() {
         r#"
         //- /Imports.sol
         import "./nes$2ted/\
-            Tar$1get.sol";
+        Tar$1get.sol";
 
         //- /nested/Target.sol
         contract Target {}

--- a/crates/parse/src/lexer/unescape/errors.rs
+++ b/crates/parse/src/lexer/unescape/errors.rs
@@ -10,6 +10,7 @@ pub enum EscapeError {
     InvalidEscape,
     /// Raw '\r' encountered.
     BareCarriageReturn,
+
     /// Numeric character escape is too short (e.g. '\x1').
     HexEscapeTooShort,
     /// Invalid character in numeric escape (e.g. '\xz1').

--- a/crates/parse/src/lexer/unescape/errors.rs
+++ b/crates/parse/src/lexer/unescape/errors.rs
@@ -10,22 +10,6 @@ pub enum EscapeError {
     InvalidEscape,
     /// Raw '\r' encountered.
     BareCarriageReturn,
-    /// Can only skip one line of whitespace.
-    ///
-    /// ```text
-    /// "this is \
-    ///  ok" == "this is ok";
-    ///
-    /// "this is \
-    ///  \
-    ///  also ok" == "this is also ok";
-    ///
-    /// "this is \
-    ///  
-    ///  not ok"; // error: cannot skip multiple lines
-    /// ```
-    CannotSkipMultipleLines,
-
     /// Numeric character escape is too short (e.g. '\x1').
     HexEscapeTooShort,
     /// Invalid character in numeric escape (e.g. '\xz1').
@@ -57,7 +41,6 @@ impl EscapeError {
             Self::LoneSlash => "invalid trailing slash in literal",
             Self::InvalidEscape => "unknown character escape",
             Self::BareCarriageReturn => "bare CR not allowed in string, use `\\r` instead",
-            Self::CannotSkipMultipleLines => "cannot skip multiple lines with `\\`",
             Self::HexEscapeTooShort => "hex escape must be followed by 2 hex digits",
             Self::InvalidHexEscape => "invalid character in hex escape",
             Self::UnicodeEscapeTooShort => "unicode escape must be followed by 4 hex digits",

--- a/crates/parse/src/lexer/unescape/mod.rs
+++ b/crates/parse/src/lexer/unescape/mod.rs
@@ -213,21 +213,17 @@ where
     F: FnMut(Range<usize>, Result<UnescapedUnit, EscapeError>),
 {
     let mut chars = src.chars();
-    // The `start` and `end` computation here is complicated because
-    // `skip_ascii_whitespace` makes us to skip over chars without counting
-    // them in the range computation.
     while let Some(c) = chars.next() {
         let start = src.len() - chars.as_str().len() - c.len_utf8();
         let res = match c {
             '\\' => match chars.clone().next() {
                 Some('\r') if chars.clone().nth(1) == Some('\n') => {
-                    // +2 for the '\\' and '\r' characters.
-                    skip_ascii_whitespace(&mut chars, start + 2, &mut callback);
+                    chars.next();
+                    chars.next();
                     continue;
                 }
                 Some('\n') => {
-                    // +1 for the '\\' character.
-                    skip_ascii_whitespace(&mut chars, start + 1, &mut callback);
+                    chars.next();
                     continue;
                 }
                 _ => scan_escape(&mut chars),
@@ -245,39 +241,6 @@ where
         let end = src.len() - chars.as_str().len();
         callback(start..end, res);
     }
-}
-
-/// Skips over whitespace after a "\\\n" escape sequence.
-///
-/// Reports errors if multiple newlines are encountered.
-fn skip_ascii_whitespace<F>(chars: &mut Chars<'_>, mut start: usize, callback: &mut F)
-where
-    F: FnMut(Range<usize>, Result<UnescapedUnit, EscapeError>),
-{
-    // Skip the first newline.
-    let mut nl = chars.next();
-    if let Some('\r') = nl {
-        nl = chars.next();
-    }
-    debug_assert_eq!(nl, Some('\n'));
-    let mut tail = chars.as_str();
-    start += 1;
-
-    loop {
-        let first_non_space =
-            tail.bytes().position(|b| !matches!(b, b' ' | b'\t')).unwrap_or(tail.len());
-        tail = &tail[first_non_space..];
-        start += first_non_space;
-
-        let Some(tail2) = tail.strip_prefix('\n').or_else(|| tail.strip_prefix("\r\n")) else {
-            break;
-        };
-        let skipped = tail.len() - tail2.len();
-        tail = tail2;
-        callback(start..start + skipped, Err(EscapeError::CannotSkipMultipleLines));
-        start += skipped;
-    }
-    *chars = tail.chars();
 }
 
 /// Unescape characters in a hex string literal.
@@ -417,31 +380,23 @@ mod tests {
             ("\n", "", &[(0..1, StrNewline)]),
             ("\\\n", "", &[]),
             ("\\\na", "a", &[]),
-            ("\\\n  a", "a", &[]),
-            ("a \\\n  b", "a b", &[]),
-            ("a\\n\\\n  b", "a\nb", &[]),
-            ("a\\t\\\n  b", "a\tb", &[]),
-            ("a\\n \\\n  b", "a\n b", &[]),
-            ("a\\n \\\n \tb", "a\n b", &[]),
-            ("a\\t \\\n  b", "a\t b", &[]),
-            ("\\\n \t a", "a", &[]),
-            (" \\\n \t a", " a", &[]),
-            ("\\\n \t a\n", "a", &[(6..7, StrNewline)]),
-            ("\\\n   \t   ", "", &[]),
-            (" \\\n   \t   ", " ", &[]),
-            (" he\\\n \\\nllo \\\n wor\\\nld", " hello world", &[]),
-            ("\\\n\na\\\nb", "ab", &[(2..3, CannotSkipMultipleLines)]),
-            ("\\\n \na\\\nb", "ab", &[(3..4, CannotSkipMultipleLines)]),
-            (
-                "\\\n \n\na\\\nb",
-                "ab",
-                &[(3..4, CannotSkipMultipleLines), (4..5, CannotSkipMultipleLines)],
-            ),
-            (
-                "a\\\n \n \t \nb\\\nc",
-                "abc",
-                &[(4..5, CannotSkipMultipleLines), (8..9, CannotSkipMultipleLines)],
-            ),
+            ("\\\n  a", "  a", &[]),
+            ("a \\\n  b", "a   b", &[]),
+            ("a\\n\\\n  b", "a\n  b", &[]),
+            ("a\\t\\\n  b", "a\t  b", &[]),
+            ("a\\n \\\n  b", "a\n   b", &[]),
+            ("a\\n \\\n \tb", "a\n  \tb", &[]),
+            ("a\\t \\\n  b", "a\t   b", &[]),
+            ("\\\n \t a", " \t a", &[]),
+            (" \\\n \t a", "  \t a", &[]),
+            ("\\\n \t a\n", " \t a", &[(6..7, StrNewline)]),
+            ("\\\n   \t   ", "   \t   ", &[]),
+            (" \\\n   \t   ", "    \t   ", &[]),
+            (" he\\\n \\\nllo \\\n wor\\\nld", " he llo  world", &[]),
+            ("\\\n\na\\\nb", "ab", &[(2..3, StrNewline)]),
+            ("\\\n \na\\\nb", " ab", &[(3..4, StrNewline)]),
+            ("\\\n \n\na\\\nb", " ab", &[(3..4, StrNewline), (4..5, StrNewline)]),
+            ("a\\\n \n \t \nb\\\nc", "a  \t bc", &[(4..5, StrNewline), (8..9, StrNewline)]),
         ];
         for &(src, expected_str, expected_errs) in cases {
             check(StrKind::Str, src, expected_str, expected_errs);
@@ -461,7 +416,7 @@ mod tests {
     #[test]
     fn line_continuation_before_form_feed() {
         check(StrKind::Str, "\\\n\x0cafter", "\x0cafter", &[]);
-        check(StrKind::Str, "\\\r\n \t\x0cafter", "\x0cafter", &[]);
+        check(StrKind::Str, "\\\r\n \t\x0cafter", " \t\x0cafter", &[]);
     }
 
     #[test]
@@ -484,6 +439,8 @@ mod tests {
             check(StrKind::Unicode, src, expected_str, e1);
             check(StrKind::Str, src, "", e2);
         }
+
+        check_parse(StrKind::Unicode, "😃, 😭,\\\n and 😈", "😃, 😭, and 😈".as_bytes());
     }
 
     #[test]

--- a/tests/ui/codegen/run-call/string_line_continuation.sol
+++ b/tests/ui/codegen/run-call/string_line_continuation.sol
@@ -1,0 +1,19 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: unicodeLine() => "😃, 😭, and 😈"
+//@ run-call: asciiLine() => "a   b"
+// ported-from: test/libsolidity/semanticTests/strings/unicode_string.sol
+
+contract StringLineContinuation {
+    function unicodeLine() external pure returns (string memory) {
+        return unicode"😃, 😭,\
+ and 😈";
+    }
+
+    function asciiLine() external pure returns (string memory) {
+        return "a \
+  b";
+    }
+}

--- a/tests/ui/lexer/string_escapes_crlf.sol
+++ b/tests/ui/lexer/string_escapes_crlf.sol
@@ -10,13 +10,13 @@ bytes constant b1 = hex"\
 //~| ERROR: invalid hex digit
 // 3x for \\, \r, \n
 
-// Escaped, but can only escape one newline
+// Only the escaped newline is removed.
 string constant s3 = "\
 
-"; //~^ ERROR: cannot skip multiple lines
+"; //~^ ERROR: unescaped newline
 string constant s4 = unicode"\
 
-"; //~^ ERROR: cannot skip multiple lines
+"; //~^ ERROR: unescaped newline
 bytes constant b2 = hex"\
 
 ";

--- a/tests/ui/lexer/string_escapes_crlf.stderr
+++ b/tests/ui/lexer/string_escapes_crlf.stderr
@@ -18,14 +18,14 @@ LL │   bytes constant b1 = hex"\
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: cannot skip multiple lines with `\`
+error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
 LL │ ┏
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: cannot skip multiple lines with `\`
+error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_crlf.sol:LL:CC
    │
 LL │ ┏

--- a/tests/ui/lexer/string_escapes_lf.sol
+++ b/tests/ui/lexer/string_escapes_lf.sol
@@ -9,13 +9,13 @@ bytes constant b1 = hex"\
 //~| ERROR: invalid hex digit
 // 2 for \\, \n
 
-// Escaped, but can only escape one newline
+// Only the escaped newline is removed.
 string constant s3 = "\
 
-"; //~^ ERROR: cannot skip multiple lines
+"; //~^ ERROR: unescaped newline
 string constant s4 = unicode"\
 
-"; //~^ ERROR: cannot skip multiple lines
+"; //~^ ERROR: unescaped newline
 bytes constant b2 = hex"\
 
 ";

--- a/tests/ui/lexer/string_escapes_lf.stderr
+++ b/tests/ui/lexer/string_escapes_lf.stderr
@@ -12,14 +12,14 @@ LL │   bytes constant b1 = hex"\
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: cannot skip multiple lines with `\`
+error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
 LL │ ┏
 LL │ ┃ ";
    ╰╴┗━┛
 
-error: cannot skip multiple lines with `\`
+error: unescaped newline
    ╭▸ ROOT/tests/ui/lexer/string_escapes_lf.sol:LL:CC
    │
 LL │ ┏


### PR DESCRIPTION
The symbolic differential runner from #1084 found and replayed a mismatch in the upstream Solidity semantic test `strings/unicode_string.sol:g()`. Solc returned the expected 20-byte string `😃, 😭, and 😈`, while the compiler returned 19 bytes after deleting the space following an escaped newline.

This preserves spaces and tabs after escaped LF and CRLF continuations, removes the non-Solidity whitespace-skipping diagnostic, and covers ordinary and Unicode strings under both line endings. The identical source reaches bounded agreement with default settings and with optimization and via-IR disabled.