### PR TITLE
fix(parser): distinguish underscore identifiers

### DIFF
--- a/crates/parse/src/parser/item.rs
+++ b/crates/parse/src/parser/item.rs
@@ -149,13 +149,17 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         };
         let flags = FunctionFlags::from_kind(kind);
         let header = self.parse_function_header(flags)?;
-        let (body_span, body) = self.parse_spanned(|this| {
+        let was_in_modifier = self.in_modifier;
+        self.in_modifier = kind.is_modifier();
+        let body = self.parse_spanned(|this| {
             Ok(if !flags.contains(FunctionFlags::ONLY_BLOCK) && this.eat(TokenKind::Semi) {
                 None
             } else {
                 Some(this.parse_block()?)
             })
-        })?;
+        });
+        self.in_modifier = was_in_modifier;
+        let (body_span, body) = body?;
 
         if !self.in_contract && !kind.allowed_in_global() {
             let msg = format!("{kind}s are not allowed in the global scope");

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -58,6 +58,8 @@ pub struct Parser<'sess, 'ast, 'cb> {
     in_yul: bool,
     /// Whether the parser is currently parsing a contract block.
     in_contract: bool,
+    /// Whether the parser is currently parsing a modifier body.
+    in_modifier: bool,
     /// Whether incomplete input should be recovered into a partial AST.
     recover_incomplete_input: bool,
 
@@ -159,6 +161,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
             tokens: tokens.into_iter(),
             in_yul: false,
             in_contract: false,
+            in_modifier: false,
             recover_incomplete_input: sess.opts.unstable.recover_incomplete_input,
             recursion_depth: 0,
             import_callback: None,

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -61,7 +61,9 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         } else if self.check_keyword(kw::Revert) && self.look_ahead(1).is_ident() {
             self.bump(); // `revert`
             self.parse_path_call().map(|(path, params)| StmtKind::Revert(path, params))
-        } else if self.check_keyword(sym::underscore) && self.look_ahead(1).kind == TokenKind::Semi
+        } else if self.in_modifier
+            && self.check_keyword(sym::underscore)
+            && self.look_ahead(1).kind == TokenKind::Semi
         {
             self.bump(); // `_`
             Ok(StmtKind::Placeholder)

--- a/tests/ui/codegen/run-call/underscore_identifier.sol
+++ b/tests/ui/codegen/run-call/underscore_identifier.sol
@@ -1,0 +1,33 @@
+//@ run-call: _ => 88
+//@ run-call: explicitCall => 88
+//@ run-call: bareReference => 33
+//@ run-call: localReference => 34
+//@ run-call: modified => 45
+contract C {
+    function _() public pure returns (uint256) {
+        return 88;
+    }
+
+    function explicitCall() public pure returns (uint256) {
+        return _();
+    }
+
+    function bareReference() public pure returns (uint256) {
+        _;
+        return 33;
+    }
+
+    function localReference() public pure returns (uint256) {
+        uint256 _ = 34;
+        _;
+        return _;
+    }
+
+    modifier passthrough() {
+        _;
+    }
+
+    function modified() public pure passthrough returns (uint256) {
+        return 45;
+    }
+}

--- a/tests/ui/typeck/invalid_placeholder.sol
+++ b/tests/ui/typeck/invalid_placeholder.sol
@@ -3,6 +3,6 @@ contract test {
       _;
     }
     function f() external {
-      _; //~ ERROR: placeholder statements can only be used in modifiers
+      _; //~ ERROR: unresolved symbol `_`
     }
 }

--- a/tests/ui/typeck/invalid_placeholder.stderr
+++ b/tests/ui/typeck/invalid_placeholder.stderr
@@ -1,8 +1,8 @@
-error: placeholder statements can only be used in modifiers
+error: unresolved symbol `_`
    ╭▸ ROOT/tests/ui/typeck/invalid_placeholder.sol:LL:CC
    │
 LL │       _;
-   ╰╴      ━━
+   ╰╴      ━
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
The symbolic differential runner from #1084 found a replay-confirmed mismatch where a valid underscore identifier was parsed as a modifier placeholder.

This restricts placeholder treatment to the grammar positions where underscore has that meaning and preserves underscore identifiers in ordinary declaration and expression contexts. Parser and runtime regressions retain the minimized case.