### PR TITLE
test(lsp): avoid watched-file test race

### DIFF
--- a/crates/lsp/src/tests/watched_files.rs
+++ b/crates/lsp/src/tests/watched_files.rs
@@ -1468,6 +1468,7 @@ async fn discovery_and_analysis_refresh_bounded_watched_file_specs() {
         }),
         ControlFlow::Continue(())
     ));
+    state.analysis_scheduler.tasks.lock().cancel();
     let discovered_specs = state.watched_file_registration.desired_specs.lock().clone().unwrap();
     assert!(
         discovered_specs
@@ -1494,7 +1495,6 @@ async fn discovery_and_analysis_refresh_bounded_watched_file_specs() {
         "**/*.sol"
     ));
 
-    state.analysis_scheduler.tasks.lock().cancel();
     let dependency_parent = project.path("/repo/dependencies");
     let outside_parent = project.path("/outside");
     let missing_parent = project.path("/repo/missing");


### PR DESCRIPTION
Cancel the background analysis before waiting for the discovery registration. This keeps the test's synthetic analysis output from racing with the worker it schedules.