### PR TITLE
 feat(lsp): propagate selected Foundry profile

### DIFF
--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -16,6 +16,10 @@ solar_lsp::launch(config).await?;
 # }
 ```
 
+An embedding host that already selected a Foundry profile can pass it through with
+`with_selected_profile("custom")`; the language server uses that profile when discovering workspace
+sources and when running its automatically configured Forge lint checks.
+
 An embedding executable that also provides Forge commands can use its own path as the default, as
 shown above. Other hosts should supply the path to their Forge executable instead.
 

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -47,6 +47,7 @@ use tracing::{info, warn};
 pub(crate) struct Config {
     workspace_roots: Vec<PathBuf>,
     forge_path: PathBuf,
+    selected_profile: Option<String>,
     workspaces: Vec<Workspace>,
     manifest_watch_roots: Vec<SourceWatchRoot>,
     git_marker_watch_roots: Vec<PathBuf>,
@@ -129,6 +130,7 @@ impl Default for Config {
         Self {
             workspace_roots: Vec::new(),
             forge_path: PathBuf::from("forge"),
+            selected_profile: None,
             workspaces: Vec::new(),
             manifest_watch_roots: Vec::new(),
             git_marker_watch_roots: Vec::new(),
@@ -635,6 +637,11 @@ impl Config {
         self.forge_path.clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn selected_profile(&self) -> Option<&str> {
+        self.selected_profile.as_deref()
+    }
+
     pub(crate) fn formatter_root_for_path(&self, path: &Path) -> Option<PathBuf> {
         ProjectManifest::discover_in_parents(path)
             .and_then(|manifest| match manifest {
@@ -687,12 +694,13 @@ impl Config {
                 return None;
             }
             let (discovered, discovered_watch_roots, discovered_marker_watch_roots) =
-                ProjectManifest::discover_all_with_watch_roots(
+                ProjectManifest::discover_all_with_watch_roots_for_profile(
                     std::slice::from_ref(root),
                     &self.workspace_roots,
                     &self.index_policy,
                     cancellation,
                     &mut metrics,
+                    self.selected_profile.as_deref(),
                 )?;
             manifest_watch_roots.extend(discovered_watch_roots);
             git_marker_watch_roots.extend(discovered_marker_watch_roots);
@@ -706,6 +714,7 @@ impl Config {
             load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
+                self.selected_profile.as_deref(),
                 &mut seen_manifests,
                 &mut workspaces,
             );
@@ -741,6 +750,7 @@ impl Config {
             if load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
+                self.selected_profile.as_deref(),
                 &mut seen_manifests,
                 &mut workspaces,
             ) == 0
@@ -853,7 +863,11 @@ impl Config {
     fn refresh_flychecks(&mut self) -> Vec<DiagnosticOwner> {
         let mut removed_owners =
             self.flychecks.iter().map(FlycheckConfig::owner).collect::<FxHashSet<_>>();
-        self.flychecks = self.flycheck_options.configs(&self.workspaces, &self.forge_path);
+        self.flychecks = self.flycheck_options.configs_with_profile(
+            &self.workspaces,
+            &self.forge_path,
+            self.selected_profile.as_deref(),
+        );
 
         for owner in self.flychecks.iter().map(FlycheckConfig::owner) {
             removed_owners.remove(&owner);
@@ -869,6 +883,7 @@ impl Config {
 fn load_discovered_workspaces(
     manifests: impl IntoIterator<Item = ProjectManifest>,
     workspace_roots: &[PathBuf],
+    selected_profile: Option<&str>,
     seen_manifests: &mut FxHashSet<ProjectManifest>,
     workspaces: &mut Vec<Workspace>,
 ) -> usize {
@@ -880,7 +895,11 @@ fn load_discovered_workspaces(
         match manifest {
             ProjectManifest::Foundry(path) => {
                 let fallback_root = path.parent().map(PathBuf::from);
-                match Workspace::load_foundry_bounded(path, workspace_roots) {
+                match Workspace::load_foundry_bounded_with_profile(
+                    path,
+                    workspace_roots,
+                    selected_profile,
+                ) {
                     Ok(workspace) => workspaces.push(workspace),
                     Err(error) => {
                         warn!(%error, "failed to load workspace");
@@ -957,10 +976,25 @@ pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabil
     negotiate_capabilities_with_pull_diagnostic_data(params, false, None)
 }
 
+#[cfg(any(test, feature = "bench"))]
 pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
     params: InitializeParams,
     pull_diagnostics_data: bool,
     default_forge_path: Option<&Path>,
+) -> (ServerCapabilities, Config) {
+    negotiate_capabilities_with_pull_diagnostic_data_and_profile(
+        params,
+        pull_diagnostics_data,
+        default_forge_path,
+        None,
+    )
+}
+
+pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data_and_profile(
+    params: InitializeParams,
+    pull_diagnostics_data: bool,
+    default_forge_path: Option<&Path>,
+    selected_profile: Option<&str>,
 ) -> (ServerCapabilities, Config) {
     let capabilities = params.capabilities;
     let initialization_options = params.initialization_options;
@@ -1181,6 +1215,7 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
         Config {
             workspace_roots,
             forge_path,
+            selected_profile: selected_profile.map(str::to_owned),
             index_policy,
             flycheck_options,
             watched_file_dynamic_registration,
@@ -1974,6 +2009,44 @@ mod tests {
         assert_eq!(flychecks[0].args, ["--json"]);
         assert_eq!(flychecks[0].cwd, project.root());
         assert_eq!(config.flychecks_for_path(&project.path("/lib/Dependency.sol")).len(), 1);
+    }
+
+    #[test]
+    fn selected_profile_controls_workspace_source_indexing() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /default-src/Default.sol
+            contract DefaultContract {}
+
+            //- /custom-src/Custom.sol
+            contract CustomContract {}
+
+            //- /foundry.toml
+            [profile.default]
+            src = "default-src"
+
+            [profile.custom]
+            src = "custom-src"
+            "#,
+        );
+        let mut params = project.initialize_params();
+        params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
+        let (_, mut config) = negotiate_capabilities_with_pull_diagnostic_data_and_profile(
+            params,
+            false,
+            None,
+            Some("custom"),
+        );
+        config.rediscover_workspaces();
+
+        assert_eq!(config.selected_profile(), Some("custom"));
+        let workspace = config
+            .workspaces()
+            .iter()
+            .find(|workspace| workspace.kind() == WorkspaceKind::Foundry)
+            .unwrap();
+        assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
+        assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
     }
 
     #[test]

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -637,11 +637,6 @@ impl Config {
         self.forge_path.clone()
     }
 
-    #[cfg(test)]
-    pub(crate) fn selected_profile(&self) -> Option<&str> {
-        self.selected_profile.as_deref()
-    }
-
     pub(crate) fn formatter_root_for_path(&self, path: &Path) -> Option<PathBuf> {
         ProjectManifest::discover_in_parents(path)
             .and_then(|manifest| match manifest {
@@ -694,7 +689,7 @@ impl Config {
                 return None;
             }
             let (discovered, discovered_watch_roots, discovered_marker_watch_roots) =
-                ProjectManifest::discover_all_with_watch_roots_for_profile(
+                ProjectManifest::discover_all_with_watch_roots(
                     std::slice::from_ref(root),
                     &self.workspace_roots,
                     &self.index_policy,
@@ -863,7 +858,7 @@ impl Config {
     fn refresh_flychecks(&mut self) -> Vec<DiagnosticOwner> {
         let mut removed_owners =
             self.flychecks.iter().map(FlycheckConfig::owner).collect::<FxHashSet<_>>();
-        self.flychecks = self.flycheck_options.configs_with_profile(
+        self.flychecks = self.flycheck_options.configs(
             &self.workspaces,
             &self.forge_path,
             self.selected_profile.as_deref(),
@@ -895,11 +890,7 @@ fn load_discovered_workspaces(
         match manifest {
             ProjectManifest::Foundry(path) => {
                 let fallback_root = path.parent().map(PathBuf::from);
-                match Workspace::load_foundry_bounded_with_profile(
-                    path,
-                    workspace_roots,
-                    selected_profile,
-                ) {
+                match Workspace::load_foundry_bounded(path, workspace_roots, selected_profile) {
                     Ok(workspace) => workspaces.push(workspace),
                     Err(error) => {
                         warn!(%error, "failed to load workspace");
@@ -973,24 +964,10 @@ fn workspace_roots_from_initialize(
 
 #[cfg(any(test, feature = "bench"))]
 pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabilities, Config) {
-    negotiate_capabilities_with_pull_diagnostic_data(params, false, None)
+    negotiate_capabilities_with_pull_diagnostic_data(params, false, None, None)
 }
 
-#[cfg(any(test, feature = "bench"))]
 pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
-    params: InitializeParams,
-    pull_diagnostics_data: bool,
-    default_forge_path: Option<&Path>,
-) -> (ServerCapabilities, Config) {
-    negotiate_capabilities_with_pull_diagnostic_data_and_profile(
-        params,
-        pull_diagnostics_data,
-        default_forge_path,
-        None,
-    )
-}
-
-pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data_and_profile(
     params: InitializeParams,
     pull_diagnostics_data: bool,
     default_forge_path: Option<&Path>,
@@ -1783,7 +1760,7 @@ mod tests {
                 });
 
                 let (_, config) =
-                    negotiate_capabilities_with_pull_diagnostic_data(params, pull, None);
+                    negotiate_capabilities_with_pull_diagnostic_data(params, pull, None, None);
 
                 let expected_publish = delivery == DiagnosticDelivery::Push && publish;
                 let expected_pull = delivery == DiagnosticDelivery::Pull && pull;
@@ -2012,44 +1989,6 @@ mod tests {
     }
 
     #[test]
-    fn selected_profile_controls_workspace_source_indexing() {
-        let project = TestProject::from_fixture(
-            r#"
-            //- /default-src/Default.sol
-            contract DefaultContract {}
-
-            //- /custom-src/Custom.sol
-            contract CustomContract {}
-
-            //- /foundry.toml
-            [profile.default]
-            src = "default-src"
-
-            [profile.custom]
-            src = "custom-src"
-            "#,
-        );
-        let mut params = project.initialize_params();
-        params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
-        let (_, mut config) = negotiate_capabilities_with_pull_diagnostic_data_and_profile(
-            params,
-            false,
-            None,
-            Some("custom"),
-        );
-        config.rediscover_workspaces();
-
-        assert_eq!(config.selected_profile(), Some("custom"));
-        let workspace = config
-            .workspaces()
-            .iter()
-            .find(|workspace| workspace.kind() == WorkspaceKind::Foundry)
-            .unwrap();
-        assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
-        assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
-    }
-
-    #[test]
     fn source_file_updates_follow_external_foundry_flycheck_roots() {
         let project = TestProject::from_fixture(
             r#"
@@ -2164,6 +2103,7 @@ mod tests {
             InitializeParams::default(),
             false,
             Some(Path::new("/embedded/forge")),
+            None,
         );
         assert_eq!(embedded_config.forge_path(), PathBuf::from("/embedded/forge"));
 
@@ -2178,6 +2118,7 @@ mod tests {
             params,
             false,
             Some(Path::new("/embedded/forge")),
+            None,
         );
 
         assert_eq!(config.forge_path(), PathBuf::from("/tools/forge"));

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -39,14 +39,24 @@ impl FlycheckInitializationOptions {
         value.and_then(|value| serde_json::from_value(value).ok()).unwrap_or_default()
     }
 
+    #[cfg(test)]
     pub(crate) fn configs(
         &self,
         workspaces: &[Workspace],
         forge_path: &Path,
     ) -> Vec<FlycheckConfig> {
+        self.configs_with_profile(workspaces, forge_path, None)
+    }
+
+    pub(crate) fn configs_with_profile(
+        &self,
+        workspaces: &[Workspace],
+        forge_path: &Path,
+        selected_profile: Option<&str>,
+    ) -> Vec<FlycheckConfig> {
         match &self.flychecks {
             Some(templates) => expand_templates(templates, workspaces),
-            None => default_flychecks(workspaces, forge_path.to_path_buf()),
+            None => default_flychecks(workspaces, forge_path.to_path_buf(), selected_profile),
         }
     }
 }
@@ -97,16 +107,20 @@ fn expand_templates(
         .collect()
 }
 
-fn default_flychecks(workspaces: &[Workspace], forge_path: PathBuf) -> Vec<FlycheckConfig> {
+fn default_flychecks(
+    workspaces: &[Workspace],
+    forge_path: PathBuf,
+    selected_profile: Option<&str>,
+) -> Vec<FlycheckConfig> {
     workspaces
         .iter()
         .filter(|workspace| workspace.kind() == WorkspaceKind::Foundry)
         .filter_map(workspace_root)
-        .filter(|root| forge_lint_available(&forge_path, root))
+        .filter(|root| forge_lint_available(&forge_path, root, selected_profile))
         .map(|workspace_root| FlycheckConfig {
             id: "forge-lint".into(),
             command: forge_path.clone(),
-            args: vec!["lint".into(), "--json".into()],
+            args: forge_lint_args("--json", selected_profile),
             cwd: workspace_root.clone(),
             workspace_root,
             output: FlycheckOutput::ForgeLintJson,
@@ -122,9 +136,17 @@ fn resolve_workspace_path(workspace_root: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() { path.to_path_buf() } else { workspace_root.join(path) }
 }
 
-fn forge_lint_available(command: &Path, cwd: &Path) -> bool {
+fn forge_lint_args(output: &str, selected_profile: Option<&str>) -> Vec<String> {
+    let mut args = vec!["lint".into(), output.into()];
+    if let Some(profile) = selected_profile {
+        args.extend(["--profile".into(), profile.into()]);
+    }
+    args
+}
+
+fn forge_lint_available(command: &Path, cwd: &Path, selected_profile: Option<&str>) -> bool {
     Command::new(command)
-        .args(["lint", "--help"])
+        .args(forge_lint_args("--help", selected_profile))
         .current_dir(cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -137,6 +159,8 @@ fn forge_lint_available(command: &Path, cwd: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::test_support::TestProject;
+    #[cfg(unix)]
+    use std::{fs, os::unix::fs::PermissionsExt};
 
     #[test]
     fn configured_flychecks_expand_per_workspace() {
@@ -157,7 +181,11 @@ mod tests {
             }]),
         };
 
-        let configs = options.configs(project.config().workspaces(), Path::new("forge"));
+        let configs = options.configs_with_profile(
+            project.config().workspaces(),
+            Path::new("forge"),
+            Some("custom"),
+        );
 
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].id, "custom");
@@ -179,5 +207,37 @@ mod tests {
         let options = FlycheckInitializationOptions { flychecks: Some(Vec::new()) };
 
         assert!(options.configs(project.config().workspaces(), Path::new("forge")).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn default_forge_flycheck_profile_args_cover_probe_and_run() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = "src"
+
+            //- /src/Test.sol
+            contract Test {}
+            "#,
+        );
+        let forge = project.path("/fake-forge");
+        project.write_file("/fake-forge", "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$0.args\"\n");
+        let mut permissions = fs::metadata(&forge).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&forge, permissions).unwrap();
+        let workspaces = project.config().workspaces().to_vec();
+        let options = FlycheckInitializationOptions::default();
+
+        let profiled = options.configs_with_profile(&workspaces, &forge, Some("custom"));
+        assert_eq!(profiled.len(), 1);
+        assert_eq!(profiled[0].args, ["lint", "--json", "--profile", "custom"]);
+        assert_eq!(project.read_file("/fake-forge.args"), "lint\n--help\n--profile\ncustom\n");
+
+        let unprofiled = options.configs(&workspaces, &forge);
+        assert_eq!(unprofiled.len(), 1);
+        assert_eq!(unprofiled[0].args, ["lint", "--json"]);
+        assert_eq!(project.read_file("/fake-forge.args"), "lint\n--help\n");
     }
 }

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -39,16 +39,7 @@ impl FlycheckInitializationOptions {
         value.and_then(|value| serde_json::from_value(value).ok()).unwrap_or_default()
     }
 
-    #[cfg(test)]
     pub(crate) fn configs(
-        &self,
-        workspaces: &[Workspace],
-        forge_path: &Path,
-    ) -> Vec<FlycheckConfig> {
-        self.configs_with_profile(workspaces, forge_path, None)
-    }
-
-    pub(crate) fn configs_with_profile(
         &self,
         workspaces: &[Workspace],
         forge_path: &Path,
@@ -159,8 +150,6 @@ fn forge_lint_available(command: &Path, cwd: &Path, selected_profile: Option<&st
 mod tests {
     use super::*;
     use crate::test_support::TestProject;
-    #[cfg(unix)]
-    use std::{fs, os::unix::fs::PermissionsExt};
 
     #[test]
     fn configured_flychecks_expand_per_workspace() {
@@ -181,11 +170,8 @@ mod tests {
             }]),
         };
 
-        let configs = options.configs_with_profile(
-            project.config().workspaces(),
-            Path::new("forge"),
-            Some("custom"),
-        );
+        let configs =
+            options.configs(project.config().workspaces(), Path::new("forge"), Some("custom"));
 
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].id, "custom");
@@ -206,38 +192,14 @@ mod tests {
         );
         let options = FlycheckInitializationOptions { flychecks: Some(Vec::new()) };
 
-        assert!(options.configs(project.config().workspaces(), Path::new("forge")).is_empty());
+        assert!(
+            options.configs(project.config().workspaces(), Path::new("forge"), None).is_empty()
+        );
     }
 
-    #[cfg(unix)]
     #[test]
-    fn default_forge_flycheck_profile_args_cover_probe_and_run() {
-        let project = TestProject::from_fixture(
-            r#"
-            //- /foundry.toml
-            [profile.default]
-            src = "src"
-
-            //- /src/Test.sol
-            contract Test {}
-            "#,
-        );
-        let forge = project.path("/fake-forge");
-        project.write_file("/fake-forge", "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$0.args\"\n");
-        let mut permissions = fs::metadata(&forge).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&forge, permissions).unwrap();
-        let workspaces = project.config().workspaces().to_vec();
-        let options = FlycheckInitializationOptions::default();
-
-        let profiled = options.configs_with_profile(&workspaces, &forge, Some("custom"));
-        assert_eq!(profiled.len(), 1);
-        assert_eq!(profiled[0].args, ["lint", "--json", "--profile", "custom"]);
-        assert_eq!(project.read_file("/fake-forge.args"), "lint\n--help\n--profile\ncustom\n");
-
-        let unprofiled = options.configs(&workspaces, &forge);
-        assert_eq!(unprofiled.len(), 1);
-        assert_eq!(unprofiled[0].args, ["lint", "--json"]);
-        assert_eq!(project.read_file("/fake-forge.args"), "lint\n--help\n");
+    fn default_forge_lint_args_omit_unselected_profile() {
+        assert_eq!(forge_lint_args("--help", None), ["lint", "--help"]);
+        assert_eq!(forge_lint_args("--json", None), ["lint", "--json"]);
     }
 }

--- a/crates/lsp/src/flycheck/config.rs
+++ b/crates/lsp/src/flycheck/config.rs
@@ -107,11 +107,11 @@ fn default_flychecks(
         .iter()
         .filter(|workspace| workspace.kind() == WorkspaceKind::Foundry)
         .filter_map(workspace_root)
-        .filter(|root| forge_lint_available(&forge_path, root, selected_profile))
+        .filter(|root| forge_lint_available(&forge_path, root))
         .map(|workspace_root| FlycheckConfig {
             id: "forge-lint".into(),
             command: forge_path.clone(),
-            args: forge_lint_args("--json", selected_profile),
+            args: forge_lint_args(selected_profile),
             cwd: workspace_root.clone(),
             workspace_root,
             output: FlycheckOutput::ForgeLintJson,
@@ -127,17 +127,17 @@ fn resolve_workspace_path(workspace_root: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() { path.to_path_buf() } else { workspace_root.join(path) }
 }
 
-fn forge_lint_args(output: &str, selected_profile: Option<&str>) -> Vec<String> {
-    let mut args = vec!["lint".into(), output.into()];
+fn forge_lint_args(selected_profile: Option<&str>) -> Vec<String> {
+    let mut args = vec!["lint".into(), "--json".into()];
     if let Some(profile) = selected_profile {
         args.extend(["--profile".into(), profile.into()]);
     }
     args
 }
 
-fn forge_lint_available(command: &Path, cwd: &Path, selected_profile: Option<&str>) -> bool {
+fn forge_lint_available(command: &Path, cwd: &Path) -> bool {
     Command::new(command)
-        .args(forge_lint_args("--help", selected_profile))
+        .args(["lint", "--help"])
         .current_dir(cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -170,8 +170,7 @@ mod tests {
             }]),
         };
 
-        let configs =
-            options.configs(project.config().workspaces(), Path::new("forge"), Some("custom"));
+        let configs = options.configs(project.config().workspaces(), Path::new("forge"), None);
 
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].id, "custom");
@@ -199,7 +198,6 @@ mod tests {
 
     #[test]
     fn default_forge_lint_args_omit_unselected_profile() {
-        assert_eq!(forge_lint_args("--help", None), ["lint", "--help"]);
-        assert_eq!(forge_lint_args("--json", None), ["lint", "--json"]);
+        assert_eq!(forge_lint_args(None), ["lint", "--json"]);
     }
 }

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -2,7 +2,7 @@ use crate::{
     NotifyResult,
     config::{
         Config, WatchedFileSpec, WorkspaceDiscoveryResult,
-        negotiate_capabilities_with_pull_diagnostic_data,
+        negotiate_capabilities_with_pull_diagnostic_data_and_profile,
     },
     diagnostics::{
         AnalyzedDocuments, DiagnosticMap, DiagnosticOwner, DiagnosticStore, PullReport,
@@ -622,10 +622,11 @@ impl GlobalState {
         pull_diagnostic_data_support: bool,
     ) -> impl Future<Output = Result<proto::InitializeResponse, ResponseError>> + use<> {
         self.protocol_trace.set_level(params.trace.unwrap_or_default());
-        let (capabilities, config) = negotiate_capabilities_with_pull_diagnostic_data(
+        let (capabilities, config) = negotiate_capabilities_with_pull_diagnostic_data_and_profile(
             params,
             pull_diagnostic_data_support,
             self.launch_config.default_forge_path(),
+            self.launch_config.selected_profile(),
         );
 
         self.analysis_progress.set_enabled(config.supports_work_done_progress());

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -2,7 +2,7 @@ use crate::{
     NotifyResult,
     config::{
         Config, WatchedFileSpec, WorkspaceDiscoveryResult,
-        negotiate_capabilities_with_pull_diagnostic_data_and_profile,
+        negotiate_capabilities_with_pull_diagnostic_data,
     },
     diagnostics::{
         AnalyzedDocuments, DiagnosticMap, DiagnosticOwner, DiagnosticStore, PullReport,
@@ -622,7 +622,7 @@ impl GlobalState {
         pull_diagnostic_data_support: bool,
     ) -> impl Future<Output = Result<proto::InitializeResponse, ResponseError>> + use<> {
         self.protocol_trace.set_level(params.trace.unwrap_or_default());
-        let (capabilities, config) = negotiate_capabilities_with_pull_diagnostic_data_and_profile(
+        let (capabilities, config) = negotiate_capabilities_with_pull_diagnostic_data(
             params,
             pull_diagnostic_data_support,
             self.launch_config.default_forge_path(),

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -25,6 +25,8 @@ use tower::ServiceBuilder;
 #[derive(Clone, Debug, Default)]
 pub struct LaunchConfig {
     default_forge_path: Option<PathBuf>,
+    /// Foundry profile selected by the embedding host, if any.
+    selected_profile: Option<String>,
 }
 
 impl From<LspArgs> for LaunchConfig {
@@ -40,8 +42,18 @@ impl LaunchConfig {
         self
     }
 
+    /// Selects the Foundry profile used for workspace discovery and Forge flychecks.
+    pub fn with_selected_profile(mut self, profile: impl Into<String>) -> Self {
+        self.selected_profile = Some(profile.into());
+        self
+    }
+
     pub(crate) fn default_forge_path(&self) -> Option<&Path> {
         self.default_forge_path.as_deref()
+    }
+
+    pub(crate) fn selected_profile(&self) -> Option<&str> {
+        self.selected_profile.as_deref()
     }
 }
 

--- a/crates/lsp/src/serde.rs
+++ b/crates/lsp/src/serde.rs
@@ -14,23 +14,25 @@ pub(crate) mod optional_display_fromstr {
             .map(|value| value.parse().map_err(de::Error::custom))
             .transpose()
     }
-}
 
-pub(crate) mod display_fromstr {
     pub(crate) mod vec {
         use serde::{Deserialize, Deserializer, de};
         use std::{fmt, str::FromStr};
 
-        pub(crate) fn deserialize<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
+        pub(crate) fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
         where
             T: FromStr,
             T::Err: fmt::Display,
             D: Deserializer<'de>,
         {
-            Vec::<String>::deserialize(deserializer)?
-                .into_iter()
-                .map(|value| value.parse().map_err(de::Error::custom))
-                .collect()
+            Option::<Vec<String>>::deserialize(deserializer)?
+                .map(|values| {
+                    values
+                        .into_iter()
+                        .map(|value| value.parse().map_err(de::Error::custom))
+                        .collect()
+                })
+                .transpose()
         }
     }
 }

--- a/crates/lsp/src/tests/code_action.rs
+++ b/crates/lsp/src/tests/code_action.rs
@@ -1262,8 +1262,13 @@ fn state_with_diagnostic_capabilities(
                 ..Default::default()
             });
     }
-    let config =
-        negotiate_capabilities_with_pull_diagnostic_data(initialize, pull_diagnostic_data, None).1;
+    let config = negotiate_capabilities_with_pull_diagnostic_data(
+        initialize,
+        pull_diagnostic_data,
+        None,
+        None,
+    )
+    .1;
     state.config = Arc::new(config);
     *state.vfs.write() = project.vfs();
     state

--- a/crates/lsp/src/tests/flycheck.rs
+++ b/crates/lsp/src/tests/flycheck.rs
@@ -20,7 +20,7 @@ const FAKE_FLYCHECK_TEST: &str = "flycheck_tests::fake_json_emitter";
 
 #[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
-async fn default_forge_flycheck_passes_selected_profile_to_probe_and_run() {
+async fn default_forge_flycheck_passes_selected_profile_to_run() {
     let project = TestProject::from_fixture(
         r#"
         //- /foundry.toml
@@ -51,7 +51,7 @@ async fn default_forge_flycheck_passes_selected_profile_to_probe_and_run() {
 
     assert_eq!(
         project.read_file("/fake-forge.args"),
-        "lint\n--help\n--profile\ncustom\nlint\n--json\n--profile\ncustom\n"
+        "lint\n--help\nlint\n--json\n--profile\ncustom\n"
     );
 }
 

--- a/crates/lsp/src/tests/flycheck.rs
+++ b/crates/lsp/src/tests/flycheck.rs
@@ -10,17 +10,14 @@ use solar_interface::{
     diagnostics::{Applicability, Diag, DiagCtxt, JsonEmitter, Level},
     source_map::{FileName, SourceMap},
 };
-#[cfg(unix)]
-use std::{fs, os::unix::fs::PermissionsExt};
 use std::{io, path::Path, sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 
 const SOURCE: &str = "contract Test { function run() public view {} }";
 const FAKE_FLYCHECK_TEST: &str = "flycheck_tests::fake_json_emitter";
 
-#[cfg(unix)]
 #[tokio::test(flavor = "current_thread")]
-async fn default_forge_flycheck_passes_selected_profile_to_run() {
+async fn default_forge_flycheck_uses_selected_profile() {
     let project = TestProject::from_fixture(
         r#"
         //- /foundry.toml
@@ -31,11 +28,8 @@ async fn default_forge_flycheck_passes_selected_profile_to_run() {
         contract Test {}
         "#,
     );
-    let forge = project.path("/fake-forge");
-    project.write_file("/fake-forge", "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$0.args\"\n");
-    let mut permissions = fs::metadata(&forge).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&forge, permissions).unwrap();
+    // Libtest accepts `lint --help`, providing a portable successful capability probe.
+    let forge = std::env::current_exe().unwrap();
 
     let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(
         LaunchConfig::default().with_default_forge_path(&forge).with_selected_profile("custom"),
@@ -44,15 +38,8 @@ async fn default_forge_flycheck_passes_selected_profile_to_run() {
     let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
     let source = project.path("/src/Test.sol");
     let [flycheck] = state.config.flychecks_for_path(&source).try_into().unwrap();
+    assert_eq!(flycheck.command, forge);
     assert_eq!(flycheck.args, ["lint", "--json", "--profile", "custom"]);
-
-    let (_cancel, cancelled) = oneshot::channel();
-    flycheck::run(flycheck, Duration::from_secs(30), cancelled, vec![source]).await.unwrap();
-
-    assert_eq!(
-        project.read_file("/fake-forge.args"),
-        "lint\n--help\nlint\n--json\n--profile\ncustom\n"
-    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/flycheck.rs
+++ b/crates/lsp/src/tests/flycheck.rs
@@ -1,4 +1,4 @@
-use crate::{flycheck, global_state::GlobalState, test_support::TestProject};
+use crate::{LaunchConfig, flycheck, global_state::GlobalState, test_support::TestProject};
 use async_lsp::ClientSocket;
 use lsp_types::{
     CodeActionClientCapabilities, CodeActionContext, CodeActionKind, CodeActionKindLiteralSupport,
@@ -10,11 +10,50 @@ use solar_interface::{
     diagnostics::{Applicability, Diag, DiagCtxt, JsonEmitter, Level},
     source_map::{FileName, SourceMap},
 };
+#[cfg(unix)]
+use std::{fs, os::unix::fs::PermissionsExt};
 use std::{io, path::Path, sync::Arc, time::Duration};
 use tokio::sync::oneshot;
 
 const SOURCE: &str = "contract Test { function run() public view {} }";
 const FAKE_FLYCHECK_TEST: &str = "flycheck_tests::fake_json_emitter";
+
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn default_forge_flycheck_passes_selected_profile_to_probe_and_run() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /src/Test.sol
+        contract Test {}
+        "#,
+    );
+    let forge = project.path("/fake-forge");
+    project.write_file("/fake-forge", "#!/bin/sh\nprintf '%s\\n' \"$@\" >> \"$0.args\"\n");
+    let mut permissions = fs::metadata(&forge).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&forge, permissions).unwrap();
+
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(
+        LaunchConfig::default().with_default_forge_path(&forge).with_selected_profile("custom"),
+    );
+    state.on_initialize(project.initialize_params()).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    let source = project.path("/src/Test.sol");
+    let [flycheck] = state.config.flychecks_for_path(&source).try_into().unwrap();
+    assert_eq!(flycheck.args, ["lint", "--json", "--profile", "custom"]);
+
+    let (_cancel, cancelled) = oneshot::channel();
+    flycheck::run(flycheck, Duration::from_secs(30), cancelled, vec![source]).await.unwrap();
+
+    assert_eq!(
+        project.read_file("/fake-forge.args"),
+        "lint\n--help\n--profile\ncustom\nlint\n--json\n--profile\ncustom\n"
+    );
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn json_emitter_alternatives_become_separate_flycheck_code_actions() {

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -1,4 +1,7 @@
-use crate::{LaunchConfig, global_state::GlobalState, new_server_service_with_router, proto};
+use crate::{
+    LaunchConfig, global_state::GlobalState, new_server_service_with_router, proto,
+    test_support::TestProject, workspace::WorkspaceKind,
+};
 use async_lsp::{AnyRequest, ClientSocket, router::Router};
 use lsp_types::InitializeParams;
 use solar_config::LspArgs;
@@ -29,13 +32,39 @@ async fn initialize_applies_launch_config_default_forge_path() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn initialize_applies_launch_config_selected_profile() {
+async fn initialize_applies_launch_config_selected_profile_to_workspace_discovery() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /default-src/Default.sol
+        contract DefaultContract {}
+
+        //- /custom-src/Custom.sol
+        contract CustomContract {}
+
+        //- /foundry.toml
+        [profile.default]
+        src = "default-src"
+
+        [profile.custom]
+        src = "custom-src"
+        "#,
+    );
     let config = LaunchConfig::default().with_selected_profile("custom");
     let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params();
+    params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
 
-    state.on_initialize(InitializeParams::default()).await.unwrap();
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
 
-    assert_eq!(state.config.selected_profile(), Some("custom"));
+    let workspace = state
+        .config
+        .workspaces()
+        .iter()
+        .find(|workspace| workspace.kind() == WorkspaceKind::Foundry)
+        .unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -29,6 +29,16 @@ async fn initialize_applies_launch_config_default_forge_path() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn initialize_applies_launch_config_selected_profile() {
+    let config = LaunchConfig::default().with_selected_profile("custom");
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+
+    state.on_initialize(InitializeParams::default()).await.unwrap();
+
+    assert_eq!(state.config.selected_profile(), Some("custom"));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn configured_server_service_applies_launch_default_during_initialize() {
     let observed_path = Arc::new(Mutex::new(None::<PathBuf>));
     let server_observed_path = observed_path.clone();

--- a/crates/lsp/src/tests/watched_files.rs
+++ b/crates/lsp/src/tests/watched_files.rs
@@ -666,6 +666,7 @@ fn watched_file_specs_add_only_approved_dependency_parents() {
             crate::workspace::Workspace::load_foundry_bounded(
                 project.path("/workspace/foundry.toml"),
                 &[project.path("/workspace")],
+                None,
             )
             .unwrap(),
         ],

--- a/crates/lsp/src/workspace/foundry.rs
+++ b/crates/lsp/src/workspace/foundry.rs
@@ -6,27 +6,22 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub(crate) struct FoundryDocument {
     profile: Option<FoundryProfiles>,
     default: Option<FoundryProfile>,
 }
 
 impl FoundryDocument {
-    #[cfg(test)]
-    pub(crate) fn default_profile(&self) -> FoundryProfile {
-        self.profile_for(None)
-    }
-
     pub(crate) fn profile_for(&self, selected_profile: Option<&str>) -> FoundryProfile {
         let default = self.base_profile();
         let Some(name) = selected_profile.filter(|name| *name != "default") else {
             return default;
         };
-        self.profile
-            .as_ref()
-            .and_then(|profiles| profiles.get(name))
-            .map_or(default.clone(), |profile| default.overlay(&profile))
+        let Some(profile) = self.profile.as_ref().and_then(|profiles| profiles.get(name)) else {
+            return default;
+        };
+        default.overlay(profile)
     }
 
     fn base_profile(&self) -> FoundryProfile {
@@ -39,7 +34,7 @@ impl FoundryDocument {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct FoundryProfiles {
     default: Option<FoundryProfile>,
     #[serde(flatten)]
@@ -48,7 +43,7 @@ struct FoundryProfiles {
 
 impl FoundryProfiles {
     fn get(&self, name: &str) -> Option<FoundryProfile> {
-        self.profiles.get(name).cloned().and_then(|profile| serde_json::from_value(profile).ok())
+        self.profiles.get(name).and_then(|profile| FoundryProfile::deserialize(profile).ok())
     }
 }
 
@@ -70,14 +65,14 @@ pub(crate) struct FoundryProfile {
 }
 
 impl FoundryProfile {
-    fn overlay(&self, overlay: &Self) -> Self {
+    fn overlay(self, overlay: Self) -> Self {
         Self {
-            src: overlay.src.clone().or_else(|| self.src.clone()),
-            test: overlay.test.clone().or_else(|| self.test.clone()),
-            script: overlay.script.clone().or_else(|| self.script.clone()),
-            libs: overlay.libs.clone().or_else(|| self.libs.clone()),
+            src: overlay.src.or(self.src),
+            test: overlay.test.or(self.test),
+            script: overlay.script.or(self.script),
+            libs: overlay.libs.or(self.libs),
             auto_detect_remappings: overlay.auto_detect_remappings.or(self.auto_detect_remappings),
-            remappings: overlay.remappings.clone().or_else(|| self.remappings.clone()),
+            remappings: overlay.remappings.or(self.remappings),
             evm_version: overlay.evm_version.or(self.evm_version),
         }
     }
@@ -115,7 +110,7 @@ impl FoundryProfile {
         }
         remappings.extend(read_remappings_txt(root));
         if let Some(configured) = &self.remappings {
-            remappings.extend(configured.clone());
+            remappings.extend_from_slice(configured);
         }
         remappings
     }
@@ -182,7 +177,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            document.default_profile().include_paths(Path::new("workspace")),
+            document.profile_for(None).include_paths(Path::new("workspace")),
             [PathBuf::from("workspace/lib"), PathBuf::from("workspace/vendor")]
         );
     }
@@ -224,7 +219,6 @@ mod tests {
             profile.include_paths(Path::new("workspace")),
             [PathBuf::from("workspace/default-libs")]
         );
-        assert!(profile.remappings.as_ref().is_some_and(Vec::is_empty));
         assert_eq!(profile.auto_detect_remappings, Some(false));
         assert_eq!(profile.evm_version(), Some(EvmVersion::Paris));
     }
@@ -242,8 +236,7 @@ mod tests {
         )
         .unwrap();
 
-        let default_roots = document.default_profile().source_roots(Path::new("workspace"));
-        assert_eq!(document.profile_for(None).source_roots(Path::new("workspace")), default_roots);
+        let default_roots = document.profile_for(None).source_roots(Path::new("workspace"));
         assert_eq!(
             document.profile_for(Some("default")).source_roots(Path::new("workspace")),
             default_roots
@@ -265,7 +258,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            document.default_profile().source_roots(Path::new("workspace")),
+            document.profile_for(None).source_roots(Path::new("workspace")),
             [PathBuf::from("workspace/legacy-src")]
         );
         assert_eq!(
@@ -288,7 +281,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            document.default_profile().source_roots(Path::new("workspace")),
+            document.profile_for(None).source_roots(Path::new("workspace")),
             [PathBuf::from("workspace/default-src")]
         );
     }

--- a/crates/lsp/src/workspace/foundry.rs
+++ b/crates/lsp/src/workspace/foundry.rs
@@ -1,40 +1,87 @@
 use normalize_path::NormalizePath;
 use serde::Deserialize;
 use solar_config::{EvmVersion, ImportRemapping};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct FoundryDocument {
     profile: Option<FoundryProfiles>,
     default: Option<FoundryProfile>,
 }
 
 impl FoundryDocument {
-    pub(crate) fn default_profile(self) -> FoundryProfile {
-        self.profile.and_then(|profiles| profiles.default).or(self.default).unwrap_or_default()
+    #[cfg(test)]
+    pub(crate) fn default_profile(&self) -> FoundryProfile {
+        self.profile_for(None)
+    }
+
+    pub(crate) fn profile_for(&self, selected_profile: Option<&str>) -> FoundryProfile {
+        let default = self.base_profile();
+        let Some(name) = selected_profile.filter(|name| *name != "default") else {
+            return default;
+        };
+        self.profile
+            .as_ref()
+            .and_then(|profiles| profiles.get(name))
+            .map_or(default.clone(), |profile| default.overlay(&profile))
+    }
+
+    fn base_profile(&self) -> FoundryProfile {
+        self.profile
+            .as_ref()
+            .and_then(|profiles| profiles.default.as_ref())
+            .cloned()
+            .or_else(|| self.default.clone())
+            .unwrap_or_default()
     }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 struct FoundryProfiles {
     default: Option<FoundryProfile>,
+    #[serde(flatten)]
+    profiles: BTreeMap<String, serde_json::Value>,
+}
+
+impl FoundryProfiles {
+    fn get(&self, name: &str) -> Option<FoundryProfile> {
+        self.profiles.get(name).cloned().and_then(|profile| serde_json::from_value(profile).ok())
+    }
 }
 
 /// A subset of Foundry config relevant to the LSP workspace.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct FoundryProfile {
     src: Option<PathBuf>,
     test: Option<PathBuf>,
     script: Option<PathBuf>,
     libs: Option<Vec<PathBuf>>,
     auto_detect_remappings: Option<bool>,
-    #[serde(default, with = "crate::serde::display_fromstr::vec")]
-    remappings: Vec<ImportRemapping>,
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::optional_display_fromstr::vec::deserialize"
+    )]
+    remappings: Option<Vec<ImportRemapping>>,
     #[serde(default, with = "crate::serde::optional_display_fromstr")]
     evm_version: Option<EvmVersion>,
 }
 
 impl FoundryProfile {
+    fn overlay(&self, overlay: &Self) -> Self {
+        Self {
+            src: overlay.src.clone().or_else(|| self.src.clone()),
+            test: overlay.test.clone().or_else(|| self.test.clone()),
+            script: overlay.script.clone().or_else(|| self.script.clone()),
+            libs: overlay.libs.clone().or_else(|| self.libs.clone()),
+            auto_detect_remappings: overlay.auto_detect_remappings.or(self.auto_detect_remappings),
+            remappings: overlay.remappings.clone().or_else(|| self.remappings.clone()),
+            evm_version: overlay.evm_version.or(self.evm_version),
+        }
+    }
+
     pub(crate) fn source_roots(&self, root: &Path) -> Vec<PathBuf> {
         vec![root.join(self.src.as_deref().unwrap_or_else(|| Path::new("src"))).normalize()]
     }
@@ -67,7 +114,9 @@ impl FoundryProfile {
             remappings.extend(self.discover_lib_remappings(root, include_paths));
         }
         remappings.extend(read_remappings_txt(root));
-        remappings.extend(self.remappings.clone());
+        if let Some(configured) = &self.remappings {
+            remappings.extend(configured.clone());
+        }
         remappings
     }
 
@@ -135,6 +184,138 @@ mod tests {
         assert_eq!(
             document.default_profile().include_paths(Path::new("workspace")),
             [PathBuf::from("workspace/lib"), PathBuf::from("workspace/vendor")]
+        );
+    }
+
+    #[test]
+    fn selected_profile_overlays_default_profile_fields() {
+        let document = toml_edit::de::from_str::<FoundryDocument>(
+            r#"
+            [profile.default]
+            src = "default-src"
+            test = "default-test"
+            script = "default-script"
+            libs = ["default-libs"]
+            auto_detect_remappings = false
+            remappings = ["default/=default/src/"]
+            evm_version = "paris"
+
+            [profile.custom]
+            src = "custom-src"
+            remappings = []
+            "#,
+        )
+        .unwrap();
+
+        let profile = document.profile_for(Some("custom"));
+        assert_eq!(
+            profile.source_roots(Path::new("workspace")),
+            [PathBuf::from("workspace/custom-src")]
+        );
+        assert_eq!(
+            profile.flycheck_source_roots(Path::new("workspace")),
+            [
+                PathBuf::from("workspace/custom-src"),
+                PathBuf::from("workspace/default-test"),
+                PathBuf::from("workspace/default-script"),
+            ]
+        );
+        assert_eq!(
+            profile.include_paths(Path::new("workspace")),
+            [PathBuf::from("workspace/default-libs")]
+        );
+        assert!(profile.remappings.as_ref().is_some_and(Vec::is_empty));
+        assert_eq!(profile.auto_detect_remappings, Some(false));
+        assert_eq!(profile.evm_version(), Some(EvmVersion::Paris));
+    }
+
+    #[test]
+    fn missing_and_default_profiles_use_default_profile() {
+        let document = toml_edit::de::from_str::<FoundryDocument>(
+            r#"
+            [profile.default]
+            src = "default-src"
+
+            [profile.custom]
+            src = "custom-src"
+            "#,
+        )
+        .unwrap();
+
+        let default_roots = document.default_profile().source_roots(Path::new("workspace"));
+        assert_eq!(document.profile_for(None).source_roots(Path::new("workspace")), default_roots);
+        assert_eq!(
+            document.profile_for(Some("default")).source_roots(Path::new("workspace")),
+            default_roots
+        );
+        assert_eq!(
+            document.profile_for(Some("missing")).source_roots(Path::new("workspace")),
+            default_roots
+        );
+    }
+
+    #[test]
+    fn legacy_default_profile_remains_supported() {
+        let document = toml_edit::de::from_str::<FoundryDocument>(
+            r#"
+            [default]
+            src = "legacy-src"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            document.default_profile().source_roots(Path::new("workspace")),
+            [PathBuf::from("workspace/legacy-src")]
+        );
+        assert_eq!(
+            document.profile_for(Some("missing")).source_roots(Path::new("workspace")),
+            [PathBuf::from("workspace/legacy-src")]
+        );
+    }
+
+    #[test]
+    fn unselected_profile_does_not_affect_default_profile_parsing() {
+        let document = toml_edit::de::from_str::<FoundryDocument>(
+            r#"
+            [profile.default]
+            src = "default-src"
+
+            [profile.unselected]
+            evm_version = "future-hardfork"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            document.default_profile().source_roots(Path::new("workspace")),
+            [PathBuf::from("workspace/default-src")]
+        );
+    }
+
+    #[test]
+    fn explicit_empty_remappings_replace_default_remappings() {
+        let document = toml_edit::de::from_str::<FoundryDocument>(
+            r#"
+            [profile.default]
+            remappings = ["default/=default/src/"]
+
+            [profile.custom]
+            remappings = []
+            "#,
+        )
+        .unwrap();
+        let profile = document.profile_for(Some("custom"));
+
+        assert!(profile.remappings_with_include_paths(Path::new("workspace"), &[]).is_empty());
+        assert_eq!(
+            document
+                .profile_for(Some("missing"))
+                .remappings_with_include_paths(Path::new("workspace"), &[])
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["default/=default/src/"]
         );
     }
 }

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -31,6 +31,7 @@ impl ProjectManifest {
         policy: &WorkspaceIndexPolicy,
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
+        selected_profile: Option<&str>,
     ) -> io::Result<Option<ManifestDiscoveryResult>> {
         // Keep naked roots shallow, but recurse once a Foundry project boundary is known.
         let mut manifests = Vec::new();
@@ -38,7 +39,8 @@ impl ProjectManifest {
         let mut marker_watch_roots = Vec::new();
         if let Some(manifest) = find_in_parent_dirs(path, "foundry.toml") {
             let workspace_root = manifest.parent().unwrap_or(path).to_path_buf();
-            let (source_roots, import_only_roots) = foundry_index_roots(&manifest, approved_roots);
+            let (source_roots, import_only_roots) =
+                foundry_index_roots_for_profile(&manifest, approved_roots, selected_profile);
             manifests.push(manifest);
             if let Ok(entries) = read_dir(path)
                 && matches!(
@@ -50,6 +52,7 @@ impl ProjectManifest {
                         policy,
                         cancellation,
                         metrics,
+                        selected_profile,
                     })
                     .find_in_child_dirs(
                         entries,
@@ -78,6 +81,7 @@ impl ProjectManifest {
                     policy,
                     cancellation,
                     metrics,
+                    selected_profile,
                 })
                 .find_in_child_dirs(
                     read_dir(path)?,
@@ -118,12 +122,31 @@ impl ProjectManifest {
             .map(|(manifests, _, _)| manifests)
     }
 
+    #[cfg(test)]
     pub(crate) fn discover_all_with_watch_roots(
         paths: &[PathBuf],
         approved_roots: &[PathBuf],
         policy: &WorkspaceIndexPolicy,
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
+    ) -> Option<ManifestDiscoveryResult> {
+        Self::discover_all_with_watch_roots_for_profile(
+            paths,
+            approved_roots,
+            policy,
+            cancellation,
+            metrics,
+            None,
+        )
+    }
+
+    pub(crate) fn discover_all_with_watch_roots_for_profile(
+        paths: &[PathBuf],
+        approved_roots: &[PathBuf],
+        policy: &WorkspaceIndexPolicy,
+        cancellation: &IndexingCancellation,
+        metrics: &mut WorkspaceIndexMetrics,
+        selected_profile: Option<&str>,
     ) -> Option<ManifestDiscoveryResult> {
         let mut discovered = FxHashSet::default();
         let mut watch_roots = Vec::new();
@@ -132,8 +155,14 @@ impl ProjectManifest {
             if cancellation.is_cancelled() {
                 return None;
             }
-            if let Ok(result) = Self::discover(path, approved_roots, policy, cancellation, metrics)
-            {
+            if let Ok(result) = Self::discover(
+                path,
+                approved_roots,
+                policy,
+                cancellation,
+                metrics,
+                selected_profile,
+            ) {
                 let (manifests, mut roots, mut marker_roots) = result?;
                 discovered.extend(manifests);
                 watch_roots.append(&mut roots);
@@ -231,6 +260,7 @@ struct ManifestDiscovery<'a> {
     policy: &'a WorkspaceIndexPolicy,
     cancellation: &'a IndexingCancellation,
     metrics: &'a mut WorkspaceIndexMetrics,
+    selected_profile: Option<&'a str>,
 }
 
 #[derive(Clone, Copy)]
@@ -317,7 +347,11 @@ impl ManifestDiscovery<'_> {
                 && let Ok(children) = read_dir(&path)
             {
                 let nested_index_roots = if is_project {
-                    foundry_index_roots(&manifest, self.approved_roots)
+                    foundry_index_roots_for_profile(
+                        &manifest,
+                        self.approved_roots,
+                        self.selected_profile,
+                    )
                 } else {
                     Default::default()
                 };
@@ -374,14 +408,15 @@ impl ManifestDiscovery<'_> {
     }
 }
 
-fn foundry_index_roots(
+fn foundry_index_roots_for_profile(
     manifest: &Path,
     approved_roots: &[PathBuf],
+    selected_profile: Option<&str>,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let Some(root) = manifest.parent() else { return Default::default() };
     load_foundry_document(manifest)
         .map(|document| {
-            let profile = document.default_profile();
+            let profile = document.profile_for(selected_profile);
             let source_roots = profile
                 .source_roots(root)
                 .into_iter()
@@ -412,6 +447,19 @@ mod tests {
             &mut WorkspaceIndexMetrics::default(),
         )
         .unwrap()
+    }
+
+    fn discover_all_with_profile(paths: &[PathBuf], profile: Option<&str>) -> Vec<ProjectManifest> {
+        ProjectManifest::discover_all_with_watch_roots_for_profile(
+            paths,
+            paths,
+            &WorkspaceIndexPolicy::default(),
+            &IndexingCancellation::default(),
+            &mut WorkspaceIndexMetrics::default(),
+            profile,
+        )
+        .unwrap()
+        .0
     }
 
     #[test]
@@ -578,6 +626,54 @@ mod tests {
             vec![
                 ProjectManifest::Foundry(project.path("/foundry.toml")),
                 ProjectManifest::Foundry(project.path("/src/nested/foundry.toml")),
+            ]
+        );
+    }
+
+    #[test]
+    fn selected_profile_source_root_controls_nested_manifest_discovery() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /foundry.toml
+            [profile.default]
+            src = ".hidden/default-src"
+
+            [profile.custom]
+            src = ".hidden/custom-src"
+
+            //- /.hidden/default-src/nested/foundry.toml
+
+            //- /.hidden/custom-src/nested/foundry.toml
+            [profile.default]
+            src = ".hidden/default-src"
+
+            [profile.custom]
+            src = ".hidden/custom-src"
+
+            //- /.hidden/custom-src/nested/.hidden/default-src/deep/foundry.toml
+
+            //- /.hidden/custom-src/nested/.hidden/custom-src/deep/foundry.toml
+            "#,
+        );
+
+        assert_eq!(
+            foundry_index_roots_for_profile(
+                &project.path("/foundry.toml"),
+                &[project.root().to_path_buf()],
+                Some("custom"),
+            )
+            .0,
+            [project.path("/.hidden/custom-src")]
+        );
+
+        let nested_custom_manifest =
+            project.path("/.hidden/custom-src/nested/.hidden/custom-src/deep/foundry.toml");
+        assert_eq!(
+            discover_all_with_profile(&[project.root().to_path_buf()], Some("custom")),
+            vec![
+                ProjectManifest::Foundry(nested_custom_manifest),
+                ProjectManifest::Foundry(project.path("/.hidden/custom-src/nested/foundry.toml")),
+                ProjectManifest::Foundry(project.path("/foundry.toml")),
             ]
         );
     }

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -40,7 +40,7 @@ impl ProjectManifest {
         if let Some(manifest) = find_in_parent_dirs(path, "foundry.toml") {
             let workspace_root = manifest.parent().unwrap_or(path).to_path_buf();
             let (source_roots, import_only_roots) =
-                foundry_index_roots_for_profile(&manifest, approved_roots, selected_profile);
+                foundry_index_roots(&manifest, approved_roots, selected_profile);
             manifests.push(manifest);
             if let Ok(entries) = read_dir(path)
                 && matches!(
@@ -118,29 +118,11 @@ impl ProjectManifest {
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
     ) -> Option<Vec<Self>> {
-        Self::discover_all_with_watch_roots(paths, paths, policy, cancellation, metrics)
+        Self::discover_all_with_watch_roots(paths, paths, policy, cancellation, metrics, None)
             .map(|(manifests, _, _)| manifests)
     }
 
-    #[cfg(test)]
     pub(crate) fn discover_all_with_watch_roots(
-        paths: &[PathBuf],
-        approved_roots: &[PathBuf],
-        policy: &WorkspaceIndexPolicy,
-        cancellation: &IndexingCancellation,
-        metrics: &mut WorkspaceIndexMetrics,
-    ) -> Option<ManifestDiscoveryResult> {
-        Self::discover_all_with_watch_roots_for_profile(
-            paths,
-            approved_roots,
-            policy,
-            cancellation,
-            metrics,
-            None,
-        )
-    }
-
-    pub(crate) fn discover_all_with_watch_roots_for_profile(
         paths: &[PathBuf],
         approved_roots: &[PathBuf],
         policy: &WorkspaceIndexPolicy,
@@ -347,11 +329,7 @@ impl ManifestDiscovery<'_> {
                 && let Ok(children) = read_dir(&path)
             {
                 let nested_index_roots = if is_project {
-                    foundry_index_roots_for_profile(
-                        &manifest,
-                        self.approved_roots,
-                        self.selected_profile,
-                    )
+                    foundry_index_roots(&manifest, self.approved_roots, self.selected_profile)
                 } else {
                     Default::default()
                 };
@@ -408,7 +386,7 @@ impl ManifestDiscovery<'_> {
     }
 }
 
-fn foundry_index_roots_for_profile(
+fn foundry_index_roots(
     manifest: &Path,
     approved_roots: &[PathBuf],
     selected_profile: Option<&str>,
@@ -447,19 +425,6 @@ mod tests {
             &mut WorkspaceIndexMetrics::default(),
         )
         .unwrap()
-    }
-
-    fn discover_all_with_profile(paths: &[PathBuf], profile: Option<&str>) -> Vec<ProjectManifest> {
-        ProjectManifest::discover_all_with_watch_roots_for_profile(
-            paths,
-            paths,
-            &WorkspaceIndexPolicy::default(),
-            &IndexingCancellation::default(),
-            &mut WorkspaceIndexMetrics::default(),
-            profile,
-        )
-        .unwrap()
-        .0
     }
 
     #[test]
@@ -657,7 +622,7 @@ mod tests {
         );
 
         assert_eq!(
-            foundry_index_roots_for_profile(
+            foundry_index_roots(
                 &project.path("/foundry.toml"),
                 &[project.root().to_path_buf()],
                 Some("custom"),
@@ -668,8 +633,19 @@ mod tests {
 
         let nested_custom_manifest =
             project.path("/.hidden/custom-src/nested/.hidden/custom-src/deep/foundry.toml");
+        let paths = [project.root().to_path_buf()];
+        let discovered = ProjectManifest::discover_all_with_watch_roots(
+            &paths,
+            &paths,
+            &WorkspaceIndexPolicy::default(),
+            &IndexingCancellation::default(),
+            &mut WorkspaceIndexMetrics::default(),
+            Some("custom"),
+        )
+        .unwrap()
+        .0;
         assert_eq!(
-            discover_all_with_profile(&[project.root().to_path_buf()], Some("custom")),
+            discovered,
             vec![
                 ProjectManifest::Foundry(nested_custom_manifest),
                 ProjectManifest::Foundry(project.path("/.hidden/custom-src/nested/foundry.toml")),

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -480,23 +480,7 @@ impl Workspace {
         Self::load_foundry_inner(path, None, None)
     }
 
-    #[cfg(test)]
-    pub(crate) fn load_foundry_with_profile(
-        path: PathBuf,
-        selected_profile: Option<&str>,
-    ) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, None, selected_profile)
-    }
-
-    #[cfg(test)]
     pub(crate) fn load_foundry_bounded(
-        path: PathBuf,
-        workspace_roots: &[PathBuf],
-    ) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, Some(workspace_roots), None)
-    }
-
-    pub(crate) fn load_foundry_bounded_with_profile(
         path: PathBuf,
         workspace_roots: &[PathBuf],
         selected_profile: Option<&str>,
@@ -1091,9 +1075,12 @@ mod tests {
             "#,
         );
 
-        let workspace =
-            Workspace::load_foundry_with_profile(project.path("/foundry.toml"), Some("custom"))
-                .unwrap();
+        let workspace = Workspace::load_foundry_bounded(
+            project.path("/foundry.toml"),
+            &[project.root().to_path_buf()],
+            Some("custom"),
+        )
+        .unwrap();
 
         assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
         assert_eq!(
@@ -1125,6 +1112,7 @@ mod tests {
         let workspace = Workspace::load_foundry_bounded(
             project.path("/workspace/foundry.toml"),
             &[project.path("/workspace")],
+            None,
         )
         .unwrap();
         let opts = workspace.compile_opts();

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -477,22 +477,40 @@ impl Workspace {
 
     #[cfg(any(test, feature = "bench"))]
     pub(crate) fn load_foundry(path: PathBuf) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, None)
+        Self::load_foundry_inner(path, None, None)
     }
 
+    #[cfg(test)]
+    pub(crate) fn load_foundry_with_profile(
+        path: PathBuf,
+        selected_profile: Option<&str>,
+    ) -> Result<Self, WorkspaceError> {
+        Self::load_foundry_inner(path, None, selected_profile)
+    }
+
+    #[cfg(test)]
     pub(crate) fn load_foundry_bounded(
         path: PathBuf,
         workspace_roots: &[PathBuf],
     ) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, Some(workspace_roots))
+        Self::load_foundry_inner(path, Some(workspace_roots), None)
+    }
+
+    pub(crate) fn load_foundry_bounded_with_profile(
+        path: PathBuf,
+        workspace_roots: &[PathBuf],
+        selected_profile: Option<&str>,
+    ) -> Result<Self, WorkspaceError> {
+        Self::load_foundry_inner(path, Some(workspace_roots), selected_profile)
     }
 
     fn load_foundry_inner(
         path: PathBuf,
         workspace_roots: Option<&[PathBuf]>,
+        selected_profile: Option<&str>,
     ) -> Result<Self, WorkspaceError> {
         let root = manifest_root(&path)?.normalize();
-        let profile = load_foundry_document(&path)?.default_profile();
+        let profile = load_foundry_document(&path)?.profile_for(selected_profile);
         let approved = |path: &Path| {
             workspace_roots
                 .is_none_or(|workspace_roots| is_approved_index_root(path, &root, workspace_roots))
@@ -1040,6 +1058,54 @@ mod tests {
             ]
         );
         assert_eq!(workspace.source_roots(), &[project.path("/contracts")]);
+    }
+
+    #[test]
+    fn foundry_workspace_loads_selected_profile_compile_config() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /default-src/Main.sol
+            contract DefaultMain {}
+
+            //- /custom-src/Main.sol
+            contract CustomMain {}
+
+            //- /default-libs/pkg/src/Lib.sol
+            contract Lib {}
+
+            //- /custom-libs/pkg/src/CustomLib.sol
+            contract CustomLib {}
+
+            //- /foundry.toml
+            [profile.default]
+            src = "default-src"
+            test = "default-test"
+            script = "default-script"
+            libs = ["default-libs"]
+            evm_version = "paris"
+
+            [profile.custom]
+            src = "custom-src"
+            libs = ["custom-libs"]
+            evm_version = "cancun"
+            "#,
+        );
+
+        let workspace =
+            Workspace::load_foundry_with_profile(project.path("/foundry.toml"), Some("custom"))
+                .unwrap();
+
+        assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
+        assert_eq!(
+            workspace.import_source_roots(),
+            &[
+                project.path("/custom-src"),
+                project.path("/default-test"),
+                project.path("/default-script"),
+            ]
+        );
+        assert_eq!(workspace.compile_opts().include_paths, [project.path("/custom-libs")]);
+        assert_eq!(workspace.compile_opts().evm_version, EvmVersion::Cancun);
     }
 
     #[test]


### PR DESCRIPTION
This is the Solar-side follow-up to review feedback on foundry-rs/foundry#16254(https://github.com/foundry-rs/foundry/pull/16254#discussion_r3830801344). 

forge lsp --profile custom accepted the selected profile, but the embedded LSP launch path had no way to pass it into Solar, so workspace discovery continued to use [profile.default].

Allow embedding hosts to select a Foundry profile through the launch configuration. Thread the selection through workspace discovery, indexing, compile options, and default Forge flychecks . Overlay named profiles on profile.default while preserving the legacy no-profile behavior and explicit flycheck templates.