### PR TITLE
fix(codegen): return values on Yul leave

### DIFF
--- a/crates/codegen/src/lower/function/statements.rs
+++ b/crates/codegen/src/lower/function/statements.rs
@@ -260,7 +260,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     self.builder.jump(target);
                 } else if !self.is_terminated() {
                     if values.is_empty() {
-                        self.builder.stop();
+                        let returns = self.returns.clone();
+                        self.finish(&returns)?;
                     } else {
                         if values.len() != self.returns.len() {
                             return report_unsupported(

--- a/tests/ui/codegen/lowering/yul_leave.sol
+++ b/tests/ui/codegen/lowering/yul_leave.sol
@@ -1,0 +1,57 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: simple() => 2
+//@ run-call: conditional(uint256) 0 => 9
+//@ run-call: conditional(uint256) 1 => 2
+//@ run-call: multiple() => 2, 3
+//@ run-call: fallthrough() => 9
+
+contract YulLeave {
+    function simple() external pure returns (uint256 result) {
+        assembly {
+            function value() -> output {
+                output := 2
+                leave
+                output := 9
+            }
+            result := value()
+        }
+    }
+
+    function conditional(uint256 condition) external pure returns (uint256 result) {
+        assembly {
+            function value(flag) -> output {
+                output := 9
+                if flag {
+                    output := 2
+                    leave
+                }
+            }
+            result := value(condition)
+        }
+    }
+
+    function multiple() external pure returns (uint256 first, uint256 second) {
+        assembly {
+            function values() -> a, b {
+                a := 2
+                b := 3
+                leave
+                a := 8
+                b := 9
+            }
+            first, second := values()
+        }
+    }
+
+    function fallthrough() external pure returns (uint256 result) {
+        assembly {
+            function value() -> output {
+                output := 9
+            }
+            result := value()
+        }
+    }
+}


### PR DESCRIPTION
solsymdiff found a replay-confirmed mismatch where an inline Yul function that executed leave returned zero while solc returned the assigned output. Bare returns now use the existing return finalization path when the current function has return bindings. Runtime coverage includes immediate and conditional leave, multiple return values, and fallthrough across optimizer modes. This targets #1161 and was developed with AI assistance.