### PR TITLE
fix(codegen): apply storage layout base slots

### DIFF
--- a/crates/codegen/src/lower/storage.rs
+++ b/crates/codegen/src/lower/storage.rs
@@ -85,7 +85,10 @@ pub(super) struct StorageLayout<'gcx> {
 impl<'gcx> StorageLayout<'gcx> {
     /// Computes Solidity's base-to-derived storage order once for a module.
     pub(super) fn for_contract(gcx: Gcx<'gcx>, contract_id: ContractId) -> Self {
-        StorageBuilder::new(gcx).lower(contract_id)
+        let base_slot = gcx.hir.contract(contract_id).layout.map_or(U256::ZERO, |layout| {
+            gcx.eval_const(layout).ok().and_then(|value| value.as_u256()).unwrap_or_default()
+        });
+        StorageBuilder::new(gcx, base_slot).lower(contract_id)
     }
 
     pub(super) fn get(&self, id: VariableId) -> Option<StorageLocation> {
@@ -303,8 +306,8 @@ struct StorageCursor {
 }
 
 impl StorageCursor {
-    fn new(transient: bool) -> Self {
-        Self { slot: U256::ZERO, offset: 0, transient }
+    fn new(slot: U256, transient: bool) -> Self {
+        Self { slot, offset: 0, transient }
     }
 
     fn take(
@@ -360,14 +363,14 @@ impl StorageCursor {
 }
 
 impl<'gcx> StorageBuilder<'gcx> {
-    fn new(gcx: Gcx<'gcx>) -> Self {
+    fn new(gcx: Gcx<'gcx>, base_slot: U256) -> Self {
         Self {
             gcx,
             locations: FxHashMap::default(),
             field_types: gcx.hir.strukt_ids().map(|_| OnceLock::new()).collect(),
             field_locations: RefCell::new(FxHashMap::default()),
-            storage_cursor: StorageCursor::new(false),
-            transient_cursor: StorageCursor::new(true),
+            storage_cursor: StorageCursor::new(base_slot, false),
+            transient_cursor: StorageCursor::new(U256::ZERO, true),
         }
     }
 
@@ -408,7 +411,7 @@ impl<'gcx> StorageBuilder<'gcx> {
             return locations.as_ref()?.get(field).copied();
         }
 
-        let mut cursor = StorageCursor::new(false);
+        let mut cursor = StorageCursor::new(U256::ZERO, false);
         let locations = self
             .struct_field_types(struct_id)
             .iter()
@@ -489,7 +492,7 @@ impl<'gcx> StorageBuilder<'gcx> {
     }
 
     fn sequence_slots(&self, tys: impl Iterator<Item = Ty<'gcx>>, span: Span) -> Option<u64> {
-        let mut cursor = StorageCursor::new(false);
+        let mut cursor = StorageCursor::new(U256::ZERO, false);
         for ty in tys {
             let encoding = self.packed_encoding(ty);
             let slots = self.storage_slots_inner(ty, span)?;

--- a/tests/ui/codegen/lowering/storage_layout_base.sol
+++ b/tests/ui/codegen/lowering/storage_layout_base.sol
@@ -1,0 +1,92 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: LayoutSlots::slots() => 7, 0, 7, 1, 8, 0
+//@ run-call: LayoutStorage::store(uint256) 99 => 99, 99
+//@ run-call: LayoutDerived::slots() => 2, 3, 4
+//@ run-call: LayoutTransient::slots() => 0, 7
+//@ run-call: LayoutErc7201::matchesReference() => true
+
+function erc7201Reference(string memory namespace) pure returns (uint256) {
+    return uint256(
+        keccak256(bytes.concat(bytes32(uint256(keccak256(bytes(namespace))) - 1)))
+    ) & ~uint256(0xff);
+}
+
+contract LayoutSlots layout at 7 {
+    int8 private x;
+    int32 private y;
+    uint256 private z;
+
+    function slots()
+        external
+        pure
+        returns (uint256 xs, uint256 xo, uint256 ys, uint256 yo, uint256 zs, uint256 zo)
+    {
+        assembly {
+            xs := x.slot
+            xo := x.offset
+            ys := y.slot
+            yo := y.offset
+            zs := z.slot
+            zo := z.offset
+        }
+    }
+}
+
+contract LayoutStorage layout at 42 {
+    uint256 private value;
+
+    function store(uint256 newValue) external returns (uint256, uint256 raw) {
+        value = newValue;
+        assembly {
+            raw := sload(42)
+        }
+        return (value, raw);
+    }
+}
+
+contract LayoutBase {
+    uint256 internal baseValue;
+}
+
+contract LayoutMiddle is LayoutBase {
+    uint32 internal middleValue;
+}
+
+contract LayoutDerived is LayoutMiddle layout at 2 {
+    uint256 internal derivedValue;
+
+    function slots() external pure returns (uint256 base, uint256 middle, uint256 derived) {
+        assembly {
+            base := baseValue.slot
+            middle := middleValue.slot
+            derived := derivedValue.slot
+        }
+    }
+}
+
+contract LayoutTransient layout at 7 {
+    uint256 transient transientValue;
+    uint256 persistentValue;
+
+    function slots() external pure returns (uint256 transientSlot, uint256 persistentSlot) {
+        assembly {
+            transientSlot := transientValue.slot
+            persistentSlot := persistentValue.slot
+        }
+    }
+}
+
+contract LayoutErc7201 layout at erc7201("example.main") {
+    uint256 private value;
+
+    function matchesReference() external pure returns (bool) {
+        uint256 slot;
+        assembly {
+            slot := value.slot
+        }
+        return slot == erc7201Reference("example.main");
+    }
+}


### PR DESCRIPTION
solsymdiff found a replay-confirmed mismatch where contracts using layout at still generated storage accesses and .slot values from slot zero. The persistent storage cursor now starts at the already-validated layout expression, while transient and struct-relative layouts remain zero-based. Runtime coverage includes packing, inheritance, direct storage access, transient storage, and an ERC-7201 expression across optimizer modes. This targets #1161 and was developed with AI assistance.