### PR TITLE
fix(codegen): preserve short call outputs

### DIFF
--- a/crates/codegen/src/transform/memory_dse.rs
+++ b/crates/codegen/src/transform/memory_dse.rs
@@ -943,6 +943,21 @@ impl MemoryStoreEliminator {
                         *size,
                     );
                 }
+                InstKind::Call { args_offset, args_size, .. }
+                | InstKind::CallCode { args_offset, args_size, .. }
+                | InstKind::StaticCall { args_offset, args_size, .. }
+                | InstKind::DelegateCall { args_offset, args_size, .. } => {
+                    // A call reads its whole input, but it only copies
+                    // `min(ret_size, returndatasize())` bytes into the output
+                    // area. The rest remains unchanged, so the output cannot
+                    // prove that an earlier store is dead.
+                    self.retain_overwritten_disjoint_from_read(
+                        func,
+                        &mut scratch.overwritten,
+                        *args_offset,
+                        *args_size,
+                    );
+                }
                 // Keccak and logs only *read* memory. A read over a constant
                 // range observes only the stores that fall in it, so a later
                 // overwrite of a disjoint slot still kills its earlier store.

--- a/tests/ui/codegen/lowering/short_call_output.sol
+++ b/tests/ui/codegen/lowering/short_call_output.sol
@@ -1,0 +1,18 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: ShortCallOutput::shortOutput() => true, 7
+
+// EVM calls only copy the bytes that the callee returned. Bytes after that
+// remain unchanged, even when the requested output area is larger.
+contract ShortCallOutput {
+    function shortOutput() external returns (bool success, uint256 word) {
+        assembly {
+            mstore(0, 7)
+            // Invalid input makes ecrecover return no bytes successfully.
+            success := call(sub(0, 1), 1, 0, 0, 0, 0, 32)
+            word := mload(0)
+        }
+    }
+}


### PR DESCRIPTION
solsymdiff found a replay-confirmed mismatch where a zero-length call result erased an earlier word in the requested output area. EVM calls copy only the smaller of the requested size and returndata size, so memory DSE must not treat the whole nominal output range as a definite overwrite. The pass now preserves that store while retaining input-range reads, with runtime coverage across optimizer modes. This targets #1161 and was developed with AI assistance.