### PR TITLE
fix(codegen): preserve qualified modifiers

### DIFF
--- a/crates/codegen/src/lower/function/modifiers.rs
+++ b/crates/codegen/src/lower/function/modifiers.rs
@@ -69,15 +69,15 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         if modifier.id.as_contract().is_some() {
             return self.lower_modifier_at(modifiers, body, index + 1);
         }
-        let hir::ItemId::Function(modifier_id) = modifier.id else {
+        let Some(modifier_id) =
+            self.context.gcx.resolve_modifier_target(self.context.contract_id, modifier)
+        else {
             return report_unsupported(
                 self.context.gcx,
                 modifier.span,
                 "base constructor modifier",
             );
         };
-        let modifier_id =
-            self.context.gcx.resolve_virtual_function(self.context.contract_id, modifier_id);
         let modifier_function = self.context.gcx.hir.function(modifier_id);
         if modifier_function.kind == hir::FunctionKind::Constructor {
             return self.lower_modifier_at(modifiers, body, index + 1);

--- a/crates/sema/src/ty/call_graph.rs
+++ b/crates/sema/src/ty/call_graph.rs
@@ -293,8 +293,7 @@ impl<'gcx> Visit<'gcx> for CallGraphBuilder<'gcx> {
         &mut self,
         modifier: &'gcx hir::Modifier<'gcx>,
     ) -> ControlFlow<Self::BreakValue> {
-        if let hir::ItemId::Function(function) = modifier.id {
-            let function = self.gcx.resolve_virtual_function(self.contract, function);
+        if let Some(function) = self.gcx.resolve_modifier_target(self.contract, modifier) {
             self.enqueue(function);
         }
         self.walk_modifier(modifier)

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1339,6 +1339,22 @@ impl<'gcx> Gcx<'gcx> {
         self.virtual_function_target((contract, function))
     }
 
+    /// Resolves virtual dispatch for an unqualified modifier while preserving an explicitly
+    /// qualified target.
+    pub fn resolve_modifier_target(
+        self,
+        contract: hir::ContractId,
+        modifier: &hir::Modifier<'_>,
+    ) -> Option<hir::FunctionId> {
+        let hir::ItemId::Function(function) = modifier.id else {
+            return None;
+        };
+        if modifier.span.lo() != modifier.name_span.lo() {
+            return Some(function);
+        }
+        Some(self.resolve_virtual_function(contract, function))
+    }
+
     /// Resolves a `super` function call in the context of the most-derived contract.
     pub fn resolve_super_function(
         self,

--- a/tests/ui/codegen/lowering/qualified_modifier.sol
+++ b/tests/ui/codegen/lowering/qualified_modifier.sol
@@ -1,0 +1,31 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: Derived::qualified() => 9, 2
+//@ run-call: Derived::virtualDispatch() => 10, 1
+// ported-from: test/libsolidity/semanticTests/modifiers/access_through_contract_name.sol
+
+contract Base {
+    uint256 internal value;
+
+    modifier setValue() virtual {
+        value = 2;
+        _;
+    }
+}
+
+contract Derived is Base {
+    modifier setValue() override {
+        value = 1;
+        _;
+    }
+
+    function qualified() external Base.setValue returns (uint256, uint256) {
+        return (9, value);
+    }
+
+    function virtualDispatch() external setValue returns (uint256, uint256) {
+        return (10, value);
+    }
+}


### PR DESCRIPTION
solsymdiff found a replay-confirmed mismatch where Base.modifier on a derived function dispatched to the derived override. Explicitly qualified modifier targets are now preserved, while unqualified modifiers retain virtual dispatch in both call-graph construction and lowering. Runtime coverage checks both paths across optimizer modes. This targets #1161 and was developed with AI assistance.