### PR TITLE
fix(codegen): preserve require evaluation order

### DIFF
--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -272,6 +272,13 @@ struct ReturnTarget {
     states: Vec<LoopState>,
 }
 
+enum PreparedRevertPayload {
+    ShortString { length: ValueId, data: ValueId },
+    EmptyString,
+    ErrorString(ValueId),
+    CustomError { selector: ValueId, layout: Arc<AbiLayout>, values: Box<[ValueId]> },
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct StorageAccess {
     slot: ValueId,

--- a/crates/codegen/src/lower/function/builtins.rs
+++ b/crates/codegen/src/lower/function/builtins.rs
@@ -166,13 +166,17 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 let (required, message) = self.builtin_args_with_optional::<1>(builtin, &args)?;
                 let condition = required.first()?;
                 let condition = self.lower_expr(condition)?;
+                let message = match message {
+                    Some(message) => Some(self.prepare_revert_payload(message)?),
+                    None => None,
+                };
                 let is_false = self.builder.iszero(condition);
                 let revert_block = self.builder.create_block();
                 let continue_block = self.builder.create_block();
                 self.builder.branch(is_false, revert_block, continue_block);
                 self.builder.switch_to_block(revert_block);
                 if let Some(message) = message {
-                    self.lower_revert_payload(message)?;
+                    self.emit_revert_payload(message);
                 } else {
                     let zero = self.builder.imm_u256(U256::ZERO);
                     self.builder.revert(zero, zero);

--- a/crates/codegen/src/lower/function/statements.rs
+++ b/crates/codegen/src/lower/function/statements.rs
@@ -307,11 +307,20 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     }
 
     pub(super) fn lower_revert_payload(&mut self, expr: &hir::Expr<'_>) -> Option<()> {
+        let payload = self.prepare_revert_payload(expr)?;
+        self.emit_revert_payload(payload);
+        Some(())
+    }
+
+    pub(super) fn prepare_revert_payload(
+        &mut self,
+        expr: &hir::Expr<'_>,
+    ) -> Option<PreparedRevertPayload> {
         if let ExprKind::Call(callee, args, _) = &expr.kind
             && let Some(hir::Res::Item(hir::ItemId::Error(error_id))) =
                 self.context.gcx.resolved_expr(callee)
         {
-            return self.lower_custom_error_revert(error_id, *args);
+            return self.prepare_custom_error_payload(error_id, *args);
         }
 
         if let Some(bytes) = self.constant_string_bytes(expr)
@@ -319,10 +328,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         {
             let length = self.builder.imm_u64(bytes.as_byte_str().len() as u64);
             let data = self.lower_string_literal_word(bytes.as_byte_str());
-            let helper = self.ensure_revert_error_helper();
-            self.builder.internal_call_void(helper, vec![length, data], 0);
-            self.builder.invalid();
-            return Some(());
+            return Some(PreparedRevertPayload::ShortString { length, data });
         }
 
         let literal = expr.peel_parens();
@@ -331,36 +337,56 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 &lit.kind
             && bytes.as_byte_str().is_empty()
         {
-            let selector = keccak256("Error(string)");
-            let selector = self.builder.imm_u256(U256::from_be_slice(&selector[..4]) << 224);
-            let zero = self.builder.imm_u64(0);
-            self.builder.mstore(zero, selector);
-            let offset = self.builder.imm_u64(4);
-            let tuple_offset = self.builder.imm_u64(32);
-            self.builder.mstore(offset, tuple_offset);
-            let length = self.builder.imm_u64(36);
-            let byte_len = self.builder.imm_u64(0);
-            self.builder.mstore(length, byte_len);
-            let size = self.builder.imm_u64(68);
-            self.builder.revert(zero, size);
-            return Some(());
+            return Some(PreparedRevertPayload::EmptyString);
         }
 
         let ty = self.context.gcx.type_of_expr(expr.id)?;
         let memory_ty = ty.with_loc_if_ref(self.context.gcx, DataLocation::Memory);
         let value = self.lower_typed_expr(expr, memory_ty)?;
         let value = self.materialize_memory_argument(memory_ty, value, expr.span)?;
-        let selector = keccak256("Error(string)");
-        let selector = self.builder.imm_u256(U256::from_be_slice(&selector[..4]) << 224);
-        let layout = Arc::new(AbiLayout::new(
-            vec![AbiType::Bytes(SliceLocation::Memory)].into_boxed_slice(),
-        ));
-        let encoded =
-            self.builder.abi_encode(layout, Some(selector), vec![value].into_boxed_slice());
-        let pointer = self.builder.slice_ptr(encoded);
-        let length = self.builder.slice_len(encoded);
-        self.builder.revert(pointer, length);
-        Some(())
+        Some(PreparedRevertPayload::ErrorString(value))
+    }
+
+    pub(super) fn emit_revert_payload(&mut self, payload: PreparedRevertPayload) {
+        match payload {
+            PreparedRevertPayload::ShortString { length, data } => {
+                let helper = self.ensure_revert_error_helper();
+                self.builder.internal_call_void(helper, vec![length, data], 0);
+                self.builder.invalid();
+            }
+            PreparedRevertPayload::EmptyString => {
+                let selector = keccak256("Error(string)");
+                let selector = self.builder.imm_u256(U256::from_be_slice(&selector[..4]) << 224);
+                let zero = self.builder.imm_u64(0);
+                self.builder.mstore(zero, selector);
+                let offset = self.builder.imm_u64(4);
+                let tuple_offset = self.builder.imm_u64(32);
+                self.builder.mstore(offset, tuple_offset);
+                let length = self.builder.imm_u64(36);
+                let byte_len = self.builder.imm_u64(0);
+                self.builder.mstore(length, byte_len);
+                let size = self.builder.imm_u64(68);
+                self.builder.revert(zero, size);
+            }
+            PreparedRevertPayload::ErrorString(value) => {
+                let selector = keccak256("Error(string)");
+                let selector = self.builder.imm_u256(U256::from_be_slice(&selector[..4]) << 224);
+                let layout = Arc::new(AbiLayout::new(
+                    vec![AbiType::Bytes(SliceLocation::Memory)].into_boxed_slice(),
+                ));
+                let encoded =
+                    self.builder.abi_encode(layout, Some(selector), vec![value].into_boxed_slice());
+                let pointer = self.builder.slice_ptr(encoded);
+                let length = self.builder.slice_len(encoded);
+                self.builder.revert(pointer, length);
+            }
+            PreparedRevertPayload::CustomError { selector, layout, values } => {
+                let encoded = self.builder.abi_encode(layout, Some(selector), values);
+                let pointer = self.builder.slice_ptr(encoded);
+                let length = self.builder.slice_len(encoded);
+                self.builder.revert(pointer, length);
+            }
+        }
     }
 
     fn constant_string_bytes(&self, expr: &hir::Expr<'_>) -> Option<ByteSymbol> {
@@ -415,11 +441,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         id
     }
 
-    pub(super) fn lower_custom_error_revert(
+    fn prepare_custom_error_payload(
         &mut self,
         error_id: hir::ErrorId,
         args: hir::CallArgs<'_>,
-    ) -> Option<()> {
+    ) -> Option<PreparedRevertPayload> {
         let parameters = self.context.gcx.item_parameters(hir::ItemId::Error(error_id));
         if args.len() != parameters.len() {
             return report_unsupported(self.context.gcx, args.span, "error arguments");
@@ -446,11 +472,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let selector = self
             .builder
             .imm_u256(U256::from_be_slice(&self.context.gcx.function_selector(error_id).0) << 224);
-        let encoded = self.builder.abi_encode(layout, Some(selector), values.into_boxed_slice());
-        let pointer = self.builder.slice_ptr(encoded);
-        let length = self.builder.slice_len(encoded);
-        self.builder.revert(pointer, length);
-        Some(())
+        Some(PreparedRevertPayload::CustomError {
+            selector,
+            layout,
+            values: values.into_boxed_slice(),
+        })
     }
 
     pub(super) fn lower_emit(&mut self, expr: &hir::Expr<'_>) -> Option<()> {

--- a/tests/ui/codegen/lowering/custom_error_payloads.sol
+++ b/tests/ui/codegen/lowering/custom_error_payloads.sol
@@ -37,9 +37,9 @@ contract CustomErrorPayloads {
     }
 
     // CHECK-LABEL: fn @require_named{{[( ]}}
+    // CHECK: [[MESSAGE:v[0-9]+]] = alloc memorybytes
     // CHECK: [[FAIL:v[0-9]+]] = iszero arg0
     // CHECK: jumpi [[FAIL]],
-    // CHECK: [[MESSAGE:v[0-9]+]] = alloc memorybytes
     // CHECK: [[PAYLOAD:v[0-9]+]] = abi_encode [word, memory_bytes], selector 0x{{[0-9a-f]+}}, args 7, [[MESSAGE]]
     // CHECK: [[PTR:v[0-9]+]] = slice_ptr [[PAYLOAD]]
     // CHECK: [[LEN:v[0-9]+]] = slice_len [[PAYLOAD]]

--- a/tests/ui/codegen/lowering/custom_error_payloads.stdout
+++ b/tests/ui/codegen/lowering/custom_error_payloads.stdout
@@ -34,13 +34,13 @@ fn @require_empty(arg0: bool) [selector=0xfa8d4a29, pure, abi_args=lazy, abi_par
 
 fn @require_named(arg0: bool) [selector=0x868ff2e0, pure, abi_args=lazy, abi_params=[bool], abi_returns=[]] {
   bb0:
-    v0 = iszero arg0
-    jumpi v0, bb1, bb2
+    v0 = alloc memorybytes, exact, uninitialized, infallible, 64
+    set_memory_object_len memorybytes, v0, 6
+    memory_object_store_word memorybytes, v0, 0, 0x6661696c65640000000000000000000000000000000000000000000000000000
+    v1 = iszero arg0
+    jumpi v1, bb1, bb2
   bb1:
-    v1 = alloc memorybytes, exact, uninitialized, infallible, 64
-    set_memory_object_len memorybytes, v1, 6
-    memory_object_store_word memorybytes, v1, 0, 0x6661696c65640000000000000000000000000000000000000000000000000000
-    v2 = abi_encode [word, memory_bytes], selector 0xb9344e200000000000000000000000000000000000000000000000000000000, args 7, v1
+    v2 = abi_encode [word, memory_bytes], selector 0xb9344e200000000000000000000000000000000000000000000000000000000, args 7, v0
     v3 = slice_ptr v2
     v4 = slice_len v2
     revert v3, v4

--- a/tests/ui/codegen/lowering/require_evaluation_order.sol
+++ b/tests/ui/codegen/lowering/require_evaluation_order.sol
@@ -1,0 +1,58 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: RequireEvaluationOrder::customError() => 1
+//@ run-call: RequireEvaluationOrder::stringError() => 1
+//@ run-call: RequireEvaluationOrder::earlyReturn() => 7
+//@ run-call-fail: RequireEvaluationOrder::customFailure() => 0x002ff0670000000000000000000000000000000000000000000000000000000000000001
+//@ run-call-fail: RequireEvaluationOrder::stringFailure() => 0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000017800000000000000000000000000000000000000000000000000000000000000
+
+contract RequireEvaluationOrder {
+    error E(uint256);
+
+    uint256 private counter;
+
+    function customError() external returns (uint256) {
+        counter = 0;
+        require(true, E(increment()));
+        return counter;
+    }
+
+    function stringError() external returns (uint256) {
+        counter = 0;
+        require(true, reason());
+        return counter;
+    }
+
+    function earlyReturn() external pure returns (uint256) {
+        require(true, E(returnSeven()));
+        return 42;
+    }
+
+    function customFailure() external {
+        counter = 0;
+        require(false, E(increment()));
+    }
+
+    function stringFailure() external {
+        counter = 0;
+        require(false, reason());
+    }
+
+    function increment() internal returns (uint256) {
+        return ++counter;
+    }
+
+    function reason() internal returns (string memory) {
+        ++counter;
+        return "x";
+    }
+
+    function returnSeven() internal pure returns (uint256) {
+        assembly {
+            mstore(0, 7)
+            return(0, 32)
+        }
+    }
+}


### PR DESCRIPTION
Solidity evaluates a `require` error expression after its condition, even when the condition succeeds. This lowers the payload inputs before branching while leaving payload encoding on the failure path.

`solsymdiff` produced concretely replayed mismatches for side-effecting custom and string errors and for an early return under both optimized via-IR and unoptimized legacy compilation. Each case now reaches bounded agreement.

Developed with AI assistance.
