### PR TITLE
fix(codegen): handle storage reference expressions

### DIFF
--- a/crates/codegen/src/lower/function/storage_values.rs
+++ b/crates/codegen/src/lower/function/storage_values.rs
@@ -545,6 +545,12 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 self.builder.bounds_check(index, length);
                 self.storage_array_element_access(base.slot, index, element, dynamic, expr.span)
             }
+            ExprKind::Assign(lhs, None, rhs) if self.is_storage_reference_binding(lhs) => {
+                let access = self.storage_access(rhs)?;
+                let id = self.context.gcx.resolved_variable(lhs)?;
+                self.storage_refs.insert(id, access);
+                Some(access)
+            }
             ExprKind::Ternary(condition, then_expr, else_expr) => {
                 self.storage_access_ternary(condition, then_expr, else_expr)
             }

--- a/tests/ui/codegen/lowering/storage_reference_reassignment.sol
+++ b/tests/ui/codegen/lowering/storage_reference_reassignment.sol
@@ -8,6 +8,8 @@
 //@ run-call: packedYulRebind false, 3, 5, 17 => 17, 0, 0
 //@ run-call: packedYulRebind true, 3, 5, 17 => 17, 0, 0
 //@ run-call: yulPackedOffset 17 => 1
+//@ run-call: assignmentExpression 3, 5, 17 => 0, 17
+//@ run-call: mappingAssignmentExpression 3, 5, 17 => 1, 0, 0, 17
 
 contract StorageReferenceReassignment {
     struct Item {
@@ -108,6 +110,30 @@ contract StorageReferenceReassignment {
             let mask := shl(shift, 0xff)
             sstore(yulPacked.slot, or(and(sload(yulPacked.slot), not(mask)), shl(shift, value)))
         }
+    }
+
+    function assignmentExpression(uint256 first, uint256 second, uint256 value)
+        external
+        returns (uint256, uint256)
+    {
+        Item storage item = items[first];
+        (item = items[second]).a = value;
+        return (items[first].a, items[second].a);
+    }
+
+    function mappingAssignmentExpression(uint256 first, uint256 second, uint8 value)
+        external
+        returns (uint8, uint8, uint8, uint8)
+    {
+        mapping(uint256 => PackedItem) storage itemsRef = packedItems;
+        itemsRef[first].second = 1;
+        (itemsRef = otherPackedItems)[second].second = value;
+        return (
+            packedItems[first].second,
+            packedItems[second].second,
+            otherPackedItems[first].second,
+            otherPackedItems[second].second
+        );
     }
 
     function readB(Item storage item) internal view returns (uint256) {


### PR DESCRIPTION
Storage-reference assignment expressions updated the binding but then resolved the surrounding expression through the stale access. This returns the newly bound access from storage expression lowering so chained member and index writes use the assigned target.

`solsymdiff` replayed struct and mapping discrepancies under both optimized via-IR and unoptimized legacy compilation. Both now reach bounded agreement.

Developed with AI assistance.
