### PR TITLE
fix(codegen): coerce explicit returns

### DIFF
--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -113,6 +113,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     }
 
     pub(super) fn lower_return_values(&mut self, expr: &hir::Expr<'_>) -> Option<Vec<ValueId>> {
+        if self.returns.len() == 1 {
+            let ty = self.context.gcx.type_of_item(self.returns[0].into());
+            return Some(vec![self.lower_typed_expr(expr, ty)?]);
+        }
         if self.returns.len() > 1
             && let ExprKind::Tuple(values) = &expr.peel_parens().kind
             && values.len() == self.returns.len()

--- a/tests/ui/codegen/run-call/inline_assembly_scalar_cleanup.sol
+++ b/tests/ui/codegen/run-call/inline_assembly_scalar_cleanup.sol
@@ -8,6 +8,7 @@
 //@ run-call-fail: decrements() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
 //@ run-call-fail: negation() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
 //@ run-call: wideningConversions() => 0x78, 0x78
+//@ run-call: explicitWideningReturn() => 0x78
 //@ run-call: implicitReturn() => 0x78
 //@ run-call-fail: invalidEnum() => 0x4e487b710000000000000000000000000000000000000000000000000000000000000021
 //@ run-call: assemblyRead() => 0x0101
@@ -81,6 +82,14 @@ contract InlineAssemblyScalarCleanup {
         }
         assigned = value;
         called = widen(value);
+    }
+
+    function explicitWideningReturn() external pure returns (uint256) {
+        uint8 value;
+        assembly {
+            value := 0x12345678
+        }
+        return value;
     }
 
     function implicitReturn() external pure returns (uint8 value) {


### PR DESCRIPTION
A single explicit return was lowered without its declared destination type, so a narrow value dirtied by inline assembly could be widened without cleanup. Route this path through the existing typed-expression coercion used by assignments and calls.

`solsymdiff` concretely replayed a `uint8` local holding the raw assembly word `0xffff` escaping as `uint256(0xffff)`, while solc returned `0xff`; optimized via-IR and unoptimized legacy compilation now reach bounded agreement. The pinned 18-project corpus remains byte-for-byte unchanged in every size-reporting case.

Developed with AI assistance.
