### PR TITLE
fix(codegen): discard static item expressions

### DIFF
--- a/crates/codegen/src/lower/function/statements.rs
+++ b/crates/codegen/src/lower/function/statements.rs
@@ -137,7 +137,22 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 }
             }
             StmtKind::Expr(expr) => {
-                if let ExprKind::Assign(lhs, None, rhs) = &expr.peel_parens().kind
+                let expr = expr.peel_parens();
+                let is_item_reference = matches!(
+                    self.context.gcx.type_of_expr(expr.id).map(|ty| ty.kind),
+                    Some(TyKind::Type(_))
+                ) || matches!(
+                    expr.kind,
+                    ExprKind::Member(receiver, _)
+                        if matches!(
+                            self.context.gcx.type_of_expr(receiver.id).map(|ty| ty.kind),
+                            Some(TyKind::Type(_))
+                        )
+                );
+                if is_item_reference {
+                    return Some(());
+                }
+                if let ExprKind::Assign(lhs, None, rhs) = &expr.kind
                     && self.is_constant_storage_assignment(lhs, rhs)
                 {
                     self.lower_constant_storage_assignment(lhs, rhs)?;

--- a/tests/ui/codegen/lowering/stray_item_expressions.sol
+++ b/tests/ui/codegen/lowering/stray_item_expressions.sol
@@ -1,0 +1,33 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: f 33 => 42
+// ported-from: test/libsolidity/semanticTests/libraries/library_enum_as_an_expression.sol
+// ported-from: test/libsolidity/semanticTests/libraries/library_stray_values.sol
+// ported-from: test/libsolidity/semanticTests/libraries/library_struct_as_an_expression.sol
+
+library Lib {
+    enum Kind {
+        A,
+        B
+    }
+
+    struct Item {
+        uint256 value;
+    }
+
+    function multiply(uint256 x, uint256 y) public pure returns (uint256) {
+        return x * y;
+    }
+}
+
+contract StrayItemExpressions {
+    function f(uint256 x) external pure returns (uint256) {
+        Lib;
+        Lib.Kind;
+        Lib.Item;
+        Lib.multiply;
+        return x + 9;
+    }
+}


### PR DESCRIPTION
Standalone library, library-member, and type references have no runtime effect, but expression-statement lowering tried to materialize them and replaced the containing function with `INVALID` after reporting an unsupported expression. Discard only statically resolved item references while preserving normal lowering for value expressions.

`solsymdiff` found this independently in the upstream library enum, struct, and stray-value semantic fixtures. All three concretely replayed under optimized via-IR and unoptimized legacy compilation; all six comparisons now reach bounded agreement. The pinned 18-case codegen corpus remains byte-for-byte unchanged.

Developed with AI assistance.
