### PR TITLE
feat(lsp): accept resolved Foundry configs

### DIFF
--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -24,25 +24,29 @@ When the host has already resolved Foundry workspace configuration (including `e
 provide the effective values directly:
 
 ```rust,no_run
-# use std::path::PathBuf;
+# fn build_config() -> Result<(), Box<dyn std::error::Error>> {
 # use solar_config::EvmVersion;
+let workspace = std::env::current_dir()?.join("workspace");
 let config = solar_lsp::LaunchConfig::default().with_foundry_workspace_config(
-    solar_lsp::FoundryWorkspaceConfig::new("/workspace")
-        .with_source_roots([PathBuf::from("/workspace/src")])
-        .with_flycheck_source_roots([PathBuf::from("/workspace/src")])
-        .with_include_paths([PathBuf::from("/workspace/lib")])
+    solar_lsp::FoundryWorkspaceConfig::new(&workspace)
+        .with_source_roots([workspace.join("src")])
+        .with_flycheck_source_roots([workspace.join("src")])
+        .with_include_paths([workspace.join("lib")])
         .with_evm_version(EvmVersion::Cancun),
 );
+# let _ = config;
+# Ok(())
+# }
 ```
 
-The workspace root and path fields in this snapshot are canonical absolute paths; matching folds
-redundant path components but does not resolve symlinks. Import remappings are final
-`solar_config::ImportRemapping` values and are passed through unchanged; as with
-`CompileOpts`, a relative remapping target is interpreted relative to the workspace base path.
+The workspace root and path fields in this snapshot must be absolute. `LaunchConfig` validates and
+lexically normalizes them without accessing the filesystem or resolving symlinks. Import
+remappings are final `solar_config::ImportRemapping` values and are passed through unchanged; as
+with `CompileOpts`, a relative remapping target is interpreted relative to the workspace base path.
 The language server matches each snapshot only to the exact manifest directory, so multiple or
 nested manifests remain isolated. The snapshot is launch-time state reused during rediscovery; the
-host should build a new `LaunchConfig` for changed Foundry settings. An unmatched manifest continues
-to use its local `foundry.toml` parser.
+host should build a new `LaunchConfig` for changed Foundry settings. An unmatched manifest
+continues to use its local `foundry.toml` parser.
 
 An embedding executable that also provides Forge commands can use its own path as the default, as
 shown above. Other hosts should supply the path to their Forge executable instead.

--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -20,6 +20,30 @@ An embedding host that already selected a Foundry profile can pass it through wi
 `with_selected_profile("custom")`; the language server uses that profile when discovering workspace
 sources and when running its automatically configured Forge lint checks.
 
+When the host has already resolved Foundry workspace configuration (including `extends`), it can
+provide the effective values directly:
+
+```rust,no_run
+# use std::path::PathBuf;
+# use solar_config::EvmVersion;
+let config = solar_lsp::LaunchConfig::default().with_foundry_workspace_config(
+    solar_lsp::FoundryWorkspaceConfig::new("/workspace")
+        .with_source_roots([PathBuf::from("/workspace/src")])
+        .with_flycheck_source_roots([PathBuf::from("/workspace/src")])
+        .with_include_paths([PathBuf::from("/workspace/lib")])
+        .with_evm_version(EvmVersion::Cancun),
+);
+```
+
+The workspace root and path fields in this snapshot are canonical absolute paths; matching folds
+redundant path components but does not resolve symlinks. Import remappings are final
+`solar_config::ImportRemapping` values and are passed through unchanged; as with
+`CompileOpts`, a relative remapping target is interpreted relative to the workspace base path.
+The language server matches each snapshot only to the exact manifest directory, so multiple or
+nested manifests remain isolated. The snapshot is launch-time state reused during rediscovery; the
+host should build a new `LaunchConfig` for changed Foundry settings. An unmatched manifest continues
+to use its local `foundry.toml` parser.
+
 An embedding executable that also provides Forge commands can use its own path as the default, as
 shown above. Other hosts should supply the path to their Forge executable instead.
 

--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -16,39 +16,6 @@ solar_lsp::launch(config).await?;
 # }
 ```
 
-An embedding host that already selected a Foundry profile can pass it through with
-`with_selected_profile("custom")`; the language server uses that profile when discovering workspace
-sources and when running its automatically configured Forge lint checks.
-
-When the host has already resolved Foundry workspace configuration (including `extends`), it can
-provide the effective values directly:
-
-```rust,no_run
-# fn build_config() -> Result<(), Box<dyn std::error::Error>> {
-# use solar_config::EvmVersion;
-let workspace = std::env::current_dir()?.join("workspace");
-let config = solar_lsp::LaunchConfig::default().with_foundry_workspace_config(
-    solar_lsp::FoundryWorkspaceConfig::new(&workspace)
-        .with_source_roots(["src"])
-        .with_flycheck_source_roots(["src", "test", "script"])
-        .with_include_paths(["lib"])
-        .with_evm_version(EvmVersion::Cancun),
-);
-# let _ = config;
-# Ok(())
-# }
-```
-
-The workspace root in this snapshot must be absolute. Source, flycheck, and include paths may be
-absolute or relative to that workspace root. `LaunchConfig` resolves relative paths and lexically
-normalizes all paths without accessing the filesystem or resolving symlinks. Import remappings are
-final `solar_config::ImportRemapping` values and are passed through unchanged; as with
-`CompileOpts`, a relative remapping target is interpreted relative to the workspace base path.
-The language server matches each snapshot only to the exact manifest directory, so multiple or
-nested manifests remain isolated. The snapshot is launch-time state reused during rediscovery; the
-host should build a new `LaunchConfig` for changed Foundry settings. An unmatched manifest
-continues to use its local `foundry.toml` parser.
-
 An embedding executable that also provides Forge commands can use its own path as the default, as
 shown above. Other hosts should supply the path to their Forge executable instead.
 

--- a/crates/lsp/README.md
+++ b/crates/lsp/README.md
@@ -29,9 +29,9 @@ provide the effective values directly:
 let workspace = std::env::current_dir()?.join("workspace");
 let config = solar_lsp::LaunchConfig::default().with_foundry_workspace_config(
     solar_lsp::FoundryWorkspaceConfig::new(&workspace)
-        .with_source_roots([workspace.join("src")])
-        .with_flycheck_source_roots([workspace.join("src")])
-        .with_include_paths([workspace.join("lib")])
+        .with_source_roots(["src"])
+        .with_flycheck_source_roots(["src", "test", "script"])
+        .with_include_paths(["lib"])
         .with_evm_version(EvmVersion::Cancun),
 );
 # let _ = config;
@@ -39,10 +39,11 @@ let config = solar_lsp::LaunchConfig::default().with_foundry_workspace_config(
 # }
 ```
 
-The workspace root and path fields in this snapshot must be absolute. `LaunchConfig` validates and
-lexically normalizes them without accessing the filesystem or resolving symlinks. Import
-remappings are final `solar_config::ImportRemapping` values and are passed through unchanged; as
-with `CompileOpts`, a relative remapping target is interpreted relative to the workspace base path.
+The workspace root in this snapshot must be absolute. Source, flycheck, and include paths may be
+absolute or relative to that workspace root. `LaunchConfig` resolves relative paths and lexically
+normalizes all paths without accessing the filesystem or resolving symlinks. Import remappings are
+final `solar_config::ImportRemapping` values and are passed through unchanged; as with
+`CompileOpts`, a relative remapping target is interpreted relative to the workspace base path.
 The language server matches each snapshot only to the exact manifest directory, so multiple or
 nested manifests remain isolated. The snapshot is launch-time state reused during rediscovery; the
 host should build a new `LaunchConfig` for changed Foundry settings. An unmatched manifest

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,11 +1,11 @@
 use crate::{
-    FoundryWorkspaceConfig, commands,
+    FoundryWorkspaceConfig, LaunchConfig, commands,
     diagnostics::DiagnosticOwner,
     file_operations::FileMoveBatch,
     flycheck::{FlycheckConfig, FlycheckInitializationOptions},
     import_resolution::ImportResolutionContext,
     workspace::{
-        SourceWatchRoot, Workspace, WorkspaceKind, WorkspacePathIndex,
+        FoundryConfigContext, SourceWatchRoot, Workspace, WorkspaceKind, WorkspacePathIndex,
         index_policy::{
             IndexingCancellation, IndexingOptions, WorkspaceIndexMetrics, WorkspaceIndexPolicy,
         },
@@ -686,6 +686,10 @@ impl Config {
         let mut manifest_watch_roots = Vec::new();
         let mut git_marker_watch_roots = Vec::new();
         let mut seen_manifests = FxHashSet::default();
+        let foundry_config = FoundryConfigContext::new(
+            self.selected_profile.as_deref(),
+            &self.foundry_workspace_configs,
+        );
         for root in &self.workspace_roots {
             if cancellation.is_cancelled() {
                 return None;
@@ -697,8 +701,7 @@ impl Config {
                     &self.index_policy,
                     cancellation,
                     &mut metrics,
-                    self.selected_profile.as_deref(),
-                    &self.foundry_workspace_configs,
+                    foundry_config,
                 )?;
             manifest_watch_roots.extend(discovered_watch_roots);
             git_marker_watch_roots.extend(discovered_marker_watch_roots);
@@ -712,8 +715,7 @@ impl Config {
             load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
-                self.selected_profile.as_deref(),
-                &self.foundry_workspace_configs,
+                foundry_config,
                 &mut seen_manifests,
                 &mut workspaces,
             );
@@ -749,8 +751,7 @@ impl Config {
             if load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
-                self.selected_profile.as_deref(),
-                &self.foundry_workspace_configs,
+                foundry_config,
                 &mut seen_manifests,
                 &mut workspaces,
             ) == 0
@@ -883,8 +884,7 @@ impl Config {
 fn load_discovered_workspaces(
     manifests: impl IntoIterator<Item = ProjectManifest>,
     workspace_roots: &[PathBuf],
-    selected_profile: Option<&str>,
-    foundry_workspace_configs: &[FoundryWorkspaceConfig],
+    foundry_config: FoundryConfigContext<'_>,
     seen_manifests: &mut FxHashSet<ProjectManifest>,
     workspaces: &mut Vec<Workspace>,
 ) -> usize {
@@ -896,12 +896,7 @@ fn load_discovered_workspaces(
         match manifest {
             ProjectManifest::Foundry(path) => {
                 let fallback_root = path.parent().map(PathBuf::from);
-                match Workspace::load_foundry_bounded(
-                    path,
-                    workspace_roots,
-                    selected_profile,
-                    foundry_workspace_configs,
-                ) {
+                match Workspace::load_foundry_bounded(path, workspace_roots, foundry_config) {
                     Ok(workspace) => workspaces.push(workspace),
                     Err(error) => {
                         warn!(%error, "failed to load workspace");
@@ -975,15 +970,13 @@ fn workspace_roots_from_initialize(
 
 #[cfg(any(test, feature = "bench"))]
 pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabilities, Config) {
-    negotiate_capabilities_with_pull_diagnostic_data(params, false, None, None, &[])
+    negotiate_capabilities_with_pull_diagnostic_data(params, false, &LaunchConfig::default())
 }
 
 pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
     params: InitializeParams,
     pull_diagnostics_data: bool,
-    default_forge_path: Option<&Path>,
-    selected_profile: Option<&str>,
-    foundry_workspace_configs: &[FoundryWorkspaceConfig],
+    launch_config: &LaunchConfig,
 ) -> (ServerCapabilities, Config) {
     let capabilities = params.capabilities;
     let initialization_options = params.initialization_options;
@@ -994,7 +987,7 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
         .as_ref()
         .and_then(|options| options.get("forgePath"))
         .and_then(|path| serde_json::from_value::<PathBuf>(path.clone()).ok())
-        .or_else(|| default_forge_path.map(Path::to_path_buf))
+        .or_else(|| launch_config.default_forge_path().map(Path::to_path_buf))
         .unwrap_or_else(|| PathBuf::from("forge"));
     let flycheck_options = FlycheckInitializationOptions::from_json(initialization_options.clone());
     let indexing_options = IndexingOptions::from_json(initialization_options.clone());
@@ -1204,8 +1197,8 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
         Config {
             workspace_roots,
             forge_path,
-            selected_profile: selected_profile.map(str::to_owned),
-            foundry_workspace_configs: foundry_workspace_configs.to_vec(),
+            selected_profile: launch_config.selected_profile().map(str::to_owned),
+            foundry_workspace_configs: launch_config.foundry_workspace_configs().to_vec(),
             index_policy,
             flycheck_options,
             watched_file_dynamic_registration,
@@ -1772,8 +1765,11 @@ mod tests {
                     ..Default::default()
                 });
 
-                let (_, config) =
-                    negotiate_capabilities_with_pull_diagnostic_data(params, pull, None, None, &[]);
+                let (_, config) = negotiate_capabilities_with_pull_diagnostic_data(
+                    params,
+                    pull,
+                    &LaunchConfig::default(),
+                );
 
                 let expected_publish = delivery == DiagnosticDelivery::Push && publish;
                 let expected_pull = delivery == DiagnosticDelivery::Pull && pull;
@@ -2112,12 +2108,11 @@ mod tests {
         let (_, default_config) = negotiate_capabilities(InitializeParams::default());
         assert_eq!(default_config.forge_path(), PathBuf::from("forge"));
 
+        let launch_config = LaunchConfig::default().with_default_forge_path("/embedded/forge");
         let (_, embedded_config) = negotiate_capabilities_with_pull_diagnostic_data(
             InitializeParams::default(),
             false,
-            Some(Path::new("/embedded/forge")),
-            None,
-            &[],
+            &launch_config,
         );
         assert_eq!(embedded_config.forge_path(), PathBuf::from("/embedded/forge"));
 
@@ -2128,13 +2123,8 @@ mod tests {
             ..Default::default()
         };
 
-        let (_, config) = negotiate_capabilities_with_pull_diagnostic_data(
-            params,
-            false,
-            Some(Path::new("/embedded/forge")),
-            None,
-            &[],
-        );
+        let (_, config) =
+            negotiate_capabilities_with_pull_diagnostic_data(params, false, &launch_config);
 
         assert_eq!(config.forge_path(), PathBuf::from("/tools/forge"));
     }

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands,
+    FoundryWorkspaceConfig, commands,
     diagnostics::DiagnosticOwner,
     file_operations::FileMoveBatch,
     flycheck::{FlycheckConfig, FlycheckInitializationOptions},
@@ -48,6 +48,7 @@ pub(crate) struct Config {
     workspace_roots: Vec<PathBuf>,
     forge_path: PathBuf,
     selected_profile: Option<String>,
+    foundry_workspace_configs: Vec<FoundryWorkspaceConfig>,
     workspaces: Vec<Workspace>,
     manifest_watch_roots: Vec<SourceWatchRoot>,
     git_marker_watch_roots: Vec<PathBuf>,
@@ -131,6 +132,7 @@ impl Default for Config {
             workspace_roots: Vec::new(),
             forge_path: PathBuf::from("forge"),
             selected_profile: None,
+            foundry_workspace_configs: Vec::new(),
             workspaces: Vec::new(),
             manifest_watch_roots: Vec::new(),
             git_marker_watch_roots: Vec::new(),
@@ -696,6 +698,7 @@ impl Config {
                     cancellation,
                     &mut metrics,
                     self.selected_profile.as_deref(),
+                    &self.foundry_workspace_configs,
                 )?;
             manifest_watch_roots.extend(discovered_watch_roots);
             git_marker_watch_roots.extend(discovered_marker_watch_roots);
@@ -710,6 +713,7 @@ impl Config {
                 discovered,
                 &self.workspace_roots,
                 self.selected_profile.as_deref(),
+                &self.foundry_workspace_configs,
                 &mut seen_manifests,
                 &mut workspaces,
             );
@@ -746,6 +750,7 @@ impl Config {
                 discovered,
                 &self.workspace_roots,
                 self.selected_profile.as_deref(),
+                &self.foundry_workspace_configs,
                 &mut seen_manifests,
                 &mut workspaces,
             ) == 0
@@ -879,6 +884,7 @@ fn load_discovered_workspaces(
     manifests: impl IntoIterator<Item = ProjectManifest>,
     workspace_roots: &[PathBuf],
     selected_profile: Option<&str>,
+    foundry_workspace_configs: &[FoundryWorkspaceConfig],
     seen_manifests: &mut FxHashSet<ProjectManifest>,
     workspaces: &mut Vec<Workspace>,
 ) -> usize {
@@ -890,7 +896,12 @@ fn load_discovered_workspaces(
         match manifest {
             ProjectManifest::Foundry(path) => {
                 let fallback_root = path.parent().map(PathBuf::from);
-                match Workspace::load_foundry_bounded(path, workspace_roots, selected_profile) {
+                match Workspace::load_foundry_bounded(
+                    path,
+                    workspace_roots,
+                    selected_profile,
+                    foundry_workspace_configs,
+                ) {
                     Ok(workspace) => workspaces.push(workspace),
                     Err(error) => {
                         warn!(%error, "failed to load workspace");
@@ -964,7 +975,7 @@ fn workspace_roots_from_initialize(
 
 #[cfg(any(test, feature = "bench"))]
 pub(crate) fn negotiate_capabilities(params: InitializeParams) -> (ServerCapabilities, Config) {
-    negotiate_capabilities_with_pull_diagnostic_data(params, false, None, None)
+    negotiate_capabilities_with_pull_diagnostic_data(params, false, None, None, &[])
 }
 
 pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
@@ -972,6 +983,7 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
     pull_diagnostics_data: bool,
     default_forge_path: Option<&Path>,
     selected_profile: Option<&str>,
+    foundry_workspace_configs: &[FoundryWorkspaceConfig],
 ) -> (ServerCapabilities, Config) {
     let capabilities = params.capabilities;
     let initialization_options = params.initialization_options;
@@ -1193,6 +1205,7 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
             workspace_roots,
             forge_path,
             selected_profile: selected_profile.map(str::to_owned),
+            foundry_workspace_configs: foundry_workspace_configs.to_vec(),
             index_policy,
             flycheck_options,
             watched_file_dynamic_registration,
@@ -1760,7 +1773,7 @@ mod tests {
                 });
 
                 let (_, config) =
-                    negotiate_capabilities_with_pull_diagnostic_data(params, pull, None, None);
+                    negotiate_capabilities_with_pull_diagnostic_data(params, pull, None, None, &[]);
 
                 let expected_publish = delivery == DiagnosticDelivery::Push && publish;
                 let expected_pull = delivery == DiagnosticDelivery::Pull && pull;
@@ -2104,6 +2117,7 @@ mod tests {
             false,
             Some(Path::new("/embedded/forge")),
             None,
+            &[],
         );
         assert_eq!(embedded_config.forge_path(), PathBuf::from("/embedded/forge"));
 
@@ -2119,6 +2133,7 @@ mod tests {
             false,
             Some(Path::new("/embedded/forge")),
             None,
+            &[],
         );
 
         assert_eq!(config.forge_path(), PathBuf::from("/tools/forge"));

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -627,6 +627,7 @@ impl GlobalState {
             pull_diagnostic_data_support,
             self.launch_config.default_forge_path(),
             self.launch_config.selected_profile(),
+            self.launch_config.foundry_workspace_configs(),
         );
 
         self.analysis_progress.set_enabled(config.supports_work_done_progress());

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -625,9 +625,7 @@ impl GlobalState {
         let (capabilities, config) = negotiate_capabilities_with_pull_diagnostic_data(
             params,
             pull_diagnostic_data_support,
-            self.launch_config.default_forge_path(),
-            self.launch_config.selected_profile(),
-            self.launch_config.foundry_workspace_configs(),
+            &self.launch_config,
         );
 
         self.analysis_progress.set_enabled(config.supports_work_done_progress());

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -13,8 +13,9 @@ use async_lsp::{
 #[cfg(test)]
 use criterion as _;
 use lsp_types::{notification as notif, request as req};
+use normalize_path::NormalizePath;
 use serde_json as _;
-use solar_config::LspArgs;
+use solar_config::{EvmVersion, ImportRemapping, LspArgs};
 use std::{
     ops::ControlFlow,
     path::{Path, PathBuf},
@@ -27,6 +28,120 @@ pub struct LaunchConfig {
     default_forge_path: Option<PathBuf>,
     /// Foundry profile selected by the embedding host, if any.
     selected_profile: Option<String>,
+    /// Effective Foundry workspace configurations supplied by the embedding host.
+    foundry_workspace_configs: Vec<FoundryWorkspaceConfig>,
+}
+
+/// Effective Foundry configuration for one workspace supplied by an embedding host.
+///
+/// `workspace_root` is the canonical absolute directory containing that workspace's
+/// `foundry.toml`. The `PathBuf` fields must also be canonical absolute paths; root matching folds
+/// redundant path components but does not resolve symlinks. Remapping target strings are final
+/// [`ImportRemapping`] values and are passed through unchanged. These values are
+/// already resolved by the host, including any inherited profiles and remappings. When this
+/// configuration matches a workspace, the language server uses these values as-is: it does not
+/// parse the local profile, read `remappings.txt`, or autodetect library remappings. The snapshot
+/// is captured when [`LaunchConfig`] is built and is reused for rediscovery during that LSP
+/// session; rebuild the launch configuration when Foundry configuration changes.
+#[derive(Clone, Debug, Default)]
+pub struct FoundryWorkspaceConfig {
+    /// Canonical absolute directory containing the workspace manifest.
+    pub workspace_root: PathBuf,
+    /// Effective source roots used for workspace indexing.
+    pub source_roots: Vec<PathBuf>,
+    /// Effective source roots used for flycheck indexing (including tests and scripts).
+    pub flycheck_source_roots: Vec<PathBuf>,
+    /// Effective Foundry library/include paths.
+    pub include_paths: Vec<PathBuf>,
+    /// Final import remappings after all host-side resolution.
+    pub import_remappings: Vec<ImportRemapping>,
+    /// Effective EVM version, if the selected Foundry configuration supplied one.
+    pub evm_version: Option<EvmVersion>,
+}
+
+impl FoundryWorkspaceConfig {
+    /// Creates an empty resolved configuration for `workspace_root`.
+    ///
+    /// The root and all paths supplied to the builder must be canonical absolute paths. Hosts
+    /// should provide every effective value they want the compiler to use.
+    pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
+        Self { workspace_root: workspace_root.into(), ..Self::default() }
+    }
+
+    /// Sets the effective workspace source roots.
+    pub fn with_source_roots<I, P>(mut self, roots: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.source_roots = roots.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the effective source roots used by flycheck.
+    pub fn with_flycheck_source_roots<I, P>(mut self, roots: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.flycheck_source_roots = roots.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the effective Foundry library/include paths.
+    pub fn with_include_paths<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.include_paths = paths.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Sets the final host-resolved import remappings.
+    pub fn with_import_remappings<I>(mut self, remappings: I) -> Self
+    where
+        I: IntoIterator<Item = ImportRemapping>,
+    {
+        self.import_remappings = remappings.into_iter().collect();
+        self
+    }
+
+    /// Sets the effective EVM version.
+    pub fn with_evm_version(mut self, evm_version: EvmVersion) -> Self {
+        self.evm_version = Some(evm_version);
+        self
+    }
+
+    /// Returns the workspace root used for exact manifest matching.
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    /// Returns the effective source roots.
+    pub fn source_roots(&self) -> &[PathBuf] {
+        &self.source_roots
+    }
+
+    /// Returns the effective flycheck source roots.
+    pub fn flycheck_source_roots(&self) -> &[PathBuf] {
+        &self.flycheck_source_roots
+    }
+
+    /// Returns the effective include paths.
+    pub fn include_paths(&self) -> &[PathBuf] {
+        &self.include_paths
+    }
+
+    /// Returns the final host-resolved import remappings.
+    pub fn import_remappings(&self) -> &[ImportRemapping] {
+        &self.import_remappings
+    }
+
+    /// Returns the effective EVM version, if one was supplied.
+    pub fn evm_version(&self) -> Option<EvmVersion> {
+        self.evm_version
+    }
 }
 
 impl From<LspArgs> for LaunchConfig {
@@ -48,12 +163,47 @@ impl LaunchConfig {
         self
     }
 
+    /// Supplies an already-resolved Foundry workspace configuration.
+    ///
+    /// The configuration is keyed by its exact canonical workspace root. Calling this method
+    /// again for the same root replaces the earlier snapshot; configurations for other roots are
+    /// retained. The snapshot is reused for workspace rediscovery until a new LSP launch.
+    pub fn with_foundry_workspace_config(mut self, config: FoundryWorkspaceConfig) -> Self {
+        let mut config = config;
+        config.workspace_root = config.workspace_root.normalize();
+        if let Some(existing) = self
+            .foundry_workspace_configs
+            .iter_mut()
+            .find(|existing| existing.workspace_root.normalize() == config.workspace_root)
+        {
+            *existing = config;
+        } else {
+            self.foundry_workspace_configs.push(config);
+        }
+        self
+    }
+
+    /// Supplies already-resolved configurations for multiple Foundry workspaces.
+    pub fn with_foundry_workspace_configs(
+        mut self,
+        configs: impl IntoIterator<Item = FoundryWorkspaceConfig>,
+    ) -> Self {
+        for config in configs {
+            self = self.with_foundry_workspace_config(config);
+        }
+        self
+    }
+
     pub(crate) fn default_forge_path(&self) -> Option<&Path> {
         self.default_forge_path.as_deref()
     }
 
     pub(crate) fn selected_profile(&self) -> Option<&str> {
         self.selected_profile.as_deref()
+    }
+
+    pub(crate) fn foundry_workspace_configs(&self) -> &[FoundryWorkspaceConfig] {
+        &self.foundry_workspace_configs
     }
 }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -35,12 +35,13 @@ pub struct LaunchConfig {
 /// Effective Foundry configuration for one workspace supplied by an embedding host.
 ///
 /// `workspace_root` is the absolute directory containing that workspace's `foundry.toml`. When the
-/// configuration enters [`LaunchConfig`], its path fields are validated as absolute and lexically
-/// normalized without accessing the filesystem or resolving symlinks. Remapping target strings are
-/// final [`ImportRemapping`] values and are passed through unchanged. These values are already
-/// resolved by the host, including any inherited profiles and remappings. When this configuration
-/// matches a workspace, the language server uses these values as-is: it does not parse the local
-/// profile, read `remappings.txt`, or autodetect library remappings. The snapshot is captured when
+/// configuration enters [`LaunchConfig`], the root is validated as absolute and its source,
+/// flycheck, and include paths are resolved against it before lexical normalization. This does not
+/// access the filesystem or resolve symlinks. Remapping target strings are final
+/// [`ImportRemapping`] values and are passed through unchanged. These values are already resolved
+/// by the host, including any inherited profiles and remappings. When this configuration matches a
+/// workspace, the language server uses these values as-is: it does not parse the local profile,
+/// read `remappings.txt`, or autodetect library remappings. The snapshot is captured when
 /// [`LaunchConfig`] is built and is reused for rediscovery during that LSP session; rebuild the
 /// launch configuration when Foundry configuration changes.
 #[derive(Clone, Debug)]
@@ -150,10 +151,12 @@ impl FoundryWorkspaceConfig {
     }
 
     fn into_normalized(mut self) -> Self {
-        self.workspace_root = normalize_foundry_workspace_path(self.workspace_root);
-        self.source_roots = normalize_foundry_workspace_paths(self.source_roots);
-        self.flycheck_source_roots = normalize_foundry_workspace_paths(self.flycheck_source_roots);
-        self.include_paths = normalize_foundry_workspace_paths(self.include_paths);
+        self.workspace_root = normalize_foundry_workspace_root(self.workspace_root);
+        let root = &self.workspace_root;
+        self.source_roots = resolve_foundry_workspace_paths(root, self.source_roots);
+        self.flycheck_source_roots =
+            resolve_foundry_workspace_paths(root, self.flycheck_source_roots);
+        self.include_paths = resolve_foundry_workspace_paths(root, self.include_paths);
         self
     }
 }
@@ -179,13 +182,14 @@ impl LaunchConfig {
 
     /// Supplies an already-resolved Foundry workspace configuration.
     ///
-    /// The configuration is keyed by its exact normalized workspace root. Calling this method
+    /// The configuration is keyed by its exact normalized workspace root. Relative source,
+    /// flycheck, and include paths are interpreted relative to that root. Calling this method
     /// again for the same root replaces the earlier snapshot; configurations for other roots are
     /// retained. The snapshot is reused for workspace rediscovery until a new LSP launch.
     ///
     /// # Panics
     ///
-    /// Panics if the workspace root or any configured path is not absolute.
+    /// Panics if the workspace root is not absolute.
     pub fn with_foundry_workspace_config(mut self, config: FoundryWorkspaceConfig) -> Self {
         let config = config.into_normalized();
         if let Some(existing) = self
@@ -224,18 +228,18 @@ impl LaunchConfig {
     }
 }
 
-fn normalize_foundry_workspace_path(path: impl Into<PathBuf>) -> PathBuf {
+fn normalize_foundry_workspace_root(path: impl Into<PathBuf>) -> PathBuf {
     let path = path.into();
     assert!(
         path.is_absolute(),
-        "Foundry workspace config paths must be absolute: `{}`",
+        "Foundry workspace config root must be absolute: `{}`",
         path.display()
     );
     path.normalize()
 }
 
-fn normalize_foundry_workspace_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
-    paths.into_iter().map(normalize_foundry_workspace_path).collect()
+fn resolve_foundry_workspace_paths(root: &Path, paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    paths.into_iter().map(|path| root.join(path).normalize()).collect()
 }
 
 mod call_hierarchy;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -34,38 +34,44 @@ pub struct LaunchConfig {
 
 /// Effective Foundry configuration for one workspace supplied by an embedding host.
 ///
-/// `workspace_root` is the canonical absolute directory containing that workspace's
-/// `foundry.toml`. The `PathBuf` fields must also be canonical absolute paths; root matching folds
-/// redundant path components but does not resolve symlinks. Remapping target strings are final
-/// [`ImportRemapping`] values and are passed through unchanged. These values are
-/// already resolved by the host, including any inherited profiles and remappings. When this
-/// configuration matches a workspace, the language server uses these values as-is: it does not
-/// parse the local profile, read `remappings.txt`, or autodetect library remappings. The snapshot
-/// is captured when [`LaunchConfig`] is built and is reused for rediscovery during that LSP
-/// session; rebuild the launch configuration when Foundry configuration changes.
-#[derive(Clone, Debug, Default)]
+/// `workspace_root` is the absolute directory containing that workspace's `foundry.toml`. When the
+/// configuration enters [`LaunchConfig`], its path fields are validated as absolute and lexically
+/// normalized without accessing the filesystem or resolving symlinks. Remapping target strings are
+/// final [`ImportRemapping`] values and are passed through unchanged. These values are already
+/// resolved by the host, including any inherited profiles and remappings. When this configuration
+/// matches a workspace, the language server uses these values as-is: it does not parse the local
+/// profile, read `remappings.txt`, or autodetect library remappings. The snapshot is captured when
+/// [`LaunchConfig`] is built and is reused for rediscovery during that LSP session; rebuild the
+/// launch configuration when Foundry configuration changes.
+#[derive(Clone, Debug)]
 pub struct FoundryWorkspaceConfig {
-    /// Canonical absolute directory containing the workspace manifest.
-    pub workspace_root: PathBuf,
+    /// Absolute directory containing the workspace manifest.
+    workspace_root: PathBuf,
     /// Effective source roots used for workspace indexing.
-    pub source_roots: Vec<PathBuf>,
+    source_roots: Vec<PathBuf>,
     /// Effective source roots used for flycheck indexing (including tests and scripts).
-    pub flycheck_source_roots: Vec<PathBuf>,
+    flycheck_source_roots: Vec<PathBuf>,
     /// Effective Foundry library/include paths.
-    pub include_paths: Vec<PathBuf>,
+    include_paths: Vec<PathBuf>,
     /// Final import remappings after all host-side resolution.
-    pub import_remappings: Vec<ImportRemapping>,
+    import_remappings: Vec<ImportRemapping>,
     /// Effective EVM version, if the selected Foundry configuration supplied one.
-    pub evm_version: Option<EvmVersion>,
+    evm_version: Option<EvmVersion>,
 }
 
 impl FoundryWorkspaceConfig {
     /// Creates an empty resolved configuration for `workspace_root`.
     ///
-    /// The root and all paths supplied to the builder must be canonical absolute paths. Hosts
-    /// should provide every effective value they want the compiler to use.
+    /// Hosts should provide every effective value they want the compiler to use.
     pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
-        Self { workspace_root: workspace_root.into(), ..Self::default() }
+        Self {
+            workspace_root: workspace_root.into(),
+            source_roots: Vec::new(),
+            flycheck_source_roots: Vec::new(),
+            include_paths: Vec::new(),
+            import_remappings: Vec::new(),
+            evm_version: None,
+        }
     }
 
     /// Sets the effective workspace source roots.
@@ -114,33 +120,41 @@ impl FoundryWorkspaceConfig {
     }
 
     /// Returns the workspace root used for exact manifest matching.
-    pub fn workspace_root(&self) -> &Path {
+    pub(crate) fn workspace_root(&self) -> &Path {
         &self.workspace_root
     }
 
     /// Returns the effective source roots.
-    pub fn source_roots(&self) -> &[PathBuf] {
+    pub(crate) fn source_roots(&self) -> &[PathBuf] {
         &self.source_roots
     }
 
     /// Returns the effective flycheck source roots.
-    pub fn flycheck_source_roots(&self) -> &[PathBuf] {
+    pub(crate) fn flycheck_source_roots(&self) -> &[PathBuf] {
         &self.flycheck_source_roots
     }
 
     /// Returns the effective include paths.
-    pub fn include_paths(&self) -> &[PathBuf] {
+    pub(crate) fn include_paths(&self) -> &[PathBuf] {
         &self.include_paths
     }
 
     /// Returns the final host-resolved import remappings.
-    pub fn import_remappings(&self) -> &[ImportRemapping] {
+    pub(crate) fn import_remappings(&self) -> &[ImportRemapping] {
         &self.import_remappings
     }
 
     /// Returns the effective EVM version, if one was supplied.
-    pub fn evm_version(&self) -> Option<EvmVersion> {
+    pub(crate) fn evm_version(&self) -> Option<EvmVersion> {
         self.evm_version
+    }
+
+    fn into_normalized(mut self) -> Self {
+        self.workspace_root = normalize_foundry_workspace_path(self.workspace_root);
+        self.source_roots = normalize_foundry_workspace_paths(self.source_roots);
+        self.flycheck_source_roots = normalize_foundry_workspace_paths(self.flycheck_source_roots);
+        self.include_paths = normalize_foundry_workspace_paths(self.include_paths);
+        self
     }
 }
 
@@ -165,16 +179,19 @@ impl LaunchConfig {
 
     /// Supplies an already-resolved Foundry workspace configuration.
     ///
-    /// The configuration is keyed by its exact canonical workspace root. Calling this method
+    /// The configuration is keyed by its exact normalized workspace root. Calling this method
     /// again for the same root replaces the earlier snapshot; configurations for other roots are
     /// retained. The snapshot is reused for workspace rediscovery until a new LSP launch.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the workspace root or any configured path is not absolute.
     pub fn with_foundry_workspace_config(mut self, config: FoundryWorkspaceConfig) -> Self {
-        let mut config = config;
-        config.workspace_root = config.workspace_root.normalize();
+        let config = config.into_normalized();
         if let Some(existing) = self
             .foundry_workspace_configs
             .iter_mut()
-            .find(|existing| existing.workspace_root.normalize() == config.workspace_root)
+            .find(|existing| existing.workspace_root == config.workspace_root)
         {
             *existing = config;
         } else {
@@ -205,6 +222,20 @@ impl LaunchConfig {
     pub(crate) fn foundry_workspace_configs(&self) -> &[FoundryWorkspaceConfig] {
         &self.foundry_workspace_configs
     }
+}
+
+fn normalize_foundry_workspace_path(path: impl Into<PathBuf>) -> PathBuf {
+    let path = path.into();
+    assert!(
+        path.is_absolute(),
+        "Foundry workspace config paths must be absolute: `{}`",
+        path.display()
+    );
+    path.normalize()
+}
+
+fn normalize_foundry_workspace_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    paths.into_iter().map(normalize_foundry_workspace_path).collect()
 }
 
 mod call_hierarchy;

--- a/crates/lsp/src/tests/code_action.rs
+++ b/crates/lsp/src/tests/code_action.rs
@@ -1,6 +1,7 @@
 use crate::{
-    code_actions::source_fingerprint, config::negotiate_capabilities_with_pull_diagnostic_data,
-    global_state::GlobalState, test_support::TestProject,
+    LaunchConfig, code_actions::source_fingerprint,
+    config::negotiate_capabilities_with_pull_diagnostic_data, global_state::GlobalState,
+    test_support::TestProject,
 };
 use async_lsp::ClientSocket;
 use lsp_types::{
@@ -1265,9 +1266,7 @@ fn state_with_diagnostic_capabilities(
     let config = negotiate_capabilities_with_pull_diagnostic_data(
         initialize,
         pull_diagnostic_data,
-        None,
-        None,
-        &[],
+        &LaunchConfig::default(),
     )
     .1;
     state.config = Arc::new(config);

--- a/crates/lsp/src/tests/code_action.rs
+++ b/crates/lsp/src/tests/code_action.rs
@@ -1267,6 +1267,7 @@ fn state_with_diagnostic_capabilities(
         pull_diagnostic_data,
         None,
         None,
+        &[],
     )
     .1;
     state.config = Arc::new(config);

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -1,10 +1,10 @@
 use crate::{
-    LaunchConfig, global_state::GlobalState, new_server_service_with_router, proto,
-    test_support::TestProject, workspace::WorkspaceKind,
+    FoundryWorkspaceConfig, LaunchConfig, global_state::GlobalState,
+    new_server_service_with_router, proto, test_support::TestProject, workspace::WorkspaceKind,
 };
 use async_lsp::{AnyRequest, ClientSocket, router::Router};
 use lsp_types::InitializeParams;
-use solar_config::LspArgs;
+use solar_config::{EvmVersion, LspArgs};
 use std::{
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -65,6 +65,190 @@ async fn initialize_applies_launch_config_selected_profile_to_workspace_discover
         .unwrap();
     assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
     assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn initialize_applies_host_resolved_foundry_workspace_config() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /default-src/Default.sol
+        contract DefaultContract {}
+
+        //- /custom-src/Custom.sol
+        contract CustomContract {}
+
+        //- /custom-libs/pkg/src/Lib.sol
+        contract Lib {}
+
+        //- /remappings.txt
+        local/=default-src/
+
+        //- /custom-src/nested/foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /custom-src/nested/src/Nested.sol
+        contract NestedContract {}
+
+        //- /base.toml
+        [profile.custom]
+        src = "custom-src"
+
+        //- /foundry.toml
+        [profile.default]
+        src = "default-src"
+
+        [profile.custom]
+        extends = "base.toml"
+        "#,
+    );
+    let resolved = FoundryWorkspaceConfig::new(project.root())
+        .with_source_roots([project.path("/custom-src")])
+        .with_flycheck_source_roots([project.path("/custom-src")])
+        .with_include_paths([project.path("/custom-libs")])
+        .with_import_remappings(["host/=custom-src/".parse().unwrap()])
+        .with_evm_version(EvmVersion::Cancun);
+    let config = LaunchConfig::default()
+        .with_selected_profile("custom")
+        .with_foundry_workspace_config(resolved);
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params();
+    params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
+
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    let workspace = state
+        .config
+        .workspaces()
+        .iter()
+        .find(|workspace| workspace.compile_opts().base_path.as_deref() == Some(project.root()))
+        .unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
+    assert_eq!(workspace.compile_opts().include_paths, [project.path("/custom-libs")]);
+    assert_eq!(workspace.compile_opts().evm_version, EvmVersion::Cancun);
+    assert_eq!(
+        workspace
+            .compile_opts()
+            .import_remappings
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+        ["host/=custom-src/"]
+    );
+    let nested = state
+        .config
+        .workspaces()
+        .iter()
+        .find(|workspace| {
+            workspace.compile_opts().base_path.as_deref()
+                == Some(project.path("/custom-src/nested").as_path())
+        })
+        .unwrap();
+    assert_eq!(nested.source_roots(), &[project.path("/custom-src/nested/src")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_foundry_workspace_configs_match_their_own_roots() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /one/local-one/One.sol
+        contract OneLocal {}
+
+        //- /one/host-one/One.sol
+        contract OneHost {}
+
+        //- /one/foundry.toml
+        [profile.default]
+        src = "local-one"
+
+        //- /two/local-two/Two.sol
+        contract TwoLocal {}
+
+        //- /two/host-two/Two.sol
+        contract TwoHost {}
+
+        //- /two/foundry.toml
+        [profile.default]
+        src = "local-two"
+
+        //- /three/local-three/Three.sol
+        contract ThreeLocal {}
+
+        //- /three/foundry.toml
+        [profile.default]
+        src = "local-three"
+        "#,
+    );
+    let config = LaunchConfig::default().with_foundry_workspace_configs([
+        FoundryWorkspaceConfig::new(project.path("/one"))
+            .with_source_roots([project.path("/one/host-one")])
+            .with_flycheck_source_roots([project.path("/one/host-one")]),
+        FoundryWorkspaceConfig::new(project.path("/two"))
+            .with_source_roots([project.path("/two/host-two")])
+            .with_flycheck_source_roots([project.path("/two/host-two")]),
+    ]);
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params_with_roots(&["/one", "/two", "/three"]);
+    params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
+
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    let source_roots = |root: &str| {
+        state
+            .config
+            .workspaces()
+            .iter()
+            .find(|workspace| workspace.compile_opts().base_path == Some(project.path(root)))
+            .unwrap()
+            .source_roots()
+            .to_vec()
+    };
+    assert_eq!(source_roots("/one"), [project.path("/one/host-one")]);
+    assert_eq!(source_roots("/two"), [project.path("/two/host-two")]);
+    assert_eq!(source_roots("/three"), [project.path("/three/local-three")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_foundry_workspace_config_does_not_change_explicit_flychecks() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /src/Main.sol
+        contract Main {}
+
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+        "#,
+    );
+    let config =
+        LaunchConfig::default().with_selected_profile("custom").with_foundry_workspace_config(
+            FoundryWorkspaceConfig::new(project.root())
+                .with_source_roots([project.path("/src")])
+                .with_flycheck_source_roots([project.path("/src")]),
+        );
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params();
+    params.initialization_options = Some(serde_json::json!({
+        "flychecks": [{
+            "id": "custom-lint",
+            "command": "custom-lint",
+            "args": ["--json"],
+            "output": "solc-json"
+        }]
+    }));
+
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    let flychecks = state.config.flychecks_for_path(&project.path("/src/Main.sol"));
+    assert_eq!(flychecks.len(), 1);
+    assert_eq!(flychecks[0].id, "custom-lint");
+    assert_eq!(flychecks[0].command, PathBuf::from("custom-lint"));
+    assert_eq!(flychecks[0].args, ["--json"]);
+    assert_eq!(flychecks[0].cwd, project.root());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -67,6 +67,50 @@ async fn initialize_applies_launch_config_selected_profile_to_workspace_discover
     assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
 }
 
+#[test]
+fn foundry_workspace_config_normalizes_absolute_paths() {
+    let project = TestProject::new();
+    let launch_config = LaunchConfig::default().with_foundry_workspace_config(
+        FoundryWorkspaceConfig::new(project.path("/workspace/./nested/.."))
+            .with_source_roots([project.path("/workspace/src/../src")])
+            .with_flycheck_source_roots([project.path("/workspace/test/../test")])
+            .with_include_paths([project.path("/workspace/lib/../lib")]),
+    );
+    let config = &launch_config.foundry_workspace_configs()[0];
+
+    assert_eq!(config.workspace_root(), project.path("/workspace"));
+    assert_eq!(config.source_roots(), [project.path("/workspace/src")]);
+    assert_eq!(config.flycheck_source_roots(), [project.path("/workspace/test")]);
+    assert_eq!(config.include_paths(), [project.path("/workspace/lib")]);
+}
+
+#[test]
+#[should_panic(expected = "Foundry workspace config paths must be absolute")]
+fn foundry_workspace_config_rejects_relative_paths() {
+    let _ = LaunchConfig::default()
+        .with_foundry_workspace_config(FoundryWorkspaceConfig::new("relative/workspace"));
+}
+
+#[test]
+fn launch_config_replaces_lexically_equivalent_foundry_root() {
+    let project = TestProject::new();
+    let launch_config = LaunchConfig::default()
+        .with_foundry_workspace_config(
+            FoundryWorkspaceConfig::new(project.path("/workspace/./nested/.."))
+                .with_source_roots([project.path("/workspace/first")]),
+        )
+        .with_foundry_workspace_config(
+            FoundryWorkspaceConfig::new(project.path("/workspace"))
+                .with_source_roots([project.path("/workspace/second")]),
+        );
+
+    assert_eq!(launch_config.foundry_workspace_configs().len(), 1);
+    assert_eq!(
+        launch_config.foundry_workspace_configs()[0].source_roots(),
+        [project.path("/workspace/second")]
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn initialize_applies_host_resolved_foundry_workspace_config() {
     let project = TestProject::from_fixture(
@@ -76,6 +120,12 @@ async fn initialize_applies_host_resolved_foundry_workspace_config() {
 
         //- /custom-src/Custom.sol
         contract CustomContract {}
+
+        //- /default-test/Default.t.sol
+        contract DefaultTest {}
+
+        //- /custom-test/Custom.t.sol
+        contract CustomTest {}
 
         //- /custom-libs/pkg/src/Lib.sol
         contract Lib {}
@@ -93,10 +143,12 @@ async fn initialize_applies_host_resolved_foundry_workspace_config() {
         //- /base.toml
         [profile.custom]
         src = "custom-src"
+        test = "custom-test"
 
         //- /foundry.toml
         [profile.default]
         src = "default-src"
+        test = "default-test"
 
         [profile.custom]
         extends = "base.toml"
@@ -104,7 +156,7 @@ async fn initialize_applies_host_resolved_foundry_workspace_config() {
     );
     let resolved = FoundryWorkspaceConfig::new(project.root())
         .with_source_roots([project.path("/custom-src")])
-        .with_flycheck_source_roots([project.path("/custom-src")])
+        .with_flycheck_source_roots([project.path("/custom-src"), project.path("/custom-test")])
         .with_include_paths([project.path("/custom-libs")])
         .with_import_remappings(["host/=custom-src/".parse().unwrap()])
         .with_evm_version(EvmVersion::Cancun);
@@ -126,6 +178,10 @@ async fn initialize_applies_host_resolved_foundry_workspace_config() {
         .unwrap();
     assert_eq!(workspace.source_roots(), &[project.path("/custom-src")]);
     assert_eq!(workspace.source_files(), &[project.path("/custom-src/Custom.sol")]);
+    assert_eq!(
+        workspace.flycheck_source_files(),
+        &[project.path("/custom-src/Custom.sol"), project.path("/custom-test/Custom.t.sol"),]
+    );
     assert_eq!(workspace.compile_opts().include_paths, [project.path("/custom-libs")]);
     assert_eq!(workspace.compile_opts().evm_version, EvmVersion::Cancun);
     assert_eq!(
@@ -209,46 +265,6 @@ async fn host_foundry_workspace_configs_match_their_own_roots() {
     assert_eq!(source_roots("/one"), [project.path("/one/host-one")]);
     assert_eq!(source_roots("/two"), [project.path("/two/host-two")]);
     assert_eq!(source_roots("/three"), [project.path("/three/local-three")]);
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn host_foundry_workspace_config_does_not_change_explicit_flychecks() {
-    let project = TestProject::from_fixture(
-        r#"
-        //- /src/Main.sol
-        contract Main {}
-
-        //- /foundry.toml
-        [profile.default]
-        src = "src"
-        "#,
-    );
-    let config =
-        LaunchConfig::default().with_selected_profile("custom").with_foundry_workspace_config(
-            FoundryWorkspaceConfig::new(project.root())
-                .with_source_roots([project.path("/src")])
-                .with_flycheck_source_roots([project.path("/src")]),
-        );
-    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
-    let mut params = project.initialize_params();
-    params.initialization_options = Some(serde_json::json!({
-        "flychecks": [{
-            "id": "custom-lint",
-            "command": "custom-lint",
-            "args": ["--json"],
-            "output": "solc-json"
-        }]
-    }));
-
-    state.on_initialize(params).await.unwrap();
-    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
-
-    let flychecks = state.config.flychecks_for_path(&project.path("/src/Main.sol"));
-    assert_eq!(flychecks.len(), 1);
-    assert_eq!(flychecks[0].id, "custom-lint");
-    assert_eq!(flychecks[0].command, PathBuf::from("custom-lint"));
-    assert_eq!(flychecks[0].args, ["--json"]);
-    assert_eq!(flychecks[0].cwd, project.root());
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -68,25 +68,34 @@ async fn initialize_applies_launch_config_selected_profile_to_workspace_discover
 }
 
 #[test]
-fn foundry_workspace_config_normalizes_absolute_paths() {
+fn foundry_workspace_config_normalizes_paths_against_root() {
     let project = TestProject::new();
     let launch_config = LaunchConfig::default().with_foundry_workspace_config(
         FoundryWorkspaceConfig::new(project.path("/workspace/./nested/.."))
-            .with_source_roots([project.path("/workspace/src/../src")])
-            .with_flycheck_source_roots([project.path("/workspace/test/../test")])
-            .with_include_paths([project.path("/workspace/lib/../lib")]),
+            .with_source_roots([PathBuf::from("src/../src"), project.path("/external/src/../src")])
+            .with_flycheck_source_roots([PathBuf::from("test/../test")])
+            .with_include_paths([
+                PathBuf::from("lib/../lib"),
+                PathBuf::from("../external/lib/../lib"),
+            ]),
     );
     let config = &launch_config.foundry_workspace_configs()[0];
 
     assert_eq!(config.workspace_root(), project.path("/workspace"));
-    assert_eq!(config.source_roots(), [project.path("/workspace/src")]);
+    assert_eq!(
+        config.source_roots(),
+        [project.path("/workspace/src"), project.path("/external/src")]
+    );
     assert_eq!(config.flycheck_source_roots(), [project.path("/workspace/test")]);
-    assert_eq!(config.include_paths(), [project.path("/workspace/lib")]);
+    assert_eq!(
+        config.include_paths(),
+        [project.path("/workspace/lib"), project.path("/external/lib")]
+    );
 }
 
 #[test]
-#[should_panic(expected = "Foundry workspace config paths must be absolute")]
-fn foundry_workspace_config_rejects_relative_paths() {
+#[should_panic(expected = "Foundry workspace config root must be absolute")]
+fn foundry_workspace_config_rejects_relative_workspace_root() {
     let _ = LaunchConfig::default()
         .with_foundry_workspace_config(FoundryWorkspaceConfig::new("relative/workspace"));
 }
@@ -155,9 +164,9 @@ async fn initialize_applies_host_resolved_foundry_workspace_config() {
         "#,
     );
     let resolved = FoundryWorkspaceConfig::new(project.root())
-        .with_source_roots([project.path("/custom-src")])
-        .with_flycheck_source_roots([project.path("/custom-src"), project.path("/custom-test")])
-        .with_include_paths([project.path("/custom-libs")])
+        .with_source_roots(["custom-src"])
+        .with_flycheck_source_roots(["custom-src", "custom-test"])
+        .with_include_paths(["custom-libs"])
         .with_import_remappings(["host/=custom-src/".parse().unwrap()])
         .with_evm_version(EvmVersion::Cancun);
     let config = LaunchConfig::default()

--- a/crates/lsp/src/tests/watched_files.rs
+++ b/crates/lsp/src/tests/watched_files.rs
@@ -667,6 +667,7 @@ fn watched_file_specs_add_only_approved_dependency_parents() {
                 project.path("/workspace/foundry.toml"),
                 &[project.path("/workspace")],
                 None,
+                &[],
             )
             .unwrap(),
         ],

--- a/crates/lsp/src/tests/watched_files.rs
+++ b/crates/lsp/src/tests/watched_files.rs
@@ -666,8 +666,7 @@ fn watched_file_specs_add_only_approved_dependency_parents() {
             crate::workspace::Workspace::load_foundry_bounded(
                 project.path("/workspace/foundry.toml"),
                 &[project.path("/workspace")],
-                None,
-                &[],
+                crate::workspace::FoundryConfigContext::default(),
             )
             .unwrap(),
         ],

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -4,11 +4,10 @@ use std::{
 };
 
 use super::{
-    SourceWatchRoot, foundry_workspace_config_for_root,
+    FoundryConfigContext, SourceWatchRoot,
     index_policy::{IndexingCancellation, WorkspaceIndexMetrics, WorkspaceIndexPolicy},
     is_approved_index_root, is_import_only_path, load_foundry_document,
 };
-use crate::FoundryWorkspaceConfig;
 use normalize_path::NormalizePath;
 use solar_interface::data_structures::map::rustc_hash::FxHashSet;
 use tokio::io;
@@ -32,8 +31,7 @@ impl ProjectManifest {
         policy: &WorkspaceIndexPolicy,
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
-        selected_profile: Option<&str>,
-        foundry_workspace_configs: &[FoundryWorkspaceConfig],
+        foundry_config: FoundryConfigContext<'_>,
     ) -> io::Result<Option<ManifestDiscoveryResult>> {
         // Keep naked roots shallow, but recurse once a Foundry project boundary is known.
         let mut manifests = Vec::new();
@@ -41,12 +39,8 @@ impl ProjectManifest {
         let mut marker_watch_roots = Vec::new();
         if let Some(manifest) = find_in_parent_dirs(path, "foundry.toml") {
             let workspace_root = manifest.parent().unwrap_or(path).to_path_buf();
-            let (source_roots, import_only_roots) = foundry_index_roots(
-                &manifest,
-                approved_roots,
-                selected_profile,
-                foundry_workspace_configs,
-            );
+            let (source_roots, import_only_roots) =
+                foundry_index_roots(&manifest, approved_roots, foundry_config);
             manifests.push(manifest);
             if let Ok(entries) = read_dir(path)
                 && matches!(
@@ -58,8 +52,7 @@ impl ProjectManifest {
                         policy,
                         cancellation,
                         metrics,
-                        selected_profile,
-                        foundry_workspace_configs,
+                        foundry_config,
                     })
                     .find_in_child_dirs(
                         entries,
@@ -88,8 +81,7 @@ impl ProjectManifest {
                     policy,
                     cancellation,
                     metrics,
-                    selected_profile,
-                    foundry_workspace_configs,
+                    foundry_config,
                 })
                 .find_in_child_dirs(
                     read_dir(path)?,
@@ -126,8 +118,15 @@ impl ProjectManifest {
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
     ) -> Option<Vec<Self>> {
-        Self::discover_all_with_watch_roots(paths, paths, policy, cancellation, metrics, None, &[])
-            .map(|(manifests, _, _)| manifests)
+        Self::discover_all_with_watch_roots(
+            paths,
+            paths,
+            policy,
+            cancellation,
+            metrics,
+            FoundryConfigContext::default(),
+        )
+        .map(|(manifests, _, _)| manifests)
     }
 
     pub(crate) fn discover_all_with_watch_roots(
@@ -136,8 +135,7 @@ impl ProjectManifest {
         policy: &WorkspaceIndexPolicy,
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
-        selected_profile: Option<&str>,
-        foundry_workspace_configs: &[FoundryWorkspaceConfig],
+        foundry_config: FoundryConfigContext<'_>,
     ) -> Option<ManifestDiscoveryResult> {
         let mut discovered = FxHashSet::default();
         let mut watch_roots = Vec::new();
@@ -146,15 +144,9 @@ impl ProjectManifest {
             if cancellation.is_cancelled() {
                 return None;
             }
-            if let Ok(result) = Self::discover(
-                path,
-                approved_roots,
-                policy,
-                cancellation,
-                metrics,
-                selected_profile,
-                foundry_workspace_configs,
-            ) {
+            if let Ok(result) =
+                Self::discover(path, approved_roots, policy, cancellation, metrics, foundry_config)
+            {
                 let (manifests, mut roots, mut marker_roots) = result?;
                 discovered.extend(manifests);
                 watch_roots.append(&mut roots);
@@ -252,8 +244,7 @@ struct ManifestDiscovery<'a> {
     policy: &'a WorkspaceIndexPolicy,
     cancellation: &'a IndexingCancellation,
     metrics: &'a mut WorkspaceIndexMetrics,
-    selected_profile: Option<&'a str>,
-    foundry_workspace_configs: &'a [FoundryWorkspaceConfig],
+    foundry_config: FoundryConfigContext<'a>,
 }
 
 #[derive(Clone, Copy)]
@@ -340,12 +331,7 @@ impl ManifestDiscovery<'_> {
                 && let Ok(children) = read_dir(&path)
             {
                 let nested_index_roots = if is_project {
-                    foundry_index_roots(
-                        &manifest,
-                        self.approved_roots,
-                        self.selected_profile,
-                        self.foundry_workspace_configs,
-                    )
+                    foundry_index_roots(&manifest, self.approved_roots, self.foundry_config)
                 } else {
                     Default::default()
                 };
@@ -405,49 +391,38 @@ impl ManifestDiscovery<'_> {
 fn foundry_index_roots(
     manifest: &Path,
     approved_roots: &[PathBuf],
-    selected_profile: Option<&str>,
-    foundry_workspace_configs: &[FoundryWorkspaceConfig],
+    foundry_config: FoundryConfigContext<'_>,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let Some(root) = manifest.parent() else { return Default::default() };
-    if let Some(config) = foundry_workspace_config_for_root(foundry_workspace_configs, root) {
-        let source_roots = config
-            .source_roots()
-            .iter()
-            .map(|path| path.normalize())
-            .filter(|path| is_approved_index_root(path, root, approved_roots))
-            .collect();
-        let import_only_roots = config
-            .include_paths()
-            .iter()
-            .map(|path| path.normalize())
-            .filter(|path| is_approved_index_root(path, root, approved_roots))
-            .collect();
-        return (source_roots, import_only_roots);
-    }
-    load_foundry_document(manifest)
-        .map(|document| {
-            let profile = document.profile_for(selected_profile);
-            let source_roots = profile
-                .source_roots(root)
-                .into_iter()
-                .map(|path| path.normalize())
-                .filter(|path| is_approved_index_root(path, root, approved_roots))
-                .collect();
-            let import_only_roots = profile
-                .include_paths(root)
-                .into_iter()
-                .map(|path| path.normalize())
-                .filter(|path| is_approved_index_root(path, root, approved_roots))
-                .collect();
+    let (source_roots, import_only_roots) =
+        if let Some(config) = foundry_config.workspace_config(root) {
+            (config.source_roots().to_vec(), config.include_paths().to_vec())
+        } else {
+            let Ok(document) = load_foundry_document(manifest) else { return Default::default() };
+            let profile = document.profile_for(foundry_config.selected_profile());
+            let source_roots = profile.source_roots(root);
+            let import_only_roots =
+                profile.include_paths(root).into_iter().map(|path| path.normalize()).collect();
             (source_roots, import_only_roots)
-        })
-        .unwrap_or_default()
+        };
+    (
+        source_roots
+            .into_iter()
+            .filter(|path| is_approved_index_root(path, root, approved_roots))
+            .collect(),
+        import_only_roots
+            .into_iter()
+            .filter(|path| is_approved_index_root(path, root, approved_roots))
+            .collect(),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_support::TestProject, workspace::index_policy::IndexingOptions};
+    use crate::{
+        FoundryWorkspaceConfig, test_support::TestProject, workspace::index_policy::IndexingOptions,
+    };
 
     fn discover_all(paths: &[PathBuf]) -> Vec<ProjectManifest> {
         ProjectManifest::discover_all(
@@ -657,8 +632,7 @@ mod tests {
             foundry_index_roots(
                 &project.path("/foundry.toml"),
                 &[project.root().to_path_buf()],
-                Some("custom"),
-                &[],
+                FoundryConfigContext::new(Some("custom"), &[]),
             )
             .0,
             [project.path("/.hidden/custom-src")]
@@ -673,8 +647,7 @@ mod tests {
             &WorkspaceIndexPolicy::default(),
             &IndexingCancellation::default(),
             &mut WorkspaceIndexMetrics::default(),
-            Some("custom"),
-            &[],
+            FoundryConfigContext::new(Some("custom"), &[]),
         )
         .unwrap()
         .0;
@@ -685,6 +658,43 @@ mod tests {
                 ProjectManifest::Foundry(project.path("/.hidden/custom-src/nested/foundry.toml")),
                 ProjectManifest::Foundry(project.path("/foundry.toml")),
             ]
+        );
+    }
+
+    #[test]
+    fn host_foundry_index_roots_keep_approved_boundaries() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /workspace/foundry.toml
+
+            //- /workspace/host-src/Inside.sol
+            contract Inside {}
+
+            //- /workspace/host-lib/Dependency.sol
+            contract HostDependency {}
+
+            //- /external/src/Outside.sol
+            contract Outside {}
+
+            //- /external/lib/Dependency.sol
+            contract Dependency {}
+            "#,
+        );
+        let config = FoundryWorkspaceConfig::new(project.path("/workspace"))
+            .with_source_roots([project.path("/workspace/host-src"), project.path("/external/src")])
+            .with_include_paths([
+                project.path("/workspace/host-lib"),
+                project.path("/external/lib"),
+            ]);
+        let configs = [config];
+
+        assert_eq!(
+            foundry_index_roots(
+                &project.path("/workspace/foundry.toml"),
+                &[project.path("/workspace")],
+                FoundryConfigContext::new(None, &configs),
+            ),
+            (vec![project.path("/workspace/host-src")], vec![project.path("/workspace/host-lib")],)
         );
     }
 

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -4,10 +4,11 @@ use std::{
 };
 
 use super::{
-    SourceWatchRoot,
+    SourceWatchRoot, foundry_workspace_config_for_root,
     index_policy::{IndexingCancellation, WorkspaceIndexMetrics, WorkspaceIndexPolicy},
     is_approved_index_root, is_import_only_path, load_foundry_document,
 };
+use crate::FoundryWorkspaceConfig;
 use normalize_path::NormalizePath;
 use solar_interface::data_structures::map::rustc_hash::FxHashSet;
 use tokio::io;
@@ -32,6 +33,7 @@ impl ProjectManifest {
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
         selected_profile: Option<&str>,
+        foundry_workspace_configs: &[FoundryWorkspaceConfig],
     ) -> io::Result<Option<ManifestDiscoveryResult>> {
         // Keep naked roots shallow, but recurse once a Foundry project boundary is known.
         let mut manifests = Vec::new();
@@ -39,8 +41,12 @@ impl ProjectManifest {
         let mut marker_watch_roots = Vec::new();
         if let Some(manifest) = find_in_parent_dirs(path, "foundry.toml") {
             let workspace_root = manifest.parent().unwrap_or(path).to_path_buf();
-            let (source_roots, import_only_roots) =
-                foundry_index_roots(&manifest, approved_roots, selected_profile);
+            let (source_roots, import_only_roots) = foundry_index_roots(
+                &manifest,
+                approved_roots,
+                selected_profile,
+                foundry_workspace_configs,
+            );
             manifests.push(manifest);
             if let Ok(entries) = read_dir(path)
                 && matches!(
@@ -53,6 +59,7 @@ impl ProjectManifest {
                         cancellation,
                         metrics,
                         selected_profile,
+                        foundry_workspace_configs,
                     })
                     .find_in_child_dirs(
                         entries,
@@ -82,6 +89,7 @@ impl ProjectManifest {
                     cancellation,
                     metrics,
                     selected_profile,
+                    foundry_workspace_configs,
                 })
                 .find_in_child_dirs(
                     read_dir(path)?,
@@ -118,7 +126,7 @@ impl ProjectManifest {
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
     ) -> Option<Vec<Self>> {
-        Self::discover_all_with_watch_roots(paths, paths, policy, cancellation, metrics, None)
+        Self::discover_all_with_watch_roots(paths, paths, policy, cancellation, metrics, None, &[])
             .map(|(manifests, _, _)| manifests)
     }
 
@@ -129,6 +137,7 @@ impl ProjectManifest {
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
         selected_profile: Option<&str>,
+        foundry_workspace_configs: &[FoundryWorkspaceConfig],
     ) -> Option<ManifestDiscoveryResult> {
         let mut discovered = FxHashSet::default();
         let mut watch_roots = Vec::new();
@@ -144,6 +153,7 @@ impl ProjectManifest {
                 cancellation,
                 metrics,
                 selected_profile,
+                foundry_workspace_configs,
             ) {
                 let (manifests, mut roots, mut marker_roots) = result?;
                 discovered.extend(manifests);
@@ -243,6 +253,7 @@ struct ManifestDiscovery<'a> {
     cancellation: &'a IndexingCancellation,
     metrics: &'a mut WorkspaceIndexMetrics,
     selected_profile: Option<&'a str>,
+    foundry_workspace_configs: &'a [FoundryWorkspaceConfig],
 }
 
 #[derive(Clone, Copy)]
@@ -329,7 +340,12 @@ impl ManifestDiscovery<'_> {
                 && let Ok(children) = read_dir(&path)
             {
                 let nested_index_roots = if is_project {
-                    foundry_index_roots(&manifest, self.approved_roots, self.selected_profile)
+                    foundry_index_roots(
+                        &manifest,
+                        self.approved_roots,
+                        self.selected_profile,
+                        self.foundry_workspace_configs,
+                    )
                 } else {
                     Default::default()
                 };
@@ -390,8 +406,24 @@ fn foundry_index_roots(
     manifest: &Path,
     approved_roots: &[PathBuf],
     selected_profile: Option<&str>,
+    foundry_workspace_configs: &[FoundryWorkspaceConfig],
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let Some(root) = manifest.parent() else { return Default::default() };
+    if let Some(config) = foundry_workspace_config_for_root(foundry_workspace_configs, root) {
+        let source_roots = config
+            .source_roots()
+            .iter()
+            .map(|path| path.normalize())
+            .filter(|path| is_approved_index_root(path, root, approved_roots))
+            .collect();
+        let import_only_roots = config
+            .include_paths()
+            .iter()
+            .map(|path| path.normalize())
+            .filter(|path| is_approved_index_root(path, root, approved_roots))
+            .collect();
+        return (source_roots, import_only_roots);
+    }
     load_foundry_document(manifest)
         .map(|document| {
             let profile = document.profile_for(selected_profile);
@@ -626,6 +658,7 @@ mod tests {
                 &project.path("/foundry.toml"),
                 &[project.root().to_path_buf()],
                 Some("custom"),
+                &[],
             )
             .0,
             [project.path("/.hidden/custom-src")]
@@ -641,6 +674,7 @@ mod tests {
             &IndexingCancellation::default(),
             &mut WorkspaceIndexMetrics::default(),
             Some("custom"),
+            &[],
         )
         .unwrap()
         .0;

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -9,9 +9,12 @@
 //! Once a project type is identified, the configuration for that project model is merged into the
 //! overall LSP config.
 
-use crate::workspace::{
-    foundry::FoundryDocument,
-    index_policy::{IndexingCancellation, WorkspaceIndexMetrics, WorkspaceIndexPolicy},
+use crate::{
+    FoundryWorkspaceConfig,
+    workspace::{
+        foundry::FoundryDocument,
+        index_policy::{IndexingCancellation, WorkspaceIndexMetrics, WorkspaceIndexPolicy},
+    },
 };
 use normalize_path::NormalizePath;
 use solar_config::{CompileOpts, EvmVersion, ImportRemapping};
@@ -477,50 +480,76 @@ impl Workspace {
 
     #[cfg(any(test, feature = "bench"))]
     pub(crate) fn load_foundry(path: PathBuf) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, None, None)
+        Self::load_foundry_inner(path, None, None, &[])
     }
 
     pub(crate) fn load_foundry_bounded(
         path: PathBuf,
         workspace_roots: &[PathBuf],
         selected_profile: Option<&str>,
+        foundry_workspace_configs: &[FoundryWorkspaceConfig],
     ) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, Some(workspace_roots), selected_profile)
+        Self::load_foundry_inner(
+            path,
+            Some(workspace_roots),
+            selected_profile,
+            foundry_workspace_configs,
+        )
     }
 
     fn load_foundry_inner(
         path: PathBuf,
         workspace_roots: Option<&[PathBuf]>,
         selected_profile: Option<&str>,
+        foundry_workspace_configs: &[FoundryWorkspaceConfig],
     ) -> Result<Self, WorkspaceError> {
         let root = manifest_root(&path)?.normalize();
-        let profile = load_foundry_document(&path)?.profile_for(selected_profile);
         let approved = |path: &Path| {
             workspace_roots
                 .is_none_or(|workspace_roots| is_approved_index_root(path, &root, workspace_roots))
         };
-        let source_roots = profile
-            .source_roots(&root)
+        let (source_roots, flycheck_source_roots, include_paths, import_remappings, evm_version) =
+            if let Some(config) =
+                foundry_workspace_config_for_root(foundry_workspace_configs, &root)
+            {
+                (
+                    config.source_roots().iter().map(|path| path.normalize()).collect(),
+                    config.flycheck_source_roots().iter().map(|path| path.normalize()).collect(),
+                    config.include_paths().iter().map(|path| path.normalize()).collect(),
+                    config.import_remappings().to_vec(),
+                    config.evm_version(),
+                )
+            } else {
+                let profile = load_foundry_document(&path)?.profile_for(selected_profile);
+                let include_paths = profile
+                    .include_paths(&root)
+                    .into_iter()
+                    .map(|path| path.normalize())
+                    .collect::<Vec<_>>();
+                let import_remappings =
+                    profile.remappings_with_include_paths(&root, &include_paths);
+                (
+                    profile.source_roots(&root),
+                    profile.flycheck_source_roots(&root),
+                    include_paths,
+                    import_remappings,
+                    profile.evm_version(),
+                )
+            };
+        let source_roots = source_roots
             .into_iter()
             .map(|path| path.normalize())
             .filter(|path| approved(path))
             .collect();
-        let flycheck_source_roots = profile
-            .flycheck_source_roots(&root)
+        let flycheck_source_roots = flycheck_source_roots
             .into_iter()
             .map(|path| path.normalize())
             .filter(|path| approved(path))
             .collect();
-        let include_paths = profile
-            .include_paths(&root)
-            .into_iter()
-            .map(|path| path.normalize())
-            .collect::<Vec<_>>();
         let index_import_only_roots =
             include_paths.iter().filter(|path| approved(path)).cloned().collect::<Vec<_>>();
-        let import_remappings = profile.remappings_with_include_paths(&root, &include_paths);
         let compile_opts =
-            compile_opts(root.clone(), include_paths, import_remappings, profile.evm_version());
+            compile_opts(root.clone(), include_paths, import_remappings, evm_version);
 
         Ok(Self {
             kind: WorkspaceKind::Foundry,
@@ -546,6 +575,14 @@ pub(crate) fn is_approved_index_root(
     let path = path.normalize();
     path.starts_with(manifest_root.normalize())
         || workspace_roots.iter().any(|root| path.starts_with(root.normalize()))
+}
+
+pub(crate) fn foundry_workspace_config_for_root<'a>(
+    configs: &'a [FoundryWorkspaceConfig],
+    root: &Path,
+) -> Option<&'a FoundryWorkspaceConfig> {
+    let root = root.normalize();
+    configs.iter().find(|config| config.workspace_root().normalize() == root)
 }
 
 fn insert_sorted(files: &mut Vec<PathBuf>, path: PathBuf) {
@@ -1079,6 +1116,7 @@ mod tests {
             project.path("/foundry.toml"),
             &[project.root().to_path_buf()],
             Some("custom"),
+            &[],
         )
         .unwrap();
 
@@ -1093,6 +1131,59 @@ mod tests {
         );
         assert_eq!(workspace.compile_opts().include_paths, [project.path("/custom-libs")]);
         assert_eq!(workspace.compile_opts().evm_version, EvmVersion::Cancun);
+    }
+
+    #[test]
+    fn foundry_workspace_config_matches_only_the_exact_normalized_root() {
+        let project = TestProject::new();
+        let outer = FoundryWorkspaceConfig::new(project.path("/outer"));
+        let nested = FoundryWorkspaceConfig::new(project.path("/outer/nested"));
+        let configs = [outer, nested];
+
+        assert!(
+            foundry_workspace_config_for_root(&configs, &project.path("/outer"))
+                .is_some_and(|config| config.workspace_root() == project.path("/outer"))
+        );
+        assert!(foundry_workspace_config_for_root(
+            &configs,
+            &project.path("/outer/./nested/../nested"),
+        )
+        .is_some_and(|config| config.workspace_root() == project.path("/outer/nested")));
+        assert!(
+            foundry_workspace_config_for_root(&configs, &project.path("/outer/other")).is_none()
+        );
+    }
+
+    #[test]
+    fn host_foundry_workspace_paths_keep_approved_index_boundaries() {
+        let project = TestProject::from_fixture(
+            r#"
+            //- /workspace/foundry.toml
+            [profile.default]
+            src = "src"
+
+            //- /external/src/Outside.sol
+            contract Outside {}
+            "#,
+        );
+        let external = project.path("/external/src");
+        let config = FoundryWorkspaceConfig::new(project.path("/workspace"))
+            .with_source_roots([external.clone()])
+            .with_flycheck_source_roots([external.clone()])
+            .with_include_paths([external.clone()]);
+
+        let workspace = Workspace::load_foundry_bounded(
+            project.path("/workspace/foundry.toml"),
+            &[project.path("/workspace")],
+            None,
+            &[config],
+        )
+        .unwrap();
+
+        assert!(workspace.source_roots().is_empty());
+        assert!(workspace.import_source_roots().is_empty());
+        assert_eq!(workspace.compile_opts().include_paths, [external]);
+        assert!(workspace.index_import_only_roots().is_empty());
     }
 
     #[test]
@@ -1113,6 +1204,7 @@ mod tests {
             project.path("/workspace/foundry.toml"),
             &[project.path("/workspace")],
             None,
+            &[],
         )
         .unwrap();
         let opts = workspace.compile_opts();

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -28,6 +28,36 @@ mod foundry;
 pub(crate) mod index_policy;
 pub(crate) mod manifest;
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FoundryConfigContext<'a> {
+    selected_profile: Option<&'a str>,
+    workspace_configs: &'a [FoundryWorkspaceConfig],
+}
+
+impl<'a> FoundryConfigContext<'a> {
+    pub(crate) fn new(
+        selected_profile: Option<&'a str>,
+        workspace_configs: &'a [FoundryWorkspaceConfig],
+    ) -> Self {
+        Self { selected_profile, workspace_configs }
+    }
+
+    pub(crate) fn selected_profile(self) -> Option<&'a str> {
+        self.selected_profile
+    }
+
+    pub(crate) fn workspace_config(self, root: &Path) -> Option<&'a FoundryWorkspaceConfig> {
+        let root = root.normalize();
+        self.workspace_configs.iter().find(|config| config.workspace_root() == root)
+    }
+}
+
+impl Default for FoundryConfigContext<'_> {
+    fn default() -> Self {
+        Self::new(None, &[])
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct Workspace {
     kind: WorkspaceKind,
@@ -480,28 +510,21 @@ impl Workspace {
 
     #[cfg(any(test, feature = "bench"))]
     pub(crate) fn load_foundry(path: PathBuf) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, None, None, &[])
+        Self::load_foundry_inner(path, None, FoundryConfigContext::default())
     }
 
     pub(crate) fn load_foundry_bounded(
         path: PathBuf,
         workspace_roots: &[PathBuf],
-        selected_profile: Option<&str>,
-        foundry_workspace_configs: &[FoundryWorkspaceConfig],
+        foundry_config: FoundryConfigContext<'_>,
     ) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(
-            path,
-            Some(workspace_roots),
-            selected_profile,
-            foundry_workspace_configs,
-        )
+        Self::load_foundry_inner(path, Some(workspace_roots), foundry_config)
     }
 
     fn load_foundry_inner(
         path: PathBuf,
         workspace_roots: Option<&[PathBuf]>,
-        selected_profile: Option<&str>,
-        foundry_workspace_configs: &[FoundryWorkspaceConfig],
+        foundry_config: FoundryConfigContext<'_>,
     ) -> Result<Self, WorkspaceError> {
         let root = manifest_root(&path)?.normalize();
         let approved = |path: &Path| {
@@ -509,18 +532,17 @@ impl Workspace {
                 .is_none_or(|workspace_roots| is_approved_index_root(path, &root, workspace_roots))
         };
         let (source_roots, flycheck_source_roots, include_paths, import_remappings, evm_version) =
-            if let Some(config) =
-                foundry_workspace_config_for_root(foundry_workspace_configs, &root)
-            {
+            if let Some(config) = foundry_config.workspace_config(&root) {
                 (
-                    config.source_roots().iter().map(|path| path.normalize()).collect(),
-                    config.flycheck_source_roots().iter().map(|path| path.normalize()).collect(),
-                    config.include_paths().iter().map(|path| path.normalize()).collect(),
+                    config.source_roots().to_vec(),
+                    config.flycheck_source_roots().to_vec(),
+                    config.include_paths().to_vec(),
                     config.import_remappings().to_vec(),
                     config.evm_version(),
                 )
             } else {
-                let profile = load_foundry_document(&path)?.profile_for(selected_profile);
+                let profile =
+                    load_foundry_document(&path)?.profile_for(foundry_config.selected_profile());
                 let include_paths = profile
                     .include_paths(&root)
                     .into_iter()
@@ -536,16 +558,9 @@ impl Workspace {
                     profile.evm_version(),
                 )
             };
-        let source_roots = source_roots
-            .into_iter()
-            .map(|path| path.normalize())
-            .filter(|path| approved(path))
-            .collect();
-        let flycheck_source_roots = flycheck_source_roots
-            .into_iter()
-            .map(|path| path.normalize())
-            .filter(|path| approved(path))
-            .collect();
+        let source_roots = source_roots.into_iter().filter(|path| approved(path)).collect();
+        let flycheck_source_roots =
+            flycheck_source_roots.into_iter().filter(|path| approved(path)).collect();
         let index_import_only_roots =
             include_paths.iter().filter(|path| approved(path)).cloned().collect::<Vec<_>>();
         let compile_opts =
@@ -575,14 +590,6 @@ pub(crate) fn is_approved_index_root(
     let path = path.normalize();
     path.starts_with(manifest_root.normalize())
         || workspace_roots.iter().any(|root| path.starts_with(root.normalize()))
-}
-
-pub(crate) fn foundry_workspace_config_for_root<'a>(
-    configs: &'a [FoundryWorkspaceConfig],
-    root: &Path,
-) -> Option<&'a FoundryWorkspaceConfig> {
-    let root = root.normalize();
-    configs.iter().find(|config| config.workspace_root().normalize() == root)
 }
 
 fn insert_sorted(files: &mut Vec<PathBuf>, path: PathBuf) {
@@ -1115,8 +1122,7 @@ mod tests {
         let workspace = Workspace::load_foundry_bounded(
             project.path("/foundry.toml"),
             &[project.root().to_path_buf()],
-            Some("custom"),
-            &[],
+            FoundryConfigContext::new(Some("custom"), &[]),
         )
         .unwrap();
 
@@ -1139,19 +1145,19 @@ mod tests {
         let outer = FoundryWorkspaceConfig::new(project.path("/outer"));
         let nested = FoundryWorkspaceConfig::new(project.path("/outer/nested"));
         let configs = [outer, nested];
+        let foundry_config = FoundryConfigContext::new(None, &configs);
 
         assert!(
-            foundry_workspace_config_for_root(&configs, &project.path("/outer"))
+            foundry_config
+                .workspace_config(&project.path("/outer"))
                 .is_some_and(|config| config.workspace_root() == project.path("/outer"))
         );
-        assert!(foundry_workspace_config_for_root(
-            &configs,
-            &project.path("/outer/./nested/../nested"),
-        )
-        .is_some_and(|config| config.workspace_root() == project.path("/outer/nested")));
         assert!(
-            foundry_workspace_config_for_root(&configs, &project.path("/outer/other")).is_none()
+            foundry_config
+                .workspace_config(&project.path("/outer/./nested/../nested"))
+                .is_some_and(|config| config.workspace_root() == project.path("/outer/nested"))
         );
+        assert!(foundry_config.workspace_config(&project.path("/outer/other")).is_none());
     }
 
     #[test]
@@ -1171,12 +1177,12 @@ mod tests {
             .with_source_roots([external.clone()])
             .with_flycheck_source_roots([external.clone()])
             .with_include_paths([external.clone()]);
+        let configs = [config];
 
         let workspace = Workspace::load_foundry_bounded(
             project.path("/workspace/foundry.toml"),
             &[project.path("/workspace")],
-            None,
-            &[config],
+            FoundryConfigContext::new(None, &configs),
         )
         .unwrap();
 
@@ -1203,8 +1209,7 @@ mod tests {
         let workspace = Workspace::load_foundry_bounded(
             project.path("/workspace/foundry.toml"),
             &[project.path("/workspace")],
-            None,
-            &[],
+            FoundryConfigContext::default(),
         )
         .unwrap();
         let opts = workspace.compile_opts();


### PR DESCRIPTION
This addresses the [inherited-profile review concern raised in foundry-rs/foundry#16254](https://github.com/foundry-rs/foundry/pull/16254#discussion_r3836421804). Forwarding only the selected profile left the embedded LSP inconsistent with Forge because the lightweight `foundry.toml` loader does not resolve `extends`: Forge could resolve `custom-src` while the LSP continued indexing`default-src`.

This adds a `LaunchConfig` API for embedding hosts to provide effective Foundry workspace values keyed by an exact normalized workspace root, including source and flycheck roots, library/include paths, final remappings, and the EVM version. 

An exact-root snapshot takes precedence during workspace discovery and loading, while unmatched manifests retain the existing local`foundry.toml` and selected-profile fallback. Relative paths are resolved against the workspace root, and snapshots are reused for rediscovery throughout the LSP session. 

This keeps Foundry-specific resolution in the embedding host while the LSP consumes only the final values it needs. The corresponding embedding-side wiring is tracked in [foundry-rs/foundry#16254](https://github.com/foundry-rs/foundry/pull/16254).

cc @figtracer @DaniPopes @mattsse 
