### PR TITLE
fix(codegen): clean mapping keys

### DIFF
--- a/crates/codegen/src/lower/function/storage_values.rs
+++ b/crates/codegen/src/lower/function/storage_values.rs
@@ -618,6 +618,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 self.builder.mapping_slot_memory(key, slot)
             }
         } else {
+            let key = self.normalize_dirty_scalar(key, key_ty);
             self.builder.mapping_slot(key, slot)
         }
     }

--- a/tests/ui/codegen/lowering/run-call/mapping_key_cleanup.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/mapping_key_cleanup.mir.stdout
@@ -1,0 +1,13 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/mapping_key_cleanup.sol:C ===
+@module C
+fn @test_cleanup() -> bool [selector=0x2b63198c, abi_args=lazy, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = and 0xffff0001, 0xffff
+    v1 = mapping_slot v0, 0
+    sstore v1, 3 !metadata(storage=symbolic(v1))
+    v2 = mapping_slot 1, 0
+    v3 = sload v2 !metadata(storage=symbolic(v2))
+    v4 = eq v3, 3
+    ret v4
+}
+

--- a/tests/ui/codegen/lowering/run-call/mapping_key_cleanup.sol
+++ b/tests/ui/codegen/lowering/run-call/mapping_key_cleanup.sol
@@ -1,0 +1,18 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: test_cleanup() => true
+// ported-from: test/libsolidity/semanticTests/viaYul/storage/mappings.sol
+
+contract C {
+    mapping(uint16 => uint) cleanup;
+
+    function test_cleanup() public returns (bool) {
+        uint16 x;
+        assembly {
+            x := 0xffff0001
+        }
+        cleanup[x] = 3;
+        return cleanup[1] == 3;
+    }
+}


### PR DESCRIPTION
`solsymdiff` replayed Solidity's upstream mapping-cleanup case and found that a `uint16` value dirtied by inline assembly selected a different storage slot from the equivalent clean key. Solc returned `true`, while Solar returned `false` for calldata `0x2b63198c` in optimized and unoptimized legacy and via-IR builds.

This normalizes fixed-width scalar mapping keys through the existing cleanup path before deriving their storage slot. The candidate reaches bounded agreement with solc in all four configurations, and the codegen size and hot-gas benchmark outputs remain identical.
