### PR TITLE
fix(codegen): materialize stack-phi sources

### DIFF
--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -3550,7 +3550,7 @@ impl<'gcx> EvmCodegen<'gcx> {
 
         for &source in Self::missing_stack_phi_sources(&self.scheduler.stack, &edge.sources).iter()
         {
-            if !self.scheduler.can_emit_value(source, func) {
+            if !self.can_emit_stack_phi_value(func, source) {
                 return false;
             }
             self.emit_operand(func, source);
@@ -3597,11 +3597,17 @@ impl<'gcx> EvmCodegen<'gcx> {
                 *count -= 1;
                 continue;
             }
-            if !self.scheduler.can_emit_value(source, func) {
+            if !self.can_emit_stack_phi_value(func, source) {
                 return false;
             }
         }
         true
+    }
+
+    /// Stack-phi preparation emits through `emit_operand`, which can recompute an unstored spill.
+    fn can_emit_stack_phi_value(&self, func: &Function, value: ValueId) -> bool {
+        self.scheduler.can_emit_value(value, func)
+            || self.scheduler.should_recompute_unstored_spill(value)
     }
 
     fn can_prepare_stack_phi_branch(
@@ -3613,7 +3619,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         if branch.union.is_empty() || branch.union.len() > MAX_STACK_ACCESS {
             return false;
         }
-        self.scheduler.can_emit_value(condition, func)
+        self.can_emit_stack_phi_value(func, condition)
             && self.can_prepare_stack_phi_edge(func, &branch.then_edge)
             && self.can_prepare_stack_phi_edge(func, &branch.else_edge)
     }
@@ -3646,7 +3652,7 @@ impl<'gcx> EvmCodegen<'gcx> {
         needed.extend_from_slice(&branch.union);
         self.pop_stack_values_not_needed_by(&needed);
         for value in Self::missing_stack_phi_sources(&self.scheduler.stack, &needed) {
-            assert!(self.scheduler.can_emit_value(value, func));
+            assert!(self.can_emit_stack_phi_value(func, value));
             self.emit_operand(func, value);
         }
         let target: Vec<_> = needed.iter().copied().map(TargetSlot::Value).collect();

--- a/tests/ui/codegen/lowering/run-call/stack_phi_recomputed_source.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/stack_phi_recomputed_source.mir.stdout
@@ -1,0 +1,26 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/stack_phi_recomputed_source.sol:StackPhiRecomputedSource ===
+@module StackPhiRecomputedSource
+fn @count(arg0: u256, arg1: calldataslice) -> u256 [selector=0xd6c2a588, pure, abi_args=lazy, abi_params=[u256, bytes], abi_returns=[word]] {
+  bb0:
+    jump bb1
+  bb1:
+    v0 = phi [bb0: 0], [bb3: v6]
+    v1 = phi [bb0: arg0], [bb3: v1]
+    v2 = phi [bb0: 0], [bb3: v5]
+    v3 = phi [bb0: arg1], [bb3: v3]
+    v4 = lt v0, v1
+    jumpi v4, bb4, bb5
+  bb2:
+    ret v2
+  bb3:
+    v6 = add v0, 1
+    jump bb1
+  bb4:
+    v5 = add v2, 1
+    jump bb6
+  bb5:
+    jump bb2
+  bb6:
+    jump bb3
+}
+

--- a/tests/ui/codegen/lowering/run-call/stack_phi_recomputed_source.sol
+++ b/tests/ui/codegen/lowering/run-call/stack_phi_recomputed_source.sol
@@ -1,0 +1,19 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: count(uint256,bytes) 0, 0x => 0
+//@ run-call: count(uint256,bytes) 1, 0x => 1
+//@ run-call: count(uint256,bytes) 2, 0x => 2
+//@ run-call: count(uint256,bytes) 0, 0x0102 => 0
+//@ run-call: count(uint256,bytes) 1, 0x0102 => 1
+//@ run-call: count(uint256,bytes) 2, 0x0102 => 2
+
+contract StackPhiRecomputedSource {
+    function count(uint256 n, bytes calldata) external pure returns (uint256 result) {
+        unchecked {
+            for (uint256 i; i < n; ++i) {
+                ++result;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stack-phi planning rejected an unstored value even when the scheduler had deliberately chosen to recompute it. The fallback then emitted copies for a physical layout that was never present, causing a stack underflow in unoptimized loop functions.

Allow the same recomputation predicate already used by `emit_operand` during stack-phi preflight. `solsymdiff` changed the reproducer from incomplete in both unoptimized pipelines to bounded agreement in all four modes; concrete boundary replays pass, and paired size, serialized-output, and hot-gas benchmarks are unchanged.