### PR TITLE
fix(codegen): clean memory bytes conversions

### DIFF
--- a/crates/codegen/src/lower/function/abi_values.rs
+++ b/crates/codegen/src/lower/function/abi_values.rs
@@ -1347,29 +1347,6 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         end_offset
     }
 
-    pub(super) fn is_calldata_dynamic_bytes_type(&self, ty: Ty<'gcx>) -> bool {
-        match ty.kind {
-            TyKind::Ref(inner, DataLocation::Calldata) => matches!(
-                inner.kind,
-                TyKind::Elementary(
-                    solar_sema::hir::ElementaryType::Bytes
-                        | solar_sema::hir::ElementaryType::String,
-                )
-            ),
-            TyKind::Slice(inner) => {
-                inner.is_ref_at(DataLocation::Calldata)
-                    && matches!(
-                        inner.peel_refs().kind,
-                        TyKind::Elementary(
-                            solar_sema::hir::ElementaryType::Bytes
-                                | solar_sema::hir::ElementaryType::String,
-                        )
-                    )
-            }
-            _ => false,
-        }
-    }
-
     fn try_pack_packed_word(
         &mut self,
         pieces: &[PackedPiece<'gcx>],

--- a/crates/codegen/src/lower/function/calls.rs
+++ b/crates/codegen/src/lower/function/calls.rs
@@ -479,23 +479,44 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         let source_size = fixed_bytes_size(from);
         let destination_size = fixed_bytes_size(to);
         if let Some(size) = destination_size
-            && self.is_calldata_dynamic_bytes_type(from)
-            && self.builder.func().value_slice_location(value) == Some(SliceLocation::Calldata)
+            && self.is_dynamic_bytes_type(from)
         {
             let zero = self.builder.imm_u64(0);
-            let word = self.builder.calldata_slice_load_word(value, zero);
-            let width = u64::from(size.bytes());
-            let fixed_mask =
-                self.builder.imm_u256(U256::MAX << (256 - usize::from(size.bytes()) * 8));
-            let length = self.builder.slice_len(value);
-            let width_value = self.builder.imm_u64(width);
-            let short = self.builder.lt(length, width_value);
-            let missing = self.builder.sub(width_value, length);
-            let bits_per_byte = self.builder.imm_u64(8);
-            let shift = self.builder.mul(bits_per_byte, missing);
-            let short_mask = self.builder.shl(shift, fixed_mask);
-            let mask = self.builder.select(short, short_mask, fixed_mask);
-            return self.builder.and(word, mask);
+            let word_and_length = match self.builder.func().value_ty(value) {
+                Some(MirType::MemoryObject(MemoryObjectKind::Bytes)) => {
+                    let word = self.builder.memory_object_load_element(
+                        value,
+                        MemoryObjectLayout::Bytes,
+                        zero,
+                    );
+                    let length = self.builder.memory_object_len(value, MemoryObjectKind::Bytes);
+                    Some((word, length))
+                }
+                Some(MirType::Slice(SliceLocation::Calldata)) => {
+                    let word = self.builder.calldata_slice_load_word(value, zero);
+                    let length = self.builder.slice_len(value);
+                    Some((word, length))
+                }
+                Some(MirType::Slice(SliceLocation::Memory)) => {
+                    let word = self.builder.memory_slice_load_word(value, zero);
+                    let length = self.builder.slice_len(value);
+                    Some((word, length))
+                }
+                _ => None,
+            };
+            if let Some((word, length)) = word_and_length {
+                let width = u64::from(size.bytes());
+                let fixed_mask =
+                    self.builder.imm_u256(U256::MAX << (256 - usize::from(size.bytes()) * 8));
+                let width_value = self.builder.imm_u64(width);
+                let short = self.builder.lt(length, width_value);
+                let missing = self.builder.sub(width_value, length);
+                let bits_per_byte = self.builder.imm_u64(8);
+                let shift = self.builder.mul(bits_per_byte, missing);
+                let short_mask = self.builder.shl(shift, fixed_mask);
+                let mask = self.builder.select(short, short_mask, fixed_mask);
+                return self.builder.and(word, mask);
+            }
         }
         if destination_size.is_some()
             && let Some(abi_type) = self.types.abi_type(from)

--- a/crates/codegen/src/lower/function/indexing.rs
+++ b/crates/codegen/src/lower/function/indexing.rs
@@ -172,11 +172,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 )
             }
         };
-        let is_bytes = self.is_calldata_dynamic_bytes_type(receiver_ty)
-            || matches!(
-                receiver_ty.peel_refs().kind,
-                TyKind::Elementary(ElementaryType::Bytes | ElementaryType::String,)
-            );
+        let is_bytes = self.is_dynamic_bytes_type(receiver_ty);
         let element_stride = if is_bytes {
             1
         } else if !matches!(receiver_ty.peel_refs().kind, TyKind::DynArray(_) | TyKind::Slice(_))

--- a/tests/ui/codegen/lowering/run-call/abi_encode_call_memory_v2.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/abi_encode_call_memory_v2.mir.stdout
@@ -120,37 +120,79 @@ fn @test() -> bytes4 [selector=0xf8a8fd6d, abi_args=lazy, abi_params=[], abi_ret
     revert 0, 36
   bb20:
     v46 = memory_object_load_element memorybytes, v26, 0
-    v47 = memory_object_load_element memorybytes, v33, 0
-    v48 = eq v46, v47
-    v49 = iszero v48
-    jumpi v49, bb21, bb22
+    v47 = memory_object_len memorybytes, v26
+    v48 = lt v47, 4
+    v49 = sub 4, v47
+    v50 = mul 8, v49
+    v51 = shl v50, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v52 = select v48, v51, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v53 = and v46, v52
+    v54 = memory_object_load_element memorybytes, v33, 0
+    v55 = memory_object_len memorybytes, v33
+    v56 = lt v55, 4
+    v57 = sub 4, v55
+    v58 = mul 8, v57
+    v59 = shl v58, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v60 = select v56, v59, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v61 = and v54, v60
+    v62 = eq v53, v61
+    v63 = iszero v62
+    jumpi v63, bb21, bb22
   bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb22:
-    v50 = memory_object_load_element memorybytes, v26, 0
-    v51 = memory_object_load_element memorybytes, v36, 0
-    v52 = eq v50, v51
-    v53 = iszero v52
-    jumpi v53, bb23, bb24
+    v64 = memory_object_load_element memorybytes, v26, 0
+    v65 = memory_object_len memorybytes, v26
+    v66 = lt v65, 4
+    v67 = sub 4, v65
+    v68 = mul 8, v67
+    v69 = shl v68, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v70 = select v66, v69, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v71 = and v64, v70
+    v72 = memory_object_load_element memorybytes, v36, 0
+    v73 = memory_object_len memorybytes, v36
+    v74 = lt v73, 4
+    v75 = sub 4, v73
+    v76 = mul 8, v75
+    v77 = shl v76, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v78 = select v74, v77, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v79 = and v72, v78
+    v80 = eq v71, v79
+    v81 = iszero v80
+    jumpi v81, bb23, bb24
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb24:
-    v54 = memory_object_load_element memorybytes, v26, 0
-    v55 = and v19, 0xffffffff
-    v56 = shl 224, v55
-    v57 = eq v54, v56
-    v58 = iszero v57
-    jumpi v58, bb25, bb26
+    v82 = memory_object_load_element memorybytes, v26, 0
+    v83 = memory_object_len memorybytes, v26
+    v84 = lt v83, 4
+    v85 = sub 4, v83
+    v86 = mul 8, v85
+    v87 = shl v86, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v88 = select v84, v87, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v89 = and v82, v88
+    v90 = and v19, 0xffffffff
+    v91 = shl 224, v90
+    v92 = eq v89, v91
+    v93 = iszero v92
+    jumpi v93, bb25, bb26
   bb25:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb26:
-    v59 = memory_object_load_element memorybytes, v26, 0
-    ret v59
+    v94 = memory_object_load_element memorybytes, v26, 0
+    v95 = memory_object_len memorybytes, v26
+    v96 = lt v95, 4
+    v97 = sub 4, v95
+    v98 = mul 8, v97
+    v99 = shl v98, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v100 = select v96, v99, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v101 = and v94, v100
+    ret v101
 }
 

--- a/tests/ui/codegen/lowering/run-call/delete_memory_reference.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/delete_memory_reference.mir.stdout
@@ -41,6 +41,13 @@ fn @bytesValue() -> (u256, u256, bytes2) [selector=0x5a286ac0, pure, abi_args=la
     v2 = memory_object_len memorybytes, v1
     v3 = memory_object_len memorybytes, v0
     v4 = memory_object_load_element memorybytes, v0, 0
-    ret v2, v3, v4
+    v5 = memory_object_len memorybytes, v0
+    v6 = lt v5, 2
+    v7 = sub 2, v5
+    v8 = mul 8, v7
+    v9 = shl v8, 0xffff000000000000000000000000000000000000000000000000000000000000
+    v10 = select v6, v9, 0xffff000000000000000000000000000000000000000000000000000000000000
+    v11 = and v4, v10
+    ret v2, v3, v11
 }
 

--- a/tests/ui/codegen/lowering/run-call/fixed_bytes_numeric_literals.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/fixed_bytes_numeric_literals.mir.stdout
@@ -45,7 +45,14 @@ fn @encodeSelector(arg0: bytes4) -> bytes4 [selector=0xe234433f, pure, abi_args=
   bb0:
     v0 = abi_encode [word], object, selector arg0, args 1
     v1 = memory_object_load_element memorybytes, v0, 0
-    ret v1
+    v2 = memory_object_len memorybytes, v0
+    v3 = lt v2, 4
+    v4 = sub 4, v2
+    v5 = mul 8, v4
+    v6 = shl v5, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v7 = select v3, v6, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v8 = and v1, v7
+    ret v8
 }
 
 fn @encodeLocalSelector() -> bytes4 [selector=0x0e6d4a3f, pure, abi_args=lazy, abi_params=[], abi_returns=[word]] {
@@ -55,7 +62,14 @@ fn @encodeLocalSelector() -> bytes4 [selector=0x0e6d4a3f, pure, abi_args=lazy, a
     memory_object_store_word memorybytes, v0, 0, 0x6162630000000000000000000000000000000000000000000000000000000000
     v1 = abi_encode [memory_bytes], object, selector 0x1234567800000000000000000000000000000000000000000000000000000000, args v0
     v2 = memory_object_load_element memorybytes, v1, 0
-    ret v2
+    v3 = memory_object_len memorybytes, v1
+    v4 = lt v3, 4
+    v5 = sub 4, v3
+    v6 = mul 8, v5
+    v7 = shl v6, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v8 = select v4, v7, 0xffffffff00000000000000000000000000000000000000000000000000000000
+    v9 = and v2, v8
+    ret v9
 }
 
 fn @orByte(arg0: bytes1, arg1: bytes1) -> bytes1 [pure] {

--- a/tests/ui/codegen/lowering/run-call/memory_bytes_to_fixed.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/memory_bytes_to_fixed.mir.stdout
@@ -1,0 +1,16 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/memory_bytes_to_fixed.sol:MemoryBytesToFixed ===
+@module MemoryBytesToFixed
+fn @shorten(arg0: memorybytes, arg1: u256) -> bytes16 [selector=0xe05b43e0, pure, abi_args=lazy, abi_params=[bytes, u256], abi_returns=[word]] {
+  bb0:
+    mstore arg0, arg1
+    v0 = memory_object_load_element memorybytes, arg0, 0
+    v1 = memory_object_len memorybytes, arg0
+    v2 = lt v1, 16
+    v3 = sub 16, v1
+    v4 = mul 8, v3
+    v5 = shl v4, 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
+    v6 = select v2, v5, 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
+    v7 = and v0, v6
+    ret v7
+}
+

--- a/tests/ui/codegen/lowering/run-call/memory_bytes_to_fixed.sol
+++ b/tests/ui/codegen/lowering/run-call/memory_bytes_to_fixed.sol
@@ -1,0 +1,17 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: shorten(bytes,uint256) 0x01020304, 0 => 0x00000000000000000000000000000000
+//@ run-call: shorten(bytes,uint256) 0x01020304, 2 => 0x01020000000000000000000000000000
+//@ run-call: shorten(bytes,uint256) 0x0102030405060708090a0b0c0d0e0f1011, 15 => 0x0102030405060708090a0b0c0d0e0f00
+//@ run-call: shorten(bytes,uint256) 0x0102030405060708090a0b0c0d0e0f1011, 17 => 0x0102030405060708090a0b0c0d0e0f10
+// ported-from: test/libsolidity/semanticTests/array/bytes_to_fixed_bytes_cleanup.sol
+
+contract MemoryBytesToFixed {
+    function shorten(bytes memory value, uint256 length) external pure returns (bytes16) {
+        assembly ("memory-safe") {
+            mstore(value, length)
+        }
+        return bytes16(value);
+    }
+}


### PR DESCRIPTION
## summary

- mask bytes beyond the semantic length when converting `bytes memory` or `string memory` to fixed bytes
- handle memory objects, memory slices, and calldata slices through the same conversion path
- reuse the existing dynamic-bytes type classifier instead of keeping a calldata-only duplicate

## proof

Solsymdiff found the upstream `bytes_to_fixed_bytes_cleanup.sol` case: after inline assembly shortens a memory byte array, Solar leaked dirty tail bytes while solc cleared them. The baseline mismatched in all four optimizer/backend combinations; this change reaches bounded agreement in all four. The standard codegen matrix regression covers lengths below, at, and above the fixed-width boundary.

## validation

- full UI suite passed
- workspace: 1453 tests passed; the load-sensitive LSP timeout passed alone, and the Foundry integration passed directly in 166s
- workspace clippy with `-D warnings`, check, build, fmt, and source diff checks
- 24-project runtime corpus and hot-call gas unchanged
- measured correctness cost: OpenZeppelin Governor creation bytecode +26 bytes and deployment gas +552; deployed size and hot-call gas unchanged