### PR TITLE
fix(codegen): lower fixed-bytes length

### DIFF
--- a/crates/codegen/src/lower/function/expressions.rs
+++ b/crates/codegen/src/lower/function/expressions.rs
@@ -385,6 +385,20 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 self.context.gcx.event_selector(event_id).as_slice(),
             )));
         }
+        if builtin == Builtin::FixedBytesLength {
+            let ExprKind::Member(receiver, _) = &expr.kind else {
+                return report_unsupported(self.context.gcx, expr.span, "fixed-bytes length");
+            };
+            let TyKind::Elementary(ElementaryType::FixedBytes(size)) =
+                self.context.gcx.type_of_expr(receiver.id)?.peel_refs().kind
+            else {
+                return report_unsupported(self.context.gcx, expr.span, "fixed-bytes length");
+            };
+            if !matches!(receiver.peel_parens().kind, ExprKind::Ident(_)) {
+                self.lower_expr(receiver)?;
+            }
+            return Some(self.builder.imm_u64(u64::from(size.bytes())));
+        }
         if builtin == Builtin::ArrayLength {
             let ExprKind::Member(receiver, _) = &expr.kind else {
                 return report_unsupported(self.context.gcx, expr.span, "array length");

--- a/tests/ui/codegen/lowering/run-call/fixed_bytes_length_access.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/fixed_bytes_length_access.mir.stdout
@@ -1,0 +1,38 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/fixed_bytes_length_access.sol:C ===
+@module C
+fn @f(arg0: bytes32) -> (u256, u256, u256) [selector=0xd7da973a, view, abi_args=lazy, abi_params=[bytes32], abi_returns=[word, word, word]] {
+  bb0:
+    v0 = shl 128, 2
+    v1 = add 1, 7
+    v2 = gt v1, 255
+    jumpi v2, bb1, bb2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb2:
+    ret 32, 16, v1
+}
+
+fn @sideEffect() -> (u256, u256) [selector=0x3a058265, abi_args=lazy, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    v0 = internal_call @makeBytes, 1
+    v1 = sload 1 !metadata(storage=slot(1))
+    ret 4, v1
+}
+
+fn @makeBytes() -> bytes4 {
+  bb0:
+    v0 = sload 1 !metadata(storage=slot(1))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb2:
+    sstore 1, v1 !metadata(storage=slot(1))
+    ret 0
+}
+

--- a/tests/ui/codegen/lowering/run-call/fixed_bytes_length_access.sol
+++ b/tests/ui/codegen/lowering/run-call/fixed_bytes_length_access.sol
@@ -1,0 +1,24 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: f(bytes32) 0x0000000000000000000000000000000000000000000000000000000000000000 => 32, 16, 8
+//@ run-call: sideEffect() => 4, 1
+// ported-from: test/libsolidity/semanticTests/array/fixed_bytes_length_access.sol
+
+contract C {
+    bytes1 a;
+    uint256 private calls;
+
+    function f(bytes32 x) public view returns (uint256, uint256, uint256) {
+        return (x.length, bytes16(uint128(2)).length, a.length + 7);
+    }
+
+    function sideEffect() external returns (uint256, uint256) {
+        return (makeBytes().length, calls);
+    }
+
+    function makeBytes() private returns (bytes4) {
+        calls += 1;
+        return 0;
+    }
+}


### PR DESCRIPTION
## summary

- lower fixed-bytes `.length` to the type's compile-time byte width
- preserve side effects when the receiver is an expression

## proof

Solsymdiff found the upstream `fixed_bytes_length_access.sol` case. Dani's rewrite branch rejected it in all four optimizer/backend combinations; this change reaches bounded agreement with solc in all four. The standard codegen matrix test covers `bytes32`, `bytes16`, storage `bytes1`, and a side-effecting `bytes4` receiver evaluated exactly once.

## validation

- focused codegen and full UI suites passed
- workspace passed; the load-sensitive Foundry wrapper passed separately with a 300-second timeout
- workspace clippy with `-D warnings`, check, and fmt passed
- 24-project runtime corpus, 175-call hot gas workload, and 258 common run-call outputs unchanged
