### PR TITLE
fix(sema): allow calldata string slices

### DIFF
--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -449,9 +449,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 } else if !is_calldata_sliceable(ty) {
                     self.dcx().emit_err(expr.span, "can only slice dynamic calldata arrays");
                 }
-                if self.index_types(ty).is_some()
-                    || matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::String))
-                {
+                if self.index_types(ty).is_some() || is_string_or_string_slice(ty) {
                     if let Some(start) = start {
                         let _ = self.expect_ty(start, self.gcx.types.uint(256));
                     }
@@ -998,7 +996,9 @@ impl<'gcx> TypeChecker<'gcx> {
             TyKind::Array(element, _) | TyKind::DynArray(element) => {
                 (self.gcx.types.uint(256), element.with_loc_if_ref_opt(self.gcx, loc))
             }
-            TyKind::Slice(array) => (self.gcx.types.uint(256), array.base_type(self.gcx)?),
+            TyKind::Slice(array) if !is_string_or_string_slice(array) => {
+                (self.gcx.types.uint(256), array.base_type(self.gcx)?)
+            }
             TyKind::Elementary(ElementaryType::Bytes)
             | TyKind::Elementary(ElementaryType::FixedBytes(_)) => {
                 (self.gcx.types.uint(256), self.gcx.types.fixed_bytes(1))
@@ -2943,13 +2943,13 @@ fn is_calldata_sliceable(ty: Ty<'_>) -> bool {
 }
 
 fn valid_string_concat_arg(ty: Ty<'_>) -> bool {
+    matches!(ty.kind, TyKind::StringLiteral(true, _)) || is_string_or_string_slice(ty)
+}
+
+fn is_string_or_string_slice(ty: Ty<'_>) -> bool {
     let ty = ty.peel_refs();
-    matches!(ty.kind, TyKind::StringLiteral(true, _) | TyKind::Elementary(ElementaryType::String))
-        || matches!(
-            ty.kind,
-            TyKind::Slice(array)
-                if matches!(array.peel_refs().kind, TyKind::Elementary(ElementaryType::String))
-        )
+    matches!(ty.kind, TyKind::Elementary(ElementaryType::String))
+        || matches!(ty.kind, TyKind::Slice(array) if is_string_or_string_slice(array))
 }
 
 fn valid_bytes_concat_arg(ty: Ty<'_>) -> bool {

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -449,7 +449,9 @@ impl<'gcx> TypeChecker<'gcx> {
                 } else if !is_calldata_sliceable(ty) {
                     self.dcx().emit_err(expr.span, "can only slice dynamic calldata arrays");
                 }
-                if let Some((_index_ty, _result_ty)) = self.index_types(ty) {
+                if self.index_types(ty).is_some()
+                    || matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::String))
+                {
                     if let Some(start) = start {
                         let _ = self.expect_ty(start, self.gcx.types.uint(256));
                     }

--- a/tests/ui/codegen/run-call/calldata_string_slicing.sol
+++ b/tests/ui/codegen/run-call/calldata_string_slicing.sol
@@ -7,12 +7,14 @@
 //@[unoptimized] run-call-fail: slice(string,uint256) "abcd", 5 => 0x
 //@[unoptimized] run-call: segment(string,uint256,uint256) "abcd", 1, 3 => "bc"
 //@[unoptimized] run-call: segment(string,uint256,uint256) "abcd", 4, 4 => ""
+//@[unoptimized] run-call: nested(string,uint256,uint256,uint256,uint256) "abcdef", 1, 5, 1, 3 => "cd"
 //@[optimized] run-call: slice(string,uint256) "abcd", 0 => "abcd"
 //@[optimized] run-call: slice(string,uint256) "abcd", 2 => "abcd"
 //@[optimized] run-call: slice(string,uint256) "abcd", 4 => "abcd"
 //@[optimized] run-call-fail: slice(string,uint256) "abcd", 5 => 0x
 //@[optimized] run-call: segment(string,uint256,uint256) "abcd", 1, 3 => "bc"
 //@[optimized] run-call: segment(string,uint256,uint256) "abcd", 4, 4 => ""
+//@[optimized] run-call: nested(string,uint256,uint256,uint256,uint256) "abcdef", 1, 5, 1, 3 => "cd"
 // ported-from: test/libsolidity/semanticTests/strings/concat/string_concat_different_types.sol
 
 contract CalldataStringSlicing {
@@ -30,6 +32,17 @@ contract CalldataStringSlicing {
         returns (string memory)
     {
         string calldata selected = value[start:end];
+        return selected;
+    }
+
+    function nested(
+        string calldata value,
+        uint256 outerStart,
+        uint256 outerEnd,
+        uint256 innerStart,
+        uint256 innerEnd
+    ) external pure returns (string memory) {
+        string calldata selected = value[outerStart:outerEnd][innerStart:innerEnd];
         return selected;
     }
 }

--- a/tests/ui/codegen/run-call/calldata_string_slicing.sol
+++ b/tests/ui/codegen/run-call/calldata_string_slicing.sol
@@ -1,0 +1,35 @@
+//@ revisions: unoptimized optimized
+//@[unoptimized] compile-flags: -O none
+//@[optimized] compile-flags: -O gas
+//@[unoptimized] run-call: slice(string,uint256) "abcd", 0 => "abcd"
+//@[unoptimized] run-call: slice(string,uint256) "abcd", 2 => "abcd"
+//@[unoptimized] run-call: slice(string,uint256) "abcd", 4 => "abcd"
+//@[unoptimized] run-call-fail: slice(string,uint256) "abcd", 5 => 0x
+//@[unoptimized] run-call: segment(string,uint256,uint256) "abcd", 1, 3 => "bc"
+//@[unoptimized] run-call: segment(string,uint256,uint256) "abcd", 4, 4 => ""
+//@[optimized] run-call: slice(string,uint256) "abcd", 0 => "abcd"
+//@[optimized] run-call: slice(string,uint256) "abcd", 2 => "abcd"
+//@[optimized] run-call: slice(string,uint256) "abcd", 4 => "abcd"
+//@[optimized] run-call-fail: slice(string,uint256) "abcd", 5 => 0x
+//@[optimized] run-call: segment(string,uint256,uint256) "abcd", 1, 3 => "bc"
+//@[optimized] run-call: segment(string,uint256,uint256) "abcd", 4, 4 => ""
+// ported-from: test/libsolidity/semanticTests/strings/concat/string_concat_different_types.sol
+
+contract CalldataStringSlicing {
+    function slice(string calldata value, uint256 split)
+        external
+        pure
+        returns (string memory)
+    {
+        return string.concat(value[:split], value[split:]);
+    }
+
+    function segment(string calldata value, uint256 start, uint256 end)
+        external
+        pure
+        returns (string memory)
+    {
+        string calldata selected = value[start:end];
+        return selected;
+    }
+}

--- a/tests/ui/typeck/calldata_string_indexing.sol
+++ b/tests/ui/typeck/calldata_string_indexing.sol
@@ -3,4 +3,9 @@ contract C {
         return value[0];
         //~^ ERROR: cannot index into string calldata
     }
+
+    function indexSlice(string calldata value) external pure returns (bytes1) {
+        return value[:][0];
+        //~^ ERROR: cannot index into string calldata slice
+    }
 }

--- a/tests/ui/typeck/calldata_string_indexing.sol
+++ b/tests/ui/typeck/calldata_string_indexing.sol
@@ -1,0 +1,6 @@
+contract C {
+    function index(string calldata value) external pure returns (bytes1) {
+        return value[0];
+        //~^ ERROR: cannot index into string calldata
+    }
+}

--- a/tests/ui/typeck/calldata_string_indexing.stderr
+++ b/tests/ui/typeck/calldata_string_indexing.stderr
@@ -1,0 +1,8 @@
+error: cannot index into string calldata
+   ╭▸ ROOT/tests/ui/typeck/calldata_string_indexing.sol:LL:CC
+   │
+LL │         return value[0];
+   ╰╴               ━━━━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/calldata_string_indexing.stderr
+++ b/tests/ui/typeck/calldata_string_indexing.stderr
@@ -4,5 +4,11 @@ error: cannot index into string calldata
 LL │         return value[0];
    ╰╴               ━━━━━━━━
 
-error: aborting due to 1 previous error
+error: cannot index into string calldata slice
+   ╭▸ ROOT/tests/ui/typeck/calldata_string_indexing.sol:LL:CC
+   │
+LL │         return value[:][0];
+   ╰╴               ━━━━━━━━━━━
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
## summary

- allow Solidity-compatible range slicing of `string calldata`
- keep direct `string[index]` access rejected

## proof

The differential campaign found Solar rejecting the upstream `string_concat_different_types.sol` slice case while solc 0.8.35 and 0.8.36 compile it. Concrete Solc/Solar replay now agrees exactly in all four optimizer/viaIR combinations across empty, valid, out-of-bounds, and maximum bounds. The symbolic run remains incomplete on dynamic string copying, so it is not used as proof here.

## validation

- focused UI, sema/codegen, and upstream Solidity target passed
- full workspace: 1,457 tests passed, one skipped
- clippy, nightly fmt, and diff checks passed
- focused analysis and warmed Solady benchmarks were neutral
