### PR TITLE
fix(codegen): preserve isolated array pop access

### DIFF
--- a/crates/codegen/src/lower/function/expressions.rs
+++ b/crates/codegen/src/lower/function/expressions.rs
@@ -59,6 +59,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 let receiver = self.lower_expr(receiver)?;
                 return Some(self.builder.balance(receiver));
             }
+            if builtin == Builtin::ArrayPop {
+                self.storage_access(receiver)?;
+                return Some(self.builder.imm_u256(U256::ZERO));
+            }
             return self.lower_environment_builtin(expr, builtin);
         }
         if let Some(value) = self.lower_internal_function_value(expr) {

--- a/tests/ui/codegen/lowering/run-call/isolated_array_pop.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/isolated_array_pop.mir.stdout
@@ -1,0 +1,131 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/isolated_array_pop.sol:IsolatedArrayPop ===
+@module IsolatedArrayPop
+fn @access() -> (u256, u256, u256) [selector=0x71907f17, abi_args=lazy, abi_params=[], abi_returns=[word, word, word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb2:
+    v3 = storage_array_data_slot 0
+    v4 = add v3, v0
+    sstore 0, v1 !metadata(storage=slot(0))
+    v5 = sload 0 !metadata(storage=slot(0))
+    v6 = add v5, 1
+    v7 = lt v6, v5
+    jumpi v7, bb3, bb4
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    v8 = storage_array_data_slot 0
+    v9 = add v8, v5
+    sstore 0, v6 !metadata(storage=slot(0))
+    v10 = add 0, 1
+    v11 = lt v10, 0
+    jumpi v11, bb5, bb6
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb6:
+    v12 = sload 0 !metadata(storage=slot(0))
+    v13 = lt 0, v12
+    v14 = iszero v13
+    jumpi v14, bb7, bb8
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb8:
+    v15 = storage_array_data_slot 0
+    v16 = add v15, 0
+    v17 = sload 0 !metadata(storage=slot(0))
+    v18 = lt 0, v17
+    v19 = iszero v18
+    jumpi v19, bb9, bb10
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb10:
+    v20 = storage_array_data_slot 0
+    v21 = add v20, 0
+    v22 = sload v21 !metadata(storage=symbolic(v20))
+    v23 = sload 1 !metadata(storage=slot(1))
+    v24 = and v23, 1
+    v25 = eq v24, 1
+    v26 = and v23, 254
+    v27 = shr 1, v26
+    v28 = shr 1, v23
+    v29 = select v25, v28, v27
+    v30 = lt v29, 32
+    v31 = eq v25, v30
+    jumpi v31, bb11, bb12
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 34 !metadata(memory=scratch)
+    revert 0, 36
+  bb12:
+    v32 = add v29, 31
+    v33 = lt v32, v29
+    jumpi v33, bb13, bb14
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb14:
+    v34 = div v32, 32
+    v35 = add v34, 1
+    v36 = lt v35, v34
+    jumpi v36, bb15, bb16
+  bb15:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb16:
+    v37 = mul v35, 32
+    v38 = iszero 32
+    v39 = div v37, 32
+    v40 = eq v39, v35
+    v41 = or v38, v40
+    v42 = iszero v41
+    jumpi v42, bb17, bb18
+  bb17:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb18:
+    v43 = alloc memorybytes, exact, zeroed, panic, v37
+    set_memory_object_len memorybytes, v43, v29
+    jumpi v25, bb20, bb19
+  bb19:
+    v44 = and v23, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
+    memory_object_store_word memorybytes, v43, 0, v44
+    jump bb21
+  bb20:
+    v45 = storage_array_data_slot 1
+    jump bb22
+  bb21:
+    v52 = memory_object_len memorybytes, v43
+    ret v10, v22, v52
+  bb22:
+    v46 = phi [bb20: 0], [bb23: v51]
+    v47 = lt v46, v34
+    jumpi v47, bb23, bb24
+  bb23:
+    v48 = add v45, v46
+    v49 = sload v48 !metadata(storage=symbolic(v48))
+    v50 = mul v46, 32
+    memory_object_store_word memorybytes, v43, v50, v49
+    v51 = add v46, 1
+    jump bb22
+  bb24:
+    jump bb21
+}
+

--- a/tests/ui/codegen/lowering/run-call/isolated_array_pop.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/isolated_array_pop.mir.stdout
@@ -60,72 +60,54 @@ fn @access() -> (u256, u256, u256) [selector=0x71907f17, abi_args=lazy, abi_para
     v23 = sload 1 !metadata(storage=slot(1))
     v24 = and v23, 1
     v25 = eq v24, 1
-    v26 = and v23, 254
-    v27 = shr 1, v26
-    v28 = shr 1, v23
-    v29 = select v25, v28, v27
-    v30 = lt v29, 32
-    v31 = eq v25, v30
-    jumpi v31, bb11, bb12
+    v26 = shr 1, v23
+    v27 = and v26, 127
+    v28 = select v25, v26, v27
+    v29 = lt v28, 32
+    v30 = eq v25, v29
+    jumpi v30, bb11, bb12
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 34 !metadata(memory=scratch)
     revert 0, 36
   bb12:
-    v32 = add v29, 31
-    v33 = lt v32, v29
-    jumpi v33, bb13, bb14
+    v31 = add v28, 31
+    v32 = div v31, 32
+    v33 = add v28, 63
+    v34 = lt v33, v28
+    jumpi v34, bb13, bb14
   bb13:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb14:
-    v34 = div v32, 32
-    v35 = add v34, 1
-    v36 = lt v35, v34
-    jumpi v36, bb15, bb16
+    v35 = not 31
+    v36 = and v33, v35
+    v37 = alloc memorybytes, exact, uninitialized, panic, v36
+    set_memory_object_len memorybytes, v37, v28
+    jumpi v25, bb16, bb15
   bb15:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    v38 = and v23, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
+    memory_object_store_word memorybytes, v37, 0, v38
+    jump bb17
   bb16:
-    v37 = mul v35, 32
-    v38 = iszero 32
-    v39 = div v37, 32
-    v40 = eq v39, v35
-    v41 = or v38, v40
-    v42 = iszero v41
-    jumpi v42, bb17, bb18
+    v39 = storage_array_data_slot 1
+    jump bb18
   bb17:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    v46 = memory_object_len memorybytes, v37
+    ret v10, v22, v46
   bb18:
-    v43 = alloc memorybytes, exact, zeroed, panic, v37
-    set_memory_object_len memorybytes, v43, v29
-    jumpi v25, bb20, bb19
+    v40 = phi [bb16: 0], [bb19: v45]
+    v41 = lt v40, v32
+    jumpi v41, bb19, bb20
   bb19:
-    v44 = and v23, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
-    memory_object_store_word memorybytes, v43, 0, v44
-    jump bb21
+    v42 = add v39, v40
+    v43 = sload v42 !metadata(storage=symbolic(v42))
+    v44 = mul v40, 32
+    memory_object_store_word memorybytes, v37, v44, v43
+    v45 = add v40, 1
+    jump bb18
   bb20:
-    v45 = storage_array_data_slot 1
-    jump bb22
-  bb21:
-    v52 = memory_object_len memorybytes, v43
-    ret v10, v22, v52
-  bb22:
-    v46 = phi [bb20: 0], [bb23: v51]
-    v47 = lt v46, v34
-    jumpi v47, bb23, bb24
-  bb23:
-    v48 = add v45, v46
-    v49 = sload v48 !metadata(storage=symbolic(v48))
-    v50 = mul v46, 32
-    memory_object_store_word memorybytes, v43, v50, v49
-    v51 = add v46, 1
-    jump bb22
-  bb24:
-    jump bb21
+    jump bb17
 }
 

--- a/tests/ui/codegen/lowering/run-call/isolated_array_pop.sol
+++ b/tests/ui/codegen/lowering/run-call/isolated_array_pop.sol
@@ -1,0 +1,23 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: access() => 1, 0, 0
+// ported-from: test/libsolidity/semanticTests/array/pop/array_pop_isolated.sol
+// ported-from: test/libsolidity/semanticTests/array/pop/byte_array_pop_isolated.sol
+
+contract IsolatedArrayPop {
+    uint256[][] private values;
+    bytes private data;
+
+    function access()
+        external
+        returns (uint256 index, uint256 arrayLength, uint256 bytesLength)
+    {
+        values.push();
+        values.push();
+        values[index++].pop;
+        data.pop;
+        arrayLength = values[0].length;
+        bytesLength = data.length;
+    }
+}


### PR DESCRIPTION
## summary

- evaluate the receiver of an isolated storage `.pop` member expression
- preserve receiver side effects without mutating the array

## proof

The differential campaign found Solar rejecting Solidity's upstream isolated array and bytes `.pop` cases. The standard codegen matrix test proves that `values[index++].pop` evaluates the indexed receiver once while neither it nor `data.pop` removes an element. The candidate reaches bounded agreement with solc in all four optimizer/backend combinations.

## validation

- full UI suite passed
- workspace remainder passed; load-sensitive LSP tests and the 140-second Foundry wrapper passed separately
- workspace clippy with `-D warnings`, check, build, and fmt passed
- 24-project runtime corpus and hot-call gas workload unchanged
- source diff checks clean; the generated MIR snapshot retains the repository-required terminal blank line
