### PR TITLE
fix(sema): resolve overridden call targets

### DIFF
--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1339,6 +1339,18 @@ impl<'gcx> Gcx<'gcx> {
         self.virtual_function_target((contract, function))
     }
 
+    /// Returns whether `function` transitively overrides `base`.
+    pub(crate) fn function_overrides(
+        self,
+        function: hir::FunctionId,
+        base: hir::FunctionId,
+    ) -> bool {
+        self.base_override_items(function.into()).iter().any(|item| {
+            let hir::ItemId::Function(overridden) = item else { return false };
+            *overridden == base || self.function_overrides(*overridden, base)
+        })
+    }
+
     /// Resolves a `super` function call in the context of the most-derived contract.
     pub fn resolve_super_function(
         self,
@@ -1511,18 +1523,11 @@ fn virtual_function_target(
     gcx: _,
     key: (hir::ContractId, hir::FunctionId)
 ) -> hir::FunctionId {
-    fn function_overrides(gcx: Gcx<'_>, function: hir::FunctionId, base: hir::FunctionId) -> bool {
-        gcx.base_override_items(function.into()).iter().any(|item| {
-            let hir::ItemId::Function(overridden) = item else { return false };
-            *overridden == base || function_overrides(gcx, *overridden, base)
-        })
-    }
-
     let (contract, function) = key;
     debug_assert!(gcx.hir.function(function).virtual_);
     for &base in gcx.hir.contract(contract).linearized_bases {
         for candidate in gcx.hir.contract(base).functions() {
-            if candidate == function || function_overrides(gcx, candidate, function) {
+            if candidate == function || gcx.function_overrides(candidate, function) {
                 return candidate;
             }
         }

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -1818,35 +1818,15 @@ impl<'gcx> TypeChecker<'gcx> {
     }
 
     fn select_most_derived_function(&self, candidates: &[hir::Res]) -> Option<hir::Res> {
-        let contract = self.contract?;
-        let bases = self.gcx.hir.contract(contract).linearized_bases;
-
-        let mut selected = None;
-        let mut selected_depth = usize::MAX;
-        let mut parameter_types = None;
-        for &candidate in candidates {
-            let hir::Res::Item(hir::ItemId::Function(id)) = candidate else { return None };
-            let function = self.gcx.hir.function(id);
-            let depth = bases.iter().position(|&base| Some(base) == function.contract)?;
-            let params = self.gcx.item_parameter_types(id);
-            if let Some(parameter_types) = parameter_types {
-                if parameter_types != params {
-                    return None;
-                }
-            } else {
-                parameter_types = Some(params);
-            }
-
-            match depth.cmp(&selected_depth) {
-                std::cmp::Ordering::Less => {
-                    selected = Some(candidate);
-                    selected_depth = depth;
-                }
-                std::cmp::Ordering::Equal => return None,
-                std::cmp::Ordering::Greater => {}
-            }
-        }
-        selected
+        candidates.iter().copied().find(|&candidate| {
+            let hir::Res::Item(hir::ItemId::Function(candidate_id)) = candidate else {
+                return false;
+            };
+            candidates.iter().copied().all(|base| {
+                let hir::Res::Item(hir::ItemId::Function(base_id)) = base else { return false };
+                candidate_id == base_id || self.gcx.function_overrides(candidate_id, base_id)
+            })
+        })
     }
 
     fn select_member_call_overload<'a>(

--- a/tests/ui/codegen/run-call/override_data_locations.sol
+++ b/tests/ui/codegen/run-call/override_data_locations.sol
@@ -1,0 +1,18 @@
+//@ run-call: f(uint256[]) [9, 8] => [9, 8]
+//@ run-call: g(uint256[]) [9, 8] => [9, 8]
+//@ compile-flags: --allow=2018
+// ported-from: test/libsolidity/semanticTests/inheritance/dataLocation/external_public_calldata.sol
+
+abstract contract A {
+    function f(uint256[] calldata a) external virtual returns (uint256[] calldata);
+}
+
+contract B is A {
+    function f(uint256[] memory a) public override returns (uint256[] memory) {
+        return a;
+    }
+
+    function g(uint256[] calldata x) public returns (uint256[] memory) {
+        return f(x);
+    }
+}


### PR DESCRIPTION
Valid external functions can be overridden by public functions while changing reference parameters from calldata to memory. Both declarations then match an unqualified internal call, but comparing their internal parameter types incorrectly leaves the call ambiguous.

This selects a target only when the validated override graph proves that it transitively overrides every other matching declaration. Unrelated overloads remain ambiguous.

The regression covers both the direct override and the internal call. `solsymdiff` found the upstream case, and the patched compiler reaches replay-confirmed bounded agreement with Solc 0.8.36 for dynamic-array lengths 0 through 3.

AI assistance: Codex helped investigate, implement, and validate this change.