### PR TITLE
fix(sema): match solc fallback and receive overrides

### DIFF
--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -801,7 +801,7 @@ impl<'gcx> OverrideChecker<'gcx> {
             .functions()
             .filter_map(|f_id| {
                 let f = self.gcx.hir.function(f_id);
-                if f.kind.is_constructor() || f.kind.is_receive() {
+                if f.kind.is_constructor() {
                     return None;
                 }
                 Some(self.signature(OverrideProxy::Function(f_id)))

--- a/crates/sema/src/typeck/override_checker.rs
+++ b/crates/sema/src/typeck/override_checker.rs
@@ -801,7 +801,7 @@ impl<'gcx> OverrideChecker<'gcx> {
             .functions()
             .filter_map(|f_id| {
                 let f = self.gcx.hir.function(f_id);
-                if f.kind.is_constructor() || f.name.is_none() {
+                if f.kind.is_constructor() || f.kind.is_receive() {
                     return None;
                 }
                 Some(self.signature(OverrideProxy::Function(f_id)))

--- a/tests/ui/codegen/run-call/fallback_override_multi.sol
+++ b/tests/ui/codegen/run-call/fallback_override_multi.sol
@@ -1,0 +1,19 @@
+//@ run-call: f => true, 0
+// ported-from: test/libsolidity/semanticTests/fallback/fallback_override_multi.sol
+
+contract A {
+    fallback() external virtual {}
+}
+
+contract B {
+    fallback() external virtual {}
+}
+
+contract C is B, A {
+    fallback() external override(B, A) {}
+
+    function f() external returns (bool, uint256) {
+        (bool success, bytes memory returndata) = address(this).call("abc");
+        return (success, returndata.length);
+    }
+}

--- a/tests/ui/codegen/run-call/receive_override_multi.sol
+++ b/tests/ui/codegen/run-call/receive_override_multi.sol
@@ -1,0 +1,18 @@
+//@ run-call: f => true
+
+contract A {
+    receive() external payable virtual {}
+}
+
+contract B {
+    receive() external payable virtual {}
+}
+
+contract C is A, B {
+    receive() external payable override(A, B) {}
+
+    function f() external returns (bool) {
+        (bool success,) = address(this).call("");
+        return success;
+    }
+}

--- a/tests/ui/overrides/fallback.sol
+++ b/tests/ui/overrides/fallback.sol
@@ -1,0 +1,15 @@
+contract VirtualFallback {
+    fallback() external virtual {}
+}
+
+contract MissingOverride is VirtualFallback {
+    fallback() external {} //~ ERROR: overriding function is missing `override` specifier
+}
+
+contract ConcreteFallback {
+    fallback() external {} //~ ERROR: cannot override non-virtual function
+}
+
+contract NonVirtualOverride is ConcreteFallback {
+    fallback() external override {}
+}

--- a/tests/ui/overrides/fallback.stderr
+++ b/tests/ui/overrides/fallback.stderr
@@ -1,0 +1,28 @@
+error[9456]: overriding function is missing `override` specifier
+   ╭▸ ROOT/tests/ui/overrides/fallback.sol:LL:CC
+   │
+LL │     fallback() external {}
+   │     ━━━━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: overridden function is here
+   ╭▸ ROOT/tests/ui/overrides/fallback.sol:LL:CC
+   │
+LL │     fallback() external virtual {}
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ╰ help: add `override` to the function signature
+
+error[4334]: cannot override non-virtual function
+   ╭▸ ROOT/tests/ui/overrides/fallback.sol:LL:CC
+   │
+LL │     fallback() external {}
+   │     ━━━━━━━━━━━━━━━━━━━━━━
+   ╰╴
+note: overriding function is here
+   ╭▸ ROOT/tests/ui/overrides/fallback.sol:LL:CC
+   │
+LL │     fallback() external override {}
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ╰ help: add `virtual` to the base function to allow overriding
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Solar excluded nameless functions from the current contract's override signatures when checking inherited ambiguity. That omitted both `fallback()` and `receive()`, so explicit overrides could leave their inherited definitions in the ambiguity set and Solar rejected contracts accepted by solc.

Match solc's `OverrideChecker` by excluding only constructors. `OverrideSignature` already includes `FunctionKind`, so fallback and receive remain distinct despite both having no name.

Validation:

- Solar UI tests exercise multi-base fallback and receive overrides at runtime.
- solc 0.8.36 (`8a079791`, the revision tracked by the Solidity submodule) compiles both fixtures and returns the same runtime results: fallback `(true, 0)` and receive `true`.
- The negative fallback fixture matches solc diagnostics 9456 (missing `override`) and 4334 (overriding a non-virtual function).
- `cargo +nightly fmt --all --check`
- `cargo +nightly clippy --package solar-sema --all-targets -- -D warnings`

AI assistance was used for implementation and validation.
