### PR TITLE
fix(sema): preserve call-option members

### DIFF
--- a/crates/codegen/src/lower/function.rs
+++ b/crates/codegen/src/lower/function.rs
@@ -507,6 +507,13 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             ExprKind::Call(callee, args, call_opts) => {
                 self.lower_call(expr, callee, *args, *call_opts)
             }
+            ExprKind::CallOptions(callee, options) => {
+                let value = self.lower_expr(callee)?;
+                for option in options.args {
+                    self.lower_expr(&option.value)?;
+                }
+                Some(value)
+            }
             ExprKind::Delete(value) => {
                 self.delete_lvalue(value)?;
                 Some(self.builder.imm_u256(U256::ZERO))

--- a/crates/sema/src/ast_lowering/resolve.rs
+++ b/crates/sema/src/ast_lowering/resolve.rs
@@ -1749,8 +1749,18 @@ impl<'gcx> ResolveContext<'gcx> {
                 ),
             },
             ast::ExprKind::Lit(lit, _) => hir::ExprKind::Lit(self.lower_lit(lit)),
-            ast::ExprKind::Member(expr, member) => {
-                hir::ExprKind::Member(self.lower_expr(expr), *member)
+            ast::ExprKind::Member(receiver, member) => {
+                let receiver =
+                    if matches!(receiver.peel_parens().kind, ast::ExprKind::CallOptions(..)) {
+                        let (callee, options) = self.lower_call_callee(receiver);
+                        let options = options.expect("call-options receiver lost its options");
+                        let kind = hir::ExprKind::CallOptions(callee, options);
+                        let id = self.next_id();
+                        self.arena.alloc(self.hir_builder().expr_owned(id, kind, receiver.span))
+                    } else {
+                        self.lower_expr(receiver)
+                    };
+                hir::ExprKind::Member(receiver, *member)
             }
             ast::ExprKind::New(ty) => hir::ExprKind::New(self.lower_type(ty)),
             ast::ExprKind::Payable(args) => 'b: {

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -1746,6 +1746,12 @@ impl Expr<'_> {
                     arg.visit(f)?;
                 }
             }
+            ExprKind::CallOptions(callee, options) => {
+                callee.visit(f)?;
+                for arg in options.args {
+                    arg.value.visit(f)?;
+                }
+            }
             ExprKind::Delete(expr)
             | ExprKind::Member(expr, _)
             | ExprKind::Payable(expr)
@@ -1810,6 +1816,9 @@ pub enum ExprKind<'hir> {
 
     /// A function call expression: `foo(42)`, `foo({ bar: 42 })`, `foo{ gas: 100_000 }(42)`.
     Call(&'hir Expr<'hir>, CallArgs<'hir>, Option<&'hir CallOptions<'hir>>),
+
+    /// Call options on a function value: `foo{ gas: 100_000 }`.
+    CallOptions(&'hir Expr<'hir>, &'hir CallOptions<'hir>),
 
     // TODO: Add a MethodCall variant
     /// A unary `delete` expression: `delete vector`.

--- a/crates/sema/src/hir/print.rs
+++ b/crates/sema/src/hir/print.rs
@@ -580,17 +580,13 @@ impl<'gcx, W: fmt::Write> HirPrinter<'gcx, W> {
             ExprKind::Call(callee, args, opts) => {
                 self.print_expr(callee)?;
                 if let Some(opts) = opts {
-                    self.out.write_str(" { ")?;
-                    for (i, arg) in opts.args.iter().enumerate() {
-                        if i != 0 {
-                            self.out.write_str(", ")?;
-                        }
-                        write!(self.out, "{}: ", arg.name)?;
-                        self.print_expr(&arg.value)?;
-                    }
-                    self.out.write_str(" }")?;
+                    self.print_call_options(opts)?;
                 }
                 self.print_call_args(args)?;
+            }
+            ExprKind::CallOptions(callee, opts) => {
+                self.print_expr(callee)?;
+                self.print_call_options(opts)?;
             }
             ExprKind::Delete(expr) => {
                 self.out.write_str("delete ")?;
@@ -670,6 +666,18 @@ impl<'gcx, W: fmt::Write> HirPrinter<'gcx, W> {
             ExprKind::Err(_) => self.out.write_str("<error>")?,
         }
         Ok(())
+    }
+
+    fn print_call_options(&mut self, opts: &hir::CallOptions<'gcx>) -> fmt::Result {
+        self.out.write_str(" { ")?;
+        for (i, arg) in opts.args.iter().enumerate() {
+            if i != 0 {
+                self.out.write_str(", ")?;
+            }
+            write!(self.out, "{}: ", arg.name)?;
+            self.print_expr(&arg.value)?;
+        }
+        self.out.write_str(" }")
     }
 
     fn print_condition(&mut self, expr: &hir::Expr<'gcx>) -> fmt::Result {

--- a/crates/sema/src/hir/visit.rs
+++ b/crates/sema/src/hir/visit.rs
@@ -157,6 +157,12 @@ pub trait Visit<'hir> {
                 }
                 self.visit_call_args(args)?;
             }
+            ExprKind::CallOptions(expr, opts) => {
+                self.visit_expr(expr)?;
+                for arg in opts.args {
+                    self.visit_expr(&arg.value)?;
+                }
+            }
             ExprKind::Delete(expr)
             | ExprKind::Member(expr, _)
             | ExprKind::Payable(expr)

--- a/crates/sema/src/stats/hir.rs
+++ b/crates/sema/src/stats/hir.rs
@@ -40,6 +40,7 @@ impl EnumVariantSize for hir::ExprKind<'_> {
             Self::Assign(lhs, op, rhs) => variant_payload_size!(self, lhs, op, rhs),
             Self::Binary(lhs, op, rhs) => variant_payload_size!(self, lhs, op, rhs),
             Self::Call(expr, args, opts) => variant_payload_size!(self, expr, args, opts),
+            Self::CallOptions(expr, opts) => variant_payload_size!(self, expr, opts),
             Self::Delete(expr) => variant_payload_size!(self, expr),
             Self::Ident(res) => variant_payload_size!(self, res),
             Self::Index(expr, index) => variant_payload_size!(self, expr, index),
@@ -349,8 +350,26 @@ impl<'hir> HirVisit<'hir> for HirStatCollector<'hir> {
         record_hir_variants!(
             (self, expr, expr.kind, hir, Expr, ExprKind),
             [
-                Array, Assign, Binary, Call, Delete, Ident, Index, Slice, Lit, Member, New,
-                Payable, Ternary, Tuple, TypeCall, Type, Unary, YulMember, Err
+                Array,
+                Assign,
+                Binary,
+                Call,
+                CallOptions,
+                Delete,
+                Ident,
+                Index,
+                Slice,
+                Lit,
+                Member,
+                New,
+                Payable,
+                Ternary,
+                Tuple,
+                TypeCall,
+                Type,
+                Unary,
+                YulMember,
+                Err
             ]
         );
         match &expr.kind {
@@ -360,6 +379,10 @@ impl<'hir> HirVisit<'hir> for HirStatCollector<'hir> {
                     self.visit_call_options(opts)?;
                 }
                 self.visit_call_args(args)?;
+            }
+            hir::ExprKind::CallOptions(expr, opts) => {
+                self.visit_expr(expr)?;
+                self.visit_call_options(opts)?;
             }
             hir::ExprKind::Delete(expr)
             | hir::ExprKind::Member(expr, _)

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -377,6 +377,12 @@ impl<'gcx> TypeChecker<'gcx> {
 
                 ty
             }
+            hir::ExprKind::CallOptions(callee, opts) => {
+                let callee_ty = self.check_expr(callee);
+                let ty = self.check_call_options(callee_ty, opts.args, opts.span);
+                self.try_set_not_lvalue(NotLvalueReason::Generic);
+                ty
+            }
             hir::ExprKind::Delete(expr) => {
                 let ty = self.require_lvalue(expr);
                 if valid_delete(ty) {
@@ -2424,6 +2430,7 @@ impl<'gcx> TypeChecker<'gcx> {
             hir::ExprKind::Array(_)
             | hir::ExprKind::Assign(..)
             | hir::ExprKind::Binary(..)
+            | hir::ExprKind::CallOptions(..)
             | hir::ExprKind::Delete(_)
             | hir::ExprKind::Slice(..)
             | hir::ExprKind::Lit(_)

--- a/tests/ui/codegen/lowering/run-call/call_options_function_members.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/call_options_function_members.mir.stdout
@@ -1,0 +1,187 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/call_options_function_members.sol:CallOptionMembers ===
+@module CallOptionMembers
+fn @g() [selector=0xe2179b8e, abi_args=lazy, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+fn @h() [selector=0xb8c9d365, payable, abi_args=lazy, abi_params=[], abi_returns=[]] {
+  bb0:
+    stop
+}
+
+fn @select() -> function {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = mul v0, 10
+    v2 = iszero 10
+    v3 = div v1, 10
+    v4 = eq v3, v0
+    v5 = or v2, v4
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb2:
+    v7 = add v1, 1
+    v8 = lt v7, v1
+    jumpi v8, bb3, bb4
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    sstore 0, v7 !metadata(storage=slot(0))
+    v9 = address
+    v10 = shl 32, v9
+    v11 = or v10, 0xb8c9d365
+    ret v11
+}
+
+fn @option(arg0: u256) -> u256 {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = mul v0, 10
+    v2 = iszero 10
+    v3 = div v1, 10
+    v4 = eq v3, v0
+    v5 = or v2, v4
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb2:
+    v7 = add v1, arg0
+    v8 = lt v7, v1
+    jumpi v8, bb3, bb4
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    sstore 0, v7 !metadata(storage=slot(0))
+    ret 0
+}
+
+fn @callOptionMembers() -> bool [selector=0x147dec44, view, abi_args=lazy, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = address
+    v1 = shl 32, v0
+    v2 = or v1, 0xe2179b8e
+    v3 = shr 32, v2
+    v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
+    v5 = address
+    v6 = shl 32, v5
+    v7 = or v6, 0xe2179b8e
+    v8 = shr 32, v7
+    v9 = and v8, 0xffffffffffffffffffffffffffffffffffffffff
+    v10 = eq v4, v9
+    jumpi v10, bb1, bb2
+  bb1:
+    v11 = address
+    v12 = shl 32, v11
+    v13 = or v12, 0xe2179b8e
+    v14 = and v13, 0xffffffff
+    v15 = shl 224, v14
+    v16 = eq v15, 0xe2179b8e00000000000000000000000000000000000000000000000000000000
+    jump bb3
+  bb2:
+    jump bb3
+  bb3:
+    v17 = phi [bb1: v16], [bb2: 0]
+    jumpi v17, bb4, bb5
+  bb4:
+    v18 = address
+    v19 = shl 32, v18
+    v20 = or v19, 0xb8c9d365
+    v21 = shr 32, v20
+    v22 = and v21, 0xffffffffffffffffffffffffffffffffffffffff
+    v23 = address
+    v24 = shl 32, v23
+    v25 = or v24, 0xb8c9d365
+    v26 = shr 32, v25
+    v27 = and v26, 0xffffffffffffffffffffffffffffffffffffffff
+    v28 = eq v22, v27
+    jump bb6
+  bb5:
+    jump bb6
+  bb6:
+    v29 = phi [bb4: v28], [bb5: 0]
+    jumpi v29, bb7, bb8
+  bb7:
+    v30 = address
+    v31 = shl 32, v30
+    v32 = or v31, 0xb8c9d365
+    v33 = and v32, 0xffffffff
+    v34 = shl 224, v33
+    v35 = eq v34, 0xb8c9d36500000000000000000000000000000000000000000000000000000000
+    jump bb9
+  bb8:
+    jump bb9
+  bb9:
+    v36 = phi [bb7: v35], [bb8: 0]
+    jumpi v36, bb10, bb11
+  bb10:
+    v37 = address
+    v38 = shl 32, v37
+    v39 = or v38, 0xb8c9d365
+    v40 = shr 32, v39
+    v41 = and v40, 0xffffffffffffffffffffffffffffffffffffffff
+    v42 = address
+    v43 = shl 32, v42
+    v44 = or v43, 0xb8c9d365
+    v45 = shr 32, v44
+    v46 = and v45, 0xffffffffffffffffffffffffffffffffffffffff
+    v47 = eq v41, v46
+    jump bb12
+  bb11:
+    jump bb12
+  bb12:
+    v48 = phi [bb10: v47], [bb11: 0]
+    jumpi v48, bb13, bb14
+  bb13:
+    v49 = address
+    v50 = shl 32, v49
+    v51 = or v50, 0xb8c9d365
+    v52 = and v51, 0xffffffff
+    v53 = shl 224, v52
+    v54 = eq v53, 0xb8c9d36500000000000000000000000000000000000000000000000000000000
+    jump bb15
+  bb14:
+    jump bb15
+  bb15:
+    v55 = phi [bb13: v54], [bb14: 0]
+    ret v55
+}
+
+fn @addressSideEffects() -> (u256, bool) [selector=0x18d25c80, abi_args=lazy, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    sstore 0, 0 !metadata(storage=slot(0))
+    v0 = internal_call @select, 1
+    v1 = internal_call @option, 1, 2
+    v2 = internal_call @option, 1, 3
+    v3 = shr 32, v0
+    v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
+    v5 = sload 0 !metadata(storage=slot(0))
+    v6 = address
+    v7 = eq v4, v6
+    ret v5, v7
+}
+
+fn @selectorSideEffects() -> (u256, bool) [selector=0x6e73c72f, abi_args=lazy, abi_params=[], abi_returns=[word, word]] {
+  bb0:
+    sstore 0, 0 !metadata(storage=slot(0))
+    v0 = internal_call @select, 1
+    v1 = internal_call @option, 1, 2
+    v2 = internal_call @option, 1, 3
+    v3 = and v0, 0xffffffff
+    v4 = shl 224, v3
+    v5 = sload 0 !metadata(storage=slot(0))
+    v6 = eq v4, 0xb8c9d36500000000000000000000000000000000000000000000000000000000
+    ret v5, v6
+}
+

--- a/tests/ui/codegen/lowering/run-call/call_options_function_members.sol
+++ b/tests/ui/codegen/lowering/run-call/call_options_function_members.sol
@@ -1,0 +1,45 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: callOptionMembers() => true
+//@ run-call: addressSideEffects() => 123, true
+//@ run-call: selectorSideEffects() => 123, true
+// ported-from: test/libsolidity/semanticTests/functionTypes/stack_height_check_on_adding_gas_variable_to_function.sol
+
+contract CallOptionMembers {
+    uint256 private order;
+
+    function g() external {}
+    function h() external payable {}
+
+    function select() internal returns (function() external payable) {
+        order = order * 10 + 1;
+        return this.h;
+    }
+
+    function option(uint256 marker) internal returns (uint256) {
+        order = order * 10 + marker;
+        return 0;
+    }
+
+    function callOptionMembers() external view returns (bool) {
+        return this.g{gas: 42}.address == this.g.address &&
+            this.g{gas: 42}.selector == this.g.selector &&
+            this.h{gas: 42}.address == this.h.address &&
+            this.h{gas: 42}.selector == this.h.selector &&
+            this.h{gas: 42, value: 5}.address == this.h.address &&
+            this.h{gas: 42, value: 5}.selector == this.h.selector;
+    }
+
+    function addressSideEffects() external returns (uint256, bool) {
+        order = 0;
+        address selected = select(){gas: option(2), value: option(3)}.address;
+        return (order, selected == address(this));
+    }
+
+    function selectorSideEffects() external returns (uint256, bool) {
+        order = 0;
+        bytes4 selected = select(){value: option(2), gas: option(3)}.selector;
+        return (order, selected == this.h.selector);
+    }
+}

--- a/tests/ui/typeck/function_calls/call_options_standalone.sol
+++ b/tests/ui/typeck/function_calls/call_options_standalone.sol
@@ -7,13 +7,16 @@ contract CallOptionMembers {
     }
 
     function callOptionMembers() external returns (bool) {
-        // solc accepts call options as a valid function value here. We currently only support
-        // call options directly on calls.
-        return this.g{gas: 42}.address == this.g.address && //~ ERROR: call options must be part of a call expression
-            this.g{gas: 42}.selector == this.g.selector && //~ ERROR: call options must be part of a call expression
-            this.h{gas: 42}.address == this.h.address && //~ ERROR: call options must be part of a call expression
-            this.h{gas: 42}.selector == this.h.selector && //~ ERROR: call options must be part of a call expression
-            this.h{gas: 42, value: 5}.address == this.h.address && //~ ERROR: call options must be part of a call expression
-            this.h{gas: 42, value: 5}.selector == this.h.selector; //~ ERROR: call options must be part of a call expression
+        return this.g{gas: 42}.address == this.g.address &&
+            this.g{gas: 42}.selector == this.g.selector &&
+            this.h{gas: 42}.address == this.h.address &&
+            this.h{gas: 42}.selector == this.h.selector &&
+            this.h{gas: 42, value: 5}.address == this.h.address &&
+            this.h{gas: 42, value: 5}.selector == this.h.selector;
+    }
+
+    function invalidOptions() external {
+        this.g{value: 5}.address; //~ ERROR: cannot set option `value` on a non-payable function type
+        this.h{gas: false}.selector; //~ ERROR: mismatched types
     }
 }

--- a/tests/ui/typeck/function_calls/call_options_standalone.stderr
+++ b/tests/ui/typeck/function_calls/call_options_standalone.stderr
@@ -6,77 +6,17 @@ LL │         this.h{gas: 42}{value: 5}();
    │
    ╰ help: combine them into a single `{...}` option
 
-error: call options must be part of a call expression
+error: cannot set option `value` on a non-payable function type
    ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
    │
-LL │         return this.g{gas: 42}.address == this.g.address &&
-   │                      ━━━━━━━━━
-   ╰╴
-note: this expression is not a function call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │         return this.g{gas: 42}.address == this.g.address &&
-   ╰╴               ━━━━━━━━━━━━━━━
+LL │         this.g{value: 5}.address;
+   ╰╴               ━━━━━
 
-error: call options must be part of a call expression
+error: mismatched types
    ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
    │
-LL │             this.g{gas: 42}.selector == this.g.selector &&
-   │                   ━━━━━━━━━
-   ╰╴
-note: this expression is not a function call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.g{gas: 42}.selector == this.g.selector &&
-   ╰╴            ━━━━━━━━━━━━━━━
+LL │         this.h{gas: false}.selector;
+   ╰╴                    ━━━━━ expected `uint256`, found `bool`
 
-error: call options must be part of a call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42}.address == this.h.address &&
-   │                   ━━━━━━━━━
-   ╰╴
-note: this expression is not a function call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42}.address == this.h.address &&
-   ╰╴            ━━━━━━━━━━━━━━━
-
-error: call options must be part of a call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42}.selector == this.h.selector &&
-   │                   ━━━━━━━━━
-   ╰╴
-note: this expression is not a function call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42}.selector == this.h.selector &&
-   ╰╴            ━━━━━━━━━━━━━━━
-
-error: call options must be part of a call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42, value: 5}.address == this.h.address &&
-   │                   ━━━━━━━━━━━━━━━━━━━
-   ╰╴
-note: this expression is not a function call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42, value: 5}.address == this.h.address &&
-   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━━
-
-error: call options must be part of a call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42, value: 5}.selector == this.h.selector;
-   │                   ━━━━━━━━━━━━━━━━━━━
-   ╰╴
-note: this expression is not a function call expression
-   ╭▸ ROOT/tests/ui/typeck/function_calls/call_options_standalone.sol:LL:CC
-   │
-LL │             this.h{gas: 42, value: 5}.selector == this.h.selector;
-   ╰╴            ━━━━━━━━━━━━━━━━━━━━━━━━━
-
-error: aborting due to 7 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/typeck/view_pure_checker/call_options_function_members.sol
+++ b/tests/ui/typeck/view_pure_checker/call_options_function_members.sol
@@ -1,0 +1,12 @@
+contract C {
+    function h() external payable {}
+
+    function selectorWithoutOptions() external pure returns (bytes4) {
+        return this.h.selector;
+    }
+
+    function selectorWithOptions() external pure returns (bytes4) {
+        return this.h{gas: 42}.selector;
+        //~^ ERROR: function declared as pure, but this expression (potentially) reads from the environment or state and thus requires `view`
+    }
+}

--- a/tests/ui/typeck/view_pure_checker/call_options_function_members.stderr
+++ b/tests/ui/typeck/view_pure_checker/call_options_function_members.stderr
@@ -1,0 +1,8 @@
+error[2527]: function declared as pure, but this expression (potentially) reads from the environment or state and thus requires `view`
+   ╭▸ ROOT/tests/ui/typeck/view_pure_checker/call_options_function_members.sol:LL:CC
+   │
+LL │         return this.h{gas: 42}.selector;
+   ╰╴               ━━━━
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
## summary

- preserve call options when an external function value is followed by `.address` or `.selector`
- evaluate the callee and option expressions in Solidity source order before extracting the member
- keep standalone option-bearing function values outside this scoped fix

## validation

- focused UI tests, including side-effect order and diagnostics
- 241 solar-sema/solar-codegen nextest tests
- clippy with warnings denied and nightly fmt
- replay-confirmed `solsymdiff` bounded agreement with Solc across legacy and via-IR settings

Stacked on #1161.

Implementation and test development were assisted by AI; the final change was manually reviewed and validated.