### PR TITLE
fix(codegen): lower contract type names

### DIFF
--- a/crates/codegen/src/lower/function/expressions.rs
+++ b/crates/codegen/src/lower/function/expressions.rs
@@ -284,7 +284,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         expr: &hir::Expr<'_>,
         builtin: Builtin,
     ) -> Option<ValueId> {
-        if matches!(builtin, Builtin::ContractCreationCode | Builtin::ContractRuntimeCode) {
+        if matches!(
+            builtin,
+            Builtin::ContractCreationCode | Builtin::ContractRuntimeCode | Builtin::ContractName
+        ) {
             let ExprKind::Member(receiver, _) = &expr.kind else {
                 return report_unsupported(self.context.gcx, expr.span, "environment builtin");
             };
@@ -294,6 +297,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             let TyKind::Contract(contract_id) = ty.peel_refs().kind else {
                 return report_unsupported(self.context.gcx, expr.span, "creation code target");
             };
+            if builtin == Builtin::ContractName {
+                let name = self.context.gcx.item_name(contract_id);
+                return self.lower_bytes_literal(name.as_str().as_bytes());
+            }
             let bytecodes = if builtin == Builtin::ContractCreationCode {
                 self.context.child_bytecodes
             } else {

--- a/tests/ui/codegen/lowering/type_contract_name.sol
+++ b/tests/ui/codegen/lowering/type_contract_name.sol
@@ -1,0 +1,54 @@
+//@ run-call: concrete() => "ConcreteTarget"
+//@ run-call: abstractContract() => "AbstractTarget"
+//@ run-call: interfaceContract() => "InterfaceTarget"
+//@ run-call: libraryContract() => "LibraryTarget"
+//@ run-call: parenthesized() => "ConcreteTarget"
+//@ run-call: constantName() => "ConcreteTarget"
+//@ run-call: longName() => "ContractNameLongerThanThirtyTwoBytes"
+// ported-from: test/libsolidity/semanticTests/metaTypes/name_other_contract.sol
+
+abstract contract AbstractTarget {
+    function probe() external pure virtual returns (uint256);
+}
+
+interface InterfaceTarget {
+    function probe() external pure returns (uint256);
+}
+
+library LibraryTarget {}
+
+contract ConcreteTarget {}
+
+contract ContractNameLongerThanThirtyTwoBytes {}
+
+contract ContractNames {
+    string private constant NAME = type(ConcreteTarget).name;
+
+    function concrete() external pure returns (string memory) {
+        return type(ConcreteTarget).name;
+    }
+
+    function abstractContract() external pure returns (string memory) {
+        return type(AbstractTarget).name;
+    }
+
+    function interfaceContract() external pure returns (string memory) {
+        return type(InterfaceTarget).name;
+    }
+
+    function libraryContract() external pure returns (string memory) {
+        return type(LibraryTarget).name;
+    }
+
+    function parenthesized() external pure returns (string memory) {
+        return (type(ConcreteTarget)).name;
+    }
+
+    function constantName() external pure returns (string memory) {
+        return NAME;
+    }
+
+    function longName() external pure returns (string memory) {
+        return type(ContractNameLongerThanThirtyTwoBytes).name;
+    }
+}


### PR DESCRIPTION
## summary

- lower `type(T).name` from the receiver semantic contract meta-type
- reuse the existing byte-literal path, including names longer than one word
- cover concrete, abstract, interface, library, parenthesized, and constant forms

## validation

- focused runtime UI coverage ported from the Solc semantic suite and extended for edge cases
- 221 solar-codegen nextest tests
- clippy with warnings denied and nightly fmt
- `solsymdiff` bounded agreement with Solc in optimized via-IR and unoptimized legacy modes

Stacked on #1161.

Implementation and test development were assisted by AI; the final change was manually reviewed and validated.