### PR TITLE
fix(sema): gate high-level EVM features

### DIFF
--- a/crates/sema/src/builtins/mod.rs
+++ b/crates/sema/src/builtins/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use solar_ast::StateMutability as SM;
 use solar_data_structures::map::FxHashMap;
-use solar_interface::{Span, Symbol, kw, sym};
+use solar_interface::{Span, Symbol, config::EvmVersion, kw, sym};
 use std::sync::OnceLock;
 
 pub(crate) mod members;
@@ -54,6 +54,22 @@ macro_rules! declare_builtins {
                     $(
                         Builtin::$variant_name => $sym::$name,
                     )*
+                }
+            }
+
+            /// Returns the EVM version required when this high-level builtin is unavailable for
+            /// `target`.
+            pub(crate) fn required_evm_version(self, target: EvmVersion) -> Option<EvmVersion> {
+                match self {
+                    Self::AddressCodehash if !target.has_ext_code_hash() => {
+                        Some(EvmVersion::Constantinople)
+                    }
+                    Self::BlockChainid if !target.has_chain_id() => Some(EvmVersion::Istanbul),
+                    Self::BlockBasefee if !target.has_base_fee() => Some(EvmVersion::London),
+                    Self::Blobhash | Self::BlockBlobbasefee if !target.has_blob_base_fee() => {
+                        Some(EvmVersion::Cancun)
+                    }
+                    _ => None,
                 }
             }
 

--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -14,6 +14,7 @@ use solar_ast::{
 use solar_data_structures::{Never, bit_set::DenseBitSet, pluralize, smallvec::SmallVec};
 use solar_interface::{
     Ident, Symbol,
+    config::EvmVersion,
     diagnostics::{DiagCtxt, ErrorGuaranteed},
     kw, sym,
 };
@@ -98,6 +99,22 @@ impl<'gcx> TypeChecker<'gcx> {
 
     fn dcx(&self) -> &'gcx DiagCtxt {
         self.gcx.dcx()
+    }
+
+    fn emit_evm_version_error(&self, span: Span, feature: &str, required: EvmVersion) {
+        self.dcx()
+            .err(format!("{feature} requires {required:?}-compatible EVM"))
+            .span(span)
+            .help(format!("compile with `--evm-version {required}` or newer"))
+            .emit();
+    }
+
+    fn check_res_evm_version(&self, res: hir::Res, span: Span) {
+        if let hir::Res::Builtin(builtin) = res
+            && let Some(required) = builtin.required_evm_version(self.gcx.sess.opts.evm_version)
+        {
+            self.emit_evm_version_error(span, &format!("builtin `{}`", builtin.name()), required);
+        }
     }
 
     fn check_storage_layout_base_slot(&mut self, slot: &'gcx hir::Expr<'gcx>) {
@@ -389,6 +406,7 @@ impl<'gcx> TypeChecker<'gcx> {
             }
             hir::ExprKind::Ident(resolutions) => {
                 let res = self.resolve_value(expr, resolutions);
+                self.check_res_evm_version(res, expr.span);
                 if let Some(reason) = self.res_not_lvalue_reason(res) {
                     self.try_set_not_lvalue(reason);
                 }
@@ -1662,6 +1680,7 @@ impl<'gcx> TypeChecker<'gcx> {
             Ok(member) => {
                 self.check_library_self_call(member, ident.span);
                 if let Some(res) = member.res {
+                    self.check_res_evm_version(res, callee.span);
                     self.results
                         .resolved_callees
                         .insert(callee.id, ResolvedCallee::new(res, member.attached));
@@ -1723,6 +1742,7 @@ impl<'gcx> TypeChecker<'gcx> {
         member: &members::Member<'gcx>,
     ) {
         if let Some(res) = member.res {
+            self.check_res_evm_version(res, expr.span);
             self.results.resolved_exprs.insert(expr.id, res);
         }
     }
@@ -1743,6 +1763,7 @@ impl<'gcx> TypeChecker<'gcx> {
                 hir::Res::Err(self.dcx().emit_err(callee.span, msg))
             }
         };
+        self.check_res_evm_version(res, callee.span);
         let ty = self.type_of_res(res);
         self.results.resolved_callees.insert(callee.id, ResolvedCallee::new(res, false));
         self.register_ty(callee, ty);
@@ -1995,6 +2016,10 @@ impl<'gcx> TypeChecker<'gcx> {
             }
         }
 
+        if creation && salt_set && !self.gcx.sess.opts.evm_version.has_create2() {
+            self.emit_evm_version_error(span, "call option `salt`", EvmVersion::Constantinople);
+        }
+
         ty
     }
 
@@ -2185,6 +2210,12 @@ impl<'gcx> TypeChecker<'gcx> {
         let _ = self.visit_ty(&var.ty);
         let ty = self.gcx.type_of_item(id.into());
         self.check_var_type_size(var, ty);
+
+        if var.data_location == Some(DataLocation::Transient)
+            && self.gcx.sess.opts.evm_version < EvmVersion::Cancun
+        {
+            self.emit_evm_version_error(var.span, "transient storage", EvmVersion::Cancun);
+        }
 
         if let Some(init) = var.initializer {
             if var.is_state_variable() && ty.has_mapping(self.gcx) {

--- a/tests/ui/typeck/evm_version/cancun.shanghai.stderr
+++ b/tests/ui/typeck/evm_version/cancun.shanghai.stderr
@@ -1,0 +1,26 @@
+error: transient storage requires Cancun-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/cancun.sol:LL:CC
+   │
+LL │     uint256 transient value;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version cancun` or newer
+
+error: builtin `blobhash` requires Cancun-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/cancun.sol:LL:CC
+   │
+LL │         return blobhash(0);
+   │                ━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version cancun` or newer
+
+error: builtin `blobbasefee` requires Cancun-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/cancun.sol:LL:CC
+   │
+LL │         return block.blobbasefee;
+   │                ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version cancun` or newer
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/typeck/evm_version/cancun.sol
+++ b/tests/ui/typeck/evm_version/cancun.sol
@@ -1,0 +1,21 @@
+//@ revisions: shanghai cancun
+//@[shanghai] compile-flags: --evm-version shanghai
+//@[cancun] compile-flags: --evm-version cancun
+// ported-from: test/libsolidity/syntaxTests/types/magic_block_blobbasefee_error.sol
+// ported-from: test/libsolidity/syntaxTests/globalFunctions/blobhash_not_declared_pre_cancun.sol
+// ported-from: test/libsolidity/syntaxTests/dataLocations/transient_storage_variable_pre_cancun.sol
+
+contract C {
+    uint256 transient value;
+    //~[shanghai]^ ERROR: transient storage requires Cancun-compatible EVM
+
+    function blobHash() public view returns (bytes32) {
+        return blobhash(0);
+        //~[shanghai]^ ERROR: builtin `blobhash` requires Cancun-compatible EVM
+    }
+
+    function blobBaseFee() public view returns (uint256) {
+        return block.blobbasefee;
+        //~[shanghai]^ ERROR: builtin `blobbasefee` requires Cancun-compatible EVM
+    }
+}

--- a/tests/ui/typeck/evm_version/constantinople.byzantium.stderr
+++ b/tests/ui/typeck/evm_version/constantinople.byzantium.stderr
@@ -1,0 +1,18 @@
+error: builtin `codehash` requires Constantinople-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/constantinople.sol:LL:CC
+   │
+LL │         return address(this).codehash;
+   │                ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version constantinople` or newer
+
+error: call option `salt` requires Constantinople-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/constantinople.sol:LL:CC
+   │
+LL │         return new Created{salt: bytes32(0)}();
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version constantinople` or newer
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/evm_version/constantinople.sol
+++ b/tests/ui/typeck/evm_version/constantinople.sol
@@ -1,0 +1,19 @@
+//@ revisions: byzantium constantinople
+//@[byzantium] compile-flags: --evm-version byzantium
+//@[constantinople] compile-flags: --evm-version constantinople
+// ported-from: test/libsolidity/syntaxTests/types/address/codehash_before_constantinople.sol
+// ported-from: test/libsolidity/syntaxTests/functionCalls/new_with_calloptions_unsupported.sol
+
+contract Created {}
+
+contract C {
+    function codehash() public view returns (bytes32) {
+        return address(this).codehash;
+        //~[byzantium]^ ERROR: builtin `codehash` requires Constantinople-compatible EVM
+    }
+
+    function create() public returns (Created) {
+        return new Created{salt: bytes32(0)}();
+        //~[byzantium]^ ERROR: call option `salt` requires Constantinople-compatible EVM
+    }
+}

--- a/tests/ui/typeck/evm_version/istanbul.petersburg.stderr
+++ b/tests/ui/typeck/evm_version/istanbul.petersburg.stderr
@@ -1,0 +1,10 @@
+error: builtin `chainid` requires Istanbul-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/istanbul.sol:LL:CC
+   │
+LL │         return block.chainid;
+   │                ━━━━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version istanbul` or newer
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/evm_version/istanbul.sol
+++ b/tests/ui/typeck/evm_version/istanbul.sol
@@ -1,0 +1,11 @@
+//@ revisions: petersburg istanbul
+//@[petersburg] compile-flags: --evm-version petersburg
+//@[istanbul] compile-flags: --evm-version istanbul
+// ported-from: test/libsolidity/syntaxTests/types/magic_block.sol
+
+contract C {
+    function chainid() public view returns (uint256) {
+        return block.chainid;
+        //~[petersburg]^ ERROR: builtin `chainid` requires Istanbul-compatible EVM
+    }
+}

--- a/tests/ui/typeck/evm_version/london.berlin.stderr
+++ b/tests/ui/typeck/evm_version/london.berlin.stderr
@@ -1,0 +1,10 @@
+error: builtin `basefee` requires London-compatible EVM
+   ╭▸ ROOT/tests/ui/typeck/evm_version/london.sol:LL:CC
+   │
+LL │         return block.basefee;
+   │                ━━━━━━━━━━━━━
+   │
+   ╰ help: compile with `--evm-version london` or newer
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/evm_version/london.sol
+++ b/tests/ui/typeck/evm_version/london.sol
@@ -1,0 +1,11 @@
+//@ revisions: berlin london
+//@[berlin] compile-flags: --evm-version berlin
+//@[london] compile-flags: --evm-version london
+// ported-from: test/libsolidity/syntaxTests/types/magic_block_basefee_error.sol
+
+contract C {
+    function basefee() public view returns (uint256) {
+        return block.basefee;
+        //~[berlin]^ ERROR: builtin `basefee` requires London-compatible EVM
+    }
+}


### PR DESCRIPTION
Solar currently accepts several high-level constructs whose opcodes are unavailable on the selected target, while Solc rejects them. This adds semantic availability checks for `address.codehash`, CREATE2 salt, `block.chainid`, `block.basefee`, `blobhash`, `block.blobbasefee`, and transient storage at their exact fork boundaries.

The parser remains intentionally permissive, following #1252; rejection happens during type checking. A Solc-versus-Solar version matrix found the family and the revisioned fixtures are attributed to the corresponding upstream Solc syntax cases.