### PR TITLE
fix(zed): improve Solidity highlighting

### DIFF
--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -31,6 +31,15 @@
 
 (comment) @comment
 
+; Built-ins
+; ---------
+
+((identifier) @variable.builtin
+  (#match? @variable.builtin "^(abi|block|msg|now|super|this|tx)$"))
+
+((identifier) @function.builtin
+  (#match? @function.builtin "^(addmod|assert|blockhash|blobhash|ecrecover|gasleft|keccak256|mulmod|require|ripemd160|selfdestruct|sha256|sha3|suicide)$"))
+
 ; Definitions and references
 ; -----------
 

--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -104,13 +104,19 @@
  "pragma"
  "abstract"
  "contract"
+ "error"
  "interface"
  "library"
+ "layout"
+ "at"
+ "type"
  "is"
  "struct"
  "enum"
  "event"
+ "anonymous"
  "using"
+ "global"
  "assembly"
  "emit"
  "public"
@@ -126,8 +132,12 @@
  "calldata"
  "var"
  "constant"
+ "let"
  (virtual)
  (override_specifier)
+ (immutable)
+ (state_location)
+ (unchecked)
  (yul_leave)
 ] @keyword
 
@@ -135,11 +145,11 @@
  "for"
  "while"
  "do"
+ "break"
+ "continue"
 ] @repeat
 
 [
- "break"
- "continue"
  "if"
  "else"
  "switch"
@@ -150,6 +160,7 @@
 [
  "try"
  "catch"
+ "revert"
 ] @exception
 
 [
@@ -162,6 +173,7 @@
 "import" @include
 (import_directive "as" @include)
 (import_directive "from" @include)
+(using_alias "as" @keyword)
 
 (event_parameter "indexed" @keyword)
 

--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -90,7 +90,7 @@
 
 ; Structs and members
 (member_expression property: (identifier) @property)
-(struct_expression type: ((expression(identifier)) @type .))
+(struct_expression type: (expression (identifier) @type))
 (struct_field_assignment name: (identifier) @property)
 
 

--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -24,6 +24,11 @@
  (yul_decimal_number)
  (yul_hex_number)
 ] @number
+(number_unit) @type
+
+(hex_string_literal "hex" @string.special)
+(unicode_string_literal "unicode" @string.special)
+(yul_hex_string_literal "hex" @string.special)
 [
  (true)
  (false)
@@ -186,6 +191,10 @@
 
 (event_parameter "indexed" @keyword)
 
+(ternary_expression
+  "?" @conditional
+  ":" @conditional)
+
 ; Punctuation
 
 [
@@ -201,6 +210,11 @@
 [
   "."
   ","
+  ";"
+  ":"
+  "->"
+  "=>"
+  ":="
 ] @punctuation.delimiter
 
 
@@ -228,6 +242,17 @@
   ">"
   "!"
   "~"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "^="
+  "&="
+  "|="
+  ">>="
+  "<<="
   "-"
   "+"
   "++"

--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -102,6 +102,7 @@
 ; Keywords
 [
  "pragma"
+ "abstract"
  "contract"
  "interface"
  "library"

--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -191,12 +191,6 @@
 
 (event_parameter "indexed" @keyword)
 
-(ternary_expression
-  [
-    "?"
-    ":"
-  ] @operator)
-
 ; Punctuation
 
 [
@@ -260,6 +254,12 @@
   "++"
   "--"
 ] @operator
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @operator)
 
 [
   "delete"

--- a/editors/zed/languages/solidity/highlights.scm
+++ b/editors/zed/languages/solidity/highlights.scm
@@ -192,8 +192,10 @@
 (event_parameter "indexed" @keyword)
 
 (ternary_expression
-  "?" @conditional
-  ":" @conditional)
+  [
+    "?"
+    ":"
+  ] @operator)
 
 ; Punctuation
 
@@ -212,9 +214,7 @@
   ","
   ";"
   ":"
-  "->"
   "=>"
-  ":="
 ] @punctuation.delimiter
 
 
@@ -253,6 +253,8 @@
   "|="
   ">>="
   "<<="
+  "->"
+  ":="
   "-"
   "+"
   "++"


### PR DESCRIPTION
Fix the invalid struct-expression query that prevented Zed from loading Solidity support. Align the query with the grammar’s upstream Neovim query and Zed’s native Tree-sitter conventions for keywords, built-ins, literals, punctuation, and operators.