### PR TITLE
fix(sema): downgrade NatSpec errors to warnings

### DIFF
--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -5,7 +5,6 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#![cfg_attr(feature = "nightly", feature(never_type))]
 #![cfg_attr(feature = "nightly", feature(rustc_attrs))]
 #![cfg_attr(feature = "nightly", feature(extern_types))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]

--- a/crates/sema/src/natspec.rs
+++ b/crates/sema/src/natspec.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use solar_ast as ast;
 use solar_data_structures::{BumpExt, map::FxHashSet, smallvec::SmallVec};
-use solar_interface::{Ident, Span, Symbol, kw};
+use solar_interface::{Ident, Span, Symbol, error_code, kw};
 use std::ops::Range;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -126,9 +126,7 @@ bitflags::bitflags! {
     /// Tracks which tags have been seen during validation.
     #[derive(Clone, Copy, Default)]
     struct SeenTags: u8 {
-        const TITLE      = 1 << 0;
-        const AUTHOR     = 1 << 1;
-        const INHERITDOC = 1 << 2;
+        const INHERITDOC = 1 << 0;
     }
 }
 
@@ -301,20 +299,15 @@ impl<'gcx> Resolver<'gcx> {
                         local_tags.push(*natspec);
                     }
                     NatSpecKind::Title => {
-                        if self.validate_tag_once(
-                            "@title",
-                            tag_span,
-                            permissions.contains(TagPermissions::TITLE_AUTHOR),
-                            &mut state.seen_tags,
-                            SeenTags::TITLE,
-                            item_id,
-                        ) {
+                        if !permissions.contains(TagPermissions::TITLE_AUTHOR) {
+                            self.emit_forbidden_tag_warning("@title", tag_span, item_id);
+                        } else {
                             local_tags.push(*natspec);
                         }
                     }
                     NatSpecKind::Author => {
                         if !permissions.contains(TagPermissions::TITLE_AUTHOR) {
-                            self.emit_forbidden_tag_error("@author", tag_span, item_id);
+                            self.emit_forbidden_tag_warning("@author", tag_span, item_id);
                         } else {
                             local_tags.push(*natspec);
                         }
@@ -340,7 +333,7 @@ impl<'gcx> Resolver<'gcx> {
                     }
                     NatSpecKind::Param { name } => {
                         if !permissions.contains(TagPermissions::PARAM) {
-                            self.emit_forbidden_tag_error("@param", tag_span, item_id);
+                            self.emit_forbidden_tag_warning("@param", tag_span, item_id);
                             continue;
                         }
 
@@ -381,13 +374,15 @@ impl<'gcx> Resolver<'gcx> {
                         if params.contains(&name.name) {
                             local_tags.push(*natspec);
                         } else {
-                            self.gcx.dcx().emit_err(
-                                tag_span,
-                                format!(
+                            self.gcx
+                                .dcx()
+                                .warn(format!(
                                     "tag `@param` references non-existent parameter '{}'",
                                     name.name
-                                ),
-                            );
+                                ))
+                                .code(error_code!(3881))
+                                .span(tag_span)
+                                .emit();
                         };
                     }
                     NatSpecKind::Return { .. } => {
@@ -396,7 +391,7 @@ impl<'gcx> Resolver<'gcx> {
                                 .as_variable()
                                 .is_some_and(|id| !self.gcx.hir.variable(id).is_public())
                         {
-                            self.emit_forbidden_tag_error("@return", tag_span, item_id);
+                            self.emit_forbidden_tag_warning("@return", tag_span, item_id);
                             continue;
                         }
 
@@ -415,12 +410,17 @@ impl<'gcx> Resolver<'gcx> {
                         let return_count = rets.len();
 
                         let return_valid = if state.return_count > return_count {
-                            self.gcx.dcx().emit_err(tag_span, format!(
-                                "too many `@return` tags: function has {} return value{}, found {}",
-                                return_count,
-                                if return_count == 1 { "" } else { "s" },
-                                state.return_count
-                            ));
+                            self.gcx
+                                .dcx()
+                                .warn(format!(
+                                    "too many `@return` tags: function has {} return value{}, found {}",
+                                    return_count,
+                                    if return_count == 1 { "" } else { "s" },
+                                    state.return_count
+                                ))
+                                .code(error_code!(2604))
+                                .span(tag_span)
+                                .emit();
                             false
                         } else {
                             true
@@ -457,10 +457,12 @@ impl<'gcx> Resolver<'gcx> {
             natspec.content_start as usize,
             natspec.content_end as usize,
         ) else {
-            self.gcx.dcx().emit_err(
-                natspec.span,
-                "tag `@return` does not contain the name of its return parameter",
-            );
+            self.gcx
+                .dcx()
+                .warn("tag `@return` does not contain the name of its return parameter")
+                .code(error_code!(5856))
+                .span(natspec.span)
+                .emit();
             return None;
         };
 
@@ -476,20 +478,24 @@ impl<'gcx> Resolver<'gcx> {
             if rets.iter().any(|&id| {
                 self.gcx.hir.variable(id).name.is_some_and(|name| name.name == documented_name)
             }) {
-                self.gcx.dcx().emit_err(
-                    name_span,
-                    format!(
+                self.gcx
+                    .dcx()
+                    .warn(format!(
                         "mismatched `@return` parameter: expected `{}`, found `{documented_name}`",
                         expected.name
-                    ),
-                );
+                    ))
+                    .code(error_code!(5856))
+                    .span(name_span)
+                    .emit();
             } else {
-                self.gcx.dcx().emit_err(
-                    natspec.span,
-                    format!(
+                self.gcx
+                    .dcx()
+                    .warn(format!(
                         "tag `@return` references non-existent return parameter '{documented_name}'"
-                    ),
-                );
+                    ))
+                    .code(error_code!(5856))
+                    .span(natspec.span)
+                    .emit();
             }
             return None;
         }
@@ -501,14 +507,24 @@ impl<'gcx> Resolver<'gcx> {
     }
 
     #[cold]
-    fn emit_forbidden_tag_error(&self, tag_name: &str, tag_span: Span, item_id: hir::ItemId) {
+    fn emit_forbidden_tag_warning(&self, tag_name: &str, tag_span: Span, item_id: hir::ItemId) {
         let item_desc = self.gcx.hir.item(item_id).description();
-        self.gcx.dcx().emit_err(tag_span, format!("tag `{tag_name}` not valid for {item_desc}s"));
+        self.gcx
+            .dcx()
+            .warn(format!("tag `{tag_name}` not valid for {item_desc}s"))
+            .code(error_code!(6546))
+            .span(tag_span)
+            .emit();
     }
 
     #[cold]
-    fn emit_duplicate_tag_error(&self, tag_name: &str, tag_span: Span) {
-        self.gcx.dcx().emit_err(tag_span, format!("tag {tag_name} can only be given once"));
+    fn emit_duplicate_tag_warning(&self, tag_name: &str, tag_span: Span) {
+        self.gcx
+            .dcx()
+            .warn(format!("tag {tag_name} can only be given once"))
+            .code(error_code!(5142))
+            .span(tag_span)
+            .emit();
     }
 
     /// Helper to validate tags that can only be defined once.
@@ -524,11 +540,11 @@ impl<'gcx> Resolver<'gcx> {
         item_id: hir::ItemId,
     ) -> bool {
         if !allowed {
-            self.emit_forbidden_tag_error(tag_name, tag_span, item_id);
+            self.emit_forbidden_tag_warning(tag_name, tag_span, item_id);
             return false;
         }
         if seen_tags.contains(tag_flag) {
-            self.emit_duplicate_tag_error(tag_name, tag_span);
+            self.emit_duplicate_tag_warning(tag_name, tag_span);
             return false;
         }
         seen_tags.insert(tag_flag);
@@ -551,13 +567,13 @@ impl<'gcx> Resolver<'gcx> {
         let contract_id = self.gcx.natspec_contract_in_source(cache_key);
 
         let Some(contract_id) = contract_id else {
-            dcx.emit_err(
-                tag_span,
-                format!(
-                    "tag `@inheritdoc` references inexistent contract \"{}\"",
-                    contract_ident.name
-                ),
-            );
+            dcx.warn(format!(
+                "tag `@inheritdoc` references inexistent contract \"{}\"",
+                contract_ident.name
+            ))
+            .code(error_code!(9397))
+            .span(tag_span)
+            .emit();
             return None;
         };
 
@@ -570,19 +586,25 @@ impl<'gcx> Resolver<'gcx> {
         if let Some(contract) = item_contract {
             let linearized_bases = &self.gcx.hir.contract(contract).linearized_bases;
             if contract == contract_id || !linearized_bases.contains(&contract_id) {
-                dcx.emit_err(tag_span, format!(
+                dcx.warn(format!(
                     "tag `@inheritdoc` references contract \"{}\", which is not a base of this contract",
                     contract_ident.name
-                ));
+                ))
+                .code(error_code!(4682))
+                .span(tag_span)
+                .emit();
                 return None;
             }
         }
 
         let Some(inherited_item) = self.find_inherited_item(item_id, contract_id) else {
-            dcx.emit_err(tag_span, format!(
+            dcx.warn(format!(
                 "tag `@inheritdoc` references contract \"{}\", but the contract does not contain a matching item that can be inherited",
                 contract_ident.name
-            ));
+            ))
+            .code(error_code!(4682))
+            .span(tag_span)
+            .emit();
             return None;
         };
 

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -284,10 +284,7 @@ fn check_duplicate_definitions(gcx: Gcx<'_>, scope: &Declarations) {
                 return false;
             }
         }
-        if !same_external_params(gcx, gcx.type_of_item(a), gcx.type_of_item(b)) {
-            return false;
-        }
-        true
+        same_external_params(gcx, gcx.type_of_item(a), gcx.type_of_item(b))
     };
 
     let mut reported = GrowableBitSet::new_empty();

--- a/tests/ui/natspec/solc_parity_shapes.sol
+++ b/tests/ui/natspec/solc_parity_shapes.sol
@@ -59,7 +59,7 @@ contract C {
      * @param nope Not a parameter anywhere.
      */
     function bad(uint256 a) public pure returns (uint256) {
-        //~^^^ ERROR: tag `@param` references non-existent parameter 'nope'
+        //~^^^ WARN: tag `@param` references non-existent parameter 'nope'
         return a;
     }
 }

--- a/tests/ui/natspec/solc_parity_shapes.stderr
+++ b/tests/ui/natspec/solc_parity_shapes.stderr
@@ -1,8 +1,6 @@
-error: tag `@param` references non-existent parameter 'nope'
+warning[3881]: tag `@param` references non-existent parameter 'nope'
    ╭▸ ROOT/tests/ui/natspec/solc_parity_shapes.sol:LL:CC
    │
 LL │      * @param nope Not a parameter anywhere.
    ╰╴        ━━━━━
-
-error: aborting due to 1 previous error
 

--- a/tests/ui/natspec/tag_returns.sol
+++ b/tests/ui/natspec/tag_returns.sol
@@ -1,11 +1,11 @@
 contract ValidReturnTags {
     /// @return The unnamed return description
-    function unnamedReturn() public returns (uint) {
+    function unnamedReturn() public pure returns (uint) {
         return 1;
     }
 
     /// @return result The named return description
-    function namedReturn() public returns (uint result) {
+    function namedReturn() public pure returns (uint result) {
         return 1;
     }
 }
@@ -14,24 +14,24 @@ contract TooManyReturns {
     /// @return First return value
     /// @return Second return value
     /// @return Third return value
-    //~^ ERROR: too many `@return` tags: function has 2 return values, found 3
+    //~^ WARN: too many `@return` tags: function has 2 return values, found 3
     function tooManyReturns() public returns (uint, uint) {}
 }
 
 contract InvalidReturnNames {
     /// @return other Invalid return name
-    //~^ ERROR: tag `@return` references non-existent return parameter 'other'
+    //~^ WARN: tag `@return` references non-existent return parameter 'other'
     function invalidName() public returns (uint result) {}
 
     /// @return
-    //~^ ERROR: tag `@return` does not contain the name of its return parameter
+    //~^ WARN: tag `@return` does not contain the name of its return parameter
     function missingName() public returns (uint result) {}
 }
 
 contract InvalidReturnOrder {
     /// @return second The second return value is documented first
-    //~^ ERROR: mismatched `@return` parameter: expected `first`, found `second`
+    //~^ WARN: mismatched `@return` parameter: expected `first`, found `second`
     /// @return first The first return value is documented second
-    //~^ ERROR: mismatched `@return` parameter: expected `second`, found `first`
+    //~^ WARN: mismatched `@return` parameter: expected `second`, found `first`
     function swappedNames() public returns (uint first, uint second) {}
 }

--- a/tests/ui/natspec/tag_returns.stderr
+++ b/tests/ui/natspec/tag_returns.stderr
@@ -1,32 +1,30 @@
-error: too many `@return` tags: function has 2 return values, found 3
+warning[2604]: too many `@return` tags: function has 2 return values, found 3
    ╭▸ ROOT/tests/ui/natspec/tag_returns.sol:LL:CC
    │
 LL │     /// @return Third return value
    ╰╴         ━━━━━━
 
-error: tag `@return` references non-existent return parameter 'other'
+warning[5856]: tag `@return` references non-existent return parameter 'other'
    ╭▸ ROOT/tests/ui/natspec/tag_returns.sol:LL:CC
    │
 LL │     /// @return other Invalid return name
    ╰╴         ━━━━━━
 
-error: tag `@return` does not contain the name of its return parameter
+warning[5856]: tag `@return` does not contain the name of its return parameter
    ╭▸ ROOT/tests/ui/natspec/tag_returns.sol:LL:CC
    │
 LL │     /// @return
    ╰╴         ━━━━━━
 
-error: mismatched `@return` parameter: expected `first`, found `second`
+warning[5856]: mismatched `@return` parameter: expected `first`, found `second`
    ╭▸ ROOT/tests/ui/natspec/tag_returns.sol:LL:CC
    │
 LL │     /// @return second The second return value is documented first
    ╰╴                ━━━━━━
 
-error: mismatched `@return` parameter: expected `second`, found `first`
+warning[5856]: mismatched `@return` parameter: expected `second`, found `first`
    ╭▸ ROOT/tests/ui/natspec/tag_returns.sol:LL:CC
    │
 LL │     /// @return first The first return value is documented second
    ╰╴                ━━━━━
-
-error: aborting due to 5 previous errors
 

--- a/tests/ui/natspec/tag_sema.sol
+++ b/tests/ui/natspec/tag_sema.sol
@@ -36,12 +36,12 @@ contract ValidItems {
     /// @param amount The amount to transfer
     /// @return success Whether the transfer succeeded
     /// @custom:throws InsufficientBalance
-    function transfer(address to, uint amount) public returns (bool success) {
+    function transfer(address to, uint amount) public pure returns (bool success) {
         return true;
     }
 }
 
-// -- ERROR TESTS - DUPLICATE TAGS ---------------------------------------------
+// -- WARNING TESTS - DUPLICATE TAGS -------------------------------------------
 
 /// @author First author
 /// @author Second author
@@ -49,7 +49,6 @@ contract DuplicateAuthor {}
 
 /// @title First title
 /// @title Second title
-//~^ ERROR: tag @title can only be given once
 contract DuplicateTitle {}
 
 contract DuplicateParamBase {
@@ -66,23 +65,23 @@ contract DuplicateInheritdocBase {
 contract DuplicateInheritdoc is DuplicateInheritdocBase {
     /// @inheritdoc DuplicateInheritdocBase
     /// @inheritdoc DuplicateInheritdocBase
-    //~^ ERROR: tag @inheritdoc can only be given once
+    //~^ WARN: tag @inheritdoc can only be given once
     function foo() public override {}
 }
 
-// -- ERROR TESTS - INVALID CONTEXT --------------------------------------------
+// -- WARNING TESTS - INVALID CONTEXT ------------------------------------------
 
 contract InvalidTagContext {
     /// @author Invalid author on function
-    //~^ ERROR: tag `@author` not valid for functions
+    //~^ WARN: tag `@author` not valid for functions
     function invalidAuthor() public {}
 
     /// @title Invalid title on function
-    //~^ ERROR: tag `@title` not valid for functions
+    //~^ WARN: tag `@title` not valid for functions
     function invalidTitle() public {}
 
     /// @return Invalid return on event
-    //~^ ERROR: tag `@return` not valid for events
+    //~^ WARN: tag `@return` not valid for events
     event InvalidReturn(address from, address to);
 }
 
@@ -92,21 +91,27 @@ contract InvalidInheritdocBase {
 
 contract InvalidInheritdoc is InvalidInheritdocBase {
     /// @inheritdoc InvalidInheritdocBase
-    //~^ ERROR: tag `@inheritdoc` not valid for events
+    //~^ WARN: tag `@inheritdoc` not valid for events
     event InvalidInheritdocEvent(address from, address to);
 }
 
 contract InvalidParamName {
     /// @param x Valid parameter
     /// @param y Invalid parameter name
-    //~^ ERROR: tag `@param` references non-existent parameter 'y'
+    //~^ WARN: tag `@param` references non-existent parameter 'y'
     function foo(uint x) public {}
 }
 
 contract SelfInheritdoc {
     /// @inheritdoc SelfInheritdoc
-    //~^ ERROR: tag `@inheritdoc` references contract "SelfInheritdoc", which is not a base of this contract
+    //~^ WARN: tag `@inheritdoc` references contract "SelfInheritdoc", which is not a base of this contract
     function foo() public {}
+}
+
+contract MissingInheritdocContract {
+    /// @inheritdoc DoesNotExist
+    //~^ WARN: tag `@inheritdoc` references inexistent contract "DoesNotExist"
+    function foo() public pure {}
 }
 
 contract InheritdocGrandparent {
@@ -117,7 +122,7 @@ contract InheritdocIntermediate is InheritdocGrandparent {}
 
 contract InvalidIntermediateInheritdoc is InheritdocIntermediate {
     /// @inheritdoc InheritdocIntermediate
-    //~^ ERROR: tag `@inheritdoc` references contract "InheritdocIntermediate", but the contract does not contain a matching item that can be inherited
+    //~^ WARN: tag `@inheritdoc` references contract "InheritdocIntermediate", but the contract does not contain a matching item that can be inherited
     function inherited() public override {}
 }
 

--- a/tests/ui/natspec/tag_sema.stderr
+++ b/tests/ui/natspec/tag_sema.stderr
@@ -1,56 +1,54 @@
-error: tag @title can only be given once
-   ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
-   │
-LL │ /// @title Second title
-   ╰╴     ━━━━━
-
-error: tag @inheritdoc can only be given once
+warning[5142]: tag @inheritdoc can only be given once
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @inheritdoc DuplicateInheritdocBase
    ╰╴         ━━━━━━━━━━
 
-error: tag `@author` not valid for functions
+warning[6546]: tag `@author` not valid for functions
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @author Invalid author on function
    ╰╴         ━━━━━━
 
-error: tag `@title` not valid for functions
+warning[6546]: tag `@title` not valid for functions
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @title Invalid title on function
    ╰╴         ━━━━━
 
-error: tag `@param` references non-existent parameter 'y'
+warning[3881]: tag `@param` references non-existent parameter 'y'
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @param y Invalid parameter name
    ╰╴         ━━━━━
 
-error: tag `@inheritdoc` references contract "SelfInheritdoc", which is not a base of this contract
+warning[4682]: tag `@inheritdoc` references contract "SelfInheritdoc", which is not a base of this contract
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @inheritdoc SelfInheritdoc
    ╰╴         ━━━━━━━━━━
 
-error: tag `@inheritdoc` references contract "InheritdocIntermediate", but the contract does not contain a matching item that can be inherited
+warning[9397]: tag `@inheritdoc` references inexistent contract "DoesNotExist"
+   ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
+   │
+LL │     /// @inheritdoc DoesNotExist
+   ╰╴         ━━━━━━━━━━
+
+warning[4682]: tag `@inheritdoc` references contract "InheritdocIntermediate", but the contract does not contain a matching item that can be inherited
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @inheritdoc InheritdocIntermediate
    ╰╴         ━━━━━━━━━━
 
-error: tag `@return` not valid for events
+warning[6546]: tag `@return` not valid for events
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @return Invalid return on event
    ╰╴         ━━━━━━
 
-error: tag `@inheritdoc` not valid for events
+warning[6546]: tag `@inheritdoc` not valid for events
    ╭▸ ROOT/tests/ui/natspec/tag_sema.sol:LL:CC
    │
 LL │     /// @inheritdoc InvalidInheritdocBase
    ╰╴         ━━━━━━━━━━
-
-error: aborting due to 9 previous errors
 

--- a/tests/ui/natspec/tag_variables.sol
+++ b/tests/ui/natspec/tag_variables.sol
@@ -5,10 +5,10 @@ contract ValidVariableTags {
 
 contract InvalidVariableTags {
     /// @return Invalid return on private variable
-    //~^ ERROR: tag `@return` not valid for variables
+    //~^ WARN: tag `@return` not valid for variables
     uint private privateVariable;
 
     /// @param owner Invalid parameter on variable
-    //~^ ERROR: tag `@param` not valid for variables
+    //~^ WARN: tag `@param` not valid for variables
     mapping(address owner => uint) public balanceOf;
 }

--- a/tests/ui/natspec/tag_variables.stderr
+++ b/tests/ui/natspec/tag_variables.stderr
@@ -1,14 +1,12 @@
-error: tag `@return` not valid for variables
+warning[6546]: tag `@return` not valid for variables
    ╭▸ ROOT/tests/ui/natspec/tag_variables.sol:LL:CC
    │
 LL │     /// @return Invalid return on private variable
    ╰╴         ━━━━━━
 
-error: tag `@param` not valid for variables
+warning[6546]: tag `@param` not valid for variables
    ╭▸ ROOT/tests/ui/natspec/tag_variables.sol:LL:CC
    │
 LL │     /// @param owner Invalid parameter on variable
    ╰╴         ━━━━━
-
-error: aborting due to 2 previous errors
 


### PR DESCRIPTION
## Summary

- downgrade NatSpec validation errors to warnings
- attach the matching solc diagnostic code to every NatSpec warning, including existing invalid-tag warnings
- accept duplicate `@title` tags like solc; code 5142 applies only to duplicate `@inheritdoc`
- update and bless all affected NatSpec UI tests, including explicit coverage for code 9397

## Tests

- `cargo uibless natspec`
- `cargo test --package=solar-compiler --test=tests -- tests/ui/natspec/`
- `cargo +nightly clippy --package solar-sema --all-targets -- -D warnings`
- `cargo +nightly fmt --all --check`

Prompted by: @DaniPopes