### PR TITLE
fix(yul): parse versioned builtin names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,6 +4620,8 @@ dependencies = [
  "evm2",
  "regex",
  "serde_json",
+ "solar-config",
+ "strum 0.28.0",
  "tempfile",
  "ui_test",
 ]

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -330,7 +330,7 @@ impl Symbol {
     #[inline]
     pub fn is_reserved_yul_builtin(self) -> bool {
         (self >= kw::Add && self <= kw::Xor)
-            || matches!(self, kw::Address | kw::Byte | kw::Return | kw::Revert)
+            || matches!(self, kw::Address | kw::Byte | kw::Clz | kw::Return | kw::Revert)
     }
 
     /// Returns `true` if the symbol is a Yul EVM builtin keyword reserved by `evm_version`.
@@ -344,6 +344,7 @@ impl Symbol {
     pub fn is_future_yul_builtin(self, evm_version: crate::config::EvmVersion) -> bool {
         match self {
             kw::Basefee => !evm_version.has_base_fee(),
+            kw::Prevrandao => !evm_version.has_prev_randao(),
             kw::Blobbasefee | kw::Blobhash | kw::Mcopy | kw::Tload | kw::Tstore => {
                 !evm_version.has_blob_base_fee()
             }

--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -151,6 +151,18 @@ impl Ident {
         self.name.is_reserved_yul_builtin()
     }
 
+    /// Returns `true` if the identifier is a Yul EVM builtin reserved by `evm_version`.
+    #[inline]
+    pub fn is_reserved_yul_builtin_in(self, evm_version: crate::config::EvmVersion) -> bool {
+        self.name.is_reserved_yul_builtin_in(evm_version)
+    }
+
+    /// Returns `true` if the identifier is a future Yul EVM builtin keyword.
+    #[inline]
+    pub fn is_future_yul_builtin(self, evm_version: crate::config::EvmVersion) -> bool {
+        self.name.is_future_yul_builtin(evm_version)
+    }
+
     /// Returns `true` if the identifier is either a keyword, either currently in use or reserved
     /// for possible future use.
     #[inline]
@@ -319,6 +331,25 @@ impl Symbol {
     pub fn is_reserved_yul_builtin(self) -> bool {
         (self >= kw::Add && self <= kw::Xor)
             || matches!(self, kw::Address | kw::Byte | kw::Return | kw::Revert)
+    }
+
+    /// Returns `true` if the symbol is a Yul EVM builtin keyword reserved by `evm_version`.
+    #[inline]
+    pub fn is_reserved_yul_builtin_in(self, evm_version: crate::config::EvmVersion) -> bool {
+        self.is_reserved_yul_builtin() && !self.is_future_yul_builtin(evm_version)
+    }
+
+    /// Returns `true` if the symbol is a future Yul EVM builtin keyword.
+    #[inline]
+    pub fn is_future_yul_builtin(self, evm_version: crate::config::EvmVersion) -> bool {
+        match self {
+            kw::Basefee => !evm_version.has_base_fee(),
+            kw::Blobbasefee | kw::Blobhash | kw::Mcopy | kw::Tload | kw::Tstore => {
+                !evm_version.has_blob_base_fee()
+            }
+            kw::Clz => !evm_version.has_clz(),
+            _ => false,
+        }
     }
 
     /// Returns `true` if the symbol is either a keyword, either currently in use or reserved for

--- a/crates/parse/src/parser/mod.rs
+++ b/crates/parse/src/parser/mod.rs
@@ -52,10 +52,10 @@ pub struct Parser<'sess, 'ast, 'cb> {
     /// The token stream.
     tokens: std::vec::IntoIter<Token>,
 
-    /// Whether the parser is in Yul mode.
-    ///
-    /// Currently, this can only happen when parsing a Yul "assembly" block.
+    /// Whether the parser is in a Yul block.
     in_yul: bool,
+    /// Whether the parser is parsing a standalone Yul file.
+    pure_yul: bool,
     /// Whether the parser is currently parsing a contract block.
     in_contract: bool,
     /// Whether the parser is currently parsing a modifier body.
@@ -160,6 +160,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
             docs: Vec::with_capacity(4),
             tokens: tokens.into_iter(),
             in_yul: false,
+            pure_yul: false,
             in_contract: false,
             in_modifier: false,
             recover_incomplete_input: sess.opts.unstable.recover_incomplete_input,
@@ -868,6 +869,15 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         res
     }
 
+    /// Runs `f` while parsing a standalone Yul file.
+    #[inline]
+    fn in_pure_yul<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        let old = std::mem::replace(&mut self.pure_yul, true);
+        let res = f(self);
+        self.pure_yul = old;
+        res
+    }
+
     /// Runs `f` with recursion depth tracking and limit enforcement.
     #[inline]
     pub fn with_recursion_limit<T>(
@@ -949,7 +959,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses either an identifier or a Yul EVM builtin.
     fn parse_yul_path_ident(&mut self) -> PResult<'sess, Ident> {
         let ident = self.ident_or_err(true)?;
-        if !ident.is_yul_builtin() && ident.is_reserved(true) {
+        if !ident.is_yul_builtin() && self.is_reserved_yul_ident(ident) {
             self.expected_ident_found_err().emit();
         }
         self.bump();
@@ -1005,7 +1015,19 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     #[track_caller]
     fn parse_ident_common(&mut self, recover: bool) -> PResult<'sess, Ident> {
         let ident = self.ident_or_err(recover)?;
-        if ident.is_reserved(self.in_yul) {
+        if self.in_yul && ident.is_future_yul_builtin(self.sess.opts.evm_version) {
+            self.dcx()
+                .warn(format!(
+                    "`{ident}` will be promoted to Yul reserved identifier in the future and will not be allowed anymore as an identifier"
+                ))
+                .span(ident.span)
+                .code(error_code!(5470))
+                .emit();
+        } else if if self.in_yul {
+            self.is_reserved_yul_ident(ident)
+        } else {
+            ident.is_reserved(false)
+        } {
             let err = self.expected_ident_found_err();
             if recover {
                 err.emit();
@@ -1015,6 +1037,14 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         }
         self.bump();
         Ok(ident)
+    }
+
+    #[inline]
+    fn is_reserved_yul_ident(&self, ident: Ident) -> bool {
+        ident.is_yul_keyword()
+            || (ident.is_yul_builtin()
+                && !ident.is_future_yul_builtin(self.sess.opts.evm_version)
+                && (self.pure_yul || ident.is_reserved_yul_builtin_in(self.sess.opts.evm_version)))
     }
 
     /// Returns Ok if the current token is an identifier. Does not advance the parser.

--- a/crates/parse/src/parser/yul.rs
+++ b/crates/parse/src/parser/yul.rs
@@ -13,20 +13,29 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// See: <https://github.com/argotorg/solidity/blob/eff410eb746f202fe756a2473fd0c8a718348457/libyul/ObjectParser.cpp#L50>
     #[instrument(level = "debug", skip_all)]
     pub fn parse_yul_file_object(&mut self) -> PResult<'sess, Object<'ast>> {
-        let docs = self.parse_doc_comments();
-        let object = if self.check_keyword(sym::object) {
-            self.parse_yul_object(docs)
-        } else {
-            let lo = self.token.span;
-            self.parse_yul_block().map(|code| {
-                let span = lo.to(self.prev_token.span);
-                let name = StrLit { span, value: sym::object };
-                let code = CodeBlock { span, code };
-                Object { docs, span, name, code, children: Box::default(), data: Box::default() }
-            })
-        }?;
-        self.expect(TokenKind::Eof)?;
-        Ok(object)
+        self.in_pure_yul(|this| {
+            let docs = this.parse_doc_comments();
+            let object = if this.check_keyword(sym::object) {
+                this.parse_yul_object(docs)
+            } else {
+                let lo = this.token.span;
+                this.parse_yul_block().map(|code| {
+                    let span = lo.to(this.prev_token.span);
+                    let name = StrLit { span, value: sym::object };
+                    let code = CodeBlock { span, code };
+                    Object {
+                        docs,
+                        span,
+                        name,
+                        code,
+                        children: Box::default(),
+                        data: Box::default(),
+                    }
+                })
+            }?;
+            this.expect(TokenKind::Eof)?;
+            Ok(object)
+        })
     }
 
     /// Parses a Yul object.
@@ -287,7 +296,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
                 // Paths are not allowed in call expressions, but Solc parses them anyway.
                 let ident = self.expect_single_ident_path(path);
                 self.parse_yul_expr_call_with(ident).map(ExprKind::Call)
-            } else if path.segments().len() == 1 && path.first().is_reserved_yul_builtin() {
+            } else if path.segments().len() == 1 && self.is_reserved_yul_ident(*path.first()) {
                 let name = path.first();
                 self.dcx()
                     .emit_err(path.span(), format!("builtin function `{name}` must be called"));
@@ -303,7 +312,7 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
 
     /// Parses a Yul function call expression with the given name.
     fn parse_yul_expr_call_with(&mut self, name: Ident) -> PResult<'sess, ExprCall<'ast>> {
-        if !name.is_yul_builtin() && name.is_reserved(true) {
+        if !name.is_yul_builtin() && self.is_reserved_yul_ident(name) {
             self.expected_ident_found_other(name.into(), false).unwrap_err().emit();
         }
         let arguments = self.parse_paren_comma_seq(true, Self::parse_yul_expr)?;
@@ -331,7 +340,8 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
         // We allow EVM builtins in any position if multiple segments are present:
         // https://github.com/argotorg/solidity/issues/16054
         let first = *path.first();
-        if first.is_yul_keyword() || (path.segments().len() == 1 && first.is_reserved_yul_builtin())
+        if first.is_yul_keyword()
+            || (path.segments().len() == 1 && self.is_reserved_yul_ident(first))
         {
             self.expected_ident_found_other(first.into(), false).unwrap_err().emit();
         }

--- a/tests/ui/parser/yul/cancun_builtin_identifiers.shanghai.stderr
+++ b/tests/ui/parser/yul/cancun_builtin_identifiers.shanghai.stderr
@@ -1,4 +1,4 @@
-error: expected identifier, found Yul EVM builtin keyword `mcopy`
+warning[5470]: `mcopy` will be promoted to Yul reserved identifier in the future and will not be allowed anymore as an identifier
    ╭▸ ROOT/tests/ui/parser/yul/cancun_builtin_identifiers.sol:LL:CC
    │
 LL │             let mcopy
@@ -44,5 +44,5 @@ LL │             tstore(0, 0)
    │
    ╰ help: compile with `--evm-version cancun` or newer
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors; 1 warning emitted
 

--- a/tests/ui/parser/yul/cancun_builtin_identifiers.sol
+++ b/tests/ui/parser/yul/cancun_builtin_identifiers.sol
@@ -6,7 +6,8 @@ contract C {
     function identifier() external pure {
         assembly {
             let mcopy
-            //~^ ERROR: expected identifier, found Yul EVM builtin keyword `mcopy`
+            //~[shanghai]^ WARN: `mcopy` will be promoted to Yul reserved identifier in the future and will not be allowed anymore as an identifier
+            //~[cancun]| ERROR: expected identifier, found Yul EVM builtin keyword `mcopy`
         }
     }
 

--- a/tools/tester/Cargo.toml
+++ b/tools/tester/Cargo.toml
@@ -24,6 +24,8 @@ alloy-primitives.workspace = true
 evm2.workspace = true
 regex.workspace = true
 serde_json.workspace = true
+solar-config.workspace = true
+strum.workspace = true
 tempfile.workspace = true
 ui_test = { git = "https://github.com/DaniPopes/ui_test", branch = "fork", version = "0.30.5" }
 

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -377,6 +377,9 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
             // HACK: skip the input file argument by using a dummy flag.
             config.program.input_file_flag = Some("-I".into());
         }
+    } else if let Some(evm_version) = solc::yul::evm_version(src) {
+        config.program.args.push("--evm-version".into());
+        config.program.args.push(evm_version.to_string().into());
     }
 }
 

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -377,7 +377,8 @@ fn solc_per_file_config(config: &mut ui_test::Config, src: &str, path: &Path, cf
             // HACK: skip the input file argument by using a dummy flag.
             config.program.input_file_flag = Some("-I".into());
         }
-    } else if let Some(evm_version) = solc::yul::evm_version(src) {
+    }
+    if let Some(evm_version) = solc::yul::evm_version(src) {
         config.program.args.push("--evm-version".into());
         config.program.args.push(evm_version.to_string().into());
     }

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -76,20 +76,9 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "broken_version_1"
         // Checked during AST validation rather than parsing.
         | "unchecked_while_body"
-        // TODO: EVM version-aware parsing.
-        | "basefee_pre_london"
-        | "basefee_berlin_function"
-        | "prevrandao_allowed_function_pre_paris"
-        | "blobbasefee_shanghai_function"
-        | "blobhash_pre_cancun"
-        | "mcopy_as_identifier_pre_cancun"
-        | "tload_tstore_not_reserved_before_cancun"
-        | "blobhash_pre_cancun_not_reserved"
-        | "clz_reserved_osaka"
         // Arbitrary `pragma experimental` values are allowed by Solc apparently.
         | "experimental_test_warning"
         // "." is not a valid import path.
-        | "boost_filesystem_bug"
         // Invalid UTF-8 is not supported.
         | "invalid_utf8_sequence"
         // Validation is in solar's AST stage (https://github.com/paradigmxyz/solar/pull/120).

--- a/tools/tester/src/solc/yul.rs
+++ b/tools/tester/src/solc/yul.rs
@@ -1,5 +1,28 @@
 use crate::utils::path_contains_curry;
+use solar_config::EvmVersion;
 use std::path::Path;
+use strum::IntoEnumIterator;
+
+pub(crate) fn evm_version(src: &str) -> Option<EvmVersion> {
+    let version = src.lines().find_map(|line| line.trim().strip_prefix("// EVMVersion:"))?.trim();
+    let (op, version) = match version.as_bytes() {
+        [b'>', b'=', ..] => (">=", &version[2..]),
+        [b'<', b'=', ..] => ("<=", &version[2..]),
+        [b'>', ..] => (">", &version[1..]),
+        [b'<', ..] => ("<", &version[1..]),
+        [b'=', ..] => ("=", &version[1..]),
+        _ => return None,
+    };
+    let version =
+        if version == "current" { EvmVersion::default() } else { version.parse().ok()? };
+    Some(match op {
+        ">=" | "=" => version,
+        ">" => EvmVersion::iter().find(|&candidate| candidate > version)?,
+        "<=" => EvmVersion::iter().rev().find(|&candidate| candidate <= version)?,
+        "<" => EvmVersion::iter().rev().find(|&candidate| candidate < version)?,
+        _ => unreachable!(),
+    })
+}
 
 pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     let path_contains = path_contains_curry(path);
@@ -55,21 +78,10 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "linkersymbol_shadowing"
         | "loadimmutable_shadowing"
         | "setimmutable_shadowing"
-        // TODO: EVM version-aware parsing.
-        | "basefee_identifier_pre_london"
-        | "blobbasefee_identifier_pre_cancun"
-        | "blobhash_pre_cancun"
-        | "mcopy_as_identifier_pre_cancun"
-        | "mcopy_pre_cancun"
-        | "tstore_tload_as_identifiers_pre_cancun"
         | "eof_names_reserved_in_eof"
         | "extcall_function_in_eof"
         | "extdelegatecall_function_in_eof"
         | "extstaticcall_function_in_eof"
-        | "clash_with_non_reserved_pure_yul_builtin"
-        | "clash_with_reserved_pure_yul_builtin_eof"
-        | "clash_with_reserved_pure_yul_builtin"
-        | "clz"
     ) {
         return Err("manually skipped");
     };

--- a/tools/tester/src/solc/yul.rs
+++ b/tools/tester/src/solc/yul.rs
@@ -68,20 +68,6 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "number_literal_3"
         | "number_literal_4"
         | "data_name_with_literal_newline"
-        | "pc_disallowed"
-        | "for_statement_nested_continue"
-        | "linkersymbol_invalid_redefine_builtin"
-        // TODO: Implemented with Yul object syntax.
-        | "datacopy_shadowing"
-        | "dataoffset_shadowing"
-        | "datasize_shadowing"
-        | "linkersymbol_shadowing"
-        | "loadimmutable_shadowing"
-        | "setimmutable_shadowing"
-        | "eof_names_reserved_in_eof"
-        | "extcall_function_in_eof"
-        | "extdelegatecall_function_in_eof"
-        | "extstaticcall_function_in_eof"
     ) {
         return Err("manually skipped");
     };


### PR DESCRIPTION
Match solc when a Yul builtin name becomes reserved: before its EVM version, Solar accepts the name and emits the future-reserved warning; from that version onward, it rejects the name. Standalone Yul now also reserves its pure-Yul builtin names without changing inline-assembly rules.

The upstream Yul runner now applies each fixture’s `EVMVersion` constraint. This enables the versioned syntax fixtures and the pure-Yul builtin collision cases.