### PR TITLE
refactor(mir): print blocks in RPO

### DIFF
--- a/crates/codegen/src/mir/display.rs
+++ b/crates/codegen/src/mir/display.rs
@@ -6,6 +6,7 @@ use super::{
     BasicBlock, BlockId, EffectKind, Function, FunctionId, InstId, InstKind, Instruction,
     MemoryRegion, Module, StorageAlias, Terminator, Value, ValueId,
 };
+use crate::analysis::CfgInfo;
 use arrayvec::ArrayVec;
 use solar_data_structures::{
     fmt::{self, FmtIteratorExt},
@@ -263,13 +264,15 @@ pub(crate) fn display_function_text<'a>(
         write!(f, "{}", display_function_attributes(func))?;
         writeln!(f, " {{")?;
 
-        write!(
-            f,
-            "{}",
-            func.blocks.iter_enumerated().format_with("", |f, (block_id, block)| {
-                write!(f, "{}", display_text_block(func, module, block_id, block))
-            })
-        )?;
+        let cfg = CfgInfo::new(func);
+        for &block_id in cfg.rpo() {
+            write!(f, "{}", display_text_block(func, module, block_id, &func.blocks[block_id]))?;
+        }
+        for (block_id, block) in func.blocks.iter_enumerated() {
+            if !cfg.is_reachable(block_id) {
+                write!(f, "{}", display_text_block(func, module, block_id, block))?;
+            }
+        }
 
         writeln!(f, "}}")
     })

--- a/crates/codegen/src/mir/mod.rs
+++ b/crates/codegen/src/mir/mod.rs
@@ -331,8 +331,17 @@ mod round_trip {
                 }
             };
             let print2 = parsed2.to_text().to_string();
-            if print1 != print2 {
-                let diff = first_diff(&print1, &print2)
+            let parsed3 = match parse_module(&sess, &print2) {
+                Ok(m) => m,
+                Err(_) => {
+                    result =
+                        Err(format!("third parse failed: {}", sess.emitted_diagnostics().unwrap()));
+                    return;
+                }
+            };
+            let print3 = parsed3.to_text().to_string();
+            if print2 != print3 {
+                let diff = first_diff(&print2, &print3)
                     .map(|(i, a, b)| format!("line {i}: `{a}` vs `{b}`"))
                     .unwrap_or_else(|| "(length mismatch)".to_string());
                 result = Err(format!("not idempotent: {diff}"));

--- a/tests/ui/codegen/lowering/abi_decode_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_calldata_slice.stdout
@@ -6,15 +6,11 @@ fn @decode(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 4
     jumpi v5, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v6 = sub v4, 4
     v7 = add v3, 4
@@ -23,10 +19,6 @@ fn @decode(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v10 = add v9, 31
     v11 = lt v10, v9
     jumpi v11, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v12 = not 31
     v13 = and v10, v12
@@ -35,10 +27,6 @@ fn @decode(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v16 = add 32, v15
     v17 = lt v16, v15
     jumpi v17, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v18 = alloc memorybytes, exact, uninitialized, infallible, v16
     set_memory_object_len memorybytes, v18, v9
@@ -52,10 +40,22 @@ fn @decode(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v24 = memory_object_data memorybytes, v18
     v25 = lt v23, 32
     jumpi v25, bb9, bb10
-  bb9:
-    revert 0, 0
   bb10:
     v26 = mload v24
     ret v26
+  bb9:
+    revert 0, 0
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_arrays.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_arrays.stdout
@@ -7,8 +7,6 @@ fn @words() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -72,6 +70,8 @@ fn @words() {
     v52 = add v48, v47
     mstore 64, v52 !metadata(memory=scratch)
     returndata v48, v43
+  bb1:
+    revert 0, 0
 }
 
 fn @bools() {
@@ -80,8 +80,6 @@ fn @bools() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -134,12 +132,6 @@ fn @bools() {
     v42 = phi [bb8: v31], [bb12: v43]
     v33 = lt v32, v21
     jumpi v33, bb10, bb11
-  bb10:
-    v36 = mload v42
-    v37 = iszero v36
-    v38 = iszero v37
-    v39 = eq v36, v38
-    jumpi v39, bb12, bb1
   bb11:
     v47 = mload 64 !metadata(memory=scratch)
     v48 = add v47, 32
@@ -158,10 +150,18 @@ fn @bools() {
     v64 = add v60, v59
     mstore 64, v64 !metadata(memory=scratch)
     returndata v60, v55
+  bb10:
+    v36 = mload v42
+    v37 = iszero v36
+    v38 = iszero v37
+    v39 = eq v36, v38
+    jumpi v39, bb12, bb1
   bb12:
     v41 = add v32, 1
     v43 = add v42, 32
     jump bb9
+  bb1:
+    revert 0, 0
 }
 
 fn @strs() {
@@ -170,8 +170,6 @@ fn @strs() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -225,10 +223,6 @@ fn @strs() {
     v64 = phi [bb8: v32], [bb19: v65]
     v34 = lt v33, v21
     jumpi v34, bb10, bb11
-  bb10:
-    v37 = mload v62
-    v38 = lt v37, v25
-    jumpi v38, bb1, bb12
   bb11:
     v69 = mload 64 !metadata(memory=scratch, effect=memory_write)
     v116 = add v69, 160
@@ -252,6 +246,56 @@ fn @strs() {
     mstore v80, v32
     mstore v81, v74
     jump bb20
+  bb20:
+    v82 = mload v69
+    jumpi v82, bb21, bb22
+  bb22:
+    v106 = mload v78
+    v107 = sub v106, v70
+    v109 = add v107, 31
+    v111 = and v109, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v112 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v118 = add v112, v111
+    mstore 64, v118 !metadata(memory=scratch)
+    returndata v112, v107
+  bb21:
+    v84 = mload v80
+    v85 = mload v84
+    v86 = mload v79
+    v87 = mload v78
+    v88 = mload v81
+    v89 = sub v87, v88
+    mstore v86, v89
+    v90 = mload v85
+    mstore v87, v90
+    v92 = add v90, 31
+    v93 = and v92, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v94 = add v87, 32
+    jumpi v93, bb23, bb24
+  bb23:
+    v96 = sub v93, 32
+    v97 = add v94, v96
+    mstore v97, 0
+    jump bb24
+  bb24:
+    v99 = add v94, v93
+    v98 = add v85, 32
+    mcopy v94, v98, v90
+    mstore v78, v99
+    v100 = mload v69
+    v101 = sub v100, 1
+    mstore v69, v101
+    v102 = mload v80
+    v103 = add v102, 32
+    mstore v80, v103
+    v104 = mload v79
+    v105 = add v104, 32
+    mstore v79, v105
+    jump bb20
+  bb10:
+    v37 = mload v62
+    v38 = lt v37, v25
+    jumpi v38, bb1, bb12
   bb12:
     v39 = add v37, 32
     v40 = lt v39, v37
@@ -279,8 +323,6 @@ fn @strs() {
     v53 = add v52, 32
     v54 = lt v53, v52
     jumpi v54, bb18, bb19
-  bb18:
-    tail_call @__revert_stub0
   bb19:
     v55 = mload 64 !metadata(memory=scratch, effect=memory_write)
     v117 = add v55, v53
@@ -297,52 +339,10 @@ fn @strs() {
     v63 = add v62, 32
     v65 = add v64, 32
     jump bb9
-  bb20:
-    v82 = mload v69
-    jumpi v82, bb21, bb22
-  bb21:
-    v84 = mload v80
-    v85 = mload v84
-    v86 = mload v79
-    v87 = mload v78
-    v88 = mload v81
-    v89 = sub v87, v88
-    mstore v86, v89
-    v90 = mload v85
-    mstore v87, v90
-    v92 = add v90, 31
-    v93 = and v92, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v94 = add v87, 32
-    jumpi v93, bb23, bb24
-  bb22:
-    v106 = mload v78
-    v107 = sub v106, v70
-    v109 = add v107, 31
-    v111 = and v109, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v112 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v118 = add v112, v111
-    mstore 64, v118 !metadata(memory=scratch)
-    returndata v112, v107
-  bb23:
-    v96 = sub v93, 32
-    v97 = add v94, v96
-    mstore v97, 0
-    jump bb24
-  bb24:
-    v99 = add v94, v93
-    v98 = add v85, 32
-    mcopy v94, v98, v90
-    mstore v78, v99
-    v100 = mload v69
-    v101 = sub v100, 1
-    mstore v69, v101
-    v102 = mload v80
-    v103 = add v102, 32
-    mstore v80, v103
-    v104 = mload v79
-    v105 = add v104, 32
-    mstore v79, v105
-    jump bb20
+  bb18:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @mixed() {
@@ -351,8 +351,6 @@ fn @mixed() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -432,8 +430,6 @@ fn @mixed() {
     v51 = add v50, 32
     v52 = lt v51, v50
     jumpi v52, bb15, bb16
-  bb15:
-    tail_call @__revert_stub0
   bb16:
     v53 = mload 64 !metadata(memory=scratch, effect=memory_write)
     v99 = add v53, v51
@@ -484,6 +480,10 @@ fn @mixed() {
     v100 = add v95, v94
     mstore 64, v100 !metadata(memory=scratch)
     returndata v95, v90
+  bb15:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_stub0() {
@@ -501,14 +501,14 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb6, [0x5a7641c8 => bb2, 0x6791505c => bb3, 0x68f4ce0b => bb4, 0xcfb203c5 => bb5]
-  bb2:
-    tail_call @words
-  bb3:
-    tail_call @mixed
-  bb4:
-    tail_call @strs
   bb5:
     tail_call @bools
+  bb4:
+    tail_call @strs
+  bb3:
+    tail_call @mixed
+  bb2:
+    tail_call @words
   bb6:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_dynamic_tuple.stdout
@@ -6,8 +6,6 @@ fn @decode(arg0: memorybytes) -> (u256, memorybytes, memorybytes) [abi_returns=[
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -31,58 +29,40 @@ fn @decode(arg0: memorybytes) -> (u256, memorybytes, memorybytes) [abi_returns=[
     v15 = memory_object_data memorybytes, v9
     v16 = lt v14, 96
     jumpi v16, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v17 = mload v15
     v18 = add v15, 32
     v19 = mload v18
     v20 = lt v19, 96
     jumpi v20, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v21 = add v19, 32
     v22 = lt v21, v19
     jumpi v22, bb7, bb8
-  bb7:
-    revert 0, 0
   bb8:
     v23 = gt v21, v14
     jumpi v23, bb9, bb10
-  bb9:
-    revert 0, 0
   bb10:
     v24 = add v15, v19
     v25 = mload v24
     v26 = add v25, 31
     v27 = lt v26, v25
     jumpi v27, bb11, bb12
-  bb11:
-    revert 0, 0
   bb12:
     v28 = not 31
     v29 = and v26, v28
     v30 = add v21, v29
     v31 = lt v30, v21
     jumpi v31, bb13, bb14
-  bb13:
-    revert 0, 0
   bb14:
     v32 = gt v30, v14
     jumpi v32, bb15, bb16
-  bb15:
-    revert 0, 0
   bb16:
     v33 = iszero v29
     v34 = select v33, 32, v29
     v35 = add 32, v34
     v36 = lt v35, v34
     jumpi v36, bb17, bb18
-  bb17:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb18:
     v37 = alloc memorybytes, exact, uninitialized, infallible, v35
     set_memory_object_len memorybytes, v37, v25
@@ -96,50 +76,34 @@ fn @decode(arg0: memorybytes) -> (u256, memorybytes, memorybytes) [abi_returns=[
     v43 = mload v42
     v44 = lt v43, 96
     jumpi v44, bb19, bb20
-  bb19:
-    revert 0, 0
   bb20:
     v45 = add v43, 32
     v46 = lt v45, v43
     jumpi v46, bb21, bb22
-  bb21:
-    revert 0, 0
   bb22:
     v47 = gt v45, v14
     jumpi v47, bb23, bb24
-  bb23:
-    revert 0, 0
   bb24:
     v48 = add v15, v43
     v49 = mload v48
     v50 = add v49, 31
     v51 = lt v50, v49
     jumpi v51, bb25, bb26
-  bb25:
-    revert 0, 0
   bb26:
     v52 = not 31
     v53 = and v50, v52
     v54 = add v45, v53
     v55 = lt v54, v45
     jumpi v55, bb27, bb28
-  bb27:
-    revert 0, 0
   bb28:
     v56 = gt v54, v14
     jumpi v56, bb29, bb30
-  bb29:
-    revert 0, 0
   bb30:
     v57 = iszero v53
     v58 = select v57, 32, v53
     v59 = add 32, v58
     v60 = lt v59, v58
     jumpi v60, bb31, bb32
-  bb31:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb32:
     v61 = alloc memorybytes, exact, uninitialized, infallible, v59
     set_memory_object_len memorybytes, v61, v49
@@ -161,6 +125,42 @@ fn @decode(arg0: memorybytes) -> (u256, memorybytes, memorybytes) [abi_returns=[
     v72 = add v69, 64
     v73 = mload v72
     ret v17, v71, v73
+  bb31:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb29:
+    revert 0, 0
+  bb27:
+    revert 0, 0
+  bb25:
+    revert 0, 0
+  bb23:
+    revert 0, 0
+  bb21:
+    revert 0, 0
+  bb19:
+    revert 0, 0
+  bb17:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb15:
+    revert 0, 0
+  bb13:
+    revert 0, 0
+  bb11:
+    revert 0, 0
+  bb9:
+    revert 0, 0
+  bb7:
+    revert 0, 0
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) -> (u256, memorybytes, memorybytes) [abi_returns=[word, memory_bytes, memory_bytes]] {
@@ -169,8 +169,6 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) -> (u256, memory
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg1
     v4 = calldataload v3
@@ -247,58 +245,40 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) -> (u256, memory
     v52 = memory_object_data memorybytes, v21
     v53 = lt v51, 96
     jumpi v53, bb7, bb8
-  bb7:
-    revert 0, 0
   bb8:
     v54 = mload v52
     v55 = add v52, 32
     v56 = mload v55
     v57 = lt v56, 96
     jumpi v57, bb9, bb10
-  bb9:
-    revert 0, 0
   bb10:
     v58 = add v56, 32
     v59 = lt v58, v56
     jumpi v59, bb11, bb12
-  bb11:
-    revert 0, 0
   bb12:
     v60 = gt v58, v51
     jumpi v60, bb13, bb14
-  bb13:
-    revert 0, 0
   bb14:
     v61 = add v52, v56
     v62 = mload v61
     v63 = add v62, 31
     v64 = lt v63, v62
     jumpi v64, bb15, bb16
-  bb15:
-    revert 0, 0
   bb16:
     v65 = not 31
     v66 = and v63, v65
     v67 = add v58, v66
     v68 = lt v67, v58
     jumpi v68, bb17, bb18
-  bb17:
-    revert 0, 0
   bb18:
     v69 = gt v67, v51
     jumpi v69, bb19, bb20
-  bb19:
-    revert 0, 0
   bb20:
     v70 = iszero v66
     v71 = select v70, 32, v66
     v72 = add 32, v71
     v73 = lt v72, v71
     jumpi v73, bb21, bb22
-  bb21:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb22:
     v74 = alloc memorybytes, exact, uninitialized, infallible, v72
     set_memory_object_len memorybytes, v74, v62
@@ -312,50 +292,34 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) -> (u256, memory
     v80 = mload v79
     v81 = lt v80, 96
     jumpi v81, bb23, bb24
-  bb23:
-    revert 0, 0
   bb24:
     v82 = add v80, 32
     v83 = lt v82, v80
     jumpi v83, bb25, bb26
-  bb25:
-    revert 0, 0
   bb26:
     v84 = gt v82, v51
     jumpi v84, bb27, bb28
-  bb27:
-    revert 0, 0
   bb28:
     v85 = add v52, v80
     v86 = mload v85
     v87 = add v86, 31
     v88 = lt v87, v86
     jumpi v88, bb29, bb30
-  bb29:
-    revert 0, 0
   bb30:
     v89 = not 31
     v90 = and v87, v89
     v91 = add v82, v90
     v92 = lt v91, v82
     jumpi v92, bb31, bb32
-  bb31:
-    revert 0, 0
   bb32:
     v93 = gt v91, v51
     jumpi v93, bb33, bb34
-  bb33:
-    revert 0, 0
   bb34:
     v94 = iszero v90
     v95 = select v94, 32, v90
     v96 = add 32, v95
     v97 = lt v96, v95
     jumpi v97, bb35, bb36
-  bb35:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb36:
     v98 = alloc memorybytes, exact, uninitialized, infallible, v96
     set_memory_object_len memorybytes, v98, v86
@@ -377,6 +341,42 @@ fn @roundtrip(arg0: u256, arg1: memorybytes, arg2: memorybytes) -> (u256, memory
     v109 = add v106, 64
     v110 = mload v109
     ret v54, v108, v110
+  bb35:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb33:
+    revert 0, 0
+  bb31:
+    revert 0, 0
+  bb29:
+    revert 0, 0
+  bb27:
+    revert 0, 0
+  bb25:
+    revert 0, 0
+  bb23:
+    revert 0, 0
+  bb21:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb19:
+    revert 0, 0
+  bb17:
+    revert 0, 0
+  bb15:
+    revert 0, 0
+  bb13:
+    revert 0, 0
+  bb11:
+    revert 0, 0
+  bb9:
+    revert 0, 0
+  bb7:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @decodeBytes(arg0: memorybytes) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -385,8 +385,6 @@ fn @decodeBytes(arg0: memorybytes) -> memorybytes [abi_returns=[memory_bytes]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -403,56 +401,38 @@ fn @decodeBytes(arg0: memorybytes) -> memorybytes [abi_returns=[memory_bytes]] {
     v13 = memory_object_data memorybytes, v9
     v14 = lt v12, 32
     jumpi v14, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v15 = mload v13
     v16 = lt v15, 32
     jumpi v16, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v17 = add v15, 32
     v18 = lt v17, v15
     jumpi v18, bb7, bb8
-  bb7:
-    revert 0, 0
   bb8:
     v19 = gt v17, v12
     jumpi v19, bb9, bb10
-  bb9:
-    revert 0, 0
   bb10:
     v20 = add v13, v15
     v21 = mload v20
     v22 = add v21, 31
     v23 = lt v22, v21
     jumpi v23, bb11, bb12
-  bb11:
-    revert 0, 0
   bb12:
     v24 = not 31
     v25 = and v22, v24
     v26 = add v17, v25
     v27 = lt v26, v17
     jumpi v27, bb13, bb14
-  bb13:
-    revert 0, 0
   bb14:
     v28 = gt v26, v12
     jumpi v28, bb15, bb16
-  bb15:
-    revert 0, 0
   bb16:
     v29 = iszero v25
     v30 = select v29, 32, v25
     v31 = add 32, v30
     v32 = lt v31, v30
     jumpi v32, bb17, bb18
-  bb17:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb18:
     v33 = alloc memorybytes, exact, uninitialized, infallible, v31
     set_memory_object_len memorybytes, v33, v21
@@ -463,5 +443,25 @@ fn @decodeBytes(arg0: memorybytes) -> memorybytes [abi_returns=[memory_bytes]] {
     v37 = add v20, 32
     mcopy v34, v37, v21
     ret v33
+  bb17:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb15:
+    revert 0, 0
+  bb13:
+    revert 0, 0
+  bb11:
+    revert 0, 0
+  bb9:
+    revert 0, 0
+  bb7:
+    revert 0, 0
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_decode_static_tuple.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_static_tuple.stdout
@@ -6,8 +6,6 @@ fn @decode(arg0: memorybytes) -> (u256, bool, address) [abi_returns=[word, word,
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -27,8 +25,6 @@ fn @decode(arg0: memorybytes) -> (u256, bool, address) [abi_returns=[word, word,
     v13 = memory_object_data memorybytes, v9
     v14 = lt v12, 96
     jumpi v14, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v15 = mload v13
     v16 = add v13, 32
@@ -38,8 +34,6 @@ fn @decode(arg0: memorybytes) -> (u256, bool, address) [abi_returns=[word, word,
     v20 = eq v17, v19
     v21 = iszero v20
     jumpi v21, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v22 = add v13, 64
     v23 = mload v22
@@ -47,8 +41,6 @@ fn @decode(arg0: memorybytes) -> (u256, bool, address) [abi_returns=[word, word,
     v25 = eq v23, v24
     v26 = iszero v25
     jumpi v26, bb7, bb8
-  bb7:
-    revert 0, 0
   bb8:
     v27 = fmp
     v28 = add v27, 32
@@ -62,5 +54,13 @@ fn @decode(arg0: memorybytes) -> (u256, bool, address) [abi_returns=[word, word,
     v33 = add v30, 64
     v34 = mload v33
     ret v15, v32, v34
+  bb7:
+    revert 0, 0
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_decode_structs.stdout
+++ b/tests/ui/codegen/lowering/abi_decode_structs.stdout
@@ -7,8 +7,6 @@ fn @dFlat() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -55,6 +53,8 @@ fn @dFlat() {
     mstore 160, v31
     mstore 192, v23
     returndata 128, 96
+  bb1:
+    revert 0, 0
 }
 
 fn @dNested() {
@@ -63,8 +63,6 @@ fn @dNested() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -123,8 +121,6 @@ fn @dNested() {
     v40 = add v39, 31
     v41 = lt v40, v39
     jumpi v41, bb6, bb7
-  bb6:
-    tail_call @__revert_stub0
   bb7:
     v43 = and v40, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v44 = iszero v43
@@ -229,6 +225,10 @@ fn @dNested() {
     v126 = add v118, v117
     mstore 64, v126 !metadata(memory=scratch)
     returndata v118, v113
+  bb6:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @dDynArr() {
@@ -237,8 +237,6 @@ fn @dDynArr() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -263,8 +261,6 @@ fn @dDynArr() {
     v18 = add v16, 32
     v19 = shr 251, v17
     jumpi v19, bb4, bb5
-  bb4:
-    tail_call @__revert_stub0
   bb5:
     v20 = shl 5, v17
     v21 = add v20, 32
@@ -286,6 +282,10 @@ fn @dDynArr() {
   bb7:
     v73 = phi [bb6: v17], [bb12: v66]
     jumpi v73, bb8, bb9
+  bb9:
+    v71 = mload v23
+    mstore 128, v71
+    returndata 128, 32
   bb8:
     v30 = mload v25
     v31 = mload v30
@@ -302,10 +302,6 @@ fn @dDynArr() {
     v39 = add v38, 31
     v40 = lt v39, v38
     jumpi v40, bb4, bb10
-  bb9:
-    v71 = mload v23
-    mstore 128, v71
-    returndata 128, 32
   bb10:
     v42 = and v39, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v43 = iszero v42
@@ -356,6 +352,10 @@ fn @dDynArr() {
     v70 = add v69, 32
     mstore v26, v70
     jump bb7
+  bb4:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_stub0() {
@@ -373,12 +373,12 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb5, [0x6644232b => bb2, 0xaca542ca => bb3, 0xfc7ec666 => bb4]
-  bb2:
-    tail_call @dFlat
-  bb3:
-    tail_call @dDynArr
   bb4:
     tail_call @dNested
+  bb3:
+    tail_call @dDynArr
+  bb2:
+    tail_call @dFlat
   bb5:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/abi_encode_bytes.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_bytes.stdout
@@ -6,8 +6,6 @@ fn @hash3(arg0: u256, arg1: u256, arg2: u256) -> bytes32 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = fmp
     mstore v3, arg0
@@ -17,6 +15,8 @@ fn @hash3(arg0: u256, arg1: u256, arg2: u256) -> bytes32 [abi_returns=[word]] {
     mstore v5, arg2
     v6 = keccak256 v3, 96
     ret v6
+  bb1:
+    revert 0, 0
 }
 
 fn @encode3(arg0: u256, arg1: u256, arg2: u256) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -25,8 +25,6 @@ fn @encode3(arg0: u256, arg1: u256, arg2: u256) -> memorybytes [abi_returns=[mem
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = fmp
     v4 = memory_object_data memorybytes, v3
@@ -40,6 +38,8 @@ fn @encode3(arg0: u256, arg1: u256, arg2: u256) -> memorybytes [abi_returns=[mem
     v8 = add v3, v7
     set_fmp v8
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @encodeDynamic(arg0: u256, arg1: memorybytes) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -48,8 +48,6 @@ fn @encodeDynamic(arg0: u256, arg1: memorybytes) -> memorybytes [abi_returns=[me
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg1
     v4 = calldataload v3
@@ -92,6 +90,8 @@ fn @encodeDynamic(arg0: u256, arg1: memorybytes) -> memorybytes [abi_returns=[me
     v29 = add v12, v28
     set_fmp v29
     ret v12
+  bb1:
+    revert 0, 0
 }
 
 fn @hashDynamic(arg0: u256, arg1: memorybytes) -> bytes32 [abi_returns=[word]] {
@@ -100,8 +100,6 @@ fn @hashDynamic(arg0: u256, arg1: memorybytes) -> bytes32 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg1
     v4 = calldataload v3
@@ -140,6 +138,8 @@ fn @hashDynamic(arg0: u256, arg1: memorybytes) -> bytes32 [abi_returns=[word]] {
     v26 = sub v25, v12
     v27 = keccak256 v12, v26
     ret v27
+  bb1:
+    revert 0, 0
 }
 
 fn @roundtrip(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -148,8 +148,6 @@ fn @roundtrip(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = fmp
     v4 = memory_object_data memorybytes, v3
@@ -162,10 +160,12 @@ fn @roundtrip(arg0: u256) -> u256 [abi_returns=[word]] {
     v8 = memory_object_data memorybytes, v3
     v9 = lt v7, 32
     jumpi v9, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v10 = mload v8
     ret v10
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_encode_call.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_call.stdout
@@ -7,8 +7,6 @@ fn @asValue() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -26,10 +24,6 @@ fn @asValue() {
     v11 = add 68, 31
     v12 = lt v11, 68
     jumpi v12, bb4, bb5
-  bb4:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb5:
     v14 = and v11, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v15 = add v14, 32
@@ -68,6 +62,12 @@ fn @asValue() {
     v49 = add v45, v44
     mstore 64, v49 !metadata(memory=scratch)
     returndata v45, v40
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @viaCall() {
@@ -76,8 +76,6 @@ fn @viaCall() {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -102,6 +100,8 @@ fn @viaCall() {
     v13 = call v12, arg0, 0, v15, 68, 0, 0
     mstore 128, v13
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @entry() [entry] {
@@ -116,10 +116,10 @@ fn @entry() [entry] {
     v3 = calldataload 0
     v4 = shr 224, v3
     switch v4, default bb5, [0x23d014a1 => bb3, 0x440a9300 => bb4]
-  bb3:
-    tail_call @viaCall
   bb4:
     tail_call @asValue
+  bb3:
+    tail_call @viaCall
   bb5:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_mixed.stdout
@@ -6,8 +6,6 @@ fn @fixedBytesArg(arg0: u256, arg1: address, arg2: bytes2) -> bytes32 [abi_retur
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -32,6 +30,8 @@ fn @fixedBytesArg(arg0: u256, arg1: address, arg2: bytes2) -> bytes32 [abi_retur
     mstore v12, arg2
     v13 = keccak256 v9, 54
     ret v13
+  bb1:
+    revert 0, 0
 }
 
 fn @dynamicArg(arg0: bytes32, arg1: memorybytes) -> bytes32 [abi_returns=[word]] {
@@ -40,8 +40,6 @@ fn @dynamicArg(arg0: bytes32, arg1: memorybytes) -> bytes32 [abi_returns=[word]]
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg1
     v4 = calldataload v3
@@ -64,6 +62,8 @@ fn @dynamicArg(arg0: bytes32, arg1: memorybytes) -> bytes32 [abi_returns=[word]]
     v17 = sub v16, v12
     v18 = keccak256 v12, v17
     ret v18
+  bb1:
+    revert 0, 0
 }
 
 fn @materialized(arg0: u16, arg1: memorybytes, arg2: bool) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -72,8 +72,6 @@ fn @materialized(arg0: u16, arg1: memorybytes, arg2: bool) -> memorybytes [abi_r
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffff
@@ -122,6 +120,8 @@ fn @materialized(arg0: u16, arg1: memorybytes, arg2: bool) -> memorybytes [abi_r
     v33 = add v19, v32
     set_fmp v33
     ret v19
+  bb1:
+    revert 0, 0
 }
 
 fn @signedStaticRun(arg0: u8, arg1: i16, arg2: bytes3) -> bytes32 [abi_returns=[word]] {
@@ -130,8 +130,6 @@ fn @signedStaticRun(arg0: u8, arg1: i16, arg2: bytes3) -> bytes32 [abi_returns=[
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -163,5 +161,7 @@ fn @signedStaticRun(arg0: u8, arg1: i16, arg2: bytes3) -> bytes32 [abi_returns=[
     mstore 3, arg2 !metadata(memory=scratch)
     v17 = keccak256 0, 6 !metadata(memory=scratch)
     ret v17
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_encode_packed_static_hash.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_packed_static_hash.stdout
@@ -6,8 +6,6 @@ fn @hash(arg0: u64, arg1: u64, arg2: bytes32) -> bytes32 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffff
@@ -31,5 +29,7 @@ fn @hash(arg0: u64, arg1: u64, arg2: bytes32) -> bytes32 [abi_returns=[word]] {
     mstore 23, arg2 !metadata(memory=scratch)
     v13 = keccak256 0, 55 !metadata(memory=scratch)
     ret v13
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_encode_semantic.stdout
+++ b/tests/ui/codegen/lowering/abi_encode_semantic.stdout
@@ -6,8 +6,6 @@ fn @forward(arg0: address, arg1: u256, arg2: calldataslice) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -28,5 +26,7 @@ fn @forward(arg0: address, arg1: u256, arg2: calldataslice) {
     revert 0, v11
   bb6:
     stop
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/abi_nested_return.stdout
+++ b/tests/ui/codegen/lowering/abi_nested_return.stdout
@@ -6,8 +6,6 @@ fn @structArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<tuple<word
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul 1, 32
     v4 = div v3, 32
@@ -21,10 +19,6 @@ fn @structArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<tuple<word
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, 1
@@ -34,10 +28,6 @@ fn @structArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<tuple<word
     v11 = add arg0, 1
     v12 = lt v11, arg0
     jumpi v12, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v13 = memory_object_field_addr memorystruct<2>, v9, 1
     mstore v13, v11
@@ -52,6 +42,16 @@ fn @structArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<tuple<word
     v16 = memory_object_element_addr memoryarray<1>, v8, 0
     mstore v16, v9
     ret v8
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @nestedArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<memory_array<word>>]] {
@@ -60,8 +60,6 @@ fn @nestedArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<memory_arr
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul 1, 32
     v4 = div v3, 32
@@ -75,10 +73,6 @@ fn @nestedArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<memory_arr
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, 1
@@ -94,10 +88,6 @@ fn @nestedArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<memory_arr
     v12 = add v9, 32
     v13 = lt v12, v9
     jumpi v13, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v14 = alloc memoryarray<1>, exact, zeroed, panic, v12
     set_memory_object_len memoryarray, v14, arg0
@@ -112,5 +102,15 @@ fn @nestedArray(arg0: u256) -> memoryarray [abi_returns=[memory_array<memory_arr
     v17 = memory_object_element_addr memoryarray<1>, v8, 0
     mstore v17, v14
     ret v8
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/array_bounds_panic.stdout
+++ b/tests/ui/codegen/lowering/array_bounds_panic.stdout
@@ -6,8 +6,6 @@ fn @memFix(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<3, 1>, exact, uninitialized, infallible, 96
     v4 = memory_object_element_addr memoryfixedarray<3, 1>, v3, 0
@@ -28,6 +26,8 @@ fn @memFix(arg0: u256) -> u256 [abi_returns=[word]] {
     v9 = memory_object_element_addr memoryfixedarray<3, 1>, v3, arg0
     v10 = mload v9
     ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @memFixConst() -> u256 [abi_returns=[word]] {
@@ -56,14 +56,14 @@ fn @memFixConstOob() -> u256 [abi_returns=[word]] {
     v3 = memory_object_element_addr memoryfixedarray<3, 1>, v0, 2
     mstore v3, 0
     jumpi 1, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v4 = memory_object_element_addr memoryfixedarray<3, 1>, v0, 5
     v5 = mload v4
     ret v5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @memDyn(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -72,8 +72,6 @@ fn @memDyn(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul arg0, 32
     v4 = div v3, 32
@@ -87,10 +85,6 @@ fn @memDyn(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, arg0
@@ -105,6 +99,12 @@ fn @memDyn(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v11 = memory_object_element_addr memoryarray<1>, v8, arg1
     v12 = mload v11
     ret v12
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @stDyn(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -113,8 +113,6 @@ fn @stDyn(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = lt arg0, v3
@@ -129,6 +127,8 @@ fn @stDyn(arg0: u256) -> u256 [abi_returns=[word]] {
     v6 = add v5, arg0
     v7 = sload v6 !metadata(storage=symbolic(v6))
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @stDynWrite(arg0: u256, arg1: u256) {
@@ -137,8 +137,6 @@ fn @stDynWrite(arg0: u256, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = lt arg0, v3
@@ -153,6 +151,8 @@ fn @stDynWrite(arg0: u256, arg1: u256) {
     v6 = add v5, arg0
     sstore v6, arg1 !metadata(storage=symbolic(v6))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @stFix(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -161,8 +161,6 @@ fn @stFix(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, 3
     jumpi v3, bb4, bb3
@@ -174,6 +172,8 @@ fn @stFix(arg0: u256) -> u256 [abi_returns=[word]] {
     v4 = add 1, arg0
     v5 = sload v4 !metadata(storage=offset(arg0, 1))
     ret v5
+  bb1:
+    revert 0, 0
 }
 
 fn @cdDyn(arg0: calldataslice, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -182,8 +182,6 @@ fn @cdDyn(arg0: calldataslice, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = lt arg1, v3
@@ -198,6 +196,8 @@ fn @cdDyn(arg0: calldataslice, arg1: u256) -> u256 [abi_returns=[word]] {
     v7 = add v5, v6
     v8 = calldataload v7
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 [abi_returns=[word]] {
@@ -206,8 +206,6 @@ fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 [abi_returns=[
     v1 = sub v0, 4
     v2 = slt v1, 128
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<3, 1>, exact, uninitialized, infallible, 96
     v4 = memory_object_element_addr memoryfixedarray<3, 1>, v3, 0
@@ -226,6 +224,8 @@ fn @cdFix(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 [abi_returns=[
     v8 = memory_object_element_addr memoryfixedarray<3, 1>, v3, arg3
     v9 = mload v8
     ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @cdBytes(arg0: calldataslice, arg1: u256) -> bytes1 [abi_returns=[word]] {
@@ -234,8 +234,6 @@ fn @cdBytes(arg0: calldataslice, arg1: u256) -> bytes1 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = lt arg1, v3
@@ -250,5 +248,7 @@ fn @cdBytes(arg0: calldataslice, arg1: u256) -> bytes1 [abi_returns=[word]] {
     v7 = calldataload v6
     v8 = and v7, 0xff00000000000000000000000000000000000000000000000000000000000000
     ret v8
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/backend_control_flow.sol
+++ b/tests/ui/codegen/lowering/backend_control_flow.sol
@@ -66,9 +66,6 @@ contract BackendControlFlow {
 
     // CHECK-LABEL: fn @phiWithTernary
     // CHECK: jumpi
-    // CHECK: [[LIQUIDITY:v[0-9]+]] = mload [[RESULT_ADDR:[0-9]+]]
-    // CHECK: [[SUPPLY:v[0-9]+]] = sload [[SUPPLY_SLOT:[0-9]+]]
-    // CHECK: [[TOTAL:v[0-9]+]] = add [[SUPPLY]], [[LIQUIDITY]]
     // CHECK: [[FIRST_NUM:v[0-9]+]] = mul
     // CHECK: [[RESERVE0:v[0-9]+]] = sload {{[0-9]+}}
     // CHECK: [[FIRST:v[0-9]+]] = div [[FIRST_NUM]], [[RESERVE0]]
@@ -76,10 +73,13 @@ contract BackendControlFlow {
     // CHECK: [[RESERVE1:v[0-9]+]] = sload {{[0-9]+}}
     // CHECK: [[SECOND:v[0-9]+]] = div [[SECOND_NUM]], [[RESERVE1]]
     // CHECK: lt [[FIRST]], [[SECOND]]
-    // CHECK: mstore [[MERGE_ADDR:[0-9]+]], [[FIRST]]
-    // CHECK: mstore [[MERGE_ADDR]], [[SECOND]]
+    // CHECK: mstore [[MERGE_ADDR:[0-9]+]], [[SECOND]]
+    // CHECK: mstore [[MERGE_ADDR]], [[FIRST]]
     // CHECK: [[MIN:v[0-9]+]] = mload [[MERGE_ADDR]]
-    // CHECK: mstore [[RESULT_ADDR]], [[MIN]]
+    // CHECK: mstore [[RESULT_ADDR:[0-9]+]], [[MIN]]
+    // CHECK: [[LIQUIDITY:v[0-9]+]] = mload [[RESULT_ADDR]]
+    // CHECK: [[SUPPLY:v[0-9]+]] = sload [[SUPPLY_SLOT:[0-9]+]]
+    // CHECK: [[TOTAL:v[0-9]+]] = add [[SUPPLY]], [[LIQUIDITY]]
     // CHECK: sstore [[SUPPLY_SLOT]], [[TOTAL]]
     function phiWithTernary() external returns (uint256 liquidity) {
         uint256 amount0 = 100;

--- a/tests/ui/codegen/lowering/backend_control_flow.stdout
+++ b/tests/ui/codegen/lowering/backend_control_flow.stdout
@@ -34,15 +34,15 @@ fn @localVarInConditional() {
     v3 = sub v0, 1
     v4 = lt v0, 1
     jumpi v4, bb3, bb4
+  bb4:
+    sstore 0, v3 !metadata(storage=slot(0))
+    jump bb2
   bb2:
     stop
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    sstore 0, v3 !metadata(storage=slot(0))
-    jump bb2
 }
 
 fn @directStorageInConditional() {
@@ -56,15 +56,15 @@ fn @directStorageInConditional() {
     v4 = sub v3, 1
     v5 = lt v3, 1
     jumpi v5, bb3, bb4
+  bb4:
+    sstore 0, v4 !metadata(storage=slot(0))
+    jump bb2
   bb2:
     stop
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    sstore 0, v4 !metadata(storage=slot(0))
-    jump bb2
 }
 
 fn @phiAfterBranch() -> u256 [abi_returns=[word]] {
@@ -73,6 +73,9 @@ fn @phiAfterBranch() -> u256 [abi_returns=[word]] {
     v0 = sload 1 !metadata(storage=slot(1))
     v1 = eq v0, 0
     jumpi v1, bb1, bb3
+  bb3:
+    mstore 128, 2
+    jump bb2
   bb1:
     mstore 128, 1
     jump bb2
@@ -82,17 +85,14 @@ fn @phiAfterBranch() -> u256 [abi_returns=[word]] {
     v4 = add v3, v2
     v5 = lt v4, v3
     jumpi v5, bb4, bb5
-  bb3:
-    mstore 128, 2
-    jump bb2
-  bb4:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb5:
     sstore 1, v4 !metadata(storage=slot(1))
     v6 = mload 128
     ret v6
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @phiUsedMultipleTimes() -> u256 [abi_returns=[word]] {
@@ -102,6 +102,9 @@ fn @phiUsedMultipleTimes() -> u256 [abi_returns=[word]] {
     v0 = sload 1 !metadata(storage=slot(1))
     v1 = eq v0, 0
     jumpi v1, bb1, bb3
+  bb3:
+    mstore 160, 2
+    jump bb2
   bb1:
     mstore 160, 1
     jump bb2
@@ -111,13 +114,6 @@ fn @phiUsedMultipleTimes() -> u256 [abi_returns=[word]] {
     v4 = add v3, v2
     v5 = lt v4, v3
     jumpi v5, bb4, bb5
-  bb3:
-    mstore 160, 2
-    jump bb2
-  bb4:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb5:
     sstore 1, v4 !metadata(storage=slot(1))
     v6 = mload 160
@@ -128,23 +124,27 @@ fn @phiUsedMultipleTimes() -> u256 [abi_returns=[word]] {
     v11 = or v8, v10
     v12 = iszero v11
     jumpi v12, bb6, bb7
-  bb6:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb7:
     v13 = mload 160
     v14 = add v7, v13
     v15 = lt v14, v7
     jumpi v15, bb8, bb9
-  bb8:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb9:
     mstore 128, v14
     v16 = mload 128
     ret v16
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @phiWithTernary() -> u256 [abi_returns=[word]] {
@@ -153,20 +153,6 @@ fn @phiWithTernary() -> u256 [abi_returns=[word]] {
     v0 = sload 1 !metadata(storage=slot(1))
     v1 = eq v0, 0
     jumpi v1, bb1, bb3
-  bb1:
-    v2 = mul 100, 200
-    v3 = iszero 200
-    v4 = div v2, 200
-    v5 = eq v4, 100
-    v6 = or v3, v5
-    v7 = iszero v6
-    jumpi v7, bb4, bb5
-  bb2:
-    v28 = mload 128
-    v29 = sload 1 !metadata(storage=slot(1))
-    v30 = add v29, v28
-    v31 = lt v30, v29
-    jumpi v31, bb17, bb18
   bb3:
     v8 = sload 1 !metadata(storage=slot(1))
     v9 = mul 100, v8
@@ -176,17 +162,6 @@ fn @phiWithTernary() -> u256 [abi_returns=[word]] {
     v13 = or v10, v12
     v14 = iszero v13
     jumpi v14, bb6, bb7
-  bb4:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb5:
-    mstore 128, v2
-    jump bb2
-  bb6:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb7:
     v15 = sload 2 !metadata(storage=slot(2))
     jumpi v15, bb9, bb8
@@ -204,10 +179,6 @@ fn @phiWithTernary() -> u256 [abi_returns=[word]] {
     v22 = or v19, v21
     v23 = iszero v22
     jumpi v23, bb10, bb11
-  bb10:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb11:
     v24 = sload 3 !metadata(storage=slot(3))
     jumpi v24, bb13, bb12
@@ -219,23 +190,52 @@ fn @phiWithTernary() -> u256 [abi_returns=[word]] {
     v25 = div v18, v24
     v26 = lt v16, v25
     jumpi v26, bb14, bb15
-  bb14:
-    mstore 0, v16 !metadata(memory=scratch)
-    jump bb16
   bb15:
     mstore 0, v25 !metadata(memory=scratch)
+    jump bb16
+  bb14:
+    mstore 0, v16 !metadata(memory=scratch)
     jump bb16
   bb16:
     v27 = mload 0 !metadata(memory=scratch)
     mstore 128, v27
     jump bb2
-  bb17:
+  bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    v2 = mul 100, 200
+    v3 = iszero 200
+    v4 = div v2, 200
+    v5 = eq v4, 100
+    v6 = or v3, v5
+    v7 = iszero v6
+    jumpi v7, bb4, bb5
+  bb5:
+    mstore 128, v2
+    jump bb2
+  bb2:
+    v28 = mload 128
+    v29 = sload 1 !metadata(storage=slot(1))
+    v30 = add v29, v28
+    v31 = lt v30, v29
+    jumpi v31, bb17, bb18
   bb18:
     sstore 1, v30 !metadata(storage=slot(1))
     v32 = mload 128
     ret v32
+  bb17:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 

--- a/tests/ui/codegen/lowering/branch.sol
+++ b/tests/ui/codegen/lowering/branch.sol
@@ -5,8 +5,8 @@ contract Branch {
     // CHECK-LABEL: fn @max{{[( ]}}
     // CHECK: [[GT:v[0-9]+]] = gt arg0, arg1
     // CHECK: jumpi [[GT]],
-    // CHECK: ret arg0
     // CHECK: ret arg1
+    // CHECK: ret arg0
     function max(uint256 a, uint256 b) public pure returns (uint256) {
         if (a > b) {
             return a;
@@ -17,8 +17,8 @@ contract Branch {
     // CHECK-LABEL: fn @abs_diff{{[( ]}}
     // CHECK: [[LT:v[0-9]+]] = lt arg0, arg1
     // CHECK: {{v[0-9]+}} = iszero [[LT]]
-    // CHECK: {{v[0-9]+}} = sub arg0, arg1
     // CHECK: {{v[0-9]+}} = sub arg1, arg0
+    // CHECK: {{v[0-9]+}} = sub arg0, arg1
     function abs_diff(uint256 a, uint256 b) public pure returns (uint256) {
         if (a >= b) {
             return a - b;

--- a/tests/ui/codegen/lowering/branch.stdout
+++ b/tests/ui/codegen/lowering/branch.stdout
@@ -6,15 +6,15 @@ fn @max(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, arg1
     jumpi v3, bb3, bb4
-  bb3:
-    ret arg0
   bb4:
     ret arg1
+  bb3:
+    ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @abs_diff(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -23,33 +23,33 @@ fn @abs_diff(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, arg1
     v4 = iszero v3
     jumpi v4, bb3, bb5
-  bb3:
-    v5 = sub arg0, arg1
-    v6 = lt arg0, arg1
-    jumpi v6, bb6, bb7
-  bb4:
-    ret 0
   bb5:
     v7 = sub arg1, arg0
     v8 = lt arg1, arg0
     jumpi v8, bb8, bb9
-  bb6:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb7:
-    ret v5
+  bb9:
+    ret v7
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb9:
-    ret v7
+  bb3:
+    v5 = sub arg0, arg1
+    v6 = lt arg0, arg1
+    jumpi v6, bb6, bb7
+  bb7:
+    ret v5
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+  bb4:
+    ret 0
 }
 

--- a/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
+++ b/tests/ui/codegen/lowering/builtin_addmod_mulmod.stdout
@@ -6,8 +6,6 @@ fn @am(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     jumpi arg2, bb4, bb3
   bb3:
@@ -17,6 +15,8 @@ fn @am(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
   bb4:
     v3 = addmod arg0, arg1, arg2
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @mm(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
@@ -25,8 +25,6 @@ fn @mm(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     jumpi arg2, bb4, bb3
   bb3:
@@ -36,5 +34,7 @@ fn @mm(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
   bb4:
     v3 = mulmod arg0, arg1, arg2
     ret v3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/bytes_memory_elements.stdout
+++ b/tests/ui/codegen/lowering/bytes_memory_elements.stdout
@@ -5,20 +5,12 @@ fn @alloc() -> bytes32 [abi_returns=[word]] {
     v0 = add 96, 31
     v1 = lt v0, 96
     jumpi v1, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v2 = not 31
     v3 = and v0, v2
     v4 = add v3, 32
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = alloc memorybytes, exact, zeroed, panic, v4
     set_memory_object_len memorybytes, v6, 96
@@ -46,6 +38,14 @@ fn @alloc() -> bytes32 [abi_returns=[word]] {
     mstore8 v14, 255
     v15 = keccak256_bytes v6
     ret v15
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @literal() -> bytes32 [abi_returns=[word]] {
@@ -76,31 +76,31 @@ fn @allocDynamic(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 31
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v5 = not 31
     v6 = and v3, v5
     v7 = add v6, 32
     v8 = lt v7, v6
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = alloc memorybytes, exact, zeroed, panic, v7
     set_memory_object_len memorybytes, v9, arg0
     v10 = mload v9
     ret v10
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @readWrite(arg0: memorybytes, arg1: u256, arg2: bytes1) -> bytes1 [abi_returns=[word]] {
@@ -109,8 +109,6 @@ fn @readWrite(arg0: memorybytes, arg1: u256, arg2: bytes1) -> bytes1 [abi_return
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -155,5 +153,7 @@ fn @readWrite(arg0: memorybytes, arg1: u256, arg2: bytes1) -> bytes1 [abi_return
     v24 = mload v23
     v25 = and v24, 0xff00000000000000000000000000000000000000000000000000000000000000
     ret v25
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_array_subslice.stdout
+++ b/tests/ui/codegen/lowering/calldata_array_subslice.stdout
@@ -6,15 +6,11 @@ fn @word(arg0: calldataslice) -> memoryarray [abi_returns=[memory_array<word>]] 
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 1
     jumpi v5, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v6 = sub v4, 1
     v7 = mul 1, 32
@@ -24,10 +20,6 @@ fn @word(arg0: calldataslice) -> memoryarray [abi_returns=[memory_array<word>]] 
     v11 = slice_ptr v9
     v12 = shr 251, v10
     jumpi v12, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v13 = mul v10, 32
     v14 = add 32, v13
@@ -36,5 +28,13 @@ fn @word(arg0: calldataslice) -> memoryarray [abi_returns=[memory_array<word>]] 
     v16 = memory_object_data memoryarray, v15
     calldatacopy v16, v11, v13
     ret v15
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_nested_forward.stdout
+++ b/tests/ui/codegen/lowering/calldata_nested_forward.stdout
@@ -6,8 +6,6 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -20,19 +18,11 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v7 = slice_len arg0
     v8 = shr 251, v7
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = mul v7, 32
     v10 = add 32, v9
     v11 = lt v10, v9
     jumpi v11, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v12 = alloc memoryarray<1>, exact, uninitialized, infallible, v10
     mstore v12, v7
@@ -48,6 +38,19 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v17 = mload v13
     v18 = gt v17, 0
     jumpi v18, bb10, bb11
+  bb11:
+    v43 = abi_encode [memory_array<memory_bytes>], selector 0x3731ba7300000000000000000000000000000000000000000000000000000000, args v12
+    v44 = slice_ptr v43
+    v45 = slice_len v43
+    v46 = gas
+    v47 = call v46, arg1, 0, v44, v45, 0, 0
+    jumpi v47, bb17, bb16
+  bb16:
+    v48 = returndatasize
+    returndatacopy 0, 0, v48 !metadata(memory=scratch)
+    revert 0, v48
+  bb17:
+    stop
   bb10:
     v19 = mload v14
     v20 = calldataload v19
@@ -56,17 +59,6 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v23 = add v22, 31
     v24 = lt v23, v22
     jumpi v24, bb12, bb13
-  bb11:
-    v43 = abi_encode [memory_array<memory_bytes>], selector 0x3731ba7300000000000000000000000000000000000000000000000000000000, args v12
-    v44 = slice_ptr v43
-    v45 = slice_len v43
-    v46 = gas
-    v47 = call v46, arg1, 0, v44, v45, 0, 0
-    jumpi v47, bb17, bb16
-  bb12:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb13:
     v25 = not 31
     v26 = and v23, v25
@@ -75,10 +67,6 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v29 = add 32, v28
     v30 = lt v29, v28
     jumpi v30, bb14, bb15
-  bb14:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb15:
     v31 = alloc memorybytes, exact, uninitialized, infallible, v29
     mstore v31, v22
@@ -100,12 +88,24 @@ fn @forward(arg0: calldataslice, arg1: address) {
     v42 = add v41, 32
     mstore v15, v42
     jump bb9
-  bb16:
-    v48 = returndatasize
-    returndatacopy 0, 0, v48 !metadata(memory=scratch)
-    revert 0, v48
-  bb17:
-    stop
+  bb14:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb12:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @forwardStructs(arg0: calldataslice, arg1: address) {
@@ -114,8 +114,6 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -128,19 +126,11 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v7 = slice_len arg0
     v8 = shr 251, v7
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = mul v7, 32
     v10 = add 32, v9
     v11 = lt v10, v9
     jumpi v11, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v12 = alloc memoryarray<1>, exact, uninitialized, infallible, v10
     mstore v12, v7
@@ -156,6 +146,19 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v17 = mload v13
     v18 = gt v17, 0
     jumpi v18, bb10, bb11
+  bb11:
+    v50 = abi_encode [memory_array<tuple<word, memory_bytes>>], selector 0x8419297e00000000000000000000000000000000000000000000000000000000, args v12
+    v51 = slice_ptr v50
+    v52 = slice_len v50
+    v53 = gas
+    v54 = call v53, arg1, 0, v51, v52, 0, 0
+    jumpi v54, bb17, bb16
+  bb16:
+    v55 = returndatasize
+    returndatacopy 0, 0, v55 !metadata(memory=scratch)
+    revert 0, v55
+  bb17:
+    stop
   bb10:
     v19 = mload v14
     v20 = calldataload v19
@@ -170,17 +173,6 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v28 = add v27, 31
     v29 = lt v28, v27
     jumpi v29, bb12, bb13
-  bb11:
-    v50 = abi_encode [memory_array<tuple<word, memory_bytes>>], selector 0x8419297e00000000000000000000000000000000000000000000000000000000, args v12
-    v51 = slice_ptr v50
-    v52 = slice_len v50
-    v53 = gas
-    v54 = call v53, arg1, 0, v51, v52, 0, 0
-    jumpi v54, bb17, bb16
-  bb12:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb13:
     v30 = not 31
     v31 = and v28, v30
@@ -189,10 +181,6 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v34 = add 32, v33
     v35 = lt v34, v33
     jumpi v35, bb14, bb15
-  bb14:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb15:
     v36 = alloc memorybytes, exact, uninitialized, infallible, v34
     mstore v36, v27
@@ -218,11 +206,23 @@ fn @forwardStructs(arg0: calldataslice, arg1: address) {
     v49 = add v48, 32
     mstore v15, v49
     jump bb9
-  bb16:
-    v55 = returndatasize
-    returndatacopy 0, 0, v55 !metadata(memory=scratch)
-    revert 0, v55
-  bb17:
-    stop
+  bb14:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb12:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_slice_bounds_revert.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_bounds_revert.stdout
@@ -7,8 +7,6 @@ fn @endPastLength() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v47 = add arg0, 36
     v48 = add arg0, 4
@@ -23,8 +21,6 @@ fn @endPastLength() {
     v11 = add v7, 31
     v12 = lt v11, v7
     jumpi v12, bb5, bb6
-  bb5:
-    tail_call @__revert_stub0
   bb6:
     v14 = and v11, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v15 = iszero v14
@@ -67,6 +63,10 @@ fn @endPastLength() {
     v51 = add v45, v44
     mstore 64, v51 !metadata(memory=scratch)
     returndata v45, v40
+  bb5:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @startAfterEnd() {
@@ -75,8 +75,6 @@ fn @startAfterEnd() {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v47 = add arg0, 36
     v48 = add arg0, 4
@@ -92,8 +90,6 @@ fn @startAfterEnd() {
     v11 = add v7, 31
     v12 = lt v11, v7
     jumpi v12, bb5, bb6
-  bb5:
-    tail_call @__revert_stub0
   bb6:
     v14 = and v11, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v15 = iszero v14
@@ -136,6 +132,10 @@ fn @startAfterEnd() {
     v51 = add v45, v44
     mstore 64, v51 !metadata(memory=scratch)
     returndata v45, v40
+  bb5:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_stub0() {
@@ -153,10 +153,10 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb4, [0x598bfb30 => bb2, 0x8063d43b => bb3]
-  bb2:
-    tail_call @startAfterEnd
   bb3:
     tail_call @endPastLength
+  bb2:
+    tail_call @startAfterEnd
   bb4:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/calldata_slice_control_flow.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_control_flow.stdout
@@ -6,8 +6,6 @@ fn @trimLen(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -18,12 +16,6 @@ fn @trimLen(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v5 = slice_len arg0
     v6 = gt v5, 8
     jumpi v6, bb4, bb5
-  bb3:
-    v11 = mload 128
-    v12 = mload 160
-    v13 = make_calldata_slice v11, v12
-    v14 = slice_len v13
-    ret v14
   bb4:
     v7 = slice_ptr arg0
     v8 = add v7, 8
@@ -34,6 +26,14 @@ fn @trimLen(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     jump bb5
   bb5:
     jump bb3
+  bb3:
+    v11 = mload 128
+    v12 = mload 160
+    v13 = make_calldata_slice v11, v12
+    v14 = slice_len v13
+    ret v14
+  bb1:
+    revert 0, 0
 }
 
 fn @_trim(arg0: calldataslice) -> memorybytes {
@@ -76,8 +76,6 @@ fn @forward(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = make_calldata_slice 0, 0
     v4 = slice_ptr v3
@@ -102,6 +100,8 @@ fn @forward(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v16 = make_calldata_slice v14, v15
     v17 = internal_call @_sum, 1, v13, v16
     ret v17
+  bb1:
+    revert 0, 0
 }
 
 fn @_sum(arg0: calldataslice, arg1: calldataslice) -> u256 {
@@ -114,21 +114,21 @@ fn @_sum(arg0: calldataslice, arg1: calldataslice) -> u256 {
     v5 = or v2, v4
     v6 = iszero v5
     jumpi v6, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v7 = slice_len arg1
     v8 = add v1, v7
     v9 = lt v8, v1
     jumpi v9, bb3, bb4
+  bb4:
+    ret v8
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v8
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @explicitTrim(arg0: calldataslice) -> u256 [abi_returns=[word]] {
@@ -137,33 +137,23 @@ fn @explicitTrim(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
     v3 = slice_len arg0
     v4 = gt v3, 4
     jumpi v4, bb4, bb5
-  bb3:
-    v15 = mload 128
-    v16 = mload 160
-    v17 = make_calldata_slice v15, v16
-    v18 = slice_len v17
-    ret v18
-  bb4:
-    v5 = slice_ptr arg0
-    v6 = slice_len arg0
-    v7 = lt v6, 4
-    jumpi v7, bb6, bb7
   bb5:
     v13 = slice_ptr arg0
     v14 = slice_len arg0
     mstore 128, v13
     mstore 160, v14
     jump bb3
-  bb6:
-    revert 0, 0
+  bb4:
+    v5 = slice_ptr arg0
+    v6 = slice_len arg0
+    v7 = lt v6, 4
+    jumpi v7, bb6, bb7
   bb7:
     v8 = sub v6, 4
     v9 = add v5, 4
@@ -173,6 +163,16 @@ fn @explicitTrim(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     mstore 128, v11
     mstore 160, v12
     jump bb3
+  bb3:
+    v15 = mload 128
+    v16 = mload 160
+    v17 = make_calldata_slice v15, v16
+    v18 = slice_len v17
+    ret v18
+  bb6:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @_explicitTrim(arg0: calldataslice) -> memorybytes {
@@ -180,56 +180,11 @@ fn @_explicitTrim(arg0: calldataslice) -> memorybytes {
     v0 = slice_len arg0
     v1 = gt v0, 4
     jumpi v1, bb1, bb2
-  bb1:
-    v2 = slice_ptr arg0
-    v3 = slice_len arg0
-    v4 = lt v3, 4
-    jumpi v4, bb3, bb4
   bb2:
     v22 = slice_len arg0
     v23 = add v22, 31
     v24 = lt v23, v22
     jumpi v24, bb9, bb10
-  bb3:
-    revert 0, 0
-  bb4:
-    v5 = sub v3, 4
-    v6 = add v2, 4
-    v7 = make_calldata_slice v6, v5
-    v8 = slice_len v7
-    v9 = add v8, 31
-    v10 = lt v9, v8
-    jumpi v10, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb6:
-    v11 = not 31
-    v12 = and v9, v11
-    v13 = iszero v12
-    v14 = select v13, 32, v12
-    v15 = add 32, v14
-    v16 = lt v15, v14
-    jumpi v16, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb8:
-    v17 = alloc memorybytes, exact, uninitialized, infallible, v15
-    set_memory_object_len memorybytes, v17, v8
-    v18 = memory_object_data memorybytes, v17
-    v19 = sub v14, 32
-    v20 = add v18, v19
-    mstore v20, 0
-    v21 = slice_ptr v7
-    calldatacopy v18, v21, v8
-    ret v17
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v25 = not 31
     v26 = and v23, v25
@@ -238,10 +193,6 @@ fn @_explicitTrim(arg0: calldataslice) -> memorybytes {
     v29 = add 32, v28
     v30 = lt v29, v28
     jumpi v30, bb11, bb12
-  bb11:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb12:
     v31 = alloc memorybytes, exact, uninitialized, infallible, v29
     set_memory_object_len memorybytes, v31, v22
@@ -252,6 +203,55 @@ fn @_explicitTrim(arg0: calldataslice) -> memorybytes {
     v35 = slice_ptr arg0
     calldatacopy v32, v35, v22
     ret v31
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    v2 = slice_ptr arg0
+    v3 = slice_len arg0
+    v4 = lt v3, 4
+    jumpi v4, bb3, bb4
+  bb4:
+    v5 = sub v3, 4
+    v6 = add v2, 4
+    v7 = make_calldata_slice v6, v5
+    v8 = slice_len v7
+    v9 = add v8, 31
+    v10 = lt v9, v8
+    jumpi v10, bb5, bb6
+  bb6:
+    v11 = not 31
+    v12 = and v9, v11
+    v13 = iszero v12
+    v14 = select v13, 32, v12
+    v15 = add 32, v14
+    v16 = lt v15, v14
+    jumpi v16, bb7, bb8
+  bb8:
+    v17 = alloc memorybytes, exact, uninitialized, infallible, v15
+    set_memory_object_len memorybytes, v17, v8
+    v18 = memory_object_data memorybytes, v17
+    v19 = sub v14, 32
+    v20 = add v18, v19
+    mstore v20, 0
+    v21 = slice_ptr v7
+    calldatacopy v18, v21, v8
+    ret v17
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
 }
 
 fn @headTail(arg0: calldataslice) -> (u256, u256) [abi_returns=[word, word]] {
@@ -260,8 +260,6 @@ fn @headTail(arg0: calldataslice) -> (u256, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -278,22 +276,6 @@ fn @headTail(arg0: calldataslice) -> (u256, u256) [abi_returns=[word, word]] {
     v7 = slice_len arg0
     v8 = lt v6, v7
     jumpi v8, bb4, bb5
-  bb3:
-    v20 = mload 192
-    v21 = mload 224
-    v22 = make_calldata_slice v20, v21
-    v23 = mload 256
-    v24 = mload 288
-    v25 = make_calldata_slice v23, v24
-    v26 = slice_len v22
-    mstore 128, v26
-    v27 = slice_len v25
-    mstore 160, v27
-    v28 = mload 128
-    v29 = mload 160
-    ret v28, v29
-  bb4:
-    revert 0, 0
   bb5:
     v9 = sub v6, v7
     v10 = add v5, v7
@@ -315,6 +297,24 @@ fn @headTail(arg0: calldataslice) -> (u256, u256) [abi_returns=[word, word]] {
     jump bb7
   bb7:
     jump bb3
+  bb3:
+    v20 = mload 192
+    v21 = mload 224
+    v22 = make_calldata_slice v20, v21
+    v23 = mload 256
+    v24 = mload 288
+    v25 = make_calldata_slice v23, v24
+    v26 = slice_len v22
+    mstore 128, v26
+    v27 = slice_len v25
+    mstore 160, v27
+    v28 = mload 128
+    v29 = mload 160
+    ret v28, v29
+  bb4:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @_split(arg0: calldataslice) -> (memorybytes, memorybytes) {
@@ -338,8 +338,6 @@ fn @_split(arg0: calldataslice) -> (memorybytes, memorybytes) {
     v10 = slice_len arg0
     v11 = lt v9, v10
     jumpi v11, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v12 = sub v9, v10
     v13 = add v8, v10
@@ -375,5 +373,7 @@ fn @_split(arg0: calldataslice) -> (memorybytes, memorybytes) {
     v35 = mload v34 !metadata(memory=internal_frame)
     v36 = make_calldata_slice v33, v35
     ret v31, v36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_slice_encode.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_encode.stdout
@@ -6,15 +6,11 @@ fn @encode(arg0: calldataslice, arg1: u256) -> memorybytes [abi_returns=[memory_
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, arg1
     jumpi v5, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v6 = sub v4, arg1
     v7 = add v3, arg1
@@ -47,6 +43,10 @@ fn @encode(arg0: calldataslice, arg1: u256) -> memorybytes [abi_returns=[memory_
     v25 = add v9, v24
     set_fmp v25
     ret v9
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
@@ -55,8 +55,6 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
@@ -76,8 +74,6 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v12 = slice_len v10
     v13 = lt v12, arg1
     jumpi v13, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v14 = sub v12, arg1
     v15 = add v11, arg1
@@ -101,5 +97,9 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     revert 0, v27
   bb8:
     stop
+  bb5:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_slice_named_return.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_named_return.stdout
@@ -7,8 +7,6 @@ fn @use() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v19 = add arg0, 36
     v20 = add arg0, 4
@@ -23,6 +21,8 @@ fn @use() {
     v18 = phi [bb2: v21], [bb3: v7]
     mstore 128, v18
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @entry() [entry] {

--- a/tests/ui/codegen/lowering/calldata_slice_param_helper.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_param_helper.stdout
@@ -7,8 +7,6 @@ fn @lastWord() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v7 = add arg0, 4
     v8 = calldataload v7
@@ -16,6 +14,8 @@ fn @lastWord() {
     v3 = internal_call @_last, 1, v6, v8
     mstore 128, v3
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @_last(arg0: calldataptr, arg1: u256) -> u256 {
@@ -32,8 +32,6 @@ fn @lastWord2() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v16 = add arg0, 36
     v17 = add arg0, 4
@@ -47,6 +45,8 @@ fn @lastWord2() {
     v11 = xor v3, v10
     mstore 128, v11
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @entry() [entry] {
@@ -57,10 +57,10 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb4, [0x3955f902 => bb2, 0x97f495a8 => bb3]
-  bb2:
-    tail_call @lastWord
   bb3:
     tail_call @lastWord2
+  bb2:
+    tail_call @lastWord
   bb4:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/calldata_slice_rebind.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_rebind.stdout
@@ -6,8 +6,6 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
@@ -27,8 +25,6 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     v12 = slice_len v10
     v13 = lt v12, arg1
     jumpi v13, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v14 = sub v12, arg1
     v15 = add v11, arg1
@@ -52,5 +48,9 @@ fn @forward(arg0: calldataslice, arg1: u256, arg2: address) {
     revert 0, v27
   bb8:
     stop
+  bb5:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_slice_ternary.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_ternary.stdout
@@ -6,8 +6,6 @@ fn @pick(arg0: bool, arg1: calldataslice, arg2: calldataslice) -> u256 [abi_retu
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -18,17 +16,17 @@ fn @pick(arg0: bool, arg1: calldataslice, arg2: calldataslice) -> u256 [abi_retu
     revert 0, 0
   bb4:
     jumpi arg0, bb5, bb6
-  bb5:
-    v7 = slice_ptr arg1
-    v8 = slice_len arg1
-    mstore 0, v7 !metadata(memory=scratch)
-    mstore 32, v8 !metadata(memory=scratch)
-    jump bb7
   bb6:
     v9 = slice_ptr arg2
     v10 = slice_len arg2
     mstore 0, v9 !metadata(memory=scratch)
     mstore 32, v10 !metadata(memory=scratch)
+    jump bb7
+  bb5:
+    v7 = slice_ptr arg1
+    v8 = slice_len arg1
+    mstore 0, v7 !metadata(memory=scratch)
+    mstore 32, v8 !metadata(memory=scratch)
     jump bb7
   bb7:
     v11 = mload 0 !metadata(memory=scratch)
@@ -36,6 +34,8 @@ fn @pick(arg0: bool, arg1: calldataslice, arg2: calldataslice) -> u256 [abi_retu
     v13 = make_calldata_slice v11, v12
     v14 = slice_len v13
     ret v14
+  bb1:
+    revert 0, 0
 }
 
 fn @adopt(arg0: bool, arg1: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -44,8 +44,6 @@ fn @adopt(arg0: bool, arg1: calldataslice) -> memorybytes [abi_returns=[memory_b
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -61,21 +59,14 @@ fn @adopt(arg0: bool, arg1: calldataslice) -> memorybytes [abi_returns=[memory_b
     v9 = add v8, 0
     mstore v9, 0xaabb000000000000000000000000000000000000000000000000000000000000
     jumpi arg0, bb5, bb6
+  bb6:
+    mstore 0, v7 !metadata(memory=scratch)
+    jump bb7
   bb5:
     v10 = slice_len arg1
     v11 = add v10, 31
     v12 = lt v11, v10
     jumpi v12, bb8, bb9
-  bb6:
-    mstore 0, v7 !metadata(memory=scratch)
-    jump bb7
-  bb7:
-    v24 = mload 0 !metadata(memory=scratch)
-    ret v24
-  bb8:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb9:
     v13 = not 31
     v14 = and v11, v13
@@ -84,10 +75,6 @@ fn @adopt(arg0: bool, arg1: calldataslice) -> memorybytes [abi_returns=[memory_b
     v17 = add 32, v16
     v18 = lt v17, v16
     jumpi v18, bb10, bb11
-  bb10:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb11:
     v19 = alloc memorybytes, exact, uninitialized, infallible, v17
     set_memory_object_len memorybytes, v19, v10
@@ -99,5 +86,18 @@ fn @adopt(arg0: bool, arg1: calldataslice) -> memorybytes [abi_returns=[memory_b
     calldatacopy v20, v23, v10
     mstore 0, v19 !metadata(memory=scratch)
     jump bb7
+  bb7:
+    v24 = mload 0 !metadata(memory=scratch)
+    ret v24
+  bb10:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_slice_yul_bounds.stdout
+++ b/tests/ui/codegen/lowering/calldata_slice_yul_bounds.stdout
@@ -42,8 +42,6 @@ fn @trimLen(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
@@ -60,6 +58,8 @@ fn @trimLen(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v11 = make_calldata_slice v9, v10
     v12 = slice_len v11
     ret v12
+  bb1:
+    revert 0, 0
 }
 
 fn @conditional(arg0: calldataslice) -> u256 [abi_returns=[word]] {
@@ -68,8 +68,6 @@ fn @conditional(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
@@ -87,5 +85,7 @@ fn @conditional(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v9 = make_calldata_slice v7, v8
     v10 = slice_len v9
     ret v10
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/calldata_struct_field_slice.stdout
+++ b/tests/ui/codegen/lowering/calldata_struct_field_slice.stdout
@@ -11,8 +11,6 @@ fn @factory.0() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 0xffffffffffffffff
     jumpi v3, bb1, bb3
@@ -38,8 +36,6 @@ fn @factory.0() {
     v16 = add v15, 31
     v17 = lt v16, v15
     jumpi v17, bb5, bb6
-  bb5:
-    tail_call @__revert_stub0
   bb6:
     v19 = and v16, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v20 = iszero v19
@@ -131,6 +127,10 @@ fn @factory.0() {
     v76 = internal_call @factory.1, 1, v5
     mstore 128, v76
     returndata 128, 32
+  bb5:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @factory.1(arg0: memptr) -> address {
@@ -140,9 +140,6 @@ fn @factory.1(arg0: memptr) -> address {
     v6 = mload v1
     v7 = lt v6, 20
     jumpi v7, bb1, bb2
-  bb1:
-    mstore 0, 0 !metadata(memory=scratch)
-    jump bb3
   bb2:
     v9 = add arg0, 256
     v10 = mload v9
@@ -153,11 +150,6 @@ fn @factory.1(arg0: memptr) -> address {
     v14 = calldataload v13
     v19 = gt 20, v14
     jumpi v19, bb4, bb5
-  bb3:
-    v29 = mload 0 !metadata(memory=scratch)
-    ret v29
-  bb4:
-    revert 0, 0
   bb5:
     v25 = calldataload v15
     v26 = and v25, 0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000
@@ -165,6 +157,14 @@ fn @factory.1(arg0: memptr) -> address {
     v28 = and v27, 0xffffffffffffffffffffffffffffffffffffffff
     mstore 0, v28 !metadata(memory=scratch)
     jump bb3
+  bb4:
+    revert 0, 0
+  bb1:
+    mstore 0, 0 !metadata(memory=scratch)
+    jump bb3
+  bb3:
+    v29 = mload 0 !metadata(memory=scratch)
+    ret v29
 }
 
 fn @tailHash.2() {
@@ -173,8 +173,6 @@ fn @tailHash.2() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 0xffffffffffffffff
     jumpi v3, bb1, bb3
@@ -200,8 +198,6 @@ fn @tailHash.2() {
     v16 = add v15, 31
     v17 = lt v16, v15
     jumpi v17, bb5, bb6
-  bb5:
-    tail_call @__revert_stub0
   bb6:
     v19 = and v16, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v20 = iszero v19
@@ -293,6 +289,10 @@ fn @tailHash.2() {
     v76 = internal_call @tailHash.3, 1, v5
     mstore 128, v76
     returndata 128, 32
+  bb5:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @tailHash.3(arg0: memptr) -> bytes32 {
@@ -302,9 +302,6 @@ fn @tailHash.3(arg0: memptr) -> bytes32 {
     v6 = mload v1
     v7 = lt v6, 20
     jumpi v7, bb1, bb2
-  bb1:
-    mstore 0, 0 !metadata(memory=scratch)
-    jump bb3
   bb2:
     v8 = add arg0, 256
     v9 = mload v8
@@ -315,19 +312,12 @@ fn @tailHash.3(arg0: memptr) -> bytes32 {
     v14 = add v12, 32
     v18 = lt v13, 20
     jumpi v18, bb4, bb5
-  bb3:
-    v37 = mload 0 !metadata(memory=scratch)
-    ret v37
-  bb4:
-    revert 0, 0
   bb5:
     v19 = sub v13, 20
     v20 = add v14, 20
     v23 = add v19, 31
     v24 = lt v23, v19
     jumpi v24, bb6, bb7
-  bb6:
-    tail_call @__revert_stub0
   bb7:
     v26 = and v23, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v27 = iszero v26
@@ -350,6 +340,16 @@ fn @tailHash.3(arg0: memptr) -> bytes32 {
     v36 = keccak256 v39, v38
     mstore 0, v36 !metadata(memory=scratch)
     jump bb3
+  bb6:
+    tail_call @__revert_stub0
+  bb4:
+    revert 0, 0
+  bb1:
+    mstore 0, 0 !metadata(memory=scratch)
+    jump bb3
+  bb3:
+    v37 = mload 0 !metadata(memory=scratch)
+    ret v37
 }
 
 fn @midWord.4() {
@@ -358,8 +358,6 @@ fn @midWord.4() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 0xffffffffffffffff
     jumpi v3, bb1, bb3
@@ -385,8 +383,6 @@ fn @midWord.4() {
     v16 = add v15, 31
     v17 = lt v16, v15
     jumpi v17, bb5, bb6
-  bb5:
-    tail_call @__revert_stub0
   bb6:
     v19 = and v16, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v20 = iszero v19
@@ -478,6 +474,10 @@ fn @midWord.4() {
     v76 = internal_call @midWord.5, 1, v5
     mstore 128, v76
     returndata 128, 32
+  bb5:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @midWord.5(arg0: memptr) -> bytes32 {
@@ -491,11 +491,11 @@ fn @midWord.5(arg0: memptr) -> bytes32 {
     v5 = calldataload v4
     v10 = gt 32, v5
     jumpi v10, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v16 = calldataload v6
     ret v16
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_stub0() {
@@ -513,12 +513,12 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb5, [0x1af91295 => bb2, 0x9850c81b => bb3, 0xbb6106d2 => bb4]
-  bb2:
-    tail_call @factory.0
-  bb3:
-    tail_call @tailHash.2
   bb4:
     tail_call @midWord.4
+  bb3:
+    tail_call @tailHash.2
+  bb2:
+    tail_call @factory.0
   bb5:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/calldata_struct_member_index.stdout
+++ b/tests/ui/codegen/lowering/calldata_struct_member_index.stdout
@@ -7,8 +7,6 @@ fn @plain() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v25 = add arg0, 4
     v26 = calldataload v25
@@ -45,6 +43,8 @@ fn @plain() {
     mstore v22, v21
     mstore 128, v21
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @member() {
@@ -53,8 +53,6 @@ fn @member() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 0xffffffffffffffff
     jumpi v3, bb1, bb3
@@ -76,8 +74,6 @@ fn @member() {
     v13 = add v11, 32
     v14 = shr 251, v12
     jumpi v14, bb5, bb6
-  bb5:
-    tail_call @__revert_stub1
   bb6:
     v15 = shl 5, v12
     v16 = add v15, 32
@@ -99,15 +95,6 @@ fn @member() {
   bb8:
     v89 = phi [bb7: v12], [bb12: v43]
     jumpi v89, bb9, bb10
-  bb9:
-    v25 = mload v20
-    v26 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v94 = add v26, 128
-    mstore 64, v94 !metadata(memory=scratch)
-    v27 = calldataload v25
-    v28 = and v27, 255
-    v29 = eq v27, v28
-    jumpi v29, bb11, bb1
   bb10:
     v48 = add v5, 32
     mstore v48, v18
@@ -118,36 +105,6 @@ fn @member() {
     v53 = add v51, 32
     v54 = shr 251, v52
     jumpi v54, bb5, bb13
-  bb11:
-    mstore v26, v27
-    v30 = add v25, 32
-    v31 = calldataload v30
-    v32 = and v31, 0xffffffffffffffffffffffffffffffffffffffff
-    v33 = eq v31, v32
-    jumpi v33, bb12, bb1
-  bb12:
-    v34 = add v26, 32
-    mstore v34, v31
-    v35 = add v25, 64
-    v36 = calldataload v35
-    v37 = add v26, 64
-    mstore v37, v36
-    v38 = add v25, 96
-    v39 = calldataload v38
-    v40 = add v26, 96
-    mstore v40, v39
-    v41 = mload v21
-    mstore v41, v26
-    v42 = mload v19
-    v43 = sub v42, 1
-    mstore v19, v43
-    v44 = mload v20
-    v45 = add v44, 128
-    mstore v20, v45
-    v46 = mload v21
-    v47 = add v46, 32
-    mstore v21, v47
-    jump bb8
   bb13:
     v55 = shl 5, v52
     v56 = add v55, 32
@@ -204,79 +161,15 @@ fn @member() {
     v88 = mload v87
     mstore 128, v88
     returndata 128, 32
-}
-
-fn @word() {
-  bb0:
-    v0 = calldatasize
-    v1 = sub v0, 4
-    v2 = slt v1, 64
-    jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    v3 = gt arg0, 0xffffffffffffffff
-    jumpi v3, bb1, bb3
-  bb3:
-    v4 = add arg0, 4
-    v5 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v90 = add v5, 160
-    mstore 64, v90 !metadata(memory=scratch)
-    v6 = calldataload v4
-    v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
-    v8 = eq v6, v7
-    jumpi v8, bb4, bb1
-  bb4:
-    mstore v5, v6
-    v9 = add arg0, 36
-    v10 = calldataload v9
-    v11 = add v4, v10
-    v12 = calldataload v11
-    v13 = add v11, 32
-    v14 = shr 251, v12
-    jumpi v14, bb5, bb6
-  bb5:
-    tail_call @__revert_stub1
-  bb6:
-    v15 = shl 5, v12
-    v16 = add v15, 32
-    v17 = lt v16, v15
-    jumpi v17, bb5, bb7
-  bb7:
-    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v91 = add v18, v16
-    mstore 64, v91 !metadata(memory=scratch)
-    mstore v18, v12
-    v19 = alloc raw, exact, uninitialized, infallible, 96 !metadata(deferred_alloc)
-    v20 = add v19, 32
-    v21 = add v19, 64
-    v22 = add v18, 32
-    mstore v19, v12
-    mstore v20, v13
-    mstore v21, v22
-    jump bb8
-  bb8:
-    v87 = phi [bb7: v12], [bb12: v43]
-    jumpi v87, bb9, bb10
   bb9:
     v25 = mload v20
     v26 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v92 = add v26, 128
-    mstore 64, v92 !metadata(memory=scratch)
+    v94 = add v26, 128
+    mstore 64, v94 !metadata(memory=scratch)
     v27 = calldataload v25
     v28 = and v27, 255
     v29 = eq v27, v28
     jumpi v29, bb11, bb1
-  bb10:
-    v48 = add v5, 32
-    mstore v48, v18
-    v49 = add arg0, 68
-    v50 = calldataload v49
-    v51 = add v4, v50
-    v52 = calldataload v51
-    v53 = add v51, 32
-    v54 = shr 251, v52
-    jumpi v54, bb5, bb13
   bb11:
     mstore v26, v27
     v30 = add v25, 32
@@ -307,6 +200,70 @@ fn @word() {
     v47 = add v46, 32
     mstore v21, v47
     jump bb8
+  bb5:
+    tail_call @__revert_stub1
+  bb1:
+    revert 0, 0
+}
+
+fn @word() {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 64
+    jumpi v2, bb1, bb2
+  bb2:
+    v3 = gt arg0, 0xffffffffffffffff
+    jumpi v3, bb1, bb3
+  bb3:
+    v4 = add arg0, 4
+    v5 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v90 = add v5, 160
+    mstore 64, v90 !metadata(memory=scratch)
+    v6 = calldataload v4
+    v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
+    v8 = eq v6, v7
+    jumpi v8, bb4, bb1
+  bb4:
+    mstore v5, v6
+    v9 = add arg0, 36
+    v10 = calldataload v9
+    v11 = add v4, v10
+    v12 = calldataload v11
+    v13 = add v11, 32
+    v14 = shr 251, v12
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = shl 5, v12
+    v16 = add v15, 32
+    v17 = lt v16, v15
+    jumpi v17, bb5, bb7
+  bb7:
+    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v91 = add v18, v16
+    mstore 64, v91 !metadata(memory=scratch)
+    mstore v18, v12
+    v19 = alloc raw, exact, uninitialized, infallible, 96 !metadata(deferred_alloc)
+    v20 = add v19, 32
+    v21 = add v19, 64
+    v22 = add v18, 32
+    mstore v19, v12
+    mstore v20, v13
+    mstore v21, v22
+    jump bb8
+  bb8:
+    v87 = phi [bb7: v12], [bb12: v43]
+    jumpi v87, bb9, bb10
+  bb10:
+    v48 = add v5, 32
+    mstore v48, v18
+    v49 = add arg0, 68
+    v50 = calldataload v49
+    v51 = add v4, v50
+    v52 = calldataload v51
+    v53 = add v51, 32
+    v54 = shr 251, v52
+    jumpi v54, bb5, bb13
   bb13:
     v55 = shl 5, v52
     v56 = add v55, 32
@@ -361,79 +318,15 @@ fn @word() {
     v86 = mload v85
     mstore 128, v86
     returndata 128, 32
-}
-
-fn @lengths() {
-  bb0:
-    v0 = calldatasize
-    v1 = sub v0, 4
-    v2 = slt v1, 32
-    jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
-  bb2:
-    v3 = gt arg0, 0xffffffffffffffff
-    jumpi v3, bb1, bb3
-  bb3:
-    v4 = add arg0, 4
-    v5 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v103 = add v5, 160
-    mstore 64, v103 !metadata(memory=scratch)
-    v6 = calldataload v4
-    v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
-    v8 = eq v6, v7
-    jumpi v8, bb4, bb1
-  bb4:
-    mstore v5, v6
-    v9 = add arg0, 36
-    v10 = calldataload v9
-    v11 = add v4, v10
-    v12 = calldataload v11
-    v13 = add v11, 32
-    v14 = shr 251, v12
-    jumpi v14, bb5, bb6
-  bb5:
-    tail_call @__revert_stub1
-  bb6:
-    v15 = shl 5, v12
-    v16 = add v15, 32
-    v17 = lt v16, v15
-    jumpi v17, bb5, bb7
-  bb7:
-    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v104 = add v18, v16
-    mstore 64, v104 !metadata(memory=scratch)
-    mstore v18, v12
-    v19 = alloc raw, exact, uninitialized, infallible, 96 !metadata(deferred_alloc)
-    v20 = add v19, 32
-    v21 = add v19, 64
-    v22 = add v18, 32
-    mstore v19, v12
-    mstore v20, v13
-    mstore v21, v22
-    jump bb8
-  bb8:
-    v100 = phi [bb7: v12], [bb12: v43]
-    jumpi v100, bb9, bb10
   bb9:
     v25 = mload v20
     v26 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v105 = add v26, 128
-    mstore 64, v105 !metadata(memory=scratch)
+    v92 = add v26, 128
+    mstore 64, v92 !metadata(memory=scratch)
     v27 = calldataload v25
     v28 = and v27, 255
     v29 = eq v27, v28
     jumpi v29, bb11, bb1
-  bb10:
-    v48 = add v5, 32
-    mstore v48, v18
-    v49 = add arg0, 68
-    v50 = calldataload v49
-    v51 = add v4, v50
-    v52 = calldataload v51
-    v53 = add v51, 32
-    v54 = shr 251, v52
-    jumpi v54, bb5, bb13
   bb11:
     mstore v26, v27
     v30 = add v25, 32
@@ -464,6 +357,70 @@ fn @lengths() {
     v47 = add v46, 32
     mstore v21, v47
     jump bb8
+  bb5:
+    tail_call @__revert_stub1
+  bb1:
+    revert 0, 0
+}
+
+fn @lengths() {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb2:
+    v3 = gt arg0, 0xffffffffffffffff
+    jumpi v3, bb1, bb3
+  bb3:
+    v4 = add arg0, 4
+    v5 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v103 = add v5, 160
+    mstore 64, v103 !metadata(memory=scratch)
+    v6 = calldataload v4
+    v7 = and v6, 0xffffffffffffffffffffffffffffffffffffffff
+    v8 = eq v6, v7
+    jumpi v8, bb4, bb1
+  bb4:
+    mstore v5, v6
+    v9 = add arg0, 36
+    v10 = calldataload v9
+    v11 = add v4, v10
+    v12 = calldataload v11
+    v13 = add v11, 32
+    v14 = shr 251, v12
+    jumpi v14, bb5, bb6
+  bb6:
+    v15 = shl 5, v12
+    v16 = add v15, 32
+    v17 = lt v16, v15
+    jumpi v17, bb5, bb7
+  bb7:
+    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v104 = add v18, v16
+    mstore 64, v104 !metadata(memory=scratch)
+    mstore v18, v12
+    v19 = alloc raw, exact, uninitialized, infallible, 96 !metadata(deferred_alloc)
+    v20 = add v19, 32
+    v21 = add v19, 64
+    v22 = add v18, 32
+    mstore v19, v12
+    mstore v20, v13
+    mstore v21, v22
+    jump bb8
+  bb8:
+    v100 = phi [bb7: v12], [bb12: v43]
+    jumpi v100, bb9, bb10
+  bb10:
+    v48 = add v5, 32
+    mstore v48, v18
+    v49 = add arg0, 68
+    v50 = calldataload v49
+    v51 = add v4, v50
+    v52 = calldataload v51
+    v53 = add v51, 32
+    v54 = shr 251, v52
+    jumpi v54, bb5, bb13
   bb13:
     v55 = shl 5, v52
     v56 = add v55, 32
@@ -517,6 +474,49 @@ fn @lengths() {
     mstore 160, v92
     mstore 192, v99
     returndata 128, 96
+  bb9:
+    v25 = mload v20
+    v26 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v105 = add v26, 128
+    mstore 64, v105 !metadata(memory=scratch)
+    v27 = calldataload v25
+    v28 = and v27, 255
+    v29 = eq v27, v28
+    jumpi v29, bb11, bb1
+  bb11:
+    mstore v26, v27
+    v30 = add v25, 32
+    v31 = calldataload v30
+    v32 = and v31, 0xffffffffffffffffffffffffffffffffffffffff
+    v33 = eq v31, v32
+    jumpi v33, bb12, bb1
+  bb12:
+    v34 = add v26, 32
+    mstore v34, v31
+    v35 = add v25, 64
+    v36 = calldataload v35
+    v37 = add v26, 64
+    mstore v37, v36
+    v38 = add v25, 96
+    v39 = calldataload v38
+    v40 = add v26, 96
+    mstore v40, v39
+    v41 = mload v21
+    mstore v41, v26
+    v42 = mload v19
+    v43 = sub v42, 1
+    mstore v19, v43
+    v44 = mload v20
+    v45 = add v44, 128
+    mstore v20, v45
+    v46 = mload v21
+    v47 = add v46, 32
+    mstore v21, v47
+    jump bb8
+  bb5:
+    tail_call @__revert_stub1
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_stub0() {
@@ -541,14 +541,14 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb6, [0x49eb8b89 => bb2, 0xb7a3bd0f => bb3, 0xc2dcee6a => bb4, 0xd192e846 => bb5]
-  bb2:
-    tail_call @member
-  bb3:
-    tail_call @lengths
-  bb4:
-    tail_call @plain
   bb5:
     tail_call @word
+  bb4:
+    tail_call @plain
+  bb3:
+    tail_call @lengths
+  bb2:
+    tail_call @member
   bb6:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/calldata_validation.stdout
+++ b/tests/ui/codegen/lowering/calldata_validation.stdout
@@ -6,8 +6,6 @@ fn @vUint8(arg0: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -17,6 +15,8 @@ fn @vUint8(arg0: u8) -> u8 [abi_returns=[word]] {
     revert 0, 0
   bb4:
     ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @vInt16(arg0: i16) -> i16 [abi_returns=[word]] {
@@ -25,8 +25,6 @@ fn @vInt16(arg0: i16) -> i16 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 1, v3
@@ -36,6 +34,8 @@ fn @vInt16(arg0: i16) -> i16 [abi_returns=[word]] {
     revert 0, 0
   bb4:
     ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @vBool(arg0: bool) -> bool [abi_returns=[word]] {
@@ -44,8 +44,6 @@ fn @vBool(arg0: bool) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -56,6 +54,8 @@ fn @vBool(arg0: bool) -> bool [abi_returns=[word]] {
     revert 0, 0
   bb4:
     ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @vAddress(arg0: address) -> address [abi_returns=[word]] {
@@ -64,8 +64,6 @@ fn @vAddress(arg0: address) -> address [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -75,6 +73,8 @@ fn @vAddress(arg0: address) -> address [abi_returns=[word]] {
     revert 0, 0
   bb4:
     ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @vBytes4(arg0: bytes4) -> bytes4 [abi_returns=[word]] {
@@ -83,8 +83,6 @@ fn @vBytes4(arg0: bytes4) -> bytes4 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffff00000000000000000000000000000000000000000000000000000000
@@ -94,6 +92,8 @@ fn @vBytes4(arg0: bytes4) -> bytes4 [abi_returns=[word]] {
     revert 0, 0
   bb4:
     ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @vEnum(arg0: u8) -> u8 [abi_returns=[word]] {
@@ -102,8 +102,6 @@ fn @vEnum(arg0: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = lt v3, 3
@@ -112,6 +110,8 @@ fn @vEnum(arg0: u8) -> u8 [abi_returns=[word]] {
     revert 0, 0
   bb4:
     ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @vMulti(arg0: u32, arg1: i8) -> u256 [abi_returns=[word]] {
@@ -120,8 +120,6 @@ fn @vMulti(arg0: u32, arg1: i8) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffff
@@ -144,12 +142,14 @@ fn @vMulti(arg0: u32, arg1: i8) -> u256 [abi_returns=[word]] {
     v13 = add v9, v12
     v14 = lt v13, v9
     jumpi v14, bb7, bb8
+  bb8:
+    ret v13
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v13
+  bb1:
+    revert 0, 0
 }
 
 fn @vFull(arg0: u256, arg1: bytes32, arg2: i256) -> u256 [abi_returns=[word]] {
@@ -158,25 +158,25 @@ fn @vFull(arg0: u256, arg1: bytes32, arg2: i256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v5 = add v3, arg2
     v6 = lt v5, v3
     jumpi v6, bb5, bb6
+  bb6:
+    ret v5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    ret v5
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/chained_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/chained_calldata_slice.stdout
@@ -6,15 +6,11 @@ fn @bytesChain(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] 
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 1
     jumpi v5, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v6 = sub v4, 1
     v7 = add v3, 1
@@ -23,8 +19,6 @@ fn @bytesChain(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] 
     v10 = slice_len v8
     v11 = lt v10, 1
     jumpi v11, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v12 = sub v10, 1
     v13 = add v9, 1
@@ -33,10 +27,6 @@ fn @bytesChain(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] 
     v16 = add v15, 31
     v17 = lt v16, v15
     jumpi v17, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v18 = not 31
     v19 = and v16, v18
@@ -45,10 +35,6 @@ fn @bytesChain(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] 
     v22 = add 32, v21
     v23 = lt v22, v21
     jumpi v23, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v24 = alloc memorybytes, exact, uninitialized, infallible, v22
     set_memory_object_len memorybytes, v24, v15
@@ -59,6 +45,20 @@ fn @bytesChain(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] 
     v28 = slice_ptr v14
     calldatacopy v25, v28, v15
     ret v24
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @arrChain(arg0: calldataslice) -> u256 [abi_returns=[word]] {
@@ -67,15 +67,11 @@ fn @arrChain(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = lt v4, 1
     jumpi v5, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v6 = sub v4, 1
     v7 = mul 1, 32
@@ -85,8 +81,6 @@ fn @arrChain(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v11 = slice_len v9
     v12 = lt v11, 1
     jumpi v12, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v13 = sub v11, 1
     v14 = mul 1, 32
@@ -109,10 +103,6 @@ fn @arrChain(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v25 = add v23, 32
     v26 = shr 251, v24
     jumpi v26, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v27 = mul v24, 32
     v28 = add 32, v27
@@ -121,5 +111,15 @@ fn @arrChain(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v30 = memory_object_data memoryarray, v29
     calldatacopy v30, v25, v27
     ret v29
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/checked_arithmetic_panic.sol
+++ b/tests/ui/codegen/lowering/checked_arithmetic_panic.sol
@@ -37,8 +37,8 @@ contract CheckedArithmeticPanic {
 
     // CHECK-LABEL: fn @pow{{[( ]}}
     // CHECK: iszero arg1
-    // CHECK: shl arg1, 1
     // CHECK: exp arg0, arg1
+    // CHECK: shl arg1, 1
     // CHECK: mstore 4, 17
     function pow(uint256 a, uint256 b) public pure returns (uint256) {
         return a ** b;
@@ -55,8 +55,8 @@ contract CheckedArithmeticPanic {
 
     // CHECK-LABEL: fn @signed_neg{{[( ]}}
     // CHECK: eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
-    // CHECK: mstore 4, 17
     // CHECK: sub 0, arg0
+    // CHECK: mstore 4, 17
     function signed_neg(int256 a) public pure returns (int256) {
         return -a;
     }

--- a/tests/ui/codegen/lowering/checked_arithmetic_panic.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_panic.stdout
@@ -6,18 +6,18 @@ fn @add(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @sub(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -26,18 +26,18 @@ fn @sub(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sub arg0, arg1
     v4 = lt arg0, arg1
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @mul(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -46,8 +46,6 @@ fn @mul(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul arg0, arg1
     v4 = iszero arg1
@@ -56,12 +54,14 @@ fn @mul(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v7 = or v4, v6
     v8 = iszero v7
     jumpi v8, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @div_zero(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -70,8 +70,6 @@ fn @div_zero(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     jumpi arg1, bb4, bb3
   bb3:
@@ -81,6 +79,8 @@ fn @div_zero(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
   bb4:
     v3 = div arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -89,14 +89,9 @@ fn @pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = iszero arg1
     jumpi v3, bb3, bb4
-  bb3:
-    v31 = phi [bb2: 1], [bb4: 0], [bb5: 1], [bb10: v8], [bb11: v16], [bb19: v30]
-    ret v31
   bb4:
     v4 = iszero arg0
     jumpi v4, bb3, bb5
@@ -106,9 +101,6 @@ fn @pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
   bb6:
     v6 = eq arg0, 2
     jumpi v6, bb7, bb8
-  bb7:
-    v7 = gt arg1, 255
-    jumpi v7, bb9, bb10
   bb8:
     v9 = lt arg0, 11
     v10 = lt arg1, 78
@@ -118,16 +110,6 @@ fn @pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v14 = and v12, v13
     v15 = or v11, v14
     jumpi v15, bb11, bb12
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb10:
-    v8 = shl arg1, 1
-    jump bb3
-  bb11:
-    v16 = exp arg0, arg1
-    jump bb3
   bb12:
     jump bb13
   bb13:
@@ -136,18 +118,21 @@ fn @pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v19 = phi [bb12: arg1], [bb17: v27]
     v20 = gt v19, 1
     jumpi v20, bb14, bb15
-  bb14:
-    v21 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
-    v22 = gt v18, v21
-    jumpi v22, bb16, bb17
   bb15:
     v28 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
     v29 = gt v17, v28
     jumpi v29, bb18, bb19
-  bb16:
+  bb19:
+    v30 = mul v17, v18
+    jump bb3
+  bb18:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb14:
+    v21 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
+    v22 = gt v18, v21
+    jumpi v22, bb16, bb17
   bb17:
     v23 = and v19, 1
     v24 = mul v17, v18
@@ -155,13 +140,28 @@ fn @pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v26 = mul v18, v18
     v27 = shr 1, v19
     jump bb13
-  bb18:
+  bb16:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb19:
-    v30 = mul v17, v18
+  bb11:
+    v16 = exp arg0, arg1
     jump bb3
+  bb7:
+    v7 = gt arg1, 255
+    jumpi v7, bb9, bb10
+  bb10:
+    v8 = shl arg1, 1
+    jump bb3
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    v31 = phi [bb2: 1], [bb4: 0], [bb5: 1], [bb10: v8], [bb11: v16], [bb19: v30]
+    ret v31
+  bb1:
+    revert 0, 0
 }
 
 fn @signed_add(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
@@ -170,20 +170,20 @@ fn @signed_add(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     v4 = slt arg0, 0
     v5 = slt v3, arg1
     v6 = xor v4, v5
     jumpi v6, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @signed_neg(arg0: i256) -> i256 [abi_returns=[word]] {
@@ -192,18 +192,18 @@ fn @signed_neg(arg0: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
     jumpi v3, bb3, bb4
+  bb4:
+    v4 = sub 0, arg0
+    ret v4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v4 = sub 0, arg0
-    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @narrow_add(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
@@ -212,8 +212,6 @@ fn @narrow_add(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -232,12 +230,14 @@ fn @narrow_add(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v9 = add arg0, arg1
     v10 = gt v9, 255
     jumpi v10, bb7, bb8
+  bb8:
+    ret v9
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @unchecked_add(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -246,11 +246,11 @@ fn @unchecked_add(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @unchecked_neg(arg0: i256) -> i256 [abi_returns=[word]] {
@@ -259,11 +259,11 @@ fn @unchecked_neg(arg0: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sub 0, arg0
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @unchecked_pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -272,11 +272,11 @@ fn @unchecked_pow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = exp arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @unchecked_call(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -285,11 +285,11 @@ fn @unchecked_call(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @checked_inner, 1, arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @checked_inner(arg0: u256, arg1: u256) -> u256 {
@@ -297,11 +297,11 @@ fn @checked_inner(arg0: u256, arg1: u256) -> u256 {
     v0 = add arg0, arg1
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 

--- a/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_arithmetic_shapes.stdout
@@ -6,20 +6,20 @@ fn @sadd(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     v4 = slt arg0, 0
     v5 = slt v3, arg1
     v6 = xor v4, v5
     jumpi v6, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @ssub(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
@@ -28,20 +28,20 @@ fn @ssub(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sub arg0, arg1
     v4 = slt arg1, 0
     v5 = sgt v3, arg0
     v6 = xor v4, v5
     jumpi v6, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @smul(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
@@ -50,8 +50,6 @@ fn @smul(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul arg0, arg1
     v4 = iszero arg1
@@ -64,12 +62,14 @@ fn @smul(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v11 = and v9, v10
     v12 = or v8, v11
     jumpi v12, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @sdiv(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
@@ -78,8 +78,6 @@ fn @sdiv(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     jumpi arg1, bb4, bb3
   bb3:
@@ -91,13 +89,15 @@ fn @sdiv(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v4 = eq arg1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     v5 = and v3, v4
     jumpi v5, bb5, bb6
+  bb6:
+    v6 = sdiv arg0, arg1
+    ret v6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    v6 = sdiv arg0, arg1
-    ret v6
+  bb1:
+    revert 0, 0
 }
 
 fn @smod(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
@@ -106,8 +106,6 @@ fn @smod(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     jumpi arg1, bb4, bb3
   bb3:
@@ -117,6 +115,8 @@ fn @smod(arg0: i256, arg1: i256) -> i256 [abi_returns=[word]] {
   bb4:
     v3 = smod arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @neg(arg0: i256) -> i256 [abi_returns=[word]] {
@@ -125,18 +125,18 @@ fn @neg(arg0: i256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
     jumpi v3, bb3, bb4
+  bb4:
+    v4 = sub 0, arg0
+    ret v4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v4 = sub 0, arg0
-    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @inc(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -145,21 +145,21 @@ fn @inc(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, arg0
     v3 = mload 128
     v4 = add v3, 1
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
+  bb4:
+    mstore 128, v4
+    ret v4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    mstore 128, v4
-    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @dec(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -168,21 +168,21 @@ fn @dec(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, arg0
     v3 = mload 128
     v4 = sub v3, 1
     v5 = lt v3, 1
     jumpi v5, bb3, bb4
+  bb4:
+    mstore 128, v4
+    ret v4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    mstore 128, v4
-    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @uadd128(arg0: u128, arg1: u128) -> u128 [abi_returns=[word]] {
@@ -191,8 +191,6 @@ fn @uadd128(arg0: u128, arg1: u128) -> u128 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffff
@@ -211,12 +209,14 @@ fn @uadd128(arg0: u128, arg1: u128) -> u128 [abi_returns=[word]] {
     v9 = add arg0, arg1
     v10 = gt v9, 0xffffffffffffffffffffffffffffffff
     jumpi v10, bb7, bb8
+  bb8:
+    ret v9
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @umul128(arg0: u128, arg1: u128) -> u128 [abi_returns=[word]] {
@@ -225,8 +225,6 @@ fn @umul128(arg0: u128, arg1: u128) -> u128 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffff
@@ -245,12 +243,14 @@ fn @umul128(arg0: u128, arg1: u128) -> u128 [abi_returns=[word]] {
     v9 = mul arg0, arg1
     v10 = gt v9, 0xffffffffffffffffffffffffffffffff
     jumpi v10, bb7, bb8
+  bb8:
+    ret v9
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @smul128(arg0: i128, arg1: i128) -> i128 [abi_returns=[word]] {
@@ -259,8 +259,6 @@ fn @smul128(arg0: i128, arg1: i128) -> i128 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 15, v3
@@ -281,12 +279,14 @@ fn @smul128(arg0: i128, arg1: i128) -> i128 [abi_returns=[word]] {
     v11 = sgt v9, 0x7fffffffffffffffffffffffffffffff
     v12 = or v10, v11
     jumpi v12, bb7, bb8
+  bb8:
+    ret v9
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @umul192(arg0: u192, arg1: u192) -> u192 [abi_returns=[word]] {
@@ -295,8 +295,6 @@ fn @umul192(arg0: u192, arg1: u192) -> u192 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffffffffffff
@@ -321,12 +319,14 @@ fn @umul192(arg0: u192, arg1: u192) -> u192 [abi_returns=[word]] {
     v15 = gt v9, 0xffffffffffffffffffffffffffffffffffffffffffffffff
     v16 = or v14, v15
     jumpi v16, bb7, bb8
+  bb8:
+    ret v9
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @leftU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
@@ -335,8 +335,6 @@ fn @leftU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -355,6 +353,8 @@ fn @leftU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v9 = shl arg1, arg0
     v10 = and v9, 255
     ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @leftU16(arg0: u16, arg1: u8) -> u16 [abi_returns=[word]] {
@@ -363,8 +363,6 @@ fn @leftU16(arg0: u16, arg1: u8) -> u16 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffff
@@ -383,6 +381,8 @@ fn @leftU16(arg0: u16, arg1: u8) -> u16 [abi_returns=[word]] {
     v9 = shl arg1, arg0
     v10 = and v9, 0xffff
     ret v10
+  bb1:
+    revert 0, 0
 }
 
 fn @leftI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
@@ -391,8 +391,6 @@ fn @leftI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 0, v3
@@ -412,6 +410,8 @@ fn @leftI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
     v10 = shl 248, v9
     v11 = sar 248, v10
     ret v11
+  bb1:
+    revert 0, 0
 }
 
 fn @leftI16(arg0: i16, arg1: u8) -> i16 [abi_returns=[word]] {
@@ -420,8 +420,6 @@ fn @leftI16(arg0: i16, arg1: u8) -> i16 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 1, v3
@@ -441,6 +439,8 @@ fn @leftI16(arg0: i16, arg1: u8) -> i16 [abi_returns=[word]] {
     v10 = shl 240, v9
     v11 = sar 240, v10
     ret v11
+  bb1:
+    revert 0, 0
 }
 
 fn @leftU256(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -449,11 +449,11 @@ fn @leftU256(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = shl arg1, arg0
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @rightU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
@@ -462,8 +462,6 @@ fn @rightU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -481,6 +479,8 @@ fn @rightU8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
   bb6:
     v9 = shr arg1, arg0
     ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @rightI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
@@ -489,8 +489,6 @@ fn @rightI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 0, v3
@@ -508,5 +506,7 @@ fn @rightI8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
   bb6:
     v9 = sar arg1, arg0
     ret v9
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/checked_pow_shapes.sol
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.sol
@@ -17,37 +17,37 @@
 contract CheckedPowShapes {
     // CHECK-LABEL: fn @upow{{[( ]}}
     // CHECK: eq arg0, 2
-    // CHECK: shl arg1, 1
-    // CHECK: exp arg0, arg1
     // CHECK: {{v[0-9]+}} = mul {{v[0-9]+}}, {{v[0-9]+}}
     // CHECK: shr 1,
+    // CHECK: exp arg0, arg1
+    // CHECK: shl arg1, 1
     function upow(uint256 a, uint256 b) public pure returns (uint256) {
         return a ** b;
     }
 
     // CHECK-LABEL: fn @spow{{[( ]}}
     // CHECK: eq arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    // CHECK: exp arg0, arg1
     // CHECK: sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, arg0
     // CHECK: mul {{v[0-9]+}}, {{v[0-9]+}}
+    // CHECK: exp arg0, arg1
     function spow(int256 a, uint256 b) public pure returns (int256) {
         return a ** b;
     }
 
     // CHECK-LABEL: fn @upow8{{[( ]}}
-    // CHECK: shl arg1, 1
-    // CHECK: gt {{v[0-9]+}}, 255
-    // CHECK: exp arg0, arg1
-    // CHECK: gt {{v[0-9]+}}, 255
+    // CHECK: [[POWER:v[0-9]+]] = exp arg0, arg1
+    // CHECK: gt [[POWER]], 255
+    // CHECK: [[SHIFT:v[0-9]+]] = shl arg1, 1
+    // CHECK: gt [[SHIFT]], 255
     function upow8(uint8 a, uint8 b) public pure returns (uint8) {
         return a ** b;
     }
 
     // CHECK-LABEL: fn @spow8{{[( ]}}
-    // CHECK: exp arg0, arg1
-    // CHECK: gt {{v[0-9]+}}, 127
     // CHECK: sdiv 127, arg0
     // CHECK: sdiv 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80,
+    // CHECK: [[POWER:v[0-9]+]] = exp arg0, arg1
+    // CHECK: gt [[POWER]], 127
     function spow8(int8 a, uint8 b) public pure returns (int8) {
         return a ** b;
     }
@@ -68,8 +68,8 @@ contract CheckedPowShapes {
 
     // CHECK-LABEL: fn @const_neg2{{[( ]}}
     // CHECK: [[BASE:v[0-9]+]] = sub 0, 2
-    // CHECK: exp [[BASE]], arg0
     // CHECK: sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, [[BASE]]
+    // CHECK: exp [[BASE]], arg0
     function const_neg2(uint256 b) public pure returns (int256) {
         return (-2) ** b;
     }

--- a/tests/ui/codegen/lowering/checked_pow_shapes.stdout
+++ b/tests/ui/codegen/lowering/checked_pow_shapes.stdout
@@ -6,14 +6,9 @@ fn @upow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = iszero arg1
     jumpi v3, bb3, bb4
-  bb3:
-    v31 = phi [bb2: 1], [bb4: 0], [bb5: 1], [bb10: v8], [bb11: v16], [bb19: v30]
-    ret v31
   bb4:
     v4 = iszero arg0
     jumpi v4, bb3, bb5
@@ -23,9 +18,6 @@ fn @upow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
   bb6:
     v6 = eq arg0, 2
     jumpi v6, bb7, bb8
-  bb7:
-    v7 = gt arg1, 255
-    jumpi v7, bb9, bb10
   bb8:
     v9 = lt arg0, 11
     v10 = lt arg1, 78
@@ -35,16 +27,6 @@ fn @upow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v14 = and v12, v13
     v15 = or v11, v14
     jumpi v15, bb11, bb12
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb10:
-    v8 = shl arg1, 1
-    jump bb3
-  bb11:
-    v16 = exp arg0, arg1
-    jump bb3
   bb12:
     jump bb13
   bb13:
@@ -53,18 +35,21 @@ fn @upow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v19 = phi [bb12: arg1], [bb17: v27]
     v20 = gt v19, 1
     jumpi v20, bb14, bb15
-  bb14:
-    v21 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
-    v22 = gt v18, v21
-    jumpi v22, bb16, bb17
   bb15:
     v28 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
     v29 = gt v17, v28
     jumpi v29, bb18, bb19
-  bb16:
+  bb19:
+    v30 = mul v17, v18
+    jump bb3
+  bb18:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb14:
+    v21 = div 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v18
+    v22 = gt v18, v21
+    jumpi v22, bb16, bb17
   bb17:
     v23 = and v19, 1
     v24 = mul v17, v18
@@ -72,13 +57,28 @@ fn @upow(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v26 = mul v18, v18
     v27 = shr 1, v19
     jump bb13
-  bb18:
+  bb16:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb19:
-    v30 = mul v17, v18
+  bb11:
+    v16 = exp arg0, arg1
     jump bb3
+  bb7:
+    v7 = gt arg1, 255
+    jumpi v7, bb9, bb10
+  bb10:
+    v8 = shl arg1, 1
+    jump bb3
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    v31 = phi [bb2: 1], [bb4: 0], [bb5: 1], [bb10: v8], [bb11: v16], [bb19: v30]
+    ret v31
+  bb1:
+    revert 0, 0
 }
 
 fn @spow(arg0: i256, arg1: u256) -> i256 [abi_returns=[word]] {
@@ -87,14 +87,9 @@ fn @spow(arg0: i256, arg1: u256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = iszero arg1
     jumpi v3, bb3, bb4
-  bb3:
-    v48 = phi [bb2: 1], [bb4: arg0], [bb5: 0], [bb7: 1], [bb14: v15], [bb17: v21], [bb29: v47]
-    ret v48
   bb4:
     v4 = eq arg1, 1
     jumpi v4, bb3, bb5
@@ -104,18 +99,26 @@ fn @spow(arg0: i256, arg1: u256) -> i256 [abi_returns=[word]] {
   bb6:
     v6 = sgt arg0, 0
     jumpi v6, bb7, bb8
-  bb7:
-    v7 = eq arg0, 1
-    jumpi v7, bb3, bb10
   bb8:
     v19 = eq arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     jumpi v19, bb17, bb18
-  bb9:
-    v24 = and arg1, 1
-    v25 = select v24, arg0, 1
-    v26 = mul arg0, arg0
-    v27 = shr 1, arg1
-    jump bb21
+  bb18:
+    v22 = sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, arg0
+    v23 = slt arg0, v22
+    jumpi v23, bb19, bb20
+  bb20:
+    jump bb9
+  bb19:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb17:
+    v20 = and arg1, 1
+    v21 = select v20, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
+    jump bb3
+  bb7:
+    v7 = eq arg0, 1
+    jumpi v7, bb3, bb10
   bb10:
     v8 = lt arg0, 11
     v9 = lt arg1, 78
@@ -125,60 +128,51 @@ fn @spow(arg0: i256, arg1: u256) -> i256 [abi_returns=[word]] {
     v13 = and v11, v12
     v14 = or v10, v13
     jumpi v14, bb11, bb12
-  bb11:
-    v15 = exp arg0, arg1
-    v16 = gt v15, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    jumpi v16, bb13, bb14
   bb12:
     v17 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, arg0
     v18 = gt arg0, v17
     jumpi v18, bb15, bb16
-  bb13:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb14:
-    jump bb3
-  bb15:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb16:
     jump bb9
-  bb17:
-    v20 = and arg1, 1
-    v21 = select v20, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
-    jump bb3
-  bb18:
-    v22 = sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, arg0
-    v23 = slt arg0, v22
-    jumpi v23, bb19, bb20
-  bb19:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb20:
-    jump bb9
+  bb9:
+    v24 = and arg1, 1
+    v25 = select v24, arg0, 1
+    v26 = mul arg0, arg0
+    v27 = shr 1, arg1
+    jump bb21
   bb21:
     v28 = phi [bb9: v25], [bb25: v36]
     v29 = phi [bb9: v26], [bb25: v37]
     v30 = phi [bb9: v27], [bb25: v38]
     v31 = gt v30, 1
     jumpi v31, bb22, bb23
-  bb22:
-    v32 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v29
-    v33 = gt v29, v32
-    jumpi v33, bb24, bb25
   bb23:
     v39 = sgt v28, 0
     v40 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v29
     v41 = gt v28, v40
     v42 = and v39, v41
     jumpi v42, bb26, bb27
-  bb24:
+  bb27:
+    v43 = slt v28, 0
+    v44 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, v29
+    v45 = slt v28, v44
+    v46 = and v43, v45
+    jumpi v46, bb28, bb29
+  bb29:
+    v47 = mul v28, v29
+    jump bb3
+  bb28:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb26:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb22:
+    v32 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v29
+    v33 = gt v29, v32
+    jumpi v33, bb24, bb25
   bb25:
     v34 = and v30, 1
     v35 = mul v28, v29
@@ -186,23 +180,29 @@ fn @spow(arg0: i256, arg1: u256) -> i256 [abi_returns=[word]] {
     v37 = mul v29, v29
     v38 = shr 1, v30
     jump bb21
-  bb26:
+  bb24:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb27:
-    v43 = slt v28, 0
-    v44 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, v29
-    v45 = slt v28, v44
-    v46 = and v43, v45
-    jumpi v46, bb28, bb29
-  bb28:
+  bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb29:
-    v47 = mul v28, v29
+  bb11:
+    v15 = exp arg0, arg1
+    v16 = gt v15, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    jumpi v16, bb13, bb14
+  bb14:
     jump bb3
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    v48 = phi [bb2: 1], [bb4: arg0], [bb5: 0], [bb7: 1], [bb14: v15], [bb17: v21], [bb29: v47]
+    ret v48
+  bb1:
+    revert 0, 0
 }
 
 fn @upow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
@@ -211,8 +211,6 @@ fn @upow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -230,9 +228,6 @@ fn @upow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
   bb6:
     v9 = iszero arg1
     jumpi v9, bb7, bb8
-  bb7:
-    v39 = phi [bb6: 1], [bb8: 0], [bb9: 1], [bb16: v14], [bb20: v23], [bb27: v38]
-    ret v39
   bb8:
     v10 = iszero arg0
     jumpi v10, bb7, bb9
@@ -242,9 +237,6 @@ fn @upow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
   bb10:
     v12 = eq arg0, 2
     jumpi v12, bb11, bb12
-  bb11:
-    v13 = gt arg1, 255
-    jumpi v13, bb13, bb14
   bb12:
     v16 = lt arg0, 11
     v17 = lt arg1, 78
@@ -254,50 +246,29 @@ fn @upow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v21 = and v19, v20
     v22 = or v18, v21
     jumpi v22, bb17, bb18
-  bb13:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb14:
-    v14 = shl arg1, 1
-    v15 = gt v14, 255
-    jumpi v15, bb15, bb16
-  bb15:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb16:
-    jump bb7
-  bb17:
-    v23 = exp arg0, arg1
-    v24 = gt v23, 255
-    jumpi v24, bb19, bb20
   bb18:
     jump bb21
-  bb19:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb20:
-    jump bb7
   bb21:
     v25 = phi [bb18: 1], [bb25: v33]
     v26 = phi [bb18: arg0], [bb25: v34]
     v27 = phi [bb18: arg1], [bb25: v35]
     v28 = gt v27, 1
     jumpi v28, bb22, bb23
-  bb22:
-    v29 = div 255, v26
-    v30 = gt v26, v29
-    jumpi v30, bb24, bb25
   bb23:
     v36 = div 255, v26
     v37 = gt v25, v36
     jumpi v37, bb26, bb27
-  bb24:
+  bb27:
+    v38 = mul v25, v26
+    jump bb7
+  bb26:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb22:
+    v29 = div 255, v26
+    v30 = gt v26, v29
+    jumpi v30, bb24, bb25
   bb25:
     v31 = and v27, 1
     v32 = mul v25, v26
@@ -305,13 +276,42 @@ fn @upow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v34 = mul v26, v26
     v35 = shr 1, v27
     jump bb21
-  bb26:
+  bb24:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb27:
-    v38 = mul v25, v26
+  bb17:
+    v23 = exp arg0, arg1
+    v24 = gt v23, 255
+    jumpi v24, bb19, bb20
+  bb20:
     jump bb7
+  bb19:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb11:
+    v13 = gt arg1, 255
+    jumpi v13, bb13, bb14
+  bb14:
+    v14 = shl arg1, 1
+    v15 = gt v14, 255
+    jumpi v15, bb15, bb16
+  bb16:
+    jump bb7
+  bb15:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    v39 = phi [bb6: 1], [bb8: 0], [bb9: 1], [bb16: v14], [bb20: v23], [bb27: v38]
+    ret v39
+  bb1:
+    revert 0, 0
 }
 
 fn @spow8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
@@ -320,8 +320,6 @@ fn @spow8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 0, v3
@@ -339,9 +337,6 @@ fn @spow8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
   bb6:
     v9 = iszero arg1
     jumpi v9, bb7, bb8
-  bb7:
-    v54 = phi [bb6: 1], [bb8: arg0], [bb9: 0], [bb11: 1], [bb18: v21], [bb21: v27], [bb33: v53]
-    ret v54
   bb8:
     v10 = eq arg1, 1
     jumpi v10, bb7, bb9
@@ -351,18 +346,26 @@ fn @spow8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
   bb10:
     v12 = sgt arg0, 0
     jumpi v12, bb11, bb12
-  bb11:
-    v13 = eq arg0, 1
-    jumpi v13, bb7, bb14
   bb12:
     v25 = eq arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     jumpi v25, bb21, bb22
-  bb13:
-    v30 = and arg1, 1
-    v31 = select v30, arg0, 1
-    v32 = mul arg0, arg0
-    v33 = shr 1, arg1
-    jump bb25
+  bb22:
+    v28 = sdiv 127, arg0
+    v29 = slt arg0, v28
+    jumpi v29, bb23, bb24
+  bb24:
+    jump bb13
+  bb23:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb21:
+    v26 = and arg1, 1
+    v27 = select v26, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
+    jump bb7
+  bb11:
+    v13 = eq arg0, 1
+    jumpi v13, bb7, bb14
   bb14:
     v14 = lt arg0, 11
     v15 = lt arg1, 78
@@ -372,60 +375,51 @@ fn @spow8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
     v19 = and v17, v18
     v20 = or v16, v19
     jumpi v20, bb15, bb16
-  bb15:
-    v21 = exp arg0, arg1
-    v22 = gt v21, 127
-    jumpi v22, bb17, bb18
   bb16:
     v23 = div 127, arg0
     v24 = gt arg0, v23
     jumpi v24, bb19, bb20
-  bb17:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb18:
-    jump bb7
-  bb19:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb20:
     jump bb13
-  bb21:
-    v26 = and arg1, 1
-    v27 = select v26, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
-    jump bb7
-  bb22:
-    v28 = sdiv 127, arg0
-    v29 = slt arg0, v28
-    jumpi v29, bb23, bb24
-  bb23:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb24:
-    jump bb13
+  bb13:
+    v30 = and arg1, 1
+    v31 = select v30, arg0, 1
+    v32 = mul arg0, arg0
+    v33 = shr 1, arg1
+    jump bb25
   bb25:
     v34 = phi [bb13: v31], [bb29: v42]
     v35 = phi [bb13: v32], [bb29: v43]
     v36 = phi [bb13: v33], [bb29: v44]
     v37 = gt v36, 1
     jumpi v37, bb26, bb27
-  bb26:
-    v38 = div 127, v35
-    v39 = gt v35, v38
-    jumpi v39, bb28, bb29
   bb27:
     v45 = sgt v34, 0
     v46 = div 127, v35
     v47 = gt v34, v46
     v48 = and v45, v47
     jumpi v48, bb30, bb31
-  bb28:
+  bb31:
+    v49 = slt v34, 0
+    v50 = sdiv 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80, v35
+    v51 = slt v34, v50
+    v52 = and v49, v51
+    jumpi v52, bb32, bb33
+  bb33:
+    v53 = mul v34, v35
+    jump bb7
+  bb32:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb30:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb26:
+    v38 = div 127, v35
+    v39 = gt v35, v38
+    jumpi v39, bb28, bb29
   bb29:
     v40 = and v36, 1
     v41 = mul v34, v35
@@ -433,23 +427,29 @@ fn @spow8(arg0: i8, arg1: u8) -> i8 [abi_returns=[word]] {
     v43 = mul v35, v35
     v44 = shr 1, v36
     jump bb25
-  bb30:
+  bb28:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb31:
-    v49 = slt v34, 0
-    v50 = sdiv 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80, v35
-    v51 = slt v34, v50
-    v52 = and v49, v51
-    jumpi v52, bb32, bb33
-  bb32:
+  bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb33:
-    v53 = mul v34, v35
+  bb15:
+    v21 = exp arg0, arg1
+    v22 = gt v21, 127
+    jumpi v22, bb17, bb18
+  bb18:
     jump bb7
+  bb17:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    v54 = phi [bb6: 1], [bb8: arg0], [bb9: 0], [bb11: 1], [bb18: v21], [bb21: v27], [bb33: v53]
+    ret v54
+  bb1:
+    revert 0, 0
 }
 
 fn @const2(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -458,18 +458,18 @@ fn @const2(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 255
     jumpi v3, bb3, bb4
+  bb4:
+    v4 = shl arg0, 1
+    ret v4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v4 = shl arg0, 1
-    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @const10(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -478,18 +478,18 @@ fn @const10(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 77
     jumpi v3, bb3, bb4
+  bb4:
+    v4 = exp 10, arg0
+    ret v4
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v4 = exp 10, arg0
-    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @const_neg2(arg0: u256) -> i256 [abi_returns=[word]] {
@@ -498,22 +498,13 @@ fn @const_neg2(arg0: u256) -> i256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq 2, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
     jumpi v3, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v4 = sub 0, 2
     v5 = iszero arg0
     jumpi v5, bb5, bb6
-  bb5:
-    v50 = phi [bb4: 1], [bb6: v4], [bb7: 0], [bb9: 1], [bb16: v17], [bb19: v23], [bb31: v49]
-    ret v50
   bb6:
     v6 = eq arg0, 1
     jumpi v6, bb5, bb7
@@ -523,18 +514,26 @@ fn @const_neg2(arg0: u256) -> i256 [abi_returns=[word]] {
   bb8:
     v8 = sgt v4, 0
     jumpi v8, bb9, bb10
-  bb9:
-    v9 = eq v4, 1
-    jumpi v9, bb5, bb12
   bb10:
     v21 = eq v4, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     jumpi v21, bb19, bb20
-  bb11:
-    v26 = and arg0, 1
-    v27 = select v26, v4, 1
-    v28 = mul v4, v4
-    v29 = shr 1, arg0
-    jump bb23
+  bb20:
+    v24 = sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v4
+    v25 = slt v4, v24
+    jumpi v25, bb21, bb22
+  bb22:
+    jump bb11
+  bb21:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb19:
+    v22 = and arg0, 1
+    v23 = select v22, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
+    jump bb5
+  bb9:
+    v9 = eq v4, 1
+    jumpi v9, bb5, bb12
   bb12:
     v10 = lt v4, 11
     v11 = lt arg0, 78
@@ -544,60 +543,51 @@ fn @const_neg2(arg0: u256) -> i256 [abi_returns=[word]] {
     v15 = and v13, v14
     v16 = or v12, v15
     jumpi v16, bb13, bb14
-  bb13:
-    v17 = exp v4, arg0
-    v18 = gt v17, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    jumpi v18, bb15, bb16
   bb14:
     v19 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v4
     v20 = gt v4, v19
     jumpi v20, bb17, bb18
-  bb15:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb16:
-    jump bb5
-  bb17:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb18:
     jump bb11
-  bb19:
-    v22 = and arg0, 1
-    v23 = select v22, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 1
-    jump bb5
-  bb20:
-    v24 = sdiv 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v4
-    v25 = slt v4, v24
-    jumpi v25, bb21, bb22
-  bb21:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb22:
-    jump bb11
+  bb11:
+    v26 = and arg0, 1
+    v27 = select v26, v4, 1
+    v28 = mul v4, v4
+    v29 = shr 1, arg0
+    jump bb23
   bb23:
     v30 = phi [bb11: v27], [bb27: v38]
     v31 = phi [bb11: v28], [bb27: v39]
     v32 = phi [bb11: v29], [bb27: v40]
     v33 = gt v32, 1
     jumpi v33, bb24, bb25
-  bb24:
-    v34 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v31
-    v35 = gt v31, v34
-    jumpi v35, bb26, bb27
   bb25:
     v41 = sgt v30, 0
     v42 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v31
     v43 = gt v30, v42
     v44 = and v41, v43
     jumpi v44, bb28, bb29
-  bb26:
+  bb29:
+    v45 = slt v30, 0
+    v46 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, v31
+    v47 = slt v30, v46
+    v48 = and v45, v47
+    jumpi v48, bb30, bb31
+  bb31:
+    v49 = mul v30, v31
+    jump bb5
+  bb30:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb28:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb24:
+    v34 = div 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, v31
+    v35 = gt v31, v34
+    jumpi v35, bb26, bb27
   bb27:
     v36 = and v32, 1
     v37 = mul v30, v31
@@ -605,23 +595,33 @@ fn @const_neg2(arg0: u256) -> i256 [abi_returns=[word]] {
     v39 = mul v31, v31
     v40 = shr 1, v32
     jump bb23
-  bb28:
+  bb26:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb29:
-    v45 = slt v30, 0
-    v46 = sdiv 0x8000000000000000000000000000000000000000000000000000000000000000, v31
-    v47 = slt v30, v46
-    v48 = and v45, v47
-    jumpi v48, bb30, bb31
-  bb30:
+  bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb31:
-    v49 = mul v30, v31
+  bb13:
+    v17 = exp v4, arg0
+    v18 = gt v17, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+    jumpi v18, bb15, bb16
+  bb16:
     jump bb5
+  bb15:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    v50 = phi [bb4: 1], [bb6: v4], [bb7: 0], [bb9: 1], [bb16: v17], [bb19: v23], [bb31: v49]
+    ret v50
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @unchecked_pow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
@@ -630,8 +630,6 @@ fn @unchecked_pow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -650,5 +648,7 @@ fn @unchecked_pow8(arg0: u8, arg1: u8) -> u8 [abi_returns=[word]] {
     v9 = exp arg0, arg1
     v10 = and v9, 255
     ret v10
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/comparison.stdout
+++ b/tests/ui/codegen/lowering/comparison.stdout
@@ -6,11 +6,11 @@ fn @eq(arg0: u256, arg1: u256) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @lt(arg0: u256, arg1: u256) -> bool [abi_returns=[word]] {
@@ -19,11 +19,11 @@ fn @lt(arg0: u256, arg1: u256) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, arg1
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @is_zero(arg0: u256) -> bool [abi_returns=[word]] {
@@ -32,10 +32,10 @@ fn @is_zero(arg0: u256) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0
     ret v3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/compound_assign.stdout
+++ b/tests/ui/codegen/lowering/compound_assign.stdout
@@ -12,20 +12,20 @@ fn @add_to_value(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = add v3, arg0
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
+  bb4:
+    sstore 0, v4 !metadata(storage=slot(0))
+    stop
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    sstore 0, v4 !metadata(storage=slot(0))
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @sub_from_value(arg0: u256) {
@@ -34,20 +34,20 @@ fn @sub_from_value(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = sub v3, arg0
     v5 = lt v3, arg0
     jumpi v5, bb3, bb4
+  bb4:
+    sstore 0, v4 !metadata(storage=slot(0))
+    stop
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    sstore 0, v4 !metadata(storage=slot(0))
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @mul_value(arg0: u256) {
@@ -56,8 +56,6 @@ fn @mul_value(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sload 0 !metadata(storage=slot(0))
     v4 = mul v3, arg0
@@ -67,13 +65,15 @@ fn @mul_value(arg0: u256) {
     v8 = or v5, v7
     v9 = iszero v8
     jumpi v9, bb3, bb4
+  bb4:
+    sstore 0, v4 !metadata(storage=slot(0))
+    stop
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    sstore 0, v4 !metadata(storage=slot(0))
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @bump_post() -> u256 [abi_returns=[word]] {
@@ -82,13 +82,13 @@ fn @bump_post() -> u256 [abi_returns=[word]] {
     v1 = add v0, 1
     v2 = lt v1, v0
     jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    sstore 0, v1 !metadata(storage=slot(0))
-    ret v0
 }
 
 fn @bump_pre() -> u256 [abi_returns=[word]] {
@@ -97,12 +97,12 @@ fn @bump_pre() -> u256 [abi_returns=[word]] {
     v1 = add v0, 1
     v2 = lt v1, v0
     jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    ret v1
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    sstore 0, v1 !metadata(storage=slot(0))
-    ret v1
 }
 

--- a/tests/ui/codegen/lowering/constructor_internal_call.mir.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_call.mir.stdout
@@ -18,8 +18,6 @@ fn @helper(arg0: u256) -> u256 {
   bb0:
     v0 = eq arg0, 0
     jumpi v0, bb1, bb2
-  bb1:
-    ret 1
   bb2:
     v1 = mul arg0, 11
     v2 = iszero 11
@@ -28,28 +26,30 @@ fn @helper(arg0: u256) -> u256 {
     v5 = or v2, v4
     v6 = iszero v5
     jumpi v6, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v7 = sub arg0, 1
     v8 = lt arg0, 1
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = internal_call @helper, 1, v7
     v10 = add v1, v9
     v11 = lt v10, v1
     jumpi v11, bb7, bb8
+  bb8:
+    ret v10
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v10
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    ret 1
 }
 

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
@@ -21,8 +21,6 @@ fn @helper(arg0: u256) -> u256 {
   bb0:
     v0 = eq arg0, 0
     jumpi v0, bb1, bb2
-  bb1:
-    ret 1
   bb2:
     v1 = mul arg0, 7
     v2 = iszero 7
@@ -31,28 +29,30 @@ fn @helper(arg0: u256) -> u256 {
     v5 = or v2, v4
     v6 = iszero v5
     jumpi v6, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v7 = sub arg0, 1
     v8 = lt arg0, 1
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = internal_call @helper, 1, v7
     v10 = add v1, v9
     v11 = lt v10, v1
     jumpi v11, bb7, bb8
+  bb8:
+    ret v10
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v10
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    ret 1
 }
 

--- a/tests/ui/codegen/lowering/custom_error_payloads.stdout
+++ b/tests/ui/codegen/lowering/custom_error_payloads.stdout
@@ -50,8 +50,6 @@ fn @require_empty(arg0: bool) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -63,12 +61,14 @@ fn @require_empty(arg0: bool) {
   bb4:
     v7 = iszero arg0
     jumpi v7, bb5, bb6
+  bb6:
+    stop
   bb5:
     v8 = alloc raw, exact, uninitialized, infallible, 4
     mstore v8, 0x4f3d7def00000000000000000000000000000000000000000000000000000000
     revert v8, 4
-  bb6:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @require_named(arg0: bool) {
@@ -77,8 +77,6 @@ fn @require_named(arg0: bool) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -90,6 +88,8 @@ fn @require_named(arg0: bool) {
   bb4:
     v7 = iszero arg0
     jumpi v7, bb5, bb6
+  bb6:
+    stop
   bb5:
     v8 = alloc memorybytes, exact, uninitialized, infallible, 64
     set_memory_object_len memorybytes, v8, 6
@@ -112,8 +112,6 @@ fn @require_named(arg0: bool) {
     v20 = add v13, 32
     v21 = iszero v19
     jumpi v21, bb8, bb7
-  bb6:
-    stop
   bb7:
     v22 = sub v19, 32
     v23 = add v20, v22
@@ -126,5 +124,7 @@ fn @require_named(arg0: bool) {
     v26 = sub v25, v12
     v27 = add v26, 4
     revert v11, v27
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/dynamic_struct_param.stdout
+++ b/tests/ui/codegen/lowering/dynamic_struct_param.stdout
@@ -6,13 +6,9 @@ fn @init(arg0: u256, arg1: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 0xffffffffffffffff
     jumpi v3, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v4 = add 4, arg0
     v5 = alloc raw, exact, uninitialized, infallible, 160
@@ -41,10 +37,6 @@ fn @init(arg0: u256, arg1: address) -> u256 [abi_returns=[word]] {
     v18 = add v17, 31
     v19 = lt v18, v17
     jumpi v19, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v20 = not 31
     v21 = and v18, v20
@@ -53,10 +45,6 @@ fn @init(arg0: u256, arg1: address) -> u256 [abi_returns=[word]] {
     v24 = add 32, v23
     v25 = lt v24, v23
     jumpi v25, bb11, bb12
-  bb11:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb12:
     v26 = alloc memorybytes, exact, uninitialized, infallible, v24
     mstore v26, v17
@@ -75,10 +63,6 @@ fn @init(arg0: u256, arg1: address) -> u256 [abi_returns=[word]] {
     v36 = add v35, 31
     v37 = lt v36, v35
     jumpi v37, bb13, bb14
-  bb13:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb14:
     v38 = not 31
     v39 = and v36, v38
@@ -87,10 +71,6 @@ fn @init(arg0: u256, arg1: address) -> u256 [abi_returns=[word]] {
     v42 = add 32, v41
     v43 = lt v42, v41
     jumpi v43, bb15, bb16
-  bb15:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb16:
     v44 = alloc memorybytes, exact, uninitialized, infallible, v42
     mstore v44, v35
@@ -117,12 +97,32 @@ fn @init(arg0: u256, arg1: address) -> u256 [abi_returns=[word]] {
     v57 = add v55, v56
     v58 = gt v57, 0xffffffffffffffffffffffffffffffffffffffff
     jumpi v58, bb19, bb20
+  bb20:
+    ret v57
   bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb20:
-    ret v57
+  bb15:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @flat(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -131,8 +131,6 @@ fn @flat(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
     v4 = memory_object_field_addr memorystruct<2>, v3, 0
@@ -149,5 +147,7 @@ fn @flat(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v9 = memory_object_field_addr memorystruct<2>, v3, 0
     v10 = mload v9
     ret v10
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/event_dynamic_data.stdout
+++ b/tests/ui/codegen/lowering/event_dynamic_data.stdout
@@ -6,8 +6,6 @@ fn @text(arg0: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -51,6 +49,8 @@ fn @text(arg0: memorybytes) {
     set_fmp v30
     log2 v12, v26, 0x1ec47f6be8a8bf4aa7aa1659aceb7cef3b607892101a00e4afd57e2ae4fbf3c4, 1
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @literal() {
@@ -99,8 +99,6 @@ fn @blob(arg0: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -142,5 +140,7 @@ fn @blob(arg0: memorybytes) {
     set_fmp v29
     log1 v12, v25, 0xd05ce3dc4caf4a4b252e3323bde615dc3b9d54623e1859c892f0b4ecf5e45164
     stop
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/event_encoding.stdout
+++ b/tests/ui/codegen/lowering/event_encoding.stdout
@@ -6,8 +6,6 @@ fn @emitArray(arg0: u256, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
     v4 = memory_object_element_addr memoryfixedarray<2, 1>, v3, 0
@@ -23,6 +21,8 @@ fn @emitArray(arg0: u256, arg1: u256) {
     v10 = add 32, 32
     log1 0, 64, 0x625921711aa49386aa5b640487cbc3efdcbda2656254ae2c5ad71b2ede1efcf4
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @emitAnonymous(arg0: address, arg1: u256) {
@@ -31,8 +31,6 @@ fn @emitAnonymous(arg0: address, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -44,6 +42,8 @@ fn @emitAnonymous(arg0: address, arg1: u256) {
     mstore 0, arg1 !metadata(memory=scratch)
     log1 0, 32, arg0
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @emitIndexedBytes(arg0: memorybytes) {
@@ -52,8 +52,6 @@ fn @emitIndexedBytes(arg0: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -69,6 +67,8 @@ fn @emitIndexedBytes(arg0: memorybytes) {
     v12 = keccak256_bytes v9
     log2 0, 0, 0x302971c456dab97076d583d969187faf914418423e0641b0c0f01537060f04e7, v12
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @emitIndexedFixedBytes() {

--- a/tests/ui/codegen/lowering/event_overloads.stdout
+++ b/tests/ui/codegen/lowering/event_overloads.stdout
@@ -6,8 +6,6 @@ fn @emitBoth(arg0: address, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -22,5 +20,7 @@ fn @emitBoth(arg0: address, arg1: u256) {
     mstore 32, arg1 !metadata(memory=scratch)
     log1 0, 64, 0x69ca02dd4edd7bf0a4abb9ed3b7af3f14778db5d61921c7dc7cd545266326de2
     stop
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.byzantium.stdout
@@ -6,8 +6,6 @@ fn @read(arg0: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -29,6 +27,8 @@ fn @read(arg0: address) -> u256 [abi_returns=[word]] {
   bb6:
     v12 = mload 0 !metadata(memory=scratch)
     ret v12
+  bb1:
+    revert 0, 0
 }
 
 fn @readPointer(arg0: function) -> u256 [abi_returns=[word]] {
@@ -37,8 +37,6 @@ fn @readPointer(arg0: function) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = and arg0, 0xffffffff
     v4 = shl 224, v3
@@ -56,5 +54,7 @@ fn @readPointer(arg0: function) -> u256 [abi_returns=[word]] {
   bb4:
     v12 = mload 0 !metadata(memory=scratch)
     ret v12
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
+++ b/tests/ui/codegen/lowering/external_view_call_evm_version.homestead.stdout
@@ -6,8 +6,6 @@ fn @read(arg0: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -27,6 +25,8 @@ fn @read(arg0: address) -> u256 [abi_returns=[word]] {
   bb6:
     v11 = mload 0 !metadata(memory=scratch)
     ret v11
+  bb1:
+    revert 0, 0
 }
 
 fn @readPointer(arg0: function) -> u256 [abi_returns=[word]] {
@@ -35,8 +35,6 @@ fn @readPointer(arg0: function) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = and arg0, 0xffffffff
     v4 = shl 224, v3
@@ -52,5 +50,7 @@ fn @readPointer(arg0: function) -> u256 [abi_returns=[word]] {
   bb4:
     v11 = mload 0 !metadata(memory=scratch)
     ret v11
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/fixed_bytes_canonical.stdout
+++ b/tests/ui/codegen/lowering/fixed_bytes_canonical.stdout
@@ -6,8 +6,6 @@ fn @fromUint(arg0: u8) -> bytes1 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -19,6 +17,8 @@ fn @fromUint(arg0: u8) -> bytes1 [abi_returns=[word]] {
     v6 = shl 248, arg0
     v7 = and v6, 0xff00000000000000000000000000000000000000000000000000000000000000
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @fromHex() -> bytes1 [abi_returns=[word]] {
@@ -32,8 +32,6 @@ fn @compareElement(arg0: memorybytes) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -63,6 +61,8 @@ fn @compareElement(arg0: memorybytes) -> bool [abi_returns=[word]] {
     v20 = and v19, 0xff00000000000000000000000000000000000000000000000000000000000000
     v21 = eq v17, v20
     ret v21
+  bb1:
+    revert 0, 0
 }
 
 fn @narrow(arg0: bytes4) -> bytes2 [abi_returns=[word]] {
@@ -71,8 +71,6 @@ fn @narrow(arg0: bytes4) -> bytes2 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffff00000000000000000000000000000000000000000000000000000000
@@ -83,5 +81,7 @@ fn @narrow(arg0: bytes4) -> bytes2 [abi_returns=[word]] {
   bb4:
     v6 = and arg0, 0xffff000000000000000000000000000000000000000000000000000000000000
     ret v6
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/function_call.mir.stdout
+++ b/tests/ui/codegen/lowering/function_call.mir.stdout
@@ -5,12 +5,12 @@ fn @double(arg0: u256) -> u256 {
     v0 = add arg0, arg0
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @quadruple(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -19,12 +19,12 @@ fn @quadruple(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @double, 1, arg0
     v4 = internal_call @double, 1, v3
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @sum_then_double(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -33,18 +33,18 @@ fn @sum_then_double(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    v5 = internal_call @double, 1, v3
+    ret v5
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v5 = internal_call @double, 1, v3
-    ret v5
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/immutable_reads.stdout
+++ b/tests/ui/codegen/lowering/immutable_reads.stdout
@@ -23,13 +23,13 @@ fn @_anonymous(arg0: u256) {
     v1 = add v0, 1
     v2 = lt v1, v0
     jumpi v2, bb1, bb2
+  bb2:
+    storeimmutable duration, v1
+    stop
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    storeimmutable duration, v1
-    stop
 }
 
 fn @end() -> u256 [abi_returns=[word]] {
@@ -39,11 +39,11 @@ fn @end() -> u256 [abi_returns=[word]] {
     v2 = add v0, v1
     v3 = lt v2, v0
     jumpi v3, bb1, bb2
+  bb2:
+    ret v2
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v2
 }
 

--- a/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.stdout
@@ -22,12 +22,12 @@ fn @__internal_dispatch_0(arg0: function) -> u256 {
   bb0:
     v0 = eq arg0, 2
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @onlyStored, 1
-    ret v1
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb1:
+    v1 = internal_call @onlyStored, 1
+    ret v1
 }
 

--- a/tests/ui/codegen/lowering/internal-function-pointer/higher_order_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/higher_order_mir.sol
@@ -47,11 +47,11 @@ contract HigherOrderFunctionPointer {
     // CHECK: internal_call @__internal_dispatch_1, 1, {{v[0-9]+}}
     // CHECK-LABEL: fn @__internal_dispatch_0(
     // CHECK: eq arg0, [[HIGHER1]]
-    // CHECK: internal_call @higher1, 1
     // CHECK: eq arg0, [[HIGHER2]]
-    // CHECK: internal_call @higher2, 1
     // CHECK: eq arg0, [[HIGHER3]]
     // CHECK: internal_call @higher3, 1
+    // CHECK: internal_call @higher2, 1
+    // CHECK: internal_call @higher1, 1
     // CHECK-LABEL: fn @__internal_dispatch_1(
     // CHECK: eq arg0, [[HIGHER0]]
     // CHECK: internal_call @higher0.7, 1

--- a/tests/ui/codegen/lowering/internal-function-pointer/higher_order_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/higher_order_mir.stdout
@@ -33,38 +33,38 @@ fn @__internal_dispatch_0(arg0: function) -> function {
   bb0:
     v0 = eq arg0, 2
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @higher1, 1
-    ret v1
   bb2:
     v2 = eq arg0, 3
     jumpi v2, bb3, bb4
-  bb3:
-    v3 = internal_call @higher2, 1
-    ret v3
   bb4:
     v4 = eq arg0, 4
     jumpi v4, bb5, bb6
-  bb5:
-    v5 = internal_call @higher3, 1
-    ret v5
   bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb5:
+    v5 = internal_call @higher3, 1
+    ret v5
+  bb3:
+    v3 = internal_call @higher2, 1
+    ret v3
+  bb1:
+    v1 = internal_call @higher1, 1
+    ret v1
 }
 
 fn @__internal_dispatch_1(arg0: function) -> u256 {
   bb0:
     v0 = eq arg0, 1
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @higher0.7, 1
-    ret v1
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb1:
+    v1 = internal_call @higher0.7, 1
+    ret v1
 }
 
 fn @higher0.7() -> u256 {

--- a/tests/ui/codegen/lowering/internal-function-pointer/inheritance_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/inheritance_mir.sol
@@ -22,9 +22,9 @@ contract PointerBase {
 // CHECK: internal_call @__internal_dispatch_0, 1, [[BASE_TARGET:[0-9]+]]
 // CHECK-LABEL: fn @__internal_dispatch_0(
 // CHECK: eq arg0, [[BASE_TARGET]]
-// CHECK: internal_call @target.5, 1
 // CHECK: eq arg0, [[DERIVED_TARGET:[0-9]+]]
 // CHECK: internal_call @target.0, 1
+// CHECK: internal_call @target.5, 1
 // CHECK-LABEL: fn @callVirtual(
 // CHECK: internal_call @callThroughVirtualPointer, 1
 // CHECK-LABEL: fn @callThroughVirtualPointer(

--- a/tests/ui/codegen/lowering/internal-function-pointer/inheritance_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/inheritance_mir.stdout
@@ -18,19 +18,19 @@ fn @__internal_dispatch_0(arg0: function) -> u256 {
   bb0:
     v0 = eq arg0, 1
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @target.5, 1
-    ret v1
   bb2:
     v2 = eq arg0, 3
     jumpi v2, bb3, bb4
-  bb3:
-    v3 = internal_call @target.0, 1
-    ret v3
   bb4:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb3:
+    v3 = internal_call @target.0, 1
+    ret v3
+  bb1:
+    v1 = internal_call @target.5, 1
+    ret v1
 }
 
 fn @callVirtual() -> u256 [abi_returns=[word]] {

--- a/tests/ui/codegen/lowering/internal-function-pointer/memory_array_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/memory_array_mir.sol
@@ -34,15 +34,15 @@ contract FunctionPointerMemoryArray {
     // CHECK: internal_call @__internal_dispatch_0, 1, [[ARRAY_FN]], arg0
     // CHECK-LABEL: fn @__internal_dispatch_0(
     // CHECK: eq arg0, [[A]]
-    // CHECK: internal_call @arrayA.7, 1, arg1
     // CHECK: eq arg0, [[B]]
-    // CHECK: internal_call @arrayB.8, 1, arg1
     // CHECK: eq arg0, [[C]]
-    // CHECK: internal_call @arrayC.9, 1, arg1
     // CHECK: eq arg0, [[D]]
-    // CHECK: internal_call @arrayD.10, 1, arg1
     // CHECK: eq arg0, [[E]]
     // CHECK: internal_call @arrayE.11, 1, arg1
+    // CHECK: internal_call @arrayD.10, 1, arg1
+    // CHECK: internal_call @arrayC.9, 1, arg1
+    // CHECK: internal_call @arrayB.8, 1, arg1
+    // CHECK: internal_call @arrayA.7, 1, arg1
     function callArray(uint256 x, uint256 index) public returns (uint256) {
         function(uint256) internal returns (uint256)[] memory functions =
             new function(uint256) internal returns (uint256)[](10);

--- a/tests/ui/codegen/lowering/internal-function-pointer/memory_array_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/memory_array_mir.stdout
@@ -6,18 +6,18 @@ fn @arrayA.0(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 1
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @arrayB.1(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -26,18 +26,18 @@ fn @arrayB.1(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 2
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @arrayC.2(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -46,18 +46,18 @@ fn @arrayC.2(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 3
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @arrayD.3(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -66,18 +66,18 @@ fn @arrayD.3(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 5
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @arrayE.4(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -86,18 +86,18 @@ fn @arrayE.4(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 8
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @callArray(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -106,8 +106,6 @@ fn @callArray(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul 10, 32
     v4 = div v3, 32
@@ -121,10 +119,6 @@ fn @callArray(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, 10
@@ -190,43 +184,49 @@ fn @callArray(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v27 = mload v26
     v28 = internal_call @__internal_dispatch_0, 1, v27, arg0
     ret v28
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @__internal_dispatch_0(arg0: function, arg1: u256) -> u256 {
   bb0:
     v0 = eq arg0, 1
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @arrayA.7, 1, arg1
-    ret v1
   bb2:
     v2 = eq arg0, 2
     jumpi v2, bb3, bb4
-  bb3:
-    v3 = internal_call @arrayB.8, 1, arg1
-    ret v3
   bb4:
     v4 = eq arg0, 3
     jumpi v4, bb5, bb6
-  bb5:
-    v5 = internal_call @arrayC.9, 1, arg1
-    ret v5
   bb6:
     v6 = eq arg0, 4
     jumpi v6, bb7, bb8
-  bb7:
-    v7 = internal_call @arrayD.10, 1, arg1
-    ret v7
   bb8:
     v8 = eq arg0, 5
     jumpi v8, bb9, bb10
-  bb9:
-    v9 = internal_call @arrayE.11, 1, arg1
-    ret v9
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb9:
+    v9 = internal_call @arrayE.11, 1, arg1
+    ret v9
+  bb7:
+    v7 = internal_call @arrayD.10, 1, arg1
+    ret v7
+  bb5:
+    v5 = internal_call @arrayC.9, 1, arg1
+    ret v5
+  bb3:
+    v3 = internal_call @arrayB.8, 1, arg1
+    ret v3
+  bb1:
+    v1 = internal_call @arrayA.7, 1, arg1
+    ret v1
 }
 
 fn @arrayA.7(arg0: u256) -> u256 {
@@ -234,12 +234,12 @@ fn @arrayA.7(arg0: u256) -> u256 {
     v0 = add arg0, 1
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @arrayB.8(arg0: u256) -> u256 {
@@ -247,12 +247,12 @@ fn @arrayB.8(arg0: u256) -> u256 {
     v0 = add arg0, 2
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @arrayC.9(arg0: u256) -> u256 {
@@ -260,12 +260,12 @@ fn @arrayC.9(arg0: u256) -> u256 {
     v0 = add arg0, 3
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @arrayD.10(arg0: u256) -> u256 {
@@ -273,12 +273,12 @@ fn @arrayD.10(arg0: u256) -> u256 {
     v0 = add arg0, 5
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @arrayE.11(arg0: u256) -> u256 {
@@ -286,11 +286,11 @@ fn @arrayE.11(arg0: u256) -> u256 {
     v0 = add arg0, 8
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 

--- a/tests/ui/codegen/lowering/internal-function-pointer/selection_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/selection_mir.sol
@@ -3,18 +3,18 @@
 
 contract FunctionPointerSelection {
     // CHECK-LABEL: fn @choose(
-    // CHECK: mstore 0, [[INCREMENT:[0-9]+]]
     // CHECK: mstore 0, [[DECREMENT:[0-9]+]]
+    // CHECK: mstore 0, [[INCREMENT:[0-9]+]]
     // CHECK: internal_call @__internal_dispatch_0, 1, {{v[0-9]+}}, arg1
     // CHECK-LABEL: fn @__internal_dispatch_0(
     // CHECK: eq arg0, [[INCREMENT]]
-    // CHECK: internal_call @increment, 1, arg1
     // CHECK: eq arg0, [[DECREMENT]]
-    // CHECK: internal_call @decrement, 1, arg1
     // CHECK: eq arg0, [[INCREMENT_VIEW:[0-9]+]]
-    // CHECK: internal_call @incrementView, 1, arg1
     // CHECK: mstore 4, 81
     // CHECK: revert 0, 36
+    // CHECK: internal_call @incrementView, 1, arg1
+    // CHECK: internal_call @decrement, 1, arg1
+    // CHECK: internal_call @increment, 1, arg1
     function choose(bool add, uint256 value) public returns (uint256) {
         function(uint256) internal returns (uint256) fn = add ? increment : decrement;
         return fn(value);

--- a/tests/ui/codegen/lowering/internal-function-pointer/selection_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/selection_mir.stdout
@@ -6,8 +6,6 @@ fn @choose(arg0: bool, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -18,41 +16,43 @@ fn @choose(arg0: bool, arg1: u256) -> u256 [abi_returns=[word]] {
     revert 0, 0
   bb4:
     jumpi arg0, bb5, bb6
-  bb5:
-    mstore 0, 2 !metadata(memory=scratch)
-    jump bb7
   bb6:
     mstore 0, 3 !metadata(memory=scratch)
+    jump bb7
+  bb5:
+    mstore 0, 2 !metadata(memory=scratch)
     jump bb7
   bb7:
     v7 = mload 0 !metadata(memory=scratch)
     v8 = internal_call @__internal_dispatch_0, 1, v7, arg1
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @__internal_dispatch_0(arg0: function, arg1: u256) -> u256 {
   bb0:
     v0 = eq arg0, 2
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @increment, 1, arg1
-    ret v1
   bb2:
     v2 = eq arg0, 3
     jumpi v2, bb3, bb4
-  bb3:
-    v3 = internal_call @decrement, 1, arg1
-    ret v3
   bb4:
     v4 = eq arg0, 7
     jumpi v4, bb5, bb6
-  bb5:
-    v5 = internal_call @incrementView, 1, arg1
-    ret v5
   bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb5:
+    v5 = internal_call @incrementView, 1, arg1
+    ret v5
+  bb3:
+    v3 = internal_call @decrement, 1, arg1
+    ret v3
+  bb1:
+    v1 = internal_call @increment, 1, arg1
+    ret v1
 }
 
 fn @increment(arg0: u256) -> u256 {
@@ -60,12 +60,12 @@ fn @increment(arg0: u256) -> u256 {
     v0 = add arg0, 1
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @decrement(arg0: u256) -> u256 {
@@ -73,12 +73,12 @@ fn @decrement(arg0: u256) -> u256 {
     v0 = sub arg0, 1
     v1 = lt arg0, 1
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @callConstant(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -87,11 +87,11 @@ fn @callConstant(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @__internal_dispatch_0, 1, 2, arg0
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @throughCast(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -100,12 +100,12 @@ fn @throughCast(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @castViewToPure, 1, 7
     v4 = internal_call @__internal_dispatch_0, 1, v3, arg0
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @castViewToPure(arg0: function) -> function {
@@ -124,17 +124,17 @@ fn @incrementView(arg0: u256) -> u256 {
     v0 = number
     v1 = eq v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     jumpi v1, bb1, bb2
-  bb1:
-    ret arg0
   bb2:
     v2 = add arg0, 1
     v3 = lt v2, arg0
     jumpi v3, bb3, bb4
+  bb4:
+    ret v2
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v2
+  bb1:
+    ret arg0
 }
 

--- a/tests/ui/codegen/lowering/internal-function-pointer/signatures_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/signatures_mir.sol
@@ -11,8 +11,8 @@ contract FunctionPointerSignatures {
     // CHECK: internal_call @__internal_dispatch_0, 0, [[SET_FLAG]]
     // CHECK-LABEL: fn @__internal_dispatch_0(
     // CHECK: eq arg0, [[SET_FLAG]]
-    // CHECK: internal_call @setFlag.12, 0
     // CHECK: mstore 4, 81
+    // CHECK: internal_call @setFlag.12, 0
     function callVoid() public returns (bool) {
         function() internal fn = setFlag;
         fn();

--- a/tests/ui/codegen/lowering/internal-function-pointer/signatures_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/signatures_mir.stdout
@@ -18,13 +18,13 @@ fn @__internal_dispatch_0(arg0: function) {
   bb0:
     v0 = eq arg0, 2
     jumpi v0, bb1, bb2
-  bb1:
-    internal_call @setFlag.12, 0
-    ret
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb1:
+    internal_call @setFlag.12, 0
+    ret
 }
 
 fn @setFlag.3() {
@@ -52,30 +52,30 @@ fn @callPair(arg0: u256) -> (u256, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @__internal_dispatch_1, 2, 5, arg0
     v4 = mload 32 !metadata(memory=scratch)
     v5 = add v4, 32
     v6 = mload v5
     ret v3, v6
+  bb1:
+    revert 0, 0
 }
 
 fn @__internal_dispatch_1(arg0: function, arg1: u256) -> (u256, u256) {
   bb0:
     v0 = eq arg0, 5
     jumpi v0, bb1, bb2
+  bb2:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 81 !metadata(memory=scratch)
+    revert 0, 36
   bb1:
     v1 = internal_call @pair, 2, arg1
     v2 = mload 32 !metadata(memory=scratch)
     v3 = add v2, 32
     v4 = mload v3
     ret v1, v4
-  bb2:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 81 !metadata(memory=scratch)
-    revert 0, 36
 }
 
 fn @pair(arg0: u256) -> (u256, u256) {
@@ -83,12 +83,12 @@ fn @pair(arg0: u256) -> (u256, u256) {
     v0 = add arg0, 1
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret arg0, v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret arg0, v0
 }
 
 fn @callZero() {
@@ -102,12 +102,12 @@ fn @sum(arg0: u256, arg1: u256) -> u256 {
     v0 = add arg0, arg1
     v1 = lt v0, arg0
     jumpi v1, bb1, bb2
+  bb2:
+    ret v0
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    ret v0
 }
 
 fn @callTwoArgs() -> u256 [abi_returns=[word]] {
@@ -120,13 +120,13 @@ fn @__internal_dispatch_2(arg0: function, arg1: u256, arg2: u256) -> u256 {
   bb0:
     v0 = eq arg0, 7
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = internal_call @sum, 1, arg1, arg2
-    ret v1
   bb2:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 81 !metadata(memory=scratch)
     revert 0, 36
+  bb1:
+    v1 = internal_call @sum, 1, arg1, arg2
+    ret v1
 }
 
 fn @setFlag.12() {

--- a/tests/ui/codegen/lowering/internal_loop_call.stdout
+++ b/tests/ui/codegen/lowering/internal_loop_call.stdout
@@ -12,16 +12,12 @@ fn @sumTo(arg0: u256) -> u256 {
     v3 = mload v2 !metadata(memory=internal_frame)
     v4 = lt v3, arg0
     jumpi v4, bb4, bb5
+  bb5:
+    jump bb2
   bb2:
     v17 = internal_frame_addr 128
     v18 = mload v17 !metadata(memory=internal_frame)
     ret v18
-  bb3:
-    v12 = internal_frame_addr 160
-    v13 = mload v12 !metadata(memory=internal_frame)
-    v14 = add v13, 1
-    v15 = lt v14, v13
-    jumpi v15, bb8, bb9
   bb4:
     v5 = internal_frame_addr 160
     v6 = mload v5 !metadata(memory=internal_frame)
@@ -30,24 +26,28 @@ fn @sumTo(arg0: u256) -> u256 {
     v9 = add v8, v6
     v10 = lt v9, v8
     jumpi v10, bb6, bb7
-  bb5:
-    jump bb2
-  bb6:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb7:
     v11 = internal_frame_addr 128
     mstore v11, v9 !metadata(memory=internal_frame)
     jump bb3
-  bb8:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
+  bb3:
+    v12 = internal_frame_addr 160
+    v13 = mload v12 !metadata(memory=internal_frame)
+    v14 = add v13, 1
+    v15 = lt v14, v13
+    jumpi v15, bb8, bb9
   bb9:
     v16 = internal_frame_addr 160
     mstore v16, v14 !metadata(memory=internal_frame)
     jump bb1
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb6:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @run(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -56,10 +56,10 @@ fn @run(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @sumTo, 1, arg0
     ret v3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/internal_void_call.sol
+++ b/tests/ui/codegen/lowering/internal_void_call.sol
@@ -48,8 +48,8 @@ contract InternalVoidCall {
 
     // CHECK-LABEL: fn @unitTernary{{[( ]}}
     // CHECK: jumpi arg0,
-    // CHECK: internal_call @writeIfNonZero, 0, arg1
     // CHECK: internal_call @clear, 0
+    // CHECK: internal_call @writeIfNonZero, 0, arg1
     // CHECK-NOT: phi
     function unitTernary(bool writeValue, uint256 newValue) public {
         writeValue ? writeIfNonZero(newValue) : clear();

--- a/tests/ui/codegen/lowering/internal_void_call.stdout
+++ b/tests/ui/codegen/lowering/internal_void_call.stdout
@@ -12,11 +12,11 @@ fn @set(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     internal_call @writeIfNonZero, 0, arg0
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @writeIfNonZero(arg0: u256) {
@@ -37,16 +37,16 @@ fn @setUnlessZero(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0
     jumpi v3, bb3, bb4
-  bb3:
-    stop
   bb4:
     sstore 0, arg0 !metadata(storage=slot(0))
     stop
+  bb3:
+    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @returnVoidCall(arg0: u256) {
@@ -55,11 +55,11 @@ fn @returnVoidCall(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     internal_call @writeIfNonZero, 0, arg0
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @returnRevert() {
@@ -73,8 +73,6 @@ fn @unitTernary(arg0: bool, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -85,14 +83,16 @@ fn @unitTernary(arg0: bool, arg1: u256) {
     revert 0, 0
   bb4:
     jumpi arg0, bb5, bb6
-  bb5:
-    internal_call @writeIfNonZero, 0, arg1
-    jump bb7
   bb6:
     internal_call @clear, 0
     jump bb7
+  bb5:
+    internal_call @writeIfNonZero, 0, arg1
+    jump bb7
   bb7:
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @clear() {

--- a/tests/ui/codegen/lowering/linear.stdout
+++ b/tests/ui/codegen/lowering/linear.stdout
@@ -6,18 +6,18 @@ fn @add(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg1
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @sub(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -26,18 +26,18 @@ fn @sub(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sub arg0, arg1
     v4 = lt arg0, arg1
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @add_one(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -46,17 +46,17 @@ fn @add_one(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 1
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/loop_simple.sol
+++ b/tests/ui/codegen/lowering/loop_simple.sol
@@ -7,11 +7,11 @@ contract LoopSimple {
     // CHECK: lt [[I]], arg0
     // CHECK: {{v[0-9]+}} = mload 128
     // CHECK: ret
-    // CHECK: [[LOOP_I:v[0-9]+]] = mload 160
-    // CHECK: add [[LOOP_I]], 1
     // CHECK: [[TOTAL:v[0-9]+]] = mload 128
     // CHECK: [[BODY_I:v[0-9]+]] = mload 160
     // CHECK: add [[TOTAL]], [[BODY_I]]
+    // CHECK: [[LOOP_I:v[0-9]+]] = mload 160
+    // CHECK: add [[LOOP_I]], 1
     function sum_to(uint256 n) public pure returns (uint256) {
         uint256 total = 0;
         for (uint256 i = 0; i < n; i++) {

--- a/tests/ui/codegen/lowering/loop_simple.stdout
+++ b/tests/ui/codegen/lowering/loop_simple.stdout
@@ -6,8 +6,6 @@ fn @sum_to(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -16,35 +14,37 @@ fn @sum_to(arg0: u256) -> u256 [abi_returns=[word]] {
     v3 = mload 160
     v4 = lt v3, arg0
     jumpi v4, bb6, bb7
+  bb7:
+    jump bb4
   bb4:
     v12 = mload 128
     ret v12
-  bb5:
-    v9 = mload 160
-    v10 = add v9, 1
-    v11 = lt v10, v9
-    jumpi v11, bb10, bb11
   bb6:
     v5 = mload 128
     v6 = mload 160
     v7 = add v5, v6
     v8 = lt v7, v5
     jumpi v8, bb8, bb9
-  bb7:
-    jump bb4
-  bb8:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb9:
     mstore 128, v7
     jump bb5
+  bb5:
+    v9 = mload 160
+    v10 = add v9, 1
+    v11 = lt v10, v9
+    jumpi v11, bb10, bb11
+  bb11:
+    mstore 160, v10
+    jump bb3
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb11:
-    mstore 160, v10
-    jump bb3
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/low_level_call_returndata.stdout
+++ b/tests/ui/codegen/lowering/low_level_call_returndata.stdout
@@ -6,8 +6,6 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -45,20 +43,11 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
     v24 = mload v22
     v25 = eq v24, 0
     jumpi v25, bb10, bb9
-  bb8:
-    v35 = phi [bb6: 0], [bb10: v34]
-    v36 = iszero v35
-    jumpi v36, bb15, bb16
   bb9:
     v26 = memory_object_len memorybytes, v22
     v27 = memory_object_data memorybytes, v22
     v28 = lt v26, 32
     jumpi v28, bb11, bb12
-  bb10:
-    v34 = phi [bb7: 1], [bb14: v31]
-    jump bb8
-  bb11:
-    revert 0, 0
   bb12:
     v29 = mload v27
     v30 = iszero v29
@@ -66,15 +55,26 @@ fn @safeTransfer(arg0: address, arg1: address, arg2: u256) {
     v32 = eq v29, v31
     v33 = iszero v32
     jumpi v33, bb13, bb14
-  bb13:
-    revert 0, 0
   bb14:
     jump bb10
+  bb13:
+    revert 0, 0
+  bb11:
+    revert 0, 0
+  bb10:
+    v34 = phi [bb7: 1], [bb14: v31]
+    jump bb8
+  bb8:
+    v35 = phi [bb6: 0], [bb10: v34]
+    v36 = iszero v35
+    jumpi v36, bb15, bb16
+  bb16:
+    stop
   bb15:
     internal_call @__revert_error, 0, 2, 0x5446000000000000000000000000000000000000000000000000000000000000
     invalid
-  bb16:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_error(arg0: u256, arg1: u256) {
@@ -92,8 +92,6 @@ fn @balanceOf(arg0: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -123,18 +121,20 @@ fn @balanceOf(arg0: address) -> u256 [abi_returns=[word]] {
     returndatacopy v22, v15, v16
     v23 = iszero v12
     jumpi v23, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v24 = memory_object_len memorybytes, v21
     v25 = memory_object_data memorybytes, v21
     v26 = lt v24, 32
     jumpi v26, bb7, bb8
-  bb7:
-    revert 0, 0
   bb8:
     v27 = mload v25
     ret v27
+  bb7:
+    revert 0, 0
+  bb5:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @forward(arg0: address, arg1: memorybytes) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -143,8 +143,6 @@ fn @forward(arg0: address, arg1: memorybytes) -> memorybytes [abi_returns=[memor
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -182,9 +180,11 @@ fn @forward(arg0: address, arg1: memorybytes) -> memorybytes [abi_returns=[memor
     returndatacopy v28, v21, v22
     v29 = iszero v18
     jumpi v29, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     ret v27
+  bb5:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/low_level_staticcall_evm_version.byzantium.stdout
+++ b/tests/ui/codegen/lowering/low_level_staticcall_evm_version.byzantium.stdout
@@ -6,8 +6,6 @@ fn @probe(arg0: address) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -19,6 +17,8 @@ fn @probe(arg0: address) -> bool [abi_returns=[word]] {
     v6 = gas
     v7 = staticcall v6, arg0, 0, 0, 0, 0
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @probeCall(arg0: address) -> u256 [abi_returns=[word]] {
@@ -27,8 +27,6 @@ fn @probeCall(arg0: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -53,5 +51,7 @@ fn @probeCall(arg0: address) -> u256 [abi_returns=[word]] {
     returndatacopy v17, v10, v11
     v18 = mload v16
     ret v18
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/mapping.stdout
+++ b/tests/ui/codegen/lowering/mapping.stdout
@@ -6,12 +6,12 @@ fn @balances(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     v4 = sload v3 !metadata(storage=symbolic(v3))
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @allowances(arg0: address, arg1: address) -> u256 [abi_returns=[word]] {
@@ -20,8 +20,6 @@ fn @allowances(arg0: address, arg1: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -41,6 +39,8 @@ fn @allowances(arg0: address, arg1: address) -> u256 [abi_returns=[word]] {
     v10 = mapping_slot arg1, v9
     v11 = sload v10 !metadata(storage=symbolic(v10))
     ret v11
+  bb1:
+    revert 0, 0
 }
 
 fn @set_balance(arg0: u256, arg1: u256) {
@@ -49,12 +49,12 @@ fn @set_balance(arg0: u256, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     sstore v3, arg1 !metadata(storage=symbolic(v3))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @add_balance(arg0: u256, arg1: u256) {
@@ -63,22 +63,22 @@ fn @add_balance(arg0: u256, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     v4 = sload v3 !metadata(storage=symbolic(v3))
     v5 = add v4, arg1
     v6 = lt v5, v4
     jumpi v6, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v7 = mapping_slot arg0, 0
     sstore v7, v5 !metadata(storage=symbolic(v7))
     stop
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @approve(arg0: address, arg1: address, arg2: u256) {
@@ -87,8 +87,6 @@ fn @approve(arg0: address, arg1: address, arg2: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -108,6 +106,8 @@ fn @approve(arg0: address, arg1: address, arg2: u256) {
     v10 = mapping_slot arg1, v9
     sstore v10, arg2 !metadata(storage=symbolic(v10))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @get_allowance(arg0: address, arg1: address) -> u256 [abi_returns=[word]] {
@@ -116,8 +116,6 @@ fn @get_allowance(arg0: address, arg1: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -137,5 +135,7 @@ fn @get_allowance(arg0: address, arg1: address) -> u256 [abi_returns=[word]] {
     v10 = mapping_slot arg1, v9
     v11 = sload v10 !metadata(storage=symbolic(v10))
     ret v11
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/mapping_bytes_values.stdout
+++ b/tests/ui/codegen/lowering/mapping_bytes_values.stdout
@@ -6,8 +6,6 @@ fn @set(arg0: u256, arg1: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg1
     v4 = calldataload v3
@@ -64,6 +62,22 @@ fn @set(arg0: u256, arg1: memorybytes) {
     v43 = mload v32
     v44 = lt v43, v31
     jumpi v44, bb6, bb7
+  bb7:
+    mstore v32, v31
+    jump bb8
+  bb8:
+    v51 = mload v32
+    v52 = lt v51, v26
+    jumpi v52, bb9, bb10
+  bb10:
+    stop
+  bb9:
+    v53 = mload v32
+    v54 = add v33, v53
+    sstore v54, 0 !metadata(storage=symbolic(v54))
+    v55 = add v53, 1
+    mstore v32, v55
+    jump bb8
   bb6:
     v45 = mload v32
     v46 = add v33, v45
@@ -74,22 +88,8 @@ fn @set(arg0: u256, arg1: memorybytes) {
     v50 = add v45, 1
     mstore v32, v50
     jump bb5
-  bb7:
-    mstore v32, v31
-    jump bb8
-  bb8:
-    v51 = mload v32
-    v52 = lt v51, v26
-    jumpi v52, bb9, bb10
-  bb9:
-    v53 = mload v32
-    v54 = add v33, v53
-    sstore v54, 0 !metadata(storage=symbolic(v54))
-    v55 = add v53, 1
-    mstore v32, v55
-    jump bb8
-  bb10:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
@@ -98,8 +98,6 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg2
     v4 = calldataload v3
@@ -157,6 +155,22 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
     v44 = mload v33
     v45 = lt v44, v32
     jumpi v45, bb6, bb7
+  bb7:
+    mstore v33, v32
+    jump bb8
+  bb8:
+    v52 = mload v33
+    v53 = lt v52, v27
+    jumpi v53, bb9, bb10
+  bb10:
+    stop
+  bb9:
+    v54 = mload v33
+    v55 = add v34, v54
+    sstore v55, 0 !metadata(storage=symbolic(v55))
+    v56 = add v54, 1
+    mstore v33, v56
+    jump bb8
   bb6:
     v46 = mload v33
     v47 = add v34, v46
@@ -167,22 +181,8 @@ fn @setNested(arg0: u256, arg1: u256, arg2: memorybytes) {
     v51 = add v46, 1
     mstore v33, v51
     jump bb5
-  bb7:
-    mstore v33, v32
-    jump bb8
-  bb8:
-    v52 = mload v33
-    v53 = lt v52, v27
-    jumpi v53, bb9, bb10
-  bb9:
-    v54 = mload v33
-    v55 = add v34, v54
-    sstore v55, 0 !metadata(storage=symbolic(v55))
-    v56 = add v54, 1
-    mstore v33, v56
-    jump bb8
-  bb10:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @get(arg0: u256) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -191,12 +191,12 @@ fn @get(arg0: u256) -> memorybytes [abi_returns=[memory_bytes]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     v4 = internal_call @__load_storage_bytes, 1, v3
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memorybytes {
@@ -228,14 +228,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -251,12 +251,12 @@ fn @getNested(arg0: u256, arg1: u256) -> memorybytes [abi_returns=[memory_bytes]
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 1
     v4 = mapping_slot arg1, v3
     v5 = internal_call @__load_storage_bytes, 1, v4
     ret v5
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/mapping_dynamic_key.stdout
+++ b/tests/ui/codegen/lowering/mapping_dynamic_key.stdout
@@ -6,12 +6,12 @@ fn @lookup(arg0: calldataslice) -> address [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot_calldata arg0, 0
     v4 = sload v3 !metadata(storage=symbolic(v3))
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @set(arg0: memorybytes, arg1: address) {
@@ -20,8 +20,6 @@ fn @set(arg0: memorybytes, arg1: address) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -44,6 +42,8 @@ fn @set(arg0: memorybytes, arg1: address) {
     v15 = mapping_slot_memory v9, 0
     sstore v15, arg1 !metadata(storage=symbolic(v15))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @get(arg0: memorybytes) -> address [abi_returns=[word]] {
@@ -52,8 +52,6 @@ fn @get(arg0: memorybytes) -> address [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -69,6 +67,8 @@ fn @get(arg0: memorybytes) -> address [abi_returns=[word]] {
     v12 = mapping_slot_memory v9, 0
     v13 = sload v12 !metadata(storage=symbolic(v12))
     ret v13
+  bb1:
+    revert 0, 0
 }
 
 // === ROOT/tests/ui/codegen/lowering/mapping_dynamic_key.sol:MappingDynamicKeyPaths ===
@@ -79,12 +79,12 @@ fn @flat(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot_calldata arg0, 0
     v4 = sload v3 !metadata(storage=symbolic(v3))
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @nestedFirst(arg0: calldataslice, arg1: address) -> u256 [abi_returns=[word]] {
@@ -93,8 +93,6 @@ fn @nestedFirst(arg0: calldataslice, arg1: address) -> u256 [abi_returns=[word]]
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 36
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -107,6 +105,8 @@ fn @nestedFirst(arg0: calldataslice, arg1: address) -> u256 [abi_returns=[word]]
     v7 = mapping_slot arg1, v6
     v8 = sload v7 !metadata(storage=symbolic(v7))
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @nestedSecond(arg0: address, arg1: calldataslice) -> u256 [abi_returns=[word]] {
@@ -115,8 +115,6 @@ fn @nestedSecond(arg0: address, arg1: calldataslice) -> u256 [abi_returns=[word]
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -129,6 +127,8 @@ fn @nestedSecond(arg0: address, arg1: calldataslice) -> u256 [abi_returns=[word]
     v7 = mapping_slot_calldata arg1, v6
     v8 = sload v7 !metadata(storage=symbolic(v7))
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @skey() -> memorybytes [abi_returns=[memory_bytes]] {
@@ -166,14 +166,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -189,8 +189,6 @@ fn @setLit(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = fmp
     v4 = add v3, 0
@@ -201,6 +199,8 @@ fn @setLit(arg0: u256) {
     v7 = keccak256 v3, v6
     sstore v7, arg0 !metadata(storage=symbolic(v7))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @setLitLong(arg0: u256) {
@@ -209,8 +209,6 @@ fn @setLitLong(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = fmp
     v4 = add v3, 0
@@ -223,6 +221,8 @@ fn @setLitLong(arg0: u256) {
     v8 = keccak256 v3, v7
     sstore v8, arg0 !metadata(storage=symbolic(v8))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @setNestedFirst(arg0: memorybytes, arg1: address, arg2: u256) {
@@ -231,8 +231,6 @@ fn @setNestedFirst(arg0: memorybytes, arg1: address, arg2: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -256,6 +254,8 @@ fn @setNestedFirst(arg0: memorybytes, arg1: address, arg2: u256) {
     v16 = mapping_slot arg1, v15
     sstore v16, arg2 !metadata(storage=symbolic(v16))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @getNestedFirst(arg0: memorybytes, arg1: address) -> u256 [abi_returns=[word]] {
@@ -264,8 +264,6 @@ fn @getNestedFirst(arg0: memorybytes, arg1: address) -> u256 [abi_returns=[word]
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -289,6 +287,8 @@ fn @getNestedFirst(arg0: memorybytes, arg1: address) -> u256 [abi_returns=[word]
     v16 = mapping_slot arg1, v15
     v17 = sload v16 !metadata(storage=symbolic(v16))
     ret v17
+  bb1:
+    revert 0, 0
 }
 
 fn @setNestedSecond(arg0: address, arg1: memorybytes, arg2: u256) {
@@ -297,8 +297,6 @@ fn @setNestedSecond(arg0: address, arg1: memorybytes, arg2: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -322,6 +320,8 @@ fn @setNestedSecond(arg0: address, arg1: memorybytes, arg2: u256) {
     v16 = mapping_slot_memory v12, v15
     sstore v16, arg2 !metadata(storage=symbolic(v16))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @setSkey(arg0: memorybytes) {
@@ -330,8 +330,6 @@ fn @setSkey(arg0: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -387,6 +385,22 @@ fn @setSkey(arg0: memorybytes) {
     v42 = mload v31
     v43 = lt v42, v30
     jumpi v43, bb6, bb7
+  bb7:
+    mstore v31, v30
+    jump bb8
+  bb8:
+    v50 = mload v31
+    v51 = lt v50, v25
+    jumpi v51, bb9, bb10
+  bb10:
+    stop
+  bb9:
+    v52 = mload v31
+    v53 = add v32, v52
+    sstore v53, 0 !metadata(storage=symbolic(v53))
+    v54 = add v52, 1
+    mstore v31, v54
+    jump bb8
   bb6:
     v44 = mload v31
     v45 = add v32, v44
@@ -397,22 +411,8 @@ fn @setSkey(arg0: memorybytes) {
     v49 = add v44, 1
     mstore v31, v49
     jump bb5
-  bb7:
-    mstore v31, v30
-    jump bb8
-  bb8:
-    v50 = mload v31
-    v51 = lt v50, v25
-    jumpi v51, bb9, bb10
-  bb9:
-    v52 = mload v31
-    v53 = add v32, v52
-    sstore v53, 0 !metadata(storage=symbolic(v53))
-    v54 = add v52, 1
-    mstore v31, v54
-    jump bb8
-  bb10:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @setViaStorageKey(arg0: u256) {
@@ -421,13 +421,13 @@ fn @setViaStorageKey(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @__load_storage_bytes, 1, 3
     v4 = mapping_slot_memory v3, 0
     sstore v4, arg0 !metadata(storage=symbolic(v4))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @setThenAlloc(arg0: calldataslice, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -436,32 +436,32 @@ fn @setThenAlloc(arg0: calldataslice, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot_calldata arg0, 0
     sstore v3, arg1 !metadata(storage=symbolic(v3))
     v4 = add 32, 31
     v5 = lt v4, 32
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = not 31
     v7 = and v4, v6
     v8 = add v7, 32
     v9 = lt v8, v7
     jumpi v9, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v10 = alloc memorybytes, exact, zeroed, panic, v8
     set_memory_object_len memorybytes, v10, 32
     v11 = mload v10
     ret v11
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/mapping_nested_struct_copy.stdout
+++ b/tests/ui/codegen/lowering/mapping_nested_struct_copy.stdout
@@ -6,8 +6,6 @@ fn @set(arg0: u256, arg1: u256, arg2: u256, arg3: u256, arg4: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 160
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memorystruct<3>, exact, uninitialized, infallible, 96
     v4 = memory_object_field_addr memorystruct<3>, v3, 0
@@ -24,6 +22,8 @@ fn @set(arg0: u256, arg1: u256, arg2: u256, arg3: u256, arg4: u256) {
     v10 = mapping_slot arg0, 0
     memory_to_storage struct<word, struct<word, word>, word>, v3, v10
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @get(arg0: u256) -> (u256, u256, u256, u256) [abi_returns=[word, word, word, word]] {
@@ -32,8 +32,6 @@ fn @get(arg0: u256) -> (u256, u256, u256, u256) [abi_returns=[word, word, word, 
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -55,6 +53,8 @@ fn @get(arg0: u256) -> (u256, u256, u256, u256) [abi_returns=[word, word, word, 
     v15 = memory_object_field_addr memorystruct<3>, v4, 2
     v16 = mload v15
     ret v6, v10, v14, v16
+  bb1:
+    revert 0, 0
 }
 
 fn @clear(arg0: u256) {
@@ -63,11 +63,11 @@ fn @clear(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     clear_storage struct<word, struct<word, word>, word>, v3
     stop
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/mapping_struct_getter.stdout
+++ b/tests/ui/codegen/lowering/mapping_struct_getter.stdout
@@ -12,8 +12,6 @@ fn @items(arg0: u256) -> (address, u256, address) [abi_returns=[word, word, word
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -25,5 +23,7 @@ fn @items(arg0: u256) -> (address, u256, address) [abi_returns=[word, word, word
     v7 = add v3, 2
     v8 = sload v7 !metadata(storage=offset(v3, 2))
     ret v4, v6, v8
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/memory_allocation_panic.sol
+++ b/tests/ui/codegen/lowering/memory_allocation_panic.sol
@@ -8,10 +8,10 @@ contract MemoryAllocationPanic {
     // CHECK-LABEL: fn @makeBytes{{[( ]}}
     // CHECK: [[PADDED:v[0-9]+]] = add arg0, 31
     // CHECK: lt [[PADDED]], arg0
-    // CHECK: mstore 4, 65
     // CHECK: [[TOTAL:v[0-9]+]] = add {{v[0-9]+}}, 32
-    // CHECK: mstore 4, 65
     // CHECK: [[BYTES:v[0-9]+]] = alloc memorybytes, exact, zeroed, panic, [[TOTAL]]
+    // CHECK: mstore 4, 65
+    // CHECK: mstore 4, 65
     function makeBytes(uint256 n) external pure returns (uint256) {
         bytes memory b = new bytes(n);
         return b.length;
@@ -21,8 +21,8 @@ contract MemoryAllocationPanic {
     // CHECK: [[BYTES:v[0-9]+]] = mul arg0, 32
     // CHECK: mstore 4, 65
     // CHECK: [[TOTAL:v[0-9]+]] = add [[BYTES]], 32
-    // CHECK: mstore 4, 65
     // CHECK: {{v[0-9]+}} = alloc memoryarray<1>, exact, zeroed, panic, [[TOTAL]]
+    // CHECK: mstore 4, 65
     function makeArray(uint256 n) external pure returns (uint256) {
         uint256[] memory a = new uint256[](n);
         return a.length;

--- a/tests/ui/codegen/lowering/memory_allocation_panic.stdout
+++ b/tests/ui/codegen/lowering/memory_allocation_panic.stdout
@@ -6,31 +6,31 @@ fn @makeBytes(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 31
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v5 = not 31
     v6 = and v3, v5
     v7 = add v6, 32
     v8 = lt v7, v6
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = alloc memorybytes, exact, zeroed, panic, v7
     set_memory_object_len memorybytes, v9, arg0
     v10 = mload v9
     ret v10
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @makeArray(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -39,8 +39,6 @@ fn @makeArray(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul arg0, 32
     v4 = div v3, 32
@@ -54,14 +52,16 @@ fn @makeArray(arg0: u256) -> u256 [abi_returns=[word]] {
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, arg0
     v9 = mload v8
     ret v9
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/memory_fixed_array_alloc.stdout
+++ b/tests/ui/codegen/lowering/memory_fixed_array_alloc.stdout
@@ -6,8 +6,6 @@ fn @guardedFix(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<3, 1>, exact, uninitialized, infallible, 96
     v4 = memory_object_element_addr memoryfixedarray<3, 1>, v3, 0
@@ -26,6 +24,8 @@ fn @guardedFix(arg0: u256) -> u256 [abi_returns=[word]] {
     v8 = memory_object_element_addr memoryfixedarray<3, 1>, v3, arg0
     v9 = mload v8
     ret v9
+  bb1:
+    revert 0, 0
 }
 
 fn @structArr(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -34,8 +34,6 @@ fn @structArr(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memorystruct<1>, exact, uninitialized, infallible, 32
     v4 = alloc memoryfixedarray<3, 1>, exact, uninitialized, infallible, 96
@@ -59,6 +57,8 @@ fn @structArr(arg0: u256) -> u256 [abi_returns=[word]] {
     v12 = memory_object_element_addr memoryfixedarray<3, 1>, v10, arg0
     v13 = mload v12
     ret v13
+  bb1:
+    revert 0, 0
 }
 
 fn @nested(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -67,8 +67,6 @@ fn @nested(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<3, 1>, exact, uninitialized, infallible, 96
     v4 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
@@ -115,6 +113,8 @@ fn @nested(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v23 = memory_object_element_addr memoryfixedarray<2, 1>, v21, arg1
     v24 = mload v23
     ret v24
+  bb1:
+    revert 0, 0
 }
 
 fn @fmpIntegrity() -> (u256, u256) [abi_returns=[word, word]] {
@@ -140,10 +140,6 @@ fn @fmpIntegrity() -> (u256, u256) [abi_returns=[word, word]] {
     v8 = add v5, 32
     v9 = lt v8, v5
     jumpi v9, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v10 = alloc memoryarray<1>, exact, zeroed, panic, v8
     set_memory_object_len memoryarray, v10, 1
@@ -170,6 +166,10 @@ fn @fmpIntegrity() -> (u256, u256) [abi_returns=[word, word]] {
     v18 = memory_object_element_addr memoryarray<1>, v10, 0
     v19 = mload v18
     ret v15, v19
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @literal() -> u256 [abi_returns=[word]] {
@@ -192,8 +192,6 @@ fn @bulkDefault(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<4, 1>, exact, uninitialized, infallible, 128
     memory_zero v3, 128
@@ -207,6 +205,8 @@ fn @bulkDefault(arg0: u256) -> u256 [abi_returns=[word]] {
     v5 = memory_object_element_addr memoryfixedarray<4, 1>, v3, arg0
     v6 = mload v5
     ret v6
+  bb1:
+    revert 0, 0
 }
 
 // === ROOT/tests/ui/codegen/lowering/memory_fixed_array_alloc.sol:NamedReturnAndDelete ===
@@ -231,20 +231,12 @@ fn @namedReturn() -> (memoryfixedarray, u256) [abi_returns=[array<3, word>, word
     v8 = add 32, 31
     v9 = lt v8, 32
     jumpi v9, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v10 = not 31
     v11 = and v8, v10
     v12 = add v11, 32
     v13 = lt v12, v11
     jumpi v13, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v14 = alloc memorybytes, exact, zeroed, panic, v12
     set_memory_object_len memorybytes, v14, 32
@@ -277,6 +269,14 @@ fn @namedReturn() -> (memoryfixedarray, u256) [abi_returns=[array<3, word>, word
     v27 = mload 128
     v28 = mload 160
     ret v27, v28
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @emptyMemoryReferences() -> u256 [abi_returns=[word]] {
@@ -299,10 +299,6 @@ fn @emptyMemoryReferences() -> u256 [abi_returns=[word]] {
     v9 = add v7, v8
     v10 = lt v9, v7
     jumpi v10, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v11 = memory_object_field_addr memorystruct<2>, v2, 0
     v12 = mload v11
@@ -310,10 +306,6 @@ fn @emptyMemoryReferences() -> u256 [abi_returns=[word]] {
     v14 = add v9, v13
     v15 = lt v14, v9
     jumpi v15, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v16 = memory_object_field_addr memorystruct<2>, v2, 1
     v17 = mload v16
@@ -321,12 +313,20 @@ fn @emptyMemoryReferences() -> u256 [abi_returns=[word]] {
     v19 = add v14, v18
     v20 = lt v19, v14
     jumpi v20, bb5, bb6
+  bb6:
+    ret v19
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    ret v19
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @emptyNamedReturns() -> (memoryarray, memorybytes) [abi_returns=[memory_array<word>, memory_bytes]] {
@@ -379,10 +379,6 @@ fn @fullyInitializedNamedStruct() -> memorystruct [abi_returns=[tuple<memory_arr
     v8 = add v5, 32
     v9 = lt v8, v5
     jumpi v9, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v10 = alloc memoryarray<1>, exact, zeroed, panic, v8
     set_memory_object_len memoryarray, v10, 1
@@ -392,20 +388,12 @@ fn @fullyInitializedNamedStruct() -> memorystruct [abi_returns=[tuple<memory_arr
     v13 = add 1, 31
     v14 = lt v13, 1
     jumpi v14, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v15 = not 31
     v16 = and v13, v15
     v17 = add v16, 32
     v18 = lt v17, v16
     jumpi v18, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v19 = alloc memorybytes, exact, zeroed, panic, v17
     set_memory_object_len memorybytes, v19, 1
@@ -414,6 +402,18 @@ fn @fullyInitializedNamedStruct() -> memorystruct [abi_returns=[tuple<memory_arr
     mstore v21, v19
     v22 = mload 128
     ret v22
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @deleteInPlace() -> (u256, u256) [abi_returns=[word, word]] {

--- a/tests/ui/codegen/lowering/mir_alloc_ops.stdout
+++ b/tests/ui/codegen/lowering/mir_alloc_ops.stdout
@@ -6,8 +6,6 @@ fn @fixedArray(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memoryfixedarray<2, 1>, exact, uninitialized, infallible, 64
     v4 = memory_object_element_addr memoryfixedarray<2, 1>, v3, 0
@@ -19,6 +17,8 @@ fn @fixedArray(arg0: u256) -> u256 [abi_returns=[word]] {
     v7 = memory_object_element_addr memoryfixedarray<2, 1>, v3, 0
     v8 = mload v7
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @dynamic(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] {
@@ -27,17 +27,11 @@ fn @dynamic(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = not 31
     v7 = and v4, v6
@@ -46,10 +40,6 @@ fn @dynamic(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] {
     v10 = add 32, v9
     v11 = lt v10, v9
     jumpi v11, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v12 = alloc memorybytes, exact, uninitialized, infallible, v10
     set_memory_object_len memorybytes, v12, v3
@@ -60,6 +50,16 @@ fn @dynamic(arg0: calldataslice) -> memorybytes [abi_returns=[memory_bytes]] {
     v16 = slice_ptr arg0
     calldatacopy v13, v16, v3
     ret v12
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @frameShadow() -> (u256, u256, u256, u256) [abi_returns=[word, word, word, word]] {

--- a/tests/ui/codegen/lowering/msg_data.stdout
+++ b/tests/ui/codegen/lowering/msg_data.stdout
@@ -16,10 +16,6 @@ fn @copy() -> memorybytes [abi_returns=[memory_bytes]] {
     v3 = add v2, 31
     v4 = lt v3, v2
     jumpi v4, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v5 = not 31
     v6 = and v3, v5
@@ -28,10 +24,6 @@ fn @copy() -> memorybytes [abi_returns=[memory_bytes]] {
     v9 = add 32, v8
     v10 = lt v9, v8
     jumpi v10, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v11 = alloc memorybytes, exact, uninitialized, infallible, v9
     set_memory_object_len memorybytes, v11, v2
@@ -42,6 +34,14 @@ fn @copy() -> memorybytes [abi_returns=[memory_bytes]] {
     v15 = slice_ptr v1
     calldatacopy v12, v15, v2
     ret v11
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @environment() -> u256 [abi_returns=[word]] {
@@ -112,8 +112,6 @@ fn @tail(arg0: u256, arg1: u256) -> memorybytes [abi_returns=[memory_bytes]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldatasize
     v4 = make_calldata_slice 0, v3
@@ -121,13 +119,9 @@ fn @tail(arg0: u256, arg1: u256) -> memorybytes [abi_returns=[memory_bytes]] {
     v6 = slice_len v4
     v7 = gt arg1, v6
     jumpi v7, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v8 = lt arg1, arg0
     jumpi v8, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v9 = sub arg1, arg0
     v10 = add v5, arg0
@@ -136,10 +130,6 @@ fn @tail(arg0: u256, arg1: u256) -> memorybytes [abi_returns=[memory_bytes]] {
     v13 = add v12, 31
     v14 = lt v13, v12
     jumpi v14, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v15 = not 31
     v16 = and v13, v15
@@ -148,10 +138,6 @@ fn @tail(arg0: u256, arg1: u256) -> memorybytes [abi_returns=[memory_bytes]] {
     v19 = add 32, v18
     v20 = lt v19, v18
     jumpi v20, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v21 = alloc memorybytes, exact, uninitialized, infallible, v19
     set_memory_object_len memorybytes, v21, v12
@@ -162,5 +148,19 @@ fn @tail(arg0: u256, arg1: u256) -> memorybytes [abi_returns=[memory_bytes]] {
     v25 = slice_ptr v11
     calldatacopy v22, v25, v12
     ret v21
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/multi_return.stdout
+++ b/tests/ui/codegen/lowering/multi_return.stdout
@@ -6,8 +6,6 @@ fn @div_mod(arg0: u256, arg1: u256) -> (u256, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     jumpi arg1, bb4, bb3
   bb3:
@@ -24,6 +22,8 @@ fn @div_mod(arg0: u256, arg1: u256) -> (u256, u256) [abi_returns=[word, word]] {
   bb6:
     v4 = mod arg0, arg1
     ret v3, v4
+  bb1:
+    revert 0, 0
 }
 
 fn @min_max(arg0: u256, arg1: u256) -> (u256, u256) [abi_returns=[word, word]] {
@@ -32,15 +32,15 @@ fn @min_max(arg0: u256, arg1: u256) -> (u256, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, arg1
     jumpi v3, bb3, bb4
-  bb3:
-    ret arg0, arg1
   bb4:
     ret arg1, arg0
+  bb3:
+    ret arg0, arg1
+  bb1:
+    revert 0, 0
 }
 
 fn @triple(arg0: u256) -> (u256, u256, u256) [abi_returns=[word, word, word]] {
@@ -49,33 +49,33 @@ fn @triple(arg0: u256) -> (u256, u256, u256) [abi_returns=[word, word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, arg0
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v5 = add arg0, arg0
     v6 = lt v5, arg0
     jumpi v6, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v7 = add v5, arg0
     v8 = lt v7, v5
     jumpi v8, bb7, bb8
+  bb8:
+    ret arg0, v3, v7
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret arg0, v3, v7
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/multi_return_call.stdout
+++ b/tests/ui/codegen/lowering/multi_return_call.stdout
@@ -9,8 +9,6 @@ fn @sat(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @tryAdd, 2, arg0, arg1
     v4 = mload 32 !metadata(memory=scratch)
@@ -18,10 +16,12 @@ fn @sat(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v6 = mload v5
     v7 = iszero v3
     jumpi v7, bb3, bb4
-  bb3:
-    ret 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   bb4:
     ret v6
+  bb3:
+    ret 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  bb1:
+    revert 0, 0
 }
 
 fn @tryAdd(arg0: u256, arg1: u256) -> (bool, u256) {
@@ -52,13 +52,13 @@ fn @tryA(arg0: u256, arg1: u256) -> (bool, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @tryAdd, 2, arg0, arg1
     v4 = mload 32 !metadata(memory=scratch)
     v5 = add v4, 32
     v6 = mload v5
     ret v3, v6
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/multi_return_named_init.stdout
+++ b/tests/ui/codegen/lowering/multi_return_named_init.stdout
@@ -16,18 +16,14 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v5 = mload v4 !metadata(memory=internal_frame)
     v6 = lt v5, 8
     jumpi v6, bb4, bb5
+  bb5:
+    jump bb2
   bb2:
     v36 = internal_frame_addr 192
     v37 = mload v36 !metadata(memory=internal_frame)
     v38 = internal_frame_addr 224
     v39 = mload v38 !metadata(memory=internal_frame)
     ret v37, v39
-  bb3:
-    v31 = internal_frame_addr 256
-    v32 = mload v31 !metadata(memory=internal_frame)
-    v33 = add v32, 1
-    v34 = lt v33, v32
-    jumpi v34, bb10, bb11
   bb4:
     v7 = internal_frame_addr 192
     v8 = mload v7 !metadata(memory=internal_frame)
@@ -40,8 +36,6 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v14 = slice_len arg0
     v15 = lt v13, v14
     jumpi v15, bb7, bb6
-  bb5:
-    jump bb2
   bb6:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -63,22 +57,28 @@ fn @readU64(arg0: calldataslice, arg1: u256) -> (u64, u256) {
     v28 = add v27, 1
     v29 = lt v28, v27
     jumpi v29, bb8, bb9
-  bb8:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb9:
     v30 = internal_frame_addr 224
     mstore v30, v28 !metadata(memory=internal_frame)
     jump bb3
-  bb10:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
+  bb3:
+    v31 = internal_frame_addr 256
+    v32 = mload v31 !metadata(memory=internal_frame)
+    v33 = add v32, 1
+    v34 = lt v33, v32
+    jumpi v34, bb10, bb11
   bb11:
     v35 = internal_frame_addr 256
     mstore v35, v33 !metadata(memory=internal_frame)
     jump bb1
+  bb10:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @readTwice(arg0: calldataslice) -> (u64, u64) [abi_returns=[word, word]] {
@@ -87,8 +87,6 @@ fn @readTwice(arg0: calldataslice) -> (u64, u64) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -99,5 +97,7 @@ fn @readTwice(arg0: calldataslice) -> (u64, u64) [abi_returns=[word, word]] {
     v5 = mload 128
     v6 = mload 160
     ret v5, v6
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/multi_return_scratch.stdout
+++ b/tests/ui/codegen/lowering/multi_return_scratch.stdout
@@ -6,38 +6,38 @@ fn @stored(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     v4 = sload v3 !metadata(storage=symbolic(v3))
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @triple(arg0: u256) -> (u256, u256, u256) {
   bb0:
     v0 = eq arg0, 0
     jumpi v0, bb1, bb2
-  bb1:
-    ret 1, 2, 3
   bb2:
     v1 = add arg0, 1
     v2 = lt v1, arg0
     jumpi v2, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v3 = add arg0, 2
     v4 = lt v3, arg0
     jumpi v4, bb5, bb6
+  bb6:
+    ret arg0, v1, v3
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    ret arg0, v1, v3
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    ret 1, 2, 3
 }
 
 fn @assign(arg0: u256, arg1: u256) -> (u256, u256, u256, u256) [abi_returns=[word, word, word, word]] {
@@ -46,8 +46,6 @@ fn @assign(arg0: u256, arg1: u256) -> (u256, u256, u256, u256) [abi_returns=[wor
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -72,5 +70,7 @@ fn @assign(arg0: u256, arg1: u256) -> (u256, u256, u256, u256) [abi_returns=[wor
     v14 = mload 192
     v15 = mload 224
     ret v12, v13, v14, v15
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/narrow_bitwise_not.stdout
+++ b/tests/ui/codegen/lowering/narrow_bitwise_not.stdout
@@ -6,8 +6,6 @@ fn @notUint8(arg0: u8) -> u8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 255
@@ -19,6 +17,8 @@ fn @notUint8(arg0: u8) -> u8 [abi_returns=[word]] {
     v6 = not arg0
     v7 = and v6, 255
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @notUint16(arg0: u16) -> u16 [abi_returns=[word]] {
@@ -27,8 +27,6 @@ fn @notUint16(arg0: u16) -> u16 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffff
@@ -40,6 +38,8 @@ fn @notUint16(arg0: u16) -> u16 [abi_returns=[word]] {
     v6 = not arg0
     v7 = and v6, 0xffff
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @notUint256(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -48,11 +48,11 @@ fn @notUint256(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = not arg0
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @notInt8(arg0: i8) -> i8 [abi_returns=[word]] {
@@ -61,8 +61,6 @@ fn @notInt8(arg0: i8) -> i8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = signextend 0, v3
@@ -73,6 +71,8 @@ fn @notInt8(arg0: i8) -> i8 [abi_returns=[word]] {
   bb4:
     v6 = not arg0
     ret v6
+  bb1:
+    revert 0, 0
 }
 
 fn @notBytes1(arg0: bytes1) -> bytes1 [abi_returns=[word]] {
@@ -81,8 +81,6 @@ fn @notBytes1(arg0: bytes1) -> bytes1 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xff00000000000000000000000000000000000000000000000000000000000000
@@ -94,6 +92,8 @@ fn @notBytes1(arg0: bytes1) -> bytes1 [abi_returns=[word]] {
     v6 = not arg0
     v7 = and v6, 0xff00000000000000000000000000000000000000000000000000000000000000
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @notBytes2(arg0: bytes2) -> bytes2 [abi_returns=[word]] {
@@ -102,8 +102,6 @@ fn @notBytes2(arg0: bytes2) -> bytes2 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffff000000000000000000000000000000000000000000000000000000000000
@@ -115,6 +113,8 @@ fn @notBytes2(arg0: bytes2) -> bytes2 [abi_returns=[word]] {
     v6 = not arg0
     v7 = and v6, 0xffff000000000000000000000000000000000000000000000000000000000000
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @notBytes32(arg0: bytes32) -> bytes32 [abi_returns=[word]] {
@@ -123,9 +123,9 @@ fn @notBytes32(arg0: bytes32) -> bytes32 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = not arg0
     ret v3
+  bb1:
+    revert 0, 0
 }

--- a/tests/ui/codegen/lowering/nested_loops.sol
+++ b/tests/ui/codegen/lowering/nested_loops.sol
@@ -7,6 +7,7 @@ contract NestedLoops {
     // CHECK: lt [[I]], arg0
     // CHECK: [[J:v[0-9]+]] = mload 192
     // CHECK: lt [[J]], arg1
+    // CHECK: {{v[0-9]+}} = mload 128
     // CHECK: [[BODY_I:v[0-9]+]] = mload 160
     // CHECK: [[BODY_J:v[0-9]+]] = mload 192
     // CHECK: {{v[0-9]+}} = mul [[BODY_I]], [[BODY_J]]

--- a/tests/ui/codegen/lowering/nested_loops.stdout
+++ b/tests/ui/codegen/lowering/nested_loops.stdout
@@ -6,8 +6,6 @@ fn @sum_grid(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -16,30 +14,34 @@ fn @sum_grid(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v3 = mload 160
     v4 = lt v3, arg0
     jumpi v4, bb6, bb7
+  bb7:
+    jump bb4
   bb4:
     v24 = mload 128
     ret v24
+  bb6:
+    mstore 192, 0
+    jump bb8
+  bb8:
+    v5 = mload 192
+    v6 = lt v5, arg1
+    jumpi v6, bb11, bb12
+  bb12:
+    jump bb9
+  bb9:
+    jump bb5
   bb5:
     v21 = mload 160
     v22 = add v21, 1
     v23 = lt v22, v21
     jumpi v23, bb19, bb20
-  bb6:
-    mstore 192, 0
-    jump bb8
-  bb7:
-    jump bb4
-  bb8:
-    v5 = mload 192
-    v6 = lt v5, arg1
-    jumpi v6, bb11, bb12
-  bb9:
-    jump bb5
-  bb10:
-    v18 = mload 192
-    v19 = add v18, 1
-    v20 = lt v19, v18
-    jumpi v20, bb17, bb18
+  bb20:
+    mstore 160, v22
+    jump bb3
+  bb19:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
   bb11:
     v7 = mload 128
     v8 = mload 160
@@ -51,37 +53,35 @@ fn @sum_grid(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v14 = or v11, v13
     v15 = iszero v14
     jumpi v15, bb13, bb14
-  bb12:
-    jump bb9
-  bb13:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb14:
     v16 = add v7, v10
     v17 = lt v16, v7
     jumpi v17, bb15, bb16
-  bb15:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb16:
     mstore 128, v16
     jump bb10
+  bb10:
+    v18 = mload 192
+    v19 = add v18, 1
+    v20 = lt v19, v18
+    jumpi v20, bb17, bb18
+  bb18:
+    mstore 192, v19
+    jump bb8
   bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb18:
-    mstore 192, v19
-    jump bb8
-  bb19:
+  bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb20:
-    mstore 160, v22
-    jump bb3
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @find_first(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -90,8 +90,6 @@ fn @find_first(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     jump bb3
@@ -99,62 +97,64 @@ fn @find_first(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v3 = mload 128
     v4 = lt v3, arg0
     jumpi v4, bb6, bb7
+  bb7:
+    jump bb4
   bb4:
     ret arg0
+  bb6:
+    mstore 160, 0
+    jump bb8
+  bb8:
+    v5 = mload 160
+    v6 = lt v5, arg0
+    jumpi v6, bb11, bb12
+  bb12:
+    jump bb9
+  bb9:
+    jump bb5
   bb5:
     v16 = mload 128
     v17 = add v16, 1
     v18 = lt v17, v16
     jumpi v18, bb19, bb20
-  bb6:
-    mstore 160, 0
-    jump bb8
-  bb7:
-    jump bb4
-  bb8:
-    v5 = mload 160
-    v6 = lt v5, arg0
-    jumpi v6, bb11, bb12
-  bb9:
-    jump bb5
-  bb10:
-    v13 = mload 160
-    v14 = add v13, 1
-    v15 = lt v14, v13
-    jumpi v15, bb17, bb18
+  bb20:
+    mstore 128, v17
+    jump bb3
+  bb19:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
   bb11:
     v7 = mload 128
     v8 = mload 160
     v9 = add v7, v8
     v10 = lt v9, v7
     jumpi v10, bb13, bb14
-  bb12:
-    jump bb9
-  bb13:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb14:
     v11 = eq v9, arg1
     jumpi v11, bb15, bb16
-  bb15:
-    v12 = mload 128
-    ret v12
   bb16:
     jump bb10
+  bb10:
+    v13 = mload 160
+    v14 = add v13, 1
+    v15 = lt v14, v13
+    jumpi v15, bb17, bb18
+  bb18:
+    mstore 160, v14
+    jump bb8
   bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb18:
-    mstore 160, v14
-    jump bb8
-  bb19:
+  bb15:
+    v12 = mload 128
+    ret v12
+  bb13:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb20:
-    mstore 128, v17
-    jump bb3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/nested_static_struct_param.stdout
+++ b/tests/ui/codegen/lowering/nested_static_struct_param.stdout
@@ -6,8 +6,6 @@ fn @take(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> (u256, u256) [abi_re
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memorystruct<3>, exact, uninitialized, infallible, 96
     v4 = memory_object_field_addr memorystruct<3>, v3, 0
@@ -30,5 +28,7 @@ fn @take(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> (u256, u256) [abi_re
     v16 = memory_object_field_addr memorystruct<3>, v3, 2
     v17 = mload v16
     ret v15, v17
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/packed_calldata_slice.stdout
+++ b/tests/ui/codegen/lowering/packed_calldata_slice.stdout
@@ -6,20 +6,14 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) -> memorybytes [abi_retur
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_ptr arg0
     v4 = slice_len arg0
     v5 = gt arg2, v4
     jumpi v5, bb3, bb4
-  bb3:
-    revert 0, 0
   bb4:
     v6 = lt arg2, arg1
     jumpi v6, bb5, bb6
-  bb5:
-    revert 0, 0
   bb6:
     v7 = sub arg2, arg1
     v8 = add v3, arg1
@@ -28,10 +22,6 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) -> memorybytes [abi_retur
     v11 = add v10, 31
     v12 = lt v11, v10
     jumpi v12, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v13 = not 31
     v14 = and v11, v13
@@ -40,10 +30,6 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) -> memorybytes [abi_retur
     v17 = add 32, v16
     v18 = lt v17, v16
     jumpi v18, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v19 = alloc memorybytes, exact, uninitialized, infallible, v17
     set_memory_object_len memorybytes, v19, v10
@@ -70,6 +56,20 @@ fn @slice(arg0: calldataslice, arg1: u256, arg2: u256) -> memorybytes [abi_retur
     v35 = add v24, v34
     set_fmp v35
     ret v24
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    revert 0, 0
+  bb3:
+    revert 0, 0
+  bb1:
+    revert 0, 0
 }
 
 fn @all() -> memorybytes [abi_returns=[memory_bytes]] {
@@ -80,10 +80,6 @@ fn @all() -> memorybytes [abi_returns=[memory_bytes]] {
     v3 = add v2, 31
     v4 = lt v3, v2
     jumpi v4, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v5 = not 31
     v6 = and v3, v5
@@ -92,10 +88,6 @@ fn @all() -> memorybytes [abi_returns=[memory_bytes]] {
     v9 = add 32, v8
     v10 = lt v9, v8
     jumpi v10, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v11 = alloc memorybytes, exact, uninitialized, infallible, v9
     set_memory_object_len memorybytes, v11, v2
@@ -120,5 +112,13 @@ fn @all() -> memorybytes [abi_returns=[memory_bytes]] {
     v26 = add v16, v25
     set_fmp v26
     ret v16
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 

--- a/tests/ui/codegen/lowering/recursive.stdout
+++ b/tests/ui/codegen/lowering/recursive.stdout
@@ -6,22 +6,14 @@ fn @fact.0(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 1
     v4 = iszero v3
     jumpi v4, bb3, bb4
-  bb3:
-    ret 1
   bb4:
     v5 = sub arg0, 1
     v6 = lt arg0, 1
     jumpi v6, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v7 = internal_call @fact.1, 1, v5
     v8 = mul arg0, v7
@@ -31,12 +23,20 @@ fn @fact.0(arg0: u256) -> u256 [abi_returns=[word]] {
     v12 = or v9, v11
     v13 = iszero v12
     jumpi v13, bb7, bb8
+  bb8:
+    ret v8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v8
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    ret 1
+  bb1:
+    revert 0, 0
 }
 
 fn @fact.1(arg0: u256) -> u256 {
@@ -44,16 +44,10 @@ fn @fact.1(arg0: u256) -> u256 {
     v0 = gt arg0, 1
     v1 = iszero v0
     jumpi v1, bb1, bb2
-  bb1:
-    ret 1
   bb2:
     v2 = sub arg0, 1
     v3 = lt arg0, 1
     jumpi v3, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v4 = internal_call @fact.1, 1, v2
     v5 = mul arg0, v4
@@ -63,12 +57,18 @@ fn @fact.1(arg0: u256) -> u256 {
     v9 = or v6, v8
     v10 = iszero v9
     jumpi v10, bb5, bb6
+  bb6:
+    ret v5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    ret v5
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    ret 1
 }
 
 fn @fib.2(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -77,42 +77,42 @@ fn @fib.2(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, 1
     v4 = iszero v3
     jumpi v4, bb3, bb4
-  bb3:
-    ret arg0
   bb4:
     v5 = sub arg0, 1
     v6 = lt arg0, 1
     jumpi v6, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v7 = internal_call @fib.3, 1, v5
     v8 = sub arg0, 2
     v9 = lt arg0, 2
     jumpi v9, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v10 = internal_call @fib.3, 1, v8
     v11 = add v7, v10
     v12 = lt v11, v7
     jumpi v12, bb9, bb10
+  bb10:
+    ret v11
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb10:
-    ret v11
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    ret arg0
+  bb1:
+    revert 0, 0
 }
 
 fn @fib.3(arg0: u256) -> u256 {
@@ -120,36 +120,36 @@ fn @fib.3(arg0: u256) -> u256 {
     v0 = gt arg0, 1
     v1 = iszero v0
     jumpi v1, bb1, bb2
-  bb1:
-    ret arg0
   bb2:
     v2 = sub arg0, 1
     v3 = lt arg0, 1
     jumpi v3, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v4 = internal_call @fib.3, 1, v2
     v5 = sub arg0, 2
     v6 = lt arg0, 2
     jumpi v6, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v7 = internal_call @fib.3, 1, v5
     v8 = add v4, v7
     v9 = lt v8, v4
     jumpi v9, bb7, bb8
+  bb8:
+    ret v8
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    ret v8
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    ret arg0
 }
 
 fn @isEven.4(arg0: u256) -> bool [abi_returns=[word]] {
@@ -158,62 +158,62 @@ fn @isEven.4(arg0: u256) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0
     jumpi v3, bb3, bb4
-  bb3:
-    ret 1
   bb4:
     v4 = sub arg0, 1
     v5 = lt arg0, 1
     jumpi v5, bb5, bb6
+  bb6:
+    v6 = internal_call @isOdd.5, 1, v4
+    ret v6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    v6 = internal_call @isOdd.5, 1, v4
-    ret v6
+  bb3:
+    ret 1
+  bb1:
+    revert 0, 0
 }
 
 fn @isOdd.5(arg0: u256) -> bool {
   bb0:
     v0 = eq arg0, 0
     jumpi v0, bb1, bb2
-  bb1:
-    ret 0
   bb2:
     v1 = sub arg0, 1
     v2 = lt arg0, 1
     jumpi v2, bb3, bb4
+  bb4:
+    v3 = internal_call @isEven.6, 1, v1
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v3 = internal_call @isEven.6, 1, v1
-    ret v3
+  bb1:
+    ret 0
 }
 
 fn @isEven.6(arg0: u256) -> bool {
   bb0:
     v0 = eq arg0, 0
     jumpi v0, bb1, bb2
-  bb1:
-    ret 1
   bb2:
     v1 = sub arg0, 1
     v2 = lt arg0, 1
     jumpi v2, bb3, bb4
+  bb4:
+    v3 = internal_call @isOdd.5, 1, v1
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    v3 = internal_call @isOdd.5, 1, v1
-    ret v3
+  bb1:
+    ret 1
 }
 
 fn @isOdd.7(arg0: u256) -> bool [abi_returns=[word]] {
@@ -222,23 +222,23 @@ fn @isOdd.7(arg0: u256) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0
     jumpi v3, bb3, bb4
-  bb3:
-    ret 0
   bb4:
     v4 = sub arg0, 1
     v5 = lt arg0, 1
     jumpi v5, bb5, bb6
+  bb6:
+    v6 = internal_call @isEven.6, 1, v4
+    ret v6
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    v6 = internal_call @isEven.6, 1, v4
-    ret v6
+  bb3:
+    ret 0
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/recursive_memory_return.sol
+++ b/tests/ui/codegen/lowering/recursive_memory_return.sol
@@ -45,11 +45,11 @@ contract C {
 
     // recursive helper returning a memory array, consumed by a public function
     // CHECK-LABEL: fn @fillImpl{{[( ]}}
-    // CHECK: ret arg0
     // CHECK: memory_object_element_addr memoryarray<1>, arg0, arg1
     // CHECK: [[NEXT:v[0-9]+]] = add arg1, 1
     // CHECK: [[RESULT:v[0-9]+]] = internal_call @fillImpl, 1, arg0, [[NEXT]]
     // CHECK: ret [[RESULT]]
+    // CHECK: ret arg0
     function fillImpl(uint256[] memory a, uint256 i) internal pure returns (uint256[] memory) {
         if (i == a.length) return a;
         a[i] = i * i;

--- a/tests/ui/codegen/lowering/recursive_memory_return.stdout
+++ b/tests/ui/codegen/lowering/recursive_memory_return.stdout
@@ -6,26 +6,13 @@ fn @build.0(arg0: u256) -> memorystruct [abi_returns=[tuple<word, word>]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = eq arg0, 0
     jumpi v3, bb3, bb4
-  bb3:
-    v4 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
-    v5 = memory_object_field_addr memorystruct<2>, v4, 0
-    mstore v5, 0
-    v6 = memory_object_field_addr memorystruct<2>, v4, 1
-    mstore v6, 0
-    ret v4
   bb4:
     v7 = sub arg0, 1
     v8 = lt arg0, 1
     jumpi v8, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v9 = internal_call @build.1, 1, v7
     v10 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
@@ -34,10 +21,6 @@ fn @build.0(arg0: u256) -> memorystruct [abi_returns=[tuple<word, word>]] {
     v13 = add v12, arg0
     v14 = lt v13, v12
     jumpi v14, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v15 = memory_object_field_addr memorystruct<2>, v10, 0
     mstore v15, v13
@@ -46,35 +29,41 @@ fn @build.0(arg0: u256) -> memorystruct [abi_returns=[tuple<word, word>]] {
     v18 = add v17, 1
     v19 = lt v18, v17
     jumpi v19, bb9, bb10
-  bb9:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb10:
     v20 = memory_object_field_addr memorystruct<2>, v10, 1
     mstore v20, v18
     ret v10
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    v4 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
+    v5 = memory_object_field_addr memorystruct<2>, v4, 0
+    mstore v5, 0
+    v6 = memory_object_field_addr memorystruct<2>, v4, 1
+    mstore v6, 0
+    ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @build.1(arg0: u256) -> memorystruct {
   bb0:
     v0 = eq arg0, 0
     jumpi v0, bb1, bb2
-  bb1:
-    v1 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
-    v2 = memory_object_field_addr memorystruct<2>, v1, 0
-    mstore v2, 0
-    v3 = memory_object_field_addr memorystruct<2>, v1, 1
-    mstore v3, 0
-    ret v1
   bb2:
     v4 = sub arg0, 1
     v5 = lt arg0, 1
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = internal_call @build.1, 1, v4
     v7 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
@@ -83,10 +72,6 @@ fn @build.1(arg0: u256) -> memorystruct {
     v10 = add v9, arg0
     v11 = lt v10, v9
     jumpi v11, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v12 = memory_object_field_addr memorystruct<2>, v7, 0
     mstore v12, v10
@@ -95,14 +80,29 @@ fn @build.1(arg0: u256) -> memorystruct {
     v15 = add v14, 1
     v16 = lt v15, v14
     jumpi v16, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v17 = memory_object_field_addr memorystruct<2>, v7, 1
     mstore v17, v15
     ret v7
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    v1 = alloc memorystruct<2>, exact, uninitialized, infallible, 64
+    v2 = memory_object_field_addr memorystruct<2>, v1, 0
+    mstore v2, 0
+    v3 = memory_object_field_addr memorystruct<2>, v1, 1
+    mstore v3, 0
+    ret v1
 }
 
 fn @mkArr(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
@@ -111,8 +111,6 @@ fn @mkArr(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul arg0, 32
     v4 = div v3, 32
@@ -126,10 +124,6 @@ fn @mkArr(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, arg0
@@ -139,13 +133,10 @@ fn @mkArr(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v9 = mload 128
     v10 = lt v9, arg0
     jumpi v10, bb10, bb11
+  bb11:
+    jump bb8
   bb8:
     ret v8
-  bb9:
-    v22 = mload 128
-    v23 = add v22, 1
-    v24 = lt v23, v22
-    jumpi v24, bb16, bb17
   bb10:
     v11 = mload 128
     v12 = mul v11, 10
@@ -155,12 +146,6 @@ fn @mkArr(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v16 = or v13, v15
     v17 = iszero v16
     jumpi v17, bb12, bb13
-  bb11:
-    jump bb8
-  bb12:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb13:
     v18 = mload 128
     v19 = memory_object_len memoryarray, v8
@@ -174,13 +159,28 @@ fn @mkArr(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v21 = memory_object_element_addr memoryarray<1>, v8, v18
     mstore v21, v12
     jump bb9
+  bb9:
+    v22 = mload 128
+    v23 = add v22, 1
+    v24 = lt v23, v22
+    jumpi v24, bb16, bb17
+  bb17:
+    mstore 128, v23
+    jump bb7
   bb16:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb17:
-    mstore 128, v23
-    jump bb7
+  bb12:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
@@ -188,8 +188,6 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
     v0 = mload arg0
     v1 = eq arg1, v0
     jumpi v1, bb1, bb2
-  bb1:
-    ret arg0
   bb2:
     v2 = mul arg1, arg1
     v3 = iszero arg1
@@ -198,10 +196,6 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
     v6 = or v3, v5
     v7 = iszero v6
     jumpi v7, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v8 = memory_object_len memoryarray, arg0
     v9 = lt arg1, v8
@@ -216,13 +210,19 @@ fn @fillImpl(arg0: memoryarray, arg1: u256) -> memoryarray {
     v11 = add arg1, 1
     v12 = lt v11, arg1
     jumpi v12, bb7, bb8
+  bb8:
+    v13 = internal_call @fillImpl, 1, arg0, v11
+    ret v13
   bb7:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
-    v13 = internal_call @fillImpl, 1, arg0, v11
-    ret v13
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    ret arg0
 }
 
 fn @squares(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
@@ -231,8 +231,6 @@ fn @squares(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mul arg0, 32
     v4 = div v3, 32
@@ -246,14 +244,16 @@ fn @squares(arg0: u256) -> memoryarray [abi_returns=[memory_array<word>]] {
     v6 = add v3, 32
     v7 = lt v6, v3
     jumpi v7, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v8 = alloc memoryarray<1>, exact, zeroed, panic, v6
     set_memory_object_len memoryarray, v8, arg0
     v9 = internal_call @fillImpl, 1, v8, 0
     ret v9
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/revert_payloads.stdout
+++ b/tests/ui/codegen/lowering/revert_payloads.stdout
@@ -6,8 +6,6 @@ fn @assert_panic(arg0: bool) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -19,12 +17,14 @@ fn @assert_panic(arg0: bool) {
   bb4:
     v7 = iszero arg0
     jumpi v7, bb5, bb6
+  bb6:
+    stop
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @require_message(arg0: bool) {
@@ -33,8 +33,6 @@ fn @require_message(arg0: bool) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -46,11 +44,13 @@ fn @require_message(arg0: bool) {
   bb4:
     v7 = iszero arg0
     jumpi v7, bb5, bb6
+  bb6:
+    stop
   bb5:
     internal_call @__revert_error, 0, 3, 0x6261640000000000000000000000000000000000000000000000000000000000
     invalid
-  bb6:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_error(arg0: u256, arg1: u256) {

--- a/tests/ui/codegen/lowering/signed_constant_ops.stdout
+++ b/tests/ui/codegen/lowering/signed_constant_ops.stdout
@@ -4,24 +4,20 @@ fn @lt() -> bool [abi_returns=[word]] {
   bb0:
     v0 = eq 1, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     jumpi v0, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v1 = sub 0, 1
     v2 = slt v1, 1
     ret v2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @div() -> i256 [abi_returns=[word]] {
   bb0:
     v0 = eq 7, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
     jumpi v0, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v1 = sub 0, 7
     jumpi 2, bb4, bb3
@@ -34,26 +30,30 @@ fn @div() -> i256 [abi_returns=[word]] {
     v3 = eq 2, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     v4 = and v2, v3
     jumpi v4, bb5, bb6
+  bb6:
+    v5 = sdiv v1, 2
+    ret v5
   bb5:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb6:
-    v5 = sdiv v1, 2
-    ret v5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @shr() -> i256 [abi_returns=[word]] {
   bb0:
     v0 = eq 8, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8
     jumpi v0, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v1 = sub 0, 8
     v2 = sar 1, v1
     ret v2
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }
 

--- a/tests/ui/codegen/lowering/storage.stdout
+++ b/tests/ui/codegen/lowering/storage.stdout
@@ -12,13 +12,13 @@ fn @increment() {
     v1 = add v0, 1
     v2 = lt v1, v0
     jumpi v2, bb1, bb2
+  bb2:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    sstore 0, v1 !metadata(storage=slot(0))
-    stop
 }
 
 fn @set(arg0: u256) {
@@ -27,11 +27,11 @@ fn @set(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     sstore 0, arg0 !metadata(storage=slot(0))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @get() -> u256 [abi_returns=[word]] {

--- a/tests/ui/codegen/lowering/storage_bytes_array_push.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_array_push.stdout
@@ -7,8 +7,6 @@ fn @pushStr() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 4
     v4 = calldataload v3
@@ -26,8 +24,6 @@ fn @pushStr() {
     v13 = add v12, 1
     v14 = lt v13, v12
     jumpi v14, bb3, bb4
-  bb3:
-    tail_call @__revert_stub0
   bb4:
     mstore 0, 0 !metadata(memory=scratch)
     v16 = add v12, 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563
@@ -72,6 +68,23 @@ fn @pushStr() {
     v60 = phi [bb6: 0], [bb8: v54]
     v48 = lt v60, v35
     jumpi v48, bb8, bb9
+  bb9:
+    mstore v36, v35
+    jump bb10
+  bb10:
+    v61 = phi [bb9: v35], [bb11: v59]
+    v56 = lt v61, v30
+    jumpi v56, bb11, bb12
+  bb12:
+    sstore 0, v13 !metadata(storage=slot(0))
+    stop
+  bb11:
+    v57 = mload v36
+    v58 = add v37, v57
+    sstore v58, 0 !metadata(storage=symbolic(v58))
+    v59 = add v57, 1
+    mstore v36, v59
+    jump bb10
   bb8:
     v49 = mload v36
     v51 = shl 5, v49
@@ -82,23 +95,10 @@ fn @pushStr() {
     v54 = add v49, 1
     mstore v36, v54
     jump bb7
-  bb9:
-    mstore v36, v35
-    jump bb10
-  bb10:
-    v61 = phi [bb9: v35], [bb11: v59]
-    v56 = lt v61, v30
-    jumpi v56, bb11, bb12
-  bb11:
-    v57 = mload v36
-    v58 = add v37, v57
-    sstore v58, 0 !metadata(storage=symbolic(v58))
-    v59 = add v57, 1
-    mstore v36, v59
-    jump bb10
-  bb12:
-    sstore 0, v13 !metadata(storage=slot(0))
-    stop
+  bb3:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @popStr() {
@@ -138,6 +138,9 @@ fn @popStr() {
     v49 = phi [bb2: 0], [bb4: v47]
     v44 = lt v49, v18
     jumpi v44, bb4, bb5
+  bb5:
+    sstore 0, v1 !metadata(storage=slot(0))
+    stop
   bb4:
     v45 = mload v24
     v46 = add v25, v45
@@ -145,9 +148,6 @@ fn @popStr() {
     v47 = add v45, 1
     mstore v24, v47
     jump bb3
-  bb5:
-    sstore 0, v1 !metadata(storage=slot(0))
-    stop
 }
 
 fn @blobAt() {
@@ -156,8 +156,6 @@ fn @blobAt() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sload 2 !metadata(storage=slot(2))
     v4 = lt arg0, v3
@@ -196,6 +194,8 @@ fn @blobAt() {
     v31 = add v29, v28
     mstore 64, v31 !metadata(memory=scratch)
     returndata v29, v24
+  bb1:
+    revert 0, 0
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memptr {
@@ -230,13 +230,13 @@ fn @__load_storage_bytes(arg0: u256) -> memptr {
     v17 = keccak256 v13, 32
     v18 = shr 5, v9
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     jumpi v19, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -252,8 +252,6 @@ fn @pushEmpty() {
     v1 = add v0, 1
     v2 = lt v1, v0
     jumpi v2, bb1, bb2
-  bb1:
-    tail_call @__revert_stub0
   bb2:
     mstore 0, 2 !metadata(memory=scratch)
     v4 = add v0, 0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace
@@ -282,6 +280,9 @@ fn @pushEmpty() {
     v50 = phi [bb2: 0], [bb4: v48]
     v45 = lt v50, v19
     jumpi v45, bb4, bb5
+  bb5:
+    sstore 2, v1 !metadata(storage=slot(2))
+    stop
   bb4:
     v46 = mload v25
     v47 = add v26, v46
@@ -289,9 +290,8 @@ fn @pushEmpty() {
     v48 = add v46, 1
     mstore v25, v48
     jump bb3
-  bb5:
-    sstore 2, v1 !metadata(storage=slot(2))
-    stop
+  bb1:
+    tail_call @__revert_stub0
 }
 
 fn @__revert_stub0() {
@@ -309,14 +309,14 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb6, [0x19d30117 => bb2, 0x5d7696c3 => bb3, 0x8f236983 => bb4, 0xe6e6accc => bb5]
-  bb2:
-    tail_call @pushEmpty
-  bb3:
-    tail_call @popStr
-  bb4:
-    tail_call @blobAt
   bb5:
     tail_call @pushStr
+  bb4:
+    tail_call @blobAt
+  bb3:
+    tail_call @popStr
+  bb2:
+    tail_call @pushEmpty
   bb6:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/storage_bytes_elements.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.stdout
@@ -35,14 +35,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -58,8 +58,6 @@ fn @init(arg0: memorybytes) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add 4, arg0
     v4 = calldataload v3
@@ -115,6 +113,22 @@ fn @init(arg0: memorybytes) {
     v42 = mload v31
     v43 = lt v42, v30
     jumpi v43, bb6, bb7
+  bb7:
+    mstore v31, v30
+    jump bb8
+  bb8:
+    v50 = mload v31
+    v51 = lt v50, v25
+    jumpi v51, bb9, bb10
+  bb10:
+    stop
+  bb9:
+    v52 = mload v31
+    v53 = add v32, v52
+    sstore v53, 0 !metadata(storage=symbolic(v53))
+    v54 = add v52, 1
+    mstore v31, v54
+    jump bb8
   bb6:
     v44 = mload v31
     v45 = add v32, v44
@@ -125,22 +139,8 @@ fn @init(arg0: memorybytes) {
     v49 = add v44, 1
     mstore v31, v49
     jump bb5
-  bb7:
-    mstore v31, v30
-    jump bb8
-  bb8:
-    v50 = mload v31
-    v51 = lt v50, v25
-    jumpi v51, bb9, bb10
-  bb9:
-    v52 = mload v31
-    v53 = add v32, v52
-    sstore v53, 0 !metadata(storage=symbolic(v53))
-    v54 = add v52, 1
-    mstore v31, v54
-    jump bb8
-  bb10:
-    stop
+  bb1:
+    revert 0, 0
 }
 
 fn @poke() {
@@ -234,14 +234,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -325,16 +325,6 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v49 = mload v38
     v50 = lt v49, v37
     jumpi v50, bb4, bb5
-  bb4:
-    v51 = mload v38
-    v52 = add v39, v51
-    v53 = mul v51, 32
-    v54 = add v20, v53
-    v55 = mload v54
-    sstore v52, v55 !metadata(storage=symbolic(v52))
-    v56 = add v51, 1
-    mstore v38, v56
-    jump bb3
   bb5:
     mstore v38, v37
     jump bb6
@@ -342,13 +332,6 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v57 = mload v38
     v58 = lt v57, v32
     jumpi v58, bb7, bb8
-  bb7:
-    v59 = mload v38
-    v60 = add v39, v59
-    sstore v60, 0 !metadata(storage=symbolic(v60))
-    v61 = add v59, 1
-    mstore v38, v61
-    jump bb6
   bb8:
     v62 = memory_object_len memorybytes, v16
     v63 = memory_object_data memorybytes, v16
@@ -393,6 +376,22 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v92 = mload v81
     v93 = lt v92, v80
     jumpi v93, bb12, bb13
+  bb13:
+    mstore v81, v80
+    jump bb14
+  bb14:
+    v100 = mload v81
+    v101 = lt v100, v75
+    jumpi v101, bb15, bb16
+  bb16:
+    stop
+  bb15:
+    v102 = mload v81
+    v103 = add v82, v102
+    sstore v103, 0 !metadata(storage=symbolic(v103))
+    v104 = add v102, 1
+    mstore v81, v104
+    jump bb14
   bb12:
     v94 = mload v81
     v95 = add v82, v94
@@ -403,22 +402,23 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v99 = add v94, 1
     mstore v81, v99
     jump bb11
-  bb13:
-    mstore v81, v80
-    jump bb14
-  bb14:
-    v100 = mload v81
-    v101 = lt v100, v75
-    jumpi v101, bb15, bb16
-  bb15:
-    v102 = mload v81
-    v103 = add v82, v102
-    sstore v103, 0 !metadata(storage=symbolic(v103))
-    v104 = add v102, 1
-    mstore v81, v104
-    jump bb14
-  bb16:
-    stop
+  bb7:
+    v59 = mload v38
+    v60 = add v39, v59
+    sstore v60, 0 !metadata(storage=symbolic(v60))
+    v61 = add v59, 1
+    mstore v38, v61
+    jump bb6
+  bb4:
+    v51 = mload v38
+    v52 = add v39, v51
+    v53 = mul v51, 32
+    v54 = add v20, v53
+    v55 = mload v54
+    sstore v52, v55 !metadata(storage=symbolic(v52))
+    v56 = add v51, 1
+    mstore v38, v56
+    jump bb3
 }
 
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringBase ===
@@ -458,14 +458,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -549,16 +549,6 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v49 = mload v38
     v50 = lt v49, v37
     jumpi v50, bb4, bb5
-  bb4:
-    v51 = mload v38
-    v52 = add v39, v51
-    v53 = mul v51, 32
-    v54 = add v20, v53
-    v55 = mload v54
-    sstore v52, v55 !metadata(storage=symbolic(v52))
-    v56 = add v51, 1
-    mstore v38, v56
-    jump bb3
   bb5:
     mstore v38, v37
     jump bb6
@@ -566,13 +556,6 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v57 = mload v38
     v58 = lt v57, v32
     jumpi v58, bb7, bb8
-  bb7:
-    v59 = mload v38
-    v60 = add v39, v59
-    sstore v60, 0 !metadata(storage=symbolic(v60))
-    v61 = add v59, 1
-    mstore v38, v61
-    jump bb6
   bb8:
     v62 = memory_object_len memorybytes, v16
     v63 = memory_object_data memorybytes, v16
@@ -617,6 +600,22 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v92 = mload v81
     v93 = lt v92, v80
     jumpi v93, bb12, bb13
+  bb13:
+    mstore v81, v80
+    jump bb14
+  bb14:
+    v100 = mload v81
+    v101 = lt v100, v75
+    jumpi v101, bb15, bb16
+  bb16:
+    stop
+  bb15:
+    v102 = mload v81
+    v103 = add v82, v102
+    sstore v103, 0 !metadata(storage=symbolic(v103))
+    v104 = add v102, 1
+    mstore v81, v104
+    jump bb14
   bb12:
     v94 = mload v81
     v95 = add v82, v94
@@ -627,22 +626,23 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
     v99 = add v94, 1
     mstore v81, v99
     jump bb11
-  bb13:
-    mstore v81, v80
-    jump bb14
-  bb14:
-    v100 = mload v81
-    v101 = lt v100, v75
-    jumpi v101, bb15, bb16
-  bb15:
-    v102 = mload v81
-    v103 = add v82, v102
-    sstore v103, 0 !metadata(storage=symbolic(v103))
-    v104 = add v102, 1
-    mstore v81, v104
-    jump bb14
-  bb16:
-    stop
+  bb7:
+    v59 = mload v38
+    v60 = add v39, v59
+    sstore v60, 0 !metadata(storage=symbolic(v60))
+    v61 = add v59, 1
+    mstore v38, v61
+    jump bb6
+  bb4:
+    v51 = mload v38
+    v52 = add v39, v51
+    v53 = mul v51, 32
+    v54 = add v20, v53
+    v55 = mload v54
+    sstore v52, v55 !metadata(storage=symbolic(v52))
+    v56 = add v51, 1
+    mstore v38, v56
+    jump bb3
 }
 
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringDerived ===
@@ -682,8 +682,6 @@ fn @_anonymous() {
     mstore v25, 0
     v26 = keccak256 v25, 32
     jumpi v23, bb3, bb2
-  bb1:
-    stop
   bb2:
     v27 = mload v7
     v28 = mul v6, 8
@@ -704,16 +702,6 @@ fn @_anonymous() {
     v36 = mload v25
     v37 = lt v36, v24
     jumpi v37, bb5, bb6
-  bb5:
-    v38 = mload v25
-    v39 = add v26, v38
-    v40 = mul v38, 32
-    v41 = add v7, v40
-    v42 = mload v41
-    sstore v39, v42 !metadata(storage=symbolic(v39))
-    v43 = add v38, 1
-    mstore v25, v43
-    jump bb4
   bb6:
     mstore v25, v24
     jump bb7
@@ -721,13 +709,6 @@ fn @_anonymous() {
     v44 = mload v25
     v45 = lt v44, v19
     jumpi v45, bb8, bb9
-  bb8:
-    v46 = mload v25
-    v47 = add v26, v46
-    sstore v47, 0 !metadata(storage=symbolic(v47))
-    v48 = add v46, 1
-    mstore v25, v48
-    jump bb7
   bb9:
     v49 = memory_object_len memorybytes, v3
     v50 = memory_object_data memorybytes, v3
@@ -772,6 +753,24 @@ fn @_anonymous() {
     v79 = mload v68
     v80 = lt v79, v67
     jumpi v80, bb13, bb14
+  bb14:
+    mstore v68, v67
+    jump bb15
+  bb15:
+    v87 = mload v68
+    v88 = lt v87, v62
+    jumpi v88, bb16, bb17
+  bb17:
+    jump bb1
+  bb1:
+    stop
+  bb16:
+    v89 = mload v68
+    v90 = add v69, v89
+    sstore v90, 0 !metadata(storage=symbolic(v90))
+    v91 = add v89, 1
+    mstore v68, v91
+    jump bb15
   bb13:
     v81 = mload v68
     v82 = add v69, v81
@@ -782,22 +781,23 @@ fn @_anonymous() {
     v86 = add v81, 1
     mstore v68, v86
     jump bb12
-  bb14:
-    mstore v68, v67
-    jump bb15
-  bb15:
-    v87 = mload v68
-    v88 = lt v87, v62
-    jumpi v88, bb16, bb17
-  bb16:
-    v89 = mload v68
-    v90 = add v69, v89
-    sstore v90, 0 !metadata(storage=symbolic(v90))
-    v91 = add v89, 1
-    mstore v68, v91
-    jump bb15
-  bb17:
-    jump bb1
+  bb8:
+    v46 = mload v25
+    v47 = add v26, v46
+    sstore v47, 0 !metadata(storage=symbolic(v47))
+    v48 = add v46, 1
+    mstore v25, v48
+    jump bb7
+  bb5:
+    v38 = mload v25
+    v39 = add v26, v38
+    v40 = mul v38, 32
+    v41 = add v7, v40
+    v42 = mload v41
+    sstore v39, v42 !metadata(storage=symbolic(v39))
+    v43 = add v38, 1
+    mstore v25, v43
+    jump bb4
 }
 
 fn @name() -> memorybytes [abi_returns=[memory_bytes]] {
@@ -835,14 +835,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -895,8 +895,6 @@ fn @constructor() {
     mstore v25, 0
     v26 = keccak256 v25, 32
     jumpi v23, bb3, bb2
-  bb1:
-    stop
   bb2:
     v27 = mload v7
     v28 = mul v6, 8
@@ -917,16 +915,6 @@ fn @constructor() {
     v36 = mload v25
     v37 = lt v36, v24
     jumpi v37, bb5, bb6
-  bb5:
-    v38 = mload v25
-    v39 = add v26, v38
-    v40 = mul v38, 32
-    v41 = add v7, v40
-    v42 = mload v41
-    sstore v39, v42 !metadata(storage=symbolic(v39))
-    v43 = add v38, 1
-    mstore v25, v43
-    jump bb4
   bb6:
     mstore v25, v24
     jump bb7
@@ -934,13 +922,6 @@ fn @constructor() {
     v44 = mload v25
     v45 = lt v44, v19
     jumpi v45, bb8, bb9
-  bb8:
-    v46 = mload v25
-    v47 = add v26, v46
-    sstore v47, 0 !metadata(storage=symbolic(v47))
-    v48 = add v46, 1
-    mstore v25, v48
-    jump bb7
   bb9:
     v49 = memory_object_len memorybytes, v3
     v50 = memory_object_data memorybytes, v3
@@ -985,6 +966,24 @@ fn @constructor() {
     v79 = mload v68
     v80 = lt v79, v67
     jumpi v80, bb13, bb14
+  bb14:
+    mstore v68, v67
+    jump bb15
+  bb15:
+    v87 = mload v68
+    v88 = lt v87, v62
+    jumpi v88, bb16, bb17
+  bb17:
+    jump bb1
+  bb1:
+    stop
+  bb16:
+    v89 = mload v68
+    v90 = add v69, v89
+    sstore v90, 0 !metadata(storage=symbolic(v90))
+    v91 = add v89, 1
+    mstore v68, v91
+    jump bb15
   bb13:
     v81 = mload v68
     v82 = add v69, v81
@@ -995,22 +994,23 @@ fn @constructor() {
     v86 = add v81, 1
     mstore v68, v86
     jump bb12
-  bb14:
-    mstore v68, v67
-    jump bb15
-  bb15:
-    v87 = mload v68
-    v88 = lt v87, v62
-    jumpi v88, bb16, bb17
-  bb16:
-    v89 = mload v68
-    v90 = add v69, v89
-    sstore v90, 0 !metadata(storage=symbolic(v90))
-    v91 = add v89, 1
-    mstore v68, v91
-    jump bb15
-  bb17:
-    jump bb1
+  bb8:
+    v46 = mload v25
+    v47 = add v26, v46
+    sstore v47, 0 !metadata(storage=symbolic(v47))
+    v48 = add v46, 1
+    mstore v25, v48
+    jump bb7
+  bb5:
+    v38 = mload v25
+    v39 = add v26, v38
+    v40 = mul v38, 32
+    v41 = add v7, v40
+    v42 = mload v41
+    sstore v39, v42 !metadata(storage=symbolic(v39))
+    v43 = add v38, 1
+    mstore v25, v43
+    jump bb4
 }
 
 fn @name() -> memorybytes [abi_returns=[memory_bytes]] {
@@ -1048,14 +1048,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23

--- a/tests/ui/codegen/lowering/storage_bytes_from_calldata.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_from_calldata.stdout
@@ -6,17 +6,11 @@ fn @setText(arg0: calldataslice) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = not 31
     v7 = and v4, v6
@@ -25,10 +19,6 @@ fn @setText(arg0: calldataslice) {
     v10 = add 32, v9
     v11 = lt v10, v9
     jumpi v11, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v12 = alloc memorybytes, exact, uninitialized, infallible, v10
     set_memory_object_len memorybytes, v12, v3
@@ -81,6 +71,22 @@ fn @setText(arg0: calldataslice) {
     v47 = mload v36
     v48 = lt v47, v35
     jumpi v48, bb10, bb11
+  bb11:
+    mstore v36, v35
+    jump bb12
+  bb12:
+    v55 = mload v36
+    v56 = lt v55, v30
+    jumpi v56, bb13, bb14
+  bb14:
+    stop
+  bb13:
+    v57 = mload v36
+    v58 = add v37, v57
+    sstore v58, 0 !metadata(storage=symbolic(v58))
+    v59 = add v57, 1
+    mstore v36, v59
+    jump bb12
   bb10:
     v49 = mload v36
     v50 = add v37, v49
@@ -91,22 +97,16 @@ fn @setText(arg0: calldataslice) {
     v54 = add v49, 1
     mstore v36, v54
     jump bb9
-  bb11:
-    mstore v36, v35
-    jump bb12
-  bb12:
-    v55 = mload v36
-    v56 = lt v55, v30
-    jumpi v56, bb13, bb14
-  bb13:
-    v57 = mload v36
-    v58 = add v37, v57
-    sstore v58, 0 !metadata(storage=symbolic(v58))
-    v59 = add v57, 1
-    mstore v36, v59
-    jump bb12
-  bb14:
-    stop
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @setBlob(arg0: calldataslice) {
@@ -115,17 +115,11 @@ fn @setBlob(arg0: calldataslice) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = not 31
     v7 = and v4, v6
@@ -134,10 +128,6 @@ fn @setBlob(arg0: calldataslice) {
     v10 = add 32, v9
     v11 = lt v10, v9
     jumpi v11, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v12 = alloc memorybytes, exact, uninitialized, infallible, v10
     set_memory_object_len memorybytes, v12, v3
@@ -190,6 +180,22 @@ fn @setBlob(arg0: calldataslice) {
     v47 = mload v36
     v48 = lt v47, v35
     jumpi v48, bb10, bb11
+  bb11:
+    mstore v36, v35
+    jump bb12
+  bb12:
+    v55 = mload v36
+    v56 = lt v55, v30
+    jumpi v56, bb13, bb14
+  bb14:
+    stop
+  bb13:
+    v57 = mload v36
+    v58 = add v37, v57
+    sstore v58, 0 !metadata(storage=symbolic(v58))
+    v59 = add v57, 1
+    mstore v36, v59
+    jump bb12
   bb10:
     v49 = mload v36
     v50 = add v37, v49
@@ -200,22 +206,16 @@ fn @setBlob(arg0: calldataslice) {
     v54 = add v49, 1
     mstore v36, v54
     jump bb9
-  bb11:
-    mstore v36, v35
-    jump bb12
-  bb12:
-    v55 = mload v36
-    v56 = lt v55, v30
-    jumpi v56, bb13, bb14
-  bb13:
-    v57 = mload v36
-    v58 = add v37, v57
-    sstore v58, 0 !metadata(storage=symbolic(v58))
-    v59 = add v57, 1
-    mstore v36, v59
-    jump bb12
-  bb14:
-    stop
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @getText() -> memorybytes [abi_returns=[memory_bytes]] {
@@ -253,14 +253,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
@@ -7,10 +7,6 @@ fn @_anonymous() {
     v2 = add v1, 1
     v3 = lt v2, v1
     jumpi v3, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v4 = add v2, 31
     v5 = not 31
@@ -72,16 +68,6 @@ fn @_anonymous() {
     v47 = mload v36
     v48 = lt v47, v35
     jumpi v48, bb6, bb7
-  bb6:
-    v49 = mload v36
-    v50 = add v37, v49
-    v51 = mul v49, 32
-    v52 = add v18, v51
-    v53 = mload v52
-    sstore v50, v53 !metadata(storage=symbolic(v50))
-    v54 = add v49, 1
-    mstore v36, v54
-    jump bb5
   bb7:
     mstore v36, v35
     jump bb8
@@ -89,23 +75,12 @@ fn @_anonymous() {
     v55 = mload v36
     v56 = lt v55, v30
     jumpi v56, bb9, bb10
-  bb9:
-    v57 = mload v36
-    v58 = add v37, v57
-    sstore v58, 0 !metadata(storage=symbolic(v58))
-    v59 = add v57, 1
-    mstore v36, v59
-    jump bb8
   bb10:
     v60 = internal_call @__load_storage_bytes, 1, 0
     v61 = memory_object_len memorybytes, v60
     v62 = add v61, 1
     v63 = lt v62, v61
     jumpi v63, bb11, bb12
-  bb11:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb12:
     v64 = add v62, 31
     v65 = not 31
@@ -167,6 +142,22 @@ fn @_anonymous() {
     v107 = mload v96
     v108 = lt v107, v95
     jumpi v108, bb16, bb17
+  bb17:
+    mstore v96, v95
+    jump bb18
+  bb18:
+    v115 = mload v96
+    v116 = lt v115, v90
+    jumpi v116, bb19, bb20
+  bb20:
+    stop
+  bb19:
+    v117 = mload v96
+    v118 = add v97, v117
+    sstore v118, 0 !metadata(storage=symbolic(v118))
+    v119 = add v117, 1
+    mstore v96, v119
+    jump bb18
   bb16:
     v109 = mload v96
     v110 = add v97, v109
@@ -177,22 +168,31 @@ fn @_anonymous() {
     v114 = add v109, 1
     mstore v96, v114
     jump bb15
-  bb17:
-    mstore v96, v95
-    jump bb18
-  bb18:
-    v115 = mload v96
-    v116 = lt v115, v90
-    jumpi v116, bb19, bb20
-  bb19:
-    v117 = mload v96
-    v118 = add v97, v117
-    sstore v118, 0 !metadata(storage=symbolic(v118))
-    v119 = add v117, 1
-    mstore v96, v119
-    jump bb18
-  bb20:
-    stop
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb9:
+    v57 = mload v36
+    v58 = add v37, v57
+    sstore v58, 0 !metadata(storage=symbolic(v58))
+    v59 = add v57, 1
+    mstore v36, v59
+    jump bb8
+  bb6:
+    v49 = mload v36
+    v50 = add v37, v49
+    v51 = mul v49, 32
+    v52 = add v18, v51
+    v53 = mload v52
+    sstore v50, v53 !metadata(storage=symbolic(v50))
+    v54 = add v49, 1
+    mstore v36, v54
+    jump bb5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @__load_storage_bytes(arg0: u256) -> memorybytes {
@@ -224,14 +224,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23
@@ -247,8 +247,6 @@ fn @pushValue(arg0: bytes1) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xff00000000000000000000000000000000000000000000000000000000000000
@@ -262,10 +260,6 @@ fn @pushValue(arg0: bytes1) {
     v8 = add v7, 1
     v9 = lt v8, v7
     jumpi v9, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v10 = add v8, 31
     v11 = not 31
@@ -328,6 +322,22 @@ fn @pushValue(arg0: bytes1) {
     v54 = mload v43
     v55 = lt v54, v42
     jumpi v55, bb10, bb11
+  bb11:
+    mstore v43, v42
+    jump bb12
+  bb12:
+    v62 = mload v43
+    v63 = lt v62, v37
+    jumpi v63, bb13, bb14
+  bb14:
+    stop
+  bb13:
+    v64 = mload v43
+    v65 = add v44, v64
+    sstore v65, 0 !metadata(storage=symbolic(v65))
+    v66 = add v64, 1
+    mstore v43, v66
+    jump bb12
   bb10:
     v56 = mload v43
     v57 = add v44, v56
@@ -338,22 +348,12 @@ fn @pushValue(arg0: bytes1) {
     v61 = add v56, 1
     mstore v43, v61
     jump bb9
-  bb11:
-    mstore v43, v42
-    jump bb12
-  bb12:
-    v62 = mload v43
-    v63 = lt v62, v37
-    jumpi v63, bb13, bb14
-  bb13:
-    v64 = mload v43
-    v65 = add v44, v64
-    sstore v65, 0 !metadata(storage=symbolic(v65))
-    v66 = add v64, 1
-    mstore v43, v66
-    jump bb12
-  bb14:
-    stop
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @pushZero() {
@@ -363,10 +363,6 @@ fn @pushZero() {
     v2 = add v1, 1
     v3 = lt v2, v1
     jumpi v3, bb1, bb2
-  bb1:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb2:
     v4 = add v2, 31
     v5 = not 31
@@ -428,6 +424,22 @@ fn @pushZero() {
     v47 = mload v36
     v48 = lt v47, v35
     jumpi v48, bb6, bb7
+  bb7:
+    mstore v36, v35
+    jump bb8
+  bb8:
+    v55 = mload v36
+    v56 = lt v55, v30
+    jumpi v56, bb9, bb10
+  bb10:
+    stop
+  bb9:
+    v57 = mload v36
+    v58 = add v37, v57
+    sstore v58, 0 !metadata(storage=symbolic(v58))
+    v59 = add v57, 1
+    mstore v36, v59
+    jump bb8
   bb6:
     v49 = mload v36
     v50 = add v37, v49
@@ -438,22 +450,10 @@ fn @pushZero() {
     v54 = add v49, 1
     mstore v36, v54
     jump bb5
-  bb7:
-    mstore v36, v35
-    jump bb8
-  bb8:
-    v55 = mload v36
-    v56 = lt v55, v30
-    jumpi v56, bb9, bb10
-  bb9:
-    v57 = mload v36
-    v58 = add v37, v57
-    sstore v58, 0 !metadata(storage=symbolic(v58))
-    v59 = add v57, 1
-    mstore v36, v59
-    jump bb8
-  bb10:
-    stop
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
 }
 
 fn @popValue() {
@@ -524,6 +524,22 @@ fn @popValue() {
     v44 = mload v33
     v45 = lt v44, v32
     jumpi v45, bb6, bb7
+  bb7:
+    mstore v33, v32
+    jump bb8
+  bb8:
+    v52 = mload v33
+    v53 = lt v52, v27
+    jumpi v53, bb9, bb10
+  bb10:
+    stop
+  bb9:
+    v54 = mload v33
+    v55 = add v34, v54
+    sstore v55, 0 !metadata(storage=symbolic(v55))
+    v56 = add v54, 1
+    mstore v33, v56
+    jump bb8
   bb6:
     v46 = mload v33
     v47 = add v34, v46
@@ -534,22 +550,6 @@ fn @popValue() {
     v51 = add v46, 1
     mstore v33, v51
     jump bb5
-  bb7:
-    mstore v33, v32
-    jump bb8
-  bb8:
-    v52 = mload v33
-    v53 = lt v52, v27
-    jumpi v53, bb9, bb10
-  bb9:
-    v54 = mload v33
-    v55 = add v34, v54
-    sstore v55, 0 !metadata(storage=symbolic(v55))
-    v56 = add v54, 1
-    mstore v33, v56
-    jump bb8
-  bb10:
-    stop
 }
 
 fn @get() -> memorybytes [abi_returns=[memory_bytes]] {

--- a/tests/ui/codegen/lowering/storage_checked_arithmetic.stdout
+++ b/tests/ui/codegen/lowering/storage_checked_arithmetic.stdout
@@ -6,8 +6,6 @@ fn @storage_sub(arg0: address, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -21,14 +19,16 @@ fn @storage_sub(arg0: address, arg1: u256) {
     v8 = sub v7, arg1
     v9 = lt v7, arg1
     jumpi v9, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v10 = mapping_slot arg0, 0
     sstore v10, v8 !metadata(storage=symbolic(v10))
     stop
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @storage_binary_sub(arg0: address, arg1: u256) {
@@ -37,8 +37,6 @@ fn @storage_binary_sub(arg0: address, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -52,14 +50,16 @@ fn @storage_binary_sub(arg0: address, arg1: u256) {
     v8 = sub v7, arg1
     v9 = lt v7, arg1
     jumpi v9, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v10 = mapping_slot arg0, 0
     sstore v10, v8 !metadata(storage=symbolic(v10))
     stop
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @storage_struct_add(arg0: address, arg1: u128) {
@@ -68,8 +68,6 @@ fn @storage_struct_add(arg0: address, arg1: u128) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -90,14 +88,16 @@ fn @storage_struct_add(arg0: address, arg1: u128) {
     v11 = add v10, arg1
     v12 = gt v11, 0xffffffffffffffffffffffffffffffff
     jumpi v12, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v13 = mapping_slot arg0, 1
     sstore v13, v11 !metadata(storage=symbolic(v13))
     stop
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @storage_struct_signed_sub(arg0: address, arg1: i8) {
@@ -106,8 +106,6 @@ fn @storage_struct_signed_sub(arg0: address, arg1: i8) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -131,14 +129,16 @@ fn @storage_struct_signed_sub(arg0: address, arg1: i8) {
     v14 = sgt v12, 127
     v15 = or v13, v14
     jumpi v15, bb7, bb8
-  bb7:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb8:
     v16 = mapping_slot arg0, 1
     v17 = add v16, 1
     sstore v17, v12 !metadata(storage=offset(v16, 1))
     stop
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
@@ -35,14 +35,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23

--- a/tests/ui/codegen/lowering/storage_packed_bool.stdout
+++ b/tests/ui/codegen/lowering/storage_packed_bool.stdout
@@ -21,8 +21,6 @@ fn @set(arg0: bool, arg1: bool) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = iszero v3
@@ -52,6 +50,8 @@ fn @set(arg0: bool, arg1: bool) {
     v19 = or v16, v18
     sstore 0, v19 !metadata(storage=slot(0))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @both() -> bool [abi_returns=[word]] {

--- a/tests/ui/codegen/lowering/storage_reference.stdout
+++ b/tests/ui/codegen/lowering/storage_reference.stdout
@@ -6,12 +6,12 @@ fn @setDirect(arg0: u256, arg1: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     sstore v3, arg1 !metadata(storage=symbolic(v3))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @getViaRef(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -20,12 +20,12 @@ fn @getViaRef(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     v4 = sload v3 !metadata(storage=symbolic(v3))
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @bump(arg0: u256) {
@@ -34,8 +34,6 @@ fn @bump(arg0: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = mapping_slot arg0, 0
     v4 = add v3, 1
@@ -43,13 +41,15 @@ fn @bump(arg0: u256) {
     v6 = add v5, 1
     v7 = lt v6, v5
     jumpi v7, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v8 = add v3, 1
     sstore v8, v6 !metadata(storage=offset(v3, 1))
     stop
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/storage_struct_array.stdout
+++ b/tests/ui/codegen/lowering/storage_struct_array.stdout
@@ -6,8 +6,6 @@ fn @setS(arg0: u256, arg1: u256, arg2: u256) {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, 3
     jumpi v3, bb4, bb3
@@ -31,6 +29,8 @@ fn @setS(arg0: u256, arg1: u256, arg2: u256) {
     v9 = add v8, 1
     sstore v9, arg2 !metadata(storage=offset(v7, 1))
     stop
+  bb1:
+    revert 0, 0
 }
 
 fn @getS(arg0: u256) -> (u256, u256) [abi_returns=[word, word]] {
@@ -39,8 +39,6 @@ fn @getS(arg0: u256) -> (u256, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, 3
     jumpi v3, bb4, bb3
@@ -64,5 +62,7 @@ fn @getS(arg0: u256) -> (u256, u256) [abi_returns=[word, word]] {
     v10 = add v9, 1
     v11 = sload v10 !metadata(storage=offset(v8, 1))
     ret v6, v11
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/storage_struct_deep_copy.sol
+++ b/tests/ui/codegen/lowering/storage_struct_deep_copy.sol
@@ -17,8 +17,8 @@ contract StorageStructDeepCopy {
 
     // SDC-LABEL: fn @assign
     // The dynamic array field's length and elements are written to storage.
-    // SDC: sstore {{v[0-9]+}}, {{v[0-9]+}}
     // SDC: sstore 1,
+    // SDC: sstore {{v[0-9]+}}, {{v[0-9]+}}
     function assign(address a, bytes4 x) public {
         bytes4[] memory ss = new bytes4[](1);
         ss[0] = x;

--- a/tests/ui/codegen/lowering/storage_struct_deep_copy.stdout
+++ b/tests/ui/codegen/lowering/storage_struct_deep_copy.stdout
@@ -7,8 +7,6 @@ fn @assign() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -26,21 +24,6 @@ fn @assign() {
     v43 = gt v41, 0xffffffffffffffff
     v44 = or v42, v43
     jumpi v44, bb9, bb8
-  bb5:
-    v28 = phi [bb8: 0], [bb6: v34]
-    v35 = phi [bb8: 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6], [bb6: v36]
-    v37 = phi [bb8: v27], [bb6: v38]
-    v29 = lt v28, v25
-    jumpi v29, bb6, bb7
-  bb6:
-    v32 = mload v37
-    sstore v35, v32 !metadata(storage=symbolic(v35))
-    v34 = add v28, 1
-    v36 = add v35, 1
-    v38 = add v37, 32
-    jump bb5
-  bb7:
-    stop
   bb8:
     mstore 64, v41 !metadata(memory=scratch)
     v46 = calldatasize
@@ -62,10 +45,27 @@ fn @assign() {
     mstore 0, 1 !metadata(memory=scratch)
     v27 = add v14, 32
     jump bb5
+  bb5:
+    v28 = phi [bb8: 0], [bb6: v34]
+    v35 = phi [bb8: 0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6], [bb6: v36]
+    v37 = phi [bb8: v27], [bb6: v38]
+    v29 = lt v28, v25
+    jumpi v29, bb6, bb7
+  bb7:
+    stop
+  bb6:
+    v32 = mload v37
+    sstore v35, v32 !metadata(storage=symbolic(v35))
+    v34 = add v28, 1
+    v36 = add v35, 1
+    v38 = add v37, 32
+    jump bb5
   bb9:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @push() {
@@ -74,8 +74,6 @@ fn @push() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -93,10 +91,25 @@ fn @push() {
     v50 = gt v48, 0xffffffffffffffff
     v51 = or v49, v50
     jumpi v51, bb11, bb10
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+  bb10:
+    mstore 64, v48 !metadata(memory=scratch)
+    v53 = calldatasize
+    calldatacopy v14, v53, 64
+    mstore v14, 1
+    v46 = add v14, 32
+    v47 = mul 0, 32
+    v17 = add v46, v47
+    mstore v17, arg1
+    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v52 = add v18, 64
+    mstore 64, v52 !metadata(memory=scratch)
+    mstore v18, arg0
+    v20 = add v18, 32
+    mstore v20, v14
+    v21 = sload 2 !metadata(storage=slot(2))
+    v22 = add v21, 1
+    v23 = lt v22, v21
+    jumpi v23, bb5, bb6
   bb6:
     mstore 0, 2 !metadata(memory=scratch)
     v25 = shl 1, v21
@@ -117,6 +130,9 @@ fn @push() {
     v44 = phi [bb6: v33], [bb8: v45]
     v36 = lt v35, v32
     jumpi v36, bb8, bb9
+  bb9:
+    sstore 2, v22 !metadata(storage=slot(2))
+    stop
   bb8:
     v39 = mload v42
     sstore v44, v39 !metadata(storage=symbolic(v44))
@@ -124,32 +140,16 @@ fn @push() {
     v43 = add v42, 32
     v45 = add v44, 1
     jump bb7
-  bb9:
-    sstore 2, v22 !metadata(storage=slot(2))
-    stop
-  bb10:
-    mstore 64, v48 !metadata(memory=scratch)
-    v53 = calldatasize
-    calldatacopy v14, v53, 64
-    mstore v14, 1
-    v46 = add v14, 32
-    v47 = mul 0, 32
-    v17 = add v46, v47
-    mstore v17, arg1
-    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v52 = add v18, 64
-    mstore 64, v52 !metadata(memory=scratch)
-    mstore v18, arg0
-    v20 = add v18, 32
-    mstore v20, v14
-    v21 = sload 2 !metadata(storage=slot(2))
-    v22 = add v21, 1
-    v23 = lt v22, v21
-    jumpi v23, bb5, bb6
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
   bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @pop() {
@@ -180,12 +180,12 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb5, [0x4bd0273c => bb2, 0xa4ece52c => bb3, 0xa60249a3 => bb4]
-  bb2:
-    tail_call @assign
-  bb3:
-    tail_call @pop
   bb4:
     tail_call @push
+  bb3:
+    tail_call @pop
+  bb2:
+    tail_call @assign
   bb5:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/ternary.sol
+++ b/tests/ui/codegen/lowering/ternary.sol
@@ -5,8 +5,8 @@ contract Ternary {
     // CHECK-LABEL: fn @max{{[( ]}}
     // CHECK: [[GT:v[0-9]+]] = gt arg0, arg1
     // CHECK: jumpi [[GT]],
-    // CHECK: mstore 0, arg0
     // CHECK: mstore 0, arg1
+    // CHECK: mstore 0, arg0
     // CHECK: mload 0
     function max(uint256 a, uint256 b) public pure returns (uint256) {
         return a > b ? a : b;
@@ -23,8 +23,8 @@ contract Ternary {
     // CHECK-LABEL: fn @abs_diff{{[( ]}}
     // CHECK: [[LT:v[0-9]+]] = lt arg0, arg1
     // CHECK: {{v[0-9]+}} = iszero [[LT]]
-    // CHECK: sub arg0, arg1
     // CHECK: sub arg1, arg0
+    // CHECK: sub arg0, arg1
     // CHECK: mload 0
     function abs_diff(uint256 a, uint256 b) public pure returns (uint256) {
         return a >= b ? a - b : b - a;

--- a/tests/ui/codegen/lowering/ternary.stdout
+++ b/tests/ui/codegen/lowering/ternary.stdout
@@ -6,20 +6,20 @@ fn @max(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = gt arg0, arg1
     jumpi v3, bb3, bb4
-  bb3:
-    mstore 0, arg0 !metadata(memory=scratch)
-    jump bb5
   bb4:
     mstore 0, arg1 !metadata(memory=scratch)
+    jump bb5
+  bb3:
+    mstore 0, arg0 !metadata(memory=scratch)
     jump bb5
   bb5:
     v4 = mload 0 !metadata(memory=scratch)
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @clamp(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
@@ -28,30 +28,30 @@ fn @clamp(arg0: u256, arg1: u256, arg2: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 96
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, arg1
     jumpi v3, bb3, bb4
-  bb3:
-    mstore 0, arg1 !metadata(memory=scratch)
-    jump bb5
   bb4:
     v4 = gt arg0, arg2
     jumpi v4, bb6, bb7
-  bb5:
-    v6 = mload 0 !metadata(memory=scratch)
-    ret v6
-  bb6:
-    mstore 0, arg2 !metadata(memory=scratch)
-    jump bb8
   bb7:
     mstore 0, arg0 !metadata(memory=scratch)
+    jump bb8
+  bb6:
+    mstore 0, arg2 !metadata(memory=scratch)
     jump bb8
   bb8:
     v5 = mload 0 !metadata(memory=scratch)
     mstore 0, v5 !metadata(memory=scratch)
     jump bb5
+  bb3:
+    mstore 0, arg1 !metadata(memory=scratch)
+    jump bb5
+  bb5:
+    v6 = mload 0 !metadata(memory=scratch)
+    ret v6
+  bb1:
+    revert 0, 0
 }
 
 fn @abs_diff(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -60,20 +60,28 @@ fn @abs_diff(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = lt arg0, arg1
     v4 = iszero v3
     jumpi v4, bb3, bb4
-  bb3:
-    v5 = sub arg0, arg1
-    v6 = lt arg0, arg1
-    jumpi v6, bb6, bb7
   bb4:
     v7 = sub arg1, arg0
     v8 = lt arg1, arg0
     jumpi v8, bb8, bb9
+  bb9:
+    mstore 0, v7 !metadata(memory=scratch)
+    jump bb5
+  bb8:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    v5 = sub arg0, arg1
+    v6 = lt arg0, arg1
+    jumpi v6, bb6, bb7
+  bb7:
+    mstore 0, v5 !metadata(memory=scratch)
+    jump bb5
   bb5:
     v9 = mload 0 !metadata(memory=scratch)
     ret v9
@@ -81,15 +89,7 @@ fn @abs_diff(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb7:
-    mstore 0, v5 !metadata(memory=scratch)
-    jump bb5
-  bb8:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb9:
-    mstore 0, v7 !metadata(memory=scratch)
-    jump bb5
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/try_catch_full.stdout
+++ b/tests/ui/codegen/lowering/try_catch_full.stdout
@@ -7,8 +7,6 @@ fn @full() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     v3 = mload 64 !metadata(memory=scratch, effect=memory_write)
@@ -24,20 +22,6 @@ fn @full() {
     v8 = gas
     v9 = staticcall v8, v7, v128, 36, 0, 0
     jumpi v9, bb3, bb4
-  bb3:
-    v10 = returndatasize
-    v14 = add v10, 31
-    v16 = and v14, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v17 = add v16, 32
-    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v216 = add v18, v17
-    mstore 64, v216 !metadata(memory=scratch)
-    mstore v18, v10
-    v19 = add v18, 32
-    returndatacopy v19, 0, v10
-    v20 = mload v18
-    v22 = lt v20, 64
-    jumpi v22, bb1, bb5
   bb4:
     v48 = returndatasize
     v49 = lt v48, 4
@@ -50,64 +34,13 @@ fn @full() {
     v54 = eq v53, 0x8c379a0
     v55 = and v54, v50
     jumpi v55, bb15, bb16
-  bb5:
-    v23 = mload v19
-    v24 = add v19, 32
-    v25 = mload v24
-    v26 = lt v25, 64
-    jumpi v26, bb1, bb6
-  bb6:
-    v27 = add v25, 32
-    v28 = lt v27, v25
-    jumpi v28, bb1, bb7
-  bb7:
-    v29 = gt v27, v20
-    jumpi v29, bb1, bb8
-  bb8:
-    v30 = add v19, v25
-    v31 = mload v30
-    v32 = add v31, 31
-    v33 = lt v32, v31
-    jumpi v33, bb1, bb9
-  bb9:
-    v35 = and v32, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v36 = add v27, v35
-    v37 = lt v36, v27
-    jumpi v37, bb1, bb10
-  bb10:
-    v38 = gt v36, v20
-    jumpi v38, bb1, bb11
-  bb11:
-    v39 = iszero v35
-    v40 = select v39, 32, v35
-    v41 = add v40, 32
-    v42 = lt v41, v40
-    jumpi v42, bb12, bb13
-  bb12:
-    tail_call @__revert_stub0
-  bb13:
-    v43 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v217 = add v43, v41
-    mstore 64, v217 !metadata(memory=scratch)
-    mstore v43, v31
-    v44 = add v43, 32
-    v45 = sub v40, 32
-    v46 = add v44, v45
-    mstore v46, 0
-    v47 = add v30, 32
-    mcopy v44, v47, v31
-    v131 = mload 64 !metadata(memory=scratch)
-    v132 = add v131, 64
-    mstore v131, v23
-    v134 = sub v132, v131
-    v133 = add v131, 32
-    mstore v133, v134
-    v135 = mload v43
-    mstore v132, v135
-    v137 = add v135, 31
-    v138 = and v137, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v139 = add v131, 96
-    jumpi v138, bb25, bb26
+  bb16:
+    v93 = eq v53, 0x4e487b71
+    v94 = and v93, v50
+    v95 = lt v48, 36
+    v96 = iszero v95
+    v97 = and v94, v96
+    jumpi v97, bb24, bb14
   bb14:
     v103 = returndatasize
     v107 = add v103, 31
@@ -131,6 +64,57 @@ fn @full() {
     v159 = and v158, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v160 = add v152, 96
     jumpi v159, bb27, bb28
+  bb27:
+    v162 = sub v159, 32
+    v163 = add v160, v162
+    mstore v163, 0
+    jump bb28
+  bb28:
+    v165 = add v160, v159
+    mcopy v160, v112, v156
+    v166 = sub v165, v152
+    v168 = add v166, 31
+    v170 = and v168, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v171 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v222 = add v171, v170
+    mstore 64, v222 !metadata(memory=scratch)
+    returndata v171, v166
+  bb24:
+    returndatacopy 0, 4, 32 !metadata(memory=scratch)
+    v98 = mload 0 !metadata(memory=scratch)
+    v99 = mload 64 !metadata(memory=scratch)
+    v100 = add v99, 32
+    mstore v100, v98
+    mstore v99, 32
+    v102 = add v99, 64
+    mstore 64, v102 !metadata(memory=scratch)
+    v194 = mload 64 !metadata(memory=scratch)
+    v195 = add v194, 64
+    mstore v194, 2
+    v197 = sub v195, v194
+    v196 = add v194, 32
+    mstore v196, v197
+    v198 = mload v99
+    mstore v195, v198
+    v200 = add v198, 31
+    v201 = and v200, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v202 = add v194, 96
+    jumpi v201, bb31, bb32
+  bb31:
+    v204 = sub v201, 32
+    v205 = add v202, v204
+    mstore v205, 0
+    jump bb32
+  bb32:
+    v207 = add v202, v201
+    mcopy v202, v100, v198
+    v208 = sub v207, v194
+    v210 = add v208, 31
+    v212 = and v210, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v213 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v224 = add v213, v212
+    mstore 64, v224 !metadata(memory=scratch)
+    returndata v213, v208
   bb15:
     v56 = returndatasize
     v60 = add v56, 31
@@ -148,13 +132,6 @@ fn @full() {
     v70 = mload v68
     v71 = lt v70, 32
     jumpi v71, bb1, bb17
-  bb16:
-    v93 = eq v53, 0x4e487b71
-    v94 = and v93, v50
-    v95 = lt v48, 36
-    v96 = iszero v95
-    v97 = and v94, v96
-    jumpi v97, bb24, bb14
   bb17:
     v72 = add v70, 32
     v73 = lt v72, v70
@@ -205,57 +182,6 @@ fn @full() {
     v180 = and v179, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
     v181 = add v173, 96
     jumpi v180, bb29, bb30
-  bb24:
-    returndatacopy 0, 4, 32 !metadata(memory=scratch)
-    v98 = mload 0 !metadata(memory=scratch)
-    v99 = mload 64 !metadata(memory=scratch)
-    v100 = add v99, 32
-    mstore v100, v98
-    mstore v99, 32
-    v102 = add v99, 64
-    mstore 64, v102 !metadata(memory=scratch)
-    v194 = mload 64 !metadata(memory=scratch)
-    v195 = add v194, 64
-    mstore v194, 2
-    v197 = sub v195, v194
-    v196 = add v194, 32
-    mstore v196, v197
-    v198 = mload v99
-    mstore v195, v198
-    v200 = add v198, 31
-    v201 = and v200, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v202 = add v194, 96
-    jumpi v201, bb31, bb32
-  bb25:
-    v141 = sub v138, 32
-    v142 = add v139, v141
-    mstore v142, 0
-    jump bb26
-  bb26:
-    v144 = add v139, v138
-    mcopy v139, v44, v135
-    v145 = sub v144, v131
-    v147 = add v145, 31
-    v149 = and v147, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v150 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v221 = add v150, v149
-    mstore 64, v221 !metadata(memory=scratch)
-    returndata v150, v145
-  bb27:
-    v162 = sub v159, 32
-    v163 = add v160, v162
-    mstore v163, 0
-    jump bb28
-  bb28:
-    v165 = add v160, v159
-    mcopy v160, v112, v156
-    v166 = sub v165, v152
-    v168 = add v166, 31
-    v170 = and v168, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v171 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v222 = add v171, v170
-    mstore 64, v222 !metadata(memory=scratch)
-    returndata v171, v166
   bb29:
     v183 = sub v180, 32
     v184 = add v181, v183
@@ -271,21 +197,95 @@ fn @full() {
     v223 = add v192, v191
     mstore 64, v223 !metadata(memory=scratch)
     returndata v192, v187
-  bb31:
-    v204 = sub v201, 32
-    v205 = add v202, v204
-    mstore v205, 0
-    jump bb32
-  bb32:
-    v207 = add v202, v201
-    mcopy v202, v100, v198
-    v208 = sub v207, v194
-    v210 = add v208, 31
-    v212 = and v210, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v213 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v224 = add v213, v212
-    mstore 64, v224 !metadata(memory=scratch)
-    returndata v213, v208
+  bb3:
+    v10 = returndatasize
+    v14 = add v10, 31
+    v16 = and v14, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v17 = add v16, 32
+    v18 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v216 = add v18, v17
+    mstore 64, v216 !metadata(memory=scratch)
+    mstore v18, v10
+    v19 = add v18, 32
+    returndatacopy v19, 0, v10
+    v20 = mload v18
+    v22 = lt v20, 64
+    jumpi v22, bb1, bb5
+  bb5:
+    v23 = mload v19
+    v24 = add v19, 32
+    v25 = mload v24
+    v26 = lt v25, 64
+    jumpi v26, bb1, bb6
+  bb6:
+    v27 = add v25, 32
+    v28 = lt v27, v25
+    jumpi v28, bb1, bb7
+  bb7:
+    v29 = gt v27, v20
+    jumpi v29, bb1, bb8
+  bb8:
+    v30 = add v19, v25
+    v31 = mload v30
+    v32 = add v31, 31
+    v33 = lt v32, v31
+    jumpi v33, bb1, bb9
+  bb9:
+    v35 = and v32, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v36 = add v27, v35
+    v37 = lt v36, v27
+    jumpi v37, bb1, bb10
+  bb10:
+    v38 = gt v36, v20
+    jumpi v38, bb1, bb11
+  bb11:
+    v39 = iszero v35
+    v40 = select v39, 32, v35
+    v41 = add v40, 32
+    v42 = lt v41, v40
+    jumpi v42, bb12, bb13
+  bb13:
+    v43 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v217 = add v43, v41
+    mstore 64, v217 !metadata(memory=scratch)
+    mstore v43, v31
+    v44 = add v43, 32
+    v45 = sub v40, 32
+    v46 = add v44, v45
+    mstore v46, 0
+    v47 = add v30, 32
+    mcopy v44, v47, v31
+    v131 = mload 64 !metadata(memory=scratch)
+    v132 = add v131, 64
+    mstore v131, v23
+    v134 = sub v132, v131
+    v133 = add v131, 32
+    mstore v133, v134
+    v135 = mload v43
+    mstore v132, v135
+    v137 = add v135, 31
+    v138 = and v137, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v139 = add v131, 96
+    jumpi v138, bb25, bb26
+  bb25:
+    v141 = sub v138, 32
+    v142 = add v139, v141
+    mstore v142, 0
+    jump bb26
+  bb26:
+    v144 = add v139, v138
+    mcopy v139, v44, v135
+    v145 = sub v144, v131
+    v147 = add v145, 31
+    v149 = and v147, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v150 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v221 = add v150, v149
+    mstore 64, v221 !metadata(memory=scratch)
+    returndata v150, v145
+  bb12:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @rethrows() {
@@ -294,8 +294,6 @@ fn @rethrows() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     v94 = mload 64 !metadata(memory=scratch, effect=memory_write)
@@ -308,20 +306,6 @@ fn @rethrows() {
     v7 = gas
     v8 = staticcall v7, v6, v94, 36, 0, 0
     jumpi v8, bb3, bb4
-  bb3:
-    v9 = returndatasize
-    v13 = add v9, 31
-    v15 = and v13, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v16 = add v15, 32
-    v17 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v98 = add v17, v16
-    mstore 64, v98 !metadata(memory=scratch)
-    mstore v17, v9
-    v18 = add v17, 32
-    returndatacopy v18, 0, v9
-    v19 = mload v17
-    v21 = lt v19, 64
-    jumpi v21, bb1, bb6
   bb4:
     v47 = returndatasize
     v48 = lt v47, 4
@@ -334,51 +318,6 @@ fn @rethrows() {
     v53 = eq v52, 0x8c379a0
     v54 = and v53, v49
     jumpi v54, bb16, bb15
-  bb5:
-    v93 = mload 128
-    mstore 128, v93
-    returndata 128, 32
-  bb6:
-    v22 = mload v18
-    v23 = add v18, 32
-    v24 = mload v23
-    v25 = lt v24, 64
-    jumpi v25, bb1, bb7
-  bb7:
-    v26 = add v24, 32
-    v27 = lt v26, v24
-    jumpi v27, bb1, bb8
-  bb8:
-    v28 = gt v26, v19
-    jumpi v28, bb1, bb9
-  bb9:
-    v29 = add v18, v24
-    v30 = mload v29
-    v31 = add v30, 31
-    v32 = lt v31, v30
-    jumpi v32, bb1, bb10
-  bb10:
-    v34 = and v31, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
-    v35 = add v26, v34
-    v36 = lt v35, v26
-    jumpi v36, bb1, bb11
-  bb11:
-    v37 = gt v35, v19
-    jumpi v37, bb1, bb12
-  bb12:
-    v38 = iszero v34
-    v39 = select v38, 32, v34
-    v40 = add v39, 32
-    v41 = lt v40, v39
-    jumpi v41, bb13, bb14
-  bb13:
-    tail_call @__revert_stub0
-  bb14:
-    v42 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v99 = add v42, v40
-    mstore 64, v99 !metadata(memory=scratch)
-    mstore 128, v22
-    jump bb5
   bb15:
     v92 = returndatasize
     returndatacopy 0, 0, v92 !metadata(memory=scratch)
@@ -433,6 +372,67 @@ fn @rethrows() {
     mstore 64, v101 !metadata(memory=scratch)
     mstore 128, 1
     jump bb5
+  bb3:
+    v9 = returndatasize
+    v13 = add v9, 31
+    v15 = and v13, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v16 = add v15, 32
+    v17 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v98 = add v17, v16
+    mstore 64, v98 !metadata(memory=scratch)
+    mstore v17, v9
+    v18 = add v17, 32
+    returndatacopy v18, 0, v9
+    v19 = mload v17
+    v21 = lt v19, 64
+    jumpi v21, bb1, bb6
+  bb6:
+    v22 = mload v18
+    v23 = add v18, 32
+    v24 = mload v23
+    v25 = lt v24, 64
+    jumpi v25, bb1, bb7
+  bb7:
+    v26 = add v24, 32
+    v27 = lt v26, v24
+    jumpi v27, bb1, bb8
+  bb8:
+    v28 = gt v26, v19
+    jumpi v28, bb1, bb9
+  bb9:
+    v29 = add v18, v24
+    v30 = mload v29
+    v31 = add v30, 31
+    v32 = lt v31, v30
+    jumpi v32, bb1, bb10
+  bb10:
+    v34 = and v31, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0
+    v35 = add v26, v34
+    v36 = lt v35, v26
+    jumpi v36, bb1, bb11
+  bb11:
+    v37 = gt v35, v19
+    jumpi v37, bb1, bb12
+  bb12:
+    v38 = iszero v34
+    v39 = select v38, 32, v34
+    v40 = add v39, 32
+    v41 = lt v40, v39
+    jumpi v41, bb13, bb14
+  bb14:
+    v42 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v99 = add v42, v40
+    mstore 64, v99 !metadata(memory=scratch)
+    mstore 128, v22
+    jump bb5
+  bb5:
+    v93 = mload 128
+    mstore 128, v93
+    returndata 128, 32
+  bb13:
+    tail_call @__revert_stub0
+  bb1:
+    revert 0, 0
 }
 
 fn @__revert_stub0() {
@@ -450,10 +450,10 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb4, [0xd7fadfb => bb2, 0xd17b272f => bb3]
-  bb2:
-    tail_call @rethrows
   bb3:
     tail_call @full
+  bb2:
+    tail_call @rethrows
   bb4:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/type_conversion.stdout
+++ b/tests/ui/codegen/lowering/type_conversion.stdout
@@ -6,8 +6,6 @@ fn @narrowAddress(arg0: address) -> u16 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -19,6 +17,8 @@ fn @narrowAddress(arg0: address) -> u16 [abi_returns=[word]] {
     v6 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
     v7 = and v6, 0xffff
     ret v7
+  bb1:
+    revert 0, 0
 }
 
 fn @narrowUint(arg0: u256) -> u16 [abi_returns=[word]] {
@@ -27,11 +27,11 @@ fn @narrowUint(arg0: u256) -> u16 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = and arg0, 0xffff
     ret v3
+  bb1:
+    revert 0, 0
 }
 
 fn @narrowSigned(arg0: i256) -> i8 [abi_returns=[word]] {
@@ -40,11 +40,11 @@ fn @narrowSigned(arg0: i256) -> i8 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = shl 248, arg0
     v4 = sar 248, v3
     ret v4
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/user_defined_operators.stdout
+++ b/tests/ui/codegen/lowering/user_defined_operators.stdout
@@ -7,12 +7,12 @@ fn @doAdd() {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @add, 1, arg0, arg1
     mstore 128, v3
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @add(arg0: i256, arg1: i256) -> i256 {
@@ -22,10 +22,10 @@ fn @add(arg0: i256, arg1: i256) -> i256 {
     v2 = slt v0, arg1
     v3 = xor v1, v2
     jumpi v3, bb1, bb2
-  bb1:
-    tail_call @__revert_stub0
   bb2:
     ret v0
+  bb1:
+    tail_call @__revert_stub0
 }
 
 fn @doNeg() {
@@ -34,23 +34,23 @@ fn @doNeg() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = internal_call @neg, 1, arg0
     mstore 128, v3
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @neg(arg0: i256) -> i256 {
   bb0:
     v0 = eq arg0, 0x8000000000000000000000000000000000000000000000000000000000000000
     jumpi v0, bb1, bb2
-  bb1:
-    tail_call @__revert_stub0
   bb2:
     v1 = sub 0, arg0
     ret v1
+  bb1:
+    tail_call @__revert_stub0
 }
 
 fn @__revert_stub0() {
@@ -68,10 +68,10 @@ fn @entry() [entry] {
     v1 = calldataload 0
     v2 = shr 224, v1
     switch v2, default bb4, [0x8fa81b4e => bb2, 0xe9148a2a => bb3]
-  bb2:
-    tail_call @doNeg
   bb3:
     tail_call @doAdd
+  bb2:
+    tail_call @doNeg
   bb4:
     revert 0, 0
 }

--- a/tests/ui/codegen/lowering/using_for_struct.stdout
+++ b/tests/ui/codegen/lowering/using_for_struct.stdout
@@ -9,8 +9,6 @@ fn @viaMethod(arg0: bytes32, arg1: bytes32) -> bytes32 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = alloc memorystruct<4>, exact, uninitialized, infallible, 128
     v4 = memory_object_field_addr memorystruct<4>, v3, 0
@@ -23,6 +21,8 @@ fn @viaMethod(arg0: bytes32, arg1: bytes32) -> bytes32 [abi_returns=[word]] {
     mstore v7, arg1
     v8 = internal_call @hashLib, 1, v3
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @hashLib(arg0: memorystruct) -> bytes32 {

--- a/tests/ui/codegen/lowering/while_loop.sol
+++ b/tests/ui/codegen/lowering/while_loop.sol
@@ -19,9 +19,9 @@ contract WhileLoop {
     // CHECK-LABEL: fn @do_at_least_once{{[( ]}}
     // CHECK: [[I:v[0-9]+]] = mload 128
     // CHECK: {{v[0-9]+}} = add [[I]], 1
-    // CHECK: ret
     // CHECK: [[LOOP_I:v[0-9]+]] = mload 128
     // CHECK: lt [[LOOP_I]], arg0
+    // CHECK: ret
     function do_at_least_once(uint256 n) public pure returns (uint256) {
         uint256 i = 0;
         do {
@@ -33,10 +33,10 @@ contract WhileLoop {
     // CHECK-LABEL: fn @break_when_found{{[( ]}}
     // CHECK: [[I:v[0-9]+]] = mload 128
     // CHECK: lt [[I]], arg0
-    // CHECK: ret
     // CHECK: [[BODY_I:v[0-9]+]] = mload 128
     // CHECK: eq [[BODY_I]], arg1
     // CHECK: add {{v[0-9]+}}, 1
+    // CHECK: ret
     function break_when_found(uint256 n, uint256 target) public pure returns (uint256) {
         uint256 i = 0;
         while (i < n) {

--- a/tests/ui/codegen/lowering/while_loop.stdout
+++ b/tests/ui/codegen/lowering/while_loop.stdout
@@ -6,8 +6,6 @@ fn @count_down(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, arg0
     jump bb3
@@ -15,6 +13,8 @@ fn @count_down(arg0: u256) -> u256 [abi_returns=[word]] {
     v3 = mload 128
     v4 = gt v3, 0
     jumpi v4, bb5, bb7
+  bb7:
+    jump bb4
   bb4:
     v8 = mload 128
     ret v8
@@ -23,17 +23,17 @@ fn @count_down(arg0: u256) -> u256 [abi_returns=[word]] {
     v6 = sub v5, 1
     v7 = lt v5, 1
     jumpi v7, bb8, bb9
+  bb9:
+    mstore 128, v6
+    jump bb6
   bb6:
     jump bb3
-  bb7:
-    jump bb4
   bb8:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb9:
-    mstore 128, v6
-    jump bb6
+  bb1:
+    revert 0, 0
 }
 
 fn @do_at_least_once(arg0: u256) -> u256 [abi_returns=[word]] {
@@ -42,8 +42,6 @@ fn @do_at_least_once(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     jump bb3
@@ -52,24 +50,26 @@ fn @do_at_least_once(arg0: u256) -> u256 [abi_returns=[word]] {
     v4 = add v3, 1
     v5 = lt v4, v3
     jumpi v5, bb5, bb6
-  bb4:
-    v8 = mload 128
-    ret v8
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     mstore 128, v4
     v6 = mload 128
     v7 = lt v6, arg0
     jumpi v7, bb7, bb9
-  bb7:
-    jump bb3
-  bb8:
-    jump bb3
   bb9:
     jump bb4
+  bb4:
+    v8 = mload 128
+    ret v8
+  bb7:
+    jump bb3
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
+  bb8:
+    jump bb3
 }
 
 fn @break_when_found(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
@@ -78,8 +78,6 @@ fn @break_when_found(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     jump bb3
@@ -87,30 +85,32 @@ fn @break_when_found(arg0: u256, arg1: u256) -> u256 [abi_returns=[word]] {
     v3 = mload 128
     v4 = lt v3, arg0
     jumpi v4, bb5, bb7
-  bb4:
-    v10 = mload 128
-    ret v10
+  bb7:
+    jump bb4
   bb5:
     v5 = mload 128
     v6 = eq v5, arg1
     jumpi v6, bb8, bb9
-  bb6:
-    jump bb3
-  bb7:
-    jump bb4
-  bb8:
-    jump bb4
   bb9:
     v7 = mload 128
     v8 = add v7, 1
     v9 = lt v8, v7
     jumpi v9, bb10, bb11
+  bb11:
+    mstore 128, v8
+    jump bb6
+  bb6:
+    jump bb3
   bb10:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb11:
-    mstore 128, v8
-    jump bb6
+  bb8:
+    jump bb4
+  bb4:
+    v10 = mload 128
+    ret v10
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/yul_calldata_array.stdout
+++ b/tests/ui/codegen/lowering/yul_calldata_array.stdout
@@ -6,8 +6,6 @@ fn @probe(arg0: calldataslice) -> (u256, u256) [abi_returns=[word, word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 0
@@ -19,5 +17,7 @@ fn @probe(arg0: calldataslice) -> (u256, u256) [abi_returns=[word, word]] {
     v6 = mload 128
     v7 = mload 160
     ret v6, v7
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/yul_local_phi.stdout
+++ b/tests/ui/codegen/lowering/yul_local_phi.stdout
@@ -6,8 +6,6 @@ fn @branchLocal(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     mstore 160, 1
@@ -22,5 +20,7 @@ fn @branchLocal(arg0: u256) -> u256 [abi_returns=[word]] {
     mstore 128, v5
     v6 = mload 128
     ret v6
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.sol
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.sol
@@ -21,10 +21,10 @@ contract YulLowLevelBuiltins {
     // CHECK-LABEL: fn @safeCall{{[( ]}}
     // CHECK: [[FMP:v[0-9]+]] = mload 64
     // CHECK: {{v[0-9]+}} = call {{v[0-9]+}}, arg0, 0, 0, 4, 0, 32
-    // CHECK: returndatacopy [[FMP]], 0,
-    // CHECK: revert [[FMP]],
     // CHECK: extcodesize arg0
     // CHECK: mstore 64, [[FMP]]
+    // CHECK: returndatacopy [[FMP]], 0,
+    // CHECK: revert [[FMP]],
     function safeCall(address token, bytes4 selector) public returns (bool success) {
         assembly {
             let fmp := mload(0x40)

--- a/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
+++ b/tests/ui/codegen/lowering/yul_low_level_builtins.stdout
@@ -6,14 +6,14 @@ fn @leadingZeros(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, 0
     v3 = clz arg0
     mstore 128, v3
     v4 = mload 128
     ret v4
+  bb1:
+    revert 0, 0
 }
 
 fn @callCode(arg0: address) -> u256 [abi_returns=[word]] {
@@ -22,8 +22,6 @@ fn @callCode(arg0: address) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -38,6 +36,8 @@ fn @callCode(arg0: address) -> u256 [abi_returns=[word]] {
     mstore 128, v7
     v8 = mload 128
     ret v8
+  bb1:
+    revert 0, 0
 }
 
 fn @safeCall(arg0: address, arg1: bytes4) -> bool [abi_returns=[word]] {
@@ -46,8 +46,6 @@ fn @safeCall(arg0: address, arg1: bytes4) -> bool [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 64
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = calldataload 4
     v4 = and v3, 0xffffffffffffffffffffffffffffffffffffffff
@@ -77,11 +75,6 @@ fn @safeCall(arg0: address, arg1: bytes4) -> bool [abi_returns=[word]] {
     v17 = eq v16, 0
     v18 = iszero v17
     jumpi v18, bb7, bb8
-  bb7:
-    v19 = returndatasize
-    returndatacopy v9, 0, v19
-    v20 = returndatasize
-    revert v9, v20
   bb8:
     v21 = mload 128
     v22 = extcodesize arg0
@@ -91,5 +84,12 @@ fn @safeCall(arg0: address, arg1: bytes4) -> bool [abi_returns=[word]] {
     mstore 64, v9 !metadata(memory=scratch)
     v25 = mload 128
     ret v25
+  bb7:
+    v19 = returndatasize
+    returndatacopy v9, 0, v19
+    v20 = returndatasize
+    revert v9, v20
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/mir/adce/adce.mir
+++ b/tests/ui/codegen/mir/adce/adce.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=adce
 //@filecheck:
 @module Adce
-// CHECK-LABEL: {{^[ +].*}}fn @removes_dead_branch_region{{[( ]}}
-// CHECK: - jumpi arg0, bb1, bb2
-// CHECK: - {{v[0-9]+}} = add 1, 2
-// CHECK: - {{v[0-9]+}} = mul 3, 4
+// CHECK-DAG: {{^[ +].*}}fn @removes_dead_branch_region{{[( ]}}
+// CHECK-DAG: - jumpi arg0, bb1, bb2
+// CHECK-DAG: - {{v[0-9]+}} = add 1, 2
+// CHECK-DAG: - {{v[0-9]+}} = mul 3, 4
 fn @removes_dead_branch_region(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -18,9 +18,9 @@ fn @removes_dead_branch_region(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @keeps_effectful_branch_region{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
-// CHECK: {{^[ +].*}}mstore 0, 1
+// CHECK-DAG: {{^[ +].*}}fn @keeps_effectful_branch_region{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK-DAG: {{^[ +].*}}mstore 0, 1
 fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -33,9 +33,9 @@ fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @keeps_phi_target{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
-// CHECK: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: 1], [bb2: 2]
+// CHECK-DAG: {{^[ +].*}}fn @keeps_phi_target{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK-DAG: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: 1], [bb2: 2]
 fn @keeps_phi_target(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/adce/adce.mir
+++ b/tests/ui/codegen/mir/adce/adce.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=adce
 //@filecheck:
 @module Adce
-// CHECK-DAG: {{^[ +].*}}fn @removes_dead_branch_region{{[( ]}}
-// CHECK-DAG: - jumpi arg0, bb1, bb2
-// CHECK-DAG: - {{v[0-9]+}} = add 1, 2
-// CHECK-DAG: - {{v[0-9]+}} = mul 3, 4
+// CHECK-LABEL: {{^[ +].*}}fn @removes_dead_branch_region{{[( ]}}
+// CHECK: - jumpi arg0, bb1, bb2
+// CHECK: - {{v[0-9]+}} = mul 3, 4
+// CHECK: - {{v[0-9]+}} = add 1, 2
 fn @removes_dead_branch_region(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -18,9 +18,9 @@ fn @removes_dead_branch_region(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @keeps_effectful_branch_region{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
-// CHECK-DAG: {{^[ +].*}}mstore 0, 1
+// CHECK-LABEL: {{^[ +].*}}fn @keeps_effectful_branch_region{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK: {{^[ +].*}}mstore 0, 1
 fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -33,9 +33,9 @@ fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @keeps_phi_target{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
-// CHECK-DAG: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: 1], [bb2: 2]
+// CHECK-LABEL: {{^[ +].*}}fn @keeps_phi_target{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: 1], [bb2: 2]
 fn @keeps_phi_target(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/adce/adce.stdout
+++ b/tests/ui/codegen/mir/adce/adce.stdout
@@ -4,26 +4,27 @@
   fn @removes_dead_branch_region(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
+-   bb2:
+-     v1 = mul 3, 4
+      jump bb3
 -   bb1:
 -     v0 = add 1, 2
-      jump bb3
-+   bb1:
-+     invalid
-    bb2:
--     v1 = mul 3, 4
 -     jump bb3
-+     invalid
     bb3:
       ret 7
++   bb1:
++     invalid
++   bb2:
++     invalid
   }
   
   fn @keeps_effectful_branch_region(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       mstore 0, 1
-      jump bb3
-    bb2:
       jump bb3
     bb3:
       ret 7
@@ -32,9 +33,9 @@
   fn @keeps_phi_target(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: 1], [bb2: 2]

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
@@ -1,9 +1,9 @@
 //@compile-flags: -Zmir-pipeline=adce
 //@filecheck:
 @module AdceBranchCycle
-// CHECK-LABEL: {{^[ +].*}}fn @keeps_branch_cycle{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi arg0, bb2, bb3
-// CHECK: {{^[ +].*}}jump bb1
+// CHECK-DAG: {{^[ +].*}}fn @keeps_branch_cycle{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb2, bb3
+// CHECK-DAG: {{^[ +].*}}jump bb1
 fn @keeps_branch_cycle(arg0: bool) -> u256 {
   bb0:
     jump bb1
@@ -15,8 +15,8 @@ fn @keeps_branch_cycle(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @keeps_branch_self_loop{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK-DAG: {{^[ +].*}}fn @keeps_branch_self_loop{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
 fn @keeps_branch_self_loop(arg0: bool) -> u256 {
   bb0:
     jump bb1
@@ -26,9 +26,9 @@ fn @keeps_branch_self_loop(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @removes_nested_transparent_diamond{{[( ]}}
-// CHECK: - jumpi arg0, bb1, bb2
-// CHECK: + jump bb5
+// CHECK-DAG: {{^[ +].*}}fn @removes_nested_transparent_diamond{{[( ]}}
+// CHECK-DAG: {{[+-]?}} jumpi arg0, bb1, bb2
+// CHECK-DAG: {{[+-]?}} jump bb5
 fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.mir
@@ -1,9 +1,9 @@
 //@compile-flags: -Zmir-pipeline=adce
 //@filecheck:
 @module AdceBranchCycle
-// CHECK-DAG: {{^[ +].*}}fn @keeps_branch_cycle{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb2, bb3
-// CHECK-DAG: {{^[ +].*}}jump bb1
+// CHECK-LABEL: {{^[ +].*}}fn @keeps_branch_cycle{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi arg0, bb2, bb3
+// CHECK: {{^[ +].*}}jump bb1
 fn @keeps_branch_cycle(arg0: bool) -> u256 {
   bb0:
     jump bb1
@@ -15,8 +15,8 @@ fn @keeps_branch_cycle(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @keeps_branch_self_loop{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK-LABEL: {{^[ +].*}}fn @keeps_branch_self_loop{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
 fn @keeps_branch_self_loop(arg0: bool) -> u256 {
   bb0:
     jump bb1
@@ -26,9 +26,9 @@ fn @keeps_branch_self_loop(arg0: bool) -> u256 {
     ret 7
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @removes_nested_transparent_diamond{{[( ]}}
-// CHECK-DAG: {{[+-]?}} jumpi arg0, bb1, bb2
-// CHECK-DAG: {{[+-]?}} jump bb5
+// CHECK-LABEL: {{^[ +].*}}fn @removes_nested_transparent_diamond{{[( ]}}
+// CHECK: - jumpi arg0, bb1, bb2
+// CHECK: {{^ +}}jump bb5
 fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
+++ b/tests/ui/codegen/mir/adce/adce_branch_cycle.stdout
@@ -6,10 +6,10 @@
       jump bb1
     bb1:
       jumpi arg0, bb2, bb3
-    bb2:
-      jump bb1
     bb3:
       ret 7
+    bb2:
+      jump bb1
   }
   
   fn @keeps_branch_self_loop(arg0: bool) -> u256 {
@@ -24,20 +24,23 @@
   fn @removes_nested_transparent_diamond(arg0: bool, arg1: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
-+     jump bb5
-    bb1:
+-   bb2:
+      jump bb5
+-   bb1:
 -     jumpi arg1, bb3, bb4
-+     invalid
-    bb2:
+-   bb4:
 -     jump bb5
-+     invalid
-    bb3:
+-   bb3:
 -     jump bb5
-+     invalid
-    bb4:
--     jump bb5
-+     invalid
     bb5:
       ret 7
++   bb1:
++     invalid
++   bb2:
++     invalid
++   bb3:
++     invalid
++   bb4:
++     invalid
   }
   

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify.stdout
@@ -16,12 +16,12 @@
   fn @branch_forwarder_preserves_successor_order(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      ret 1
     bb2:
 -     jump bb3
 -   bb3:
       ret 2
+    bb1:
+      ret 1
   }
   
   fn @degenerate_branch_refreshes_successors(arg0: bool) -> u256 {
@@ -34,10 +34,10 @@
   fn @ordered_switch(arg0: u256) -> u256 {
     bb0:
       switch 5, default bb1, [arg0 => bb1, 5 => bb2]
-    bb1:
-      ret 1
     bb2:
       ret 2
+    bb1:
+      ret 1
   }
   
   fn @degenerate_switch_refreshes_successors(arg0: u256) -> u256 {

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir
@@ -13,10 +13,10 @@ fn @target_b() {
 }
 
 // Tail calls with different targets must NOT merge.
-// CHECK-LABEL: {{^[ +].*}}fn @keep_distinct_targets{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
-// CHECK: {{^[ +].*}}tail_call @target_a
-// CHECK: {{^[ +].*}}tail_call @target_b
+// CHECK-DAG: {{^[ +].*}}fn @keep_distinct_targets{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK-DAG: {{^[ +].*}}tail_call @target_a
+// CHECK-DAG: {{^[ +].*}}tail_call @target_b
 fn @keep_distinct_targets(arg0: bool) {
   bb0:
     jumpi arg0, bb1, bb2
@@ -27,9 +27,9 @@ fn @keep_distinct_targets(arg0: bool) {
 }
 
 // Tail calls with the same target still merge.
-// CHECK-LABEL: {{^[ +].*}}fn @dedup_same_target{{[( ]}}
-// CHECK: - jumpi arg0, bb1, bb2
-// CHECK: {{^[ +].*}}tail_call @target_a
+// CHECK-DAG: {{^[ +].*}}fn @dedup_same_target{{[( ]}}
+// CHECK-DAG: - jumpi arg0, bb1, bb2
+// CHECK-DAG: {{^[ +].*}}tail_call @target_a
 fn @dedup_same_target(arg0: bool) {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.mir
@@ -13,10 +13,10 @@ fn @target_b() {
 }
 
 // Tail calls with different targets must NOT merge.
-// CHECK-DAG: {{^[ +].*}}fn @keep_distinct_targets{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi arg0, bb1, bb2
-// CHECK-DAG: {{^[ +].*}}tail_call @target_a
-// CHECK-DAG: {{^[ +].*}}tail_call @target_b
+// CHECK-LABEL: {{^[ +].*}}fn @keep_distinct_targets{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi arg0, bb1, bb2
+// CHECK: {{^[ +].*}}tail_call @target_b
+// CHECK: {{^[ +].*}}tail_call @target_a
 fn @keep_distinct_targets(arg0: bool) {
   bb0:
     jumpi arg0, bb1, bb2
@@ -27,9 +27,9 @@ fn @keep_distinct_targets(arg0: bool) {
 }
 
 // Tail calls with the same target still merge.
-// CHECK-DAG: {{^[ +].*}}fn @dedup_same_target{{[( ]}}
-// CHECK-DAG: - jumpi arg0, bb1, bb2
-// CHECK-DAG: {{^[ +].*}}tail_call @target_a
+// CHECK-LABEL: {{^[ +].*}}fn @dedup_same_target{{[( ]}}
+// CHECK: - jumpi arg0, bb1, bb2
+// CHECK: {{^[ +].*}}tail_call @target_a
 fn @dedup_same_target(arg0: bool) {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_tail_calls.stdout
@@ -14,18 +14,18 @@
   fn @keep_distinct_targets(arg0: bool) {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      tail_call @target_a
     bb2:
       tail_call @target_b
+    bb1:
+      tail_call @target_a
   }
   
   fn @dedup_same_target(arg0: bool) {
     bb0:
 -     jumpi arg0, bb1, bb2
--   bb1:
--     tail_call @target_a
 -   bb2:
+-     tail_call @target_a
+-   bb1:
       tail_call @target_a
   }
   

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_dedup_terminal_blocks.stdout
@@ -4,85 +4,87 @@
   fn @dedup_identical_panics(arg0: u256, arg1: u256) {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-      mstore 4, 17
-      revert 0, 36
     bb2:
 -     jumpi arg1, bb3, bb4
+-   bb4:
+-     stop
 +     jumpi arg1, bb1, bb3
     bb3:
 -     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
 -     mstore 4, 17
 -     revert 0, 36
--   bb4:
-      stop
++     stop
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 36
   }
   
   fn @keep_distinct_panic_codes(arg0: u256, arg1: u256) {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-      mstore 4, 17
-      revert 0, 36
     bb2:
       jumpi arg1, bb3, bb4
+    bb4:
+      stop
     bb3:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 18
       revert 0, 36
-    bb4:
-      stop
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 36
   }
   
   fn @keep_distinct_revert_sizes(arg0: u256, arg1: u256) {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-      mstore 4, 17
-      revert 0, 36
     bb2:
       jumpi arg1, bb3, bb4
+    bb4:
+      stop
     bb3:
       mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
       mstore 4, 17
       revert 0, 32
-    bb4:
-      stop
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 17
+      revert 0, 36
   }
   
   fn @dedup_local_computations(arg0: u256, arg1: u256) {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = add arg0, 1
-      mstore 0, v0
-      revert 0, 32
     bb2:
 -     jumpi arg1, bb3, bb4
+-   bb4:
+-     stop
 +     jumpi arg1, bb1, bb3
     bb3:
 -     v1 = add arg0, 1
 -     mstore 0, v1
 -     revert 0, 32
--   bb4:
-      stop
++     stop
+    bb1:
+      v0 = add arg0, 1
+      mstore 0, v0
+      revert 0, 32
   }
   
   fn @keep_distinct_outside_operands(arg0: u256, arg1: u256) {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      mstore 0, arg0
-      revert 0, 32
     bb2:
       jumpi arg1, bb3, bb4
+    bb4:
+      stop
     bb3:
       mstore 0, arg1
       revert 0, 32
-    bb4:
-      stop
+    bb1:
+      mstore 0, arg0
+      revert 0, 32
   }
   

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_forwarders.stdout
@@ -4,14 +4,15 @@
   fn @keep_conflicting_diamond(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
+-   bb2:
+-     jump bb3
 +     jumpi arg0, bb2, bb1
     bb1:
 -     jump bb3
-+     jump bb2
-    bb2:
--     jump bb3
 -   bb3:
 -     v0 = phi [bb1: 1], [bb2: 2]
++     jump bb2
++   bb2:
 +     v0 = phi [bb0: 1], [bb1: 2]
       ret v0
   }
@@ -19,14 +20,15 @@
   fn @fold_equal_value_diamond(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
+-   bb2:
+-     jump bb3
 +     jumpi arg0, bb2, bb1
     bb1:
 -     jump bb3
-+     jump bb2
-    bb2:
--     jump bb3
 -   bb3:
 -     v0 = phi [bb1: 7], [bb2: 7]
++     jump bb2
++   bb2:
 +     v0 = phi [bb0: 7], [bb1: 7]
       ret v0
   }

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.mir
@@ -1,22 +1,22 @@
 //@compile-flags: -Zmir-pipeline=cfg-simplify
-//@filecheck: --check-prefix=RPO
+//@filecheck: --enable-var-scope
 @module CfgSimplifyPhiRewrites
-// RPO: @module CfgSimplifyPhiRewrites
 
 // CHECK-LABEL: @empty_forwarder
-// CHECK-DAG:       [[ENTRY:bb[0-9]+]]:
-// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[OTHER_BLOCK:bb[0-9]+]], [[REMOVED_BLOCK:bb[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[MERGE:bb[0-9]+]], [[OTHER_BLOCK]]
-// CHECK-DAG:       [[OTHER_BLOCK]]:
-// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE:bb[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     [[REMOVED_BLOCK]]:
-// CHECK-DAG:       [[OTHER:v[0-9]+]] = add 7, 42
-// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE]]
-// CHECK-DAG: {{[+-]?}}     [[OLD_MERGE]]:
-// CHECK-DAG: {{[+-]?}}     jump {{bb[0-9]+}}
-// CHECK-DAG: {{[+-]?}}     [[MERGE]]:
-// CHECK-DAG:       [[PHI:v[0-9]+]] = phi [[[ENTRY]]: 42], [[[OTHER_BLOCK]]: [[OTHER]]]
-// CHECK-DAG:       ret [[PHI]]
+// CHECK:       [[ENTRY:bb[0-9]+]]:
+// CHECK: -     jumpi arg0, [[OTHER_BLOCK:bb[0-9]+]], [[REMOVED_BLOCK:bb[0-9]+]]
+// CHECK: -     [[REMOVED_BLOCK]]:
+// CHECK: -     [[OTHER:v[0-9]+]] = add 7, 42
+// CHECK: -     jump [[OLD_MERGE:bb[0-9]+]]
+// CHECK: +     jumpi arg0, [[MERGE:bb[0-9]+]], [[OTHER_BLOCK]]
+// CHECK:       [[OTHER_BLOCK]]:
+// CHECK: -     jump [[OLD_MERGE]]
+// CHECK: -     [[OLD_MERGE]]:
+// CHECK: +     [[OTHER]] = add 7, 42
+// CHECK: +     jump [[MERGE]]
+// CHECK: +     [[MERGE]]:
+// CHECK:       [[PHI:v[0-9]+]] = phi [[[ENTRY]]: 42], [[[OTHER_BLOCK]]: [[OTHER]]]
+// CHECK:       ret [[PHI]]
 fn @empty_forwarder(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -31,24 +31,24 @@ fn @empty_forwarder(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: @block_merge
-// CHECK-DAG:       {{bb[0-9]+}}:
-// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[LEFT_BLOCK:bb[0-9]+]], [[OLD_RIGHT:bb[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[LEFT_BLOCK]], [[RIGHT_BLOCK:bb[0-9]+]]
-// CHECK-DAG:       [[LEFT_BLOCK]]:
-// CHECK-DAG: {{[+-]?}}     jump [[OLD_LEFT:bb[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     [[OLD_LEFT]]:
-// CHECK-DAG:       [[LEFT:v[0-9]+]] = add 1, 2
-// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE:bb[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     [[OLD_RIGHT]]:
-// CHECK-DAG: {{[+-]?}}     jump [[MERGE:bb[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     [[RIGHT_BLOCK]]:
-// CHECK-DAG:       [[RIGHT:v[0-9]+]] = add 3, 4
-// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE]]
-// CHECK-DAG: {{[+-]?}}     [[OLD_MERGE]]:
-// CHECK-DAG: {{[+-]?}}     jump [[MERGE]]
-// CHECK-DAG: {{[+-]?}}     [[MERGE]]:
-// CHECK-DAG:       [[PHI:v[0-9]+]] = phi [[[LEFT_BLOCK]]: [[LEFT]]], [[[RIGHT_BLOCK]]: [[RIGHT]]]
-// CHECK-DAG:       ret [[PHI]]
+// CHECK:       {{bb[0-9]+}}:
+// CHECK: -     jumpi arg0, [[LEFT_BLOCK:bb[0-9]+]], [[OLD_RIGHT:bb[0-9]+]]
+// CHECK: -     [[OLD_RIGHT]]:
+// CHECK: +     jumpi arg0, [[LEFT_BLOCK]], [[RIGHT_BLOCK:bb[0-9]+]]
+// CHECK: +     [[RIGHT_BLOCK]]:
+// CHECK:       [[RIGHT:v[0-9]+]] = add 3, 4
+// CHECK: -     jump [[OLD_MERGE:bb[0-9]+]]
+// CHECK: +     jump [[MERGE:bb[0-9]+]]
+// CHECK:       [[LEFT_BLOCK]]:
+// CHECK: -     jump [[OLD_LEFT:bb[0-9]+]]
+// CHECK: -     [[OLD_LEFT]]:
+// CHECK:       [[LEFT:v[0-9]+]] = add 1, 2
+// CHECK: -     jump [[OLD_MERGE]]
+// CHECK: -     [[OLD_MERGE]]:
+// CHECK: +     jump [[MERGE]]
+// CHECK: +     [[MERGE]]:
+// CHECK:       [[PHI:v[0-9]+]] = phi [[[LEFT_BLOCK]]: [[LEFT]]], [[[RIGHT_BLOCK]]: [[RIGHT]]]
+// CHECK:       ret [[PHI]]
 fn @block_merge(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb3

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.mir
@@ -1,21 +1,22 @@
 //@compile-flags: -Zmir-pipeline=cfg-simplify
-//@filecheck: --enable-var-scope
+//@filecheck: --check-prefix=RPO
 @module CfgSimplifyPhiRewrites
+// RPO: @module CfgSimplifyPhiRewrites
 
 // CHECK-LABEL: @empty_forwarder
-// CHECK:       [[ENTRY:bb[0-9]+]]:
-// CHECK: -     jumpi arg0, [[OTHER_BLOCK:bb[0-9]+]], [[REMOVED_BLOCK:bb[0-9]+]]
-// CHECK: +     jumpi arg0, [[MERGE:bb[0-9]+]], [[OTHER_BLOCK]]
-// CHECK:       [[OTHER_BLOCK]]:
-// CHECK: -     jump [[OLD_MERGE:bb[0-9]+]]
-// CHECK: -     [[REMOVED_BLOCK]]:
-// CHECK:       [[OTHER:v[0-9]+]] = add 7, 42
-// CHECK: -     jump [[OLD_MERGE]]
-// CHECK: -     [[OLD_MERGE]]:
-// CHECK: +     jump [[MERGE]]
-// CHECK: +     [[MERGE]]:
-// CHECK:       [[PHI:v[0-9]+]] = phi [[[ENTRY]]: 42], [[[OTHER_BLOCK]]: [[OTHER]]]
-// CHECK:       ret [[PHI]]
+// CHECK-DAG:       [[ENTRY:bb[0-9]+]]:
+// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[OTHER_BLOCK:bb[0-9]+]], [[REMOVED_BLOCK:bb[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[MERGE:bb[0-9]+]], [[OTHER_BLOCK]]
+// CHECK-DAG:       [[OTHER_BLOCK]]:
+// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE:bb[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     [[REMOVED_BLOCK]]:
+// CHECK-DAG:       [[OTHER:v[0-9]+]] = add 7, 42
+// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE]]
+// CHECK-DAG: {{[+-]?}}     [[OLD_MERGE]]:
+// CHECK-DAG: {{[+-]?}}     jump {{bb[0-9]+}}
+// CHECK-DAG: {{[+-]?}}     [[MERGE]]:
+// CHECK-DAG:       [[PHI:v[0-9]+]] = phi [[[ENTRY]]: 42], [[[OTHER_BLOCK]]: [[OTHER]]]
+// CHECK-DAG:       ret [[PHI]]
 fn @empty_forwarder(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -30,24 +31,24 @@ fn @empty_forwarder(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: @block_merge
-// CHECK:       {{bb[0-9]+}}:
-// CHECK: -     jumpi arg0, [[LEFT_BLOCK:bb[0-9]+]], [[OLD_RIGHT:bb[0-9]+]]
-// CHECK: +     jumpi arg0, [[LEFT_BLOCK]], [[RIGHT_BLOCK:bb[0-9]+]]
-// CHECK:       [[LEFT_BLOCK]]:
-// CHECK: -     jump [[OLD_LEFT:bb[0-9]+]]
-// CHECK: -     [[OLD_LEFT]]:
-// CHECK:       [[LEFT:v[0-9]+]] = add 1, 2
-// CHECK: -     jump [[OLD_MERGE:bb[0-9]+]]
-// CHECK: -     [[OLD_RIGHT]]:
-// CHECK: +     jump [[MERGE:bb[0-9]+]]
-// CHECK: +     [[RIGHT_BLOCK]]:
-// CHECK:       [[RIGHT:v[0-9]+]] = add 3, 4
-// CHECK: -     jump [[OLD_MERGE]]
-// CHECK: -     [[OLD_MERGE]]:
-// CHECK: +     jump [[MERGE]]
-// CHECK: +     [[MERGE]]:
-// CHECK:       [[PHI:v[0-9]+]] = phi [[[LEFT_BLOCK]]: [[LEFT]]], [[[RIGHT_BLOCK]]: [[RIGHT]]]
-// CHECK:       ret [[PHI]]
+// CHECK-DAG:       {{bb[0-9]+}}:
+// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[LEFT_BLOCK:bb[0-9]+]], [[OLD_RIGHT:bb[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     jumpi arg0, [[LEFT_BLOCK]], [[RIGHT_BLOCK:bb[0-9]+]]
+// CHECK-DAG:       [[LEFT_BLOCK]]:
+// CHECK-DAG: {{[+-]?}}     jump [[OLD_LEFT:bb[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     [[OLD_LEFT]]:
+// CHECK-DAG:       [[LEFT:v[0-9]+]] = add 1, 2
+// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE:bb[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     [[OLD_RIGHT]]:
+// CHECK-DAG: {{[+-]?}}     jump [[MERGE:bb[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     [[RIGHT_BLOCK]]:
+// CHECK-DAG:       [[RIGHT:v[0-9]+]] = add 3, 4
+// CHECK-DAG: {{[+-]?}}     jump [[OLD_MERGE]]
+// CHECK-DAG: {{[+-]?}}     [[OLD_MERGE]]:
+// CHECK-DAG: {{[+-]?}}     jump [[MERGE]]
+// CHECK-DAG: {{[+-]?}}     [[MERGE]]:
+// CHECK-DAG:       [[PHI:v[0-9]+]] = phi [[[LEFT_BLOCK]]: [[LEFT]]], [[[RIGHT_BLOCK]]: [[RIGHT]]]
+// CHECK-DAG:       ret [[PHI]]
 fn @block_merge(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb3

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_phi_rewrites.stdout
@@ -4,14 +4,15 @@
   fn @empty_forwarder(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
+-   bb2:
+-     v0 = add 7, 42
+-     jump bb3
 +     jumpi arg0, bb2, bb1
     bb1:
 -     jump bb3
--   bb2:
-      v0 = add 7, 42
--     jump bb3
 -   bb3:
 -     v1 = phi [bb1: 42], [bb2: v0]
++     v0 = add 7, 42
 +     jump bb2
 +   bb2:
 +     v1 = phi [bb0: 42], [bb1: v0]
@@ -21,16 +22,16 @@
   fn @block_merge(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb3
+-   bb3:
 +     jumpi arg0, bb1, bb2
++   bb2:
+      v1 = add 3, 4
+-     jump bb4
++     jump bb3
     bb1:
 -     jump bb2
 -   bb2:
       v0 = add 1, 2
--     jump bb4
--   bb3:
-+     jump bb3
-+   bb2:
-      v1 = add 3, 4
 -     jump bb4
 -   bb4:
 -     v2 = phi [bb2: v0], [bb3: v1]

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.stdout
@@ -4,10 +4,10 @@
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
+    bb2:
       log0 0, 0
       jump bb3
-    bb2:
+    bb1:
       log0 0, 0
       jump bb3
     bb3:
@@ -22,12 +22,12 @@
     bb1:
 -     v0 = phi [bb0: arg0], [bb2: v0]
       jumpi arg1, bb2, bb3
-    bb2:
-      log0 0, 0
-      jump bb1
     bb3:
 -     ret v0
 +     ret arg0
+    bb2:
+      log0 0, 0
+      jump bb1
   }
   
 - // === ROOT/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi.mir (before dce) ===
@@ -36,10 +36,10 @@
   fn @fold_same_value_phi(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
+    bb2:
       log0 0, 0
       jump bb3
-    bb2:
+    bb1:
       log0 0, 0
       jump bb3
     bb3:
@@ -51,10 +51,10 @@
       jump bb1
     bb1:
       jumpi arg1, bb2, bb3
+    bb3:
+      ret arg0
     bb2:
       log0 0, 0
       jump bb1
-    bb3:
-      ret arg0
   }
   

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
@@ -4,11 +4,11 @@
 // v1, itself a trivial phi deleted in the same batch. Uses of v2 must resolve
 // through the chain to arg0, not to the deleted intermediate.
 @module CfgSimplifyTrivialPhiChain
-// CHECK-LABEL: {{^[ +].*}}fn @chained_trivial{{[( ]}}
-// CHECK: - {{v[0-9]+}} = phi [bb0: arg0], [bb3: {{v[0-9]+}}]
-// CHECK: - {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}]
-// CHECK: + {{v[0-9]+}} = add arg0, 1
-// CHECK: + ret arg0
+// CHECK-DAG: {{^[ +].*}}fn @chained_trivial{{[( ]}}
+// CHECK-DAG: - {{v[0-9]+}} = phi [bb0: arg0], [bb3: {{v[0-9]+}}]
+// CHECK-DAG: - {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}]
+// CHECK-DAG: + {{v[0-9]+}} = add arg0, 1
+// CHECK-DAG: + ret arg0
 fn @chained_trivial(arg0: u256) -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.mir
@@ -4,11 +4,11 @@
 // v1, itself a trivial phi deleted in the same batch. Uses of v2 must resolve
 // through the chain to arg0, not to the deleted intermediate.
 @module CfgSimplifyTrivialPhiChain
-// CHECK-DAG: {{^[ +].*}}fn @chained_trivial{{[( ]}}
-// CHECK-DAG: - {{v[0-9]+}} = phi [bb0: arg0], [bb3: {{v[0-9]+}}]
-// CHECK-DAG: - {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}]
-// CHECK-DAG: + {{v[0-9]+}} = add arg0, 1
-// CHECK-DAG: + ret arg0
+// CHECK-LABEL: {{^[ +].*}}fn @chained_trivial{{[( ]}}
+// CHECK: - {{v[0-9]+}} = phi [bb0: arg0], [bb3: {{v[0-9]+}}]
+// CHECK: - {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}]
+// CHECK: + ret arg0
+// CHECK: + {{v[0-9]+}} = add arg0, 1
 fn @chained_trivial(arg0: u256) -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
+++ b/tests/ui/codegen/mir/cfg-simplify/cfg_simplify_trivial_phi_chain.stdout
@@ -7,17 +7,18 @@
     bb1:
 -     v0 = phi [bb0: arg0], [bb3: v0]
 -     jumpi arg0, bb2, bb4
-+     jumpi arg0, bb2, bb3
-    bb2:
+-   bb4:
+-     ret v0
+-   bb2:
 -     v1 = phi [bb1: v0], [bb2: v1]
 -     v2 = add v1, 1
 -     jumpi v2, bb2, bb3
-+     v2 = add arg0, 1
-+     jumpi v2, bb2, bb1
++     jumpi arg0, bb2, bb3
     bb3:
 -     jump bb1
--   bb4:
--     ret v0
 +     ret arg0
++   bb2:
++     v2 = add arg0, 1
++     jumpi v2, bb2, bb1
   }
   

--- a/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_add_bounds.stdout
@@ -5,32 +5,32 @@
     bb0:
       v0 = lt arg0, 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
       jumpi v0, bb1, bb2
+    bb2:
+      ret 0
     bb1:
       v1 = add arg0, 2
       v2 = lt v1, arg0
 -     jumpi v2, bb3, bb4
 +     jump bb4
-    bb2:
-      ret 0
-    bb3:
-      revert 0, 0
     bb4:
       ret v1
+    bb3:
+      revert 0, 0
   }
   
   fn @keep_wrappable_boundary(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       jumpi v0, bb1, bb2
+    bb2:
+      ret 0
     bb1:
       v1 = add arg0, 2
       v2 = lt v1, arg0
       jumpi v2, bb3, bb4
-    bb2:
-      ret 0
-    bb3:
-      revert 0, 0
     bb4:
       ret v1
+    bb3:
+      revert 0, 0
   }
   

--- a/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_index_guard.stdout
@@ -5,20 +5,24 @@
     bb0:
       v0 = lt arg0, 3
       jumpi v0, bb1, bb4
+    bb4:
+      ret 0
     bb1:
       v1 = lt arg0, 3
 -     jumpi v1, bb3, bb2
+-   bb2:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+-     mstore 4, 50
+-     revert 0, 36
 +     jump bb3
-    bb2:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-      mstore 4, 50
-      revert 0, 36
     bb3:
       v2 = shl 5, arg0
       v3 = mload v2
       ret v3
-    bb4:
-      ret 0
++   bb2:
++     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
++     mstore 4, 50
++     revert 0, 36
   }
   
   fn @fold_dyn_len_check(arg0: u256) -> u256 {
@@ -26,26 +30,32 @@
       v0 = sload 0
       v1 = lt arg0, v0
       jumpi v1, bb1, bb4
+    bb4:
+      ret 0
     bb1:
       v2 = lt arg0, v0
 -     jumpi v2, bb3, bb2
+-   bb2:
+-     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+-     mstore 4, 50
+-     revert 0, 36
 +     jump bb3
-    bb2:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-      mstore 4, 50
-      revert 0, 36
     bb3:
       v3 = add arg0, 100
       v4 = sload v3
       ret v4
-    bb4:
-      ret 0
++   bb2:
++     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
++     mstore 4, 50
++     revert 0, 36
   }
   
   fn @keep_weaker_guard(arg0: u256) -> u256 {
     bb0:
       v0 = lt arg0, 5
       jumpi v0, bb1, bb4
+    bb4:
+      ret 0
     bb1:
       v1 = lt arg0, 3
       jumpi v1, bb3, bb2
@@ -57,7 +67,5 @@
       v2 = shl 5, arg0
       v3 = mload v2
       ret v3
-    bb4:
-      ret 0
   }
   

--- a/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_loop_increment.stdout
@@ -8,17 +8,17 @@
       v0 = phi [bb0: 0], [bb4: v2]
       v1 = lt v0, arg0
       jumpi v1, bb2, bb5
+    bb5:
+      ret v0
     bb2:
       v2 = add v0, 1
       v3 = lt v2, v0
 -     jumpi v3, bb3, bb4
 +     jump bb4
-    bb3:
-      revert 0, 0
     bb4:
       jump bb1
-    bb5:
-      ret v0
+    bb3:
+      revert 0, 0
   }
   
   fn @keep_non_dominating_guard(arg0: u256, arg1: bool) -> u256 {
@@ -33,9 +33,9 @@
       v1 = add arg0, 1
       v2 = lt v1, arg0
       jumpi v2, bb4, bb5
-    bb4:
-      revert 0, 0
     bb5:
       ret v1
+    bb4:
+      revert 0, 0
   }
   

--- a/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_mul_div.stdout
@@ -5,6 +5,8 @@
     bb0:
       v0 = lt arg0, 100
       jumpi v0, bb1, bb2
+    bb2:
+      ret 0
     bb1:
       v1 = mul arg0, 3
       v2 = div v1, 3
@@ -12,12 +14,10 @@
       v4 = iszero v3
 -     jumpi v4, bb3, bb4
 +     jump bb4
-    bb2:
-      ret 0
-    bb3:
-      revert 0, 0
     bb4:
       ret v1
+    bb3:
+      revert 0, 0
   }
   
   fn @keep_mul_check_without_bound(arg0: u256) -> u256 {
@@ -27,9 +27,9 @@
       v2 = eq v1, arg0
       v3 = iszero v2
       jumpi v3, bb1, bb2
-    bb1:
-      revert 0, 0
     bb2:
       ret v0
+    bb1:
+      revert 0, 0
   }
   

--- a/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_phi_kept.stdout
@@ -5,6 +5,8 @@
     bb0:
       v0 = lt arg0, 100
       jumpi v0, bb1, bb5
+    bb5:
+      ret 0
     bb1:
       jump bb2
     bb2:
@@ -14,11 +16,9 @@
       jumpi v3, bb4, bb3
     bb3:
       jumpi arg1, bb2, bb6
-    bb4:
-      revert 0, 0
-    bb5:
-      ret 0
     bb6:
       ret v2
+    bb4:
+      revert 0, 0
   }
   

--- a/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
+++ b/tests/ui/codegen/mir/check-elim/check_elim_sub_guard.stdout
@@ -7,17 +7,19 @@
       v1 = iszero v0
       v2 = iszero v1
       jumpi v2, bb1, bb2
-    bb1:
-      revert 0, 0
     bb2:
       v3 = sub arg0, arg1
       v4 = lt arg0, arg1
 -     jumpi v4, bb3, bb4
 +     jump bb4
-    bb3:
-      revert 0, 0
     bb4:
       ret v3
+-   bb3:
+-     revert 0, 0
+    bb1:
++     revert 0, 0
++   bb3:
+      revert 0, 0
   }
   
   fn @keep_sub_without_guard(arg0: u256, arg1: u256) -> u256 {
@@ -25,26 +27,26 @@
       v0 = sub arg0, arg1
       v1 = lt arg0, arg1
       jumpi v1, bb1, bb2
-    bb1:
-      revert 0, 0
     bb2:
       ret v0
+    bb1:
+      revert 0, 0
   }
   
   fn @keep_sub_on_other_value(arg0: u256, arg1: u256) -> u256 {
     bb0:
       v0 = gt arg1, arg0
       jumpi v0, bb1, bb2
-    bb1:
-      revert 0, 0
     bb2:
       v1 = mload 0
       v2 = sub v1, arg1
       v3 = lt v1, arg1
       jumpi v3, bb3, bb4
-    bb3:
-      revert 0, 0
     bb4:
       ret v2
+    bb3:
+      revert 0, 0
+    bb1:
+      revert 0, 0
   }
   

--- a/tests/ui/codegen/mir/cse/cse_global.mir
+++ b/tests/ui/codegen/mir/cse/cse_global.mir
@@ -1,11 +1,11 @@
 //@compile-flags: -Zmir-pipeline=cse
 //@filecheck:
 @module CseGlobal
-// CHECK-DAG: {{^[ +].*}}fn @dominating_pure_expr{{[( ]}}
-// CHECK-DAG: - {{v[0-9]+}} = add arg0, arg1
-// CHECK-DAG: + {{v[0-9]+}} = mul [[DOMINATING:v[0-9]+]], 2
-// CHECK-DAG: - {{v[0-9]+}} = add arg1, arg0
-// CHECK-DAG: + {{v[0-9]+}} = mul [[DOMINATING]], 3
+// CHECK-LABEL: {{^[ +].*}}fn @dominating_pure_expr{{[( ]}}
+// CHECK: - {{v[0-9]+}} = add arg1, arg0
+// CHECK: + {{v[0-9]+}} = mul [[DOMINATING:v[0-9]+]], 3
+// CHECK: - {{v[0-9]+}} = add arg0, arg1
+// CHECK: + {{v[0-9]+}} = mul [[DOMINATING]], 2
 fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
   bb0:
     v3 = add arg0, arg1

--- a/tests/ui/codegen/mir/cse/cse_global.mir
+++ b/tests/ui/codegen/mir/cse/cse_global.mir
@@ -1,11 +1,11 @@
 //@compile-flags: -Zmir-pipeline=cse
 //@filecheck:
 @module CseGlobal
-// CHECK-LABEL: {{^[ +].*}}fn @dominating_pure_expr{{[( ]}}
-// CHECK: - {{v[0-9]+}} = add arg0, arg1
-// CHECK: + {{v[0-9]+}} = mul [[DOMINATING:v[0-9]+]], 2
-// CHECK: - {{v[0-9]+}} = add arg1, arg0
-// CHECK: + {{v[0-9]+}} = mul [[DOMINATING]], 3
+// CHECK-DAG: {{^[ +].*}}fn @dominating_pure_expr{{[( ]}}
+// CHECK-DAG: - {{v[0-9]+}} = add arg0, arg1
+// CHECK-DAG: + {{v[0-9]+}} = mul [[DOMINATING:v[0-9]+]], 2
+// CHECK-DAG: - {{v[0-9]+}} = add arg1, arg0
+// CHECK-DAG: + {{v[0-9]+}} = mul [[DOMINATING]], 3
 fn @dominating_pure_expr(arg0: u256, arg1: u256, arg2: bool) -> u256 {
   bb0:
     v3 = add arg0, arg1

--- a/tests/ui/codegen/mir/cse/cse_global.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global.stdout
@@ -5,15 +5,15 @@
     bb0:
       v0 = add arg0, arg1
       jumpi arg2, bb1, bb2
-    bb1:
--     v1 = add arg0, arg1
--     v2 = mul v1, 2
-+     v2 = mul v0, 2
-      jump bb3
     bb2:
 -     v3 = add arg1, arg0
 -     v4 = mul v3, 3
 +     v4 = mul v0, 3
+      jump bb3
+    bb1:
+-     v1 = add arg0, arg1
+-     v2 = mul v1, 2
++     v2 = mul v0, 2
       jump bb3
     bb3:
       v5 = phi [bb1: v2], [bb2: v4]

--- a/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_clobber_paths.stdout
@@ -5,10 +5,10 @@
     bb0:
       v0 = sload 0
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       sstore 0, 7
-      jump bb3
-    bb2:
       jump bb3
     bb3:
       v1 = sload 0
@@ -20,9 +20,9 @@
     bb0:
       v0 = sload 0
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
 -     v1 = sload 0
@@ -35,10 +35,10 @@
     bb0:
       v0 = sload 0
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       sstore 1, 7
-      jump bb3
-    bb2:
       jump bb3
     bb3:
 -     v1 = sload 0
@@ -55,12 +55,12 @@
       v1 = sload 0
       v2 = lt v1, arg0
       jumpi v2, bb2, bb3
-    bb2:
-      sstore 0, 7
-      jump bb1
     bb3:
       v3 = add v0, v1
       ret v3
+    bb2:
+      sstore 0, 7
+      jump bb1
   }
   
   fn @loop_sload_clean_body(arg0: u256) -> u256 {
@@ -72,12 +72,12 @@
 -     v2 = lt v1, arg0
 +     v2 = lt v0, arg0
       jumpi v2, bb2, bb3
-    bb2:
-      jump bb1
     bb3:
 -     v3 = add v0, v1
 +     v3 = add v0, v0
       ret v3
+    bb2:
+      jump bb1
   }
   
   fn @diamond_mload_clobbered_arm(arg0: bool) -> u256 {
@@ -85,10 +85,10 @@
       mstore 0, 11
       v0 = mload 0
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       mstore 0, 22
-      jump bb3
-    bb2:
       jump bb3
     bb3:
       v1 = mload 0
@@ -101,10 +101,10 @@
       v0 = balance arg1
       v1 = extcodesize arg1
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       v2 = call 0x186a0, arg1, 0, 0, 0, 0, 0
-      jump bb3
-    bb2:
       jump bb3
     bb3:
       v3 = balance arg1

--- a/tests/ui/codegen/mir/cse/cse_global_loads.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.mir
@@ -1,13 +1,12 @@
 //@compile-flags: -Zmir-pipeline=cse
-//@filecheck: --check-prefix=RPO
+//@filecheck:
 @module CseGlobalLoads
-// RPO: @module CseGlobalLoads
 immutables:
   value: u256
 
 // CHECK-LABEL: {{^[ +].*}}fn @dominating_mload{{[( ]}}
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = mload 0
-// CHECK-DAG: {{[+-]?}} ret {{v[0-9]+}}
+// CHECK: - {{v[0-9]+}} = mload 0
+// CHECK: + ret {{v[0-9]+}}
 fn @dominating_mload(arg0: bool) -> u256 {
   bb0:
     mstore 0, 11
@@ -23,8 +22,8 @@ fn @dominating_mload(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @dominating_sload{{[( ]}}
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = sload 0
-// CHECK-DAG: {{[+-]?}} ret {{v[0-9]+}}
+// CHECK: - {{v[0-9]+}} = sload 0
+// CHECK: + ret {{v[0-9]+}}
 fn @dominating_sload(arg0: bool) -> u256 {
   bb0:
     v1 = sload 0
@@ -39,11 +38,11 @@ fn @dominating_sload(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @dominating_loadimmutable{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}[[LOAD:v[0-9]+]] = loadimmutable value
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = loadimmutable value
-// CHECK-DAG: {{[+-]?}} ret [[LOAD]]
-// CHECK-DAG: {{^[ +].*}}storeimmutable value, 7
-// CHECK-DAG: {{^[ +-].*}}{{v[0-9]+}} = loadimmutable value
+// CHECK: {{^[ +].*}}[[LOAD:v[0-9]+]] = loadimmutable value
+// CHECK: {{^[ +].*}}storeimmutable value, 7
+// CHECK-NEXT: {{^[ +].*}}{{v[0-9]+}} = loadimmutable value
+// CHECK: - {{v[0-9]+}} = loadimmutable value
+// CHECK: + ret [[LOAD]]
 fn @dominating_loadimmutable(arg0: bool) -> u256 {
   bb0:
     v1 = loadimmutable value
@@ -58,11 +57,11 @@ fn @dominating_loadimmutable(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @keep_phi_immutable_loads_before_branch_stores{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}[[LEFT:v[0-9]+]] = loadimmutable value
-// CHECK-DAG: {{^[ +].*}}storeimmutable value, 1
-// CHECK-DAG: {{^[ +].*}}[[RIGHT:v[0-9]+]] = loadimmutable value
-// CHECK-DAG: {{^[ +].*}}storeimmutable value, 2
-// CHECK-DAG: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: [[LEFT]]], [bb2: [[RIGHT]]]
+// CHECK: {{^[ +].*}}[[RIGHT:v[0-9]+]] = loadimmutable value
+// CHECK: {{^[ +].*}}storeimmutable value, 2
+// CHECK: {{^[ +].*}}[[LEFT:v[0-9]+]] = loadimmutable value
+// CHECK: {{^[ +].*}}storeimmutable value, 1
+// CHECK: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: [[LEFT]]], [bb2: [[RIGHT]]]
 fn @keep_phi_immutable_loads_before_branch_stores(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/cse/cse_global_loads.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.mir
@@ -58,9 +58,9 @@ fn @dominating_loadimmutable(arg0: bool) -> u256 {
 
 // CHECK-LABEL: {{^[ +].*}}fn @keep_phi_immutable_loads_before_branch_stores{{[( ]}}
 // CHECK: {{^[ +].*}}[[RIGHT:v[0-9]+]] = loadimmutable value
-// CHECK: {{^[ +].*}}storeimmutable value, 2
+// CHECK-NEXT: {{^[ +].*}}storeimmutable value, 2
 // CHECK: {{^[ +].*}}[[LEFT:v[0-9]+]] = loadimmutable value
-// CHECK: {{^[ +].*}}storeimmutable value, 1
+// CHECK-NEXT: {{^[ +].*}}storeimmutable value, 1
 // CHECK: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: [[LEFT]]], [bb2: [[RIGHT]]]
 fn @keep_phi_immutable_loads_before_branch_stores(arg0: bool) -> u256 {
   bb0:

--- a/tests/ui/codegen/mir/cse/cse_global_loads.mir
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.mir
@@ -1,12 +1,13 @@
 //@compile-flags: -Zmir-pipeline=cse
-//@filecheck:
+//@filecheck: --check-prefix=RPO
 @module CseGlobalLoads
+// RPO: @module CseGlobalLoads
 immutables:
   value: u256
 
 // CHECK-LABEL: {{^[ +].*}}fn @dominating_mload{{[( ]}}
-// CHECK: - {{v[0-9]+}} = mload 0
-// CHECK: + ret {{v[0-9]+}}
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = mload 0
+// CHECK-DAG: {{[+-]?}} ret {{v[0-9]+}}
 fn @dominating_mload(arg0: bool) -> u256 {
   bb0:
     mstore 0, 11
@@ -22,8 +23,8 @@ fn @dominating_mload(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @dominating_sload{{[( ]}}
-// CHECK: - {{v[0-9]+}} = sload 0
-// CHECK: + ret {{v[0-9]+}}
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = sload 0
+// CHECK-DAG: {{[+-]?}} ret {{v[0-9]+}}
 fn @dominating_sload(arg0: bool) -> u256 {
   bb0:
     v1 = sload 0
@@ -38,11 +39,11 @@ fn @dominating_sload(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @dominating_loadimmutable{{[( ]}}
-// CHECK: {{^[ +].*}}[[LOAD:v[0-9]+]] = loadimmutable value
-// CHECK: - {{v[0-9]+}} = loadimmutable value
-// CHECK: + ret [[LOAD]]
-// CHECK: {{^[ +].*}}storeimmutable value, 7
-// CHECK-NEXT: {{^[ +].*}}{{v[0-9]+}} = loadimmutable value
+// CHECK-DAG: {{^[ +].*}}[[LOAD:v[0-9]+]] = loadimmutable value
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = loadimmutable value
+// CHECK-DAG: {{[+-]?}} ret [[LOAD]]
+// CHECK-DAG: {{^[ +].*}}storeimmutable value, 7
+// CHECK-DAG: {{^[ +-].*}}{{v[0-9]+}} = loadimmutable value
 fn @dominating_loadimmutable(arg0: bool) -> u256 {
   bb0:
     v1 = loadimmutable value
@@ -57,11 +58,11 @@ fn @dominating_loadimmutable(arg0: bool) -> u256 {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @keep_phi_immutable_loads_before_branch_stores{{[( ]}}
-// CHECK: {{^[ +].*}}[[LEFT:v[0-9]+]] = loadimmutable value
-// CHECK-NEXT: {{^[ +].*}}storeimmutable value, 1
-// CHECK: {{^[ +].*}}[[RIGHT:v[0-9]+]] = loadimmutable value
-// CHECK-NEXT: {{^[ +].*}}storeimmutable value, 2
-// CHECK: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: [[LEFT]]], [bb2: [[RIGHT]]]
+// CHECK-DAG: {{^[ +].*}}[[LEFT:v[0-9]+]] = loadimmutable value
+// CHECK-DAG: {{^[ +].*}}storeimmutable value, 1
+// CHECK-DAG: {{^[ +].*}}[[RIGHT:v[0-9]+]] = loadimmutable value
+// CHECK-DAG: {{^[ +].*}}storeimmutable value, 2
+// CHECK-DAG: {{^[ +].*}}{{v[0-9]+}} = phi [bb1: [[LEFT]]], [bb2: [[RIGHT]]]
 fn @keep_phi_immutable_loads_before_branch_stores(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2

--- a/tests/ui/codegen/mir/cse/cse_global_loads.stdout
+++ b/tests/ui/codegen/mir/cse/cse_global_loads.stdout
@@ -9,54 +9,54 @@
       mstore 0, 11
       v0 = mload 0
       jumpi arg0, bb1, bb2
-    bb1:
--     v1 = mload 0
--     ret v1
-+     ret v0
     bb2:
       mstore 0, 22
       v2 = mload 0
       ret v2
+    bb1:
+-     v1 = mload 0
+-     ret v1
++     ret v0
   }
   
   fn @dominating_sload(arg0: bool) -> u256 {
     bb0:
       v0 = sload 0
       jumpi arg0, bb1, bb2
-    bb1:
--     v1 = sload 0
--     ret v1
-+     ret v0
     bb2:
       sstore 0, 7
       v2 = sload 0
       ret v2
+    bb1:
+-     v1 = sload 0
+-     ret v1
++     ret v0
   }
   
   fn @dominating_loadimmutable(arg0: bool) -> u256 {
     bb0:
       v0 = loadimmutable value
       jumpi arg0, bb1, bb2
-    bb1:
--     v1 = loadimmutable value
--     ret v1
-+     ret v0
     bb2:
       storeimmutable value, 7
       v2 = loadimmutable value
       ret v2
+    bb1:
+-     v1 = loadimmutable value
+-     ret v1
++     ret v0
   }
   
   fn @keep_phi_immutable_loads_before_branch_stores(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = loadimmutable value
-      storeimmutable value, 1
-      jump bb3
     bb2:
       v1 = loadimmutable value
       storeimmutable value, 2
+      jump bb3
+    bb1:
+      v0 = loadimmutable value
+      storeimmutable value, 1
       jump bb3
     bb3:
       v2 = phi [bb1: v0], [bb2: v1]

--- a/tests/ui/codegen/mir/cse/cse_gvn.stdout
+++ b/tests/ui/codegen/mir/cse/cse_gvn.stdout
@@ -6,13 +6,13 @@
       v0 = add arg0, 16
       v1 = add v0, 16
       jumpi arg1, bb1, bb2
+    bb2:
+      ret v1
     bb1:
 -     v2 = add arg0, 32
 -     v3 = add v1, v2
 +     v3 = add v1, v1
       ret v3
-    bb2:
-      ret v1
   }
   
   fn @commuted_nested_offsets(arg0: u256, arg1: bool) -> u256 {
@@ -20,12 +20,12 @@
       v0 = add 16, arg0
       v1 = add 16, v0
       jumpi arg1, bb1, bb2
+    bb2:
+      ret v1
     bb1:
 -     v2 = add arg0, 32
 -     ret v2
 +     ret v1
-    bb2:
-      ret v1
   }
   
   fn @reuse_keccak_with_equivalent_offset(arg0: u256, arg1: bool) -> u256 {
@@ -34,13 +34,13 @@
       v1 = add v0, 16
       v2 = keccak256 v1, 32
       jumpi arg1, bb1, bb2
+    bb2:
+      ret v2
     bb1:
 -     v3 = add arg0, 32
 -     v4 = keccak256 v3, 32
 -     ret v4
 +     ret v2
-    bb2:
-      ret v2
   }
   
   fn @keep_load_after_equivalent_overlapping_store(arg0: u256, arg1: bool) -> u256 {
@@ -49,14 +49,14 @@
       v1 = add v0, 16
       v2 = mload v1
       jumpi arg1, bb1, bb2
+    bb2:
+      ret v2
     bb1:
 -     v3 = add arg0, 32
 -     mstore v3, 7
 +     mstore v1, 7
       v4 = mload v1
       ret v4
-    bb2:
-      ret v2
   }
   
   fn @keep_distinct_negative_memory_offsets(arg0: u256) -> u256 {
@@ -72,11 +72,11 @@
   fn @sink_common_phi_expression(arg0: u256, arg1: u256, arg2: bool) -> u256 {
     bb0:
       jumpi arg2, bb1, bb2
-    bb1:
--     v0 = add arg0, arg1
-      jump bb3
     bb2:
 -     v1 = add arg1, arg0
+      jump bb3
+    bb1:
+-     v0 = add arg0, arg1
       jump bb3
     bb3:
 -     v2 = phi [bb1: v0], [bb2: v1]
@@ -89,13 +89,13 @@
   fn @keep_phi_expression_with_branch_local_operands(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      v0 = add arg0, 1
-      v1 = mul v0, 2
-      jump bb3
     bb2:
       v2 = add arg0, 1
       v3 = mul v2, 2
+      jump bb3
+    bb1:
+      v0 = add arg0, 1
+      v1 = mul v0, 2
       jump bb3
     bb3:
       v4 = phi [bb1: v1], [bb2: v3]

--- a/tests/ui/codegen/mir/cse/cse_unreachable_pred.stdout
+++ b/tests/ui/codegen/mir/cse/cse_unreachable_pred.stdout
@@ -4,8 +4,6 @@
   fn @no_dangling_use(arg0: u256) -> u256 {
     bb0:
       jump bb2
-    bb1:
-      jump bb2
     bb2:
       v0 = sload arg0
 -     v1 = sload arg0
@@ -14,5 +12,7 @@
 -     v2 = add v0, v1
 +     v2 = add v0, v0
       ret v2
+    bb1:
+      jump bb2
   }
   

--- a/tests/ui/codegen/mir/dce/dce_unreachable.stdout
+++ b/tests/ui/codegen/mir/dce/dce_unreachable.stdout
@@ -4,12 +4,12 @@
   fn @skip(arg0: u256) -> u256 {
     bb0:
       jump bb2
+    bb2:
+      ret arg0
     bb1:
 -     v0 = add arg0, 1
 -     v1 = mul v0, v0
 -     ret v1
 +     invalid
-    bb2:
-      ret arg0
   }
   

--- a/tests/ui/codegen/mir/dead-arg-elim/dead_arg_elim_args.stdout
+++ b/tests/ui/codegen/mir/dead-arg-elim/dead_arg_elim_args.stdout
@@ -21,12 +21,12 @@
 + fn @recursive(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      ret arg1
     bb1:
 -     v0 = internal_call @recursive, 1, 0, arg1, arg2
 +     v0 = internal_call @recursive, 1, 0, arg1
       ret v0
-    bb2:
-      ret arg1
   }
   
   fn @external_keeps_abi(arg0: u256, arg1: u256) -> u256 {

--- a/tests/ui/codegen/mir/dead-arg-elim/dead_arg_elim_returns.stdout
+++ b/tests/ui/codegen/mir/dead-arg-elim/dead_arg_elim_returns.stdout
@@ -12,12 +12,12 @@
   fn @recursive(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = internal_call @recursive, 1, 0, arg1
-      ret v0
     bb2:
       sstore 1, arg1
       ret arg1
+    bb1:
+      v0 = internal_call @recursive, 1, 0, arg1
+      ret v0
   }
   
   fn @kept(arg0: u256) -> u256 {

--- a/tests/ui/codegen/mir/dump_phase.gas.stdout
+++ b/tests/ui/codegen/mir/dump_phase.gas.stdout
@@ -7,11 +7,11 @@ fn @f() {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     mstore 128, arg0
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @entry() [entry] {

--- a/tests/ui/codegen/mir/dump_phase.none.stdout
+++ b/tests/ui/codegen/mir/dump_phase.none.stdout
@@ -6,17 +6,17 @@ fn @f(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 0
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/mir/dump_phase.pipeline.stdout
+++ b/tests/ui/codegen/mir/dump_phase.pipeline.stdout
@@ -6,16 +6,16 @@ fn @f(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 0
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }

--- a/tests/ui/codegen/mir/dump_phase.substitute.stdout
+++ b/tests/ui/codegen/mir/dump_phase.substitute.stdout
@@ -6,17 +6,17 @@ fn @f(arg0: u256) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = add arg0, 0
     v4 = lt v3, arg0
     jumpi v4, bb3, bb4
+  bb4:
+    ret v3
   bb3:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb4:
-    ret v3
+  bb1:
+    revert 0, 0
 }
 

--- a/tests/ui/codegen/mir/evm-inst-schedule/policy_boundaries.mir
+++ b/tests/ui/codegen/mir/evm-inst-schedule/policy_boundaries.mir
@@ -3,13 +3,13 @@
 @module EvmInstSchedulePolicy
 
 // Schedule a complete expression tree in EVM stack-input order.
-// CHECK-LABEL: {{^[ +].*}}fn @deep_dependency_tree{{[( ]}}
-// CHECK: + [[XOR:v[0-9]+]] = xor arg4, arg5
-// CHECK-NEXT: [[MUL:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD]], [[MUL]]
-// CHECK-NEXT: - [[XOR]] = xor arg4, arg5
-// CHECK-NEXT: {{v[0-9]+}} = div [[SUB]], [[XOR]]
+// CHECK-DAG: {{^[ +].*}}fn @deep_dependency_tree{{[( ]}}
+// CHECK-DAG: + [[XOR:v[0-9]+]] = xor arg4, arg5
+// CHECK-DAG: [[MUL:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD]], [[MUL]]
+// CHECK-DAG: - [[XOR]] = xor arg4, arg5
+// CHECK-DAG: {{v[0-9]+}} = div [[SUB]], [[XOR]]
 fn @deep_dependency_tree(
   arg0: u256,
   arg1: u256,
@@ -28,16 +28,16 @@ fn @deep_dependency_tree(
 }
 
 // Schedule both sides of a write barrier without moving instructions across it.
-// CHECK-LABEL: {{^[ +].*}}fn @independent_barrier_segments{{[( ]}}
-// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
-// CHECK-NEXT: [[SUB1:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-NEXT: mstore 0, [[SUB1]]
-// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
-// CHECK-NEXT: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
+// CHECK-DAG: {{^[ +].*}}fn @independent_barrier_segments{{[( ]}}
+// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD1]] = add arg0, arg1
+// CHECK-DAG: [[SUB1:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-DAG: mstore 0, [[SUB1]]
+// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-DAG: + [[ADD2]] = add arg0, arg2
+// CHECK-DAG: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
 fn @independent_barrier_segments(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
   bb0:
     v4 = add arg0, arg1
@@ -51,15 +51,15 @@ fn @independent_barrier_segments(arg0: u256, arg1: u256, arg2: u256, arg3: u256)
 }
 
 // A shared producer stays pinned while the single-use islands around it are scheduled.
-// CHECK-LABEL: {{^[ +].*}}fn @shared_result_schedules_islands{{[( ]}}
-// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
-// CHECK-NEXT: [[SHARED:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add [[SHARED]], arg2
-// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul [[SHARED]], arg3
-// CHECK-NEXT: + [[ADD2]] = add [[SHARED]], arg2
-// CHECK-NEXT: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
+// CHECK-DAG: {{^[ +].*}}fn @shared_result_schedules_islands{{[( ]}}
+// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD1]] = add arg0, arg1
+// CHECK-DAG: [[SHARED:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-DAG: - [[ADD2:v[0-9]+]] = add [[SHARED]], arg2
+// CHECK-DAG: [[MUL2:v[0-9]+]] = mul [[SHARED]], arg3
+// CHECK-DAG: + [[ADD2]] = add [[SHARED]], arg2
+// CHECK-DAG: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
 fn @shared_result_schedules_islands(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
   bb0:
     v4 = add arg0, arg1
@@ -72,11 +72,11 @@ fn @shared_result_schedules_islands(arg0: u256, arg1: u256, arg2: u256, arg3: u2
 }
 
 // Keep producer order when the backend can lower either comparison orientation.
-// CHECK-LABEL: {{^[ +].*}}fn @comparison_producer_order{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}fn @comparison_producer_order{{[( ]}}
 // CHECK-NOT: {{^[+-]}}
-// CHECK: [[LEFT:v[0-9]+]] = sub arg0, arg1
-// CHECK-NEXT: [[RIGHT:v[0-9]+]] = div arg2, arg3
-// CHECK-NEXT: {{v[0-9]+}} = lt [[LEFT]], [[RIGHT]]
+// CHECK-DAG: [[LEFT:v[0-9]+]] = sub arg0, arg1
+// CHECK-DAG: [[RIGHT:v[0-9]+]] = div arg2, arg3
+// CHECK-DAG: {{v[0-9]+}} = lt [[LEFT]], [[RIGHT]]
 fn @comparison_producer_order(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> bool {
   bb0:
     v4 = sub arg0, arg1
@@ -86,11 +86,11 @@ fn @comparison_producer_order(arg0: u256, arg1: u256, arg2: u256, arg3: u256) ->
 }
 
 // Multiple return values are terminator roots and follow stack-input order.
-// CHECK-LABEL: {{^[ +].*}}fn @multiple_terminator_roots{{[( ]}}
-// CHECK: - [[ADD:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD]] = add arg0, arg1
-// CHECK-NEXT: ret [[ADD]], [[MUL]]
+// CHECK-DAG: {{^[ +].*}}fn @multiple_terminator_roots{{[( ]}}
+// CHECK-DAG: - [[ADD:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD]] = add arg0, arg1
+// CHECK-DAG: ret [[ADD]], [[MUL]]
 fn @multiple_terminator_roots(
   arg0: u256,
   arg1: u256,
@@ -104,11 +104,11 @@ fn @multiple_terminator_roots(
 }
 
 // Keep a disconnected instruction below the value consumed by the terminator.
-// CHECK-LABEL: {{^[ +].*}}fn @disconnected_root_is_retained{{[( ]}}
-// CHECK: - [[RETURNED:v[0-9]+]] = mul arg1, 2
-// CHECK-NEXT: {{v[0-9]+}} = add arg0, 1
-// CHECK-NEXT: + [[RETURNED]] = mul arg1, 2
-// CHECK-NEXT: ret [[RETURNED]]
+// CHECK-DAG: {{^[ +].*}}fn @disconnected_root_is_retained{{[( ]}}
+// CHECK-DAG: - [[RETURNED:v[0-9]+]] = mul arg1, 2
+// CHECK-DAG: {{v[0-9]+}} = add arg0, 1
+// CHECK-DAG: + [[RETURNED]] = mul arg1, 2
+// CHECK-DAG: ret [[RETURNED]]
 fn @disconnected_root_is_retained(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = mul arg1, 2
@@ -117,14 +117,14 @@ fn @disconnected_root_is_retained(arg0: u256, arg1: u256) -> u256 {
 }
 
 // Memory, transient-storage, and environment reads may share one movable segment.
-// CHECK-LABEL: {{^[ +].*}}fn @read_effects_are_movable{{[( ]}}
-// CHECK: - [[MEMORY:v[0-9]+]] = mload arg0
-// CHECK-NEXT: - [[TRANSIENT:v[0-9]+]] = tload arg1
-// CHECK-NEXT: [[CALLER:v[0-9]+]] = caller
-// CHECK-NEXT: + [[TRANSIENT]] = tload arg1
-// CHECK-NEXT: + [[MEMORY]] = mload arg0
-// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[MEMORY]], [[TRANSIENT]]
-// CHECK-NEXT: {{v[0-9]+}} = div [[SUB]], [[CALLER]]
+// CHECK-DAG: {{^[ +].*}}fn @read_effects_are_movable{{[( ]}}
+// CHECK-DAG: - [[MEMORY:v[0-9]+]] = mload arg0
+// CHECK-DAG: - [[TRANSIENT:v[0-9]+]] = tload arg1
+// CHECK-DAG: [[CALLER:v[0-9]+]] = caller
+// CHECK-DAG: + [[TRANSIENT]] = tload arg1
+// CHECK-DAG: + [[MEMORY]] = mload arg0
+// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[MEMORY]], [[TRANSIENT]]
+// CHECK-DAG: {{v[0-9]+}} = div [[SUB]], [[CALLER]]
 fn @read_effects_are_movable(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = mload arg0
@@ -136,11 +136,11 @@ fn @read_effects_are_movable(arg0: u256, arg1: u256) -> u256 {
 }
 
 // `clz` is a pure unary operation and follows its consumer's stack-input order.
-// CHECK-LABEL: {{^[ +].*}}fn @clz_is_movable{{[( ]}}
-// CHECK: - [[CLZ:v[0-9]+]] = clz arg0
-// CHECK-NEXT: [[MUL:v[0-9]+]] = mul arg1, arg2
-// CHECK-NEXT: + [[CLZ]] = clz arg0
-// CHECK-NEXT: {{v[0-9]+}} = sub [[CLZ]], [[MUL]]
+// CHECK-DAG: {{^[ +].*}}fn @clz_is_movable{{[( ]}}
+// CHECK-DAG: - [[CLZ:v[0-9]+]] = clz arg0
+// CHECK-DAG: [[MUL:v[0-9]+]] = mul arg1, arg2
+// CHECK-DAG: + [[CLZ]] = clz arg0
+// CHECK-DAG: {{v[0-9]+}} = sub [[CLZ]], [[MUL]]
 fn @clz_is_movable(arg0: u256, arg1: u256, arg2: u256) -> u256 {
   bb0:
     v3 = clz arg0
@@ -150,17 +150,17 @@ fn @clz_is_movable(arg0: u256, arg1: u256, arg2: u256) -> u256 {
 }
 
 // `callcode` separates independently scheduled segments.
-// CHECK-LABEL: {{^[ +].*}}fn @callcode_is_a_barrier{{[( ]}}
-// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
-// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-NEXT: [[CALL:v[0-9]+]] = callcode [[SUB]],
-// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
-// CHECK-NEXT: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
-// CHECK-NEXT: ret [[CALL]], [[DIV]]
+// CHECK-DAG: {{^[ +].*}}fn @callcode_is_a_barrier{{[( ]}}
+// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD1]] = add arg0, arg1
+// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-DAG: [[CALL:v[0-9]+]] = callcode [[SUB]],
+// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-DAG: + [[ADD2]] = add arg0, arg2
+// CHECK-DAG: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
+// CHECK-DAG: ret [[CALL]], [[DIV]]
 fn @callcode_is_a_barrier(
   arg0: u256,
   arg1: u256,
@@ -179,17 +179,17 @@ fn @callcode_is_a_barrier(
 }
 
 // `msize` splits two independently scheduled segments.
-// CHECK-LABEL: {{^[ +].*}}fn @msize_is_a_barrier{{[( ]}}
-// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
-// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-NEXT: [[MSIZE:v[0-9]+]] = msize
-// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
-// CHECK-NEXT: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
-// CHECK-NEXT: ret [[SUB]], [[MSIZE]], [[DIV]]
+// CHECK-DAG: {{^[ +].*}}fn @msize_is_a_barrier{{[( ]}}
+// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD1]] = add arg0, arg1
+// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-DAG: [[MSIZE:v[0-9]+]] = msize
+// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-DAG: + [[ADD2]] = add arg0, arg2
+// CHECK-DAG: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
+// CHECK-DAG: ret [[SUB]], [[MSIZE]], [[DIV]]
 fn @msize_is_a_barrier(
   arg0: u256,
   arg1: u256,
@@ -208,12 +208,12 @@ fn @msize_is_a_barrier(
 }
 
 // A phi remains at the start of its block even when a later tree consumes it.
-// CHECK-LABEL: {{^[ +].*}}fn @phi_is_a_barrier{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}fn @phi_is_a_barrier{{[( ]}}
 // CHECK-NOT: {{^[+-]}}
-// CHECK: bb3:
-// CHECK-NEXT: [[PHI:v[0-9]+]] = phi
-// CHECK-NEXT: {{v[0-9]+}} = add arg0, arg1
-// CHECK-NEXT: {{v[0-9]+}} = mul [[PHI]], arg2
+// CHECK-DAG: bb3:
+// CHECK-DAG: [[PHI:v[0-9]+]] = phi
+// CHECK-DAG: {{v[0-9]+}} = add arg0, arg1
+// CHECK-DAG: {{v[0-9]+}} = mul [[PHI]], arg2
 fn @phi_is_a_barrier(arg0: u256, arg1: u256, arg2: u256, arg3: bool) -> u256 {
   bb0:
     jumpi arg3, bb1, bb2
@@ -229,16 +229,16 @@ fn @phi_is_a_barrier(arg0: u256, arg1: u256, arg2: u256, arg3: bool) -> u256 {
 }
 
 // An explicit write effect overrides an opcode's default pure effect.
-// CHECK-LABEL: {{^[ +].*}}fn @metadata_effect_is_a_barrier{{[( ]}}
-// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
-// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-NEXT: {{v[0-9]+}} = xor arg0, arg3 !metadata(effect=memory_write)
-// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
-// CHECK-NEXT: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
+// CHECK-DAG: {{^[ +].*}}fn @metadata_effect_is_a_barrier{{[( ]}}
+// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD1]] = add arg0, arg1
+// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-DAG: {{v[0-9]+}} = xor arg0, arg3 !metadata(effect=memory_write)
+// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-DAG: + [[ADD2]] = add arg0, arg2
+// CHECK-DAG: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
 fn @metadata_effect_is_a_barrier(
   arg0: u256,
   arg1: u256,
@@ -257,18 +257,18 @@ fn @metadata_effect_is_a_barrier(
 }
 
 // Each block starts with empty scheduling scratch state.
-// CHECK-LABEL: {{^[ +].*}}fn @block_local_scratch{{[( ]}}
-// CHECK: - [[ADD0:v[0-9]+]] = add arg0, arg1
-// CHECK-NEXT: [[MUL0:v[0-9]+]] = mul arg2, arg3
-// CHECK-NEXT: + [[ADD0]] = add arg0, arg1
-// CHECK: bb1:
-// CHECK-NEXT: - [[ADD1:v[0-9]+]] = add arg0, arg2
-// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg1, arg3
-// CHECK-NEXT: + [[ADD1]] = add arg0, arg2
-// CHECK: bb2:
-// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg3
-// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg2
-// CHECK-NEXT: + [[ADD2]] = add arg0, arg3
+// CHECK-DAG: {{^[ +].*}}fn @block_local_scratch{{[( ]}}
+// CHECK-DAG: - [[ADD0:v[0-9]+]] = add arg0, arg1
+// CHECK-DAG: [[MUL0:v[0-9]+]] = mul arg2, arg3
+// CHECK-DAG: + [[ADD0]] = add arg0, arg1
+// CHECK-DAG: bb1:
+// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg2
+// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg1, arg3
+// CHECK-DAG: + [[ADD1]] = add arg0, arg2
+// CHECK-DAG: bb2:
+// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg3
+// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg2
+// CHECK-DAG: + [[ADD2]] = add arg0, arg3
 fn @block_local_scratch(
   arg0: u256,
   arg1: u256,

--- a/tests/ui/codegen/mir/evm-inst-schedule/policy_boundaries.mir
+++ b/tests/ui/codegen/mir/evm-inst-schedule/policy_boundaries.mir
@@ -3,13 +3,13 @@
 @module EvmInstSchedulePolicy
 
 // Schedule a complete expression tree in EVM stack-input order.
-// CHECK-DAG: {{^[ +].*}}fn @deep_dependency_tree{{[( ]}}
-// CHECK-DAG: + [[XOR:v[0-9]+]] = xor arg4, arg5
-// CHECK-DAG: [[MUL:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD]], [[MUL]]
-// CHECK-DAG: - [[XOR]] = xor arg4, arg5
-// CHECK-DAG: {{v[0-9]+}} = div [[SUB]], [[XOR]]
+// CHECK-LABEL: {{^[ +].*}}fn @deep_dependency_tree{{[( ]}}
+// CHECK: + [[XOR:v[0-9]+]] = xor arg4, arg5
+// CHECK-NEXT: [[MUL:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD]], [[MUL]]
+// CHECK-NEXT: - [[XOR]] = xor arg4, arg5
+// CHECK-NEXT: {{v[0-9]+}} = div [[SUB]], [[XOR]]
 fn @deep_dependency_tree(
   arg0: u256,
   arg1: u256,
@@ -28,16 +28,16 @@ fn @deep_dependency_tree(
 }
 
 // Schedule both sides of a write barrier without moving instructions across it.
-// CHECK-DAG: {{^[ +].*}}fn @independent_barrier_segments{{[( ]}}
-// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD1]] = add arg0, arg1
-// CHECK-DAG: [[SUB1:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-DAG: mstore 0, [[SUB1]]
-// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-DAG: + [[ADD2]] = add arg0, arg2
-// CHECK-DAG: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
+// CHECK-LABEL: {{^[ +].*}}fn @independent_barrier_segments{{[( ]}}
+// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
+// CHECK-NEXT: [[SUB1:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-NEXT: mstore 0, [[SUB1]]
+// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
+// CHECK-NEXT: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
 fn @independent_barrier_segments(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
   bb0:
     v4 = add arg0, arg1
@@ -51,15 +51,15 @@ fn @independent_barrier_segments(arg0: u256, arg1: u256, arg2: u256, arg3: u256)
 }
 
 // A shared producer stays pinned while the single-use islands around it are scheduled.
-// CHECK-DAG: {{^[ +].*}}fn @shared_result_schedules_islands{{[( ]}}
-// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD1]] = add arg0, arg1
-// CHECK-DAG: [[SHARED:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-DAG: - [[ADD2:v[0-9]+]] = add [[SHARED]], arg2
-// CHECK-DAG: [[MUL2:v[0-9]+]] = mul [[SHARED]], arg3
-// CHECK-DAG: + [[ADD2]] = add [[SHARED]], arg2
-// CHECK-DAG: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
+// CHECK-LABEL: {{^[ +].*}}fn @shared_result_schedules_islands{{[( ]}}
+// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
+// CHECK-NEXT: [[SHARED:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add [[SHARED]], arg2
+// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul [[SHARED]], arg3
+// CHECK-NEXT: + [[ADD2]] = add [[SHARED]], arg2
+// CHECK-NEXT: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
 fn @shared_result_schedules_islands(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
   bb0:
     v4 = add arg0, arg1
@@ -72,11 +72,11 @@ fn @shared_result_schedules_islands(arg0: u256, arg1: u256, arg2: u256, arg3: u2
 }
 
 // Keep producer order when the backend can lower either comparison orientation.
-// CHECK-DAG: {{^[ +].*}}fn @comparison_producer_order{{[( ]}}
+// CHECK-LABEL: {{^[ +].*}}fn @comparison_producer_order{{[( ]}}
 // CHECK-NOT: {{^[+-]}}
-// CHECK-DAG: [[LEFT:v[0-9]+]] = sub arg0, arg1
-// CHECK-DAG: [[RIGHT:v[0-9]+]] = div arg2, arg3
-// CHECK-DAG: {{v[0-9]+}} = lt [[LEFT]], [[RIGHT]]
+// CHECK: [[LEFT:v[0-9]+]] = sub arg0, arg1
+// CHECK-NEXT: [[RIGHT:v[0-9]+]] = div arg2, arg3
+// CHECK-NEXT: {{v[0-9]+}} = lt [[LEFT]], [[RIGHT]]
 fn @comparison_producer_order(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> bool {
   bb0:
     v4 = sub arg0, arg1
@@ -86,11 +86,11 @@ fn @comparison_producer_order(arg0: u256, arg1: u256, arg2: u256, arg3: u256) ->
 }
 
 // Multiple return values are terminator roots and follow stack-input order.
-// CHECK-DAG: {{^[ +].*}}fn @multiple_terminator_roots{{[( ]}}
-// CHECK-DAG: - [[ADD:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD]] = add arg0, arg1
-// CHECK-DAG: ret [[ADD]], [[MUL]]
+// CHECK-LABEL: {{^[ +].*}}fn @multiple_terminator_roots{{[( ]}}
+// CHECK: - [[ADD:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD]] = add arg0, arg1
+// CHECK-NEXT: ret [[ADD]], [[MUL]]
 fn @multiple_terminator_roots(
   arg0: u256,
   arg1: u256,
@@ -104,11 +104,11 @@ fn @multiple_terminator_roots(
 }
 
 // Keep a disconnected instruction below the value consumed by the terminator.
-// CHECK-DAG: {{^[ +].*}}fn @disconnected_root_is_retained{{[( ]}}
-// CHECK-DAG: - [[RETURNED:v[0-9]+]] = mul arg1, 2
-// CHECK-DAG: {{v[0-9]+}} = add arg0, 1
-// CHECK-DAG: + [[RETURNED]] = mul arg1, 2
-// CHECK-DAG: ret [[RETURNED]]
+// CHECK-LABEL: {{^[ +].*}}fn @disconnected_root_is_retained{{[( ]}}
+// CHECK: - [[RETURNED:v[0-9]+]] = mul arg1, 2
+// CHECK-NEXT: {{v[0-9]+}} = add arg0, 1
+// CHECK-NEXT: + [[RETURNED]] = mul arg1, 2
+// CHECK-NEXT: ret [[RETURNED]]
 fn @disconnected_root_is_retained(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = mul arg1, 2
@@ -117,14 +117,14 @@ fn @disconnected_root_is_retained(arg0: u256, arg1: u256) -> u256 {
 }
 
 // Memory, transient-storage, and environment reads may share one movable segment.
-// CHECK-DAG: {{^[ +].*}}fn @read_effects_are_movable{{[( ]}}
-// CHECK-DAG: - [[MEMORY:v[0-9]+]] = mload arg0
-// CHECK-DAG: - [[TRANSIENT:v[0-9]+]] = tload arg1
-// CHECK-DAG: [[CALLER:v[0-9]+]] = caller
-// CHECK-DAG: + [[TRANSIENT]] = tload arg1
-// CHECK-DAG: + [[MEMORY]] = mload arg0
-// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[MEMORY]], [[TRANSIENT]]
-// CHECK-DAG: {{v[0-9]+}} = div [[SUB]], [[CALLER]]
+// CHECK-LABEL: {{^[ +].*}}fn @read_effects_are_movable{{[( ]}}
+// CHECK: - [[MEMORY:v[0-9]+]] = mload arg0
+// CHECK-NEXT: - [[TRANSIENT:v[0-9]+]] = tload arg1
+// CHECK-NEXT: [[CALLER:v[0-9]+]] = caller
+// CHECK-NEXT: + [[TRANSIENT]] = tload arg1
+// CHECK-NEXT: + [[MEMORY]] = mload arg0
+// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[MEMORY]], [[TRANSIENT]]
+// CHECK-NEXT: {{v[0-9]+}} = div [[SUB]], [[CALLER]]
 fn @read_effects_are_movable(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = mload arg0
@@ -136,11 +136,11 @@ fn @read_effects_are_movable(arg0: u256, arg1: u256) -> u256 {
 }
 
 // `clz` is a pure unary operation and follows its consumer's stack-input order.
-// CHECK-DAG: {{^[ +].*}}fn @clz_is_movable{{[( ]}}
-// CHECK-DAG: - [[CLZ:v[0-9]+]] = clz arg0
-// CHECK-DAG: [[MUL:v[0-9]+]] = mul arg1, arg2
-// CHECK-DAG: + [[CLZ]] = clz arg0
-// CHECK-DAG: {{v[0-9]+}} = sub [[CLZ]], [[MUL]]
+// CHECK-LABEL: {{^[ +].*}}fn @clz_is_movable{{[( ]}}
+// CHECK: - [[CLZ:v[0-9]+]] = clz arg0
+// CHECK-NEXT: [[MUL:v[0-9]+]] = mul arg1, arg2
+// CHECK-NEXT: + [[CLZ]] = clz arg0
+// CHECK-NEXT: {{v[0-9]+}} = sub [[CLZ]], [[MUL]]
 fn @clz_is_movable(arg0: u256, arg1: u256, arg2: u256) -> u256 {
   bb0:
     v3 = clz arg0
@@ -150,17 +150,17 @@ fn @clz_is_movable(arg0: u256, arg1: u256, arg2: u256) -> u256 {
 }
 
 // `callcode` separates independently scheduled segments.
-// CHECK-DAG: {{^[ +].*}}fn @callcode_is_a_barrier{{[( ]}}
-// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD1]] = add arg0, arg1
-// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-DAG: [[CALL:v[0-9]+]] = callcode [[SUB]],
-// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-DAG: + [[ADD2]] = add arg0, arg2
-// CHECK-DAG: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
-// CHECK-DAG: ret [[CALL]], [[DIV]]
+// CHECK-LABEL: {{^[ +].*}}fn @callcode_is_a_barrier{{[( ]}}
+// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
+// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-NEXT: [[CALL:v[0-9]+]] = callcode [[SUB]],
+// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
+// CHECK-NEXT: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
+// CHECK-NEXT: ret [[CALL]], [[DIV]]
 fn @callcode_is_a_barrier(
   arg0: u256,
   arg1: u256,
@@ -179,17 +179,17 @@ fn @callcode_is_a_barrier(
 }
 
 // `msize` splits two independently scheduled segments.
-// CHECK-DAG: {{^[ +].*}}fn @msize_is_a_barrier{{[( ]}}
-// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD1]] = add arg0, arg1
-// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-DAG: [[MSIZE:v[0-9]+]] = msize
-// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-DAG: + [[ADD2]] = add arg0, arg2
-// CHECK-DAG: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
-// CHECK-DAG: ret [[SUB]], [[MSIZE]], [[DIV]]
+// CHECK-LABEL: {{^[ +].*}}fn @msize_is_a_barrier{{[( ]}}
+// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
+// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-NEXT: [[MSIZE:v[0-9]+]] = msize
+// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
+// CHECK-NEXT: [[DIV:v[0-9]+]] = div [[ADD2]], [[MUL2]]
+// CHECK-NEXT: ret [[SUB]], [[MSIZE]], [[DIV]]
 fn @msize_is_a_barrier(
   arg0: u256,
   arg1: u256,
@@ -208,12 +208,12 @@ fn @msize_is_a_barrier(
 }
 
 // A phi remains at the start of its block even when a later tree consumes it.
-// CHECK-DAG: {{^[ +].*}}fn @phi_is_a_barrier{{[( ]}}
+// CHECK-LABEL: {{^[ +].*}}fn @phi_is_a_barrier{{[( ]}}
 // CHECK-NOT: {{^[+-]}}
-// CHECK-DAG: bb3:
-// CHECK-DAG: [[PHI:v[0-9]+]] = phi
-// CHECK-DAG: {{v[0-9]+}} = add arg0, arg1
-// CHECK-DAG: {{v[0-9]+}} = mul [[PHI]], arg2
+// CHECK: bb3:
+// CHECK-NEXT: [[PHI:v[0-9]+]] = phi
+// CHECK-NEXT: {{v[0-9]+}} = add arg0, arg1
+// CHECK-NEXT: {{v[0-9]+}} = mul [[PHI]], arg2
 fn @phi_is_a_barrier(arg0: u256, arg1: u256, arg2: u256, arg3: bool) -> u256 {
   bb0:
     jumpi arg3, bb1, bb2
@@ -229,16 +229,16 @@ fn @phi_is_a_barrier(arg0: u256, arg1: u256, arg2: u256, arg3: bool) -> u256 {
 }
 
 // An explicit write effect overrides an opcode's default pure effect.
-// CHECK-DAG: {{^[ +].*}}fn @metadata_effect_is_a_barrier{{[( ]}}
-// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD1]] = add arg0, arg1
-// CHECK-DAG: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
-// CHECK-DAG: {{v[0-9]+}} = xor arg0, arg3 !metadata(effect=memory_write)
-// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg2
-// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg3
-// CHECK-DAG: + [[ADD2]] = add arg0, arg2
-// CHECK-DAG: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
+// CHECK-LABEL: {{^[ +].*}}fn @metadata_effect_is_a_barrier{{[( ]}}
+// CHECK: - [[ADD1:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD1]] = add arg0, arg1
+// CHECK-NEXT: [[SUB:v[0-9]+]] = sub [[ADD1]], [[MUL1]]
+// CHECK-NEXT: {{v[0-9]+}} = xor arg0, arg3 !metadata(effect=memory_write)
+// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg2
+// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg3
+// CHECK-NEXT: + [[ADD2]] = add arg0, arg2
+// CHECK-NEXT: {{v[0-9]+}} = div [[ADD2]], [[MUL2]]
 fn @metadata_effect_is_a_barrier(
   arg0: u256,
   arg1: u256,
@@ -257,18 +257,18 @@ fn @metadata_effect_is_a_barrier(
 }
 
 // Each block starts with empty scheduling scratch state.
-// CHECK-DAG: {{^[ +].*}}fn @block_local_scratch{{[( ]}}
-// CHECK-DAG: - [[ADD0:v[0-9]+]] = add arg0, arg1
-// CHECK-DAG: [[MUL0:v[0-9]+]] = mul arg2, arg3
-// CHECK-DAG: + [[ADD0]] = add arg0, arg1
-// CHECK-DAG: bb1:
-// CHECK-DAG: - [[ADD1:v[0-9]+]] = add arg0, arg2
-// CHECK-DAG: [[MUL1:v[0-9]+]] = mul arg1, arg3
-// CHECK-DAG: + [[ADD1]] = add arg0, arg2
-// CHECK-DAG: bb2:
-// CHECK-DAG: - [[ADD2:v[0-9]+]] = add arg0, arg3
-// CHECK-DAG: [[MUL2:v[0-9]+]] = mul arg1, arg2
-// CHECK-DAG: + [[ADD2]] = add arg0, arg3
+// CHECK-LABEL: {{^[ +].*}}fn @block_local_scratch{{[( ]}}
+// CHECK: - [[ADD0:v[0-9]+]] = add arg0, arg1
+// CHECK-NEXT: [[MUL0:v[0-9]+]] = mul arg2, arg3
+// CHECK-NEXT: + [[ADD0]] = add arg0, arg1
+// CHECK: bb2:
+// CHECK-NEXT: - [[ADD2:v[0-9]+]] = add arg0, arg3
+// CHECK-NEXT: [[MUL2:v[0-9]+]] = mul arg1, arg2
+// CHECK-NEXT: + [[ADD2]] = add arg0, arg3
+// CHECK: bb1:
+// CHECK-NEXT: - [[ADD1:v[0-9]+]] = add arg0, arg2
+// CHECK-NEXT: [[MUL1:v[0-9]+]] = mul arg1, arg3
+// CHECK-NEXT: + [[ADD1]] = add arg0, arg2
 fn @block_local_scratch(
   arg0: u256,
   arg1: u256,

--- a/tests/ui/codegen/mir/evm-inst-schedule/policy_boundaries.stdout
+++ b/tests/ui/codegen/mir/evm-inst-schedule/policy_boundaries.stdout
@@ -116,9 +116,9 @@
   fn @phi_is_a_barrier(arg0: u256, arg1: u256, arg2: u256, arg3: bool) -> u256 {
     bb0:
       jumpi arg3, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: arg0], [bb2: arg1]
@@ -149,17 +149,17 @@
       v2 = sub v0, v1
       v3 = iszero v2
       jumpi v3, bb1, bb2
-    bb1:
--     v4 = add arg0, arg2
-      v5 = mul arg1, arg3
-+     v4 = add arg0, arg2
-      v6 = div v4, v5
-      ret v6
     bb2:
 -     v7 = add arg0, arg3
       v8 = mul arg1, arg2
 +     v7 = add arg0, arg3
       v9 = mod v7, v8
       ret v9
+    bb1:
+-     v4 = add arg0, arg2
+      v5 = mul arg1, arg3
++     v4 = add arg0, arg2
+      v6 = div v4, v5
+      ret v6
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.mir
@@ -1,32 +1,32 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion
-//@filecheck: --check-prefix=RPO
+//@filecheck: --enable-var-scope
 @module FramePromotionBuilderCases
-// RPO: @module FramePromotionBuilderCases
 
 // CHECK-LABEL: @loop_carried
-// CHECK-DAG:       [[ENTRY:bb[0-9]+]]:
-// CHECK-DAG:       [[ENTRY_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: {{[+-]?}}     mstore [[ENTRY_FRAME]], 0
-// CHECK-DAG:       jump [[HEADER:bb[0-9]+]]
-// CHECK-DAG:       [[HEADER]]:
-// CHECK-DAG:       [[INDEX:v[0-9]+]] = phi [[[ENTRY]]: 0], [[[BODY:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
-// CHECK-DAG:       [[HEADER_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: {{[+-]?}}     [[OLD_INDEX:v[0-9]+]] = mload [[HEADER_FRAME]]
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = lt [[OLD_INDEX]], 4
-// CHECK-DAG:       [[COND:v[0-9]+]] = lt [[INDEX]], 4
-// CHECK-DAG:       jumpi [[COND]], [[BODY]], [[EXIT:bb[0-9]+]]
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG:       [[BODY_LOAD_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: {{[+-]?}}     [[OLD_BODY_INDEX:v[0-9]+]] = mload [[BODY_LOAD_FRAME]]
-// CHECK-DAG:       [[NEXT]] = add [[INDEX]], 1
-// CHECK-DAG:       [[BODY_STORE_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: {{[+-]?}}     mstore [[BODY_STORE_FRAME]], [[OLD_NEXT]]
-// CHECK-DAG:       jump [[HEADER]]
-// CHECK-DAG:       [[EXIT]]:
-// CHECK-DAG:       [[EXIT_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: {{[+-]?}}     [[OLD_RESULT:v[0-9]+]] = mload [[EXIT_FRAME]]
-// CHECK-DAG: {{[+-]?}}     ret [[OLD_RESULT]]
-// CHECK-DAG:       ret [[INDEX]]
+// CHECK:       [[ENTRY:bb[0-9]+]]:
+// CHECK:       [[ENTRY_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     mstore [[ENTRY_FRAME]], 0
+// CHECK:       jump [[HEADER:bb[0-9]+]]
+// CHECK:       [[HEADER]]:
+// CHECK:       [[INDEX:v[0-9]+]] = phi [[[ENTRY]]: 0], [[[BODY:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
+// CHECK:       [[HEADER_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     [[OLD_INDEX:v[0-9]+]] = mload [[HEADER_FRAME]]
+// CHECK: -     {{v[0-9]+}} = lt [[OLD_INDEX]], 4
+// CHECK:       [[COND:v[0-9]+]] = lt [[INDEX]], 4
+// CHECK:       jumpi [[COND]], [[BODY]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:       [[EXIT_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     [[OLD_RESULT:v[0-9]+]] = mload [[EXIT_FRAME]]
+// CHECK: -     ret [[OLD_RESULT]]
+// CHECK:       ret [[INDEX]]
+// CHECK:       [[BODY]]:
+// CHECK:       [[BODY_LOAD_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     [[OLD_BODY_INDEX:v[0-9]+]] = mload [[BODY_LOAD_FRAME]]
+// CHECK: -     [[OLD_NEXT:v[0-9]+]] = add [[OLD_BODY_INDEX]], 1
+// CHECK:       [[NEXT]] = add [[INDEX]], 1
+// CHECK:       [[BODY_STORE_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     mstore [[BODY_STORE_FRAME]], [[OLD_NEXT]]
+// CHECK:       jump [[HEADER]]
 fn @loop_carried() -> u256 {
   bb0:
     v0 = internal_frame_addr 128
@@ -51,10 +51,10 @@ fn @loop_carried() -> u256 {
 }
 
 // CHECK-LABEL: @escaped_address
-// CHECK-DAG: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
-// CHECK-DAG: {{^ +}}[[HASH:v[0-9]+]] = keccak256 [[FRAME]], 32
-// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
-// CHECK-DAG: {{^ +}}ret [[HASH]], [[LOAD]]
+// CHECK: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
+// CHECK: {{^ +}}[[HASH:v[0-9]+]] = keccak256 [[FRAME]], 32
+// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
+// CHECK: {{^ +}}ret [[HASH]], [[LOAD]]
 fn @escaped_address() -> (bytes32, u256) {
   bb0:
     v0 = internal_frame_addr 128
@@ -65,10 +65,10 @@ fn @escaped_address() -> (bytes32, u256) {
 }
 
 // CHECK-LABEL: @gas_observed
-// CHECK-DAG: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = gas
-// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
-// CHECK-DAG: {{^ +}}ret [[LOAD]]
+// CHECK: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
+// CHECK: {{^ +}}{{v[0-9]+}} = gas
+// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
+// CHECK: {{^ +}}ret [[LOAD]]
 fn @gas_observed() -> u256 {
   bb0:
     v0 = internal_frame_addr 128
@@ -79,12 +79,12 @@ fn @gas_observed() -> u256 {
 }
 
 // CHECK-LABEL: @internal_call
-// CHECK-DAG:       [[FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: {{[+-]?}}     mstore [[FRAME]], 42
-// CHECK-LABEL:       internal_call @callee, 0
-// CHECK-DAG: {{[+-]?}}     [[OLD:v[0-9]+]] = mload [[FRAME]]
-// CHECK-DAG: {{[+-]?}}     ret [[OLD]]
-// CHECK-DAG:       ret 42
+// CHECK:       [[FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     mstore [[FRAME]], 42
+// CHECK:       internal_call @callee, 0
+// CHECK: -     [[OLD:v[0-9]+]] = mload [[FRAME]]
+// CHECK: -     ret [[OLD]]
+// CHECK:       ret 42
 fn @internal_call() -> u256 {
   bb0:
     v0 = internal_frame_addr 128
@@ -100,14 +100,14 @@ fn @callee() {
 }
 
 // CHECK-LABEL: @constant_offset
-// CHECK-DAG:       [[BASE1:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG:       [[ADDR1:v[0-9]+]] = add [[BASE1]], [[OFFSET:[0-9]+]]
-// CHECK-DAG: {{[+-]?}}     mstore [[ADDR1]], 99
-// CHECK-DAG:       [[BASE2:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG:       [[ADDR2:v[0-9]+]] = add [[BASE2]], [[OFFSET]]
-// CHECK-DAG: {{[+-]?}}     [[OLD:v[0-9]+]] = mload [[ADDR2]]
-// CHECK-DAG: {{[+-]?}}     ret [[OLD]]
-// CHECK-DAG:       ret 99
+// CHECK:       [[BASE1:v[0-9]+]] = internal_frame_addr
+// CHECK:       [[ADDR1:v[0-9]+]] = add [[BASE1]], [[OFFSET:[0-9]+]]
+// CHECK: -     mstore [[ADDR1]], 99
+// CHECK:       [[BASE2:v[0-9]+]] = internal_frame_addr
+// CHECK:       [[ADDR2:v[0-9]+]] = add [[BASE2]], [[OFFSET]]
+// CHECK: -     [[OLD:v[0-9]+]] = mload [[ADDR2]]
+// CHECK: -     ret [[OLD]]
+// CHECK:       ret 99
 fn @constant_offset() -> u256 {
   bb0:
     v0 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.mir
@@ -1,32 +1,32 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion
-//@filecheck: --enable-var-scope
+//@filecheck: --check-prefix=RPO
 @module FramePromotionBuilderCases
+// RPO: @module FramePromotionBuilderCases
 
 // CHECK-LABEL: @loop_carried
-// CHECK:       [[ENTRY:bb[0-9]+]]:
-// CHECK:       [[ENTRY_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     mstore [[ENTRY_FRAME]], 0
-// CHECK:       jump [[HEADER:bb[0-9]+]]
-// CHECK:       [[HEADER]]:
-// CHECK:       [[INDEX:v[0-9]+]] = phi [[[ENTRY]]: 0], [[[BODY:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
-// CHECK:       [[HEADER_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     [[OLD_INDEX:v[0-9]+]] = mload [[HEADER_FRAME]]
-// CHECK: -     {{v[0-9]+}} = lt [[OLD_INDEX]], 4
-// CHECK:       [[COND:v[0-9]+]] = lt [[INDEX]], 4
-// CHECK:       jumpi [[COND]], [[BODY]], [[EXIT:bb[0-9]+]]
-// CHECK:       [[BODY]]:
-// CHECK:       [[BODY_LOAD_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     [[OLD_BODY_INDEX:v[0-9]+]] = mload [[BODY_LOAD_FRAME]]
-// CHECK: -     [[OLD_NEXT:v[0-9]+]] = add [[OLD_BODY_INDEX]], 1
-// CHECK:       [[NEXT]] = add [[INDEX]], 1
-// CHECK:       [[BODY_STORE_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     mstore [[BODY_STORE_FRAME]], [[OLD_NEXT]]
-// CHECK:       jump [[HEADER]]
-// CHECK:       [[EXIT]]:
-// CHECK:       [[EXIT_FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     [[OLD_RESULT:v[0-9]+]] = mload [[EXIT_FRAME]]
-// CHECK: -     ret [[OLD_RESULT]]
-// CHECK:       ret [[INDEX]]
+// CHECK-DAG:       [[ENTRY:bb[0-9]+]]:
+// CHECK-DAG:       [[ENTRY_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: {{[+-]?}}     mstore [[ENTRY_FRAME]], 0
+// CHECK-DAG:       jump [[HEADER:bb[0-9]+]]
+// CHECK-DAG:       [[HEADER]]:
+// CHECK-DAG:       [[INDEX:v[0-9]+]] = phi [[[ENTRY]]: 0], [[[BODY:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
+// CHECK-DAG:       [[HEADER_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: {{[+-]?}}     [[OLD_INDEX:v[0-9]+]] = mload [[HEADER_FRAME]]
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = lt [[OLD_INDEX]], 4
+// CHECK-DAG:       [[COND:v[0-9]+]] = lt [[INDEX]], 4
+// CHECK-DAG:       jumpi [[COND]], [[BODY]], [[EXIT:bb[0-9]+]]
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG:       [[BODY_LOAD_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: {{[+-]?}}     [[OLD_BODY_INDEX:v[0-9]+]] = mload [[BODY_LOAD_FRAME]]
+// CHECK-DAG:       [[NEXT]] = add [[INDEX]], 1
+// CHECK-DAG:       [[BODY_STORE_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: {{[+-]?}}     mstore [[BODY_STORE_FRAME]], [[OLD_NEXT]]
+// CHECK-DAG:       jump [[HEADER]]
+// CHECK-DAG:       [[EXIT]]:
+// CHECK-DAG:       [[EXIT_FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: {{[+-]?}}     [[OLD_RESULT:v[0-9]+]] = mload [[EXIT_FRAME]]
+// CHECK-DAG: {{[+-]?}}     ret [[OLD_RESULT]]
+// CHECK-DAG:       ret [[INDEX]]
 fn @loop_carried() -> u256 {
   bb0:
     v0 = internal_frame_addr 128
@@ -51,10 +51,10 @@ fn @loop_carried() -> u256 {
 }
 
 // CHECK-LABEL: @escaped_address
-// CHECK: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
-// CHECK: {{^ +}}[[HASH:v[0-9]+]] = keccak256 [[FRAME]], 32
-// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
-// CHECK: {{^ +}}ret [[HASH]], [[LOAD]]
+// CHECK-DAG: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
+// CHECK-DAG: {{^ +}}[[HASH:v[0-9]+]] = keccak256 [[FRAME]], 32
+// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
+// CHECK-DAG: {{^ +}}ret [[HASH]], [[LOAD]]
 fn @escaped_address() -> (bytes32, u256) {
   bb0:
     v0 = internal_frame_addr 128
@@ -65,10 +65,10 @@ fn @escaped_address() -> (bytes32, u256) {
 }
 
 // CHECK-LABEL: @gas_observed
-// CHECK: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
-// CHECK: {{^ +}}{{v[0-9]+}} = gas
-// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
-// CHECK: {{^ +}}ret [[LOAD]]
+// CHECK-DAG: {{^ +}}mstore [[FRAME:v[0-9]+]], 42
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = gas
+// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[FRAME]]
+// CHECK-DAG: {{^ +}}ret [[LOAD]]
 fn @gas_observed() -> u256 {
   bb0:
     v0 = internal_frame_addr 128
@@ -79,12 +79,12 @@ fn @gas_observed() -> u256 {
 }
 
 // CHECK-LABEL: @internal_call
-// CHECK:       [[FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     mstore [[FRAME]], 42
-// CHECK:       internal_call @callee, 0
-// CHECK: -     [[OLD:v[0-9]+]] = mload [[FRAME]]
-// CHECK: -     ret [[OLD]]
-// CHECK:       ret 42
+// CHECK-DAG:       [[FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: {{[+-]?}}     mstore [[FRAME]], 42
+// CHECK-LABEL:       internal_call @callee, 0
+// CHECK-DAG: {{[+-]?}}     [[OLD:v[0-9]+]] = mload [[FRAME]]
+// CHECK-DAG: {{[+-]?}}     ret [[OLD]]
+// CHECK-DAG:       ret 42
 fn @internal_call() -> u256 {
   bb0:
     v0 = internal_frame_addr 128
@@ -100,14 +100,14 @@ fn @callee() {
 }
 
 // CHECK-LABEL: @constant_offset
-// CHECK:       [[BASE1:v[0-9]+]] = internal_frame_addr
-// CHECK:       [[ADDR1:v[0-9]+]] = add [[BASE1]], [[OFFSET:[0-9]+]]
-// CHECK: -     mstore [[ADDR1]], 99
-// CHECK:       [[BASE2:v[0-9]+]] = internal_frame_addr
-// CHECK:       [[ADDR2:v[0-9]+]] = add [[BASE2]], [[OFFSET]]
-// CHECK: -     [[OLD:v[0-9]+]] = mload [[ADDR2]]
-// CHECK: -     ret [[OLD]]
-// CHECK:       ret 99
+// CHECK-DAG:       [[BASE1:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG:       [[ADDR1:v[0-9]+]] = add [[BASE1]], [[OFFSET:[0-9]+]]
+// CHECK-DAG: {{[+-]?}}     mstore [[ADDR1]], 99
+// CHECK-DAG:       [[BASE2:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG:       [[ADDR2:v[0-9]+]] = add [[BASE2]], [[OFFSET]]
+// CHECK-DAG: {{[+-]?}}     [[OLD:v[0-9]+]] = mload [[ADDR2]]
+// CHECK-DAG: {{[+-]?}}     ret [[OLD]]
+// CHECK-DAG:       ret 99
 fn @constant_offset() -> u256 {
   bb0:
     v0 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/builder_cases.stdout
@@ -13,6 +13,11 @@
 -     v3 = lt v2, 4
 +     v3 = lt v10, 4
       jumpi v3, bb2, bb3
+    bb3:
+      v8 = internal_frame_addr 128
+-     v9 = mload v8
+-     ret v9
++     ret v10
     bb2:
       v4 = internal_frame_addr 128
 -     v5 = mload v4
@@ -21,11 +26,6 @@
       v7 = internal_frame_addr 128
 -     mstore v7, v6
       jump bb1
-    bb3:
-      v8 = internal_frame_addr 128
--     v9 = mload v8
--     ret v9
-+     ret v10
   }
   
   fn @escaped_address() -> (bytes32, u256) {

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion
 //@filecheck:
 @module FramePromotionDeadMerge
-// CHECK-LABEL: {{^[ +].*}}fn @dead_merge{{[( ]}}
-// CHECK: + [[COUNTER:v[0-9]+]] = phi [bb3: 0], [bb5: [[NEXT:v[0-9]+]]]
-// CHECK: + [[NEXT]] = add [[COUNTER]], 1
-// CHECK: + ret [[COUNTER]]
+// CHECK-DAG: {{^[ +].*}}fn @dead_merge{{[( ]}}
+// CHECK-DAG: + [[COUNTER:v[0-9]+]] = phi [bb3: 0], [bb5: [[NEXT:v[0-9]+]]]
+// CHECK-DAG: + [[NEXT]] = add [[COUNTER]], 1
+// CHECK-DAG: + ret [[COUNTER]]
 fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion
 //@filecheck:
 @module FramePromotionDeadMerge
-// CHECK-DAG: {{^[ +].*}}fn @dead_merge{{[( ]}}
-// CHECK-DAG: + [[COUNTER:v[0-9]+]] = phi [bb3: 0], [bb5: [[NEXT:v[0-9]+]]]
-// CHECK-DAG: + [[NEXT]] = add [[COUNTER]], 1
-// CHECK-DAG: + ret [[COUNTER]]
+// CHECK-LABEL: {{^[ +].*}}fn @dead_merge{{[( ]}}
+// CHECK: + [[COUNTER:v[0-9]+]] = phi [bb3: 0], [bb5: [[NEXT:v[0-9]+]]]
+// CHECK: + ret [[COUNTER]]
+// CHECK: + [[NEXT]] = add [[COUNTER]], 1
 fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_dead_merge.stdout
@@ -4,9 +4,9 @@
   fn @dead_merge(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = internal_frame_addr 128
@@ -19,16 +19,16 @@
 -     v3 = lt v2, arg0
 +     v3 = lt v8, arg0
       jumpi v3, bb5, bb6
+    bb6:
+      v6 = internal_frame_addr 128
+-     v7 = mload v6
+-     ret v7
++     ret v8
     bb5:
 -     v4 = add v2, 1
 +     v4 = add v8, 1
       v5 = internal_frame_addr 128
 -     mstore v5, v4
       jump bb4
-    bb6:
-      v6 = internal_frame_addr 128
--     v7 = mload v6
--     ret v7
-+     ret v8
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
@@ -1,13 +1,13 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion,cfg-simplify,dce
 //@filecheck:
 @module NestedCounter
-// CHECK-DAG: {{^[ +].*}}fn @nested{{[( ]}}
-// CHECK-DAG: + [[SUM:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_SUM:v[0-9]+]]]
-// CHECK-DAG: + [[OUTER:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_OUTER:v[0-9]+]]]
-// CHECK-DAG: + [[NEXT_SUM]] = phi [bb2: [[SUM]]], [bb4: {{v[0-9]+}}]
-// CHECK-DAG: + [[INNER:v[0-9]+]] = phi [bb2: 0], [bb4: [[NEXT_INNER:v[0-9]+]]]
-// CHECK-DAG: + [[NEXT_INNER]] = add [[INNER]], 1
-// CHECK-DAG: + [[NEXT_OUTER]] = add [[OUTER]], 1
+// CHECK-LABEL: {{^[ +].*}}fn @nested{{[( ]}}
+// CHECK: + [[SUM:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_SUM:v[0-9]+]]]
+// CHECK: + [[OUTER:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_OUTER:v[0-9]+]]]
+// CHECK: + [[NEXT_SUM]] = phi [bb2: [[SUM]]], [bb4: {{v[0-9]+}}]
+// CHECK: + [[INNER:v[0-9]+]] = phi [bb2: 0], [bb4: [[NEXT_INNER:v[0-9]+]]]
+// CHECK: + [[NEXT_OUTER]] = add [[OUTER]], 1
+// CHECK: + [[NEXT_INNER]] = add [[INNER]], 1
 fn @nested(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v1 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir
@@ -1,13 +1,13 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion,cfg-simplify,dce
 //@filecheck:
 @module NestedCounter
-// CHECK-LABEL: {{^[ +].*}}fn @nested{{[( ]}}
-// CHECK: + [[SUM:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_SUM:v[0-9]+]]]
-// CHECK: + [[OUTER:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_OUTER:v[0-9]+]]]
-// CHECK: + [[NEXT_SUM]] = phi [bb2: [[SUM]]], [bb4: {{v[0-9]+}}]
-// CHECK: + [[INNER:v[0-9]+]] = phi [bb2: 0], [bb4: [[NEXT_INNER:v[0-9]+]]]
-// CHECK: + [[NEXT_INNER]] = add [[INNER]], 1
-// CHECK: + [[NEXT_OUTER]] = add [[OUTER]], 1
+// CHECK-DAG: {{^[ +].*}}fn @nested{{[( ]}}
+// CHECK-DAG: + [[SUM:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_SUM:v[0-9]+]]]
+// CHECK-DAG: + [[OUTER:v[0-9]+]] = phi [bb0: 0], [bb5: [[NEXT_OUTER:v[0-9]+]]]
+// CHECK-DAG: + [[NEXT_SUM]] = phi [bb2: [[SUM]]], [bb4: {{v[0-9]+}}]
+// CHECK-DAG: + [[INNER:v[0-9]+]] = phi [bb2: 0], [bb4: [[NEXT_INNER:v[0-9]+]]]
+// CHECK-DAG: + [[NEXT_INNER]] = add [[INNER]], 1
+// CHECK-DAG: + [[NEXT_OUTER]] = add [[OUTER]], 1
 fn @nested(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v1 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.stdout
@@ -16,6 +16,11 @@
 -     v4 = lt v3, arg0
 +     v4 = lt v25, arg0
       jumpi v4, bb2, bb6
+    bb6:
+      v21 = internal_frame_addr 128
+-     v22 = mload v21
+-     ret v22
++     ret v23
     bb2:
       v5 = internal_frame_addr 192
 -     mstore v5, 0
@@ -28,6 +33,14 @@
 -     v8 = lt v7, arg1
 +     v8 = lt v26, arg1
       jumpi v8, bb4, bb5
+    bb5:
+      v17 = internal_frame_addr 160
+-     v18 = mload v17
+-     v19 = add v18, 1
++     v19 = add v25, 1
+      v20 = internal_frame_addr 160
+-     mstore v20, v19
+      jump bb1
     bb4:
       v9 = internal_frame_addr 128
 -     v10 = mload v9
@@ -42,19 +55,6 @@
       v16 = internal_frame_addr 192
 -     mstore v16, v15
       jump bb3
-    bb5:
-      v17 = internal_frame_addr 160
--     v18 = mload v17
--     v19 = add v18, 1
-+     v19 = add v25, 1
-      v20 = internal_frame_addr 160
--     mstore v20, v19
-      jump bb1
-    bb6:
-      v21 = internal_frame_addr 128
--     v22 = mload v21
--     ret v22
-+     ret v23
   }
   
 - // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before cfg-simplify) ===
@@ -71,6 +71,9 @@
       v2 = internal_frame_addr 160
       v4 = lt v25, arg0
       jumpi v4, bb2, bb6
+    bb6:
+      v21 = internal_frame_addr 128
+      ret v23
     bb2:
       v5 = internal_frame_addr 192
       jump bb3
@@ -80,6 +83,11 @@
       v6 = internal_frame_addr 192
       v8 = lt v26, arg1
       jumpi v8, bb4, bb5
+    bb5:
+      v17 = internal_frame_addr 160
+      v19 = add v25, 1
+      v20 = internal_frame_addr 160
+      jump bb1
     bb4:
       v9 = internal_frame_addr 128
       v11 = add v24, 1
@@ -88,14 +96,6 @@
       v15 = add v26, 1
       v16 = internal_frame_addr 192
       jump bb3
-    bb5:
-      v17 = internal_frame_addr 160
-      v19 = add v25, 1
-      v20 = internal_frame_addr 160
-      jump bb1
-    bb6:
-      v21 = internal_frame_addr 128
-      ret v23
   }
   
 - // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_inner_counter.mir (before dce) ===
@@ -112,6 +112,9 @@
 -     v2 = internal_frame_addr 160
       v4 = lt v25, arg0
       jumpi v4, bb2, bb6
+    bb6:
+-     v21 = internal_frame_addr 128
+      ret v23
     bb2:
 -     v5 = internal_frame_addr 192
       jump bb3
@@ -121,6 +124,11 @@
 -     v6 = internal_frame_addr 192
       v8 = lt v26, arg1
       jumpi v8, bb4, bb5
+    bb5:
+-     v17 = internal_frame_addr 160
+      v19 = add v25, 1
+-     v20 = internal_frame_addr 160
+      jump bb1
     bb4:
 -     v9 = internal_frame_addr 128
       v11 = add v24, 1
@@ -129,13 +137,5 @@
       v15 = add v26, 1
 -     v16 = internal_frame_addr 192
       jump bb3
-    bb5:
--     v17 = internal_frame_addr 160
-      v19 = add v25, 1
--     v20 = internal_frame_addr 160
-      jump bb1
-    bb6:
--     v21 = internal_frame_addr 128
-      ret v23
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.stdout
@@ -16,20 +16,6 @@
 -     v4 = lt v3, arg0
 +     v4 = lt v29, arg0
       jumpi v4, bb2, bb3
-    bb2:
-      v5 = internal_frame_addr 128
--     v6 = mload v5
--     v7 = add v6, 1
-+     v7 = add v27, 1
-      v8 = internal_frame_addr 128
--     mstore v8, v7
-      v9 = internal_frame_addr 160
--     v10 = mload v9
--     v11 = add v10, 1
-+     v11 = add v29, 1
-      v12 = internal_frame_addr 160
--     mstore v12, v11
-      jump bb1
     bb3:
       v13 = internal_frame_addr 192
 -     mstore v13, 0
@@ -42,6 +28,11 @@
 -     v16 = lt v15, arg0
 +     v16 = lt v30, arg0
       jumpi v16, bb5, bb6
+    bb6:
+      v25 = internal_frame_addr 128
+-     v26 = mload v25
+-     ret v26
++     ret v28
     bb5:
       v17 = internal_frame_addr 128
 -     v18 = mload v17
@@ -56,11 +47,20 @@
       v24 = internal_frame_addr 192
 -     mstore v24, v23
       jump bb4
-    bb6:
-      v25 = internal_frame_addr 128
--     v26 = mload v25
--     ret v26
-+     ret v28
+    bb2:
+      v5 = internal_frame_addr 128
+-     v6 = mload v5
+-     v7 = add v6, 1
++     v7 = add v27, 1
+      v8 = internal_frame_addr 128
+-     mstore v8, v7
+      v9 = internal_frame_addr 160
+-     v10 = mload v9
+-     v11 = add v10, 1
++     v11 = add v29, 1
+      v12 = internal_frame_addr 160
+-     mstore v12, v11
+      jump bb1
   }
   
 - // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before cfg-simplify) ===
@@ -77,14 +77,6 @@
       v2 = internal_frame_addr 160
       v4 = lt v29, arg0
       jumpi v4, bb2, bb3
-    bb2:
-      v5 = internal_frame_addr 128
-      v7 = add v27, 1
-      v8 = internal_frame_addr 128
-      v9 = internal_frame_addr 160
-      v11 = add v29, 1
-      v12 = internal_frame_addr 160
-      jump bb1
     bb3:
       v13 = internal_frame_addr 192
       jump bb4
@@ -94,6 +86,9 @@
       v14 = internal_frame_addr 192
       v16 = lt v30, arg0
       jumpi v16, bb5, bb6
+    bb6:
+      v25 = internal_frame_addr 128
+      ret v28
     bb5:
       v17 = internal_frame_addr 128
       v19 = add v28, 1
@@ -102,9 +97,14 @@
       v23 = add v30, 1
       v24 = internal_frame_addr 192
       jump bb4
-    bb6:
-      v25 = internal_frame_addr 128
-      ret v28
+    bb2:
+      v5 = internal_frame_addr 128
+      v7 = add v27, 1
+      v8 = internal_frame_addr 128
+      v9 = internal_frame_addr 160
+      v11 = add v29, 1
+      v12 = internal_frame_addr 160
+      jump bb1
   }
   
 - // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/frame_promotion_sequential_counter.mir (before dce) ===
@@ -121,14 +121,6 @@
 -     v2 = internal_frame_addr 160
       v4 = lt v29, arg0
       jumpi v4, bb2, bb3
-    bb2:
--     v5 = internal_frame_addr 128
-      v7 = add v27, 1
--     v8 = internal_frame_addr 128
--     v9 = internal_frame_addr 160
-      v11 = add v29, 1
--     v12 = internal_frame_addr 160
-      jump bb1
     bb3:
 -     v13 = internal_frame_addr 192
       jump bb4
@@ -138,6 +130,9 @@
 -     v14 = internal_frame_addr 192
       v16 = lt v30, arg0
       jumpi v16, bb5, bb6
+    bb6:
+-     v25 = internal_frame_addr 128
+      ret v28
     bb5:
 -     v17 = internal_frame_addr 128
       v19 = add v28, 1
@@ -146,8 +141,13 @@
       v23 = add v30, 1
 -     v24 = internal_frame_addr 192
       jump bb4
-    bb6:
--     v25 = internal_frame_addr 128
-      ret v28
+    bb2:
+-     v5 = internal_frame_addr 128
+      v7 = add v27, 1
+-     v8 = internal_frame_addr 128
+-     v9 = internal_frame_addr 160
+      v11 = add v29, 1
+-     v12 = internal_frame_addr 160
+      jump bb1
   }
   

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion,dce
 //@filecheck:
 @module LocalSlotPromotion
-// CHECK-DAG: {{^[ +].*}}fn @promote_loop_carried_slot{{[( ]}}
-// CHECK-DAG: + [[COUNTER:v[0-9]+]] = phi [bb0: 0], [bb2: [[NEXT:v[0-9]+]]]
-// CHECK-DAG: + [[NEXT]] = add [[COUNTER]], 1
-// CHECK-DAG: + ret [[COUNTER]]
+// CHECK-LABEL: {{^[ +].*}}fn @promote_loop_carried_slot{{[( ]}}
+// CHECK: + [[COUNTER:v[0-9]+]] = phi [bb0: 0], [bb2: [[NEXT:v[0-9]+]]]
+// CHECK: + ret [[COUNTER]]
+// CHECK: + [[NEXT]] = add [[COUNTER]], 1
 fn @promote_loop_carried_slot(arg0: u256) -> u256 {
   bb0:
     v1 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=frame-slot-promotion,dce
 //@filecheck:
 @module LocalSlotPromotion
-// CHECK-LABEL: {{^[ +].*}}fn @promote_loop_carried_slot{{[( ]}}
-// CHECK: + [[COUNTER:v[0-9]+]] = phi [bb0: 0], [bb2: [[NEXT:v[0-9]+]]]
-// CHECK: + [[NEXT]] = add [[COUNTER]], 1
-// CHECK: + ret [[COUNTER]]
+// CHECK-DAG: {{^[ +].*}}fn @promote_loop_carried_slot{{[( ]}}
+// CHECK-DAG: + [[COUNTER:v[0-9]+]] = phi [bb0: 0], [bb2: [[NEXT:v[0-9]+]]]
+// CHECK-DAG: + [[NEXT]] = add [[COUNTER]], 1
+// CHECK-DAG: + ret [[COUNTER]]
 fn @promote_loop_carried_slot(arg0: u256) -> u256 {
   bb0:
     v1 = internal_frame_addr 128

--- a/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
+++ b/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.stdout
@@ -13,6 +13,11 @@
 -     v3 = lt v2, arg0
 +     v3 = lt v10, arg0
       jumpi v3, bb2, bb3
+    bb3:
+      v8 = internal_frame_addr 128
+-     v9 = mload v8
+-     ret v9
++     ret v10
     bb2:
       v4 = internal_frame_addr 128
 -     v5 = mload v4
@@ -21,11 +26,6 @@
       v7 = internal_frame_addr 128
 -     mstore v7, v6
       jump bb1
-    bb3:
-      v8 = internal_frame_addr 128
--     v9 = mload v8
--     ret v9
-+     ret v10
   }
   
 - // === ROOT/tests/ui/codegen/mir/frame-slot-promotion/local_slot_promotion.mir (before dce) ===
@@ -40,13 +40,13 @@
 -     v1 = internal_frame_addr 128
       v3 = lt v10, arg0
       jumpi v3, bb2, bb3
+    bb3:
+-     v8 = internal_frame_addr 128
+      ret v10
     bb2:
 -     v4 = internal_frame_addr 128
       v6 = add v10, 1
 -     v7 = internal_frame_addr 128
       jump bb1
-    bb3:
--     v8 = internal_frame_addr 128
-      ret v10
   }
   

--- a/tests/ui/codegen/mir/gvn/gvn.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn.stdout
@@ -51,13 +51,13 @@
   fn @no_replacement_across_siblings(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      v0 = add arg0, 1
-      v1 = mul v0, 3
-      jump bb3
     bb2:
       v2 = add arg0, 1
       v3 = mul v2, 3
+      jump bb3
+    bb1:
+      v0 = add arg0, 1
+      v1 = mul v0, 3
       jump bb3
     bb3:
       v4 = phi [bb1: v1], [bb2: v3]

--- a/tests/ui/codegen/mir/gvn/gvn_phi.stdout
+++ b/tests/ui/codegen/mir/gvn/gvn_phi.stdout
@@ -4,9 +4,9 @@
   fn @congruent_phis_collapse(arg0: u256, arg1: u256, arg2: bool) -> u256 {
     bb0:
       jumpi arg2, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: arg0], [bb2: arg1]
@@ -20,9 +20,9 @@
     bb0:
       v0 = add arg0, 1
       jumpi arg1, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
 -     v1 = phi [bb1: v0], [bb2: v0]
@@ -35,10 +35,10 @@
     bb0:
       v0 = add arg0, 1
       jumpi arg1, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
 -     v1 = add arg0, 1
-      jump bb3
-    bb2:
       jump bb3
     bb3:
 -     v2 = phi [bb1: v1], [bb2: v0]
@@ -49,9 +49,9 @@
   fn @phi_of_equal_immediates(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
 -     v0 = phi [bb1: 7], [bb2: 7]
@@ -67,12 +67,12 @@
       v1 = phi [bb0: 0], [bb2: v4]
       v2 = lt v0, arg0
       jumpi v2, bb2, bb3
+    bb3:
+      v5 = add v0, v1
+      ret v5
     bb2:
       v3 = add v0, 1
       v4 = add v1, 1
       jump bb1
-    bb3:
-      v5 = add v0, v1
-      ret v5
   }
   

--- a/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
+++ b/tests/ui/codegen/mir/indvar-simplify/indvar_simplify.stdout
@@ -9,6 +9,8 @@
 +     v5 = phi [bb0: arg0], [bb2: v6]
       v1 = lt v0, 4
       jumpi v1, bb2, bb3
+    bb3:
+      ret 0
     bb2:
       v2 = shl 5, v0
       v3 = add arg0, v2
@@ -17,8 +19,6 @@
       v4 = add v0, 1
 +     v6 = add v5, 32
       jump bb1
-    bb3:
-      ret 0
   }
   
   fn @strength_reduce_scaled_address_with_offset(arg0: u256) -> u256 {
@@ -30,6 +30,8 @@
 +     v7 = phi [bb0: v6], [bb2: v8]
       v1 = lt v0, 4
       jumpi v1, bb2, bb3
+    bb3:
+      ret 0
     bb2:
       v2 = mul v0, 32
       v3 = add arg0, v2
@@ -39,8 +41,6 @@
       v5 = add v0, 1
 +     v8 = add v7, 32
       jump bb1
-    bb3:
-      ret 0
   }
   
   fn @strength_reduce_scale_one_address(arg0: u256) -> u256 {
@@ -51,6 +51,8 @@
 +     v4 = phi [bb0: arg0], [bb2: v5]
       v1 = lt v0, 4
       jumpi v1, bb2, bb3
+    bb3:
+      ret 0
     bb2:
       v2 = add arg0, v0
 -     mstore8 v2, v0
@@ -58,7 +60,5 @@
       v3 = add v0, 1
 +     v5 = add v4, 1
       jump bb1
-    bb3:
-      ret 0
   }
   

--- a/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.stdout
+++ b/tests/ui/codegen/mir/inline-tiny-leaves/inline_tiny_leaves.stdout
@@ -6,15 +6,15 @@
 -     v0 = internal_call @tiny, 1, arg0
 -     ret v0
 +     jump bb2
-+   bb1:
-+     v5 = phi [bb2: v4]
-+     ret v5
 +   bb2:
 +     v1 = add arg0, 1
 +     v2 = xor v1, 2
 +     v3 = mul v2, 3
 +     v4 = sub v3, 4
 +     jump bb1
++   bb1:
++     v5 = phi [bb2: v4]
++     ret v5
   }
   
   fn @tiny(arg0: u256) -> u256 {
@@ -31,9 +31,6 @@
 -     v0 = internal_call @large, 1, arg0
 -     ret v0
 +     jump bb2
-+   bb1:
-+     v6 = phi [bb2: v5]
-+     ret v6
 +   bb2:
 +     v1 = add arg0, 1
 +     v2 = xor v1, 2
@@ -41,6 +38,9 @@
 +     v4 = sub v3, 4
 +     v5 = and v4, 5
 +     jump bb1
++   bb1:
++     v6 = phi [bb2: v5]
++     ret v6
   }
   
   fn @large(arg0: u256) -> u256 {

--- a/tests/ui/codegen/mir/inline/inline_internal_call.mir
+++ b/tests/ui/codegen/mir/inline/inline_internal_call.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=inline
 //@filecheck:
 @module InlineInternalCall
-// CHECK-DAG: {{^[ +].*}}fn @caller{{[( ]}}
-// CHECK-DAG: - {{.*}}internal_call @callee
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: [[INLINED:v[0-9]+]]]
-// CHECK-DAG: + [[INLINED]] = add arg0, 1
+// CHECK-LABEL: {{^[ +].*}}fn @caller{{[( ]}}
+// CHECK: - {{.*}}internal_call @callee
+// CHECK: + [[INLINED:v[0-9]+]] = add arg0, 1
+// CHECK: + {{v[0-9]+}} = phi [bb2: [[INLINED]]]
 fn @caller(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn1, 1, arg0

--- a/tests/ui/codegen/mir/inline/inline_internal_call.mir
+++ b/tests/ui/codegen/mir/inline/inline_internal_call.mir
@@ -1,10 +1,10 @@
 //@compile-flags: -Zmir-pipeline=inline
 //@filecheck:
 @module InlineInternalCall
-// CHECK-LABEL: {{^[ +].*}}fn @caller{{[( ]}}
-// CHECK: - {{.*}}internal_call @callee
-// CHECK: + {{v[0-9]+}} = phi [bb2: [[INLINED:v[0-9]+]]]
-// CHECK: + [[INLINED]] = add arg0, 1
+// CHECK-DAG: {{^[ +].*}}fn @caller{{[( ]}}
+// CHECK-DAG: - {{.*}}internal_call @callee
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: [[INLINED:v[0-9]+]]]
+// CHECK-DAG: + [[INLINED]] = add arg0, 1
 fn @caller(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn1, 1, arg0

--- a/tests/ui/codegen/mir/inline/inline_internal_call.stdout
+++ b/tests/ui/codegen/mir/inline/inline_internal_call.stdout
@@ -6,12 +6,12 @@
 -     v0 = internal_call @callee, 1, arg0
 -     ret v0
 +     jump bb2
-+   bb1:
-+     v2 = phi [bb2: v1]
-+     ret v2
 +   bb2:
 +     v1 = add arg0, 1
 +     jump bb1
++   bb1:
++     v2 = phi [bb2: v1]
++     ret v2
   }
   
   fn @callee(arg0: u256) -> u256 {

--- a/tests/ui/codegen/mir/inline/inline_loop_return.stdout
+++ b/tests/ui/codegen/mir/inline/inline_loop_return.stdout
@@ -6,10 +6,6 @@
 -     v0 = internal_call @callee, 1, 4
 -     v1 = add v0, 1
 +     jump bb2
-+   bb1:
-+     v12 = phi [bb5: v11]
-+     v1 = add v12, 1
-      ret v1
 +   bb2:
 +     v2 = internal_frame_addr 0
 +     mstore v2, 0
@@ -19,6 +15,14 @@
 +     v4 = mload v3
 +     v5 = lt v4, 4
 +     jumpi v5, bb4, bb5
++   bb5:
++     v10 = internal_frame_addr 0
++     v11 = mload v10
++     jump bb1
++   bb1:
++     v12 = phi [bb5: v11]
++     v1 = add v12, 1
+      ret v1
 +   bb4:
 +     v6 = internal_frame_addr 0
 +     v7 = mload v6
@@ -26,10 +30,6 @@
 +     v9 = internal_frame_addr 0
 +     mstore v9, v8
 +     jump bb3
-+   bb5:
-+     v10 = internal_frame_addr 0
-+     v11 = mload v10
-+     jump bb1
   }
   
   fn @callee(arg0: u256) -> u256 {
@@ -42,6 +42,10 @@
       v2 = mload v1
       v3 = lt v2, arg0
       jumpi v3, bb2, bb3
+    bb3:
+      v8 = internal_frame_addr 128
+      v9 = mload v8
+      ret v9
     bb2:
       v4 = internal_frame_addr 128
       v5 = mload v4
@@ -49,9 +53,5 @@
       v7 = internal_frame_addr 128
       mstore v7, v6
       jump bb1
-    bb3:
-      v8 = internal_frame_addr 128
-      v9 = mload v8
-      ret v9
   }
   

--- a/tests/ui/codegen/mir/inline/inline_v2_profitability.mir
+++ b/tests/ui/codegen/mir/inline/inline_v2_profitability.mir
@@ -2,10 +2,10 @@
 //@filecheck:
 @module InlineV2Profitability
 
-// CHECK-LABEL: {{^[ +].*}}fn @single_large_caller{{[( ]}}
-// CHECK: - {{.*}}internal_call @single_large_callee
-// CHECK: + {{v[0-9]+}} = phi [bb13: [[INLINED:v[0-9]+]]]
-// CHECK: + [[INLINED]] = add arg0, 1
+// CHECK-DAG: {{^[ +].*}}fn @single_large_caller{{[( ]}}
+// CHECK-DAG: - {{.*}}internal_call @single_large_callee
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb13: [[INLINED:v[0-9]+]]]
+// CHECK-DAG: + [[INLINED]] = add arg0, 1
 fn @single_large_caller(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn1, 1, arg0
@@ -42,10 +42,10 @@ fn @single_large_callee(arg0: u256) -> u256 {
     ret v1
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @multi_return_caller{{[( ]}}
-// CHECK: - {{.*}}internal_call @multi_return_callee
-// CHECK: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
-// CHECK: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
+// CHECK-DAG: {{^[ +].*}}fn @multi_return_caller{{[( ]}}
+// CHECK-DAG: - {{.*}}internal_call @multi_return_callee
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
 fn @multi_return_caller(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn3, 2, arg0
@@ -61,10 +61,10 @@ fn @multi_return_callee(arg0: u256) -> (u256, u256) {
     ret v1, v2
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @tiny_stateful_caller{{[( ]}}
-// CHECK: - {{.*}}internal_call @tiny_stateful_callee
-// CHECK: + sstore 0, arg0
-// CHECK: + sstore 0, arg1
+// CHECK-DAG: {{^[ +].*}}fn @tiny_stateful_caller{{[( ]}}
+// CHECK-DAG: - {{.*}}internal_call @tiny_stateful_callee
+// CHECK-DAG: + sstore 0, arg0
+// CHECK-DAG: + sstore 0, arg1
 fn @tiny_stateful_caller(arg0: u256, arg1: u256) {
   bb0:
     internal_call fn5, 0, arg0
@@ -80,8 +80,8 @@ fn @tiny_stateful_callee(arg0: u256) {
 
 // A shared callee above the ordinary 10-block cap inlines at only its most
 // tail-like call site, even when the less profitable site appears first.
-// CHECK-LABEL: {{^[ +].*}}fn @large_shared_nontail{{[( ]}}
-// CHECK: {{^[ +].*}}internal_call @large_shared_callee
+// CHECK-DAG: {{^[ +].*}}fn @large_shared_nontail{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}internal_call @large_shared_callee
 fn @large_shared_nontail(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn8, 1, arg0
@@ -90,10 +90,10 @@ fn @large_shared_nontail(arg0: u256) -> u256 {
     ret v3
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @large_shared_tail{{[( ]}}
-// CHECK: - {{.*}}internal_call @large_shared_callee
-// CHECK: + {{v[0-9]+}} = phi [bb13: [[INLINED:v[0-9]+]]]
-// CHECK: + [[INLINED]] = add arg0, 1
+// CHECK-DAG: {{^[ +].*}}fn @large_shared_tail{{[( ]}}
+// CHECK-DAG: - {{.*}}internal_call @large_shared_callee
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb13: [[INLINED:v[0-9]+]]]
+// CHECK-DAG: + [[INLINED]] = add arg0, 1
 fn @large_shared_tail(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn8, 1, arg0

--- a/tests/ui/codegen/mir/inline/inline_v2_profitability.mir
+++ b/tests/ui/codegen/mir/inline/inline_v2_profitability.mir
@@ -2,10 +2,10 @@
 //@filecheck:
 @module InlineV2Profitability
 
-// CHECK-DAG: {{^[ +].*}}fn @single_large_caller{{[( ]}}
-// CHECK-DAG: - {{.*}}internal_call @single_large_callee
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb13: [[INLINED:v[0-9]+]]]
-// CHECK-DAG: + [[INLINED]] = add arg0, 1
+// CHECK-LABEL: {{^[ +].*}}fn @single_large_caller{{[( ]}}
+// CHECK: - {{.*}}internal_call @single_large_callee
+// CHECK: + [[INLINED:v[0-9]+]] = add arg0, 1
+// CHECK: + {{v[0-9]+}} = phi [bb13: [[INLINED]]]
 fn @single_large_caller(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn1, 1, arg0
@@ -42,10 +42,10 @@ fn @single_large_callee(arg0: u256) -> u256 {
     ret v1
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @multi_return_caller{{[( ]}}
-// CHECK-DAG: - {{.*}}internal_call @multi_return_callee
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
+// CHECK-LABEL: {{^[ +].*}}fn @multi_return_caller{{[( ]}}
+// CHECK: - {{.*}}internal_call @multi_return_callee
+// CHECK: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
+// CHECK: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}]
 fn @multi_return_caller(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn3, 2, arg0
@@ -61,10 +61,10 @@ fn @multi_return_callee(arg0: u256) -> (u256, u256) {
     ret v1, v2
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @tiny_stateful_caller{{[( ]}}
-// CHECK-DAG: - {{.*}}internal_call @tiny_stateful_callee
-// CHECK-DAG: + sstore 0, arg0
-// CHECK-DAG: + sstore 0, arg1
+// CHECK-LABEL: {{^[ +].*}}fn @tiny_stateful_caller{{[( ]}}
+// CHECK: - {{.*}}internal_call @tiny_stateful_callee
+// CHECK: + sstore 0, arg0
+// CHECK: + sstore 0, arg1
 fn @tiny_stateful_caller(arg0: u256, arg1: u256) {
   bb0:
     internal_call fn5, 0, arg0
@@ -80,8 +80,8 @@ fn @tiny_stateful_callee(arg0: u256) {
 
 // A shared callee above the ordinary 10-block cap inlines at only its most
 // tail-like call site, even when the less profitable site appears first.
-// CHECK-DAG: {{^[ +].*}}fn @large_shared_nontail{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}internal_call @large_shared_callee
+// CHECK-LABEL: {{^[ +].*}}fn @large_shared_nontail{{[( ]}}
+// CHECK: {{^[ +].*}}internal_call @large_shared_callee
 fn @large_shared_nontail(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn8, 1, arg0
@@ -90,10 +90,10 @@ fn @large_shared_nontail(arg0: u256) -> u256 {
     ret v3
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @large_shared_tail{{[( ]}}
-// CHECK-DAG: - {{.*}}internal_call @large_shared_callee
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb13: [[INLINED:v[0-9]+]]]
-// CHECK-DAG: + [[INLINED]] = add arg0, 1
+// CHECK-LABEL: {{^[ +].*}}fn @large_shared_tail{{[( ]}}
+// CHECK: - {{.*}}internal_call @large_shared_callee
+// CHECK: + [[INLINED:v[0-9]+]] = add arg0, 1
+// CHECK: + {{v[0-9]+}} = phi [bb13: [[INLINED]]]
 fn @large_shared_tail(arg0: u256) -> u256 {
   bb0:
     v1 = internal_call fn8, 1, arg0

--- a/tests/ui/codegen/mir/inline/inline_v2_profitability.stdout
+++ b/tests/ui/codegen/mir/inline/inline_v2_profitability.stdout
@@ -6,9 +6,6 @@
 -     v0 = internal_call @single_large_callee, 1, arg0
 -     ret v0
 +     jump bb2
-+   bb1:
-+     v2 = phi [bb13: v1]
-+     ret v2
 +   bb2:
 +     jump bb3
 +   bb3:
@@ -34,6 +31,9 @@
 +   bb13:
 +     v1 = add arg0, 1
 +     jump bb1
++   bb1:
++     v2 = phi [bb13: v1]
++     ret v2
   }
   
   fn @single_large_callee(arg0: u256) -> u256 {
@@ -68,6 +68,10 @@
     bb0:
 -     v0 = internal_call @multi_return_callee, 2, arg0
 +     jump bb2
++   bb2:
++     v3 = add arg0, 1
++     v4 = add arg0, 2
++     jump bb1
 +   bb1:
 +     v5 = phi [bb2: v3]
 +     v6 = phi [bb2: v4]
@@ -79,10 +83,6 @@
 -     v2 = add v0, v1
 +     v2 = add v5, v1
       ret v2
-+   bb2:
-+     v3 = add arg0, 1
-+     v4 = add arg0, 2
-+     jump bb1
   }
   
   fn @multi_return_callee(arg0: u256) -> (u256, u256) {
@@ -97,16 +97,16 @@
 -     internal_call @tiny_stateful_callee, 0, arg0
 -     internal_call @tiny_stateful_callee, 0, arg1
 +     jump bb2
-+   bb1:
-+     jump bb4
 +   bb2:
 +     sstore 0, arg0
 +     jump bb1
-+   bb3:
-      stop
++   bb1:
++     jump bb4
 +   bb4:
 +     sstore 0, arg1
 +     jump bb3
++   bb3:
+      stop
   }
   
   fn @tiny_stateful_callee(arg0: u256) {
@@ -128,9 +128,6 @@
 -     v0 = internal_call @large_shared_callee, 1, arg0
 -     ret v0
 +     jump bb2
-+   bb1:
-+     v2 = phi [bb13: v1]
-+     ret v2
 +   bb2:
 +     jump bb3
 +   bb3:
@@ -156,6 +153,9 @@
 +   bb13:
 +     v1 = add arg0, 1
 +     jump bb1
++   bb1:
++     v2 = phi [bb13: v1]
++     ret v2
   }
   
   fn @large_shared_callee(arg0: u256) -> u256 {

--- a/tests/ui/codegen/mir/inst-simplify/identities.stdout
+++ b/tests/ui/codegen/mir/inst-simplify/identities.stdout
@@ -81,11 +81,13 @@
       v0 = lt 0, arg0
       v1 = iszero v0
 -     jumpi v1, bb1, bb2
+-   bb2:
+-     stop
 +     jumpi arg0, bb2, bb1
     bb1:
       stop
-    bb2:
-      stop
++   bb2:
++     stop
   }
   
   fn @masked_own_balance() -> u256 {

--- a/tests/ui/codegen/mir/jump-threading/jump_threading.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading.stdout
@@ -4,13 +4,15 @@
   fn @forwarder_chain(arg0: u256) -> u256 {
     bb0:
 -     jump bb1
-+     jump bb3
-    bb1:
+-   bb1:
 -     jump bb2
-+     jump bb3
-    bb2:
+-   bb2:
       jump bb3
     bb3:
       ret arg0
++   bb1:
++     jump bb3
++   bb2:
++     jump bb3
   }
   

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_branch.stdout
@@ -4,14 +4,18 @@
   fn @branch_forwarders(arg0: u256) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
+-   bb2:
+-     jump bb4
 +     jumpi arg0, bb3, bb4
-    bb1:
-      jump bb3
-    bb2:
-      jump bb4
-    bb3:
-      ret arg0
     bb4:
       ret arg0
+-   bb1:
+-     jump bb3
+    bb3:
+      ret arg0
++   bb1:
++     jump bb3
++   bb2:
++     jump bb4
   }
   

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_constants.stdout
@@ -4,41 +4,50 @@
   fn @thread_branch_on_phi_constant(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
+-   bb2:
+-     jump bb3
 +     jumpi arg0, bb5, bb4
++   bb4:
++     ret 11
++   bb5:
++     ret 22
     bb1:
 -     jump bb3
 +     jump bb5
-    bb2:
--     jump bb3
++   bb2:
 +     jump bb4
     bb3:
 -     v0 = phi [bb1: 0], [bb2: 1]
 +     v0 = phi
       jumpi v0, bb4, bb5
-    bb4:
-      ret 11
-    bb5:
-      ret 22
+-   bb5:
+-     ret 22
+-   bb4:
+-     ret 11
   }
   
   fn @thread_switch_on_phi_constant(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb2
-+     jumpi arg0, bb4, bb5
-    bb1:
+-   bb2:
 -     jump bb3
-+     jump bb4
-    bb2:
+-   bb1:
 -     jump bb3
-+     jump bb5
-    bb3:
+-   bb3:
 -     v0 = phi [bb1: 1], [bb2: 2]
-+     v0 = phi
-      switch v0, default bb6, [1 => bb4, 2 => bb5]
-    bb4:
-      ret 11
+-     switch v0, default bb6, [1 => bb4, 2 => bb5]
++     jumpi arg0, bb4, bb5
     bb5:
       ret 22
+    bb4:
+      ret 11
++   bb1:
++     jump bb4
++   bb2:
++     jump bb5
++   bb3:
++     v0 = phi
++     switch v0, default bb6, [1 => bb4, 2 => bb5]
     bb6:
       ret 33
   }
@@ -46,33 +55,33 @@
   fn @keep_unknown_phi(arg0: bool, arg1: u256, arg2: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: arg1], [bb2: arg2]
       jumpi v0, bb4, bb5
-    bb4:
-      ret 11
     bb5:
       ret 22
+    bb4:
+      ret 11
   }
   
   fn @keep_phi_used_in_successor(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: 0], [bb2: 1]
       jumpi v0, bb4, bb5
+    bb5:
+      ret 22
     bb4:
       v1 = add v0, 1
       ret v1
-    bb5:
-      ret 22
   }
   

--- a/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
+++ b/tests/ui/codegen/mir/jump-threading/jump_threading_phi_forwarder.stdout
@@ -4,9 +4,9 @@
   fn @keep_phi_only_block(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: 1], [bb2: 2]

--- a/tests/ui/codegen/mir/licm/builder_cases.mir
+++ b/tests/ui/codegen/mir/licm/builder_cases.mir
@@ -2,13 +2,13 @@
 //@filecheck: --enable-var-scope
 @module LicmBuilderCases
 
-// CHECK-LABEL: @hoist_mul
-// CHECK: +     [[MUL:v[0-9]+]] = mul arg0, 7
-// CHECK-NEXT: {{^ +}}jump [[HEADER:bb[0-9]+]]
-// CHECK: {{^ +}}[[HEADER]]:
-// CHECK-NEXT: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK: {{^ +}}[[BODY]]:
-// CHECK: -     [[MUL]] = mul arg0, 7
+// CHECK-DAG: @hoist_mul
+// CHECK-DAG: +     [[MUL:v[0-9]+]] = mul arg0, 7
+// CHECK-DAG: {{^ +}}jump [[HEADER:bb[0-9]+]]
+// CHECK-DAG: {{^ +}}[[HEADER]]:
+// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG: {{^ +}}[[BODY]]:
+// CHECK-DAG: -     [[MUL]] = mul arg0, 7
 fn @hoist_mul(arg0: u256) {
   bb0:
     jump bb1
@@ -21,13 +21,13 @@ fn @hoist_mul(arg0: u256) {
     stop
 }
 
-// CHECK-LABEL: @hoist_clz
-// CHECK: +     [[CLZ:v[0-9]+]] = clz arg0
-// CHECK-NEXT: {{^ +}}jump [[HEADER:bb[0-9]+]]
-// CHECK: {{^ +}}[[HEADER]]:
-// CHECK-NEXT: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK: {{^ +}}[[BODY]]:
-// CHECK: -     [[CLZ]] = clz arg0
+// CHECK-DAG: @hoist_clz
+// CHECK-DAG: +     [[CLZ:v[0-9]+]] = clz arg0
+// CHECK-DAG: {{^ +}}jump [[HEADER:bb[0-9]+]]
+// CHECK-DAG: {{^ +}}[[HEADER]]:
+// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG: {{^ +}}[[BODY]]:
+// CHECK-DAG: -     [[CLZ]] = clz arg0
 fn @hoist_clz(arg0: u256) {
   bb0:
     jump bb1
@@ -40,11 +40,11 @@ fn @hoist_clz(arg0: u256) {
     stop
 }
 
-// CHECK-LABEL: @hoist_non_aliasing_sload
-// CHECK: +     [[LOAD:v[0-9]+]] = sload [[SLOT:[0-9]+]]
-// CHECK-NEXT:  jump {{bb[0-9]+}}
-// CHECK: -     [[LOAD]] = sload [[SLOT]]
-// CHECK:       ret [[LOAD]]
+// CHECK-DAG: @hoist_non_aliasing_sload
+// CHECK-DAG: +     [[LOAD:v[0-9]+]] = sload [[SLOT:[0-9]+]]
+// CHECK-DAG:  jump {{bb[0-9]+}}
+// CHECK-DAG: -     [[LOAD]] = sload [[SLOT]]
+// CHECK-DAG:       ret [[LOAD]]
 fn @hoist_non_aliasing_sload() -> u256 {
   bb0:
     jump bb1
@@ -58,11 +58,11 @@ fn @hoist_non_aliasing_sload() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @keep_aliasing_sload
-// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK: {{^ +}}[[BODY]]:
-// CHECK: +     {{v[0-9]+}} = sload [[SLOT:[0-9]+]]
-// CHECK: +     sstore [[SLOT]], 1
+// CHECK-DAG: @keep_aliasing_sload
+// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG: {{^ +}}[[BODY]]:
+// CHECK-DAG: +     {{v[0-9]+}} = sload [[SLOT:[0-9]+]]
+// CHECK-DAG: +     sstore [[SLOT]], 1
 fn @keep_aliasing_sload() -> u256 {
   bb0:
     jump bb1
@@ -76,13 +76,13 @@ fn @keep_aliasing_sload() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @keep_work_after_gas
-// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK: {{^ +}}[[BODY]]:
-// CHECK: {{^ +}}{{v[0-9]+}} = gas
-// CHECK: {{^ +}}[[MUL:v[0-9]+]] = mul arg0, 7
-// CHECK: {{^ +}}jump
-// CHECK: {{^ +}}ret [[MUL]]
+// CHECK-DAG: @keep_work_after_gas
+// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG: {{^ +}}[[BODY]]:
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = gas
+// CHECK-DAG: {{^ +}}[[MUL:v[0-9]+]] = mul arg0, 7
+// CHECK-DAG: {{^ +}}jump
+// CHECK-DAG: {{^ +}}ret [[MUL]]
 fn @keep_work_after_gas(arg0: u256) -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/licm/builder_cases.mir
+++ b/tests/ui/codegen/mir/licm/builder_cases.mir
@@ -2,13 +2,13 @@
 //@filecheck: --enable-var-scope
 @module LicmBuilderCases
 
-// CHECK-DAG: @hoist_mul
-// CHECK-DAG: +     [[MUL:v[0-9]+]] = mul arg0, 7
-// CHECK-DAG: {{^ +}}jump [[HEADER:bb[0-9]+]]
-// CHECK-DAG: {{^ +}}[[HEADER]]:
-// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG: {{^ +}}[[BODY]]:
-// CHECK-DAG: -     [[MUL]] = mul arg0, 7
+// CHECK-LABEL: @hoist_mul
+// CHECK: +     [[MUL:v[0-9]+]] = mul arg0, 7
+// CHECK-NEXT: {{^ +}}jump [[HEADER:bb[0-9]+]]
+// CHECK: {{^ +}}[[HEADER]]:
+// CHECK-NEXT: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: -     [[MUL]] = mul arg0, 7
 fn @hoist_mul(arg0: u256) {
   bb0:
     jump bb1
@@ -21,13 +21,13 @@ fn @hoist_mul(arg0: u256) {
     stop
 }
 
-// CHECK-DAG: @hoist_clz
-// CHECK-DAG: +     [[CLZ:v[0-9]+]] = clz arg0
-// CHECK-DAG: {{^ +}}jump [[HEADER:bb[0-9]+]]
-// CHECK-DAG: {{^ +}}[[HEADER]]:
-// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG: {{^ +}}[[BODY]]:
-// CHECK-DAG: -     [[CLZ]] = clz arg0
+// CHECK-LABEL: @hoist_clz
+// CHECK: +     [[CLZ:v[0-9]+]] = clz arg0
+// CHECK-NEXT: {{^ +}}jump [[HEADER:bb[0-9]+]]
+// CHECK: {{^ +}}[[HEADER]]:
+// CHECK-NEXT: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: -     [[CLZ]] = clz arg0
 fn @hoist_clz(arg0: u256) {
   bb0:
     jump bb1
@@ -40,11 +40,11 @@ fn @hoist_clz(arg0: u256) {
     stop
 }
 
-// CHECK-DAG: @hoist_non_aliasing_sload
-// CHECK-DAG: +     [[LOAD:v[0-9]+]] = sload [[SLOT:[0-9]+]]
-// CHECK-DAG:  jump {{bb[0-9]+}}
-// CHECK-DAG: -     [[LOAD]] = sload [[SLOT]]
-// CHECK-DAG:       ret [[LOAD]]
+// CHECK-LABEL: @hoist_non_aliasing_sload
+// CHECK: +     [[LOAD:v[0-9]+]] = sload [[SLOT:[0-9]+]]
+// CHECK-NEXT:  jump {{bb[0-9]+}}
+// CHECK:       ret [[LOAD]]
+// CHECK: -     [[LOAD]] = sload [[SLOT]]
 fn @hoist_non_aliasing_sload() -> u256 {
   bb0:
     jump bb1
@@ -58,11 +58,11 @@ fn @hoist_non_aliasing_sload() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @keep_aliasing_sload
-// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG: {{^ +}}[[BODY]]:
-// CHECK-DAG: +     {{v[0-9]+}} = sload [[SLOT:[0-9]+]]
-// CHECK-DAG: +     sstore [[SLOT]], 1
+// CHECK-LABEL: @keep_aliasing_sload
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: +     {{v[0-9]+}} = sload [[SLOT:[0-9]+]]
+// CHECK: +     sstore [[SLOT]], 1
 fn @keep_aliasing_sload() -> u256 {
   bb0:
     jump bb1
@@ -76,13 +76,13 @@ fn @keep_aliasing_sload() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @keep_work_after_gas
-// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG: {{^ +}}[[BODY]]:
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = gas
-// CHECK-DAG: {{^ +}}[[MUL:v[0-9]+]] = mul arg0, 7
-// CHECK-DAG: {{^ +}}jump
-// CHECK-DAG: {{^ +}}ret [[MUL]]
+// CHECK-LABEL: @keep_work_after_gas
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}ret [[MUL:v[0-9]+]]
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: {{^ +}}{{v[0-9]+}} = gas
+// CHECK: {{^ +}}[[MUL]] = mul arg0, 7
+// CHECK: {{^ +}}jump
 fn @keep_work_after_gas(arg0: u256) -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/licm/builder_cases.stdout
+++ b/tests/ui/codegen/mir/licm/builder_cases.stdout
@@ -7,11 +7,11 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      stop
     bb2:
 -     v0 = mul arg0, 7
       jump bb1
-    bb3:
-      stop
   }
   
   fn @hoist_clz(arg0: u256) {
@@ -20,11 +20,11 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      stop
     bb2:
 -     v0 = clz arg0
       jump bb1
-    bb3:
-      stop
   }
   
   fn @hoist_non_aliasing_sload() -> u256 {
@@ -33,13 +33,13 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v0
     bb2:
 -     v0 = sload 0
 -     sstore 1, 1
 +     sstore 1, 1 !metadata(storage=slot(1))
       jump bb1
-    bb3:
-      ret v0
   }
   
   fn @keep_aliasing_sload() -> u256 {
@@ -47,14 +47,14 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v0
     bb2:
 -     v0 = sload 0
 -     sstore 0, 1
 +     v0 = sload 0 !metadata(storage=slot(0))
 +     sstore 0, 1 !metadata(storage=slot(0))
       jump bb1
-    bb3:
-      ret v0
   }
   
   fn @keep_work_after_gas(arg0: u256) -> u256 {
@@ -62,11 +62,11 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = gas
       v1 = mul arg0, 7
       jump bb1
-    bb3:
-      ret v1
   }
   

--- a/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
+++ b/tests/ui/codegen/mir/licm/licm_descending_iv.stdout
@@ -8,6 +8,8 @@
       v0 = phi [bb0: 64], [bb2: v3]
       v1 = lt v0, 100
       jumpi v1, bb2, bb3
+    bb3:
+      ret v2
     bb2:
       v2 = mload 0
 -     sstore v0, v2
@@ -15,8 +17,6 @@
       mstore v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       v3 = sub v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   
   fn @hoist_mload_ascending_iv() -> u256 {
@@ -27,6 +27,8 @@
       v0 = phi [bb0: 64], [bb2: v3]
       v1 = lt v0, 100
       jumpi v1, bb2, bb3
+    bb3:
+      ret v2
     bb2:
 -     v2 = mload 0
 -     sstore v0, v2
@@ -34,7 +36,5 @@
       mstore v0, 7
       v3 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   

--- a/tests/ui/codegen/mir/licm/licm_env_reads.stdout
+++ b/tests/ui/codegen/mir/licm/licm_env_reads.stdout
@@ -6,13 +6,13 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = balance 0xbeef
       v1 = mul v0, 3
       v2 = call 0x3e8, 0xbeef, 1, 0, 0, 0, 0
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @keep_balance_with_callcode() -> u256 {
@@ -20,13 +20,13 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = balance 0xbeef
       v1 = mul v0, 3
       v2 = callcode 0x3e8, 0xbeef, 1, 0, 0, 0, 0
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @hoist_balance_without_calls() -> u256 {
@@ -36,12 +36,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
 -     v0 = balance 0xbeef
 -     v1 = mul v0, 3
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @keep_extcodesize_with_create() -> u256 {
@@ -49,13 +49,13 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = extcodesize 0xbeef
       v1 = mul v0, 3
       v2 = create 0, 0, 32
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @keep_returndatasize_with_staticcall() -> u256 {
@@ -63,13 +63,13 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = returndatasize
       v1 = mul v0, 3
       v2 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @keep_msize() -> u256 {
@@ -77,11 +77,11 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = msize
       v1 = mul v0, 3
       jump bb1
-    bb3:
-      ret v1
   }
   

--- a/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
+++ b/tests/ui/codegen/mir/licm/licm_loop_bound.stdout
@@ -30,6 +30,8 @@
       v0 = phi [bb0: 0], [bb4: v5]
       v1 = lt v0, 100
       jumpi v1, bb2, bb5
+    bb5:
+      ret v2
     bb2:
       v2 = mload 64
       v3 = mul v0, 32
@@ -41,7 +43,5 @@
     bb4:
       v5 = add v0, 1
       jump bb1
-    bb5:
-      ret v2
   }
   

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.mir
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.mir
@@ -4,11 +4,11 @@
 immutables:
   value: u256
 
-// CHECK-LABEL: @hoist_non_aliasing_mload
-// CHECK: +     [[LOAD:v[0-9]+]] = mload [[ADDR:[0-9]+]]
-// CHECK-NEXT:  jump {{bb[0-9]+}}
-// CHECK: -     [[LOAD]] = mload [[ADDR]]
-// CHECK:       ret [[LOAD]]
+// CHECK-DAG: @hoist_non_aliasing_mload
+// CHECK-DAG: +     [[LOAD:v[0-9]+]] = mload [[ADDR:[0-9]+]]
+// CHECK-DAG:  jump {{bb[0-9]+}}
+// CHECK-DAG: -     [[LOAD]] = mload [[ADDR]]
+// CHECK-DAG:       ret [[LOAD]]
 fn @hoist_non_aliasing_mload() -> u256 {
   bb0:
     jump bb1
@@ -22,11 +22,11 @@ fn @hoist_non_aliasing_mload() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @keep_aliasing_mload
-// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK: {{^ +}}[[BODY]]:
-// CHECK: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
-// CHECK: {{^ +}}mstore {{[0-9]+}}, 1
+// CHECK-DAG: @keep_aliasing_mload
+// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG: {{^ +}}[[BODY]]:
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
+// CHECK-DAG: {{^ +}}mstore {{[0-9]+}}, 1
 fn @keep_aliasing_mload() -> u256 {
   bb0:
     jump bb1
@@ -40,11 +40,11 @@ fn @keep_aliasing_mload() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @hoist_non_aliasing_keccak
-// CHECK: +     [[HASH:v[0-9]+]] = keccak256 [[ADDR:[0-9]+]], [[SIZE:[0-9]+]]
-// CHECK-NEXT:  jump {{bb[0-9]+}}
-// CHECK: -     [[HASH]] = keccak256 [[ADDR]], [[SIZE]]
-// CHECK:       ret [[HASH]]
+// CHECK-DAG: @hoist_non_aliasing_keccak
+// CHECK-DAG: +     [[HASH:v[0-9]+]] = keccak256 [[ADDR:[0-9]+]], [[SIZE:[0-9]+]]
+// CHECK-DAG:  jump {{bb[0-9]+}}
+// CHECK-DAG: -     [[HASH]] = keccak256 [[ADDR]], [[SIZE]]
+// CHECK-DAG:       ret [[HASH]]
 fn @hoist_non_aliasing_keccak() -> bytes32 {
   bb0:
     jump bb1
@@ -58,11 +58,11 @@ fn @hoist_non_aliasing_keccak() -> bytes32 {
     ret v0
 }
 
-// CHECK-LABEL: @keep_aliasing_keccak
-// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK: {{^ +}}[[BODY]]:
-// CHECK: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
-// CHECK: {{^ +}}mstore {{[0-9]+}}, 1
+// CHECK-DAG: @keep_aliasing_keccak
+// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG: {{^ +}}[[BODY]]:
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
+// CHECK-DAG: {{^ +}}mstore {{[0-9]+}}, 1
 fn @keep_aliasing_keccak() -> bytes32 {
   bb0:
     jump bb1
@@ -76,13 +76,13 @@ fn @keep_aliasing_keccak() -> bytes32 {
     ret v0
 }
 
-// CHECK-LABEL: @hoist_unassigned_immutable
-// CHECK: +     [[LOAD:v[0-9]+]] = loadimmutable value
-// CHECK-NEXT: +     [[VALUE:v[0-9]+]] = mul [[LOAD]], 2
-// CHECK-NEXT:       jump {{bb[0-9]+}}
-// CHECK: -     [[LOAD]] = loadimmutable value
-// CHECK-NEXT: -     [[VALUE]] = mul [[LOAD]], 2
-// CHECK:       ret [[VALUE]]
+// CHECK-DAG: @hoist_unassigned_immutable
+// CHECK-DAG: +     [[LOAD:v[0-9]+]] = loadimmutable value
+// CHECK-DAG: +     [[VALUE:v[0-9]+]] = mul [[LOAD]], 2
+// CHECK-DAG:       jump {{bb[0-9]+}}
+// CHECK-DAG: -     [[LOAD]] = loadimmutable value
+// CHECK-DAG: -     [[VALUE]] = mul [[LOAD]], 2
+// CHECK-DAG:       ret [[VALUE]]
 fn @hoist_unassigned_immutable() -> u256 {
   bb0:
     jump bb1
@@ -96,10 +96,10 @@ fn @hoist_unassigned_immutable() -> u256 {
     ret v1
 }
 
-// CHECK-LABEL: @keep_assigned_immutable
-// CHECK: {{^ +}}{{v[0-9]+}} = loadimmutable value
-// CHECK-NEXT: {{^ +}}{{v[0-9]+}} = mul {{v[0-9]+}}, 2
-// CHECK-NEXT: {{^ +}}storeimmutable value, 1
+// CHECK-DAG: @keep_assigned_immutable
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = loadimmutable value
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = mul {{v[0-9]+}}, 2
+// CHECK-DAG: {{^ +}}storeimmutable value, 1
 fn @keep_assigned_immutable() -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.mir
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.mir
@@ -4,11 +4,11 @@
 immutables:
   value: u256
 
-// CHECK-DAG: @hoist_non_aliasing_mload
-// CHECK-DAG: +     [[LOAD:v[0-9]+]] = mload [[ADDR:[0-9]+]]
-// CHECK-DAG:  jump {{bb[0-9]+}}
-// CHECK-DAG: -     [[LOAD]] = mload [[ADDR]]
-// CHECK-DAG:       ret [[LOAD]]
+// CHECK-LABEL: @hoist_non_aliasing_mload
+// CHECK: +     [[LOAD:v[0-9]+]] = mload [[ADDR:[0-9]+]]
+// CHECK-NEXT:  jump {{bb[0-9]+}}
+// CHECK:       ret [[LOAD]]
+// CHECK: -     [[LOAD]] = mload [[ADDR]]
 fn @hoist_non_aliasing_mload() -> u256 {
   bb0:
     jump bb1
@@ -22,11 +22,11 @@ fn @hoist_non_aliasing_mload() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @keep_aliasing_mload
-// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG: {{^ +}}[[BODY]]:
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
-// CHECK-DAG: {{^ +}}mstore {{[0-9]+}}, 1
+// CHECK-LABEL: @keep_aliasing_mload
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
+// CHECK: {{^ +}}mstore {{[0-9]+}}, 1
 fn @keep_aliasing_mload() -> u256 {
   bb0:
     jump bb1
@@ -40,11 +40,11 @@ fn @keep_aliasing_mload() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @hoist_non_aliasing_keccak
-// CHECK-DAG: +     [[HASH:v[0-9]+]] = keccak256 [[ADDR:[0-9]+]], [[SIZE:[0-9]+]]
-// CHECK-DAG:  jump {{bb[0-9]+}}
-// CHECK-DAG: -     [[HASH]] = keccak256 [[ADDR]], [[SIZE]]
-// CHECK-DAG:       ret [[HASH]]
+// CHECK-LABEL: @hoist_non_aliasing_keccak
+// CHECK: +     [[HASH:v[0-9]+]] = keccak256 [[ADDR:[0-9]+]], [[SIZE:[0-9]+]]
+// CHECK-NEXT:  jump {{bb[0-9]+}}
+// CHECK:       ret [[HASH]]
+// CHECK: -     [[HASH]] = keccak256 [[ADDR]], [[SIZE]]
 fn @hoist_non_aliasing_keccak() -> bytes32 {
   bb0:
     jump bb1
@@ -58,11 +58,11 @@ fn @hoist_non_aliasing_keccak() -> bytes32 {
     ret v0
 }
 
-// CHECK-DAG: @keep_aliasing_keccak
-// CHECK-DAG: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG: {{^ +}}[[BODY]]:
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
-// CHECK-DAG: {{^ +}}mstore {{[0-9]+}}, 1
+// CHECK-LABEL: @keep_aliasing_keccak
+// CHECK: {{^ +}}jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK: {{^ +}}[[BODY]]:
+// CHECK: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
+// CHECK: {{^ +}}mstore {{[0-9]+}}, 1
 fn @keep_aliasing_keccak() -> bytes32 {
   bb0:
     jump bb1
@@ -76,13 +76,13 @@ fn @keep_aliasing_keccak() -> bytes32 {
     ret v0
 }
 
-// CHECK-DAG: @hoist_unassigned_immutable
-// CHECK-DAG: +     [[LOAD:v[0-9]+]] = loadimmutable value
-// CHECK-DAG: +     [[VALUE:v[0-9]+]] = mul [[LOAD]], 2
-// CHECK-DAG:       jump {{bb[0-9]+}}
-// CHECK-DAG: -     [[LOAD]] = loadimmutable value
-// CHECK-DAG: -     [[VALUE]] = mul [[LOAD]], 2
-// CHECK-DAG:       ret [[VALUE]]
+// CHECK-LABEL: @hoist_unassigned_immutable
+// CHECK: +     [[LOAD:v[0-9]+]] = loadimmutable value
+// CHECK-NEXT: +     [[VALUE:v[0-9]+]] = mul [[LOAD]], 2
+// CHECK-NEXT:       jump {{bb[0-9]+}}
+// CHECK:       ret [[VALUE]]
+// CHECK: -     [[LOAD]] = loadimmutable value
+// CHECK-NEXT: -     [[VALUE]] = mul [[LOAD]], 2
 fn @hoist_unassigned_immutable() -> u256 {
   bb0:
     jump bb1
@@ -96,10 +96,10 @@ fn @hoist_unassigned_immutable() -> u256 {
     ret v1
 }
 
-// CHECK-DAG: @keep_assigned_immutable
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = loadimmutable value
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = mul {{v[0-9]+}}, 2
-// CHECK-DAG: {{^ +}}storeimmutable value, 1
+// CHECK-LABEL: @keep_assigned_immutable
+// CHECK: {{^ +}}{{v[0-9]+}} = loadimmutable value
+// CHECK-NEXT: {{^ +}}{{v[0-9]+}} = mul {{v[0-9]+}}, 2
+// CHECK-NEXT: {{^ +}}storeimmutable value, 1
 fn @keep_assigned_immutable() -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
+++ b/tests/ui/codegen/mir/licm/licm_memory_alias.stdout
@@ -10,12 +10,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v0
     bb2:
 -     v0 = mload 0
       mstore 64, 1
       jump bb1
-    bb3:
-      ret v0
   }
   
   fn @keep_aliasing_mload() -> u256 {
@@ -23,12 +23,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v0
     bb2:
       v0 = mload 0
       mstore 16, 1
       jump bb1
-    bb3:
-      ret v0
   }
   
   fn @hoist_non_aliasing_keccak() -> bytes32 {
@@ -37,12 +37,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v0
     bb2:
 -     v0 = keccak256 0, 32
       mstore 64, 1
       jump bb1
-    bb3:
-      ret v0
   }
   
   fn @keep_aliasing_keccak() -> bytes32 {
@@ -50,12 +50,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v0
     bb2:
       v0 = keccak256 0, 32
       mstore 16, 1
       jump bb1
-    bb3:
-      ret v0
   }
   
   fn @hoist_unassigned_immutable() -> u256 {
@@ -65,12 +65,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
 -     v0 = loadimmutable value
 -     v1 = mul v0, 2
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @keep_assigned_immutable() -> u256 {
@@ -78,12 +78,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       v0 = loadimmutable value
       v1 = mul v0, 2
       storeimmutable value, 1
       jump bb1
-    bb3:
-      ret v1
   }
   

--- a/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
+++ b/tests/ui/codegen/mir/licm/licm_multi_latch.stdout
@@ -9,20 +9,20 @@
       v0 = phi [bb0: 0], [bb3: v5], [bb4: v6]
       v1 = lt v0, 10
       jumpi v1, bb2, bb5
+    bb5:
+      ret v3
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
       v3 = mload 288
 -     v4 = calldataload 0
       jumpi v4, bb3, bb4
-    bb3:
-      v5 = add v0, 1
-      jump bb1
     bb4:
       v6 = add v0, 7
       jump bb1
-    bb5:
-      ret v3
+    bb3:
+      v5 = add v0, 1
+      jump bb1
   }
   
   fn @multi_latch_same_value() -> u256 {
@@ -34,6 +34,8 @@
       v0 = phi [bb0: 0], [bb3: v4], [bb4: v4]
       v1 = lt v0, 10
       jumpi v1, bb2, bb5
+    bb5:
+      ret v3
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
@@ -41,11 +43,9 @@
       v4 = add v0, 1
 -     v5 = calldataload 0
       jumpi v5, bb3, bb4
-    bb3:
-      jump bb1
     bb4:
       jump bb1
-    bb5:
-      ret v3
+    bb3:
+      jump bb1
   }
   

--- a/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
+++ b/tests/ui/codegen/mir/licm/licm_rotated_guard.stdout
@@ -11,11 +11,11 @@
       v2 = mload 320
       v3 = lt v0, 10
       jumpi v3, bb2, bb3
+    bb3:
+      ret v2
     bb2:
       v4 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   
   fn @dowhile_latch_guard_overlap() -> u256 {
@@ -41,14 +41,14 @@
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
       jumpi v1, bb2, bb3
+    bb3:
+      ret v3
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
 -     v3 = mload 320
       v4 = add v0, 1
       jump bb1
-    bb3:
-      ret v3
   }
   
   fn @disjoint_past_widened_range() -> u256 {
@@ -62,10 +62,10 @@
 -     v2 = mload 384
       v3 = lt v0, 10
       jumpi v3, bb2, bb3
+    bb3:
+      ret v2
     bb2:
       v4 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   

--- a/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
+++ b/tests/ui/codegen/mir/licm/licm_staticcall_storage.stdout
@@ -9,13 +9,13 @@
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
       jumpi v1, bb2, bb3
+    bb3:
+      ret v2
     bb2:
 -     v2 = sload 5
       v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
       v4 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   
   fn @hoist_tload_with_staticcall() -> u256 {
@@ -26,13 +26,13 @@
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
       jumpi v1, bb2, bb3
+    bb3:
+      ret v2
     bb2:
 -     v2 = tload 5
       v3 = staticcall 0x3e8, 0xbeef, 0, 0, 0, 0
       v4 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   
   fn @keep_sload_with_call() -> u256 {
@@ -42,13 +42,13 @@
       v0 = phi [bb0: 0], [bb2: v4]
       v1 = lt v0, 10
       jumpi v1, bb2, bb3
+    bb3:
+      ret v2
     bb2:
 -     v2 = sload 5
 +     v2 = sload 5 !metadata(storage=slot(5))
       v3 = call 0x3e8, 0xbeef, 0, 0, 0, 0, 0
       v4 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   

--- a/tests/ui/codegen/mir/licm/licm_v2.stdout
+++ b/tests/ui/codegen/mir/licm/licm_v2.stdout
@@ -11,6 +11,8 @@
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, 4
       jumpi v1, bb2, bb3
+    bb3:
+      ret v3
     bb2:
 -     v2 = add arg0, 1
 -     v3 = sload v2
@@ -19,8 +21,6 @@
 +     sstore v4, 9 !metadata(storage=offset(arg0, 2))
       v5 = add v0, 1
       jump bb1
-    bb3:
-      ret v3
   }
   
   fn @keep_aliasing_symbolic_offset_sload(arg0: u256) -> u256 {
@@ -32,6 +32,8 @@
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, 4
       jumpi v1, bb2, bb3
+    bb3:
+      ret v3
     bb2:
 -     v2 = add arg0, 1
 -     v3 = sload v2
@@ -41,8 +43,6 @@
 +     sstore v4, 9 !metadata(storage=offset(arg0, 1))
       v5 = add v0, 1
       jump bb1
-    bb3:
-      ret v3
   }
   
   fn @do_not_speculate_symbolic_offset_sload(arg0: u256, arg1: bool) -> u256 {
@@ -52,6 +52,8 @@
       jump bb1
     bb1:
       jumpi arg1, bb2, bb3
+    bb3:
+      ret v1
     bb2:
 -     v0 = add arg0, 1
 -     v1 = sload v0
@@ -60,8 +62,6 @@
 +     v1 = sload v0 !metadata(storage=offset(arg0, 1))
 +     sstore v2, 9 !metadata(storage=offset(arg0, 2))
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @hoist_affine_memory_base(arg0: u256) -> u256 {
@@ -72,6 +72,8 @@
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, 4
       jumpi v1, bb2, bb3
+    bb3:
+      ret 0
     bb2:
 -     v2 = add arg0, 32
       v3 = mul v0, 32
@@ -79,8 +81,6 @@
       mstore v4, v0
       v5 = add v0, 1
       jump bb1
-    bb3:
-      ret 0
   }
   
   fn @hoist_unknown_trip_affine_memory_base(arg0: u256, arg1: u256) -> u256 {
@@ -91,6 +91,8 @@
       v0 = phi [bb0: 0], [bb2: v5]
       v1 = lt v0, arg1
       jumpi v1, bb2, bb3
+    bb3:
+      ret 0
     bb2:
 -     v2 = add arg0, 32
       v3 = mul v0, 32
@@ -98,7 +100,5 @@
       mstore v4, v0
       v5 = add v0, 1
       jump bb1
-    bb3:
-      ret 0
   }
   

--- a/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
+++ b/tests/ui/codegen/mir/licm/licm_wrap_add_descending.stdout
@@ -8,13 +8,13 @@
       v0 = phi [bb0: 64], [bb2: v4]
       v1 = lt v0, 100
       jumpi v1, bb2, bb3
+    bb3:
+      ret v3
     bb2:
       v2 = mul v0, 32
       mstore v2, 1
       v3 = mload 0
       v4 = add v0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
       jump bb1
-    bb3:
-      ret v3
   }
   

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.mir
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.mir
@@ -4,9 +4,9 @@
 
 // The bound is unknown, so the loop may run zero times: speculating the sload
 // into the always-executed preheader is a pure gas pessimization.
-// CHECK-LABEL: {{^[ +].*}}fn @keep_sload_zero_trip{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi
-// CHECK: + [[LOAD:v[0-9]+]] = sload 5
+// CHECK-DAG: {{^[ +].*}}fn @keep_sload_zero_trip{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi
+// CHECK-DAG: + [[LOAD:v[0-9]+]] = sload 5
 fn @keep_sload_zero_trip() -> u256 {
   bb0:
     v0 = calldatasize
@@ -25,9 +25,9 @@ fn @keep_sload_zero_trip() -> u256 {
 
 // Hoisting the mload would unconditionally expand memory to 0x1000000 even
 // when the loop runs zero times (out-of-gas risk).
-// CHECK-LABEL: {{^[ +].*}}fn @keep_mload_zero_trip{{[( ]}}
-// CHECK: {{^[ +].*}}jumpi
-// CHECK: {{^[ +].*}}mload 0x1000000
+// CHECK-DAG: {{^[ +].*}}fn @keep_mload_zero_trip{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}jumpi
+// CHECK-DAG: {{^[ +].*}}mload 0x1000000
 fn @keep_mload_zero_trip() -> u256 {
   bb0:
     v0 = calldatasize
@@ -46,9 +46,9 @@ fn @keep_mload_zero_trip() -> u256 {
 
 // A verified trip count of 10 guarantees the body executes, so the sload is
 // still hoisted.
-// CHECK-LABEL: {{^[ +].*}}fn @hoist_sload_known_trip{{[( ]}}
-// CHECK: + [[LOAD:v[0-9]+]] = sload 5
-// CHECK: - [[LOAD]] = sload 5
+// CHECK-DAG: {{^[ +].*}}fn @hoist_sload_known_trip{{[( ]}}
+// CHECK-DAG: + [[LOAD:v[0-9]+]] = sload 5
+// CHECK-DAG: - [[LOAD]] = sload 5
 fn @hoist_sload_known_trip() -> u256 {
   bb0:
     jump bb1
@@ -66,9 +66,9 @@ fn @hoist_sload_known_trip() -> u256 {
 
 // Do-while shape: the mload's block dominates the loop exit, so it executes
 // whenever the loop is entered and may be hoisted despite the unknown bound.
-// CHECK-LABEL: {{^[ +].*}}fn @hoist_mload_dominates_exits{{[( ]}}
-// CHECK: {{^[ +].*}}[[LOAD:v[0-9]+]] = mload 64
-// CHECK: + jump bb1
+// CHECK-DAG: {{^[ +].*}}fn @hoist_mload_dominates_exits{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}[[LOAD:v[0-9]+]] = mload 64
+// CHECK-DAG: + jump bb1
 fn @hoist_mload_dominates_exits() -> u256 {
   bb0:
     jump bb1
@@ -83,9 +83,9 @@ fn @hoist_mload_dominates_exits() -> u256 {
 
 // The msize after the loop makes any early memory expansion observable;
 // keep the mload in place even though the trip count is known.
-// CHECK-LABEL: {{^[ +].*}}fn @keep_mload_msize_in_function{{[( ]}}
-// CHECK: {{^[ +].*}}mload 64
-// CHECK: {{^[ +].*}}msize
+// CHECK-DAG: {{^[ +].*}}fn @keep_mload_msize_in_function{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}mload 64
+// CHECK-DAG: {{^[ +].*}}msize
 fn @keep_mload_msize_in_function() -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.mir
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.mir
@@ -4,9 +4,9 @@
 
 // The bound is unknown, so the loop may run zero times: speculating the sload
 // into the always-executed preheader is a pure gas pessimization.
-// CHECK-DAG: {{^[ +].*}}fn @keep_sload_zero_trip{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi
-// CHECK-DAG: + [[LOAD:v[0-9]+]] = sload 5
+// CHECK-LABEL: {{^[ +].*}}fn @keep_sload_zero_trip{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi
+// CHECK: + [[LOAD:v[0-9]+]] = sload 5
 fn @keep_sload_zero_trip() -> u256 {
   bb0:
     v0 = calldatasize
@@ -25,9 +25,9 @@ fn @keep_sload_zero_trip() -> u256 {
 
 // Hoisting the mload would unconditionally expand memory to 0x1000000 even
 // when the loop runs zero times (out-of-gas risk).
-// CHECK-DAG: {{^[ +].*}}fn @keep_mload_zero_trip{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}jumpi
-// CHECK-DAG: {{^[ +].*}}mload 0x1000000
+// CHECK-LABEL: {{^[ +].*}}fn @keep_mload_zero_trip{{[( ]}}
+// CHECK: {{^[ +].*}}jumpi
+// CHECK: {{^[ +].*}}mload 0x1000000
 fn @keep_mload_zero_trip() -> u256 {
   bb0:
     v0 = calldatasize
@@ -46,9 +46,9 @@ fn @keep_mload_zero_trip() -> u256 {
 
 // A verified trip count of 10 guarantees the body executes, so the sload is
 // still hoisted.
-// CHECK-DAG: {{^[ +].*}}fn @hoist_sload_known_trip{{[( ]}}
-// CHECK-DAG: + [[LOAD:v[0-9]+]] = sload 5
-// CHECK-DAG: - [[LOAD]] = sload 5
+// CHECK-LABEL: {{^[ +].*}}fn @hoist_sload_known_trip{{[( ]}}
+// CHECK: + [[LOAD:v[0-9]+]] = sload 5
+// CHECK: - [[LOAD]] = sload 5
 fn @hoist_sload_known_trip() -> u256 {
   bb0:
     jump bb1
@@ -66,9 +66,9 @@ fn @hoist_sload_known_trip() -> u256 {
 
 // Do-while shape: the mload's block dominates the loop exit, so it executes
 // whenever the loop is entered and may be hoisted despite the unknown bound.
-// CHECK-DAG: {{^[ +].*}}fn @hoist_mload_dominates_exits{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}[[LOAD:v[0-9]+]] = mload 64
-// CHECK-DAG: + jump bb1
+// CHECK-LABEL: {{^[ +].*}}fn @hoist_mload_dominates_exits{{[( ]}}
+// CHECK: {{^[ +].*}}[[LOAD:v[0-9]+]] = mload 64
+// CHECK: + jump bb1
 fn @hoist_mload_dominates_exits() -> u256 {
   bb0:
     jump bb1
@@ -83,9 +83,9 @@ fn @hoist_mload_dominates_exits() -> u256 {
 
 // The msize after the loop makes any early memory expansion observable;
 // keep the mload in place even though the trip count is known.
-// CHECK-DAG: {{^[ +].*}}fn @keep_mload_msize_in_function{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}mload 64
-// CHECK-DAG: {{^[ +].*}}msize
+// CHECK-LABEL: {{^[ +].*}}fn @keep_mload_msize_in_function{{[( ]}}
+// CHECK: {{^[ +].*}}msize
+// CHECK: {{^[ +].*}}mload 64
 fn @keep_mload_msize_in_function() -> u256 {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
+++ b/tests/ui/codegen/mir/licm/licm_zero_trip.stdout
@@ -9,13 +9,13 @@
       v1 = phi [bb0: 0], [bb2: v4]
       v2 = lt v1, v0
       jumpi v2, bb2, bb3
+    bb3:
+      ret v3
     bb2:
 -     v3 = sload 5
 +     v3 = sload 5 !metadata(storage=slot(5))
       v4 = add v1, 1
       jump bb1
-    bb3:
-      ret v3
   }
   
   fn @keep_mload_zero_trip() -> u256 {
@@ -26,12 +26,12 @@
       v1 = phi [bb0: 0], [bb2: v4]
       v2 = lt v1, v0
       jumpi v2, bb2, bb3
+    bb3:
+      ret v3
     bb2:
       v3 = mload 0x1000000
       v4 = add v1, 1
       jump bb1
-    bb3:
-      ret v3
   }
   
   fn @hoist_sload_known_trip() -> u256 {
@@ -42,12 +42,12 @@
       v0 = phi [bb0: 0], [bb2: v3]
       v1 = lt v0, 10
       jumpi v1, bb2, bb3
+    bb3:
+      ret v2
     bb2:
 -     v2 = sload 5
       v3 = add v0, 1
       jump bb1
-    bb3:
-      ret v2
   }
   
   fn @hoist_mload_dominates_exits() -> u256 {
@@ -71,13 +71,13 @@
       v0 = phi [bb0: 0], [bb2: v3]
       v1 = lt v0, 10
       jumpi v1, bb2, bb3
-    bb2:
-      v2 = mload 64
-      v3 = add v0, 1
-      jump bb1
     bb3:
       v4 = msize
       v5 = add v2, v4
       ret v5
+    bb2:
+      v2 = mload 64
+      v3 = add v0, 1
+      jump bb1
   }
   

--- a/tests/ui/codegen/mir/load-pre/load_pre.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre.stdout
@@ -4,11 +4,11 @@
   fn @full_diamond(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = sload 5
-      jump bb3
     bb2:
       v1 = sload 5
+      jump bb3
+    bb1:
+      v0 = sload 5
       jump bb3
     bb3:
 -     v2 = sload 5
@@ -20,11 +20,11 @@
   fn @store_forward_arm(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      sstore 5, arg1
-      jump bb3
     bb2:
       v0 = sload 5
+      jump bb3
+    bb1:
+      sstore 5, arg1
       jump bb3
     bb3:
 -     v1 = sload 5
@@ -36,11 +36,11 @@
   fn @partial_insert_diamond(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = sload 5
-      jump bb3
     bb2:
 +     v2 = sload 5
+      jump bb3
+    bb1:
+      v0 = sload 5
       jump bb3
     bb3:
 -     v1 = sload 5
@@ -52,11 +52,11 @@
   fn @transient_store_forward(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      tstore 5, arg1
-      jump bb3
     bb2:
       v0 = tload 5
+      jump bb3
+    bb1:
+      tstore 5, arg1
       jump bb3
     bb3:
 -     v1 = tload 5

--- a/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_clobbers.stdout
@@ -5,61 +5,61 @@
     bb0:
       v0 = sload 5
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       sstore arg1, 7
       jumpi arg0, bb3, bb4
-    bb2:
-      jump bb3
+    bb4:
+      ret v0
     bb3:
       v1 = sload 5
       ret v1
-    bb4:
-      ret v0
   }
   
   fn @call_kills_storage(arg0: bool, arg1: address) -> u256 {
     bb0:
       v0 = sload 5
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       v1 = call 0x186a0, arg1, 0, 0, 0, 0, 0
       jumpi arg0, bb3, bb4
-    bb2:
-      jump bb3
+    bb4:
+      ret v0
     bb3:
       v2 = sload 5
       ret v2
-    bb4:
-      ret v0
   }
   
   fn @staticcall_preserves_storage(arg0: bool, arg1: address) -> u256 {
     bb0:
       v0 = sload 5
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
       jumpi arg0, bb3, bb4
-    bb2:
-      jump bb3
+    bb4:
+      ret v0
     bb3:
 -     v2 = sload 5
 -     ret v2
 +     ret v0
-    bb4:
-      ret v0
   }
   
   fn @clobbered_arm_reload_after_store(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      v1 = sload 5
+      jump bb3
     bb1:
       v0 = sload 5
       sstore arg1, 7
 +     v3 = sload 5
-      jump bb3
-    bb2:
-      v1 = sload 5
       jump bb3
     bb3:
 -     v2 = sload 5
@@ -71,11 +71,11 @@
   fn @gas_blocks_rewrite(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = sload 5
-      jump bb3
     bb2:
       v1 = sload 5
+      jump bb3
+    bb1:
+      v0 = sload 5
       jump bb3
     bb3:
       v2 = gas

--- a/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_keccak.stdout
@@ -4,11 +4,11 @@
   fn @keccak_same_dynamic_size(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = keccak256 0, arg1
-      jump bb3
     bb2:
       v1 = keccak256 0, arg1
+      jump bb3
+    bb1:
+      v0 = keccak256 0, arg1
       jump bb3
     bb3:
 -     v2 = keccak256 0, arg1
@@ -20,11 +20,11 @@
   fn @keccak_different_dynamic_size(arg0: bool, arg1: u256, arg2: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = keccak256 0, arg1
-      jump bb3
     bb2:
       v1 = keccak256 0, arg1
+      jump bb3
+    bb1:
+      v0 = keccak256 0, arg1
       jump bb3
     bb3:
       v2 = keccak256 0, arg2

--- a/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_loop.stdout
@@ -11,11 +11,11 @@
 +     v3 = phi [bb0: v0], [bb2: v3]
 +     v2 = lt v3, arg0
       jumpi v2, bb2, bb3
-    bb2:
-      jump bb1
     bb3:
 -     ret v1
 +     ret v3
+    bb2:
+      jump bb1
   }
   
   fn @loop_clobbered_keeps_reload(arg0: u256, arg1: u256) -> u256 {
@@ -26,11 +26,11 @@
       v1 = sload 5
       v2 = lt v1, arg0
       jumpi v2, bb2, bb3
+    bb3:
+      ret v1
     bb2:
       sstore arg1, 9
       jump bb1
-    bb3:
-      ret v1
   }
   
   fn @loop_clobbered_no_insert(arg0: u256, arg1: u256) -> u256 {

--- a/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
+++ b/tests/ui/codegen/mir/load-pre/load_pre_memory.stdout
@@ -4,11 +4,11 @@
   fn @mload_full_diamond(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = mload 128
-      jump bb3
     bb2:
       v1 = mload 128
+      jump bb3
+    bb1:
+      v0 = mload 128
       jump bb3
     bb3:
       v2 = mload 128
@@ -18,11 +18,11 @@
   fn @mstore_forwarding(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      mstore 128, arg1
-      jump bb3
     bb2:
       v0 = mload 128
+      jump bb3
+    bb1:
+      mstore 128, arg1
       jump bb3
     bb3:
       v1 = mload 128
@@ -33,25 +33,25 @@
     bb0:
       v0 = mload 128
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       mstore8 159, 7
       jumpi arg0, bb3, bb4
-    bb2:
-      jump bb3
+    bb4:
+      ret v0
     bb3:
       v1 = mload 128
       ret v1
-    bb4:
-      ret v0
   }
   
   fn @mload_partial_rejected(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       v0 = mload 128
-      jump bb3
-    bb2:
       jump bb3
     bb3:
       v1 = mload 128
@@ -61,11 +61,11 @@
   fn @mload_partial_repeated_profitable(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = mload 128
-      jump bb3
     bb2:
 +     v4 = mload 128
+      jump bb3
+    bb1:
+      v0 = mload 128
       jump bb3
     bb3:
 -     v1 = mload 128
@@ -79,11 +79,11 @@
   fn @mload_partial_two_available(arg0: u256) -> u256 {
     bb0:
       switch arg0, default bb3, [1 => bb1, 2 => bb2]
-    bb1:
-      v0 = mload 128
-      jump bb4
     bb2:
       v1 = mload 128
+      jump bb4
+    bb1:
+      v0 = mload 128
       jump bb4
     bb3:
       jump bb4
@@ -102,38 +102,38 @@
 +     v3 = phi [bb0: v0], [bb2: v3]
 +     v2 = lt v3, arg0
       jumpi v2, bb2, bb3
-    bb2:
-      jump bb1
     bb3:
 -     ret v1
 +     ret v3
+    bb2:
+      jump bb1
   }
   
   fn @staticcall_zero_return_preserves_memory(arg0: bool, arg1: address) -> u256 {
     bb0:
       v0 = mload 128
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       v1 = staticcall 0x186a0, arg1, 0, 0, 0, 0
       jumpi arg0, bb3, bb4
-    bb2:
-      jump bb3
+    bb4:
+      ret v0
     bb3:
 -     v2 = mload 128
 -     ret v2
 +     ret v0
-    bb4:
-      ret v0
   }
   
   fn @msize_blocks_memory(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      v0 = mload 128
-      jump bb3
     bb2:
       v1 = mload 128
+      jump bb3
+    bb1:
+      v0 = mload 128
       jump bb3
     bb3:
       v2 = msize

--- a/tests/ui/codegen/mir/load-pre/memory_object_load_pre.stdout
+++ b/tests/ui/codegen/mir/load-pre/memory_object_load_pre.stdout
@@ -4,10 +4,10 @@
   fn @forward_length_across_join(arg0: memorybytes, arg1: bool, arg2: u256) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
+    bb2:
       set_memory_object_len memorybytes, arg0, arg2
       jump bb3
-    bb2:
+    bb1:
       set_memory_object_len memorybytes, arg0, arg2
       jump bb3
     bb3:

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
@@ -1,9 +1,9 @@
 //@compile-flags: -Zmir-pipeline=loop-canonicalize
 //@filecheck:
 @module LoopCanonicalize
-// CHECK-DAG: {{^[ +].*}}fn @insert_preheader{{[( ]}}
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb4: 30], [bb6: [[ENTRY:v[0-9]+]]]
-// CHECK-DAG: + [[ENTRY]] = phi [bb1: 10], [bb2: 20]
+// CHECK-LABEL: {{^[ +].*}}fn @insert_preheader{{[( ]}}
+// CHECK: + [[ENTRY:v[0-9]+]] = phi [bb1: 10], [bb2: 20]
+// CHECK: + {{v[0-9]+}} = phi [bb4: 30], [bb6: [[ENTRY]]]
 fn @insert_preheader(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -20,9 +20,9 @@ fn @insert_preheader(arg0: bool) -> u256 {
     ret v1
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @split_conditional_predecessor{{[( ]}}
-// CHECK-DAG: + jumpi arg0, bb4, bb3
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: 1], [bb4: 0]
+// CHECK-LABEL: {{^[ +].*}}fn @split_conditional_predecessor{{[( ]}}
+// CHECK: + jumpi arg0, bb4, bb3
+// CHECK: + {{v[0-9]+}} = phi [bb2: 1], [bb4: 0]
 fn @split_conditional_predecessor(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb3

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.mir
@@ -1,9 +1,9 @@
 //@compile-flags: -Zmir-pipeline=loop-canonicalize
 //@filecheck:
 @module LoopCanonicalize
-// CHECK-LABEL: {{^[ +].*}}fn @insert_preheader{{[( ]}}
-// CHECK: + {{v[0-9]+}} = phi [bb4: 30], [bb6: [[ENTRY:v[0-9]+]]]
-// CHECK: + [[ENTRY]] = phi [bb1: 10], [bb2: 20]
+// CHECK-DAG: {{^[ +].*}}fn @insert_preheader{{[( ]}}
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb4: 30], [bb6: [[ENTRY:v[0-9]+]]]
+// CHECK-DAG: + [[ENTRY]] = phi [bb1: 10], [bb2: 20]
 fn @insert_preheader(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb2
@@ -20,9 +20,9 @@ fn @insert_preheader(arg0: bool) -> u256 {
     ret v1
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @split_conditional_predecessor{{[( ]}}
-// CHECK: + jumpi arg0, bb4, bb3
-// CHECK: + {{v[0-9]+}} = phi [bb2: 1], [bb4: 0]
+// CHECK-DAG: {{^[ +].*}}fn @split_conditional_predecessor{{[( ]}}
+// CHECK-DAG: + jumpi arg0, bb4, bb3
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: 1], [bb4: 0]
 fn @split_conditional_predecessor(arg0: bool) -> u256 {
   bb0:
     jumpi arg0, bb1, bb3

--- a/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
+++ b/tests/ui/codegen/mir/loop-canonicalize/loop_canonicalize.stdout
@@ -4,38 +4,37 @@
   fn @insert_preheader(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
--     jump bb3
-+     jump bb6
     bb2:
 -     jump bb3
 +     jump bb6
+    bb1:
++     jump bb6
++   bb6:
++     v1 = phi [bb1: 10], [bb2: 20]
+      jump bb3
     bb3:
 -     v0 = phi [bb1: 10], [bb2: 20], [bb4: 30]
 +     v0 = phi [bb4: 30], [bb6: v1]
       jumpi 1, bb4, bb5
-    bb4:
-      jump bb3
     bb5:
       ret v0
-+   bb6:
-+     v1 = phi [bb1: 10], [bb2: 20]
-+     jump bb3
+    bb4:
+      jump bb3
   }
   
   fn @split_conditional_predecessor(arg0: bool) -> u256 {
     bb0:
 -     jumpi arg0, bb1, bb3
 +     jumpi arg0, bb4, bb3
++   bb4:
++     jump bb1
     bb1:
 -     v0 = phi [bb0: 0], [bb2: 1]
 +     v0 = phi [bb2: 1], [bb4: 0]
       jumpi 1, bb2, bb3
-    bb2:
-      jump bb1
     bb3:
       ret 0
-+   bb4:
-+     jump bb1
+    bb2:
+      jump bb1
   }
   

--- a/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
+++ b/tests/ui/codegen/mir/lower-mapping-slots/mapping_slot_builtin.stdout
@@ -14,14 +14,14 @@
     bb0:
       v0 = mapping_slot arg0, 7
       jumpi arg1, bb1, bb2
-    bb1:
-      mstore 0, 1
-      revert 0, 0
     bb2:
 -     v1 = mapping_slot arg0, 7
 -     v2 = add v0, v1
 +     v2 = add v0, v0
       ret v2
+    bb1:
+      mstore 0, 1
+      revert 0, 0
   }
   
   fn @memory(arg0: memptr) -> u256 {
@@ -63,13 +63,13 @@
 +     mstore 32, 7 !metadata(memory=scratch)
 +     v3 = keccak256 0, 64 !metadata(memory=scratch)
       jumpi arg1, bb1, bb2
-    bb1:
-      mstore 0, 1
-      revert 0, 0
     bb2:
 -     v2 = add v0, v0
 +     v2 = add v3, v3
       ret v2
+    bb1:
+      mstore 0, 1
+      revert 0, 0
   }
   
   fn @memory(arg0: memptr) -> u256 {
@@ -132,12 +132,12 @@
       mstore 32, 7 !metadata(memory=scratch)
       v3 = keccak256 0, 64 !metadata(memory=scratch)
       jumpi arg1, bb1, bb2
-    bb1:
-      mstore 0, 1
-      revert 0, 0
     bb2:
       v2 = add v3, v3
       ret v2
+    bb1:
+      mstore 0, 1
+      revert 0, 0
   }
   
   fn @memory(arg0: memptr) -> u256 {

--- a/tests/ui/codegen/mir/lower-slices/split_aggregates.stdout
+++ b/tests/ui/codegen/mir/lower-slices/split_aggregates.stdout
@@ -17,9 +17,9 @@
     bb0:
 -     jumpi arg2, bb1, bb2
 +     jumpi arg4, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
 -     v0 = phi [bb1: arg0], [bb2: arg1]

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.mir
@@ -6,15 +6,15 @@
 // wrappers are already argument-free.
 @module LowerDispatch
 @phase abi
-// CHECK-DAG: after lower-dispatch
-// CHECK-DAG: + fn @entry{{[( ]}}
-// CHECK-DAG: + [[SIZE:v[0-9]+]] = calldatasize
-// CHECK-DAG: + [[SHORT:v[0-9]+]] = lt {{v[0-9]+}}, 4
-// CHECK-DAG: + jumpi [[SHORT]]
-// CHECK-DAG: + [[SELECTOR:v[0-9]+]] = shr 224
-// CHECK-DAG: + switch [[SELECTOR]], default {{.*}}[0x12000000 =>
-// CHECK-DAG: + tail_call @ping
-// CHECK-DAG: + tail_call @pong
+// CHECK-LABEL: after lower-dispatch
+// CHECK: + fn @entry{{[( ]}}
+// CHECK: + [[SIZE:v[0-9]+]] = calldatasize
+// CHECK: + [[SHORT:v[0-9]+]] = lt {{v[0-9]+}}, 4
+// CHECK: + jumpi [[SHORT]]
+// CHECK: + [[SELECTOR:v[0-9]+]] = shr 224
+// CHECK: + switch [[SELECTOR]], default {{.*}}[0x12000000 =>
+// CHECK: + tail_call @pong
+// CHECK: + tail_call @ping
 fn @ping() [selector=0x12000000] {
   bb0:
     stop

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.mir
@@ -6,15 +6,15 @@
 // wrappers are already argument-free.
 @module LowerDispatch
 @phase abi
-// CHECK-LABEL: after lower-dispatch
-// CHECK: + fn @entry{{[( ]}}
-// CHECK: + [[SIZE:v[0-9]+]] = calldatasize
-// CHECK: + [[SHORT:v[0-9]+]] = lt {{v[0-9]+}}, 4
-// CHECK: + jumpi [[SHORT]]
-// CHECK: + [[SELECTOR:v[0-9]+]] = shr 224
-// CHECK: + switch [[SELECTOR]], default {{.*}}[0x12000000 =>
-// CHECK: + tail_call @ping
-// CHECK: + tail_call @pong
+// CHECK-DAG: after lower-dispatch
+// CHECK-DAG: + fn @entry{{[( ]}}
+// CHECK-DAG: + [[SIZE:v[0-9]+]] = calldatasize
+// CHECK-DAG: + [[SHORT:v[0-9]+]] = lt {{v[0-9]+}}, 4
+// CHECK-DAG: + jumpi [[SHORT]]
+// CHECK-DAG: + [[SELECTOR:v[0-9]+]] = shr 224
+// CHECK-DAG: + switch [[SELECTOR]], default {{.*}}[0x12000000 =>
+// CHECK-DAG: + tail_call @ping
+// CHECK-DAG: + tail_call @pong
 fn @ping() [selector=0x12000000] {
   bb0:
     stop

--- a/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch.stdout
@@ -25,10 +25,10 @@
 +     v3 = calldataload 0
 +     v4 = shr 224, v3
 +     switch v4, default bb5, [0x12000000 => bb3, 0x8d3a3e57 => bb4]
-+   bb3:
-+     tail_call @ping
 +   bb4:
 +     tail_call @pong
++   bb3:
++     tail_call @ping
 +   bb5:
 +     revert 0, 0
   }

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir
@@ -5,14 +5,14 @@
 // receive/fallback: empty calldata and unknown selectors both revert.
 @module DispatchHoisted
 @phase abi
-// CHECK-DAG: {{^[ +].*}}after lower-dispatch
-// CHECK-DAG: + fn @entry{{[( ]}}
-// CHECK-DAG: + [[VALUE:v[0-9]+]] = callvalue
-// CHECK-DAG: + jumpi [[VALUE]]
+// CHECK-LABEL: {{^[ +].*}}after lower-dispatch
+// CHECK: + fn @entry{{[( ]}}
+// CHECK: + [[VALUE:v[0-9]+]] = callvalue
+// CHECK: + jumpi [[VALUE]]
 // CHECK-NOT: calldatasize
-// CHECK-DAG: + switch {{.*}}[1 => {{.*}}2 =>
-// CHECK-DAG: + tail_call @a
-// CHECK-DAG: + tail_call @b
+// CHECK: + switch {{.*}}[1 => {{.*}}2 =>
+// CHECK: + tail_call @b
+// CHECK: + tail_call @a
 fn @a() [selector=0x00000001] {
   bb0:
     stop

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.mir
@@ -5,14 +5,14 @@
 // receive/fallback: empty calldata and unknown selectors both revert.
 @module DispatchHoisted
 @phase abi
-// CHECK-LABEL: {{^[ +].*}}after lower-dispatch
-// CHECK: + fn @entry{{[( ]}}
-// CHECK: + [[VALUE:v[0-9]+]] = callvalue
-// CHECK: + jumpi [[VALUE]]
+// CHECK-DAG: {{^[ +].*}}after lower-dispatch
+// CHECK-DAG: + fn @entry{{[( ]}}
+// CHECK-DAG: + [[VALUE:v[0-9]+]] = callvalue
+// CHECK-DAG: + jumpi [[VALUE]]
 // CHECK-NOT: calldatasize
-// CHECK: + switch {{.*}}[1 => {{.*}}2 =>
-// CHECK: + tail_call @a
-// CHECK: + tail_call @b
+// CHECK-DAG: + switch {{.*}}[1 => {{.*}}2 =>
+// CHECK-DAG: + tail_call @a
+// CHECK-DAG: + tail_call @b
 fn @a() [selector=0x00000001] {
   bb0:
     stop

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_hoisted_callvalue.stdout
@@ -21,10 +21,10 @@
 +     v1 = calldataload 0
 +     v2 = shr 224, v1
 +     switch v2, default bb4, [1 => bb2, 2 => bb3]
-+   bb2:
-+     tail_call @a
 +   bb3:
 +     tail_call @b
++   bb2:
++     tail_call @a
 +   bb4:
 +     revert 0, 0
   }

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir
@@ -6,13 +6,13 @@
 // be hoisted. Receive is payable and needs no check.
 @module DispatchParity
 @phase abi
-// CHECK-DAG: {{^[ +].*}}after lower-dispatch
-// CHECK-DAG: + fn @entry{{[( ]}}
-// CHECK-DAG: + tail_call @recv
-// CHECK-DAG: + switch {{.*}}default bb6, [1 => bb4, 2 => bb5]
-// CHECK-DAG: + tail_call @pay
-// CHECK-DAG: + tail_call @nopay
-// CHECK-DAG: + tail_call @fb
+// CHECK-LABEL: {{^[ +].*}}after lower-dispatch
+// CHECK: + fn @entry{{[( ]}}
+// CHECK: + tail_call @recv
+// CHECK: + switch {{.*}}default bb6, [1 => bb4, 2 => bb5]
+// CHECK: + tail_call @nopay
+// CHECK: + tail_call @pay
+// CHECK: + tail_call @fb
 fn @pay() [selector=0x00000001, payable] {
   bb0:
     stop

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.mir
@@ -6,13 +6,13 @@
 // be hoisted. Receive is payable and needs no check.
 @module DispatchParity
 @phase abi
-// CHECK-LABEL: {{^[ +].*}}after lower-dispatch
-// CHECK: + fn @entry{{[( ]}}
-// CHECK: + tail_call @recv
-// CHECK: + switch {{.*}}default bb6, [1 => bb4, 2 => bb5]
-// CHECK: + tail_call @pay
-// CHECK: + tail_call @nopay
-// CHECK: + tail_call @fb
+// CHECK-DAG: {{^[ +].*}}after lower-dispatch
+// CHECK-DAG: + fn @entry{{[( ]}}
+// CHECK-DAG: + tail_call @recv
+// CHECK-DAG: + switch {{.*}}default bb6, [1 => bb4, 2 => bb5]
+// CHECK-DAG: + tail_call @pay
+// CHECK-DAG: + tail_call @nopay
+// CHECK-DAG: + tail_call @fb
 fn @pay() [selector=0x00000001, payable] {
   bb0:
     stop

--- a/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
+++ b/tests/ui/codegen/mir/lowering/lower_dispatch_parity.stdout
@@ -35,10 +35,10 @@
 +     v1 = calldataload 0
 +     v2 = shr 224, v1
 +     switch v2, default bb6, [1 => bb4, 2 => bb5]
-+   bb4:
-+     tail_call @pay
 +   bb5:
 +     tail_call @nopay
++   bb4:
++     tail_call @pay
 +   bb6:
 +     tail_call @fb
 +   bb7:

--- a/tests/ui/codegen/mir/memory-dse/builder_cases.mir
+++ b/tests/ui/codegen/mir/memory-dse/builder_cases.mir
@@ -2,9 +2,9 @@
 //@filecheck: --enable-var-scope
 @module MemoryDseBuilderCases
 
-// CHECK-LABEL: @overwritten_store
-// CHECK: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK:       mstore [[ADDR]], 42
+// CHECK-DAG: @overwritten_store
+// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK-DAG:       mstore [[ADDR]], 42
 fn @overwritten_store() {
   bb0:
     mstore 128, 0
@@ -12,12 +12,12 @@ fn @overwritten_store() {
     stop
 }
 
-// CHECK-LABEL: @store_observed_only_by_load
-// CHECK: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK:       mstore [[ADDR]], 42
-// CHECK: -     ret [[LOAD]]
-// CHECK:       ret 0
+// CHECK-DAG: @store_observed_only_by_load
+// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK-DAG:       mstore [[ADDR]], 42
+// CHECK-DAG: -     ret [[LOAD]]
+// CHECK-DAG:       ret 0
 fn @store_observed_only_by_load() -> u256 {
   bb0:
     mstore 128, 0
@@ -26,10 +26,10 @@ fn @store_observed_only_by_load() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @disjoint_keccak
-// CHECK: -     mstore [[STORE_ADDR:[0-9]+]], 0
-// CHECK:       keccak256 {{[0-9]+}}, {{[0-9]+}}
-// CHECK:       mstore [[STORE_ADDR]], 1
+// CHECK-DAG: @disjoint_keccak
+// CHECK-DAG: -     mstore [[STORE_ADDR:[0-9]+]], 0
+// CHECK-DAG:       keccak256 {{[0-9]+}}, {{[0-9]+}}
+// CHECK-DAG:       mstore [[STORE_ADDR]], 1
 fn @disjoint_keccak() {
   bb0:
     mstore 128, 0
@@ -38,10 +38,10 @@ fn @disjoint_keccak() {
     stop
 }
 
-// CHECK-LABEL: @overlapping_keccak
-// CHECK: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
-// CHECK: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
-// CHECK: {{^ +}}mstore [[STORE_ADDR]], 1
+// CHECK-DAG: @overlapping_keccak
+// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
+// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR]], 1
 fn @overlapping_keccak() {
   bb0:
     mstore 128, 0
@@ -50,12 +50,12 @@ fn @overlapping_keccak() {
     stop
 }
 
-// CHECK-LABEL: @cross_block_dead_store
-// CHECK: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK:       jumpi arg0, [[READ:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK:       [[READ]]:
-// CHECK:       mstore [[ADDR]], 1
-// CHECK:       returndata [[ADDR]]
+// CHECK-DAG: @cross_block_dead_store
+// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK-DAG:       jumpi arg0, [[READ:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG:       [[READ]]:
+// CHECK-DAG:       mstore [[ADDR]], 1
+// CHECK-DAG:       returndata [[ADDR]]
 fn @cross_block_dead_store(arg0: u256) {
   bb0:
     mstore 128, 0
@@ -67,13 +67,13 @@ fn @cross_block_dead_store(arg0: u256) {
     revert 0, 0
 }
 
-// CHECK-LABEL: @cross_block_read_path
-// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 7
-// CHECK: {{^ +}}jumpi arg0, [[READ:bb[0-9]+]], [[OVERWRITE:bb[0-9]+]]
-// CHECK: {{^ +}}[[READ]]:
-// CHECK: {{^ +}}returndata [[ADDR]]
-// CHECK: {{^ +}}[[OVERWRITE]]:
-// CHECK: {{^ +}}mstore [[ADDR]], 9
+// CHECK-DAG: @cross_block_read_path
+// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 7
+// CHECK-DAG: {{^ +}}jumpi arg0, [[READ:bb[0-9]+]], [[OVERWRITE:bb[0-9]+]]
+// CHECK-DAG: {{^ +}}[[READ]]:
+// CHECK-DAG: {{^ +}}returndata [[ADDR]]
+// CHECK-DAG: {{^ +}}[[OVERWRITE]]:
+// CHECK-DAG: {{^ +}}mstore [[ADDR]], 9
 fn @cross_block_read_path(arg0: u256) {
   bb0:
     mstore 128, 7
@@ -85,19 +85,19 @@ fn @cross_block_read_path(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-LABEL: @return_pointer
-// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 42
-// CHECK: {{^ +}}ret [[ADDR]]
+// CHECK-DAG: @return_pointer
+// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 42
+// CHECK-DAG: {{^ +}}ret [[ADDR]]
 fn @return_pointer() -> u256 {
   bb0:
     mstore 160, 42
     ret 160
 }
 
-// CHECK-LABEL: @gas_barrier
-// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 0
-// CHECK: {{^ +}}{{v[0-9]+}} = gas
-// CHECK: {{^ +}}mstore [[ADDR]], 42
+// CHECK-DAG: @gas_barrier
+// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 0
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = gas
+// CHECK-DAG: {{^ +}}mstore [[ADDR]], 42
 fn @gas_barrier() {
   bb0:
     mstore 128, 0
@@ -106,9 +106,9 @@ fn @gas_barrier() {
     stop
 }
 
-// CHECK-LABEL: @distinct_immediate_addresses
-// CHECK: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK:       mstore [[ADDR]], 42
+// CHECK-DAG: @distinct_immediate_addresses
+// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK-DAG:       mstore [[ADDR]], 42
 fn @distinct_immediate_addresses() {
   bb0:
     mstore 128, 0
@@ -116,13 +116,13 @@ fn @distinct_immediate_addresses() {
     stop
 }
 
-// CHECK-LABEL: @equivalent_base_load
-// CHECK:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
-// CHECK:       mstore [[FIRST]], 42
-// CHECK:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
-// CHECK: -     [[LOAD:v[0-9]+]] = mload [[SECOND]]
-// CHECK: -     ret [[LOAD]]
-// CHECK:       ret 42
+// CHECK-DAG: @equivalent_base_load
+// CHECK-DAG:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
+// CHECK-DAG:       mstore [[FIRST]], 42
+// CHECK-DAG:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
+// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[SECOND]]
+// CHECK-DAG: -     ret [[LOAD]]
+// CHECK-DAG:       ret 42
 fn @equivalent_base_load(arg0: u256) -> u256 {
   bb0:
     v1 = add arg0, 32
@@ -132,11 +132,11 @@ fn @equivalent_base_load(arg0: u256) -> u256 {
     ret v3
 }
 
-// CHECK-LABEL: @equivalent_base_overwrite
-// CHECK:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
-// CHECK: -     mstore [[FIRST]], 0
-// CHECK:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
-// CHECK:       mstore [[SECOND]], 42
+// CHECK-DAG: @equivalent_base_overwrite
+// CHECK-DAG:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
+// CHECK-DAG: -     mstore [[FIRST]], 0
+// CHECK-DAG:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
+// CHECK-DAG:       mstore [[SECOND]], 42
 fn @equivalent_base_overwrite(arg0: u256) {
   bb0:
     v1 = add arg0, 32
@@ -146,10 +146,10 @@ fn @equivalent_base_overwrite(arg0: u256) {
     stop
 }
 
-// CHECK-LABEL: @unused_frame_store
-// CHECK:       [[FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK: -     mstore [[FRAME]], 0
-// CHECK:       ret 0
+// CHECK-DAG: @unused_frame_store
+// CHECK-DAG:       [[FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK-DAG: -     mstore [[FRAME]], 0
+// CHECK-DAG:       ret 0
 fn @unused_frame_store() -> u256 {
   bb0:
     v0 = internal_frame_addr 192
@@ -157,13 +157,13 @@ fn @unused_frame_store() -> u256 {
     ret 0
 }
 
-// CHECK-LABEL: @immutable_copy_reuse
-// CHECK:       [[FIRST:v[0-9]+]] = mload [[ADDR:[0-9]+]]
-// CHECK: -     codecopy [[ADDR]]
-// CHECK: -     {{v[0-9]+}} = mload [[ADDR]]
-// CHECK:       mstore [[ADDR]], [[FIRST]]
-// CHECK:       [[SUM:v[0-9]+]] = add [[FIRST]], [[FIRST]]
-// CHECK:       ret [[SUM]]
+// CHECK-DAG: @immutable_copy_reuse
+// CHECK-DAG:       [[FIRST:v[0-9]+]] = mload [[ADDR:[0-9]+]]
+// CHECK-DAG: -     codecopy [[ADDR]]
+// CHECK-DAG: -     {{v[0-9]+}} = mload [[ADDR]]
+// CHECK-DAG:       mstore [[ADDR]], [[FIRST]]
+// CHECK-DAG:       [[SUM:v[0-9]+]] = add [[FIRST]], [[FIRST]]
+// CHECK-DAG:       ret [[SUM]]
 fn @immutable_copy_reuse() -> u256 {
   bb0:
     v0 = codesize
@@ -180,10 +180,10 @@ fn @immutable_copy_reuse() -> u256 {
     ret v6
 }
 
-// CHECK-LABEL: @overlapping_load
-// CHECK: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
-// CHECK: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
-// CHECK: {{^ +}}mstore [[STORE_ADDR]], 42
+// CHECK-DAG: @overlapping_load
+// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
+// CHECK-DAG: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
+// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR]], 42
 fn @overlapping_load() {
   bb0:
     mstore 128, 0
@@ -192,11 +192,11 @@ fn @overlapping_load() {
     stop
 }
 
-// CHECK-LABEL: @forward_load
-// CHECK:       mstore [[ADDR:[0-9]+]], 42
-// CHECK: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK: -     ret [[LOAD]]
-// CHECK:       ret 42
+// CHECK-DAG: @forward_load
+// CHECK-DAG:       mstore [[ADDR:[0-9]+]], 42
+// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK-DAG: -     ret [[LOAD]]
+// CHECK-DAG:       ret 42
 fn @forward_load() -> u256 {
   bb0:
     mstore 128, 42
@@ -204,12 +204,12 @@ fn @forward_load() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @forward_through_pure_op
-// CHECK:       mstore [[ADDR:[0-9]+]], 42
-// CHECK:       {{v[0-9]+}} = add 1, 1
-// CHECK: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK: -     ret [[LOAD]]
-// CHECK:       ret 42
+// CHECK-DAG: @forward_through_pure_op
+// CHECK-DAG:       mstore [[ADDR:[0-9]+]], 42
+// CHECK-DAG:       {{v[0-9]+}} = add 1, 1
+// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK-DAG: -     ret [[LOAD]]
+// CHECK-DAG:       ret 42
 fn @forward_through_pure_op() -> u256 {
   bb0:
     mstore 128, 42
@@ -218,11 +218,11 @@ fn @forward_through_pure_op() -> u256 {
     ret v1
 }
 
-// CHECK-LABEL: @memory_write_barrier
-// CHECK: {{^ +}}mstore [[SOURCE:[0-9]+]], 42
-// CHECK: {{^ +}}mcopy {{[0-9]+}}, [[SOURCE]], {{[0-9]+}}
-// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[SOURCE]]
-// CHECK: {{^ +}}ret [[LOAD]]
+// CHECK-DAG: @memory_write_barrier
+// CHECK-DAG: {{^ +}}mstore [[SOURCE:[0-9]+]], 42
+// CHECK-DAG: {{^ +}}mcopy {{[0-9]+}}, [[SOURCE]], {{[0-9]+}}
+// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[SOURCE]]
+// CHECK-DAG: {{^ +}}ret [[LOAD]]
 fn @memory_write_barrier() -> u256 {
   bb0:
     mstore 128, 42
@@ -231,11 +231,11 @@ fn @memory_write_barrier() -> u256 {
     ret v0
 }
 
-// CHECK-LABEL: @internal_call_barrier
-// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 42
-// CHECK: {{^ +}}internal_call @callee
-// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK: {{^ +}}ret [[LOAD]]
+// CHECK-DAG: @internal_call_barrier
+// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 42
+// CHECK-DAG: {{^ +}}internal_call @callee
+// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK-DAG: {{^ +}}ret [[LOAD]]
 fn @internal_call_barrier() -> u256 {
   bb0:
     mstore 128, 42
@@ -249,14 +249,14 @@ fn @callee() {
     ret
 }
 
-// CHECK-LABEL: @chained_forwarding
-// CHECK:       mstore [[FIRST_ADDR:[0-9]+]], 42
-// CHECK: -     [[FIRST:v[0-9]+]] = mload [[FIRST_ADDR]]
-// CHECK: -     mstore [[SECOND_ADDR:[0-9]+]], [[FIRST]]
-// CHECK: -     [[SECOND:v[0-9]+]] = mload [[SECOND_ADDR]]
-// CHECK: -     ret [[SECOND]]
-// CHECK:       mstore [[SECOND_ADDR]], 42
-// CHECK:       ret 42
+// CHECK-DAG: @chained_forwarding
+// CHECK-DAG:       mstore [[FIRST_ADDR:[0-9]+]], 42
+// CHECK-DAG: -     [[FIRST:v[0-9]+]] = mload [[FIRST_ADDR]]
+// CHECK-DAG: -     mstore [[SECOND_ADDR:[0-9]+]], [[FIRST]]
+// CHECK-DAG: -     [[SECOND:v[0-9]+]] = mload [[SECOND_ADDR]]
+// CHECK-DAG: -     ret [[SECOND]]
+// CHECK-DAG:       mstore [[SECOND_ADDR]], 42
+// CHECK-DAG:       ret 42
 fn @chained_forwarding() -> u256 {
   bb0:
     mstore 128, 42

--- a/tests/ui/codegen/mir/memory-dse/builder_cases.mir
+++ b/tests/ui/codegen/mir/memory-dse/builder_cases.mir
@@ -2,9 +2,9 @@
 //@filecheck: --enable-var-scope
 @module MemoryDseBuilderCases
 
-// CHECK-DAG: @overwritten_store
-// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK-DAG:       mstore [[ADDR]], 42
+// CHECK-LABEL: @overwritten_store
+// CHECK: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK:       mstore [[ADDR]], 42
 fn @overwritten_store() {
   bb0:
     mstore 128, 0
@@ -12,12 +12,12 @@ fn @overwritten_store() {
     stop
 }
 
-// CHECK-DAG: @store_observed_only_by_load
-// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK-DAG:       mstore [[ADDR]], 42
-// CHECK-DAG: -     ret [[LOAD]]
-// CHECK-DAG:       ret 0
+// CHECK-LABEL: @store_observed_only_by_load
+// CHECK: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK:       mstore [[ADDR]], 42
+// CHECK: -     ret [[LOAD]]
+// CHECK:       ret 0
 fn @store_observed_only_by_load() -> u256 {
   bb0:
     mstore 128, 0
@@ -26,10 +26,10 @@ fn @store_observed_only_by_load() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @disjoint_keccak
-// CHECK-DAG: -     mstore [[STORE_ADDR:[0-9]+]], 0
-// CHECK-DAG:       keccak256 {{[0-9]+}}, {{[0-9]+}}
-// CHECK-DAG:       mstore [[STORE_ADDR]], 1
+// CHECK-LABEL: @disjoint_keccak
+// CHECK: -     mstore [[STORE_ADDR:[0-9]+]], 0
+// CHECK:       keccak256 {{[0-9]+}}, {{[0-9]+}}
+// CHECK:       mstore [[STORE_ADDR]], 1
 fn @disjoint_keccak() {
   bb0:
     mstore 128, 0
@@ -38,10 +38,10 @@ fn @disjoint_keccak() {
     stop
 }
 
-// CHECK-DAG: @overlapping_keccak
-// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
-// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR]], 1
+// CHECK-LABEL: @overlapping_keccak
+// CHECK: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
+// CHECK: {{^ +}}{{v[0-9]+}} = keccak256 {{[0-9]+}}, {{[0-9]+}}
+// CHECK: {{^ +}}mstore [[STORE_ADDR]], 1
 fn @overlapping_keccak() {
   bb0:
     mstore 128, 0
@@ -50,12 +50,12 @@ fn @overlapping_keccak() {
     stop
 }
 
-// CHECK-DAG: @cross_block_dead_store
-// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK-DAG:       jumpi arg0, [[READ:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG:       [[READ]]:
-// CHECK-DAG:       mstore [[ADDR]], 1
-// CHECK-DAG:       returndata [[ADDR]]
+// CHECK-LABEL: @cross_block_dead_store
+// CHECK: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK:       jumpi arg0, [[READ:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       [[READ]]:
+// CHECK:       mstore [[ADDR]], 1
+// CHECK:       returndata [[ADDR]]
 fn @cross_block_dead_store(arg0: u256) {
   bb0:
     mstore 128, 0
@@ -67,13 +67,13 @@ fn @cross_block_dead_store(arg0: u256) {
     revert 0, 0
 }
 
-// CHECK-DAG: @cross_block_read_path
-// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 7
-// CHECK-DAG: {{^ +}}jumpi arg0, [[READ:bb[0-9]+]], [[OVERWRITE:bb[0-9]+]]
-// CHECK-DAG: {{^ +}}[[READ]]:
-// CHECK-DAG: {{^ +}}returndata [[ADDR]]
-// CHECK-DAG: {{^ +}}[[OVERWRITE]]:
-// CHECK-DAG: {{^ +}}mstore [[ADDR]], 9
+// CHECK-LABEL: @cross_block_read_path
+// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 7
+// CHECK: {{^ +}}jumpi arg0, [[READ:bb[0-9]+]], [[OVERWRITE:bb[0-9]+]]
+// CHECK: {{^ +}}[[OVERWRITE]]:
+// CHECK: {{^ +}}mstore [[ADDR]], 9
+// CHECK: {{^ +}}[[READ]]:
+// CHECK: {{^ +}}returndata [[ADDR]]
 fn @cross_block_read_path(arg0: u256) {
   bb0:
     mstore 128, 7
@@ -85,19 +85,19 @@ fn @cross_block_read_path(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-DAG: @return_pointer
-// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 42
-// CHECK-DAG: {{^ +}}ret [[ADDR]]
+// CHECK-LABEL: @return_pointer
+// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 42
+// CHECK: {{^ +}}ret [[ADDR]]
 fn @return_pointer() -> u256 {
   bb0:
     mstore 160, 42
     ret 160
 }
 
-// CHECK-DAG: @gas_barrier
-// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 0
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = gas
-// CHECK-DAG: {{^ +}}mstore [[ADDR]], 42
+// CHECK-LABEL: @gas_barrier
+// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 0
+// CHECK: {{^ +}}{{v[0-9]+}} = gas
+// CHECK: {{^ +}}mstore [[ADDR]], 42
 fn @gas_barrier() {
   bb0:
     mstore 128, 0
@@ -106,9 +106,9 @@ fn @gas_barrier() {
     stop
 }
 
-// CHECK-DAG: @distinct_immediate_addresses
-// CHECK-DAG: -     mstore [[ADDR:[0-9]+]], 0
-// CHECK-DAG:       mstore [[ADDR]], 42
+// CHECK-LABEL: @distinct_immediate_addresses
+// CHECK: -     mstore [[ADDR:[0-9]+]], 0
+// CHECK:       mstore [[ADDR]], 42
 fn @distinct_immediate_addresses() {
   bb0:
     mstore 128, 0
@@ -116,13 +116,13 @@ fn @distinct_immediate_addresses() {
     stop
 }
 
-// CHECK-DAG: @equivalent_base_load
-// CHECK-DAG:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
-// CHECK-DAG:       mstore [[FIRST]], 42
-// CHECK-DAG:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
-// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[SECOND]]
-// CHECK-DAG: -     ret [[LOAD]]
-// CHECK-DAG:       ret 42
+// CHECK-LABEL: @equivalent_base_load
+// CHECK:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
+// CHECK:       mstore [[FIRST]], 42
+// CHECK:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
+// CHECK: -     [[LOAD:v[0-9]+]] = mload [[SECOND]]
+// CHECK: -     ret [[LOAD]]
+// CHECK:       ret 42
 fn @equivalent_base_load(arg0: u256) -> u256 {
   bb0:
     v1 = add arg0, 32
@@ -132,11 +132,11 @@ fn @equivalent_base_load(arg0: u256) -> u256 {
     ret v3
 }
 
-// CHECK-DAG: @equivalent_base_overwrite
-// CHECK-DAG:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
-// CHECK-DAG: -     mstore [[FIRST]], 0
-// CHECK-DAG:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
-// CHECK-DAG:       mstore [[SECOND]], 42
+// CHECK-LABEL: @equivalent_base_overwrite
+// CHECK:       [[FIRST:v[0-9]+]] = add arg0, [[OFFSET:[0-9]+]]
+// CHECK: -     mstore [[FIRST]], 0
+// CHECK:       [[SECOND:v[0-9]+]] = add arg0, [[OFFSET]]
+// CHECK:       mstore [[SECOND]], 42
 fn @equivalent_base_overwrite(arg0: u256) {
   bb0:
     v1 = add arg0, 32
@@ -146,10 +146,10 @@ fn @equivalent_base_overwrite(arg0: u256) {
     stop
 }
 
-// CHECK-DAG: @unused_frame_store
-// CHECK-DAG:       [[FRAME:v[0-9]+]] = internal_frame_addr
-// CHECK-DAG: -     mstore [[FRAME]], 0
-// CHECK-DAG:       ret 0
+// CHECK-LABEL: @unused_frame_store
+// CHECK:       [[FRAME:v[0-9]+]] = internal_frame_addr
+// CHECK: -     mstore [[FRAME]], 0
+// CHECK:       ret 0
 fn @unused_frame_store() -> u256 {
   bb0:
     v0 = internal_frame_addr 192
@@ -157,13 +157,13 @@ fn @unused_frame_store() -> u256 {
     ret 0
 }
 
-// CHECK-DAG: @immutable_copy_reuse
-// CHECK-DAG:       [[FIRST:v[0-9]+]] = mload [[ADDR:[0-9]+]]
-// CHECK-DAG: -     codecopy [[ADDR]]
-// CHECK-DAG: -     {{v[0-9]+}} = mload [[ADDR]]
-// CHECK-DAG:       mstore [[ADDR]], [[FIRST]]
-// CHECK-DAG:       [[SUM:v[0-9]+]] = add [[FIRST]], [[FIRST]]
-// CHECK-DAG:       ret [[SUM]]
+// CHECK-LABEL: @immutable_copy_reuse
+// CHECK:       [[FIRST:v[0-9]+]] = mload [[ADDR:[0-9]+]]
+// CHECK: -     codecopy [[ADDR]]
+// CHECK: -     {{v[0-9]+}} = mload [[ADDR]]
+// CHECK:       mstore [[ADDR]], [[FIRST]]
+// CHECK:       [[SUM:v[0-9]+]] = add [[FIRST]], [[FIRST]]
+// CHECK:       ret [[SUM]]
 fn @immutable_copy_reuse() -> u256 {
   bb0:
     v0 = codesize
@@ -180,10 +180,10 @@ fn @immutable_copy_reuse() -> u256 {
     ret v6
 }
 
-// CHECK-DAG: @overlapping_load
-// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
-// CHECK-DAG: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
-// CHECK-DAG: {{^ +}}mstore [[STORE_ADDR]], 42
+// CHECK-LABEL: @overlapping_load
+// CHECK: {{^ +}}mstore [[STORE_ADDR:[0-9]+]], 0
+// CHECK: {{^ +}}{{v[0-9]+}} = mload {{[0-9]+}}
+// CHECK: {{^ +}}mstore [[STORE_ADDR]], 42
 fn @overlapping_load() {
   bb0:
     mstore 128, 0
@@ -192,11 +192,11 @@ fn @overlapping_load() {
     stop
 }
 
-// CHECK-DAG: @forward_load
-// CHECK-DAG:       mstore [[ADDR:[0-9]+]], 42
-// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK-DAG: -     ret [[LOAD]]
-// CHECK-DAG:       ret 42
+// CHECK-LABEL: @forward_load
+// CHECK:       mstore [[ADDR:[0-9]+]], 42
+// CHECK: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK: -     ret [[LOAD]]
+// CHECK:       ret 42
 fn @forward_load() -> u256 {
   bb0:
     mstore 128, 42
@@ -204,12 +204,12 @@ fn @forward_load() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @forward_through_pure_op
-// CHECK-DAG:       mstore [[ADDR:[0-9]+]], 42
-// CHECK-DAG:       {{v[0-9]+}} = add 1, 1
-// CHECK-DAG: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK-DAG: -     ret [[LOAD]]
-// CHECK-DAG:       ret 42
+// CHECK-LABEL: @forward_through_pure_op
+// CHECK:       mstore [[ADDR:[0-9]+]], 42
+// CHECK:       {{v[0-9]+}} = add 1, 1
+// CHECK: -     [[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK: -     ret [[LOAD]]
+// CHECK:       ret 42
 fn @forward_through_pure_op() -> u256 {
   bb0:
     mstore 128, 42
@@ -218,11 +218,11 @@ fn @forward_through_pure_op() -> u256 {
     ret v1
 }
 
-// CHECK-DAG: @memory_write_barrier
-// CHECK-DAG: {{^ +}}mstore [[SOURCE:[0-9]+]], 42
-// CHECK-DAG: {{^ +}}mcopy {{[0-9]+}}, [[SOURCE]], {{[0-9]+}}
-// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[SOURCE]]
-// CHECK-DAG: {{^ +}}ret [[LOAD]]
+// CHECK-LABEL: @memory_write_barrier
+// CHECK: {{^ +}}mstore [[SOURCE:[0-9]+]], 42
+// CHECK: {{^ +}}mcopy {{[0-9]+}}, [[SOURCE]], {{[0-9]+}}
+// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[SOURCE]]
+// CHECK: {{^ +}}ret [[LOAD]]
 fn @memory_write_barrier() -> u256 {
   bb0:
     mstore 128, 42
@@ -231,11 +231,11 @@ fn @memory_write_barrier() -> u256 {
     ret v0
 }
 
-// CHECK-DAG: @internal_call_barrier
-// CHECK-DAG: {{^ +}}mstore [[ADDR:[0-9]+]], 42
-// CHECK-DAG: {{^ +}}internal_call @callee
-// CHECK-DAG: {{^ +}}[[LOAD:v[0-9]+]] = mload [[ADDR]]
-// CHECK-DAG: {{^ +}}ret [[LOAD]]
+// CHECK-LABEL: @internal_call_barrier
+// CHECK: {{^ +}}mstore [[ADDR:[0-9]+]], 42
+// CHECK: {{^ +}}internal_call @callee
+// CHECK: {{^ +}}[[LOAD:v[0-9]+]] = mload [[ADDR]]
+// CHECK: {{^ +}}ret [[LOAD]]
 fn @internal_call_barrier() -> u256 {
   bb0:
     mstore 128, 42
@@ -249,14 +249,14 @@ fn @callee() {
     ret
 }
 
-// CHECK-DAG: @chained_forwarding
-// CHECK-DAG:       mstore [[FIRST_ADDR:[0-9]+]], 42
-// CHECK-DAG: -     [[FIRST:v[0-9]+]] = mload [[FIRST_ADDR]]
-// CHECK-DAG: -     mstore [[SECOND_ADDR:[0-9]+]], [[FIRST]]
-// CHECK-DAG: -     [[SECOND:v[0-9]+]] = mload [[SECOND_ADDR]]
-// CHECK-DAG: -     ret [[SECOND]]
-// CHECK-DAG:       mstore [[SECOND_ADDR]], 42
-// CHECK-DAG:       ret 42
+// CHECK-LABEL: @chained_forwarding
+// CHECK:       mstore [[FIRST_ADDR:[0-9]+]], 42
+// CHECK: -     [[FIRST:v[0-9]+]] = mload [[FIRST_ADDR]]
+// CHECK: -     mstore [[SECOND_ADDR:[0-9]+]], [[FIRST]]
+// CHECK: -     [[SECOND:v[0-9]+]] = mload [[SECOND_ADDR]]
+// CHECK: -     ret [[SECOND]]
+// CHECK:       mstore [[SECOND_ADDR]], 42
+// CHECK:       ret 42
 fn @chained_forwarding() -> u256 {
   bb0:
     mstore 128, 42

--- a/tests/ui/codegen/mir/memory-dse/builder_cases.stdout
+++ b/tests/ui/codegen/mir/memory-dse/builder_cases.stdout
@@ -37,21 +37,21 @@
     bb0:
 -     mstore 128, 0
       jumpi arg0, bb1, bb2
+    bb2:
+      revert 0, 0
     bb1:
       mstore 128, 1
       returndata 128, 32
-    bb2:
-      revert 0, 0
   }
   
   fn @cross_block_read_path(arg0: u256) {
     bb0:
       mstore 128, 7
       jumpi arg0, bb1, bb2
-    bb1:
-      returndata 128, 32
     bb2:
       mstore 128, 9
+      returndata 128, 32
+    bb1:
       returndata 128, 32
   }
   

--- a/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
+++ b/tests/ui/codegen/mir/memory-dse/memory_dse_cross_block.stdout
@@ -25,10 +25,10 @@
   fn @keep_store_into_multi_pred_successor(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      jump bb3
     bb1:
       mstore 128, 1
-      jump bb3
-    bb2:
       jump bb3
     bb3:
       mstore 128, 2

--- a/tests/ui/codegen/mir/merge-equivalent-functions/merge_equivalent_functions.stdout
+++ b/tests/ui/codegen/mir/merge-equivalent-functions/merge_equivalent_functions.stdout
@@ -46,22 +46,22 @@
   fn @recursive_a(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      ret arg1
     bb1:
       v0 = internal_call @recursive_a, 1, 0, arg1
       ret v0
-    bb2:
-      ret arg1
   }
   
   fn @recursive_b(arg0: bool, arg1: u256) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
+    bb2:
+      ret arg1
     bb1:
 -     v0 = internal_call @recursive_b, 1, 0, arg1
 +     v0 = internal_call @recursive_a, 1, 0, arg1
       ret v0
-    bb2:
-      ret arg1
   }
   
   fn @recursive_entry() {

--- a/tests/ui/codegen/mir/none/display.mir
+++ b/tests/ui/codegen/mir/none/display.mir
@@ -3,21 +3,21 @@
 
 @module Display
 
-// CHECK-LABEL: @linear
-// CHECK: {{^ +}}[[SUM:v[0-9]+]] = add arg0, 1
-// CHECK: {{^ +}}ret [[SUM]]
+// CHECK-DAG: @linear
+// CHECK-DAG: {{^ +}}[[SUM:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{^ +}}ret [[SUM]]
 fn @linear(arg0: u256) -> u256 {
   bb0:
     v0 = add arg0, 1
     ret v0
 }
 
-// CHECK-LABEL: @diamond
-// CHECK: {{^ +}}jumpi arg1, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
-// CHECK: {{^ +}}[[THEN]]:
-// CHECK: {{^ +}}ret arg0
-// CHECK: {{^ +}}[[ELSE]]:
-// CHECK: {{^ +}}ret arg0
+// CHECK-DAG: @diamond
+// CHECK-DAG: {{^ +}}jumpi arg1, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
+// CHECK-DAG: {{^ +}}[[THEN]]:
+// CHECK-DAG: {{^ +}}ret arg0
+// CHECK-DAG: {{^ +}}[[ELSE]]:
+// CHECK-DAG: {{^ +}}ret arg0
 fn @diamond(arg0: u256, arg1: bool) {
   bb0:
     jumpi arg1, bb1, bb2
@@ -27,10 +27,10 @@ fn @diamond(arg0: u256, arg1: bool) {
     ret arg0
 }
 
-// CHECK-LABEL: @storage_ops
-// CHECK: {{^ +}}sstore arg0, arg1 !metadata(storage=symbolic(arg0))
-// CHECK: {{^ +}}[[LOADED:v[0-9]+]] = sload arg0 !metadata(storage=symbolic(arg0))
-// CHECK: {{^ +}}ret [[LOADED]]
+// CHECK-DAG: @storage_ops
+// CHECK-DAG: {{^ +}}sstore arg0, arg1 !metadata(storage=symbolic(arg0))
+// CHECK-DAG: {{^ +}}[[LOADED:v[0-9]+]] = sload arg0 !metadata(storage=symbolic(arg0))
+// CHECK-DAG: {{^ +}}ret [[LOADED]]
 fn @storage_ops(arg0: u256, arg1: u256) {
   bb0:
     sstore arg0, arg1 !metadata(storage=symbolic(arg0))
@@ -38,16 +38,16 @@ fn @storage_ops(arg0: u256, arg1: u256) {
     ret v0
 }
 
-// CHECK-LABEL: fn @over.load.4(
-// CHECK: internal_call @over.load.5, 1
+// CHECK-DAG: fn @over.load.4(
+// CHECK-DAG: internal_call @over.load.5, 1
 fn @over.load.4() -> u256 {
   bb0:
     v0 = internal_call @over.load.5, 1
     ret v0
 }
 
-// CHECK-LABEL: fn @over.load.5(
-// CHECK: ret 1
+// CHECK-DAG: fn @over.load.5(
+// CHECK-DAG: ret 1
 fn @over.load.5() -> u256 {
   bb0:
     ret 1

--- a/tests/ui/codegen/mir/none/display.mir
+++ b/tests/ui/codegen/mir/none/display.mir
@@ -3,21 +3,21 @@
 
 @module Display
 
-// CHECK-DAG: @linear
-// CHECK-DAG: {{^ +}}[[SUM:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{^ +}}ret [[SUM]]
+// CHECK-LABEL: @linear
+// CHECK: {{^ +}}[[SUM:v[0-9]+]] = add arg0, 1
+// CHECK: {{^ +}}ret [[SUM]]
 fn @linear(arg0: u256) -> u256 {
   bb0:
     v0 = add arg0, 1
     ret v0
 }
 
-// CHECK-DAG: @diamond
-// CHECK-DAG: {{^ +}}jumpi arg1, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
-// CHECK-DAG: {{^ +}}[[THEN]]:
-// CHECK-DAG: {{^ +}}ret arg0
-// CHECK-DAG: {{^ +}}[[ELSE]]:
-// CHECK-DAG: {{^ +}}ret arg0
+// CHECK-LABEL: @diamond
+// CHECK: {{^ +}}jumpi arg1, [[THEN:bb[0-9]+]], [[ELSE:bb[0-9]+]]
+// CHECK: {{^ +}}[[ELSE]]:
+// CHECK: {{^ +}}ret arg0
+// CHECK: {{^ +}}[[THEN]]:
+// CHECK: {{^ +}}ret arg0
 fn @diamond(arg0: u256, arg1: bool) {
   bb0:
     jumpi arg1, bb1, bb2
@@ -27,10 +27,10 @@ fn @diamond(arg0: u256, arg1: bool) {
     ret arg0
 }
 
-// CHECK-DAG: @storage_ops
-// CHECK-DAG: {{^ +}}sstore arg0, arg1 !metadata(storage=symbolic(arg0))
-// CHECK-DAG: {{^ +}}[[LOADED:v[0-9]+]] = sload arg0 !metadata(storage=symbolic(arg0))
-// CHECK-DAG: {{^ +}}ret [[LOADED]]
+// CHECK-LABEL: @storage_ops
+// CHECK: {{^ +}}sstore arg0, arg1 !metadata(storage=symbolic(arg0))
+// CHECK: {{^ +}}[[LOADED:v[0-9]+]] = sload arg0 !metadata(storage=symbolic(arg0))
+// CHECK: {{^ +}}ret [[LOADED]]
 fn @storage_ops(arg0: u256, arg1: u256) {
   bb0:
     sstore arg0, arg1 !metadata(storage=symbolic(arg0))
@@ -38,16 +38,16 @@ fn @storage_ops(arg0: u256, arg1: u256) {
     ret v0
 }
 
-// CHECK-DAG: fn @over.load.4(
-// CHECK-DAG: internal_call @over.load.5, 1
+// CHECK-LABEL: fn @over.load.4(
+// CHECK: internal_call @over.load.5, 1
 fn @over.load.4() -> u256 {
   bb0:
     v0 = internal_call @over.load.5, 1
     ret v0
 }
 
-// CHECK-DAG: fn @over.load.5(
-// CHECK-DAG: ret 1
+// CHECK-LABEL: fn @over.load.5(
+// CHECK: ret 1
 fn @over.load.5() -> u256 {
   bb0:
     ret 1

--- a/tests/ui/codegen/mir/none/display.stdout
+++ b/tests/ui/codegen/mir/none/display.stdout
@@ -10,9 +10,9 @@
   fn @diamond(arg0: u256, arg1: bool) {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      ret arg0
     bb2:
+      ret arg0
+    bb1:
       ret arg0
   }
   

--- a/tests/ui/codegen/mir/none/phi.stdout
+++ b/tests/ui/codegen/mir/none/phi.stdout
@@ -4,9 +4,9 @@
   fn @diamond(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: 10], [bb2: 20]

--- a/tests/ui/codegen/mir/none/switch.stdout
+++ b/tests/ui/codegen/mir/none/switch.stdout
@@ -4,12 +4,12 @@
   fn @dispatch(arg0: u256) -> u256 {
     bb0:
       switch arg0, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
-    bb1:
-      ret arg0
-    bb2:
-      ret 0
     bb3:
       ret 1
+    bb2:
+      ret 0
+    bb1:
+      ret arg0
     bb4:
       ret 2
   }

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
@@ -7,8 +7,8 @@
 
 @module OutlineReverts
 
-// CHECK-DAG: {{^[ +].*}}fn @first{{[( ]}}
-// CHECK-DAG: {{[+-]?}} tail_call @[[STUB:__revert_stub[0-9]+]]
+// CHECK-LABEL: {{^[ +].*}}fn @first{{[( ]}}
+// CHECK: + tail_call @[[STUB:__revert_stub[0-9]+]]
 fn @first(arg0: u256) {
   bb0:
     v1 = add arg0, 1
@@ -23,8 +23,8 @@ fn @first(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @second{{[( ]}}
-// CHECK-DAG: {{[+-]?}} tail_call @[[STUB]]
+// CHECK-LABEL: {{^[ +].*}}fn @second{{[( ]}}
+// CHECK: + tail_call @[[STUB]]
 fn @second(arg0: u256) {
   bb0:
     v1 = mul arg0, 2
@@ -39,9 +39,9 @@ fn @second(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @third{{[( ]}}
-// CHECK-DAG: {{^[ +].*}}mstore 4, 18
-// CHECK-DAG: {{^[ +].*}}revert 0, 36
+// CHECK-LABEL: {{^[ +].*}}fn @third{{[( ]}}
+// CHECK: {{^[ +].*}}mstore 4, 18
+// CHECK: {{^[ +].*}}revert 0, 36
 fn @third(arg0: u256) {
   bb0:
     v1 = sub arg0, 1
@@ -56,6 +56,6 @@ fn @third(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-DAG: {{[+-]?}} fn @__revert_stub{{[0-9]+}}
-// CHECK-DAG: {{[+-]?}} mstore 4, 17
-// CHECK-DAG: {{[+-]?}} revert 0, 36
+// CHECK-LABEL: + fn @__revert_stub{{[0-9]+}}
+// CHECK: + mstore 4, 17
+// CHECK: {{^ +}}revert 0, 36

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.mir
@@ -7,8 +7,8 @@
 
 @module OutlineReverts
 
-// CHECK-LABEL: {{^[ +].*}}fn @first{{[( ]}}
-// CHECK: + tail_call @[[STUB:__revert_stub[0-9]+]]
+// CHECK-DAG: {{^[ +].*}}fn @first{{[( ]}}
+// CHECK-DAG: {{[+-]?}} tail_call @[[STUB:__revert_stub[0-9]+]]
 fn @first(arg0: u256) {
   bb0:
     v1 = add arg0, 1
@@ -23,8 +23,8 @@ fn @first(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @second{{[( ]}}
-// CHECK: + tail_call @[[STUB]]
+// CHECK-DAG: {{^[ +].*}}fn @second{{[( ]}}
+// CHECK-DAG: {{[+-]?}} tail_call @[[STUB]]
 fn @second(arg0: u256) {
   bb0:
     v1 = mul arg0, 2
@@ -39,9 +39,9 @@ fn @second(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @third{{[( ]}}
-// CHECK: {{^[ +].*}}mstore 4, 18
-// CHECK: {{^[ +].*}}revert 0, 36
+// CHECK-DAG: {{^[ +].*}}fn @third{{[( ]}}
+// CHECK-DAG: {{^[ +].*}}mstore 4, 18
+// CHECK-DAG: {{^[ +].*}}revert 0, 36
 fn @third(arg0: u256) {
   bb0:
     v1 = sub arg0, 1
@@ -56,6 +56,6 @@ fn @third(arg0: u256) {
     returndata 128, 32
 }
 
-// CHECK-LABEL: + fn @__revert_stub{{[0-9]+}}
-// CHECK: + mstore 4, 17
-// CHECK: + revert 0, 36
+// CHECK-DAG: {{[+-]?}} fn @__revert_stub{{[0-9]+}}
+// CHECK-DAG: {{[+-]?}} mstore 4, 17
+// CHECK-DAG: {{[+-]?}} revert 0, 36

--- a/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
+++ b/tests/ui/codegen/mir/outline-reverts/outline_reverts.stdout
@@ -6,14 +6,14 @@
       v0 = add arg0, 1
       v1 = lt v0, arg0
       jumpi v1, bb1, bb2
+    bb2:
+      mstore 128, v0
+      returndata 128, 32
     bb1:
 -     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
 -     mstore 4, 17
 -     revert 0, 36
 +     tail_call @__revert_stub0
-    bb2:
-      mstore 128, v0
-      returndata 128, 32
   }
   
   fn @second(arg0: u256) {
@@ -21,14 +21,14 @@
       v0 = mul arg0, 2
       v1 = lt v0, arg0
       jumpi v1, bb1, bb2
+    bb2:
+      mstore 128, v0
+      returndata 128, 32
     bb1:
 -     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
 -     mstore 4, 17
 -     revert 0, 36
 +     tail_call @__revert_stub0
-    bb2:
-      mstore 128, v0
-      returndata 128, 32
   }
   
   fn @third(arg0: u256) {
@@ -36,19 +36,19 @@
       v0 = sub arg0, 1
       v1 = gt v0, arg0
       jumpi v1, bb1, bb2
-    bb1:
-      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
-      mstore 4, 18
-      revert 0, 36
     bb2:
       mstore 128, v0
       returndata 128, 32
+    bb1:
+      mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000
+      mstore 4, 18
++     revert 0, 36
 + }
 + 
 + fn @__revert_stub0() {
 +   bb0:
 +     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
 +     mstore 4, 17 !metadata(memory=scratch)
-+     revert 0, 36
+      revert 0, 36
   }
   

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
@@ -9,18 +9,18 @@
 // pipeline the loop-header guard `i < n` must fold the increment's
 // Panic(0x11) check — no `lt` after `add v, 1` and only one panic block —
 // while the unguarded accumulator check on `s += i` must survive.
-// CHECK-DAG: fn @sum{{[( ]}}
-// CHECK-DAG: bb0:
-// CHECK-DAG: jump [[HEADER:bb[0-9]+]]
-// CHECK-DAG: [[HEADER]]:
-// CHECK-DAG: [[INDEX:v[0-9]+]] = phi [bb0: 0], [[[LATCH:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
-// CHECK-DAG: [[SUM:v[0-9]+]] = add {{v[0-9]+}}, [[INDEX]]
-// CHECK-DAG: {{v[0-9]+}} = lt [[SUM]], {{v[0-9]+}}
-// CHECK-DAG: mstore 4, 17 !metadata(memory=scratch)
-// CHECK-DAG: revert 0, 36
-// CHECK-DAG: [[LATCH]]:
-// CHECK-DAG: [[NEXT]] = add [[INDEX]], 1
-// CHECK-DAG: jump [[HEADER]]
+// CHECK-LABEL: fn @sum{{[( ]}}
+// CHECK: bb0:
+// CHECK: jump [[HEADER:bb[0-9]+]]
+// CHECK: [[HEADER]]:
+// CHECK-NEXT: [[INDEX:v[0-9]+]] = phi [bb0: 0], [[[LATCH:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
+// CHECK: [[SUM:v[0-9]+]] = add {{v[0-9]+}}, [[INDEX]]
+// CHECK: {{v[0-9]+}} = lt [[SUM]], {{v[0-9]+}}
+// CHECK: [[LATCH]]:
+// CHECK: [[NEXT]] = add [[INDEX]], 1
+// CHECK-NEXT: jump [[HEADER]]
+// CHECK: mstore 4, 17 !metadata(memory=scratch)
+// CHECK: revert 0, 36
 fn @sum(arg0: u256) {
   bb0:
     mstore 128, 0

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.mir
@@ -9,18 +9,18 @@
 // pipeline the loop-header guard `i < n` must fold the increment's
 // Panic(0x11) check — no `lt` after `add v, 1` and only one panic block —
 // while the unguarded accumulator check on `s += i` must survive.
-// CHECK-LABEL: fn @sum{{[( ]}}
-// CHECK: bb0:
-// CHECK: jump [[HEADER:bb[0-9]+]]
-// CHECK: [[HEADER]]:
-// CHECK-NEXT: [[INDEX:v[0-9]+]] = phi [bb0: 0], [[[LATCH:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
-// CHECK: [[SUM:v[0-9]+]] = add {{v[0-9]+}}, [[INDEX]]
-// CHECK: {{v[0-9]+}} = lt [[SUM]], {{v[0-9]+}}
-// CHECK: mstore 4, 17 !metadata(memory=scratch)
-// CHECK: revert 0, 36
-// CHECK: [[LATCH]]:
-// CHECK: [[NEXT]] = add [[INDEX]], 1
-// CHECK-NEXT: jump [[HEADER]]
+// CHECK-DAG: fn @sum{{[( ]}}
+// CHECK-DAG: bb0:
+// CHECK-DAG: jump [[HEADER:bb[0-9]+]]
+// CHECK-DAG: [[HEADER]]:
+// CHECK-DAG: [[INDEX:v[0-9]+]] = phi [bb0: 0], [[[LATCH:bb[0-9]+]]: [[NEXT:v[0-9]+]]]
+// CHECK-DAG: [[SUM:v[0-9]+]] = add {{v[0-9]+}}, [[INDEX]]
+// CHECK-DAG: {{v[0-9]+}} = lt [[SUM]], {{v[0-9]+}}
+// CHECK-DAG: mstore 4, 17 !metadata(memory=scratch)
+// CHECK-DAG: revert 0, 36
+// CHECK-DAG: [[LATCH]]:
+// CHECK-DAG: [[NEXT]] = add [[INDEX]], 1
+// CHECK-DAG: jump [[HEADER]]
 fn @sum(arg0: u256) {
   bb0:
     mstore 128, 0

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_loop.stdout
@@ -18,12 +18,12 @@ fn @sum(arg0: u256) {
     v6 = add v5, v0
     v7 = lt v6, v5
     jumpi v7, bb4, bb5
-  bb4:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
   bb5:
     mstore 128, v6
     v3 = add v0, 1
     jump bb1
+  bb4:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
 }

--- a/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
+++ b/tests/ui/codegen/mir/pipeline/check_elim_pipeline_require_sub.stdout
@@ -5,12 +5,12 @@ fn @guarded(arg0: u256, arg1: u256) {
   bb0:
     v0 = gt arg1, arg0
     jumpi v0, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = sub arg0, arg1
     mstore 128, v3
     returndata 128, 32
+  bb1:
+    revert 0, 0
 }
 
 fn @unguarded(arg0: u256, arg1: u256) {
@@ -18,11 +18,11 @@ fn @unguarded(arg0: u256, arg1: u256) {
     v0 = sub arg0, arg1
     v1 = lt arg0, arg1
     jumpi v1, bb1, bb2
+  bb2:
+    mstore 128, v0
+    returndata 128, 32
   bb1:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb2:
-    mstore 128, v0
-    returndata 128, 32
 }

--- a/tests/ui/codegen/mir/pipeline/pipeline.passes.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline.passes.stdout
@@ -6,11 +6,12 @@
       v0 = add arg0, 1
       v1 = mul arg0, arg0
 -     jump bb1
-+     jump bb2
-    bb1:
+-   bb1:
       jump bb2
     bb2:
       ret v0
++   bb1:
++     jump bb2
   }
   
 - // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before cfg-simplify) ===
@@ -21,10 +22,10 @@
       v0 = add arg0, 1
       v1 = mul arg0, arg0
 -     jump bb2
--   bb1:
--     jump bb2
 -   bb2:
       ret v0
+-   bb1:
+-     jump bb2
   }
   
 - // === ROOT/tests/ui/codegen/mir/pipeline/pipeline.mir (before dce) ===

--- a/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
+++ b/tests/ui/codegen/mir/pipeline/pipeline_frame_indvar.stdout
@@ -9,11 +9,11 @@ fn @frame_counter_feeds_affine_address(arg0: u256, arg1: u256) -> u256 {
     v9 = phi [bb0: arg1], [bb2: v10]
     v3 = lt v8, arg0
     jumpi v3, bb2, bb3
+  bb3:
+    ret 0
   bb2:
     mstore v9, v8
     v6 = add v8, 1
     v10 = add v9, 32
     jump bb1
-  bb3:
-    ret 0
 }

--- a/tests/ui/codegen/mir/pipeline/pre_pingpong.pre.stdout
+++ b/tests/ui/codegen/mir/pipeline/pre_pingpong.pre.stdout
@@ -4,18 +4,18 @@
   fn @pingpong(arg0: u256, arg1: u256) {
     bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4]
-    bb1:
-      v0 = add arg0, 7
-      jump bb5
-    bb2:
-      v1 = add arg0, 7
-      jump bb5
-    bb3:
-      v2 = add arg0, 7
-      jump bb6
     bb4:
       v3 = add arg0, 7
       jump bb6
+    bb3:
+      v2 = add arg0, 7
+      jump bb6
+    bb2:
+      v1 = add arg0, 7
+      jump bb5
+    bb1:
+      v0 = add arg0, 7
+      jump bb5
     bb5:
 -     v4 = add arg0, 7
 +     v6 = phi [bb1: v0], [bb2: v1], [bb6: v5]

--- a/tests/ui/codegen/mir/pre/memory_object_pre.stdout
+++ b/tests/ui/codegen/mir/pre/memory_object_pre.stdout
@@ -4,11 +4,11 @@
   fn @hoist_projection(arg0: memorystruct, arg1: bool) -> memptr {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      v0 = memory_object_field_addr memorystruct<3>, arg0, 2
-      jump bb3
     bb2:
 +     v2 = memory_object_field_addr memorystruct<3>, arg0, 2
+      jump bb3
+    bb1:
+      v0 = memory_object_field_addr memorystruct<3>, arg0, 2
       jump bb3
     bb3:
 -     v1 = memory_object_field_addr memorystruct<3>, arg0, 2

--- a/tests/ui/codegen/mir/pre/pre.mir
+++ b/tests/ui/codegen/mir/pre/pre.mir
@@ -1,9 +1,9 @@
 //@compile-flags: -Zmir-pipeline=pre
 //@filecheck:
 @module Pre
-// CHECK-LABEL: {{^[ +].*}}fn @insert_missing_predecessor{{[( ]}}
-// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 7
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
+// CHECK-DAG: {{^[ +].*}}fn @insert_missing_predecessor{{[( ]}}
+// CHECK-DAG: + [[INSERTED:v[0-9]+]] = add arg0, 7
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
 fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
   bb0:
     switch arg1, default bb3, [1 => bb1, 2 => bb2]
@@ -20,9 +20,9 @@ fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
     ret v4
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @translate_join_phi{{[( ]}}
-// CHECK: + [[INSERTED:v[0-9]+]] = add arg2, 1
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
+// CHECK-DAG: {{^[ +].*}}fn @translate_join_phi{{[( ]}}
+// CHECK-DAG: + [[INSERTED:v[0-9]+]] = add arg2, 1
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
 fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
   bb0:
     switch arg3, default bb3, [1 => bb1, 2 => bb2]
@@ -40,9 +40,9 @@ fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
     ret v7
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @two_way_join{{[( ]}}
-// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 1
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: [[INSERTED]]]
+// CHECK-DAG: {{^[ +].*}}fn @two_way_join{{[( ]}}
+// CHECK-DAG: + [[INSERTED:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: [[INSERTED]]]
 fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2
@@ -56,10 +56,10 @@ fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
     ret v3
 }
 
-// CHECK-LABEL: {{^[ +].*}}fn @split_branch_terminated_pred{{[( ]}}
-// CHECK: + jumpi arg1, bb5, bb4
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED:v[0-9]+]]]
-// CHECK: + [[INSERTED]] = add arg0, 1
+// CHECK-DAG: {{^[ +].*}}fn @split_branch_terminated_pred{{[( ]}}
+// CHECK-DAG: + jumpi arg1, bb5, bb4
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED:v[0-9]+]]]
+// CHECK-DAG: + [[INSERTED]] = add arg0, 1
 fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2

--- a/tests/ui/codegen/mir/pre/pre.mir
+++ b/tests/ui/codegen/mir/pre/pre.mir
@@ -1,9 +1,9 @@
 //@compile-flags: -Zmir-pipeline=pre
 //@filecheck:
 @module Pre
-// CHECK-DAG: {{^[ +].*}}fn @insert_missing_predecessor{{[( ]}}
-// CHECK-DAG: + [[INSERTED:v[0-9]+]] = add arg0, 7
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
+// CHECK-LABEL: {{^[ +].*}}fn @insert_missing_predecessor{{[( ]}}
+// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 7
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
 fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
   bb0:
     switch arg1, default bb3, [1 => bb1, 2 => bb2]
@@ -20,9 +20,9 @@ fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
     ret v4
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @translate_join_phi{{[( ]}}
-// CHECK-DAG: + [[INSERTED:v[0-9]+]] = add arg2, 1
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
+// CHECK-LABEL: {{^[ +].*}}fn @translate_join_phi{{[( ]}}
+// CHECK: + [[INSERTED:v[0-9]+]] = add arg2, 1
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: {{v[0-9]+}}], [bb3: [[INSERTED]]]
 fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
   bb0:
     switch arg3, default bb3, [1 => bb1, 2 => bb2]
@@ -40,9 +40,9 @@ fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
     ret v7
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @two_way_join{{[( ]}}
-// CHECK-DAG: + [[INSERTED:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: [[INSERTED]]]
+// CHECK-LABEL: {{^[ +].*}}fn @two_way_join{{[( ]}}
+// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 1
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb2: [[INSERTED]]]
 fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2
@@ -56,10 +56,10 @@ fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
     ret v3
 }
 
-// CHECK-DAG: {{^[ +].*}}fn @split_branch_terminated_pred{{[( ]}}
-// CHECK-DAG: + jumpi arg1, bb5, bb4
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED:v[0-9]+]]]
-// CHECK-DAG: + [[INSERTED]] = add arg0, 1
+// CHECK-LABEL: {{^[ +].*}}fn @split_branch_terminated_pred{{[( ]}}
+// CHECK: + jumpi arg1, bb5, bb4
+// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 1
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED]]]
 fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2

--- a/tests/ui/codegen/mir/pre/pre.stdout
+++ b/tests/ui/codegen/mir/pre/pre.stdout
@@ -4,11 +4,11 @@
   fn @insert_missing_predecessor(arg0: u256, arg1: u256) -> u256 {
     bb0:
       switch arg1, default bb3, [1 => bb1, 2 => bb2]
-    bb1:
-      v0 = add arg0, 7
-      jump bb4
     bb2:
       v1 = add 7, arg0
+      jump bb4
+    bb1:
+      v0 = add arg0, 7
       jump bb4
     bb3:
 +     v3 = add arg0, 7
@@ -23,11 +23,11 @@
   fn @translate_join_phi(arg0: u256, arg1: u256, arg2: u256, arg3: u256) -> u256 {
     bb0:
       switch arg3, default bb3, [1 => bb1, 2 => bb2]
-    bb1:
-      v0 = add arg0, 1
-      jump bb4
     bb2:
       v1 = add arg1, 1
+      jump bb4
+    bb1:
+      v0 = add arg0, 1
       jump bb4
     bb3:
 +     v4 = add arg2, 1
@@ -43,11 +43,11 @@
   fn @two_way_join(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      v0 = add arg0, 1
-      jump bb3
     bb2:
 +     v2 = add arg0, 1
+      jump bb3
+    bb1:
+      v0 = add arg0, 1
       jump bb3
     bb3:
 -     v1 = add arg0, 1
@@ -59,21 +59,21 @@
   fn @split_branch_terminated_pred(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      v0 = add arg0, 1
-      jump bb3
     bb2:
 -     jumpi arg1, bb3, bb4
 +     jumpi arg1, bb5, bb4
-    bb3:
--     v1 = add arg0, 1
--     ret v1
-+     v3 = phi [bb1: v0], [bb5: v2]
-+     ret v3
     bb4:
       ret arg0
 +   bb5:
 +     v2 = add arg0, 1
 +     jump bb3
+    bb1:
+      v0 = add arg0, 1
+      jump bb3
+    bb3:
+-     v1 = add arg0, 1
+-     ret v1
++     v3 = phi [bb1: v0], [bb5: v2]
++     ret v3
   }
   

--- a/tests/ui/codegen/mir/pre/pre_dominator_availability.stdout
+++ b/tests/ui/codegen/mir/pre/pre_dominator_availability.stdout
@@ -4,16 +4,16 @@
   fn @reuse_dominating_def(arg0: u256, arg1: u256) -> u256 {
     bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3]
-    bb1:
-      v0 = add arg0, 7
-      jump bb5
-    bb2:
-      v1 = add arg0, 7
-      jump bb5
     bb3:
       v2 = add arg0, 7
       jump bb4
     bb4:
+      jump bb5
+    bb2:
+      v1 = add arg0, 7
+      jump bb5
+    bb1:
+      v0 = add arg0, 7
       jump bb5
     bb5:
 -     v3 = add arg0, 7
@@ -26,9 +26,9 @@
     bb0:
       v0 = add arg0, 7
       switch arg1, default bb1, [1 => bb2]
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
 -     v1 = add arg0, 7

--- a/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
+++ b/tests/ui/codegen/mir/pre/pre_join_shapes.stdout
@@ -4,14 +4,14 @@
   fn @duplicate_pred_edges(arg0: u256, arg1: u256, arg2: u256) -> u256 {
     bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3]
-    bb1:
-      v0 = add arg0, 7
+    bb3:
++     v3 = add arg0, 7
       jump bb4
     bb2:
       v1 = add arg0, 7
       switch arg2, default bb4, [1 => bb4]
-    bb3:
-+     v3 = add arg0, 7
+    bb1:
+      v0 = add arg0, 7
       jump bb4
     bb4:
 -     v2 = add arg0, 7
@@ -23,11 +23,11 @@
   fn @self_loop_join(arg0: u256, arg1: u256) -> u256 {
     bb0:
       switch arg1, default bb3, [1 => bb1, 2 => bb2]
-    bb1:
-      v0 = add arg0, 7
-      jump bb4
     bb2:
       v1 = add arg0, 7
+      jump bb4
+    bb1:
+      v0 = add arg0, 7
       jump bb4
     bb3:
 +     v4 = add arg0, 7
@@ -49,14 +49,14 @@
     bb1:
       v0 = phi [bb0: arg0], [bb6: v5]
       switch arg1, default bb2, [1 => bb3, 2 => bb4]
-    bb2:
-      v1 = add v0, 7
+    bb4:
++     v6 = add v0, 7
       jump bb5
     bb3:
       v2 = add 7, v0
       jump bb5
-    bb4:
-+     v6 = add v0, 7
+    bb2:
+      v1 = add v0, 7
       jump bb5
     bb5:
 -     v3 = add v0, 7
@@ -64,31 +64,31 @@
 +     v7 = phi [bb2: v1], [bb3: v2], [bb4: v6]
 +     v4 = lt v7, arg1
       jumpi v4, bb6, bb7
-    bb6:
-      v5 = add v0, 1
-      jump bb1
     bb7:
 -     ret v3
 +     ret v7
+    bb6:
+      v5 = add v0, 1
+      jump bb1
   }
   
   fn @insertion_cap(arg0: u256, arg1: u256) -> u256 {
     bb0:
       switch arg1, default bb1, [1 => bb2, 2 => bb3, 3 => bb4, 4 => bb5, 5 => bb6]
-    bb1:
-      v0 = add arg0, 7
+    bb6:
       jump bb7
-    bb2:
-      v1 = add arg0, 7
+    bb5:
+      jump bb7
+    bb4:
       jump bb7
     bb3:
       v2 = add arg0, 7
       jump bb7
-    bb4:
+    bb2:
+      v1 = add arg0, 7
       jump bb7
-    bb5:
-      jump bb7
-    bb6:
+    bb1:
+      v0 = add arg0, 7
       jump bb7
     bb7:
       v3 = add arg0, 7

--- a/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
+++ b/tests/ui/codegen/mir/pre/pre_loop_invariant.stdout
@@ -12,13 +12,13 @@
 +     v6 = phi [bb0: v5], [bb2: v4]
 +     v2 = lt v6, arg1
       jumpi v2, bb2, bb3
+    bb3:
+-     ret v1
++     ret v6
     bb2:
       v3 = add v0, 1
       v4 = add v3, 7
       jump bb1
-    bb3:
--     ret v1
-+     ret v6
   }
   
   fn @hoist_header_expr_two_latches(arg0: u256, arg1: u256) -> u256 {
@@ -32,18 +32,18 @@
 +     v8 = phi [bb0: v7], [bb3: v4], [bb4: v6]
 +     v2 = lt v8, arg1
       jumpi v2, bb2, bb5
+    bb5:
+-     ret v1
++     ret v8
     bb2:
       switch arg1, default bb3, [1 => bb4]
-    bb3:
-      v3 = add v0, 1
-      v4 = add v3, 7
-      jump bb1
     bb4:
       v5 = add v0, 2
       v6 = add v5, 7
       jump bb1
-    bb5:
--     ret v1
-+     ret v8
+    bb3:
+      v3 = add v0, 1
+      v4 = add v3, 7
+      jump bb1
   }
   

--- a/tests/ui/codegen/mir/pre/pre_split_edges.mir
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.mir
@@ -6,10 +6,10 @@
 
 // bb2 reaches the join through two switch cases: both retarget to the same
 // split block, so the join phi gets exactly one new incoming entry.
-// CHECK-LABEL: {{^[ +].*}}fn @switch_pred_two_cases{{[( ]}}
-// CHECK: + switch arg1, default bb4, [2 => bb5, 3 => bb5]
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED:v[0-9]+]]]
-// CHECK: + [[INSERTED]] = add arg0, 7
+// CHECK-DAG: {{^[ +].*}}fn @switch_pred_two_cases{{[( ]}}
+// CHECK-DAG: + switch arg1, default bb4, [2 => bb5, 3 => bb5]
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED:v[0-9]+]]]
+// CHECK-DAG: + [[INSERTED]] = add arg0, 7
 fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
   bb0:
     switch arg1, default bb1, [1 => bb2]
@@ -27,10 +27,10 @@ fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
 
 // bb2 branches to the join on both arms: one logical edge, one split block,
 // one phi entry.
-// CHECK-LABEL: {{^[ +].*}}fn @branch_both_arms_to_join{{[( ]}}
-// CHECK: + jumpi arg1, bb4, bb4
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
-// CHECK: + [[INSERTED]] = add arg0, 7
+// CHECK-DAG: {{^[ +].*}}fn @branch_both_arms_to_join{{[( ]}}
+// CHECK-DAG: + jumpi arg1, bb4, bb4
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
+// CHECK-DAG: + [[INSERTED]] = add arg0, 7
 fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2
@@ -47,9 +47,9 @@ fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
 // The join is its own branch-terminated predecessor and the backedge
 // translation of the expression is not available: the backedge is split and
 // the new block carries the per-iteration recomputation.
-// CHECK-LABEL: {{^[ +].*}}fn @self_loop_backedge_insertion{{[( ]}}
-// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
-// CHECK: + [[INSERTED]] = add {{v[0-9]+}}, 7
+// CHECK-DAG: {{^[ +].*}}fn @self_loop_backedge_insertion{{[( ]}}
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
+// CHECK-DAG: + [[INSERTED]] = add {{v[0-9]+}}, 7
 fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
   bb0:
     jump bb1
@@ -68,10 +68,10 @@ fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
 
 // Loop-invariant PRE through a branch-terminated preheader: the entry edge
 // into the header is split and the hoisted computation lands on it.
-// CHECK-LABEL: {{^[ +].*}}fn @hoist_through_branch_preheader{{[( ]}}
-// CHECK: + jumpi {{v[0-9]+}}, bb5, bb4
-// CHECK: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}], [bb5: [[HOISTED:v[0-9]+]]]
-// CHECK: + [[HOISTED]] = add arg0, 7
+// CHECK-DAG: {{^[ +].*}}fn @hoist_through_branch_preheader{{[( ]}}
+// CHECK-DAG: + jumpi {{v[0-9]+}}, bb5, bb4
+// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}], [bb5: [[HOISTED:v[0-9]+]]]
+// CHECK-DAG: + [[HOISTED]] = add arg0, 7
 fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = lt arg0, arg1

--- a/tests/ui/codegen/mir/pre/pre_split_edges.mir
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.mir
@@ -6,10 +6,10 @@
 
 // bb2 reaches the join through two switch cases: both retarget to the same
 // split block, so the join phi gets exactly one new incoming entry.
-// CHECK-DAG: {{^[ +].*}}fn @switch_pred_two_cases{{[( ]}}
-// CHECK-DAG: + switch arg1, default bb4, [2 => bb5, 3 => bb5]
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED:v[0-9]+]]]
-// CHECK-DAG: + [[INSERTED]] = add arg0, 7
+// CHECK-LABEL: {{^[ +].*}}fn @switch_pred_two_cases{{[( ]}}
+// CHECK: + switch arg1, default bb4, [2 => bb5, 3 => bb5]
+// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 7
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb5: [[INSERTED]]]
 fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
   bb0:
     switch arg1, default bb1, [1 => bb2]
@@ -27,10 +27,10 @@ fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
 
 // bb2 branches to the join on both arms: one logical edge, one split block,
 // one phi entry.
-// CHECK-DAG: {{^[ +].*}}fn @branch_both_arms_to_join{{[( ]}}
-// CHECK-DAG: + jumpi arg1, bb4, bb4
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
-// CHECK-DAG: + [[INSERTED]] = add arg0, 7
+// CHECK-LABEL: {{^[ +].*}}fn @branch_both_arms_to_join{{[( ]}}
+// CHECK: + jumpi arg1, bb4, bb4
+// CHECK: + [[INSERTED:v[0-9]+]] = add arg0, 7
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED]]]
 fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
   bb0:
     jumpi arg1, bb1, bb2
@@ -47,9 +47,9 @@ fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
 // The join is its own branch-terminated predecessor and the backedge
 // translation of the expression is not available: the backedge is split and
 // the new block carries the per-iteration recomputation.
-// CHECK-DAG: {{^[ +].*}}fn @self_loop_backedge_insertion{{[( ]}}
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
-// CHECK-DAG: + [[INSERTED]] = add {{v[0-9]+}}, 7
+// CHECK-LABEL: {{^[ +].*}}fn @self_loop_backedge_insertion{{[( ]}}
+// CHECK: + {{v[0-9]+}} = phi [bb1: {{v[0-9]+}}], [bb4: [[INSERTED:v[0-9]+]]]
+// CHECK: + [[INSERTED]] = add {{v[0-9]+}}, 7
 fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
   bb0:
     jump bb1
@@ -68,10 +68,10 @@ fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
 
 // Loop-invariant PRE through a branch-terminated preheader: the entry edge
 // into the header is split and the hoisted computation lands on it.
-// CHECK-DAG: {{^[ +].*}}fn @hoist_through_branch_preheader{{[( ]}}
-// CHECK-DAG: + jumpi {{v[0-9]+}}, bb5, bb4
-// CHECK-DAG: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}], [bb5: [[HOISTED:v[0-9]+]]]
-// CHECK-DAG: + [[HOISTED]] = add arg0, 7
+// CHECK-LABEL: {{^[ +].*}}fn @hoist_through_branch_preheader{{[( ]}}
+// CHECK: + jumpi {{v[0-9]+}}, bb5, bb4
+// CHECK: + [[HOISTED:v[0-9]+]] = add arg0, 7
+// CHECK: + {{v[0-9]+}} = phi [bb2: {{v[0-9]+}}], [bb5: [[HOISTED]]]
 fn @hoist_through_branch_preheader(arg0: u256, arg1: u256) -> u256 {
   bb0:
     v2 = lt arg0, arg1

--- a/tests/ui/codegen/mir/pre/pre_split_edges.stdout
+++ b/tests/ui/codegen/mir/pre/pre_split_edges.stdout
@@ -4,41 +4,41 @@
   fn @switch_pred_two_cases(arg0: u256, arg1: u256) -> u256 {
     bb0:
       switch arg1, default bb1, [1 => bb2]
-    bb1:
-      v0 = add arg0, 7
-      jump bb3
     bb2:
 -     switch arg1, default bb4, [2 => bb3, 3 => bb3]
 +     switch arg1, default bb4, [2 => bb5, 3 => bb5]
++   bb5:
++     v2 = add arg0, 7
++     jump bb3
+    bb4:
+      ret arg0
+    bb1:
+      v0 = add arg0, 7
+      jump bb3
     bb3:
 -     v1 = add arg0, 7
 -     ret v1
 +     v3 = phi [bb1: v0], [bb5: v2]
 +     ret v3
-    bb4:
-      ret arg0
-+   bb5:
-+     v2 = add arg0, 7
-+     jump bb3
   }
   
   fn @branch_both_arms_to_join(arg0: u256, arg1: bool) -> u256 {
     bb0:
       jumpi arg1, bb1, bb2
-    bb1:
-      v0 = add arg0, 7
-      jump bb3
     bb2:
 -     jumpi arg1, bb3, bb3
 +     jumpi arg1, bb4, bb4
++   bb4:
++     v2 = add arg0, 7
++     jump bb3
+    bb1:
+      v0 = add arg0, 7
+      jump bb3
     bb3:
 -     v1 = add arg0, 7
 -     ret v1
 +     v3 = phi [bb1: v0], [bb4: v2]
 +     ret v3
-+   bb4:
-+     v2 = add arg0, 7
-+     jump bb3
   }
   
   fn @self_loop_backedge_insertion(arg0: u256, arg1: u256) -> u256 {
@@ -69,6 +69,11 @@
       v0 = lt arg0, arg1
 -     jumpi v0, bb1, bb4
 +     jumpi v0, bb5, bb4
+    bb4:
+      ret arg0
++   bb5:
++     v6 = add arg0, 7
++     jump bb1
     bb1:
 -     v1 = phi [bb0: arg0], [bb2: v4]
 -     v2 = add v1, 7
@@ -77,17 +82,12 @@
 +     v7 = phi [bb2: v5], [bb5: v6]
 +     v3 = lt v7, arg1
       jumpi v3, bb2, bb3
+    bb3:
+-     ret v2
++     ret v7
     bb2:
       v4 = add v1, 1
       v5 = add v4, 7
       jump bb1
-    bb3:
--     ret v2
-+     ret v7
-    bb4:
-      ret arg0
-+   bb5:
-+     v6 = add arg0, 7
-+     jump bb1
   }
   

--- a/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
+++ b/tests/ui/codegen/mir/pure-eval/pure_eval_loop.stdout
@@ -9,12 +9,13 @@
 -     v0 = phi [bb0: 0], [bb2: 3]
 -     v1 = lt v0, 3
 -     jumpi v1, bb2, bb3
+-   bb3:
+-     ret v0
 +     invalid
     bb2:
 -     jump bb1
 +     invalid
-    bb3:
--     ret v0
++   bb3:
 +     invalid
   }
   
@@ -55,10 +56,10 @@
     bb0:
       v0 = address
       switch 1, default bb3, [v0 => bb1, 1 => bb2]
-    bb1:
-      ret 1
     bb2:
       ret 2
+    bb1:
+      ret 1
     bb3:
       ret 3
   }

--- a/tests/ui/codegen/mir/sccp/sccp_branch.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_branch.stdout
@@ -5,11 +5,12 @@
     bb0:
 -     v0 = lt 5, 10
 -     jumpi v0, bb1, bb2
+-   bb2:
+-     ret 0
 +     jump bb1
     bb1:
       ret 1
-    bb2:
--     ret 0
++   bb2:
 +     invalid
   }
   

--- a/tests/ui/codegen/mir/sccp/sccp_edge.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_edge.stdout
@@ -5,24 +5,25 @@
     bb0:
 -     v0 = eq 1, 1
 -     jumpi v0, bb1, bb2
+-   bb2:
+-     jump bb3
 +     jump bb1
     bb1:
       jump bb3
-    bb2:
--     jump bb3
-+     invalid
     bb3:
 -     v1 = phi [bb1: 11], [bb2: 22]
 -     ret v1
 +     ret 11
++   bb2:
++     invalid
   }
   
   fn @unknown_branch_keeps_phi(arg0: bool) -> u256 {
     bb0:
       jumpi arg0, bb1, bb2
-    bb1:
-      jump bb3
     bb2:
+      jump bb3
+    bb1:
       jump bb3
     bb3:
       v0 = phi [bb1: 11], [bb2: 22]
@@ -32,14 +33,15 @@
   fn @constant_switch_selects_one_case() -> u256 {
     bb0:
 -     switch 2, default bb4, [1 => bb1, 2 => bb2, 3 => bb3]
+-   bb3:
+-     ret 33
 +     jump bb2
+    bb2:
+      ret 22
     bb1:
 -     ret 11
 +     invalid
-    bb2:
-      ret 22
-    bb3:
--     ret 33
++   bb3:
 +     invalid
     bb4:
 -     ret 44

--- a/tests/ui/codegen/mir/sccp/sccp_switch_order.stdout
+++ b/tests/ui/codegen/mir/sccp/sccp_switch_order.stdout
@@ -4,10 +4,10 @@
   fn @earlier_unknown_case_blocks_fold(arg0: u256) -> u256 {
     bb0:
       switch 5, default bb3, [arg0 => bb1, 5 => bb2]
-    bb1:
-      ret 1
     bb2:
       ret 2
+    bb1:
+      ret 1
     bb3:
 -     ret 3
 +     invalid
@@ -17,11 +17,11 @@
     bb0:
 -     switch 5, default bb3, [1 => bb1, 5 => bb2]
 +     jump bb2
+    bb2:
+      ret 2
     bb1:
 -     ret 1
 +     invalid
-    bb2:
-      ret 2
     bb3:
 -     ret 3
 +     invalid
@@ -30,11 +30,11 @@
   fn @unknown_case_keeps_default(arg0: u256) -> u256 {
     bb0:
       switch 5, default bb3, [arg0 => bb1, 4 => bb2]
-    bb1:
-      ret 1
     bb2:
 -     ret 2
 +     invalid
+    bb1:
+      ret 1
     bb3:
       ret 3
   }

--- a/tests/ui/codegen/mir/static-alloc/derived_chain.mir
+++ b/tests/ui/codegen/mir/static-alloc/derived_chain.mir
@@ -4,12 +4,12 @@
 
 // The CFG visits bb5 through bb1, opposite the block storage order. Discovering
 // the full derived-address chain therefore requires more than four scans.
-// CHECK-LABEL: + // === {{.*}} (after static-alloc) ===
-// CHECK:   fn @derived_chain{{.*}}
-// CHECK: -     {{v[0-9]+}} = alloc raw, exact, uninitialized, infallible, 32
-// CHECK:       [[LOAD:v[0-9]+]] = mload {{v[0-9]+}}
-// CHECK:       ret [[LOAD]]
-// CHECK: +     {{v[0-9]+}} = add 128, 0
+// CHECK-DAG: + // === {{.*}} (after static-alloc) ===
+// CHECK-DAG:   fn @derived_chain{{.*}}
+// CHECK-DAG: -     {{v[0-9]+}} = alloc raw, exact, uninitialized, infallible, 32
+// CHECK-DAG:       [[LOAD:v[0-9]+]] = mload {{v[0-9]+}}
+// CHECK-DAG:       ret [[LOAD]]
+// CHECK-DAG: +     {{v[0-9]+}} = add 128, 0
 fn @derived_chain() -> u256 [selector=0x01020304] {
   bb0:
     v0 = alloc raw, exact, uninitialized, infallible, 32
@@ -34,8 +34,8 @@ fn @derived_chain() -> u256 [selector=0x01020304] {
 
 // Storage promotion gives another entry a 32-byte frame, providing the shadow
 // region used by the explicit static-allocation pass.
-// CHECK-LABEL:   fn @reserve_frame{{.*}}
-// CHECK:       mstore 128, 1
+// CHECK-DAG:   fn @reserve_frame{{.*}}
+// CHECK-DAG:       mstore 128, 1
 fn @reserve_frame() [selector=0x01020305] {
   bb0:
     sstore 0, 1

--- a/tests/ui/codegen/mir/static-alloc/derived_chain.mir
+++ b/tests/ui/codegen/mir/static-alloc/derived_chain.mir
@@ -4,12 +4,12 @@
 
 // The CFG visits bb5 through bb1, opposite the block storage order. Discovering
 // the full derived-address chain therefore requires more than four scans.
-// CHECK-DAG: + // === {{.*}} (after static-alloc) ===
-// CHECK-DAG:   fn @derived_chain{{.*}}
-// CHECK-DAG: -     {{v[0-9]+}} = alloc raw, exact, uninitialized, infallible, 32
-// CHECK-DAG:       [[LOAD:v[0-9]+]] = mload {{v[0-9]+}}
-// CHECK-DAG:       ret [[LOAD]]
-// CHECK-DAG: +     {{v[0-9]+}} = add 128, 0
+// CHECK-LABEL: + // === {{.*}} (after static-alloc) ===
+// CHECK:   fn @derived_chain{{.*}}
+// CHECK: -     {{v[0-9]+}} = alloc raw, exact, uninitialized, infallible, 32
+// CHECK: +     {{v[0-9]+}} = add 128, 0
+// CHECK:       [[LOAD:v[0-9]+]] = mload {{v[0-9]+}}
+// CHECK:       ret [[LOAD]]
 fn @derived_chain() -> u256 [selector=0x01020304] {
   bb0:
     v0 = alloc raw, exact, uninitialized, infallible, 32
@@ -34,8 +34,8 @@ fn @derived_chain() -> u256 [selector=0x01020304] {
 
 // Storage promotion gives another entry a 32-byte frame, providing the shadow
 // region used by the explicit static-allocation pass.
-// CHECK-DAG:   fn @reserve_frame{{.*}}
-// CHECK-DAG:       mstore 128, 1
+// CHECK-LABEL:   fn @reserve_frame{{.*}}
+// CHECK:       mstore 128, 1
 fn @reserve_frame() [selector=0x01020305] {
   bb0:
     sstore 0, 1

--- a/tests/ui/codegen/mir/static-alloc/derived_chain.stdout
+++ b/tests/ui/codegen/mir/static-alloc/derived_chain.stdout
@@ -5,22 +5,22 @@
     bb0:
       v0 = alloc raw, exact, uninitialized, infallible, 32
       jump bb5
+    bb5:
+      v6 = add v0, 0
+      jump bb4
+    bb4:
+      v5 = add v6, 0
+      jump bb3
+    bb3:
+      v4 = add v5, 0
+      jump bb2
+    bb2:
+      v3 = add v4, 0
+      jump bb1
     bb1:
       v1 = add v3, 0
       v2 = mload v1
       ret v2
-    bb2:
-      v3 = add v4, 0
-      jump bb1
-    bb3:
-      v4 = add v5, 0
-      jump bb2
-    bb4:
-      v5 = add v6, 0
-      jump bb3
-    bb5:
-      v6 = add v0, 0
-      jump bb4
   }
   
   fn @reserve_frame() {
@@ -30,6 +30,10 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v2 = mload 128
++     sstore 0, v2
+      stop
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -39,10 +43,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-+     v2 = mload 128
-+     sstore 0, v2
-      stop
   }
   
 - // === ROOT/tests/ui/codegen/mir/static-alloc/derived_chain.mir (before static-alloc) ===
@@ -52,23 +52,23 @@
     bb0:
 -     v0 = alloc raw, exact, uninitialized, infallible, 32
       jump bb5
-    bb1:
-      v1 = add v3, 0
-      v2 = mload v1
-      ret v2
-    bb2:
-      v3 = add v4, 0
-      jump bb1
-    bb3:
-      v4 = add v5, 0
-      jump bb2
-    bb4:
-      v5 = add v6, 0
-      jump bb3
     bb5:
 -     v6 = add v0, 0
 +     v6 = add 128, 0
       jump bb4
+    bb4:
+      v5 = add v6, 0
+      jump bb3
+    bb3:
+      v4 = add v5, 0
+      jump bb2
+    bb2:
+      v3 = add v4, 0
+      jump bb1
+    bb1:
+      v1 = add v3, 0
+      v2 = mload v1
+      ret v2
   }
   
   fn @reserve_frame() {
@@ -77,6 +77,10 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
+      v2 = mload 128
+      sstore 0, v2
+      stop
     bb2:
       v0 = mload 128
       v1 = add v0, 1
@@ -84,9 +88,5 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-      v2 = mload 128
-      sstore 0, v2
-      stop
   }
   

--- a/tests/ui/codegen/mir/storage-promotion/non_external.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/non_external.stdout
@@ -7,6 +7,8 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
+      stop
     bb2:
       v0 = sload 0
       v1 = mul v0, 2
@@ -14,7 +16,5 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-      stop
   }
   

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
@@ -1,24 +1,23 @@
 //@compile-flags: -Zmir-pipeline=storage-promotion
-//@filecheck: --check-prefix=RPO
+//@filecheck: --enable-var-scope
 @module StoragePromotion
-// RPO: @module StoragePromotion
 
 // CHECK-LABEL: @promote_recomputed_offset_slot
-// CHECK-DAG:       [[SLOT:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{[+-]?}}     sstore [[SLOT]], 1
-// CHECK-DAG:       mstore [[VALUE_ADDR:[0-9]+]], 1
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG:       [[BODY_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[BODY_SLOT]]
-// CHECK-DAG:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK-DAG:       {{v[0-9]+}} = mul {{v[0-9]+}}, 2
-// CHECK-DAG:       [[STORE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{[+-]?}}     sstore {{.*}}
-// CHECK-DAG:       mstore [[VALUE_ADDR]], [[UPDATED]]
-// CHECK-DAG:       [[EXIT]]:
-// CHECK-DAG:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK-DAG:       sstore [[SLOT]], [[VALUE]]
+// CHECK:       [[SLOT:v[0-9]+]] = add arg0, 1
+// CHECK: -     sstore [[SLOT]], 1
+// CHECK:       mstore [[VALUE_ADDR:[0-9]+]], 1
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK:       sstore [[SLOT]], [[VALUE]]
+// CHECK:       [[BODY]]:
+// CHECK:       [[BODY_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK: -     {{v[0-9]+}} = sload [[BODY_SLOT]]
+// CHECK:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK:       [[UPDATED:v[0-9]+]] = mul [[BODY_VALUE]], 2
+// CHECK:       [[STORE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK: -     sstore [[STORE_SLOT]], [[UPDATED]]
+// CHECK:       mstore [[VALUE_ADDR]], [[UPDATED]]
 fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
   bb0:
     v1 = add arg0, 1
@@ -40,10 +39,10 @@ fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @reject_loop_variant_offset_slot
-// CHECK-DAG:       [[SLOT:v[0-9]+]] = add arg0
-// CHECK-DAG: {{[+-]?}}     [[LOAD:v[0-9]+]] = sload [[SLOT]]
-// CHECK-DAG:       [[VALUE:v[0-9]+]] = add [[LOAD]], 2
-// CHECK-DAG: {{[+-]?}}     sstore [[SLOT]], [[VALUE]]
+// CHECK:       [[SLOT:v[0-9]+]] = add arg0
+// CHECK: +     [[LOAD:v[0-9]+]] = sload [[SLOT]]
+// CHECK:       [[VALUE:v[0-9]+]] = add [[LOAD]], 2
+// CHECK: +     sstore [[SLOT]], [[VALUE]]
 fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb1
@@ -62,15 +61,15 @@ fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_store_only_without_initial_load
-// CHECK-DAG:       mstore [[DIRTY_ADDR:[0-9]+]], 0
-// CHECK-DAG: {{[+-]?}}     sstore [[SLOT:[0-9]+]], 7
-// CHECK-DAG:       mstore [[VALUE_ADDR:[0-9]+]], 7
-// CHECK-DAG:       mstore [[DIRTY_ADDR]], 1
-// CHECK-DAG:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
-// CHECK-DAG:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG:       [[FLUSH]]:
-// CHECK-DAG:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK-DAG:       sstore [[SLOT]], [[VALUE]]
+// CHECK:       mstore [[DIRTY_ADDR:[0-9]+]], 0
+// CHECK:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
+// CHECK:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       [[FLUSH]]:
+// CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR:[0-9]+]]
+// CHECK:       sstore [[SLOT:[0-9]+]], [[VALUE]]
+// CHECK: -     sstore [[SLOT]], 7
+// CHECK:       mstore [[VALUE_ADDR]], 7
+// CHECK:       mstore [[DIRTY_ADDR]], 1
 fn @promote_store_only_without_initial_load() [selector=0x01020304] {
   bb0:
     jump bb1
@@ -86,27 +85,27 @@ fn @promote_store_only_without_initial_load() [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_two_initialized_slots
-// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT:[0-9]+]], 1
-// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT:[0-9]+]], 2
-// CHECK-DAG:       mstore [[ZERO_ADDR:[0-9]+]], 1
-// CHECK-DAG:       mstore [[ONE_ADDR:[0-9]+]], 2
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ZERO_SLOT]]
-// CHECK-DAG:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK-DAG:       [[ZERO_UPDATED:v[0-9]+]] = mul [[ZERO_VALUE]], 2
-// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ONE_SLOT]]
-// CHECK-DAG:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
-// CHECK-DAG:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK-DAG:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
-// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
-// CHECK-DAG:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
-// CHECK-DAG:       [[EXIT]]:
-// CHECK-DAG:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK-DAG:       sstore [[ONE_SLOT]], [[ONE]]
-// CHECK-DAG:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK-DAG:       sstore [[ZERO_SLOT]], [[ZERO]]
+// CHECK: -     sstore [[ZERO_SLOT:[0-9]+]], 1
+// CHECK: -     sstore [[ONE_SLOT:[0-9]+]], 2
+// CHECK:       mstore [[ZERO_ADDR:[0-9]+]], 1
+// CHECK:       mstore [[ONE_ADDR:[0-9]+]], 2
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK:       sstore [[ONE_SLOT]], [[ONE]]
+// CHECK:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK:       sstore [[ZERO_SLOT]], [[ZERO]]
+// CHECK:       [[BODY]]:
+// CHECK: -     {{v[0-9]+}} = sload [[ZERO_SLOT]]
+// CHECK:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK:       [[ZERO_UPDATED:v[0-9]+]] = mul [[ZERO_VALUE]], 2
+// CHECK: -     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
+// CHECK: -     {{v[0-9]+}} = sload [[ONE_SLOT]]
+// CHECK:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
+// CHECK:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
+// CHECK: -     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
+// CHECK:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
 fn @promote_two_initialized_slots() [selector=0x01020304] {
   bb0:
     sstore 0, 1
@@ -129,31 +128,31 @@ fn @promote_two_initialized_slots() [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_without_init_rewrites_successor_phi
-// CHECK-DAG:       [[INIT:v[0-9]+]] = sload [[SLOT:[0-9]+]]
-// CHECK-DAG:       mstore [[VALUE_ADDR:[0-9]+]], [[INIT]]
-// CHECK-DAG:       mstore [[DIRTY_ADDR:[0-9]+]], 0
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[LOOP_EXIT:bb[0-9]+]]
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[SLOT]]
-// CHECK-DAG:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK-DAG:       [[UPDATED:v[0-9]+]] = add [[BODY_VALUE]], 2
-// CHECK-DAG: {{[+-]?}}     sstore [[SLOT]], [[UPDATED]]
-// CHECK-DAG:       mstore [[VALUE_ADDR]], [[UPDATED]]
-// CHECK-DAG:       mstore [[DIRTY_ADDR]], 1
-// CHECK-DAG:       [[LOOP_EXIT]]:
-// CHECK-DAG:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
-// CHECK-DAG:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], [[CLEAN:bb[0-9]+]]
-// CHECK-DAG:       [[MERGE:bb[0-9]+]]:
-// CHECK-DAG:       [[PHI:v[0-9]+]] = phi [[[CLEAN]]: 7], [[[OTHER:bb[0-9]+]]: 9]
-// CHECK-DAG:       ret [[PHI]]
-// CHECK-DAG:       [[OTHER]]:
-// CHECK-DAG:       jump [[MERGE]]
-// CHECK-DAG:       [[CLEAN]]:
-// CHECK-DAG:       jump [[MERGE]]
-// CHECK-DAG:       [[FLUSH]]:
-// CHECK-DAG:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK-DAG:       sstore [[SLOT]], [[VALUE]]
-// CHECK-DAG:       jump [[CLEAN]]
+// CHECK:       [[INIT:v[0-9]+]] = sload [[SLOT:[0-9]+]]
+// CHECK:       mstore [[VALUE_ADDR:[0-9]+]], [[INIT]]
+// CHECK:       mstore [[DIRTY_ADDR:[0-9]+]], 0
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[LOOP_EXIT:bb[0-9]+]]
+// CHECK:       [[LOOP_EXIT]]:
+// CHECK:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
+// CHECK:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], [[CLEAN:bb[0-9]+]]
+// CHECK:       [[FLUSH]]:
+// CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK:       sstore [[SLOT]], [[VALUE]]
+// CHECK:       jump [[CLEAN]]
+// CHECK:       [[CLEAN]]:
+// CHECK:       jump [[MERGE:bb[0-9]+]]
+// CHECK:       [[MERGE]]:
+// CHECK:       [[PHI:v[0-9]+]] = phi [[[CLEAN]]: 7], [[[OTHER:bb[0-9]+]]: 9]
+// CHECK:       ret [[PHI]]
+// CHECK:       [[BODY]]:
+// CHECK: -     {{v[0-9]+}} = sload [[SLOT]]
+// CHECK:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK:       [[UPDATED:v[0-9]+]] = add [[BODY_VALUE]], 2
+// CHECK: -     sstore [[SLOT]], [[UPDATED]]
+// CHECK:       mstore [[VALUE_ADDR]], [[UPDATED]]
+// CHECK:       mstore [[DIRTY_ADDR]], 1
+// CHECK:       [[OTHER]]:
+// CHECK:       jump [[MERGE]]
 fn @promote_without_init_rewrites_successor_phi() -> u256 [selector=0x01020304] {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.mir
@@ -1,23 +1,24 @@
 //@compile-flags: -Zmir-pipeline=storage-promotion
-//@filecheck: --enable-var-scope
+//@filecheck: --check-prefix=RPO
 @module StoragePromotion
+// RPO: @module StoragePromotion
 
 // CHECK-LABEL: @promote_recomputed_offset_slot
-// CHECK:       [[SLOT:v[0-9]+]] = add arg0, 1
-// CHECK: -     sstore [[SLOT]], 1
-// CHECK:       mstore [[VALUE_ADDR:[0-9]+]], 1
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK:       [[BODY]]:
-// CHECK:       [[BODY_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK: -     {{v[0-9]+}} = sload [[BODY_SLOT]]
-// CHECK:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK:       [[UPDATED:v[0-9]+]] = mul [[BODY_VALUE]], 2
-// CHECK:       [[STORE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK: -     sstore [[STORE_SLOT]], [[UPDATED]]
-// CHECK:       mstore [[VALUE_ADDR]], [[UPDATED]]
-// CHECK:       [[EXIT]]:
-// CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK:       sstore [[SLOT]], [[VALUE]]
+// CHECK-DAG:       [[SLOT:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{[+-]?}}     sstore [[SLOT]], 1
+// CHECK-DAG:       mstore [[VALUE_ADDR:[0-9]+]], 1
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG:       [[BODY_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[BODY_SLOT]]
+// CHECK-DAG:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK-DAG:       {{v[0-9]+}} = mul {{v[0-9]+}}, 2
+// CHECK-DAG:       [[STORE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{[+-]?}}     sstore {{.*}}
+// CHECK-DAG:       mstore [[VALUE_ADDR]], [[UPDATED]]
+// CHECK-DAG:       [[EXIT]]:
+// CHECK-DAG:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK-DAG:       sstore [[SLOT]], [[VALUE]]
 fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
   bb0:
     v1 = add arg0, 1
@@ -39,10 +40,10 @@ fn @promote_recomputed_offset_slot(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @reject_loop_variant_offset_slot
-// CHECK:       [[SLOT:v[0-9]+]] = add arg0
-// CHECK: +     [[LOAD:v[0-9]+]] = sload [[SLOT]]
-// CHECK:       [[VALUE:v[0-9]+]] = add [[LOAD]], 2
-// CHECK: +     sstore [[SLOT]], [[VALUE]]
+// CHECK-DAG:       [[SLOT:v[0-9]+]] = add arg0
+// CHECK-DAG: {{[+-]?}}     [[LOAD:v[0-9]+]] = sload [[SLOT]]
+// CHECK-DAG:       [[VALUE:v[0-9]+]] = add [[LOAD]], 2
+// CHECK-DAG: {{[+-]?}}     sstore [[SLOT]], [[VALUE]]
 fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb1
@@ -61,15 +62,15 @@ fn @reject_loop_variant_offset_slot(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_store_only_without_initial_load
-// CHECK:       mstore [[DIRTY_ADDR:[0-9]+]], 0
-// CHECK: -     sstore [[SLOT:[0-9]+]], 7
-// CHECK:       mstore [[VALUE_ADDR:[0-9]+]], 7
-// CHECK:       mstore [[DIRTY_ADDR]], 1
-// CHECK:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
-// CHECK:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK:       [[FLUSH]]:
-// CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK:       sstore [[SLOT]], [[VALUE]]
+// CHECK-DAG:       mstore [[DIRTY_ADDR:[0-9]+]], 0
+// CHECK-DAG: {{[+-]?}}     sstore [[SLOT:[0-9]+]], 7
+// CHECK-DAG:       mstore [[VALUE_ADDR:[0-9]+]], 7
+// CHECK-DAG:       mstore [[DIRTY_ADDR]], 1
+// CHECK-DAG:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
+// CHECK-DAG:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG:       [[FLUSH]]:
+// CHECK-DAG:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK-DAG:       sstore [[SLOT]], [[VALUE]]
 fn @promote_store_only_without_initial_load() [selector=0x01020304] {
   bb0:
     jump bb1
@@ -85,27 +86,27 @@ fn @promote_store_only_without_initial_load() [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_two_initialized_slots
-// CHECK: -     sstore [[ZERO_SLOT:[0-9]+]], 1
-// CHECK: -     sstore [[ONE_SLOT:[0-9]+]], 2
-// CHECK:       mstore [[ZERO_ADDR:[0-9]+]], 1
-// CHECK:       mstore [[ONE_ADDR:[0-9]+]], 2
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK:       [[BODY]]:
-// CHECK: -     {{v[0-9]+}} = sload [[ZERO_SLOT]]
-// CHECK:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK:       [[ZERO_UPDATED:v[0-9]+]] = mul [[ZERO_VALUE]], 2
-// CHECK: -     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
-// CHECK: -     {{v[0-9]+}} = sload [[ONE_SLOT]]
-// CHECK:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
-// CHECK:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
-// CHECK: -     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
-// CHECK:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
-// CHECK:       [[EXIT]]:
-// CHECK:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK:       sstore [[ONE_SLOT]], [[ONE]]
-// CHECK:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK:       sstore [[ZERO_SLOT]], [[ZERO]]
+// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT:[0-9]+]], 1
+// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT:[0-9]+]], 2
+// CHECK-DAG:       mstore [[ZERO_ADDR:[0-9]+]], 1
+// CHECK-DAG:       mstore [[ONE_ADDR:[0-9]+]], 2
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ZERO_SLOT]]
+// CHECK-DAG:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK-DAG:       [[ZERO_UPDATED:v[0-9]+]] = mul [[ZERO_VALUE]], 2
+// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ONE_SLOT]]
+// CHECK-DAG:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
+// CHECK-DAG:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK-DAG:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
+// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
+// CHECK-DAG:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
+// CHECK-DAG:       [[EXIT]]:
+// CHECK-DAG:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK-DAG:       sstore [[ONE_SLOT]], [[ONE]]
+// CHECK-DAG:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK-DAG:       sstore [[ZERO_SLOT]], [[ZERO]]
 fn @promote_two_initialized_slots() [selector=0x01020304] {
   bb0:
     sstore 0, 1
@@ -128,31 +129,31 @@ fn @promote_two_initialized_slots() [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_without_init_rewrites_successor_phi
-// CHECK:       [[INIT:v[0-9]+]] = sload [[SLOT:[0-9]+]]
-// CHECK:       mstore [[VALUE_ADDR:[0-9]+]], [[INIT]]
-// CHECK:       mstore [[DIRTY_ADDR:[0-9]+]], 0
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[LOOP_EXIT:bb[0-9]+]]
-// CHECK:       [[BODY]]:
-// CHECK: -     {{v[0-9]+}} = sload [[SLOT]]
-// CHECK:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK:       [[UPDATED:v[0-9]+]] = add [[BODY_VALUE]], 2
-// CHECK: -     sstore [[SLOT]], [[UPDATED]]
-// CHECK:       mstore [[VALUE_ADDR]], [[UPDATED]]
-// CHECK:       mstore [[DIRTY_ADDR]], 1
-// CHECK:       [[LOOP_EXIT]]:
-// CHECK:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
-// CHECK:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], [[CLEAN:bb[0-9]+]]
-// CHECK:       [[MERGE:bb[0-9]+]]:
-// CHECK:       [[PHI:v[0-9]+]] = phi [[[CLEAN]]: 7], [[[OTHER:bb[0-9]+]]: 9]
-// CHECK:       ret [[PHI]]
-// CHECK:       [[OTHER]]:
-// CHECK:       jump [[MERGE]]
-// CHECK:       [[CLEAN]]:
-// CHECK:       jump [[MERGE]]
-// CHECK:       [[FLUSH]]:
-// CHECK:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
-// CHECK:       sstore [[SLOT]], [[VALUE]]
-// CHECK:       jump [[CLEAN]]
+// CHECK-DAG:       [[INIT:v[0-9]+]] = sload [[SLOT:[0-9]+]]
+// CHECK-DAG:       mstore [[VALUE_ADDR:[0-9]+]], [[INIT]]
+// CHECK-DAG:       mstore [[DIRTY_ADDR:[0-9]+]], 0
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[LOOP_EXIT:bb[0-9]+]]
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[SLOT]]
+// CHECK-DAG:       [[BODY_VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK-DAG:       [[UPDATED:v[0-9]+]] = add [[BODY_VALUE]], 2
+// CHECK-DAG: {{[+-]?}}     sstore [[SLOT]], [[UPDATED]]
+// CHECK-DAG:       mstore [[VALUE_ADDR]], [[UPDATED]]
+// CHECK-DAG:       mstore [[DIRTY_ADDR]], 1
+// CHECK-DAG:       [[LOOP_EXIT]]:
+// CHECK-DAG:       [[DIRTY:v[0-9]+]] = mload [[DIRTY_ADDR]]
+// CHECK-DAG:       jumpi [[DIRTY]], [[FLUSH:bb[0-9]+]], [[CLEAN:bb[0-9]+]]
+// CHECK-DAG:       [[MERGE:bb[0-9]+]]:
+// CHECK-DAG:       [[PHI:v[0-9]+]] = phi [[[CLEAN]]: 7], [[[OTHER:bb[0-9]+]]: 9]
+// CHECK-DAG:       ret [[PHI]]
+// CHECK-DAG:       [[OTHER]]:
+// CHECK-DAG:       jump [[MERGE]]
+// CHECK-DAG:       [[CLEAN]]:
+// CHECK-DAG:       jump [[MERGE]]
+// CHECK-DAG:       [[FLUSH]]:
+// CHECK-DAG:       [[VALUE:v[0-9]+]] = mload [[VALUE_ADDR]]
+// CHECK-DAG:       sstore [[SLOT]], [[VALUE]]
+// CHECK-DAG:       jump [[CLEAN]]
 fn @promote_without_init_rewrites_successor_phi() -> u256 [selector=0x01020304] {
   bb0:
     jump bb1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion.stdout
@@ -9,6 +9,10 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v5 = mload 128
++     sstore v0, v5
+      stop
     bb2:
       v1 = add arg0, 1
 -     v2 = sload v1
@@ -20,10 +24,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-+     v5 = mload 128
-+     sstore v0, v5
-      stop
   }
   
   fn @reject_loop_variant_offset_slot(arg0: u256) {
@@ -32,6 +32,8 @@
     bb1:
       v0 = phi [bb0: 0], [bb2: v4]
       jumpi 1, bb2, bb3
+    bb3:
+      stop
     bb2:
       v1 = add arg0, v0
 -     v2 = sload v1
@@ -41,8 +43,6 @@
 +     sstore v1, v3 !metadata(storage=symbolic(v1))
       v4 = add v0, 1
       jump bb1
-    bb3:
-      stop
   }
   
   fn @promote_store_only_without_initial_load() {
@@ -51,6 +51,15 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v0 = mload 160
++     jumpi v0, bb6, bb5
++   bb6:
++     v1 = mload 128
++     sstore 0, v1
++     jump bb5
++   bb5:
+      stop
     bb2:
 -     sstore 0, 7
 +     mstore 128, 7
@@ -58,15 +67,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-+     v0 = mload 160
-+     jumpi v0, bb6, bb5
-+   bb5:
-      stop
-+   bb6:
-+     v1 = mload 128
-+     sstore 0, v1
-+     jump bb5
   }
   
   fn @promote_two_initialized_slots() {
@@ -78,6 +78,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v5 = mload 160
++     sstore 1, v5
++     v4 = mload 128
++     sstore 0, v4
+      stop
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -92,12 +98,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-+     v5 = mload 160
-+     sstore 1, v5
-+     v4 = mload 128
-+     sstore 0, v4
-      stop
   }
   
   fn @promote_without_init_rewrites_successor_phi() -> u256 {
@@ -108,6 +108,19 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v4 = mload 160
++     jumpi v4, bb8, bb7
++   bb8:
++     v5 = mload 128
++     sstore 0, v5
++     jump bb7
++   bb7:
+      jump bb5
+    bb5:
+-     v2 = phi [bb4: 7], [bb6: 9]
++     v2 = phi [bb7: 7], [bb6: 9]
+      ret v2
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -118,21 +131,7 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
--     jump bb5
-+     v4 = mload 160
-+     jumpi v4, bb8, bb7
-    bb5:
--     v2 = phi [bb4: 7], [bb6: 9]
-+     v2 = phi [bb7: 7], [bb6: 9]
-      ret v2
     bb6:
       jump bb5
-+   bb7:
-+     jump bb5
-+   bb8:
-+     v5 = mload 128
-+     sstore 0, v5
-+     jump bb7
   }
   

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
@@ -1,18 +1,19 @@
 //@compile-flags: -Zmir-pipeline=storage-promotion
-//@filecheck: --enable-var-scope
+//@filecheck: --check-prefix=RPO
 @module StoragePromotionAlias
+// RPO: @module StoragePromotionAlias
 
 // CHECK-LABEL: @reject_two_symbolic_slots
-// CHECK: +     sstore arg0, 1
-// CHECK: +     sstore arg1, 2
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK:       [[BODY]]:
-// CHECK: +     [[FIRST:v[0-9]+]] = sload arg0
-// CHECK:       [[FIRST_UPDATED:v[0-9]+]] = mul [[FIRST]], 2
-// CHECK: +     sstore arg0, [[FIRST_UPDATED]]
-// CHECK: +     [[SECOND:v[0-9]+]] = sload arg1
-// CHECK:       [[SECOND_UPDATED:v[0-9]+]] = add [[SECOND]], 3
-// CHECK: +     sstore arg1, [[SECOND_UPDATED]]
+// CHECK-DAG: {{[+-]?}}     sstore arg0, 1
+// CHECK-DAG: {{[+-]?}}     sstore arg1, 2
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG: {{[+-]?}}     [[FIRST:v[0-9]+]] = sload arg0
+// CHECK-DAG:       [[FIRST_UPDATED:v[0-9]+]] = mul [[FIRST]], 2
+// CHECK-DAG: {{[+-]?}}     sstore arg0, [[FIRST_UPDATED]]
+// CHECK-DAG: {{[+-]?}}     [[SECOND:v[0-9]+]] = sload arg1
+// CHECK-DAG:       [[SECOND_UPDATED:v[0-9]+]] = add [[SECOND]], 3
+// CHECK-DAG: {{[+-]?}}     sstore arg1, [[SECOND_UPDATED]]
 fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
   bb0:
     sstore arg0, 1
@@ -35,16 +36,16 @@ fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @reject_symbolic_and_constant_slots
-// CHECK: +     sstore arg0, 1
-// CHECK: +     sstore [[CONSTANT_SLOT:[0-9]+]], 2
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK:       [[BODY]]:
-// CHECK: +     [[SYMBOLIC:v[0-9]+]] = sload arg0
-// CHECK:       [[SYMBOLIC_UPDATED:v[0-9]+]] = mul [[SYMBOLIC]], 2
-// CHECK: +     sstore arg0, [[SYMBOLIC_UPDATED]]
-// CHECK: +     [[CONSTANT:v[0-9]+]] = sload [[CONSTANT_SLOT]]
-// CHECK:       [[CONSTANT_UPDATED:v[0-9]+]] = add [[CONSTANT]], 3
-// CHECK: +     sstore [[CONSTANT_SLOT]], [[CONSTANT_UPDATED]]
+// CHECK-DAG: {{[+-]?}}     sstore arg0, 1
+// CHECK-DAG: {{[+-]?}}     sstore [[CONSTANT_SLOT:[0-9]+]], 2
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG: {{[+-]?}}     [[SYMBOLIC:v[0-9]+]] = sload arg0
+// CHECK-DAG:       [[SYMBOLIC_UPDATED:v[0-9]+]] = mul [[SYMBOLIC]], 2
+// CHECK-DAG: {{[+-]?}}     sstore arg0, [[SYMBOLIC_UPDATED]]
+// CHECK-DAG: {{[+-]?}}     [[CONSTANT:v[0-9]+]] = sload [[CONSTANT_SLOT]]
+// CHECK-DAG:       [[CONSTANT_UPDATED:v[0-9]+]] = add [[CONSTANT]], 3
+// CHECK-DAG: {{[+-]?}}     sstore [[CONSTANT_SLOT]], [[CONSTANT_UPDATED]]
 fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
   bb0:
     sstore arg0, 1
@@ -67,27 +68,27 @@ fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_two_constant_slots
-// CHECK: -     sstore [[ZERO_SLOT:[0-9]+]], 1
-// CHECK: -     sstore [[ONE_SLOT:[0-9]+]], 2
-// CHECK:       mstore [[ZERO_ADDR:[0-9]+]], 1
-// CHECK:       mstore [[ONE_ADDR:[0-9]+]], 2
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK:       [[BODY]]:
-// CHECK: -     {{v[0-9]+}} = sload [[ZERO_SLOT]]
-// CHECK:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK:       [[ZERO_UPDATED:v[0-9]+]] = mul [[ZERO_VALUE]], 2
-// CHECK: -     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
-// CHECK: -     {{v[0-9]+}} = sload [[ONE_SLOT]]
-// CHECK:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
-// CHECK:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
-// CHECK: -     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
-// CHECK:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
-// CHECK:       [[EXIT]]:
-// CHECK:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK:       sstore [[ONE_SLOT]], [[ONE]]
-// CHECK:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK:       sstore [[ZERO_SLOT]], [[ZERO]]
+// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT:[0-9]+]], 1
+// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT:[0-9]+]], 2
+// CHECK-DAG:       mstore [[ZERO_ADDR:[0-9]+]], 1
+// CHECK-DAG:       mstore [[ONE_ADDR:[0-9]+]], 2
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ZERO_SLOT]]
+// CHECK-DAG:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK-DAG:       {{v[0-9]+}} = mul {{v[0-9]+}}, 2
+// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ONE_SLOT]]
+// CHECK-DAG:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
+// CHECK-DAG:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK-DAG:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
+// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
+// CHECK-DAG:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
+// CHECK-DAG:       [[EXIT]]:
+// CHECK-DAG:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK-DAG:       sstore [[ONE_SLOT]], [[ONE]]
+// CHECK-DAG:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK-DAG:       sstore [[ZERO_SLOT]], [[ZERO]]
 fn @promote_two_constant_slots() [selector=0x01020304] {
   bb0:
     sstore 0, 1
@@ -110,33 +111,33 @@ fn @promote_two_constant_slots() [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_same_base_distinct_offsets
-// CHECK:       [[ONE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK: -     sstore [[ONE_SLOT]], 1
-// CHECK:       mstore [[ONE_ADDR:[0-9]+]], 1
-// CHECK:       [[TWO_SLOT:v[0-9]+]] = add arg0, 2
-// CHECK: -     sstore [[TWO_SLOT]], 2
-// CHECK:       mstore [[TWO_ADDR:[0-9]+]], 2
-// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK:       [[BODY]]:
-// CHECK:       [[BODY_ONE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK: -     {{v[0-9]+}} = sload [[BODY_ONE_SLOT]]
-// CHECK:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK:       [[ONE_UPDATED:v[0-9]+]] = mul [[ONE_VALUE]], 2
-// CHECK:       [[STORE_ONE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK: -     sstore [[STORE_ONE_SLOT]], [[ONE_UPDATED]]
-// CHECK:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
-// CHECK:       [[BODY_TWO_SLOT:v[0-9]+]] = add arg0, 2
-// CHECK: -     {{v[0-9]+}} = sload [[BODY_TWO_SLOT]]
-// CHECK:       [[TWO_VALUE:v[0-9]+]] = mload [[TWO_ADDR]]
-// CHECK:       [[TWO_UPDATED:v[0-9]+]] = add [[TWO_VALUE]], 3
-// CHECK:       [[STORE_TWO_SLOT:v[0-9]+]] = add arg0, 2
-// CHECK: -     sstore [[STORE_TWO_SLOT]], [[TWO_UPDATED]]
-// CHECK:       mstore [[TWO_ADDR]], [[TWO_UPDATED]]
-// CHECK:       [[EXIT]]:
-// CHECK:       [[TWO_FLUSH:v[0-9]+]] = mload [[TWO_ADDR]]
-// CHECK:       sstore [[TWO_SLOT]], [[TWO_FLUSH]]
-// CHECK:       [[ONE_FLUSH:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK:       sstore [[ONE_SLOT]], [[ONE_FLUSH]]
+// CHECK-DAG:       [[ONE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT]], 1
+// CHECK-DAG:       mstore [[ONE_ADDR:[0-9]+]], 1
+// CHECK-DAG:       [[TWO_SLOT:v[0-9]+]] = add arg0, 2
+// CHECK-DAG: {{[+-]?}}     sstore [[TWO_SLOT]], 2
+// CHECK-DAG:       mstore [[TWO_ADDR:[0-9]+]], 2
+// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK-DAG:       [[BODY]]:
+// CHECK-DAG:       [[BODY_ONE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[BODY_ONE_SLOT]]
+// CHECK-DAG:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK-DAG:       [[ONE_UPDATED:v[0-9]+]] = mul [[ONE_VALUE]], 2
+// CHECK-DAG:       [[STORE_ONE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK-DAG: {{[+-]?}}     sstore [[STORE_ONE_SLOT]], [[ONE_UPDATED]]
+// CHECK-DAG:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
+// CHECK-DAG:       [[BODY_TWO_SLOT:v[0-9]+]] = add arg0, 2
+// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[BODY_TWO_SLOT]]
+// CHECK-DAG:       [[TWO_VALUE:v[0-9]+]] = mload [[TWO_ADDR]]
+// CHECK-DAG:       [[TWO_UPDATED:v[0-9]+]] = add [[TWO_VALUE]], 3
+// CHECK-DAG:       [[STORE_TWO_SLOT:v[0-9]+]] = add arg0, 2
+// CHECK-DAG: {{[+-]?}}     sstore [[STORE_TWO_SLOT]], [[TWO_UPDATED]]
+// CHECK-DAG:       mstore [[TWO_ADDR]], [[TWO_UPDATED]]
+// CHECK-DAG:       [[EXIT]]:
+// CHECK-DAG:       [[TWO_FLUSH:v[0-9]+]] = mload [[TWO_ADDR]]
+// CHECK-DAG:       sstore [[TWO_SLOT]], [[TWO_FLUSH]]
+// CHECK-DAG:       [[ONE_FLUSH:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK-DAG:       sstore [[ONE_SLOT]], [[ONE_FLUSH]]
 fn @promote_same_base_distinct_offsets(arg0: u256) [selector=0x01020304] {
   bb0:
     v1 = add arg0, 1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.mir
@@ -1,19 +1,18 @@
 //@compile-flags: -Zmir-pipeline=storage-promotion
-//@filecheck: --check-prefix=RPO
+//@filecheck: --enable-var-scope
 @module StoragePromotionAlias
-// RPO: @module StoragePromotionAlias
 
 // CHECK-LABEL: @reject_two_symbolic_slots
-// CHECK-DAG: {{[+-]?}}     sstore arg0, 1
-// CHECK-DAG: {{[+-]?}}     sstore arg1, 2
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG: {{[+-]?}}     [[FIRST:v[0-9]+]] = sload arg0
-// CHECK-DAG:       [[FIRST_UPDATED:v[0-9]+]] = mul [[FIRST]], 2
-// CHECK-DAG: {{[+-]?}}     sstore arg0, [[FIRST_UPDATED]]
-// CHECK-DAG: {{[+-]?}}     [[SECOND:v[0-9]+]] = sload arg1
-// CHECK-DAG:       [[SECOND_UPDATED:v[0-9]+]] = add [[SECOND]], 3
-// CHECK-DAG: {{[+-]?}}     sstore arg1, [[SECOND_UPDATED]]
+// CHECK: +     sstore arg0, 1
+// CHECK: +     sstore arg1, 2
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       [[BODY]]:
+// CHECK: +     [[FIRST:v[0-9]+]] = sload arg0
+// CHECK:       [[FIRST_UPDATED:v[0-9]+]] = mul [[FIRST]], 2
+// CHECK: +     sstore arg0, [[FIRST_UPDATED]]
+// CHECK: +     [[SECOND:v[0-9]+]] = sload arg1
+// CHECK:       [[SECOND_UPDATED:v[0-9]+]] = add [[SECOND]], 3
+// CHECK: +     sstore arg1, [[SECOND_UPDATED]]
 fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
   bb0:
     sstore arg0, 1
@@ -36,16 +35,16 @@ fn @reject_two_symbolic_slots(arg0: u256, arg1: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @reject_symbolic_and_constant_slots
-// CHECK-DAG: {{[+-]?}}     sstore arg0, 1
-// CHECK-DAG: {{[+-]?}}     sstore [[CONSTANT_SLOT:[0-9]+]], 2
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG: {{[+-]?}}     [[SYMBOLIC:v[0-9]+]] = sload arg0
-// CHECK-DAG:       [[SYMBOLIC_UPDATED:v[0-9]+]] = mul [[SYMBOLIC]], 2
-// CHECK-DAG: {{[+-]?}}     sstore arg0, [[SYMBOLIC_UPDATED]]
-// CHECK-DAG: {{[+-]?}}     [[CONSTANT:v[0-9]+]] = sload [[CONSTANT_SLOT]]
-// CHECK-DAG:       [[CONSTANT_UPDATED:v[0-9]+]] = add [[CONSTANT]], 3
-// CHECK-DAG: {{[+-]?}}     sstore [[CONSTANT_SLOT]], [[CONSTANT_UPDATED]]
+// CHECK: +     sstore arg0, 1
+// CHECK: +     sstore [[CONSTANT_SLOT:[0-9]+]], 2
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], {{bb[0-9]+}}
+// CHECK:       [[BODY]]:
+// CHECK: +     [[SYMBOLIC:v[0-9]+]] = sload arg0
+// CHECK:       [[SYMBOLIC_UPDATED:v[0-9]+]] = mul [[SYMBOLIC]], 2
+// CHECK: +     sstore arg0, [[SYMBOLIC_UPDATED]]
+// CHECK: +     [[CONSTANT:v[0-9]+]] = sload [[CONSTANT_SLOT]]
+// CHECK:       [[CONSTANT_UPDATED:v[0-9]+]] = add [[CONSTANT]], 3
+// CHECK: +     sstore [[CONSTANT_SLOT]], [[CONSTANT_UPDATED]]
 fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
   bb0:
     sstore arg0, 1
@@ -68,27 +67,27 @@ fn @reject_symbolic_and_constant_slots(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_two_constant_slots
-// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT:[0-9]+]], 1
-// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT:[0-9]+]], 2
-// CHECK-DAG:       mstore [[ZERO_ADDR:[0-9]+]], 1
-// CHECK-DAG:       mstore [[ONE_ADDR:[0-9]+]], 2
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ZERO_SLOT]]
-// CHECK-DAG:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK-DAG:       {{v[0-9]+}} = mul {{v[0-9]+}}, 2
-// CHECK-DAG: {{[+-]?}}     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[ONE_SLOT]]
-// CHECK-DAG:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
-// CHECK-DAG:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK-DAG:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
-// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
-// CHECK-DAG:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
-// CHECK-DAG:       [[EXIT]]:
-// CHECK-DAG:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK-DAG:       sstore [[ONE_SLOT]], [[ONE]]
-// CHECK-DAG:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
-// CHECK-DAG:       sstore [[ZERO_SLOT]], [[ZERO]]
+// CHECK: -     sstore [[ZERO_SLOT:[0-9]+]], 1
+// CHECK: -     sstore [[ONE_SLOT:[0-9]+]], 2
+// CHECK:       mstore [[ZERO_ADDR:[0-9]+]], 1
+// CHECK:       mstore [[ONE_ADDR:[0-9]+]], 2
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:       [[ONE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK:       sstore [[ONE_SLOT]], [[ONE]]
+// CHECK:       [[ZERO:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK:       sstore [[ZERO_SLOT]], [[ZERO]]
+// CHECK:       [[BODY]]:
+// CHECK: -     {{v[0-9]+}} = sload [[ZERO_SLOT]]
+// CHECK:       [[ZERO_VALUE:v[0-9]+]] = mload [[ZERO_ADDR]]
+// CHECK:       [[ZERO_UPDATED:v[0-9]+]] = mul [[ZERO_VALUE]], 2
+// CHECK: -     sstore [[ZERO_SLOT]], [[ZERO_UPDATED]]
+// CHECK: -     {{v[0-9]+}} = sload [[ONE_SLOT]]
+// CHECK:       mstore [[ZERO_ADDR]], [[ZERO_UPDATED]]
+// CHECK:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK:       [[ONE_UPDATED:v[0-9]+]] = add [[ONE_VALUE]], 3
+// CHECK: -     sstore [[ONE_SLOT]], [[ONE_UPDATED]]
+// CHECK:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
 fn @promote_two_constant_slots() [selector=0x01020304] {
   bb0:
     sstore 0, 1
@@ -111,33 +110,33 @@ fn @promote_two_constant_slots() [selector=0x01020304] {
 }
 
 // CHECK-LABEL: @promote_same_base_distinct_offsets
-// CHECK-DAG:       [[ONE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{[+-]?}}     sstore [[ONE_SLOT]], 1
-// CHECK-DAG:       mstore [[ONE_ADDR:[0-9]+]], 1
-// CHECK-DAG:       [[TWO_SLOT:v[0-9]+]] = add arg0, 2
-// CHECK-DAG: {{[+-]?}}     sstore [[TWO_SLOT]], 2
-// CHECK-DAG:       mstore [[TWO_ADDR:[0-9]+]], 2
-// CHECK-DAG:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
-// CHECK-DAG:       [[BODY]]:
-// CHECK-DAG:       [[BODY_ONE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[BODY_ONE_SLOT]]
-// CHECK-DAG:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK-DAG:       [[ONE_UPDATED:v[0-9]+]] = mul [[ONE_VALUE]], 2
-// CHECK-DAG:       [[STORE_ONE_SLOT:v[0-9]+]] = add arg0, 1
-// CHECK-DAG: {{[+-]?}}     sstore [[STORE_ONE_SLOT]], [[ONE_UPDATED]]
-// CHECK-DAG:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
-// CHECK-DAG:       [[BODY_TWO_SLOT:v[0-9]+]] = add arg0, 2
-// CHECK-DAG: {{[+-]?}}     {{v[0-9]+}} = sload [[BODY_TWO_SLOT]]
-// CHECK-DAG:       [[TWO_VALUE:v[0-9]+]] = mload [[TWO_ADDR]]
-// CHECK-DAG:       [[TWO_UPDATED:v[0-9]+]] = add [[TWO_VALUE]], 3
-// CHECK-DAG:       [[STORE_TWO_SLOT:v[0-9]+]] = add arg0, 2
-// CHECK-DAG: {{[+-]?}}     sstore [[STORE_TWO_SLOT]], [[TWO_UPDATED]]
-// CHECK-DAG:       mstore [[TWO_ADDR]], [[TWO_UPDATED]]
-// CHECK-DAG:       [[EXIT]]:
-// CHECK-DAG:       [[TWO_FLUSH:v[0-9]+]] = mload [[TWO_ADDR]]
-// CHECK-DAG:       sstore [[TWO_SLOT]], [[TWO_FLUSH]]
-// CHECK-DAG:       [[ONE_FLUSH:v[0-9]+]] = mload [[ONE_ADDR]]
-// CHECK-DAG:       sstore [[ONE_SLOT]], [[ONE_FLUSH]]
+// CHECK:       [[ONE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK: -     sstore [[ONE_SLOT]], 1
+// CHECK:       mstore [[ONE_ADDR:[0-9]+]], 1
+// CHECK:       [[TWO_SLOT:v[0-9]+]] = add arg0, 2
+// CHECK: -     sstore [[TWO_SLOT]], 2
+// CHECK:       mstore [[TWO_ADDR:[0-9]+]], 2
+// CHECK:       jumpi {{.*}}, [[BODY:bb[0-9]+]], [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:       [[TWO_FLUSH:v[0-9]+]] = mload [[TWO_ADDR]]
+// CHECK:       sstore [[TWO_SLOT]], [[TWO_FLUSH]]
+// CHECK:       [[ONE_FLUSH:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK:       sstore [[ONE_SLOT]], [[ONE_FLUSH]]
+// CHECK:       [[BODY]]:
+// CHECK:       [[BODY_ONE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK: -     {{v[0-9]+}} = sload [[BODY_ONE_SLOT]]
+// CHECK:       [[ONE_VALUE:v[0-9]+]] = mload [[ONE_ADDR]]
+// CHECK:       [[ONE_UPDATED:v[0-9]+]] = mul [[ONE_VALUE]], 2
+// CHECK:       [[STORE_ONE_SLOT:v[0-9]+]] = add arg0, 1
+// CHECK: -     sstore [[STORE_ONE_SLOT]], [[ONE_UPDATED]]
+// CHECK:       mstore [[ONE_ADDR]], [[ONE_UPDATED]]
+// CHECK:       [[BODY_TWO_SLOT:v[0-9]+]] = add arg0, 2
+// CHECK: -     {{v[0-9]+}} = sload [[BODY_TWO_SLOT]]
+// CHECK:       [[TWO_VALUE:v[0-9]+]] = mload [[TWO_ADDR]]
+// CHECK:       [[TWO_UPDATED:v[0-9]+]] = add [[TWO_VALUE]], 3
+// CHECK:       [[STORE_TWO_SLOT:v[0-9]+]] = add arg0, 2
+// CHECK: -     sstore [[STORE_TWO_SLOT]], [[TWO_UPDATED]]
+// CHECK:       mstore [[TWO_ADDR]], [[TWO_UPDATED]]
 fn @promote_same_base_distinct_offsets(arg0: u256) [selector=0x01020304] {
   bb0:
     v1 = add arg0, 1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_alias.stdout
@@ -10,6 +10,8 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
+      stop
     bb2:
 -     v0 = sload arg0
 +     v0 = sload arg0 !metadata(storage=symbolic(arg0))
@@ -24,8 +26,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-      stop
   }
   
   fn @reject_symbolic_and_constant_slots(arg0: u256) {
@@ -37,6 +37,8 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
+      stop
     bb2:
 -     v0 = sload arg0
 +     v0 = sload arg0 !metadata(storage=symbolic(arg0))
@@ -51,8 +53,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-      stop
   }
   
   fn @promote_two_constant_slots() {
@@ -64,6 +64,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v5 = mload 160
++     sstore 1, v5
++     v4 = mload 128
++     sstore 0, v4
+      stop
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -78,12 +84,6 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-+     v5 = mload 160
-+     sstore 1, v5
-+     v4 = mload 128
-+     sstore 0, v4
-      stop
   }
   
   fn @promote_same_base_distinct_offsets(arg0: u256) {
@@ -97,6 +97,12 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb4
+    bb4:
++     v11 = mload 160
++     sstore v1, v11
++     v10 = mload 128
++     sstore v0, v10
+      stop
     bb2:
       v2 = add arg0, 1
 -     v3 = sload v2
@@ -115,11 +121,5 @@
       jump bb3
     bb3:
       jump bb1
-    bb4:
-+     v11 = mload 160
-+     sstore v1, v11
-+     v10 = mload 128
-+     sstore v0, v10
-      stop
   }
   

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
@@ -9,10 +9,11 @@
 // The relocated inner flush writes the same slot the outer latch updates, so
 // after re-analysis the outer loop promotes both stores consistently.
 // CHECK-LABEL: {{^[ +].*}}fn @promote_outer_after_inner_flush_split{{[( ]}}
-// CHECK-DAG: {{[+-]?}} [[INITIAL:v[0-9]+]] = sload 0
-// CHECK-DAG: {{[+-]?}} mstore 192, [[INITIAL]]
-// CHECK-DAG: {{[+-]?}} [[FLUSH:v[0-9]+]] = mload 192
-// CHECK-DAG: {{[+-]?}} sstore 0, [[FLUSH]]
+// CHECK: + [[INITIAL:v[0-9]+]] = sload 0
+// CHECK: + mstore 192, [[INITIAL]]
+// CHECK: + [[FLUSH:v[0-9]+]] = mload 192
+// CHECK: + sstore 0, [[FLUSH]]
+// CHECK: + {{v[0-9]+}} = mload 192
 fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
   bb0:
     jump bb6
@@ -41,8 +42,8 @@ fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
 // The relocated inner flush targets a symbolic slot that may alias the outer
 // latch's constant slot, so the outer loop must not be promoted.
 // CHECK-LABEL: {{^[ +].*}}fn @reject_outer_when_inner_flush_may_alias{{[( ]}}
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = sload 0
-// CHECK-DAG: {{[+-]?}} sstore 0
+// CHECK: + {{v[0-9]+}} = sload 0
+// CHECK: + sstore 0
 fn @reject_outer_when_inner_flush_may_alias(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb6

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.mir
@@ -9,11 +9,10 @@
 // The relocated inner flush writes the same slot the outer latch updates, so
 // after re-analysis the outer loop promotes both stores consistently.
 // CHECK-LABEL: {{^[ +].*}}fn @promote_outer_after_inner_flush_split{{[( ]}}
-// CHECK: + [[INITIAL:v[0-9]+]] = sload 0
-// CHECK: + mstore 192, [[INITIAL]]
-// CHECK: + {{v[0-9]+}} = mload 192
-// CHECK: + [[FLUSH:v[0-9]+]] = mload 192
-// CHECK: + sstore 0, [[FLUSH]]
+// CHECK-DAG: {{[+-]?}} [[INITIAL:v[0-9]+]] = sload 0
+// CHECK-DAG: {{[+-]?}} mstore 192, [[INITIAL]]
+// CHECK-DAG: {{[+-]?}} [[FLUSH:v[0-9]+]] = mload 192
+// CHECK-DAG: {{[+-]?}} sstore 0, [[FLUSH]]
 fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
   bb0:
     jump bb6
@@ -42,8 +41,8 @@ fn @promote_outer_after_inner_flush_split() [selector=0x01020304] {
 // The relocated inner flush targets a symbolic slot that may alias the outer
 // latch's constant slot, so the outer loop must not be promoted.
 // CHECK-LABEL: {{^[ +].*}}fn @reject_outer_when_inner_flush_may_alias{{[( ]}}
-// CHECK: + {{v[0-9]+}} = sload 0
-// CHECK: + sstore 0
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = sload 0
+// CHECK-DAG: {{[+-]?}} sstore 0
 fn @reject_outer_when_inner_flush_may_alias(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb6

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_nested.stdout
@@ -7,19 +7,32 @@
 +     mstore 192, v4
 +     mstore 224, 0
       jump bb6
+    bb6:
+      jumpi 1, bb7, bb8
+    bb8:
++     v5 = mload 224
++     jumpi v5, bb12, bb11
++   bb12:
++     v6 = mload 192
++     sstore 0, v6
++     jump bb11
++   bb11:
+      stop
+    bb7:
++     mstore 160, 0
+      jump bb1
     bb1:
       jumpi 1, bb2, bb4
-    bb2:
--     sstore 0, 7
-+     mstore 128, 7
-+     mstore 160, 1
-      jump bb3
-    bb3:
-      jump bb1
     bb4:
--     jump bb5
 +     v2 = mload 160
 +     jumpi v2, bb10, bb9
++   bb10:
++     v3 = mload 128
++     mstore 192, v3
++     mstore 224, 1
++     jump bb9
++   bb9:
+      jump bb5
     bb5:
 -     v0 = sload 0
 +     v0 = mload 192
@@ -28,45 +41,36 @@
 +     mstore 192, v1
 +     mstore 224, 1
       jump bb6
-    bb6:
-      jumpi 1, bb7, bb8
-    bb7:
-+     mstore 160, 0
-      jump bb1
-    bb8:
-+     v5 = mload 224
-+     jumpi v5, bb12, bb11
-+   bb9:
-+     jump bb5
-+   bb10:
-+     v3 = mload 128
-+     mstore 192, v3
-+     mstore 224, 1
-+     jump bb9
-+   bb11:
-      stop
-+   bb12:
-+     v6 = mload 192
-+     sstore 0, v6
-+     jump bb11
-  }
-  
-  fn @reject_outer_when_inner_flush_may_alias(arg0: u256) {
-    bb0:
-      jump bb6
-    bb1:
-      jumpi 1, bb2, bb4
     bb2:
--     sstore arg0, 7
+-     sstore 0, 7
 +     mstore 128, 7
 +     mstore 160, 1
       jump bb3
     bb3:
       jump bb1
+  }
+  
+  fn @reject_outer_when_inner_flush_may_alias(arg0: u256) {
+    bb0:
+      jump bb6
+    bb6:
+      jumpi 1, bb7, bb8
+    bb8:
+      stop
+    bb7:
++     mstore 160, 0
+      jump bb1
+    bb1:
+      jumpi 1, bb2, bb4
     bb4:
--     jump bb5
 +     v2 = mload 160
 +     jumpi v2, bb10, bb9
++   bb10:
++     v3 = mload 128
++     sstore arg0, v3
++     jump bb9
++   bb9:
+      jump bb5
     bb5:
 -     v0 = sload 0
 +     v0 = sload 0 !metadata(storage=slot(0))
@@ -74,18 +78,12 @@
 -     sstore 0, v1
 +     sstore 0, v1 !metadata(storage=slot(0))
       jump bb6
-    bb6:
-      jumpi 1, bb7, bb8
-    bb7:
-+     mstore 160, 0
+    bb2:
+-     sstore arg0, 7
++     mstore 128, 7
++     mstore 160, 1
+      jump bb3
+    bb3:
       jump bb1
-    bb8:
-      stop
-+   bb9:
-+     jump bb5
-+   bb10:
-+     v3 = mload 128
-+     sstore arg0, v3
-+     jump bb9
   }
   

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
@@ -1,12 +1,12 @@
 //@compile-flags: -Zmir-pipeline=storage-promotion
-//@filecheck:
+//@filecheck: --check-prefix=RPO
 @module StoragePromotionRevertExit
+// RPO: @module StoragePromotionRevertExit
 // CHECK-LABEL: {{^[ +].*}}fn @promote_checked_sum_loop{{[( ]}}
-// CHECK: + [[INITIAL:v[0-9]+]] = sload 0
-// CHECK: + mstore 128, [[INITIAL]]
-// CHECK: + {{v[0-9]+}} = mload 128
-// CHECK: + [[FLUSH:v[0-9]+]] = mload 128
-// CHECK: + sstore 0, [[FLUSH]]
+// CHECK-DAG: {{[+-]?}} [[INITIAL:v[0-9]+]] = sload 0
+// CHECK-DAG: {{[+-]?}} mstore 128, [[INITIAL]]
+// CHECK-DAG: {{[+-]?}} [[FLUSH:v[0-9]+]] = mload 128
+// CHECK-DAG: {{[+-]?}} sstore 0, [[FLUSH]]
 fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb1
@@ -32,11 +32,11 @@ fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @promote_revert_exit_reads_slot{{[( ]}}
-// CHECK: + mstore 128, 1
-// CHECK: + {{v[0-9]+}} = mload 128
-// CHECK: + {{v[0-9]+}} = mload 128
-// CHECK: + [[FLUSH:v[0-9]+]] = mload 128
-// CHECK: + sstore 0, [[FLUSH]]
+// CHECK-DAG: {{[+-]?}} mstore 128, 1
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = mload 128
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = mload 128
+// CHECK-DAG: {{[+-]?}} [[FLUSH:v[0-9]+]] = mload 128
+// CHECK-DAG: {{[+-]?}} sstore 0, [[FLUSH]]
 fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
   bb0:
     sstore 0, 1
@@ -60,9 +60,9 @@ fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @reject_revert_exit_with_call{{[( ]}}
-// CHECK: + sstore 0, 1
-// CHECK: + {{v[0-9]+}} = sload 0
-// CHECK: {{^[ +].*[ =]call[[:space:]]}}
+// CHECK-DAG: {{[+-]?}} sstore 0, 1
+// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = sload 0
+// CHECK-DAG: {{^[ +].*[ =]call[[:space:]]}}
 fn @reject_revert_exit_with_call(arg0: u256) [selector=0x01020304] {
   bb0:
     sstore 0, 1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.mir
@@ -1,12 +1,12 @@
 //@compile-flags: -Zmir-pipeline=storage-promotion
-//@filecheck: --check-prefix=RPO
+//@filecheck:
 @module StoragePromotionRevertExit
-// RPO: @module StoragePromotionRevertExit
 // CHECK-LABEL: {{^[ +].*}}fn @promote_checked_sum_loop{{[( ]}}
-// CHECK-DAG: {{[+-]?}} [[INITIAL:v[0-9]+]] = sload 0
-// CHECK-DAG: {{[+-]?}} mstore 128, [[INITIAL]]
-// CHECK-DAG: {{[+-]?}} [[FLUSH:v[0-9]+]] = mload 128
-// CHECK-DAG: {{[+-]?}} sstore 0, [[FLUSH]]
+// CHECK: + [[INITIAL:v[0-9]+]] = sload 0
+// CHECK: + mstore 128, [[INITIAL]]
+// CHECK: + [[FLUSH:v[0-9]+]] = mload 128
+// CHECK: + sstore 0, [[FLUSH]]
+// CHECK: + {{v[0-9]+}} = mload 128
 fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
   bb0:
     jump bb1
@@ -32,11 +32,11 @@ fn @promote_checked_sum_loop(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @promote_revert_exit_reads_slot{{[( ]}}
-// CHECK-DAG: {{[+-]?}} mstore 128, 1
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = mload 128
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = mload 128
-// CHECK-DAG: {{[+-]?}} [[FLUSH:v[0-9]+]] = mload 128
-// CHECK-DAG: {{[+-]?}} sstore 0, [[FLUSH]]
+// CHECK: + mstore 128, 1
+// CHECK: + [[FLUSH:v[0-9]+]] = mload 128
+// CHECK: + sstore 0, [[FLUSH]]
+// CHECK: + {{v[0-9]+}} = mload 128
+// CHECK: + {{v[0-9]+}} = mload 128
 fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
   bb0:
     sstore 0, 1
@@ -60,9 +60,9 @@ fn @promote_revert_exit_reads_slot(arg0: u256) [selector=0x01020304] {
 }
 
 // CHECK-LABEL: {{^[ +].*}}fn @reject_revert_exit_with_call{{[( ]}}
-// CHECK-DAG: {{[+-]?}} sstore 0, 1
-// CHECK-DAG: {{[+-]?}} {{v[0-9]+}} = sload 0
-// CHECK-DAG: {{^[ +].*[ =]call[[:space:]]}}
+// CHECK: + sstore 0, 1
+// CHECK: + {{v[0-9]+}} = sload 0
+// CHECK: {{^[ +].*[ =]call[[:space:]]}}
 fn @reject_revert_exit_with_call(arg0: u256) [selector=0x01020304] {
   bb0:
     sstore 0, 1

--- a/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
+++ b/tests/ui/codegen/mir/storage-promotion/storage_promotion_revert_exit.stdout
@@ -11,14 +11,21 @@
       v0 = phi [bb0: 0], [bb5: v5]
       v1 = lt v0, arg0
       jumpi v1, bb2, bb6
+    bb6:
++     v7 = mload 160
++     jumpi v7, bb8, bb7
++   bb8:
++     v8 = mload 128
++     sstore 0, v8
++     jump bb7
++   bb7:
+      stop
     bb2:
 -     v2 = sload 0
 +     v2 = mload 128
       v3 = add v2, v0
       v4 = lt v3, v2
       jumpi v4, bb3, bb4
-    bb3:
-      revert 0, 0
     bb4:
 -     sstore 0, v3
 +     mstore 128, v3
@@ -27,15 +34,8 @@
     bb5:
       v5 = add v0, 1
       jump bb1
-    bb6:
-+     v7 = mload 160
-+     jumpi v7, bb8, bb7
-+   bb7:
-      stop
-+   bb8:
-+     v8 = mload 128
-+     sstore 0, v8
-+     jump bb7
+    bb3:
+      revert 0, 0
   }
   
   fn @promote_revert_exit_reads_slot(arg0: u256) {
@@ -45,6 +45,10 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb5
+    bb5:
++     v4 = mload 128
++     sstore 0, v4
+      stop
     bb2:
 -     v0 = sload 0
 +     v0 = mload 128
@@ -60,10 +64,6 @@
       revert 0, 32
     bb4:
       jump bb1
-    bb5:
-+     v4 = mload 128
-+     sstore 0, v4
-      stop
   }
   
   fn @reject_revert_exit_with_call(arg0: u256) {
@@ -73,6 +73,8 @@
       jump bb1
     bb1:
       jumpi 1, bb2, bb5
+    bb5:
+      stop
     bb2:
 -     v0 = sload 0
 +     v0 = sload 0 !metadata(storage=slot(0))
@@ -86,7 +88,5 @@
       revert 0, 32
     bb4:
       jump bb1
-    bb5:
-      stop
   }
   

--- a/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
+++ b/tests/ui/codegen/mir/validation/tail_call_roundtrip.stdout
@@ -14,10 +14,10 @@
       v1 = shr 224, v0
       v2 = eq v1, 0x9507d39a
       jumpi v2, bb1, bb2
+    bb2:
+      revert 0, 0
     bb1:
       v3 = calldataload 4
       tail_call @wrapper, v3
-    bb2:
-      revert 0, 0
   }
   

--- a/tests/ui/erc7201/codegen.stdout
+++ b/tests/ui/erc7201/codegen.stdout
@@ -31,17 +31,11 @@ fn @calldataParam(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v1 = sub v0, 4
     v2 = slt v1, 32
     jumpi v2, bb1, bb2
-  bb1:
-    revert 0, 0
   bb2:
     v3 = slice_len arg0
     v4 = add v3, 31
     v5 = lt v4, v3
     jumpi v5, bb3, bb4
-  bb3:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb4:
     v6 = not 31
     v7 = and v4, v6
@@ -50,10 +44,6 @@ fn @calldataParam(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v10 = add 32, v9
     v11 = lt v10, v9
     jumpi v11, bb5, bb6
-  bb5:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
   bb6:
     v12 = alloc memorybytes, exact, uninitialized, infallible, v10
     set_memory_object_len memorybytes, v12, v3
@@ -69,6 +59,16 @@ fn @calldataParam(arg0: calldataslice) -> u256 [abi_returns=[word]] {
     v19 = keccak256 0, 32 !metadata(memory=scratch)
     v20 = and v19, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
     ret v20
+  bb5:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    revert 0, 0
 }
 
 fn @storageValue() -> u256 [abi_returns=[word]] {
@@ -111,14 +111,14 @@ fn @__load_storage_bytes(arg0: u256) -> memorybytes {
     v17 = keccak256 v13, 32
     v18 = div v9, 32
     jump bb4
-  bb3:
-    ret v14
   bb4:
     v19 = phi [bb2: v18], [bb5: v26]
     v20 = phi [bb2: v17], [bb5: v24]
     v21 = phi [bb2: v15], [bb5: v25]
     v22 = gt v19, 0
     jumpi v22, bb5, bb3
+  bb3:
+    ret v14
   bb5:
     v23 = sload v20 !metadata(storage=symbolic(v20))
     mstore v21, v23


### PR DESCRIPTION
MIR text dumps now print reachable blocks in reverse postorder and retain unreachable blocks at the end. EVM IR dumps keep their physical layout because it controls fallthrough.