### PR TITLE
test(codegen): exhaustively cover nullary read rematerialization

### DIFF
--- a/crates/codegen/src/backend/evm/codegen.rs
+++ b/crates/codegen/src/backend/evm/codegen.rs
@@ -9580,22 +9580,40 @@ mod tests {
     }
 
     #[test]
-    fn stable_nullary_reads_are_always_rematerializable() {
+    fn nullary_reads_have_expected_rematerialization_opcodes() {
         let mut function = Function::new(Ident::with_dummy_span(sym::Test));
-        let (_, calldata_size) = function
-            .alloc_value_inst(Instruction::new(InstKind::CalldataSize, Some(MirType::uint256())));
-        let (_, block_number) = function
-            .alloc_value_inst(Instruction::new(InstKind::BlockNumber, Some(MirType::uint256())));
-        let (_, returndata_size) = function
-            .alloc_value_inst(Instruction::new(InstKind::ReturnDataSize, Some(MirType::uint256())));
-        let (_, gas) =
-            function.alloc_value_inst(Instruction::new(InstKind::Gas, Some(MirType::uint256())));
 
-        assert!(EvmCodegen::is_always_rematerializable_value(&function, calldata_size));
-        assert!(EvmCodegen::is_always_rematerializable_value(&function, block_number));
-        assert!(!EvmCodegen::can_own_spill_slot(&function, calldata_size));
-        assert!(!EvmCodegen::is_always_rematerializable_value(&function, returndata_size));
-        assert!(!EvmCodegen::is_always_rematerializable_value(&function, gas));
+        for (kind, expected_op) in [
+            (InstKind::CalldataSize, op::CALLDATASIZE),
+            (InstKind::CodeSize, op::CODESIZE),
+            (InstKind::Caller, op::CALLER),
+            (InstKind::CallValue, op::CALLVALUE),
+            (InstKind::Address, op::ADDRESS),
+            (InstKind::Origin, op::ORIGIN),
+            (InstKind::GasPrice, op::GASPRICE),
+            (InstKind::Coinbase, op::COINBASE),
+            (InstKind::Timestamp, op::TIMESTAMP),
+            (InstKind::BlockNumber, op::NUMBER),
+            (InstKind::PrevRandao, op::PREVRANDAO),
+            (InstKind::GasLimit, op::GASLIMIT),
+            (InstKind::ChainId, op::CHAINID),
+            (InstKind::BaseFee, op::BASEFEE),
+            (InstKind::BlobBaseFee, op::BLOBBASEFEE),
+        ] {
+            let (_, value) =
+                function.alloc_value_inst(Instruction::new(kind, Some(MirType::uint256())));
+            assert_eq!(EvmCodegen::always_rematerializable_op(&function, value), Some(expected_op));
+            assert!(!EvmCodegen::can_own_spill_slot(&function, value));
+        }
+
+        for kind in
+            [InstKind::MSize, InstKind::ReturnDataSize, InstKind::SelfBalance, InstKind::Gas]
+        {
+            let (_, value) =
+                function.alloc_value_inst(Instruction::new(kind, Some(MirType::uint256())));
+            assert_eq!(EvmCodegen::always_rematerializable_op(&function, value), None);
+            assert!(EvmCodegen::can_own_spill_slot(&function, value));
+        }
     }
 
     #[test]

--- a/tests/ui/codegen/lowering/rematerialize_nullary_reads.sol
+++ b/tests/ui/codegen/lowering/rematerialize_nullary_reads.sol
@@ -1,0 +1,72 @@
+//@ compile-flags: -O none -Zdump=evm-ir-runtime
+//@ filecheck:
+
+contract RematerializeNullaryReads {
+    // Each value is defined once and used twice. Stable two-gas reads should be
+    // re-emitted at both stores instead of being retained or spilled.
+    // CHECK-COUNT-2: {{^ +}}calldatasize{{$}}
+    // CHECK-COUNT-2: {{^ +}}codesize{{$}}
+    // CHECK-COUNT-2: {{^ +}}caller{{$}}
+    // CHECK-COUNT-2: {{^ +}}callvalue{{$}}
+    // CHECK-COUNT-2: {{^ +}}address{{$}}
+    // CHECK-COUNT-2: {{^ +}}origin{{$}}
+    // CHECK-COUNT-2: {{^ +}}gasprice{{$}}
+    // CHECK-COUNT-2: {{^ +}}coinbase{{$}}
+    // CHECK-COUNT-2: {{^ +}}timestamp{{$}}
+    // CHECK-COUNT-2: {{^ +}}number{{$}}
+    // CHECK-COUNT-2: {{^ +}}prevrandao{{$}}
+    // CHECK-COUNT-2: {{^ +}}gaslimit{{$}}
+    // CHECK-COUNT-2: {{^ +}}chainid{{$}}
+    // CHECK-COUNT-2: {{^ +}}basefee{{$}}
+    // CHECK-COUNT-2: {{^ +}}blobbasefee{{$}}
+    function readTwice() external payable {
+        assembly {
+            let v0 := calldatasize()
+            mstore(0x00, v0)
+            mstore(0x20, v0)
+            let v1 := codesize()
+            mstore(0x40, v1)
+            mstore(0x60, v1)
+            let v2 := caller()
+            mstore(0x80, v2)
+            mstore(0xa0, v2)
+            let v3 := callvalue()
+            mstore(0xc0, v3)
+            mstore(0xe0, v3)
+            let v4 := address()
+            mstore(0x100, v4)
+            mstore(0x120, v4)
+            let v5 := origin()
+            mstore(0x140, v5)
+            mstore(0x160, v5)
+            let v6 := gasprice()
+            mstore(0x180, v6)
+            mstore(0x1a0, v6)
+            let v7 := coinbase()
+            mstore(0x1c0, v7)
+            mstore(0x1e0, v7)
+            let v8 := timestamp()
+            mstore(0x200, v8)
+            mstore(0x220, v8)
+            let v9 := number()
+            mstore(0x240, v9)
+            mstore(0x260, v9)
+            let v10 := prevrandao()
+            mstore(0x280, v10)
+            mstore(0x2a0, v10)
+            let v11 := gaslimit()
+            mstore(0x2c0, v11)
+            mstore(0x2e0, v11)
+            let v12 := chainid()
+            mstore(0x300, v12)
+            mstore(0x320, v12)
+            let v13 := basefee()
+            mstore(0x340, v13)
+            mstore(0x360, v13)
+            let v14 := blobbasefee()
+            mstore(0x380, v14)
+            mstore(0x3a0, v14)
+            return(0, 0x3c0)
+        }
+    }
+}

--- a/tests/ui/codegen/lowering/rematerialize_nullary_reads.stdout
+++ b/tests/ui/codegen/lowering/rematerialize_nullary_reads.stdout
@@ -1,0 +1,116 @@
+// === ROOT/tests/ui/codegen/lowering/rematerialize_nullary_reads.sol:RematerializeNullaryReads (runtime) ===
+@module runtime
+bb0:
+  push 0
+  calldataload
+  push 224
+  shr
+  dup1
+  push 0x5895c907
+  eq
+  push bb1
+  jumpi
+  jump bb2
+bb1:
+  jump bb3
+bb2 [cold]:
+  push 0
+  dup1
+  revert
+bb3:
+  push 128
+  push 64
+  mstore
+  calldatasize
+  push 0
+  mstore
+  calldatasize
+  push 32
+  mstore
+  codesize
+  push 64
+  mstore
+  codesize
+  push 96
+  mstore
+  caller
+  push 128
+  mstore
+  caller
+  push 160
+  mstore
+  callvalue
+  push 192
+  mstore
+  callvalue
+  push 224
+  mstore
+  address
+  push 256
+  mstore
+  address
+  push 288
+  mstore
+  origin
+  push 320
+  mstore
+  origin
+  push 352
+  mstore
+  gasprice
+  push 384
+  mstore
+  gasprice
+  push 416
+  mstore
+  coinbase
+  push 448
+  mstore
+  coinbase
+  push 480
+  mstore
+  timestamp
+  push 512
+  mstore
+  timestamp
+  push 544
+  mstore
+  number
+  push 576
+  mstore
+  number
+  push 608
+  mstore
+  prevrandao
+  push 640
+  mstore
+  prevrandao
+  push 672
+  mstore
+  gaslimit
+  push 704
+  mstore
+  gaslimit
+  push 736
+  mstore
+  chainid
+  push 768
+  mstore
+  chainid
+  push 800
+  mstore
+  basefee
+  push 832
+  mstore
+  basefee
+  push 864
+  mstore
+  blobbasefee
+  push 896
+  mstore
+  blobbasefee
+  push 928
+  mstore
+  push 960
+  push 0
+  return


### PR DESCRIPTION
## Summary

- replace the spot-check with table-driven coverage for all 15 rematerializable nullary reads and their exact EVM opcodes
- verify mutable or non-cheap nullary reads remain spillable and are not rematerialized
- add a UI codegen fixture proving every eligible read is re-emitted at both uses through the Solidity-to-EVM pipeline

## Testing

- cargo test -p solar-codegen nullary_reads_have_expected_rematerialization_opcodes
- FILECHECK=/usr/lib/llvm-22/bin/FileCheck cargo test --package=solar-compiler --test=tests -- rematerialize_nullary_reads
- cargo +nightly fmt --all -- --check

Prompted by: @DaniPopes