### PR TITLE
feat(bench): add benchmark modes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -137,6 +137,7 @@ jobs:
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
             --solar target/release/solar \
             --suite all \
+            --include-heavy \
             --compile-repeats 5 \
             --gas \
             --gas-profile hot \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -136,8 +136,8 @@ jobs:
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
             --solar target/release/solar \
+            --mode runtime compile-time \
             --suite all \
-            --include-heavy \
             --compile-repeats 5 \
             --gas \
             --gas-profile hot \

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -1,14 +1,14 @@
-# Codegen runtime corpus
+# Codegen benchmark corpus
 
-This directory contains the runtime-specific fixtures and workload documentation for the codegen
-runtime benchmark. The shared project archives live in `../../testdata/projects/`; archives group
-cases from the same upstream project. The runner selects only each entrypoint's transitive Solidity
-import closure before compiling it. Keeping the inputs here makes the benchmark reproducible from this
-checkout and removes the CI dependency on a second repository and its recursive submodules.
+This directory contains fixtures and workload documentation for the codegen benchmark. The shared
+project archives live in `../../testdata/projects/`; archives group cases from the same upstream
+project. The default `runtime` mode selects each entrypoint's transitive Solidity import closure and
+omits the heavy full-project cases. The `compile-time` mode measures those cases by passing full
+archived Standard JSON inputs to both compilers without deployment or runtime workloads. CI runs
+both modes with `--mode runtime compile-time`.
 
-The `heavy` suite passes full archived Standard JSON inputs to both compilers and measures compile
-time without deployment or runtime workloads. `--suite all` omits it by default. CI includes it
-with `--include-heavy`.
+Keeping the inputs here makes the benchmark reproducible from this checkout and removes the CI
+dependency on a second repository and its recursive submodules.
 
 The workload definitions and helper fixtures were imported from
 [`walnuthq/solidity-compiler-benchmarks`](https://github.com/walnuthq/solidity-compiler-benchmarks)

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -6,9 +6,9 @@ cases from the same upstream project. The runner selects only each entrypoint's 
 import closure before compiling it. Keeping the inputs here makes the benchmark reproducible from this
 checkout and removes the CI dependency on a second repository and its recursive submodules.
 
-The separate `benches/runtime/benchmark.py --suite heavy` suite passes the full archived
-Standard JSON inputs to both compilers and measures compile time without deployment or runtime
-workloads.
+The `heavy` suite passes full archived Standard JSON inputs to both compilers and measures compile
+time without deployment or runtime workloads. `--suite all` omits it by default. CI includes it
+with `--include-heavy`.
 
 The workload definitions and helper fixtures were imported from
 [`walnuthq/solidity-compiler-benchmarks`](https://github.com/walnuthq/solidity-compiler-benchmarks)

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1185,14 +1185,15 @@ def run_test_case(
     return entry
 
 
-def select_suite_tests(suite: str, include_heavy: bool = False) -> Sequence[TestCase]:
-    if suite == "all":
-        return [
-            test
-            for test in TEST_CASES
-            if include_heavy or test.suite != "heavy"
-        ]
-    return [test for test in TEST_CASES if test.suite == suite]
+def select_tests(modes: Sequence[str], suite: str) -> Sequence[TestCase]:
+    runtime = "runtime" in modes
+    compile_time = "compile-time" in modes
+    return [
+        test
+        for test in TEST_CASES
+        if (suite == "all" or test.suite == suite)
+        and ((test.whole_project and compile_time) or (not test.whole_project and runtime))
+    ]
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -1205,15 +1206,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help="Path to solar binary (default: solar or target/{release,debug}/solar)",
     )
     parser.add_argument(
-        "--suite",
-        choices=("micro", "repository", "large", "heavy", "all"),
-        default="micro",
-        help="Benchmark suite to run (all excludes heavy by default)",
+        "--mode",
+        choices=("runtime", "compile-time"),
+        nargs="+",
+        default=("runtime",),
+        help="Benchmark modes to run (default: runtime)",
     )
     parser.add_argument(
-        "--include-heavy",
-        action="store_true",
-        help="Include full-project compile-time cases with --suite all",
+        "--suite",
+        choices=("micro", "repository", "large", "heavy", "all"),
+        default="all",
+        help="Subset of the selected modes to run (default: all)",
     )
     parser.add_argument(
         "--compile-repeats",
@@ -1248,7 +1251,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    suite_tests = select_suite_tests(args.suite, args.include_heavy)
+    suite_tests = select_tests(args.mode, args.suite)
 
     if args.projects:
         project_set = set(args.projects)

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1185,6 +1185,16 @@ def run_test_case(
     return entry
 
 
+def select_suite_tests(suite: str, include_heavy: bool = False) -> Sequence[TestCase]:
+    if suite == "all":
+        return [
+            test
+            for test in TEST_CASES
+            if include_heavy or test.suite != "heavy"
+        ]
+    return [test for test in TEST_CASES if test.suite == suite]
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Benchmark solc vs Solar codegen on inline and repository contracts"
@@ -1198,7 +1208,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "--suite",
         choices=("micro", "repository", "large", "heavy", "all"),
         default="micro",
-        help="Benchmark suite to run (heavy measures full project compile time)",
+        help="Benchmark suite to run (all excludes heavy by default)",
+    )
+    parser.add_argument(
+        "--include-heavy",
+        action="store_true",
+        help="Include full-project compile-time cases with --suite all",
     )
     parser.add_argument(
         "--compile-repeats",
@@ -1233,19 +1248,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    all_tests = [
-        test
-        for test in TEST_CASES
-        if args.suite == "all" or test.suite == args.suite
-    ]
+    suite_tests = select_suite_tests(args.suite, args.include_heavy)
 
     if args.projects:
         project_set = set(args.projects)
-        all_tests = [test for test in all_tests if test.project in project_set]
+        suite_tests = [test for test in suite_tests if test.project in project_set]
 
-    test_map = {test.test_id: test for test in all_tests}
+    test_map = {test.test_id: test for test in suite_tests}
     if args.list_tests:
-        for test in all_tests:
+        for test in suite_tests:
             if test.project_file is not None:
                 print(f"{test.test_id}	{test.project}	{test.source}	{test.contract_name}")
             else:
@@ -1288,7 +1299,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             return 1
         tests = [test_map[test_id] for test_id in args.tests]
     else:
-        tests = list(all_tests)
+        tests = list(suite_tests)
 
     skipped = []
     if not args.include_incompatible:

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -85,6 +85,17 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(payload, archive)
         self.assertEqual(len(payload["sources"]), 208)
 
+    def test_select_suite_tests(self) -> None:
+        heavy = [case for case in benchmark.TEST_CASES if case.suite == "heavy"]
+        default = [case for case in benchmark.TEST_CASES if case.suite != "heavy"]
+
+        self.assertEqual(benchmark.select_suite_tests("all"), default)
+        self.assertEqual(
+            benchmark.select_suite_tests("all", include_heavy=True),
+            list(benchmark.TEST_CASES),
+        )
+        self.assertEqual(benchmark.select_suite_tests("heavy"), heavy)
+
     def test_parse_full_project_output_counts_contract_artifacts(self) -> None:
         case = next(case for case in benchmark.TEST_CASES if case.whole_project)
         stdout = json.dumps(

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -85,16 +85,18 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(payload, archive)
         self.assertEqual(len(payload["sources"]), 208)
 
-    def test_select_suite_tests(self) -> None:
+    def test_select_tests(self) -> None:
         heavy = [case for case in benchmark.TEST_CASES if case.suite == "heavy"]
-        default = [case for case in benchmark.TEST_CASES if case.suite != "heavy"]
+        micro = [case for case in benchmark.TEST_CASES if case.suite == "micro"]
+        runtime = [case for case in benchmark.TEST_CASES if case.suite != "heavy"]
 
-        self.assertEqual(benchmark.select_suite_tests("all"), default)
+        self.assertEqual(benchmark.select_tests(("runtime",), "all"), runtime)
+        self.assertEqual(benchmark.select_tests(("compile-time",), "all"), heavy)
         self.assertEqual(
-            benchmark.select_suite_tests("all", include_heavy=True),
+            benchmark.select_tests(("runtime", "compile-time"), "all"),
             list(benchmark.TEST_CASES),
         )
-        self.assertEqual(benchmark.select_suite_tests("heavy"), heavy)
+        self.assertEqual(benchmark.select_tests(("runtime",), "micro"), micro)
 
     def test_parse_full_project_output_counts_contract_artifacts(self) -> None:
         case = next(case for case in benchmark.TEST_CASES if case.whole_project)


### PR DESCRIPTION
The benchmark now separates its corpus into runtime and compile-time modes. Runtime is the default and skips whole-project heavy cases, while compile-time selects those cases. CI requests both modes in one invocation so its combined result artifact and report remain intact.