### PR TITLE
fix(codegen): keep wide array bounds

### DIFF
--- a/crates/codegen/src/lower/function/expressions.rs
+++ b/crates/codegen/src/lower/function/expressions.rs
@@ -175,7 +175,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             if !matches!(receiver.peel_parens().kind, ExprKind::Ident(_)) {
                 self.lower_expr(receiver)?;
             }
-            return Some(self.builder.imm_u64(u64::try_from(len).ok()?));
+            return Some(self.builder.imm_u256(len));
         }
         if receiver_ty.is_ref_at(DataLocation::Storage) {
             if let Some(access) = self.storage_access(receiver) {

--- a/crates/codegen/src/lower/function/storage_values.rs
+++ b/crates/codegen/src/lower/function/storage_values.rs
@@ -343,9 +343,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                     });
                 }
                 let (element, dynamic, length) = match ty.kind {
-                    TyKind::Array(element, len) => {
-                        (element, false, self.builder.imm_u64(u64::try_from(len).ok()?))
-                    }
+                    TyKind::Array(element, len) => (element, false, self.builder.imm_u256(len)),
                     TyKind::DynArray(element) => (element, true, self.builder.sload(base.slot)),
                     _ => return None,
                 };

--- a/tests/ui/codegen/lowering/run-call/storage_large_fixed_array_index.sol
+++ b/tests/ui/codegen/lowering/run-call/storage_large_fixed_array_index.sol
@@ -1,0 +1,23 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: test() => 7, 8
+//@ run-call: read(uint256) 0xffffffffffffffffffffffffffffffffffffffffffffffffff => 0
+//@ run-call-fail: read(uint256) 0x100000000000000000000000000000000000000000000000000 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000032
+
+contract StorageLargeFixedArrayIndex {
+    mapping(uint256 => uint256[2][2 ** 200]) private arrays;
+
+    function test() external returns (uint256, uint256) {
+        uint256[2][2 ** 200] storage array = arrays[0];
+        uint256 index = 1 << 199;
+        array[index][1] = 7;
+        array[index + 1][0] = 8;
+        return (array[index][1], array[index + 1][0]);
+    }
+
+    function read(uint256 index) external view returns (uint256) {
+        return arrays[0][index][0];
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/storage_large_fixed_array_index.sol
+++ b/tests/ui/codegen/lowering/run-call/storage_large_fixed_array_index.sol
@@ -3,6 +3,7 @@
 //@[gas] compile-flags: -O gas
 //@[size] compile-flags: -O size
 //@ run-call: test() => 7, 8
+//@ run-call: hasExpectedLength() => true
 //@ run-call: read(uint256) 0xffffffffffffffffffffffffffffffffffffffffffffffffff => 0
 //@ run-call-fail: read(uint256) 0x100000000000000000000000000000000000000000000000000 => 0x4e487b710000000000000000000000000000000000000000000000000000000000000032
 
@@ -19,5 +20,9 @@ contract StorageLargeFixedArrayIndex {
 
     function read(uint256 index) external view returns (uint256) {
         return arrays[0][index][0];
+    }
+
+    function hasExpectedLength() external view returns (bool) {
+        return arrays[0].length == 2 ** 200;
     }
 }


### PR DESCRIPTION
Fixed storage-array lengths are 256-bit Solidity values. Indexed-access and array-length lowering each narrowed fixed bounds to u64, so a legal array larger than u64 elements could not be lowered and its function fell back to invalid bytecode.

Keep both bounds as U256 MIR immediates. The regression covers a nested uint256[2][2 ** 200] storage array, including two-slot element stride, its compile-time length, the last valid index, and the first out-of-bounds index across the standard optimizer matrix.

solsymdiff found the indexed-access divergence in an upstream storage-boundary fixture: Solc executed the access while Solar reached INVALID. Auditing the same narrowing path exposed the length case; its runtime regression failed with INVALID before the fix and passed afterward. The fixed indexed-access reproducer reports bounded agreement.

This targets the codegen-lowering rewrite.

Validation: full UI suite; 223 solar-codegen tests; focused Foundry storage project; nightly workspace clippy; formatting and diff checks.

AI assistance: Codex assisted with differential discovery, implementation, and validation.