### PR TITLE
chore: add benchmark report to job summary

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -168,6 +168,10 @@ jobs:
           fi
           python3 benches/runtime/report.py "${args[@]}"
 
+      - name: Add report to job summary
+        if: always()
+        run: cat target/codegen-bench/report.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Comment on PR
         if: >-
           github.event_name == 'pull_request' &&


### PR DESCRIPTION
The runtime benchmark already renders its comparison as Markdown for comments and artifacts. Append that report to the GitHub Actions job summary on every run so results remain directly visible even when no PR comment is posted.

Prompted by: @DaniPopes
