### PR TITLE
fix(codegen): rebind nested storage refs

### DIFF
--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -3,8 +3,16 @@
 use super::*;
 
 enum PreparedTupleAssignment<'gcx> {
-    Value { place: LValuePlace<'gcx>, value: ValueId, source_ty: Option<Ty<'gcx>> },
+    Value { place: LValuePlace<'gcx>, rhs: TupleAssignmentRhs<'gcx> },
     StorageReference { id: VariableId, access: StorageAccess },
+}
+
+enum TupleAssignmentRhs<'gcx> {
+    Materialized { value: ValueId, source_ty: Option<Ty<'gcx>>, span: Span },
+    // Capture the source slot during RHS evaluation, but copy its contents when
+    // this assignment is committed.
+    StorageCopy { access: StorageAccess, source_ty: Ty<'gcx>, span: Span },
+    StorageReference { access: StorageAccess },
 }
 
 impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
@@ -150,21 +158,27 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             if values.len() != elements.len() {
                 return report_unsupported(self.context.gcx, rhs.span, "storage reference tuple");
             }
-            let mut assignment_values = Vec::with_capacity(elements.len());
-            for (element, (mut value, access)) in elements.iter().zip(values) {
+            let ExprKind::Call(callee, ..) = &rhs.kind else {
+                unreachable!("storage reference values only come from calls")
+            };
+            let function_id = self.context.gcx.resolved_function(callee)?;
+            let returns = self.context.gcx.hir.function(function_id).returns;
+            let mut assignments = Vec::with_capacity(elements.len());
+            for (element, ((value, access), &return_id)) in
+                elements.iter().zip(values.into_iter().zip(returns))
+            {
                 let Some(element) = element else { continue };
+                let source_ty = self.context.gcx.type_of_item(return_id.into());
                 if let Some(access) = access {
-                    if !self.is_storage_reference_binding(element) {
-                        // A storage-reference return assigned to a plain
-                        // storage lvalue copies the referenced value, matching
-                        // solc: the reference itself only binds to a local
-                        // storage variable.
-                        let ty = self.type_of_expr_or_variable(element)?;
-                        value = self.load_storage_object(ty, value, element.span)?;
-                        assignment_values.push((*element, value, None));
-                    } else {
-                        assignment_values.push((*element, value, Some(access)));
+                    if self.is_storage_reference_binding(element) {
+                        assignments
+                            .push((*element, TupleAssignmentRhs::StorageReference { access }));
+                        continue;
                     }
+                    let value =
+                        TupleAssignmentRhs::StorageCopy { access, source_ty, span: rhs.span };
+                    let value = self.prepare_tuple_rhs(element, value)?;
+                    assignments.push((*element, value));
                 } else if self.is_storage_reference_binding(element) {
                     return report_unsupported(
                         self.context.gcx,
@@ -172,29 +186,18 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                         "mixed storage tuple",
                     );
                 } else {
-                    assignment_values.push((*element, value, None));
+                    let value = self.prepare_tuple_rhs(
+                        element,
+                        TupleAssignmentRhs::Materialized {
+                            value,
+                            source_ty: Some(source_ty),
+                            span: rhs.span,
+                        },
+                    )?;
+                    assignments.push((*element, value));
                 }
             }
-            let mut assignments = Vec::with_capacity(assignment_values.len());
-            for (element, value, access) in assignment_values {
-                if let Some(access) = access {
-                    let Some(id) = self.context.gcx.resolved_variable(element) else {
-                        return report_unsupported(
-                            self.context.gcx,
-                            element.span,
-                            "storage reference target",
-                        );
-                    };
-                    assignments.push(PreparedTupleAssignment::StorageReference { id, access });
-                } else {
-                    assignments.push(PreparedTupleAssignment::Value {
-                        place: self.resolve_lvalue_place(element)?,
-                        value,
-                        source_ty: None,
-                    });
-                }
-            }
-            return self.apply_tuple_assignments(assignments);
+            return self.store_prepared_tuple_values(assignments);
         }
         if let ExprKind::Tuple(rhs_elements) = &rhs.peel_parens().kind
             && rhs_elements.len() == elements.len()
@@ -265,20 +268,11 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             }
             let mut values = Vec::with_capacity(rhs_elements.len());
             self.lower_tuple_assignment_values(elements, rhs_elements, rhs.span, &mut values)?;
-            let mut assignments = Vec::with_capacity(values.len());
-            for (element, rhs, value, source_ty) in values {
-                let lhs_ty = self.type_of_expr_or_variable(element)?;
-                let rhs_ty =
-                    source_ty.or_else(|| self.context.gcx.type_of_expr(rhs.id)).unwrap_or(lhs_ty);
-                let value = if lhs_ty.is_ref_at(DataLocation::Storage) {
-                    value
-                } else {
-                    self.materialize_memory_argument(lhs_ty, value, rhs.span)?
-                };
-                let value = self.coerce_value(value, rhs_ty, lhs_ty);
-                assignments.push((element, value, Some(rhs_ty)));
-            }
-            return self.store_tuple_values(assignments);
+            let values = values
+                .into_iter()
+                .map(|(element, rhs)| Some((element, self.prepare_tuple_rhs(element, rhs)?)))
+                .collect::<Option<Vec<_>>>()?;
+            return self.store_prepared_tuple_values(values);
         }
         let values = self.lower_values(rhs)?;
         if values.len() < elements.len() {
@@ -292,19 +286,69 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         )
     }
 
+    fn prepare_tuple_rhs(
+        &mut self,
+        element: &hir::Expr<'_>,
+        rhs: TupleAssignmentRhs<'gcx>,
+    ) -> Option<TupleAssignmentRhs<'gcx>> {
+        let target_ty = self.type_of_expr_or_variable(element)?;
+        let (value, source_ty, span) = match rhs {
+            TupleAssignmentRhs::StorageCopy { access, source_ty, span }
+                if target_ty.is_ref_at(DataLocation::Storage) =>
+            {
+                return Some(TupleAssignmentRhs::StorageCopy { access, source_ty, span });
+            }
+            TupleAssignmentRhs::StorageCopy { access, source_ty, span } => {
+                (self.load_storage_value(source_ty, access, span)?, Some(source_ty), span)
+            }
+            TupleAssignmentRhs::Materialized { value, source_ty, span } => (value, source_ty, span),
+            TupleAssignmentRhs::StorageReference { .. } => {
+                unreachable!("storage references are not copied as values")
+            }
+        };
+        let source_ty = source_ty.unwrap_or(target_ty);
+        let value = if target_ty.is_ref_at(DataLocation::Storage) {
+            value
+        } else {
+            self.materialize_memory_argument(target_ty, value, span)?
+        };
+        let value = self.coerce_value(value, source_ty, target_ty);
+        Some(TupleAssignmentRhs::Materialized { value, source_ty: Some(source_ty), span })
+    }
+
     fn store_tuple_values<'hir>(
         &mut self,
         values: impl IntoIterator<Item = (&'hir hir::Expr<'hir>, ValueId, Option<Ty<'gcx>>)>,
+    ) -> Option<()> {
+        self.store_prepared_tuple_values(values.into_iter().map(|(element, value, source_ty)| {
+            (element, TupleAssignmentRhs::Materialized { value, source_ty, span: element.span })
+        }))
+    }
+
+    fn store_prepared_tuple_values<'hir>(
+        &mut self,
+        values: impl IntoIterator<Item = (&'hir hir::Expr<'hir>, TupleAssignmentRhs<'gcx>)>,
     ) -> Option<()> {
         // Solidity evaluates tuple targets left-to-right after the RHS, then
         // commits their writes right-to-left.
         let assignments = values
             .into_iter()
-            .map(|(element, value, source_ty)| {
-                Some(PreparedTupleAssignment::Value {
-                    place: self.resolve_lvalue_place(element)?,
-                    value,
-                    source_ty,
+            .map(|(element, value)| {
+                Some(match value {
+                    TupleAssignmentRhs::StorageReference { access } => {
+                        let Some(id) = self.context.gcx.resolved_variable(element) else {
+                            return report_unsupported(
+                                self.context.gcx,
+                                element.span,
+                                "storage reference target",
+                            );
+                        };
+                        PreparedTupleAssignment::StorageReference { id, access }
+                    }
+                    rhs => PreparedTupleAssignment::Value {
+                        place: self.resolve_lvalue_place(element)?,
+                        rhs,
+                    },
                 })
             })
             .collect::<Option<Vec<_>>>()?;
@@ -317,13 +361,24 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
     ) -> Option<()> {
         for assignment in assignments.into_iter().rev() {
             match assignment {
-                PreparedTupleAssignment::Value { mut place, value, source_ty } => {
+                PreparedTupleAssignment::Value { mut place, rhs } => {
                     if let LValuePlace::StorageByte { slot, index, ty, .. } = place {
                         // Place resolution materializes storage bytes for its bounds check. Reload
                         // before each write so aliased byte targets do not restore a stale copy.
                         let object = self.load_storage_bytes(slot);
                         place = LValuePlace::StorageByte { slot, object, index, ty };
                     }
+                    let (value, source_ty) = match rhs {
+                        TupleAssignmentRhs::Materialized { value, source_ty, .. } => {
+                            (value, source_ty)
+                        }
+                        TupleAssignmentRhs::StorageCopy { access, source_ty, span } => {
+                            (self.load_storage_value(source_ty, access, span)?, Some(source_ty))
+                        }
+                        TupleAssignmentRhs::StorageReference { .. } => {
+                            unreachable!("storage reference reached value assignment")
+                        }
+                    };
                     self.store_lvalue_place_with_source(&place, value, source_ty)?;
                 }
                 PreparedTupleAssignment::StorageReference { id, access } => {
@@ -339,7 +394,7 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         elements: &[Option<&'hir hir::Expr<'hir>>],
         rhs_elements: &[Option<&'hir hir::Expr<'hir>>],
         span: Span,
-        values: &mut Vec<(&'hir hir::Expr<'hir>, &'hir hir::Expr<'hir>, ValueId, Option<Ty<'gcx>>)>,
+        values: &mut Vec<(&'hir hir::Expr<'hir>, TupleAssignmentRhs<'gcx>)>,
     ) -> Option<()> {
         if rhs_elements.len() < elements.len() {
             return report_unsupported(self.context.gcx, span, "tuple assignment arity");
@@ -383,12 +438,49 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                                 "nested tuple assignment target",
                             );
                         }
-                        values.push((lhs, rhs, value, Some(rhs_ty)));
+                        let value = if rhs_ty.is_ref_at(DataLocation::Storage)
+                            && self.types.memory_layout(rhs_ty).is_some()
+                        {
+                            TupleAssignmentRhs::StorageCopy {
+                                access: StorageAccess {
+                                    slot: value,
+                                    location: StorageLocation::word(U256::ZERO),
+                                    offset: None,
+                                },
+                                source_ty: rhs_ty,
+                                span: rhs.span,
+                            }
+                        } else {
+                            TupleAssignmentRhs::Materialized {
+                                value,
+                                source_ty: Some(rhs_ty),
+                                span: rhs.span,
+                            }
+                        };
+                        values.push((lhs, value));
                     }
                 } else {
-                    let value = self.lower_expr(rhs)?;
                     if let Some(lhs) = lhs {
-                        values.push((lhs, rhs, value, None));
+                        let source_ty = self.context.gcx.type_of_expr(rhs.id);
+                        let value = if source_ty.is_some_and(|ty| {
+                            ty.is_ref_at(DataLocation::Storage)
+                                && self.types.memory_layout(ty).is_some()
+                        }) {
+                            TupleAssignmentRhs::StorageCopy {
+                                access: self.storage_access(rhs)?,
+                                source_ty: source_ty?,
+                                span: rhs.span,
+                            }
+                        } else {
+                            TupleAssignmentRhs::Materialized {
+                                value: self.lower_expr(rhs)?,
+                                source_ty,
+                                span: rhs.span,
+                            }
+                        };
+                        values.push((lhs, value));
+                    } else {
+                        self.lower_expr(rhs)?;
                     }
                 }
                 continue;

--- a/crates/codegen/src/lower/function/values.rs
+++ b/crates/codegen/src/lower/function/values.rs
@@ -302,8 +302,8 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 (self.load_storage_value(source_ty, access, span)?, Some(source_ty), span)
             }
             TupleAssignmentRhs::Materialized { value, source_ty, span } => (value, source_ty, span),
-            TupleAssignmentRhs::StorageReference { .. } => {
-                unreachable!("storage references are not copied as values")
+            TupleAssignmentRhs::StorageReference { access } => {
+                return Some(TupleAssignmentRhs::StorageReference { access });
             }
         };
         let source_ty = source_ty.unwrap_or(target_ty);
@@ -438,17 +438,26 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                                 "nested tuple assignment target",
                             );
                         }
-                        let value = if rhs_ty.is_ref_at(DataLocation::Storage)
-                            && self.types.memory_layout(rhs_ty).is_some()
-                        {
-                            TupleAssignmentRhs::StorageCopy {
-                                access: StorageAccess {
-                                    slot: value,
-                                    location: StorageLocation::word(U256::ZERO),
-                                    offset: None,
-                                },
-                                source_ty: rhs_ty,
-                                span: rhs.span,
+                        let value = if rhs_ty.is_ref_at(DataLocation::Storage) {
+                            let access = StorageAccess {
+                                slot: value,
+                                location: StorageLocation::word(U256::ZERO),
+                                offset: None,
+                            };
+                            if self.is_storage_reference_binding(lhs) {
+                                TupleAssignmentRhs::StorageReference { access }
+                            } else if self.types.memory_layout(rhs_ty).is_some() {
+                                TupleAssignmentRhs::StorageCopy {
+                                    access,
+                                    source_ty: rhs_ty,
+                                    span: rhs.span,
+                                }
+                            } else {
+                                TupleAssignmentRhs::Materialized {
+                                    value,
+                                    source_ty: Some(rhs_ty),
+                                    span: rhs.span,
+                                }
                             }
                         } else {
                             TupleAssignmentRhs::Materialized {
@@ -462,7 +471,13 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
                 } else {
                     if let Some(lhs) = lhs {
                         let source_ty = self.context.gcx.type_of_expr(rhs.id);
-                        let value = if source_ty.is_some_and(|ty| {
+                        let value = if self.is_storage_reference_binding(lhs)
+                            && source_ty.is_some_and(|ty| ty.is_ref_at(DataLocation::Storage))
+                        {
+                            TupleAssignmentRhs::StorageReference {
+                                access: self.storage_access(rhs)?,
+                            }
+                        } else if source_ty.is_some_and(|ty| {
                             ty.is_ref_at(DataLocation::Storage)
                                 && self.types.memory_layout(ty).is_some()
                         }) {

--- a/tests/ui/codegen/lowering/run-call/mixed_storage_tuple.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/mixed_storage_tuple.mir.stdout
@@ -59,18 +59,18 @@ fn @test_g() -> (u256, u256) [selector=0xc51b800f, abi_params=[], abi_returns=[w
     v1 = frame_load multi_return, word, 0 !metadata(memory=scratch)
     v2 = add v1, 32
     v3 = mload v2
-    v4 = alloc memorystruct<1>, exact, uninitialized, panic, 32
-    v5 = sload v3 !metadata(storage=symbolic(v3))
-    memory_object_store_field memorystruct<1>, v4, 0, v5
-    v6 = sload 0 !metadata(storage=slot(0))
-    v7 = lt 1, v6
-    v8 = iszero v7
-    jumpi v8, bb1, bb2
+    v4 = sload 0 !metadata(storage=slot(0))
+    v5 = lt 1, v4
+    v6 = iszero v5
+    jumpi v6, bb1, bb2
   bb2:
-    v9 = storage_array_data_slot 0
-    v10 = add v9, 1
-    v11 = memory_object_load_field memorystruct<1>, v4, 0
-    sstore v10, v11 !metadata(storage=offset(v9, 1))
+    v7 = storage_array_data_slot 0
+    v8 = add v7, 1
+    v9 = alloc memorystruct<1>, exact, uninitialized, panic, 32
+    v10 = sload v3 !metadata(storage=symbolic(v3))
+    memory_object_store_field memorystruct<1>, v9, 0, v10
+    v11 = memory_object_load_field memorystruct<1>, v9, 0
+    sstore v8, v11 !metadata(storage=offset(v7, 1))
     sstore 1, v0 !metadata(storage=slot(1))
     v12 = sload 1 !metadata(storage=slot(1))
     v13 = sload 0 !metadata(storage=slot(0))

--- a/tests/ui/codegen/lowering/run-call/nested_storage_reference_tuple.sol
+++ b/tests/ui/codegen/lowering/run-call/nested_storage_reference_tuple.sol
@@ -1,0 +1,46 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: fromCall() => 10, 31, 41, 7
+//@ run-call: fromTuple() => 10, 31, 41, 7
+
+contract NestedStorageReferenceTuple {
+    struct Item {
+        uint256 value;
+    }
+
+    Item[3] private items;
+
+    function fromCall() external returns (uint256, uint256, uint256, uint256) {
+        initialize();
+        Item storage first = items[0];
+        Item storage second = items[1];
+        uint256 marker;
+        ((first, second), marker) = (pair(), 7);
+        first.value = 31;
+        second.value = 41;
+        return (items[0].value, items[1].value, items[2].value, marker);
+    }
+
+    function fromTuple() external returns (uint256, uint256, uint256, uint256) {
+        initialize();
+        Item storage first = items[0];
+        Item storage second = items[1];
+        uint256 marker;
+        ((first, second), marker) = ((items[1], items[2]), 7);
+        first.value = 31;
+        second.value = 41;
+        return (items[0].value, items[1].value, items[2].value, marker);
+    }
+
+    function initialize() private {
+        items[0].value = 10;
+        items[1].value = 20;
+    }
+
+    function pair() private view returns (Item storage first, Item storage second) {
+        first = items[1];
+        second = items[2];
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/storage_tuple_aliasing.sol
+++ b/tests/ui/codegen/lowering/run-call/storage_tuple_aliasing.sol
@@ -1,0 +1,100 @@
+//@ revisions: none gas size
+//@[none] compile-flags: -O none
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: storageAliases() => 10, 10, 2, 1
+//@ run-call: lhsMutation() => 99, 20
+//@ run-call: memorySnapshot() => 10, 99
+//@ run-call: returnedReferences() => 10, 10
+//@ run-call: nestedReturnedReferences() => 10, 10, 20
+//@ run-call: dynamicArrays() => 1, 1, 1, 1
+//@ run-call: byteArrays() => 0x0102, 0x0102
+
+contract StorageTupleAliasing {
+    struct Item {
+        uint256 value;
+    }
+
+    Item[3] private items;
+    uint256 private lhsIndex;
+    uint256 private rhsIndex;
+    uint256[] private x;
+    uint256[] private y;
+    bytes private firstBytes;
+    bytes private secondBytes;
+
+    function storageAliases() external returns (uint256, uint256, uint256, uint256) {
+        items[0].value = 10;
+        items[1].value = 20;
+        lhsIndex = 0;
+        rhsIndex = 1;
+        (items[nextLhs()], items[nextLhs()]) = (items[nextRhs()], items[nextRhs()]);
+        return (items[0].value, items[1].value, lhsIndex, rhsIndex);
+    }
+
+    function lhsMutation() external returns (uint256, uint256) {
+        items[0].value = 10;
+        items[1].value = 20;
+        (items[mutateSource()], items[1]) = (items[0], items[1]);
+        return (items[0].value, items[1].value);
+    }
+
+    function memorySnapshot() external returns (uint256, uint256) {
+        items[0].value = 10;
+        Item memory copy;
+        uint256[1] memory targets;
+        // Storage-to-memory copies stay eager; only storage-to-storage copies are deferred.
+        (copy, targets[mutateSource()]) = (items[0], 1);
+        return (copy.value, items[0].value);
+    }
+
+    function returnedReferences() external returns (uint256, uint256) {
+        items[0].value = 10;
+        items[1].value = 20;
+        (items[0], items[1]) = pair();
+        return (items[0].value, items[1].value);
+    }
+
+    function nestedReturnedReferences() external returns (uint256, uint256, uint256) {
+        items[0].value = 10;
+        items[1].value = 20;
+        ((items[0], items[1]), items[2]) = (pair(), items[1]);
+        return (items[0].value, items[1].value, items[2].value);
+    }
+
+    function dynamicArrays() external returns (uint256, uint256, uint256, uint256) {
+        delete x;
+        delete y;
+        x.push(1);
+        y.push(2);
+        y.push(3);
+        (x, y) = (y, x);
+        return (x.length, x[0], y.length, y[0]);
+    }
+
+    function byteArrays() external returns (bytes memory, bytes memory) {
+        firstBytes = hex"0102";
+        secondBytes = hex"030405";
+        (firstBytes, secondBytes) = (secondBytes, firstBytes);
+        return (firstBytes, secondBytes);
+    }
+
+    function nextLhs() private returns (uint256 index) {
+        index = lhsIndex++;
+    }
+
+    function nextRhs() private returns (uint256 index) {
+        index = rhsIndex;
+        rhsIndex ^= 1;
+    }
+
+    function mutateSource() private returns (uint256) {
+        items[0].value = 99;
+        return 0;
+    }
+
+    function pair() private view returns (Item storage first, Item storage second) {
+        first = items[1];
+        second = items[0];
+    }
+}


### PR DESCRIPTION
Nested tuple lowering treated storage-typed leaves as value copies even when their targets were local storage references. The assignment therefore wrote through each variable's old referent instead of rebinding it.

This preserves captured storage locations as reference assignments for both nested tuple literals and nested multi-return calls, then reuses the existing right-to-left commit path.

`solsymdiff` replayed both minimized forms under legacy/via-IR and optimized/unoptimized settings. The #1301 parent mismatched all eight combinations; this commit reports bounded agreement for all eight. A concrete replay returns `(10, 31, 41, 7)` with Solc instead of the parent's `(31, 41, 0, 7)`.

Validation covered the full UI suite, 1,463 ordinary workspace tests, the full Foundry comparison corpus, nightly clippy, formatting, and diff checks.

This depends on #1301 and targets the codegen-lowering rewrite. The new reviewable commit is `ac376db9`.

AI assistance: Codex assisted with differential discovery, implementation, and validation.
