### PR TITLE
fix(sema): reject dynamic calldata slices

### DIFF
--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -483,6 +483,13 @@ impl<'gcx> TypeChecker<'gcx> {
                     self.dcx().emit_err(expr.span, "can only slice arrays");
                 } else if !is_calldata_sliceable(ty) {
                     self.dcx().emit_err(expr.span, "can only slice dynamic calldata arrays");
+                } else if let Some(element) = slice_element_type(ty)
+                    && element.is_dynamically_encoded(self.gcx)
+                {
+                    self.dcx().emit_err(
+                        expr.span,
+                        "index range access is not supported for arrays with dynamically encoded base types",
+                    );
                 }
                 if self.index_types(ty).is_some() || is_string_or_string_slice(ty) {
                     if let Some(start) = start {
@@ -2981,6 +2988,16 @@ fn valid_delete(ty: Ty<'_>) -> bool {
 fn is_calldata_sliceable(ty: Ty<'_>) -> bool {
     ty.is_ref_at(DataLocation::Calldata)
         || matches!(ty.kind, TyKind::Slice(array) if array.data_stored_in(DataLocation::Calldata))
+}
+
+/// The element type of an array-typed expression, descending through slices.
+/// Returns `None` for bytes and string, whose range access is always allowed.
+fn slice_element_type(ty: Ty<'_>) -> Option<Ty<'_>> {
+    match ty.peel_refs().kind {
+        TyKind::DynArray(element) | TyKind::Array(element, _) => Some(element),
+        TyKind::Slice(array) => slice_element_type(array),
+        _ => None,
+    }
 }
 
 fn valid_string_concat_arg(ty: Ty<'_>) -> bool {

--- a/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.sol
+++ b/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.sol
@@ -1,11 +1,8 @@
-//@compile-flags: -O none -Zdump=mir
-
 contract CalldataArraySubsliceDynamic {
-    // A sub-slice of a dynamic-element array keeps element offsets relative to
-    // the original base, which a rebuild cannot recover, so it is rejected
-    // rather than miscompiled.
+    // Range access on arrays with dynamically encoded base types is rejected
+    // by solc itself, so the compiler matches that semantics instead of
+    // carrying a codegen bail.
     function dynamic(bytes[] calldata data) external pure returns (bytes[] memory) {
-        return data[1:]; //~ ERROR: codegen does not support slicing a calldata array of dynamic elements yet
-        //~^ ERROR: codegen does not support slicing a calldata array of dynamic elements yet
+        return data[1:]; //~ ERROR: index range access is not supported for arrays with dynamically encoded base types
     }
 }

--- a/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.stderr
+++ b/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.stderr
@@ -1,14 +1,8 @@
-error: codegen does not support slicing a calldata array of dynamic elements yet
+error: index range access is not supported for arrays with dynamically encoded base types
    ╭▸ ROOT/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.sol:LL:CC
    │
 LL │         return data[1:];
    ╰╴               ━━━━━━━━
 
-error: codegen does not support slicing a calldata array of dynamic elements yet
-   ╭▸ ROOT/tests/ui/codegen/lowering/calldata_array_subslice_dynamic.sol:LL:CC
-   │
-LL │         return data[1:];
-   ╰╴               ━━━━━━━━
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
Reject range access on calldata arrays with dynamically encoded elements during type checking. This matches solc and prevents the request from reaching the backend fallback diagnostic.