### PR TITLE
fix(bench): improve benchmark reports

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,47 +86,90 @@ jobs:
           "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" --version
 
       - name: Build Solar
-        run: cargo build --release -p solar-compiler --bin solar
+        run: |
+          cargo build --release -p solar-compiler --bin solar
+          cp target/release/solar target/release/solar-head
 
-      - name: Download baseline (${{ env.BASE_BRANCH }} branch)
+      - name: Download exact baseline (${{ env.BASE_BRANCH }} branch)
         id: baseline
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           mkdir -p target/codegen-bench/baseline
 
+          base_sha="$BASE_SHA"
+          if [[ -z "$base_sha" ]]; then
+            base_sha="$(git rev-parse "origin/$BASE_BRANCH")"
+          fi
+          echo "sha=$base_sha" >> "$GITHUB_OUTPUT"
+
           run_ids="$(
             gh run list \
               --workflow bench.yml \
-              --branch "$BASE_BRANCH" \
+              --commit "$base_sha" \
               --status success \
-              --limit 20 \
+              --limit 10 \
               --json databaseId \
               --jq '.[].databaseId' \
               2>/dev/null || true
           )"
           if [[ -z "$run_ids" ]]; then
-            echo "::warning::No successful $BASE_BRANCH benchmark run was found for baseline comparison"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No successful benchmark run was found for exact base $base_sha"
             exit 0
           fi
 
           for run_id in $run_ids; do
-            if gh run download "$run_id" \
-              --name codegen-runtime-baseline \
-              --dir target/codegen-bench/baseline \
-              2>/dev/null && [[ -f target/codegen-bench/baseline/results.json ]]; then
-              exit 0
-            fi
-            if gh run download "$run_id" \
-              --name codegen-runtime-results \
-              --dir target/codegen-bench/baseline \
-              2>/dev/null && [[ -f target/codegen-bench/baseline/results.json ]]; then
-              exit 0
-            fi
+            for artifact in codegen-runtime-baseline codegen-runtime-results; do
+              download_dir="$RUNNER_TEMP/codegen-baseline-$run_id-$artifact"
+              mkdir -p "$download_dir"
+              if gh run download "$run_id" \
+                --name "$artifact" \
+                --dir "$download_dir" \
+                2>/dev/null && [[ -f "$download_dir/results.json" ]]; then
+                cp "$download_dir/results.json" target/codegen-bench/baseline/results.json
+                echo "found=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            done
           done
 
-          echo "::warning::No $BASE_BRANCH baseline artifact was available for comparison"
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::Exact base $base_sha has no complete baseline artifact"
+
+      - name: Build exact-base compiler
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.found != 'true'
+        env:
+          BASE_SHA: ${{ steps.baseline.outputs.sha }}
+        run: |
+          set -euo pipefail
+          git checkout --detach "$BASE_SHA"
+          if ! cargo build --release -p solar-compiler --bin solar; then
+            git checkout --detach "$GITHUB_SHA"
+            exit 1
+          fi
+          cp target/release/solar target/release/solar-base
+          git checkout --detach "$GITHUB_SHA"
+
+      - name: Run exact-base benchmark
+        if: github.event_name == 'pull_request' && steps.baseline.outputs.found != 'true'
+        run: |
+          set -euo pipefail
+          if ! python3 benches/runtime/benchmark.py --verbose \
+            --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
+            --solar target/release/solar-base \
+            --mode runtime compile-time \
+            --suite all \
+            --compile-repeats 5 \
+            --gas \
+            --gas-profile hot \
+            --start-anvil \
+            --allow-failures \
+            --output target/codegen-bench/baseline/results.json; then
+            echo "::warning::Exact-base codegen benchmark failed to complete"
+          fi
 
       - name: Run codegen benchmark
         id: codegen-bench
@@ -135,7 +178,7 @@ jobs:
           mkdir -p target/codegen-bench
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/release/solar \
+            --solar target/release/solar-head \
             --mode runtime compile-time \
             --suite all \
             --compile-repeats 5 \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build Solar
         run: |
           cargo build --profile bench -p solar-compiler --bin solar
-          cp target/bench/solar target/bench/solar-head
+          cp target/release/solar target/release/solar-head
 
       - name: Download exact baseline (${{ env.BASE_BRANCH }} branch)
         id: baseline
@@ -177,7 +177,7 @@ jobs:
             git checkout --detach "$GITHUB_SHA"
             exit 1
           fi
-          cp target/bench/solar target/bench/solar-base
+          cp target/release/solar target/release/solar-base
           git checkout --detach "$GITHUB_SHA"
 
       - name: Run exact-base benchmark
@@ -186,7 +186,7 @@ jobs:
           set -euo pipefail
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/bench/solar-base \
+            --solar target/release/solar-base \
             --mode runtime compile-time \
             --suite all \
             --compile-repeats 5 \
@@ -205,7 +205,7 @@ jobs:
           mkdir -p target/codegen-bench
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/bench/solar-head \
+            --solar target/release/solar-head \
             --mode runtime compile-time \
             --suite all \
             --compile-repeats 5 \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,6 +94,7 @@ jobs:
         id: baseline
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -105,19 +106,45 @@ jobs:
           fi
           echo "sha=$base_sha" >> "$GITHUB_OUTPUT"
 
-          run_ids="$(
+          runs_json="$(
             gh run list \
               --workflow bench.yml \
               --commit "$base_sha" \
-              --status success \
               --limit 10 \
-              --json databaseId \
-              --jq '.[].databaseId' \
+              --json createdAt,databaseId,status \
               2>/dev/null || true
+          )"
+          latest_run_id="$(
+            jq -r --argjson current "$CURRENT_RUN_ID" \
+              '[.[] | select(.databaseId != $current)] | max_by(.createdAt).databaseId // empty' \
+              <<< "$runs_json"
+          )"
+          if [[ "${{ github.event_name }}" == "pull_request" && -n "$latest_run_id" ]]; then
+            latest_status="$(
+              jq -r --argjson run_id "$latest_run_id" \
+                '.[] | select(.databaseId == $run_id) | .status' \
+                <<< "$runs_json"
+            )"
+            if [[ "$latest_status" != "completed" ]]; then
+              echo "Waiting for exact-base benchmark run $latest_run_id"
+              gh run watch "$latest_run_id" --interval 10
+              runs_json="$(
+                gh run list \
+                  --workflow bench.yml \
+                  --commit "$base_sha" \
+                  --limit 10 \
+                  --json createdAt,databaseId,status
+              )"
+            fi
+          fi
+          run_ids="$(
+            jq -r --argjson current "$CURRENT_RUN_ID" \
+              '[.[] | select(.databaseId != $current and .status == "completed")] | sort_by(.createdAt) | reverse | .[].databaseId' \
+              <<< "$runs_json"
           )"
           if [[ -z "$run_ids" ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No successful benchmark run was found for exact base $base_sha"
+            echo "::warning::No completed benchmark run was found for exact base $base_sha"
             exit 0
           fi
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -170,7 +170,14 @@ jobs:
 
       - name: Add report to job summary
         if: always()
-        run: cat target/codegen-bench/report.md >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          if [[ -f target/codegen-bench/report.md ]]; then
+            cat target/codegen-bench/report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Codegen benchmark' >> "$GITHUB_STEP_SUMMARY"
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo 'The benchmark did not produce a report.' >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Comment on PR
         if: >-

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Build Solar
         run: |
-          cargo build --release -p solar-compiler --bin solar
-          cp target/release/solar target/release/solar-head
+          cargo build --profile bench -p solar-compiler --bin solar
+          cp target/bench/solar target/bench/solar-head
 
       - name: Download exact baseline (${{ env.BASE_BRANCH }} branch)
         id: baseline
@@ -173,11 +173,11 @@ jobs:
         run: |
           set -euo pipefail
           git checkout --detach "$BASE_SHA"
-          if ! cargo build --release -p solar-compiler --bin solar; then
+          if ! cargo build --profile bench -p solar-compiler --bin solar; then
             git checkout --detach "$GITHUB_SHA"
             exit 1
           fi
-          cp target/release/solar target/release/solar-base
+          cp target/bench/solar target/bench/solar-base
           git checkout --detach "$GITHUB_SHA"
 
       - name: Run exact-base benchmark
@@ -186,7 +186,7 @@ jobs:
           set -euo pipefail
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/release/solar-base \
+            --solar target/bench/solar-base \
             --mode runtime compile-time \
             --suite all \
             --compile-repeats 5 \
@@ -205,7 +205,7 @@ jobs:
           mkdir -p target/codegen-bench
           if ! python3 benches/runtime/benchmark.py --verbose \
             --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/release/solar-head \
+            --solar target/bench/solar-head \
             --mode runtime compile-time \
             --suite all \
             --compile-repeats 5 \

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1357,6 +1357,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.solar,
         [
             "solar",
+            "target/bench/solar",
             "target/release/solar",
             "target/debug/solar",
         ],

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import gzip
 import hashlib
 import json
@@ -15,6 +16,7 @@ import shutil
 import subprocess
 import statistics
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from functools import lru_cache
@@ -57,6 +59,8 @@ CAST_TX_TIMEOUT = 30
 CAST_READ_TIMEOUT = 10
 CAST_RPC_TIMEOUT = 10
 CAST_GAS_LIMIT = "80000000"
+# Linux limits each argument to 32 pages, or 128 KiB on CI.
+CAST_CREATE_FILE_THRESHOLD = 100_000
 RUNTIME_FIXTURES = ROOT / "fixtures/runtime/RuntimeFixtures.sol"
 
 RESET = "\033[0m"
@@ -514,32 +518,91 @@ def deploy_creation_code(
         return None, None, "constructor args require constructor_sig"
     bytecode += encoded
 
-    proc = run(
-        [
-            "cast",
-            "send",
-            "--rpc-url",
-            rpc_url,
-            "--rpc-timeout",
-            str(CAST_RPC_TIMEOUT),
-            "--timeout",
-            str(CAST_RPC_TIMEOUT),
-            "--gas-limit",
-            CAST_GAS_LIMIT,
-            "--private-key",
-            private_key,
-            "--json",
-            "--create",
-            bytecode,
-        ],
-        timeout=CAST_DEPLOY_TIMEOUT,
-    )
+    if len(bytecode) > CAST_CREATE_FILE_THRESHOLD:
+        return deploy_large_creation_code(bytecode, rpc_url, private_key)
+
+    try:
+        proc = run(
+            [
+                "cast",
+                "send",
+                "--rpc-url",
+                rpc_url,
+                "--rpc-timeout",
+                str(CAST_RPC_TIMEOUT),
+                "--timeout",
+                str(CAST_RPC_TIMEOUT),
+                "--gas-limit",
+                CAST_GAS_LIMIT,
+                "--private-key",
+                private_key,
+                "--json",
+                "--create",
+                bytecode,
+            ],
+            timeout=CAST_DEPLOY_TIMEOUT,
+        )
+    except OSError as exc:
+        if exc.errno != errno.E2BIG:
+            raise
+        return deploy_large_creation_code(bytecode, rpc_url, private_key)
     if proc.returncode != 0:
         return None, None, proc.stderr[:1000]
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
         return None, None, f"invalid deploy JSON: {exc}"
+    return parse_deploy_receipt(data)
+
+
+def deploy_large_creation_code(
+    bytecode: str,
+    rpc_url: str,
+    private_key: str,
+) -> Tuple[Optional[str], Optional[int], str]:
+    sender, error = private_key_address(private_key)
+    if sender is None:
+        return None, None, error
+
+    transaction = {
+        "from": sender,
+        "data": bytecode,
+        "gas": hex(int(CAST_GAS_LIMIT)),
+    }
+    tx_hash, error = rpc_request_from_file(
+        "eth_sendTransaction",
+        (transaction,),
+        rpc_url,
+        CAST_DEPLOY_TIMEOUT,
+    )
+    if not isinstance(tx_hash, str):
+        return None, None, error or "deploy transaction missing hash"
+
+    deadline = time.monotonic() + CAST_DEPLOY_TIMEOUT
+    while True:
+        receipt, error = rpc_request("eth_getTransactionReceipt", (tx_hash,), rpc_url)
+        if error:
+            return None, None, error
+        if isinstance(receipt, dict):
+            return parse_deploy_receipt(receipt)
+        if time.monotonic() >= deadline:
+            return None, None, "timed out waiting for deploy receipt"
+        time.sleep(0.1)
+
+
+@lru_cache
+def private_key_address(private_key: str) -> Tuple[Optional[str], str]:
+    if private_key == DEFAULT_PRIVATE_KEY:
+        return DEFAULT_SENDER, ""
+    proc = run(["cast", "wallet", "address", "--private-key", private_key], timeout=30)
+    if proc.returncode != 0:
+        return None, proc.stderr[:1000]
+    return proc.stdout.strip(), ""
+
+
+def parse_deploy_receipt(
+    data: dict[str, object],
+) -> Tuple[Optional[str], Optional[int], str]:
     status = parse_receipt_int(data.get("status"))
     gas = data.get("gasUsed")
     deploy_gas = parse_receipt_int(gas)
@@ -547,7 +610,39 @@ def deploy_creation_code(
         return None, deploy_gas, f"deploy transaction failed (status={status}, gasUsed={deploy_gas})"
     if deploy_gas is None:
         return None, None, "deploy receipt missing gasUsed"
-    return data.get("contractAddress"), deploy_gas, ""
+    contract_address = data.get("contractAddress")
+    return contract_address if isinstance(contract_address, str) else None, deploy_gas, ""
+
+
+def rpc_request_from_file(
+    method: str,
+    params: Sequence[object],
+    rpc_url: str,
+    timeout: int = CAST_READ_TIMEOUT,
+) -> Tuple[Optional[object], str]:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix="solar-bench-rpc-",
+        suffix=".json",
+        delete=False,
+    ) as params_file:
+        json.dump(list(params), params_file)
+        params_path = Path(params_file.name)
+    try:
+        proc = run(
+            ["cast", "rpc", "--rpc-url", rpc_url, "--raw", method],
+            input_path=params_path,
+            timeout=timeout,
+        )
+    finally:
+        params_path.unlink(missing_ok=True)
+    if proc.returncode != 0:
+        return None, (proc.stderr or proc.stdout or f"{method} failed")[:1000]
+    try:
+        return json.loads(proc.stdout), ""
+    except json.JSONDecodeError as exc:
+        return None, f"invalid {method} JSON: {exc}"
 
 
 def call_contract(

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import argparse
-import errno
 import gzip
 import hashlib
 import json
@@ -59,8 +58,6 @@ CAST_TX_TIMEOUT = 30
 CAST_READ_TIMEOUT = 10
 CAST_RPC_TIMEOUT = 10
 CAST_GAS_LIMIT = "80000000"
-# Linux limits each argument to 32 pages, or 128 KiB on CI.
-CAST_CREATE_FILE_THRESHOLD = 100_000
 RUNTIME_FIXTURES = ROOT / "fixtures/runtime/RuntimeFixtures.sol"
 
 RESET = "\033[0m"
@@ -517,45 +514,10 @@ def deploy_creation_code(
     if encoded is None:
         return None, None, "constructor args require constructor_sig"
     bytecode += encoded
-
-    if len(bytecode) > CAST_CREATE_FILE_THRESHOLD:
-        return deploy_large_creation_code(bytecode, rpc_url, private_key)
-
-    try:
-        proc = run(
-            [
-                "cast",
-                "send",
-                "--rpc-url",
-                rpc_url,
-                "--rpc-timeout",
-                str(CAST_RPC_TIMEOUT),
-                "--timeout",
-                str(CAST_RPC_TIMEOUT),
-                "--gas-limit",
-                CAST_GAS_LIMIT,
-                "--private-key",
-                private_key,
-                "--json",
-                "--create",
-                bytecode,
-            ],
-            timeout=CAST_DEPLOY_TIMEOUT,
-        )
-    except OSError as exc:
-        if exc.errno != errno.E2BIG:
-            raise
-        return deploy_large_creation_code(bytecode, rpc_url, private_key)
-    if proc.returncode != 0:
-        return None, None, proc.stderr[:1000]
-    try:
-        data = json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        return None, None, f"invalid deploy JSON: {exc}"
-    return parse_deploy_receipt(data)
+    return deploy_creation_code_from_file(bytecode, rpc_url, private_key)
 
 
-def deploy_large_creation_code(
+def deploy_creation_code_from_file(
     bytecode: str,
     rpc_url: str,
     private_key: str,

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1357,7 +1357,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         args.solar,
         [
             "solar",
-            "target/bench/solar",
             "target/release/solar",
             "target/debug/solar",
         ],

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1103,6 +1103,31 @@ def compare_runtime_results(entry: Dict[str, object], specs: Sequence[CompilerSp
         entry["runtime_status"] = "ok"
 
 
+def failed_test_result(
+    test_case: TestCase,
+    specs: Sequence[CompilerSpec],
+    gas_profile: str,
+    error: Exception,
+) -> Dict[str, object]:
+    message = f"unexpected benchmark failure: {type(error).__name__}: {error}"[:1000]
+    entry: Dict[str, object] = {
+        "test_id": test_case.test_id,
+        "description": test_case.description,
+        "contract_name": test_case.contract_name,
+        "suite": test_case.suite,
+        "gas_profile": gas_profile,
+        "benchmark_error": message,
+        "compilers": {
+            spec.compiler_id: {"status": "failed", "error": message}
+            for spec in specs
+        },
+    }
+    if test_case.project_file is not None:
+        entry["project"] = test_case.project
+        entry["source"] = test_case.source
+    return entry
+
+
 def run_test_case(
     test_case: TestCase,
     specs: Sequence[CompilerSpec],
@@ -1410,7 +1435,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     try:
         if args.gas and args.start_anvil:
             print("Starting anvil...")
-            anvil_proc = start_anvil(args.rpc_url)
+            try:
+                anvil_proc = start_anvil(args.rpc_url)
+            except Exception as exc:
+                print(_color(f"Benchmark setup failed: {exc}", RED), file=sys.stderr)
+                results.extend(
+                    failed_test_result(test, specs, args.gas_profile, exc)
+                    for test in tests
+                )
+                tests = []
         current_suite = None
         suite_started = None
         for test in tests:
@@ -1420,8 +1453,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     timings[current_suite] = timings.get(current_suite, 0.0) + time.monotonic() - suite_started
                 current_suite = suite
                 suite_started = time.monotonic()
-            results.append(
-                run_test_case(
+            try:
+                result = run_test_case(
                     test,
                     specs,
                     args.gas,
@@ -1431,13 +1464,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     args.verbose,
                     args.compile_repeats,
                 )
-            )
+            except Exception as exc:
+                print(
+                    _color(f"[{test.test_id}] Unexpected benchmark failure: {exc}", RED),
+                    file=sys.stderr,
+                )
+                result = failed_test_result(test, specs, args.gas_profile, exc)
+            results.append(result)
         if current_suite is not None and suite_started is not None:
             timings[current_suite] = timings.get(current_suite, 0.0) + time.monotonic() - suite_started
     finally:
         if anvil_proc:
             print("Stopping anvil...")
-            stop_anvil(anvil_proc)
+            try:
+                stop_anvil(anvil_proc)
+            except Exception as exc:
+                print(_color(f"Failed to stop anvil: {exc}", RED), file=sys.stderr)
 
     if args.verbose:
         for result in results:

--- a/benches/runtime/common.py
+++ b/benches/runtime/common.py
@@ -76,15 +76,20 @@ def run(
     if stdin is None and input_text is not None:
         stdin = subprocess.PIPE
     try:
-        proc = subprocess.Popen(
-            run_cmd,
-            stdin=stdin,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=cwd,
-            **kwargs,
-        )
+        try:
+            proc = subprocess.Popen(
+                run_cmd,
+                stdin=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=cwd,
+                **kwargs,
+            )
+        except OSError as exc:
+            if peak_rss_path is not None:
+                peak_rss_path.unlink(missing_ok=True)
+            return CommandResult(-1, "", f"failed to run {cmd[0]}: {exc}")
     finally:
         if input_file is not None:
             input_file.close()

--- a/benches/runtime/common.py
+++ b/benches/runtime/common.py
@@ -52,7 +52,11 @@ def run(
     timeout: int = 120,
     cwd: Optional[Path] = None,
     measure_peak_rss: bool = False,
+    input_path: Optional[Path] = None,
 ) -> CommandResult:
+    if input_text is not None and input_path is not None:
+        raise ValueError("input_text and input_path are mutually exclusive")
+
     start = time.monotonic()
     peak_rss_path = None
     run_cmd = list(cmd)
@@ -67,15 +71,23 @@ def run(
     kwargs = {}
     if os.name != "nt":
         kwargs["start_new_session"] = True
-    proc = subprocess.Popen(
-        run_cmd,
-        stdin=subprocess.PIPE if input_text is not None else None,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=cwd,
-        **kwargs,
-    )
+    input_file = input_path.open() if input_path is not None else None
+    stdin = input_file
+    if stdin is None and input_text is not None:
+        stdin = subprocess.PIPE
+    try:
+        proc = subprocess.Popen(
+            run_cmd,
+            stdin=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+            **kwargs,
+        )
+    finally:
+        if input_file is not None:
+            input_file.close()
     try:
         stdout, stderr = proc.communicate(input=input_text, timeout=timeout)
     except subprocess.TimeoutExpired:

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -154,6 +154,48 @@ COMPILE_TIME_TOTAL_CHANGE = 0.10
 COMPILE_TIME_TOTAL_ABSOLUTE_CHANGE = 1.0
 
 
+def compiler_status(result: dict[str, Any] | None, compiler: str) -> str | None:
+    if result is None:
+        return None
+    data = compiler_data(result, compiler)
+    if not data:
+        return None
+    return "ok" if data.get("status") == "ok" else "n/a"
+
+
+def compilation_failure_report(
+    results: list[dict[str, Any]],
+    baseline_results: list[dict[str, Any]],
+    baseline_ref: str,
+) -> list[str]:
+    current = by_test_id(results)
+    baseline = by_test_id(baseline_results)
+    keys = [*current, *(key for key in baseline if key not in current)]
+    rows = []
+    for key in keys:
+        current_status = compiler_status(current.get(key), "solar")
+        baseline_status = compiler_status(baseline.get(key), "solar")
+        if "n/a" not in (current_status, baseline_status):
+            continue
+
+        statuses = []
+        if baseline_status is not None:
+            statuses.append(f"`{baseline_ref}` = `{baseline_status}`")
+        if current_status is not None:
+            statuses.append(f"branch = `{current_status}`")
+        rows.append(f"> - `{'/'.join(key)}`: {', '.join(statuses)}")
+
+    if not rows:
+        return []
+    return [
+        "> [!NOTE]",
+        "> The compiler failed on these benchmarks; `n/a` marks the failed revision:",
+        ">",
+        *rows,
+        "",
+    ]
+
+
 def has_codegen_changes(
     results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]
 ) -> bool:
@@ -162,6 +204,15 @@ def has_codegen_changes(
         base = baseline.get(suite_key(result))
         if base is None:
             continue
+
+        current_status = compiler_status(result, "solar")
+        baseline_status = compiler_status(base, "solar")
+        if (
+            current_status is not None
+            and baseline_status is not None
+            and current_status != baseline_status
+        ):
+            return True
 
         solar_gas = total_gas(result, "solar")
         base_solar_gas = total_gas(base, "solar")
@@ -566,6 +617,7 @@ def report_section(
         lines.extend(
             [f"No `{baseline_ref}` baseline artifact was available for comparison.", ""]
         )
+    lines.extend(compilation_failure_report(results, baseline_results, baseline_ref))
 
     rows = benchmark_rows(results, baseline)
     if rows:

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -64,6 +64,9 @@ def compiler_failures(results: list[dict[str, Any]]) -> list[str]:
     failures = []
     for result in results:
         test_id = "/".join(suite_key(result))
+        if error := result.get("benchmark_error"):
+            failures.append(f"{test_id}: {error}")
+            continue
         compilers = result.get("compilers", {})
         for compiler_id, data in compilers.items():
             if data.get("status") != "ok":

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -651,15 +651,6 @@ def emit_warnings(results: list[dict[str, Any]], baseline_results: list[dict[str
         warning(f"benchmark regression recorded: {detail}")
 
 
-def append_step_summary(markdown: str) -> None:
-    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not summary_path:
-        return
-    with open(summary_path, "a") as f:
-        f.write(markdown)
-        f.write("\n")
-
-
 def append_github_output(name: str, value: str) -> None:
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
@@ -859,7 +850,6 @@ def main() -> int:
         should_comment |= has_compile_time_changes(results, baseline_results)
     markdown = format_report(report, should_comment, branch_is_behind(base_ref), base_ref)
     print(markdown)
-    append_step_summary(markdown)
     append_github_output("report", markdown)
     append_github_output("should_comment", "true" if should_comment else "false")
     if args.report_output is not None:

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -204,12 +204,18 @@ class RuntimeComparisonTests(unittest.TestCase):
 
 
 class RpcTransportTests(unittest.TestCase):
-    def test_streams_large_params_through_stdin(self) -> None:
+    def test_streams_large_params_through_file(self) -> None:
         bytecode = "ab" * 100_000
         process = mock.Mock(returncode=0, stdout='"0x1234"\n', stderr="")
+        observed = {}
 
-        with mock.patch.object(benchmark, "run", return_value=process) as run:
-            value, error = benchmark.rpc_request(
+        def run_with_file(command, **kwargs):
+            observed["path"] = kwargs["input_path"]
+            observed["params"] = kwargs["input_path"].read_text()
+            return process
+
+        with mock.patch.object(benchmark, "run", side_effect=run_with_file) as run:
+            value, error = benchmark.rpc_request_from_file(
                 "eth_sendTransaction",
                 ({"data": "0x" + bytecode},),
                 "http://127.0.0.1:8545",
@@ -220,8 +226,76 @@ class RpcTransportTests(unittest.TestCase):
         command = run.call_args.args[0]
         self.assertTrue(all(bytecode not in argument for argument in command))
         self.assertEqual(
-            run.call_args.kwargs["input_text"],
+            observed["params"],
             json.dumps([{"data": "0x" + bytecode}]),
+        )
+        self.assertFalse(observed["path"].exists())
+
+    def test_deploys_large_creation_code_from_file(self) -> None:
+        bytecode = "ab" * benchmark.CAST_CREATE_FILE_THRESHOLD
+        receipt = {
+            "status": "0x1",
+            "gasUsed": "0x5208",
+            "contractAddress": "0x1234",
+        }
+
+        with (
+            mock.patch.object(
+                benchmark,
+                "rpc_request_from_file",
+                return_value=("0xtx", ""),
+            ) as send,
+            mock.patch.object(
+                benchmark,
+                "rpc_request",
+                return_value=(receipt, ""),
+            ) as request,
+        ):
+            address, gas, error = benchmark.deploy_creation_code(
+                bytecode,
+                (),
+                None,
+                "http://127.0.0.1:8545",
+                benchmark.DEFAULT_PRIVATE_KEY,
+            )
+
+        self.assertEqual((address, gas, error), ("0x1234", 21000, ""))
+        transaction = send.call_args.args[1][0]
+        self.assertEqual(transaction["from"], benchmark.DEFAULT_SENDER)
+        self.assertEqual(transaction["data"], "0x" + bytecode)
+        self.assertEqual(transaction["gas"], hex(int(benchmark.CAST_GAS_LIMIT)))
+        request.assert_called_once_with(
+            "eth_getTransactionReceipt",
+            ("0xtx",),
+            "http://127.0.0.1:8545",
+        )
+
+    def test_falls_back_to_file_when_argument_is_too_long(self) -> None:
+        with (
+            mock.patch.object(
+                benchmark,
+                "run",
+                side_effect=OSError(benchmark.errno.E2BIG, "argument list too long"),
+            ),
+            mock.patch.object(
+                benchmark,
+                "deploy_large_creation_code",
+                return_value=("0x1234", 21000, ""),
+            ) as deploy,
+        ):
+            result = benchmark.deploy_creation_code(
+                "00",
+                (),
+                None,
+                "http://127.0.0.1:8545",
+                benchmark.DEFAULT_PRIVATE_KEY,
+            )
+
+        self.assertEqual(result, ("0x1234", 21000, ""))
+        deploy.assert_called_once_with(
+            "0x00",
+            "http://127.0.0.1:8545",
+            benchmark.DEFAULT_PRIVATE_KEY,
         )
 
 

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -231,8 +231,8 @@ class RpcTransportTests(unittest.TestCase):
         )
         self.assertFalse(observed["path"].exists())
 
-    def test_deploys_large_creation_code_from_file(self) -> None:
-        bytecode = "ab" * benchmark.CAST_CREATE_FILE_THRESHOLD
+    def test_deploys_creation_code_from_file(self) -> None:
+        bytecode = "ab"
         receipt = {
             "status": "0x1",
             "gasUsed": "0x5208",
@@ -268,34 +268,6 @@ class RpcTransportTests(unittest.TestCase):
             "eth_getTransactionReceipt",
             ("0xtx",),
             "http://127.0.0.1:8545",
-        )
-
-    def test_falls_back_to_file_when_argument_is_too_long(self) -> None:
-        with (
-            mock.patch.object(
-                benchmark,
-                "run",
-                side_effect=OSError(benchmark.errno.E2BIG, "argument list too long"),
-            ),
-            mock.patch.object(
-                benchmark,
-                "deploy_large_creation_code",
-                return_value=("0x1234", 21000, ""),
-            ) as deploy,
-        ):
-            result = benchmark.deploy_creation_code(
-                "00",
-                (),
-                None,
-                "http://127.0.0.1:8545",
-                benchmark.DEFAULT_PRIVATE_KEY,
-            )
-
-        self.assertEqual(result, ("0x1234", 21000, ""))
-        deploy.assert_called_once_with(
-            "0x00",
-            "http://127.0.0.1:8545",
-            benchmark.DEFAULT_PRIVATE_KEY,
         )
 
 

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -1,6 +1,7 @@
 import importlib.util
 import json
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -168,6 +169,59 @@ class CorpusTests(unittest.TestCase):
         self.assertEqual(
             list(benchmark.project_slice(project, "src/A.sol")),
             ["shared/D.sol", "src/A.sol", "src/B.sol", "vendor/pkg/C.sol"],
+        )
+
+
+class FailureHandlingTests(unittest.TestCase):
+    def test_process_spawn_error_is_a_command_failure(self) -> None:
+        with mock.patch(
+            "common.subprocess.Popen",
+            side_effect=OSError(7, "Argument list too long"),
+        ):
+            result = benchmark.run(["cast", "send"])
+
+        self.assertEqual(result.returncode, -1)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Argument list too long", result.stderr)
+
+    def test_unexpected_test_error_is_written_as_a_failure(self) -> None:
+        test_id = benchmark.TEST_CASES[0].test_id
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            benchmark,
+            "find_binary",
+            side_effect=lambda value, _fallbacks: Path(value),
+        ), mock.patch.object(
+            benchmark,
+            "binary_version",
+            return_value=("0.8.36", ""),
+        ), mock.patch.object(
+            benchmark,
+            "run_test_case",
+            side_effect=RuntimeError("unexpected"),
+        ):
+            output = Path(directory) / "results.json"
+            return_code = benchmark.main(
+                [
+                    "--solc",
+                    "solc",
+                    "--solar",
+                    "solar",
+                    "--tests",
+                    test_id,
+                    "--allow-failures",
+                    "--output",
+                    str(output),
+                ]
+            )
+            document = json.loads(output.read_text())
+
+        self.assertEqual(return_code, 0)
+        self.assertEqual(len(document["results"]), 1)
+        failure = document["results"][0]
+        self.assertIn("RuntimeError: unexpected", failure["benchmark_error"])
+        self.assertEqual(
+            {compiler["status"] for compiler in failure["compilers"].values()},
+            {"failed"},
         )
 
 

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -148,6 +148,56 @@ class ReportFormattingTests(unittest.TestCase):
             "| micro | 10 (~0%) | n/a (n/a) | 20B (~0%) | n/a (n/a) |\n",
         )
 
+    def test_codegen_report_labels_failed_revision(self):
+        def timed_result(test_id, solar_status):
+            return {
+                "test_id": test_id,
+                "suite": "repository",
+                "compilers": {
+                    "solc": {"status": "ok", "compile_time_seconds": 0.100},
+                    "solar": {
+                        "status": solar_status,
+                        "compile_time_seconds": 0.010,
+                        "command": "target/release/solar --standard-json",
+                        "label": "solar 0.2.0",
+                        "input_fingerprint": "input",
+                    },
+                },
+            }
+
+        current = [
+            timed_result("base-failed", "ok"),
+            timed_result("branch-failed", "failed"),
+            timed_result("both-failed", "failed"),
+        ]
+        baseline = [
+            timed_result("base-failed", "failed"),
+            timed_result("branch-failed", "ok"),
+            timed_result("both-failed", "failed"),
+        ]
+        report = benchmark.codegen_report(current, baseline)
+        self.assertIn(
+            "> [!NOTE]\n"
+            "> The compiler failed on these benchmarks; `n/a` marks the failed revision:\n"
+            ">\n"
+            "> - `repository/base-failed`: `main` = `n/a`, branch = `ok`\n"
+            "> - `repository/branch-failed`: `main` = `ok`, branch = `n/a`\n"
+            "> - `repository/both-failed`: `main` = `n/a`, branch = `n/a`\n",
+            report,
+        )
+        self.assertIn(
+            "| base-failed | 10.0 ms (n/a) | 100.0 ms (✅ +900.00%) |", report
+        )
+        self.assertIn(
+            "| branch-failed | n/a (n/a) | 100.0 ms (n/a) |", report
+        )
+
+        for index in range(2):
+            self.assertTrue(
+                benchmark.has_codegen_changes([current[index]], [baseline[index]])
+            )
+        self.assertFalse(benchmark.has_codegen_changes(current[2:], baseline[2:]))
+
 
 class CommonBenchmarkResultTests(unittest.TestCase):
     def write_result(self, results, timings=None):

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -198,6 +198,25 @@ class ReportFormattingTests(unittest.TestCase):
             )
         self.assertFalse(benchmark.has_codegen_changes(current[2:], baseline[2:]))
 
+    def test_unexpected_benchmark_failure_is_reported_once(self):
+        failure = {
+            "test_id": "crashed",
+            "suite": "repository",
+            "benchmark_error": "unexpected benchmark failure: RuntimeError: broken",
+            "compilers": {
+                "solc": {"status": "failed"},
+                "solar": {"status": "failed"},
+            },
+        }
+
+        self.assertEqual(
+            benchmark.compiler_failures([failure]),
+            [
+                "repository/crashed: unexpected benchmark failure: "
+                "RuntimeError: broken"
+            ],
+        )
+
 
 class CommonBenchmarkResultTests(unittest.TestCase):
     def write_result(self, results, timings=None):

--- a/tools/tester/src/foundry.rs
+++ b/tools/tester/src/foundry.rs
@@ -572,7 +572,7 @@ fn run_forge_test(
     let mut cmd = Command::new("forge");
     cmd.current_dir(project_dir);
     if config.build_only {
-        cmd.arg("build").arg("--force");
+        cmd.arg("build").arg("--force").arg("--no-lint");
     } else {
         cmd.arg("test").arg("--force").arg("--json");
         if config.traces {


### PR DESCRIPTION
The benchmark report now lists compiler failures in a visible note and labels each benchmark by base and branch status, placing n/a on the revision that failed. It uses one always-running workflow step to write the job summary, adds a fallback note if report generation fails, and treats compilation status changes as report changes.

Every deployment now sends its creation bytecode through a temporary JSON-RPC file, keeping code out of process arguments. Process launch and unexpected per-test errors become failed benchmark rows, so the suite continues and writes one complete results document. Baseline lookup waits for the newest run at the exact PR base SHA, accepts only an artifact from that revision, and benchmarks that base compiler with the current harness if the completed run has no result. Both compilers use the bench profile. Build-only Foundry comparisons also skip the post-build lint pass to keep their logs focused.
