### PR TITLE
fix(parser): match solc syntax errors

### DIFF
--- a/crates/interface/src/symbol.rs
+++ b/crates/interface/src/symbol.rs
@@ -313,6 +313,7 @@ impl Symbol {
                 | kw::Break
                 | kw::Continue
                 | kw::Leave
+                | kw::Hex
                 | kw::True
                 | kw::False
         )
@@ -1052,6 +1053,7 @@ symbols! {
         err,
         error,
         evm_dash_shaped: "evm-shaped",
+        evmasm,
         exact,
         experimental,
         external_call,

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -6,7 +6,7 @@ use solar_ast::{
 };
 use solar_data_structures::hint::cold_path;
 use solar_interface::{
-    BytePos, Session, Span, Symbol, diagnostics::DiagCtxt, source_map::SourceFile,
+    BytePos, Session, Span, Symbol, diagnostics::DiagCtxt, error_code, source_map::SourceFile,
 };
 
 mod cursor;
@@ -148,6 +148,15 @@ impl<'sess, 'src> Lexer<'sess, 'src> {
                     TokenKind::Ident(sym)
                 }
                 RawTokenKind::Literal { kind } => {
+                    if matches!(kind, RawLiteralKind::Int { .. } | RawLiteralKind::Rational { .. })
+                        && self.cursor.as_bytes().first().is_some_and(|&c| is_id_start_byte(c))
+                    {
+                        self.dcx()
+                            .err("identifier-start is not allowed at end of a number")
+                            .code(error_code!(8936))
+                            .span(self.new_span(self.pos, self.pos + 1))
+                            .emit();
+                    }
                     let (kind, symbol) = self.cook_literal(start, self.pos, kind);
                     TokenKind::Literal(kind, symbol)
                 }

--- a/crates/parse/src/lexer/mod.rs
+++ b/crates/parse/src/lexer/mod.rs
@@ -529,7 +529,6 @@ mod tests {
             ("hex \"\"", &[(0..3, id("hex")), (4..6, lit(Str, ""))]),
             //
             ("0", &[(0..1, lit(Integer, "0"))]),
-            ("0a", &[(0..1, lit(Integer, "0")), (1..2, id("a"))]),
             ("0.e1", &[(0..1, lit(Integer, "0")), (1..2, Dot), (2..4, id("e1"))]),
             (
                 "0.e-1",
@@ -551,12 +550,13 @@ mod tests {
         ];
 
         checks_full![
+            ("0a", true, &[(0..1, lit(Integer, "0")), (1..2, id("a"))]),
             ("0b0", true, &[(0..3, lit(Integer, "0b0"))]),
-            ("0B0", false, &[(0..1, lit(Integer, "0")), (1..3, id("B0"))]),
+            ("0B0", true, &[(0..1, lit(Integer, "0")), (1..3, id("B0"))]),
             ("0o0", true, &[(0..3, lit(Integer, "0o0"))]),
-            ("0O0", false, &[(0..1, lit(Integer, "0")), (1..3, id("O0"))]),
+            ("0O0", true, &[(0..1, lit(Integer, "0")), (1..3, id("O0"))]),
             ("0xa", false, &[(0..3, lit(Integer, "0xa"))]),
-            ("0Xa", false, &[(0..1, lit(Integer, "0")), (1..3, id("Xa"))]),
+            ("0Xa", true, &[(0..1, lit(Integer, "0")), (1..3, id("Xa"))]),
         ];
     }
 

--- a/crates/parse/src/parser/stmt.rs
+++ b/crates/parse/src/parser/stmt.rs
@@ -3,7 +3,7 @@ use crate::{PResult, Parser, parser::SeqSep};
 use smallvec::SmallVec;
 use solar_ast::{token::*, *};
 use solar_data_structures::CollectAndApply;
-use solar_interface::{Ident, Span, SpannedOption, Symbol, kw, sym};
+use solar_interface::{Ident, Span, SpannedOption, Symbol, error_code, kw, sym};
 
 impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses a statement.
@@ -174,6 +174,15 @@ impl<'sess, 'ast, 'cb> Parser<'sess, 'ast, 'cb> {
     /// Parses an assembly block.
     fn parse_stmt_assembly(&mut self) -> PResult<'sess, StmtAssembly<'ast>> {
         let dialect = self.parse_str_lit_opt();
+        if let Some(dialect) = &dialect
+            && dialect.value != sym::evmasm
+        {
+            self.dcx()
+                .err("`evmasm` is the only supported assembly dialect")
+                .code(error_code!(4531))
+                .span(dialect.span)
+                .emit();
+        }
         let flags = if self.check(TokenKind::OpenDelim(Delimiter::Parenthesis)) {
             self.parse_paren_comma_seq(false, Self::parse_str_lit)?
         } else {

--- a/tests/ui/parser/invalid_denomination_no_whitespace.sol
+++ b/tests/ui/parser/invalid_denomination_no_whitespace.sol
@@ -1,0 +1,5 @@
+// ported-from: test/libsolidity/syntaxTests/denominations/invalid_denomination_no_whitespace.sol
+
+contract C {
+    uint constant y = 1wei; //~ ERROR: identifier-start is not allowed at end of a number
+}

--- a/tests/ui/parser/invalid_denomination_no_whitespace.stderr
+++ b/tests/ui/parser/invalid_denomination_no_whitespace.stderr
@@ -1,0 +1,8 @@
+error[8936]: identifier-start is not allowed at end of a number
+   ╭▸ ROOT/tests/ui/parser/invalid_denomination_no_whitespace.sol:LL:CC
+   │
+LL │     uint constant y = 1wei;
+   ╰╴                       ━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/pragma_unknown.sol
+++ b/tests/ui/parser/pragma_unknown.sol
@@ -9,5 +9,7 @@ pragma amogus 69;
 //~^ ERROR: unknown pragma
 pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
 //~^ ERROR: unknown pragma
+//~| ERROR: identifier-start is not allowed at end of a number
+//~| ERROR: identifier-start is not allowed at end of a number
 pragma amogus 0.8.15;
 //~^ ERROR: only `solidity` is supported as a version pragma

--- a/tests/ui/parser/pragma_unknown.stderr
+++ b/tests/ui/parser/pragma_unknown.stderr
@@ -1,3 +1,15 @@
+error[8936]: identifier-start is not allowed at end of a number
+   ╭▸ ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
+   │
+LL │ pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
+   ╰╴                                     ━
+
+error[8936]: identifier-start is not allowed at end of a number
+   ╭▸ ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
+   │
+LL │ pragma amogus 69 diwqbn9ru3b2q945 390ru31290r 0qjr09wadm;
+   ╰╴                                               ━
+
 error: unknown pragma
    ╭▸ ROOT/tests/ui/parser/pragma_unknown.sol:LL:CC
    │
@@ -34,5 +46,5 @@ error: only `solidity` is supported as a version pragma
 LL │ pragma amogus 0.8.15;
    ╰╴       ━━━━━━
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/yul/assembly_dialect_leading_space.sol
+++ b/tests/ui/parser/yul/assembly_dialect_leading_space.sol
@@ -1,0 +1,5 @@
+// ported-from: test/libsolidity/syntaxTests/inlineAssembly/assembly_dialect_leading_space.sol
+
+function f() pure {
+    assembly " evmasm" {} //~ ERROR: `evmasm` is the only supported assembly dialect
+}

--- a/tests/ui/parser/yul/assembly_dialect_leading_space.stderr
+++ b/tests/ui/parser/yul/assembly_dialect_leading_space.stderr
@@ -1,0 +1,8 @@
+error[4531]: `evmasm` is the only supported assembly dialect
+   ╭▸ ROOT/tests/ui/parser/yul/assembly_dialect_leading_space.sol:LL:CC
+   │
+LL │     assembly " evmasm" {}
+   ╰╴             ━━━━━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/yul/assembly_invalid_type.sol
+++ b/tests/ui/parser/yul/assembly_invalid_type.sol
@@ -1,0 +1,7 @@
+// ported-from: test/libsolidity/syntaxTests/parsing/assembly_invalid_type.sol
+
+contract C {
+    function f() public pure {
+        assembly "failasm" {} //~ ERROR: `evmasm` is the only supported assembly dialect
+    }
+}

--- a/tests/ui/parser/yul/assembly_invalid_type.stderr
+++ b/tests/ui/parser/yul/assembly_invalid_type.stderr
@@ -1,0 +1,8 @@
+error[4531]: `evmasm` is the only supported assembly dialect
+   ╭▸ ROOT/tests/ui/parser/yul/assembly_invalid_type.sol:LL:CC
+   │
+LL │         assembly "failasm" {}
+   ╰╴                 ━━━━━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/yul/hex_as_identifier.sol
+++ b/tests/ui/parser/yul/hex_as_identifier.sol
@@ -1,0 +1,7 @@
+// ported-from: test/libsolidity/syntaxTests/string/hex_as_identifier.sol
+
+function g() pure {
+    assembly {
+        let hex := 1 //~ ERROR: expected identifier
+    }
+}

--- a/tests/ui/parser/yul/hex_as_identifier.stderr
+++ b/tests/ui/parser/yul/hex_as_identifier.stderr
@@ -1,0 +1,8 @@
+error: expected identifier, found keyword `hex`
+   ╭▸ ROOT/tests/ui/parser/yul/hex_as_identifier.sol:LL:CC
+   │
+LL │         let hex := 1
+   ╰╴            ━━━
+
+error: aborting due to 1 previous error
+

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -25,7 +25,7 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         return Err("no JSON AST");
     }
 
-    if path_contains("/functionDependencyGraphTests/") || path_contains("/experimental/") {
+    if path_contains("/functionDependencyGraphTests/") || path_contains("/experimental") {
         return Err("solidity experimental is not implemented");
     }
 
@@ -70,6 +70,8 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         | "broken_version_1"
         // Checked during AST validation rather than parsing.
         | "unchecked_while_body"
+        // Arbitrary `pragma experimental` values are allowed by Solc apparently.
+        | "experimental_test_warning"
         // Invalid UTF-8 is not supported.
         | "invalid_utf8_sequence"
         // Validation is in solar's AST stage (https://github.com/paradigmxyz/solar/pull/120).

--- a/tools/tester/src/solc/solidity.rs
+++ b/tools/tester/src/solc/solidity.rs
@@ -25,7 +25,7 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         return Err("no JSON AST");
     }
 
-    if path_contains("/functionDependencyGraphTests/") || path_contains("/experimental") {
+    if path_contains("/functionDependencyGraphTests/") || path_contains("/experimental/") {
         return Err("solidity experimental is not implemented");
     }
 
@@ -57,7 +57,8 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
     #[rustfmt::skip]
     if matches!(
         stem,
-        // Exponent is too large, but apparently it's fine in Solc because the result is 0 or it gets evaluated at compile time.
+        // Solc supports unlimited-precision rational arithmetic, while we reject these literals
+        // as too large during parsing.
         | "rational_number_exp_limit_fine"
         | "exponent_fine"
         | "rational_large_1"
@@ -65,20 +66,10 @@ pub(crate) fn should_skip(path: &Path) -> Result<(), &'static str> {
         // `address payable` is allowed by the grammar (see `elementary-type-name`), but not by Solc.
         | "address_payable_type_expression"
         | "mapping_from_address_payable"
-        // `hex` is not a keyword, looks like just a Solc limitation?
-        | "hex_as_identifier"
-        // TODO: These should be checked after parsing.
-        | "assembly_invalid_type"
-        | "assembly_dialect_leading_space"
-        // `1wei` gets lexed as two different tokens, I think it's fine.
-        | "invalid_denomination_no_whitespace"
-        // Not actually a broken version, we just don't check "^0 and ^1".
+        // Compiler version requirements are not enforced.
         | "broken_version_1"
         // Checked during AST validation rather than parsing.
         | "unchecked_while_body"
-        // Arbitrary `pragma experimental` values are allowed by Solc apparently.
-        | "experimental_test_warning"
-        // "." is not a valid import path.
         // Invalid UTF-8 is not supported.
         | "invalid_utf8_sequence"
         // Validation is in solar's AST stage (https://github.com/paradigmxyz/solar/pull/120).


### PR DESCRIPTION
Match solc’s parser for unsupported inline assembly dialects, reserved `hex` Yul identifiers, and identifiers that directly follow numeric literals. Port the corresponding upstream syntax fixtures into the local UI suite with exact diagnostic snapshots.