### PR TITLE
perf(bench): reuse base solc results

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -203,17 +203,27 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target/codegen-bench
-          if ! python3 benches/runtime/benchmark.py --verbose \
-            --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}" \
-            --solar target/release/solar-head \
-            --mode runtime compile-time \
-            --suite all \
-            --compile-repeats 5 \
-            --gas \
-            --gas-profile hot \
-            --start-anvil \
-            --allow-failures \
-            --output target/codegen-bench/results.json; then
+          args=(
+            --verbose
+            --solc "$RUNNER_TEMP/solc/solc-${SOLC_VERSION}"
+            --solar target/release/solar-head
+            --mode runtime compile-time
+            --suite all
+            --compile-repeats 5
+            --gas
+            --gas-profile hot
+            --start-anvil
+            --allow-failures
+            --output target/codegen-bench/results.json
+          )
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" && \
+            -f target/codegen-bench/baseline/results.json ]]; then
+            args+=(
+              --solar-only
+              --reference-results target/codegen-bench/baseline/results.json
+            )
+          fi
+          if ! python3 benches/runtime/benchmark.py "${args[@]}"; then
             echo "::warning::Codegen benchmark failed to complete"
           fi
 

--- a/benches/analyze/main.py
+++ b/benches/analyze/main.py
@@ -6,7 +6,6 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -44,11 +43,11 @@ class BenchmarkEntry:
 class BenchmarkData:
     """Encapsulates benchmark data and provides methods for analysis and visualization."""
 
-    def __init__(self, entries: List[BenchmarkEntry]) -> None:
+    def __init__(self, entries: list[BenchmarkEntry]) -> None:
         """Initialize with a list of benchmark entries."""
         self.entries = entries
-        self.parsers = sorted(set(entry.parser for entry in entries))
-        self.benchmarks = sorted(set(entry.bench_name for entry in entries))
+        self.parsers = sorted({entry.parser for entry in entries})
+        self.benchmarks = sorted({entry.bench_name for entry in entries})
         self.kinds = KINDS
 
         # Filter out the "empty" benchmark
@@ -56,10 +55,10 @@ class BenchmarkData:
 
     def get_entries(
         self,
-        bench_name: Optional[str] = None,
-        parser: Optional[str] = None,
-        kind: Optional[str] = None,
-    ) -> List[BenchmarkEntry]:
+        bench_name: str | None = None,
+        parser: str | None = None,
+        kind: str | None = None,
+    ) -> list[BenchmarkEntry]:
         """Get entries filtered by benchmark name, parser, and/or kind."""
         result = self.entries
         if bench_name:
@@ -70,7 +69,7 @@ class BenchmarkData:
             result = [e for e in result if e.kind == kind]
         return result
 
-    def get_available_parsers(self, kind: str) -> List[str]:
+    def get_available_parsers(self, kind: str) -> list[str]:
         """Get parsers that have data for a specific kind."""
         available_parsers = []
         for parser in self.get_sorted_parsers()[kind]:
@@ -79,8 +78,8 @@ class BenchmarkData:
         return available_parsers
 
     def get_complete_benchmarks(
-        self, benchmarks: List[str], parsers: List[str], kind: str
-    ) -> List[str]:
+        self, benchmarks: list[str], parsers: list[str], kind: str
+    ) -> list[str]:
         """Get benchmarks with data from every parser."""
         return [
             bench_name
@@ -103,7 +102,7 @@ class BenchmarkData:
             return 0
         return max(e.time_ns for e in entries)
 
-    def calculate_parser_avg_times(self) -> Dict[str, Dict[str, float]]:
+    def calculate_parser_avg_times(self) -> dict[str, dict[str, float]]:
         """Calculate average times for each parser and kind."""
         parser_avg_times = {kind: {} for kind in self.kinds}
 
@@ -116,7 +115,7 @@ class BenchmarkData:
 
         return parser_avg_times
 
-    def calculate_benchmark_avg_times(self) -> Dict[str, Dict[str, float]]:
+    def calculate_benchmark_avg_times(self) -> dict[str, dict[str, float]]:
         """Calculate average times for each benchmark and kind."""
         bench_avg_times = {kind: {} for kind in self.kinds}
 
@@ -129,7 +128,7 @@ class BenchmarkData:
 
         return bench_avg_times
 
-    def get_sorted_parsers(self) -> Dict[str, List[str]]:
+    def get_sorted_parsers(self) -> dict[str, list[str]]:
         """Get parsers sorted by average time (fastest first)."""
         parser_avg_times = self.calculate_parser_avg_times()
 
@@ -142,7 +141,7 @@ class BenchmarkData:
             for kind in self.kinds
         }
 
-    def get_sorted_benchmarks(self) -> Dict[str, List[str]]:
+    def get_sorted_benchmarks(self) -> dict[str, list[str]]:
         """Get benchmarks sorted by average time (fastest first)."""
         bench_avg_times = self.calculate_benchmark_avg_times()
 
@@ -225,7 +224,7 @@ def main() -> None:
         print(out_s)
 
 
-def read_input() -> List[str]:
+def read_input() -> list[str]:
     """Read and preprocess input from stdin."""
     lines = sys.stdin.readlines()
     if not lines:
@@ -240,7 +239,7 @@ def read_input() -> List[str]:
     return lines
 
 
-def extract_benchmarks(lines: List[str]) -> List[Tuple[str, int, int]]:
+def extract_benchmarks(lines: list[str]) -> list[tuple[str, int, int]]:
     """Extract benchmark information from input lines."""
     benchmark_re = re.compile(r"(\w+): (?:\d+ files, )?(\d+) LoC, (\d+) bytes")
     benchmarks = []
@@ -258,7 +257,7 @@ def extract_benchmarks(lines: List[str]) -> List[Tuple[str, int, int]]:
 
 
 def extract_timing_data(
-    lines: List[str], benchmarks: List[Tuple[str, int, int]]
+    lines: list[str], benchmarks: list[tuple[str, int, int]]
 ) -> BenchmarkData:
     """Extract timing data from input lines."""
     time = r"(\s*[\d\.]+ \w+)"
@@ -279,7 +278,7 @@ def extract_timing_data(
 
 
 def generate_markdown_tables(
-    data: BenchmarkData, benchmarks: List[Tuple[str, int, int]]
+    data: BenchmarkData, benchmarks: list[tuple[str, int, int]]
 ) -> str:
     """
     Generate markdown tables for each benchmark and kind.
@@ -336,11 +335,11 @@ def generate_markdown_tables(
                     (
                         slowest_time / time_ns,
                         [
-                        parser,
-                        relative,
-                        time_s,
-                        loc_s,
-                        bytes_s,
+                            parser,
+                            relative,
+                            time_s,
+                            loc_s,
+                            bytes_s,
                         ],
                     )
                 )
@@ -349,7 +348,9 @@ def generate_markdown_tables(
                 continue
 
             # Sort by relative speed (fastest first).
-            table.extend(row for _, row in sorted(rows, key=lambda row: row[0], reverse=True))
+            table.extend(
+                row for _, row in sorted(rows, key=lambda row: row[0], reverse=True)
+            )
 
             out_s += f"#### {kind.capitalize()}\n"
             out_s += tabulate(table, headers="firstrow", tablefmt="pipe")
@@ -358,7 +359,7 @@ def generate_markdown_tables(
     return out_s
 
 
-def plot_benchmark_times(data: BenchmarkData) -> Dict[str, str]:
+def plot_benchmark_times(data: BenchmarkData) -> dict[str, str]:
     """
     Plot the parsing and lexing times on a log chart for all parsers.
 
@@ -417,8 +418,8 @@ def plot_benchmark_times(data: BenchmarkData) -> Dict[str, str]:
 def create_plot(
     data: BenchmarkData,
     kind: str,
-    sorted_bench_names: List[str],
-    available_parsers: List[str],
+    sorted_bench_names: list[str],
+    available_parsers: list[str],
     output_dir: str,
     color_map,
 ) -> str:
@@ -493,8 +494,8 @@ def create_plot(
 def create_relative_plot(
     data: BenchmarkData,
     kind: str,
-    sorted_bench_names: List[str],
-    available_parsers: List[str],
+    sorted_bench_names: list[str],
+    available_parsers: list[str],
     output_dir: str,
     color_map,
 ) -> str:

--- a/benches/lsp/benchmark.py
+++ b/benches/lsp/benchmark.py
@@ -17,14 +17,14 @@ import stat
 import subprocess
 import sys
 import tempfile
-from functools import lru_cache
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
 from enum import Enum
+from functools import cache
 from pathlib import Path
-from typing import Any, Iterable, Sequence
+from typing import Any
 from urllib.parse import urlsplit
-
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 FIXTURE_DIR = SCRIPT_DIR / "fixture"
@@ -100,9 +100,7 @@ METHOD_CONFIG: dict[str, dict[str, Any]] = {
 
 RESULT_METHOD_CONFIG: dict[str, dict[str, Any]] = {
     method: {
-        key: value
-        for key, value in config.items()
-        if key in {"line", "col", "trigger"}
+        key: value for key, value in config.items() if key in {"line", "col", "trigger"}
     }
     for method, config in METHOD_CONFIG.items()
 }
@@ -187,9 +185,7 @@ def validate_context(
         raise ValidationError("head SHA must equal merge candidate SHA")
     if not isinstance(run_url, str):
         raise ValidationError("run URL must be a string")
-    if any(
-        ord(character) < 0x20 or ord(character) == 0x7F for character in run_url
-    ):
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in run_url):
         raise ValidationError("run URL contains control characters")
 
     try:
@@ -274,8 +270,7 @@ def _strict_json_equal(left: Any, right: Any) -> bool:
         )
     if isinstance(left, list):
         return len(left) == len(right) and all(
-            _strict_json_equal(item, expected)
-            for item, expected in zip(left, right)
+            _strict_json_equal(item, expected) for item, expected in zip(left, right)
         )
     return left == right
 
@@ -301,7 +296,9 @@ def _read_json(path: Path, max_bytes: int, label: str) -> Any:
 
 def _write_bytes_atomic(path: Path, data: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
     temporary_path = Path(temporary_name)
     try:
         with os.fdopen(descriptor, "wb") as output:
@@ -315,7 +312,9 @@ def _write_bytes_atomic(path: Path, data: bytes) -> None:
 
 
 def _write_json_atomic(path: Path, value: Any) -> None:
-    data = (json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+    data = (
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
     _write_bytes_atomic(path, data)
 
 
@@ -442,7 +441,9 @@ def _verify_upstream_binary(binary: Path) -> None:
                 env=environment,
             )
         except (OSError, subprocess.TimeoutExpired) as error:
-            raise ExecutionError("could not execute the pinned lsp-bench binary") from error
+            raise ExecutionError(
+                "could not execute the pinned lsp-bench binary"
+            ) from error
     version = completed.stdout.strip()
     if completed.returncode != 0 or version != expected:
         raise ExecutionError("lsp-bench binary version does not match upstream.json")
@@ -558,9 +559,15 @@ def _validate_generated_config(
         if server.get("label") != role or not isinstance(arguments, list):
             raise ValidationError(f"config.servers[{index}] does not match role {role}")
         if arguments != ["lsp"]:
-            raise ValidationError(f"config.servers[{index}].args is not the Solar contract")
+            raise ValidationError(
+                f"config.servers[{index}].args is not the Solar contract"
+            )
         command = server.get("cmd")
-        if not isinstance(command, str) or not command or not Path(command).is_absolute():
+        if (
+            not isinstance(command, str)
+            or not command
+            or not Path(command).is_absolute()
+        ):
             raise ValidationError(f"config.servers[{index}].cmd must be absolute")
     return config
 
@@ -578,9 +585,7 @@ def _position(value: Any, path: str) -> tuple[int, int]:
     return line, character
 
 
-def _lsp_range(
-    value: Any, path: str
-) -> tuple[tuple[int, int], tuple[int, int]]:
+def _lsp_range(value: Any, path: str) -> tuple[tuple[int, int], tuple[int, int]]:
     location_range = _mapping(value, path)
     if set(location_range) != {"start", "end"}:
         raise ValidationError(f"{path} is not an LSP range")
@@ -602,13 +607,9 @@ def _location(
             raise ValidationError(f"{path} is not an LSP location link")
         uri = location.get("targetUri")
         location_range = _lsp_range(location.get("targetRange"), f"{path}.targetRange")
-        _lsp_range(
-            location.get("targetSelectionRange"), f"{path}.targetSelectionRange"
-        )
+        _lsp_range(location.get("targetSelectionRange"), f"{path}.targetSelectionRange")
         if "originSelectionRange" in location:
-            _lsp_range(
-                location["originSelectionRange"], f"{path}.originSelectionRange"
-            )
+            _lsp_range(location["originSelectionRange"], f"{path}.originSelectionRange")
     else:
         if set(location) != {"uri", "range"}:
             raise ValidationError(f"{path} is not an LSP location")
@@ -675,7 +676,9 @@ def _symbol_kind(value: Any, path: str) -> int:
 
 def _validate_symbol_tags(value: Any, path: str) -> None:
     tags = _array(value, path)
-    if any(isinstance(tag, bool) or not isinstance(tag, int) or tag != 1 for tag in tags):
+    if any(
+        isinstance(tag, bool) or not isinstance(tag, int) or tag != 1 for tag in tags
+    ):
         raise ValidationError(f"{path} contains an invalid LSP symbol tag")
 
 
@@ -689,11 +692,15 @@ def _validate_response(
 
     if method == UPSTREAM_DIAGNOSTICS_BENCHMARK:
         params = _mapping(response, path)
-        if not {"uri", "diagnostics"} <= set(params) <= {
-            "uri",
-            "version",
-            "diagnostics",
-        }:
+        if (
+            not {"uri", "diagnostics"}
+            <= set(params)
+            <= {
+                "uri",
+                "version",
+                "diagnostics",
+            }
+        ):
             raise ValidationError(f"{path} is not publishDiagnostics params")
         uri = params.get("uri")
         if uri != _fixture_uri(config, "Main.sol"):
@@ -784,9 +791,7 @@ def _validate_response(
         return
 
     if method == "textDocument/definition":
-        locations = _locations(
-            response, path, allow_single=True, allow_links=True
-        )
+        locations = _locations(response, path, allow_single=True, allow_links=True)
         expected_uri = _fixture_uri(config, "Math.sol")
         if any(uri != expected_uri for uri, _ in locations) or not any(
             location_range[0][0] == 4 for _, location_range in locations
@@ -808,7 +813,9 @@ def _validate_response(
             (8, 13),
             (13, 15),
         }.issubset(positions):
-            raise ValidationError(f"{path} is missing the declaration or call reference")
+            raise ValidationError(
+                f"{path} is missing the declaration or call reference"
+            )
         return
 
     if method == "textDocument/completion":
@@ -917,7 +924,9 @@ def _validate_response(
     raise ValidationError(f"{path} uses an unexpected benchmark method")
 
 
-def _expected_benchmark_input(method: str, config: dict[str, Any]) -> dict[str, Any] | None:
+def _expected_benchmark_input(
+    method: str, config: dict[str, Any]
+) -> dict[str, Any] | None:
     if method in {"initialize", UPSTREAM_DIAGNOSTICS_BENCHMARK}:
         return None
 
@@ -1039,9 +1048,7 @@ def _validate_results(
                 _nonnegative_integer(row["rss_kb"], f"{row_path}.rss_kb")
             if "response" not in row:
                 raise ValidationError(f"{row_path} has no canonical response")
-            _validate_response(
-                method, row["response"], f"{row_path}.response", config
-            )
+            _validate_response(method, row["response"], f"{row_path}.response", config)
 
             iterations = _array(row.get("iterations"), f"{row_path}.iterations")
             if len(iterations) != MEASURED_ITERATIONS:
@@ -1052,7 +1059,9 @@ def _validate_results(
                 iteration = _mapping(iteration, iteration_path)
                 if set(iteration) != {"ms", "response"}:
                     raise ValidationError(f"{iteration_path} has unexpected fields")
-                samples.append(_positive_number(iteration.get("ms"), f"{iteration_path}.ms"))
+                samples.append(
+                    _positive_number(iteration.get("ms"), f"{iteration_path}.ms")
+                )
                 if "response" not in iteration:
                     raise ValidationError(f"{iteration_path} has no response")
                 _validate_response(
@@ -1212,7 +1221,10 @@ def _validate_manifest(value: Any, expected: Context) -> dict[str, Any]:
     }
     if set(manifest) != expected_keys:
         raise ValidationError("manifest fields do not match the raw artifact contract")
-    if manifest.get("schema_version") != RAW_SCHEMA_VERSION or manifest.get("kind") != RAW_KIND:
+    if (
+        manifest.get("schema_version") != RAW_SCHEMA_VERSION
+        or manifest.get("kind") != RAW_KIND
+    ):
         raise ValidationError("manifest schema is unsupported")
 
     context = _mapping(manifest.get("context"), "manifest.context")
@@ -1230,7 +1242,9 @@ def _validate_manifest(value: Any, expected: Context) -> dict[str, Any]:
         "run_url": expected.run_url,
     }
     if context != expected_context:
-        raise ValidationError("manifest context does not match the trusted workflow context")
+        raise ValidationError(
+            "manifest context does not match the trusted workflow context"
+        )
 
     protocol = _mapping(manifest.get("protocol"), "manifest.protocol")
     expected_protocol = {
@@ -1248,9 +1262,13 @@ def _validate_manifest(value: Any, expected: Context) -> dict[str, Any]:
     if protocol != expected_protocol:
         raise ValidationError("manifest protocol does not match the trusted adapter")
     if manifest.get("upstream") != pinned_upstream():
-        raise ValidationError("manifest upstream metadata does not match the pinned release")
+        raise ValidationError(
+            "manifest upstream metadata does not match the pinned release"
+        )
     if manifest.get("fixture") != {"sha256": fixture_sha256()}:
-        raise ValidationError("manifest fixture digest does not match the trusted fixture")
+        raise ValidationError(
+            "manifest fixture digest does not match the trusted fixture"
+        )
 
     binaries = _mapping(manifest.get("binaries"), "manifest.binaries")
     if set(binaries) != {"base", "head"}:
@@ -1275,10 +1293,7 @@ def _validate_artifact_layout(root: Path) -> None:
     expected_directories = {
         "passes",
         *(f"passes/{pass_name}" for pass_name, _ in PASSES),
-        *(
-            f"passes/{pass_name}/{session}"
-            for pass_name, session, _ in PASS_SESSIONS
-        ),
+        *(f"passes/{pass_name}/{session}" for pass_name, session, _ in PASS_SESSIONS),
     }
     seen_files: set[str] = set()
     seen_directories: set[str] = set()
@@ -1292,7 +1307,9 @@ def _validate_artifact_layout(root: Path) -> None:
             elif stat.S_ISDIR(metadata.st_mode) and relative in expected_directories:
                 seen_directories.add(relative)
             else:
-                raise ValidationError(f"raw artifact contains unexpected entry {relative}")
+                raise ValidationError(
+                    f"raw artifact contains unexpected entry {relative}"
+                )
     except OSError as error:
         raise ValidationError("raw artifact layout could not be inspected") from error
     if seen_files != expected_files or seen_directories != expected_directories:
@@ -1329,16 +1346,24 @@ def validate_artifact(
         ):
             raise ValidationError(f"manifest.passes[{index}] has the wrong pass order")
 
-        config_metadata = _mapping(entry.get("config"), f"manifest.passes[{index}].config")
-        results_metadata = _mapping(entry.get("results"), f"manifest.passes[{index}].results")
+        config_metadata = _mapping(
+            entry.get("config"), f"manifest.passes[{index}].config"
+        )
+        results_metadata = _mapping(
+            entry.get("results"), f"manifest.passes[{index}].results"
+        )
         expected_config_path = f"passes/{pass_name}/{session}/config.json"
         expected_results_path = f"passes/{pass_name}/{session}/results.json"
-        if config_metadata.get("path") != expected_config_path or set(config_metadata) != {
+        if config_metadata.get("path") != expected_config_path or set(
+            config_metadata
+        ) != {
             "path",
             "sha256",
         }:
             raise ValidationError(f"manifest.passes[{index}].config is invalid")
-        if results_metadata.get("path") != expected_results_path or set(results_metadata) != {
+        if results_metadata.get("path") != expected_results_path or set(
+            results_metadata
+        ) != {
             "path",
             "sha256",
         }:
@@ -1352,12 +1377,20 @@ def validate_artifact(
         expected_results_digest = _require_sha256(
             results_metadata.get("sha256"), f"manifest.passes[{index}].results.sha256"
         )
-        config_bytes = _read_regular_file(config_path, MAX_CONFIG_BYTES, f"{pass_name} config")
-        results_bytes = _read_regular_file(results_path, MAX_RESULTS_BYTES, f"{pass_name} results")
+        config_bytes = _read_regular_file(
+            config_path, MAX_CONFIG_BYTES, f"{pass_name} config"
+        )
+        results_bytes = _read_regular_file(
+            results_path, MAX_RESULTS_BYTES, f"{pass_name} results"
+        )
         if hashlib.sha256(config_bytes).hexdigest() != expected_config_digest:
-            raise ValidationError(f"{pass_name} config digest does not match the manifest")
+            raise ValidationError(
+                f"{pass_name} config digest does not match the manifest"
+            )
         if hashlib.sha256(results_bytes).hexdigest() != expected_results_digest:
-            raise ValidationError(f"{pass_name} results digest does not match the manifest")
+            raise ValidationError(
+                f"{pass_name} results digest does not match the manifest"
+            )
 
         config = _validate_generated_config(
             _loads_json(config_bytes, f"{pass_name} config"), server_order
@@ -1408,7 +1441,7 @@ def _decimal_percentile(samples: Iterable[Decimal], percent: float) -> Decimal:
     return ordered[index]
 
 
-@lru_cache(maxsize=None)
+@cache
 def _paired_bootstrap_interval(
     base: tuple[Decimal, ...], head: tuple[Decimal, ...]
 ) -> dict[str, tuple[Decimal, Decimal]]:
@@ -1444,8 +1477,7 @@ def method_verdict(strata: Sequence[dict[str, Any]]) -> str:
     absolute_threshold = Decimal(str(THRESHOLD_ABSOLUTE_MS))
 
     regression = all(
-        stratum["confidence_interval_95"][delta_kind][percentile_name][0]
-        >= threshold
+        stratum["confidence_interval_95"][delta_kind][percentile_name][0] >= threshold
         for stratum in strata
         for percentile_name in ("p50", "p95")
         for delta_kind, threshold in (
@@ -1457,8 +1489,7 @@ def method_verdict(strata: Sequence[dict[str, Any]]) -> str:
         return "regression"
 
     improvement = all(
-        stratum["confidence_interval_95"][delta_kind][percentile_name][1]
-        <= -threshold
+        stratum["confidence_interval_95"][delta_kind][percentile_name][1] <= -threshold
         for stratum in strata
         for percentile_name in ("p50", "p95")
         for delta_kind, threshold in (
@@ -1494,7 +1525,9 @@ def _rounded_delta(value: Decimal, path: str, decimals: int, rounding: str) -> f
         quantum = Decimal(1).scaleb(-decimals)
         rounded = float(value.quantize(quantum, rounding=rounding))
     except (ArithmeticError, OverflowError, ValueError) as error:
-        raise ValidationError(f"{path} must remain finite after trusted rounding") from error
+        raise ValidationError(
+            f"{path} must remain finite after trusted rounding"
+        ) from error
     if not math.isfinite(rounded):
         raise ValidationError(f"{path} must remain finite after trusted rounding")
     return rounded
@@ -1522,8 +1555,12 @@ def _statistics_for_sessions(
         }
 
     for percentile_name, percent in (("p50", 50), ("p95", 95)):
-        base = [_session_metric(session, "base", method, percent) for session in sessions]
-        head = [_session_metric(session, "head", method, percent) for session in sessions]
+        base = [
+            _session_metric(session, "base", method, percent) for session in sessions
+        ]
+        head = [
+            _session_metric(session, "head", method, percent) for session in sessions
+        ]
         base_estimate = _decimal_mean(base)
         head_estimate = _decimal_mean(head)
         absolute_delta = head_estimate - base_estimate
@@ -1631,9 +1668,7 @@ def build_comparison(
                     **_comparison_statistics(statistics, f"{method} {pass_name}"),
                 }
             )
-        methods.append(
-            method_comparison
-        )
+        methods.append(method_comparison)
 
     if "regression" in verdicts:
         overall = "regression"
@@ -1696,9 +1731,7 @@ def add_publication_state(
     current_main_sha: str,
     current_pr_head_sha: str,
 ) -> dict[str, Any]:
-    state = validate_publication_state(
-        context, current_main_sha, current_pr_head_sha
-    )
+    state = validate_publication_state(context, current_main_sha, current_pr_head_sha)
     result = dict(comparison)
     result["freshness"] = state.value
     result["current_main_sha"] = current_main_sha
@@ -1851,8 +1884,17 @@ def render_artifact(
             comparison, context, current_main_sha, current_pr_head_sha
         )
         valid = True
-    except (BenchmarkError, OSError, ArithmeticError, KeyError, TypeError, ValueError) as error:
-        comparison = inconclusive_comparison(context, str(error) or "artifact validation failed")
+    except (
+        BenchmarkError,
+        OSError,
+        ArithmeticError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as error:
+        comparison = inconclusive_comparison(
+            context, str(error) or "artifact validation failed"
+        )
         valid = False
     _write_json_atomic(comparison_path.resolve(), comparison)
     _write_text_atomic(report_path.resolve(), render_markdown(comparison))

--- a/benches/lsp/test_benchmark.py
+++ b/benches/lsp/test_benchmark.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
-
 MODULE_PATH = Path(__file__).with_name("benchmark.py")
 MODULE_SPEC = importlib.util.spec_from_file_location("solar_lsp_benchmark", MODULE_PATH)
 if MODULE_SPEC is None or MODULE_SPEC.loader is None:
@@ -113,7 +112,9 @@ def valid_response(method: str, config: dict[str, Any] = RESPONSE_CONFIG) -> Any
 
 
 def write_json(path: Path, value: Any) -> bytes:
-    data = (json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+    data = (
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(data)
     return data
@@ -228,7 +229,9 @@ class RawArtifact:
             benchmark_result = {"name": method, "servers": rows}
             benchmark_input = benchmark._expected_benchmark_input(method, config)
             if benchmark_input is not None:
-                benchmark_result["input"] = json.dumps(benchmark_input, separators=(",", ":"))
+                benchmark_result["input"] = json.dumps(
+                    benchmark_input, separators=(",", ":")
+                )
             benchmarks.append(benchmark_result)
         return {
             "timestamp": "2026-08-17T13:00:00Z",
@@ -340,7 +343,9 @@ class ConfigTests(unittest.TestCase):
         )
         self.assertNotIn("commit", config["servers"][0])
         self.assertNotIn("repo", config["servers"][0])
-        self.assertIs(benchmark._validate_generated_config(config, ("head", "base")), config)
+        self.assertIs(
+            benchmark._validate_generated_config(config, ("head", "base")), config
+        )
 
     def test_generated_config_validation_rejects_contract_drift(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -360,9 +365,7 @@ class ConfigTests(unittest.TestCase):
         upstream = benchmark.pinned_upstream()
 
         self.assertEqual(upstream["version"], "0.3.3")
-        self.assertEqual(
-            upstream["commit"], "ca0651f86f430290dacdbeb62c9c6987a3ad6966"
-        )
+        self.assertEqual(upstream["commit"], "ca0651f86f430290dacdbeb62c9c6987a3ad6966")
         self.assertEqual(
             upstream["source"]["sha256"],
             "145dc03c5606d6b5ec66647d233486bab9f4e65022275763bf445bc26414470e",
@@ -393,9 +396,11 @@ class ConfigTests(unittest.TestCase):
         self.assertNotIn("GITHUB_TOKEN", run.call_args.kwargs["env"])
 
         bad = mock.Mock(returncode=0, stdout="lsp-bench 0.3.4\n")
-        with mock.patch.object(benchmark.subprocess, "run", return_value=bad):
-            with self.assertRaises(benchmark.ExecutionError):
-                benchmark._verify_upstream_binary(Path("/tmp/lsp-bench"))
+        with (
+            mock.patch.object(benchmark.subprocess, "run", return_value=bad),
+            self.assertRaises(benchmark.ExecutionError),
+        ):
+            benchmark._verify_upstream_binary(Path("/tmp/lsp-bench"))
 
     def test_run_rejects_the_same_binary_path_for_both_roles(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -414,7 +419,9 @@ class ConfigTests(unittest.TestCase):
 
 
 class ContextTests(unittest.TestCase):
-    def test_context_requires_base_to_be_main_and_head_to_be_merge_candidate(self) -> None:
+    def test_context_requires_base_to_be_main_and_head_to_be_merge_candidate(
+        self,
+    ) -> None:
         with self.assertRaisesRegex(benchmark.ValidationError, "equal main"):
             benchmark.validate_context(
                 CONTEXT.repository,
@@ -429,9 +436,7 @@ class ContextTests(unittest.TestCase):
                 CONTEXT.run_url,
             )
 
-        with self.assertRaisesRegex(
-            benchmark.ValidationError, "equal merge candidate"
-        ):
+        with self.assertRaisesRegex(benchmark.ValidationError, "equal merge candidate"):
             benchmark.validate_context(
                 CONTEXT.repository,
                 CONTEXT.pr_head_repository,
@@ -461,14 +466,16 @@ class ContextTests(unittest.TestCase):
             {"run_url": f"{CONTEXT.run_url}\t"},
         )
         for values in invalid:
-            with self.subTest(values=values):
-                with self.assertRaises(benchmark.ValidationError):
-                    context = {
-                        key: value
-                        for key, value in CONTEXT.__dict__.items()
-                        if key != "comparison_mode"
-                    } | values
-                    benchmark.validate_context(**context)
+            with (
+                self.subTest(values=values),
+                self.assertRaises(benchmark.ValidationError),
+            ):
+                context = {
+                    key: value
+                    for key, value in CONTEXT.__dict__.items()
+                    if key != "comparison_mode"
+                } | values
+                benchmark.validate_context(**context)
 
 
 class ArgumentParserTests(unittest.TestCase):
@@ -531,7 +538,9 @@ class ArgumentParserTests(unittest.TestCase):
 
                 self.assertEqual(parsed.command, command)
                 self.assertEqual(parsed.pr_number, CONTEXT.pr_number)
-                self.assertEqual(parsed.workflow_repository, CONTEXT.workflow_repository)
+                self.assertEqual(
+                    parsed.workflow_repository, CONTEXT.workflow_repository
+                )
 
 
 class ResponseValidationTests(unittest.TestCase):
@@ -575,17 +584,21 @@ class ResponseValidationTests(unittest.TestCase):
             "textDocument/documentSymbol": [{"name": "Main"}],
         }
         for method, response in invalid.items():
-            with self.subTest(method=method):
-                with self.assertRaises(benchmark.ValidationError):
-                    benchmark._validate_response(
-                        method, response, "response", RESPONSE_CONFIG
-                    )
+            with (
+                self.subTest(method=method),
+                self.assertRaises(benchmark.ValidationError),
+            ):
+                benchmark._validate_response(
+                    method, response, "response", RESPONSE_CONFIG
+                )
 
     def test_rejects_deceptive_hover_and_malformed_completion(self) -> None:
         invalid = (
             (
                 "textDocument/hover",
-                {"contents": "not a signature: double takes address and returns uint256"},
+                {
+                    "contents": "not a signature: double takes address and returns uint256"
+                },
             ),
             (
                 "textDocument/completion",
@@ -597,11 +610,13 @@ class ResponseValidationTests(unittest.TestCase):
         )
 
         for method, response in invalid:
-            with self.subTest(method=method):
-                with self.assertRaises(benchmark.ValidationError):
-                    benchmark._validate_response(
-                        method, response, "response", RESPONSE_CONFIG
-                    )
+            with (
+                self.subTest(method=method),
+                self.assertRaises(benchmark.ValidationError),
+            ):
+                benchmark._validate_response(
+                    method, response, "response", RESPONSE_CONFIG
+                )
 
     def test_references_reject_malformed_extra_locations(self) -> None:
         response = [location("Main.sol", 8), location("Main.sol", 13), {"uri": 7}]
@@ -616,7 +631,9 @@ class ResponseValidationTests(unittest.TestCase):
             "textDocument/diagnostic": valid_response("textDocument/diagnostic"),
             "textDocument/definition": valid_response("textDocument/definition"),
             "textDocument/references": valid_response("textDocument/references"),
-            "textDocument/documentSymbol": valid_response("textDocument/documentSymbol"),
+            "textDocument/documentSymbol": valid_response(
+                "textDocument/documentSymbol"
+            ),
         }
         cases["textDocument/diagnostic"]["uri"] = "file:///untrusted/Main.sol"
         cases["textDocument/definition"][0]["uri"] = "file:///untrusted/Math.sol"
@@ -626,11 +643,13 @@ class ResponseValidationTests(unittest.TestCase):
         )
 
         for method, response in cases.items():
-            with self.subTest(method=method):
-                with self.assertRaises(benchmark.ValidationError):
-                    benchmark._validate_response(
-                        method, response, "response", RESPONSE_CONFIG
-                    )
+            with (
+                self.subTest(method=method),
+                self.assertRaises(benchmark.ValidationError),
+            ):
+                benchmark._validate_response(
+                    method, response, "response", RESPONSE_CONFIG
+                )
 
 
 class ArtifactValidationTests(unittest.TestCase):
@@ -666,7 +685,9 @@ class ArtifactValidationTests(unittest.TestCase):
             artifact.manifest["context"]["head_sha"] = "3" * 40
             artifact.rewrite_manifest()
 
-            with self.assertRaisesRegex(benchmark.ValidationError, "trusted workflow context"):
+            with self.assertRaisesRegex(
+                benchmark.ValidationError, "trusted workflow context"
+            ):
                 benchmark.validate_artifact(artifact.root, CONTEXT)
 
     def test_rejects_tampered_result_digest(self) -> None:
@@ -681,11 +702,11 @@ class ArtifactValidationTests(unittest.TestCase):
     def test_rejects_missing_pass_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             artifact = RawArtifact(Path(directory))
-            (
-                artifact.root / "passes" / "head-first" / "1" / "config.json"
-            ).unlink()
+            (artifact.root / "passes" / "head-first" / "1" / "config.json").unlink()
 
-            with self.assertRaisesRegex(benchmark.ValidationError, "layout is incomplete"):
+            with self.assertRaisesRegex(
+                benchmark.ValidationError, "layout is incomplete"
+            ):
                 benchmark.validate_artifact(artifact.root, CONTEXT)
 
     def test_rejects_files_not_covered_by_the_manifest(self) -> None:
@@ -693,7 +714,9 @@ class ArtifactValidationTests(unittest.TestCase):
             artifact = RawArtifact(Path(directory))
             (artifact.root / "workflow.txt").write_text("untrusted sibling")
 
-            with self.assertRaisesRegex(benchmark.ValidationError, "unexpected entry workflow.txt"):
+            with self.assertRaisesRegex(
+                benchmark.ValidationError, "unexpected entry workflow.txt"
+            ):
                 benchmark.validate_artifact(artifact.root, CONTEXT)
 
     def test_rejects_unexpected_config_fields_after_digest_verification(self) -> None:
@@ -728,7 +751,10 @@ class ArtifactValidationTests(unittest.TestCase):
             ),
         )
         for mutate in mutations:
-            with self.subTest(mutate=mutate), tempfile.TemporaryDirectory() as directory:
+            with (
+                self.subTest(mutate=mutate),
+                tempfile.TemporaryDirectory() as directory,
+            ):
                 artifact = RawArtifact(Path(directory))
                 hover = next(
                     item
@@ -778,11 +804,16 @@ class ArtifactValidationTests(unittest.TestCase):
     def test_rejects_malformed_and_duplicate_key_json(self) -> None:
         invalid_documents = (b"{", b'{"schema_version": 1, "schema_version": 1}')
         for document in invalid_documents:
-            with self.subTest(document=document), tempfile.TemporaryDirectory() as directory:
+            with (
+                self.subTest(document=document),
+                tempfile.TemporaryDirectory() as directory,
+            ):
                 artifact = RawArtifact(Path(directory))
                 (artifact.root / "manifest.json").write_bytes(document)
 
-                with self.assertRaisesRegex(benchmark.ValidationError, "valid strict JSON"):
+                with self.assertRaisesRegex(
+                    benchmark.ValidationError, "valid strict JSON"
+                ):
                     benchmark.validate_artifact(artifact.root, CONTEXT)
 
     def test_rejects_incorrect_measured_response(self) -> None:
@@ -793,12 +824,12 @@ class ArtifactValidationTests(unittest.TestCase):
                 for item in artifact.results[("base-first", 1)]["benchmarks"]
                 if item["name"] == "textDocument/hover"
             )
-            hover["servers"][0]["iterations"][4]["response"] = {
-                "contents": "unrelated"
-            }
+            hover["servers"][0]["iterations"][4]["response"] = {"contents": "unrelated"}
             artifact.rewrite_results("base-first")
 
-            with self.assertRaisesRegex(benchmark.ValidationError, "double function hover"):
+            with self.assertRaisesRegex(
+                benchmark.ValidationError, "double function hover"
+            ):
                 benchmark.validate_artifact(artifact.root, CONTEXT)
 
     def test_rejects_invalid_rss_even_though_rss_is_not_a_verdict_metric(self) -> None:
@@ -817,7 +848,9 @@ class ArtifactValidationTests(unittest.TestCase):
             artifact.configs[("base-first", 1)]["servers"][0]["commit"] = "main"
             artifact.rewrite_config("base-first")
 
-            with self.assertRaisesRegex(benchmark.ValidationError, "unsupported server fields"):
+            with self.assertRaisesRegex(
+                benchmark.ValidationError, "unsupported server fields"
+            ):
                 benchmark.validate_artifact(artifact.root, CONTEXT)
 
     @unittest.skipIf(os.name == "nt", "symlink semantics differ on Windows")
@@ -832,7 +865,9 @@ class ArtifactValidationTests(unittest.TestCase):
             with self.assertRaisesRegex(benchmark.ValidationError, "unexpected entry"):
                 benchmark.validate_artifact(artifact.root, CONTEXT)
 
-    def test_render_artifact_turns_invalid_input_into_escaped_inconclusive_report(self) -> None:
+    def test_render_artifact_turns_invalid_input_into_escaped_inconclusive_report(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             artifact = RawArtifact(root / "raw")
@@ -885,7 +920,9 @@ class ArtifactValidationTests(unittest.TestCase):
                     for item in artifact.results[(pass_name, session)]["benchmarks"]
                     if item["name"] == "initialize"
                 )
-                head = next(row for row in initialize["servers"] if row["server"] == "head")
+                head = next(
+                    row for row in initialize["servers"] if row["server"] == "head"
+                )
                 head.update(p50_ms=1e308, p95_ms=1e308, mean_ms=1e308)
                 for iteration in head["iterations"]:
                     iteration["ms"] = 1e308
@@ -984,9 +1021,7 @@ class StatisticsTests(unittest.TestCase):
         comparison = benchmark.build_comparison(constant_sessions(), CONTEXT)
 
         self.assertEqual(benchmark.METHODS[1], "textDocument/diagnostic")
-        self.assertEqual(
-            comparison["methods"][1]["name"], "didOpen/publishDiagnostics"
-        )
+        self.assertEqual(comparison["methods"][1]["name"], "didOpen/publishDiagnostics")
         rendered = benchmark.render_markdown(
             benchmark.add_publication_state(
                 comparison, CONTEXT, CURRENT_MAIN_SHA, CURRENT_PR_HEAD_SHA
@@ -1006,9 +1041,11 @@ class StatisticsTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "at least one sample"):
             benchmark.percentile([], 50)
         for percent in (0, -1, 101):
-            with self.subTest(percent=percent):
-                with self.assertRaisesRegex(ValueError, "must be in"):
-                    benchmark.percentile([1], percent)
+            with (
+                self.subTest(percent=percent),
+                self.assertRaisesRegex(ValueError, "must be in"),
+            ):
+                benchmark.percentile([1], percent)
 
     def test_method_verdict_requires_both_order_strata(self) -> None:
         cases = (
@@ -1085,7 +1122,9 @@ class StatisticsTests(unittest.TestCase):
         self.assertEqual(comparison["methods"][0]["delta_ms"], {"p50": 2.0, "p95": 0.0})
         self.assertEqual(comparison["methods"][0]["verdict"], "stable")
 
-    def test_build_comparison_recomputes_metrics_and_prioritizes_regressions(self) -> None:
+    def test_build_comparison_recomputes_metrics_and_prioritizes_regressions(
+        self,
+    ) -> None:
         sessions = constant_sessions()
         for session in sessions:
             session.samples["head"][benchmark.METHODS[0]] = [12.0] * 10
@@ -1160,7 +1199,9 @@ class MarkdownTests(unittest.TestCase):
             "+2.0000 ms (+20.00%) | 10.00 ms | 12.00 ms | "
             "+2.0000 ms (+20.00%) | regression |"
         )
-        self.assertTrue(rendered.startswith("<!-- solar-lsp-benchmark -->\n## LSP benchmark\n"))
+        self.assertTrue(
+            rendered.startswith("<!-- solar-lsp-benchmark -->\n## LSP benchmark\n")
+        )
         self.assertIn("**Overall:** `regression`", rendered)
         self.assertIn(expected_row, rendered)
         self.assertIn(f"/commit/{CONTEXT.merge_candidate_sha}", rendered)

--- a/benches/lsp/test_direct_adapter.py
+++ b/benches/lsp/test_direct_adapter.py
@@ -8,7 +8,6 @@ import re
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 LSP_DIR = ROOT / "benches" / "lsp"
 UPSTREAM_PATH = LSP_DIR / "upstream.json"
@@ -46,9 +45,7 @@ class DirectAdapterTests(unittest.TestCase):
             self.metadata["source"]["url"],
             f"https://codeload.github.com/asyncswap/lsp-bench/tar.gz/{commit}",
         )
-        self.assertEqual(
-            self.metadata["source"]["name"], f"lsp-bench-{commit}.tar.gz"
-        )
+        self.assertEqual(self.metadata["source"]["name"], f"lsp-bench-{commit}.tar.gz")
         self.assertEqual(
             self.metadata["source"]["sha256"],
             "145dc03c5606d6b5ec66647d233486bab9f4e65022275763bf445bc26414470e",
@@ -69,12 +66,8 @@ class DirectAdapterTests(unittest.TestCase):
 
         self.assertEqual(old_paths, ["a/build.rs", "a/src/main.rs"])
         self.assertEqual(new_paths, ["b/build.rs", "b/src/main.rs"])
-        self.assertIn(
-            f'.filter(|commit| commit == "{short_commit}")', self.patch
-        )
-        self.assertIn(
-            f'.unwrap_or_else(|| "{short_commit}".to_string())', self.patch
-        )
+        self.assertIn(f'.filter(|commit| commit == "{short_commit}")', self.patch)
+        self.assertIn(f'.unwrap_or_else(|| "{short_commit}".to_string())', self.patch)
         self.assertIn("is_valid_initialize_response", self.patch)
         self.assertIn("is_fixture_ready_diagnostics", self.patch)
         self.assertIn('Some("textDocument/publishDiagnostics")', self.patch)

--- a/benches/lsp/test_schema.py
+++ b/benches/lsp/test_schema.py
@@ -9,10 +9,14 @@ import unittest
 from pathlib import Path
 
 from jsonschema import Draft202012Validator, ValidationError
-
-from test_benchmark import CONTEXT, RawArtifact, benchmark, constant_sessions
-from test_benchmark import CURRENT_MAIN_SHA, CURRENT_PR_HEAD_SHA
-
+from test_benchmark import (
+    CONTEXT,
+    CURRENT_MAIN_SHA,
+    CURRENT_PR_HEAD_SHA,
+    RawArtifact,
+    benchmark,
+    constant_sessions,
+)
 
 DIRECTORY = Path(__file__).resolve().parent
 RAW_SCHEMA = json.loads((DIRECTORY / "raw.schema.json").read_text(encoding="utf-8"))

--- a/benches/lsp/test_workflow.py
+++ b/benches/lsp/test_workflow.py
@@ -13,7 +13,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = ROOT / ".github/workflows/lsp-bench-command.yml"
 WORKFLOW = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -72,7 +71,9 @@ def run_script(step: str) -> str:
 
 def github_script(step: str) -> str:
     script = step.split("          script: |\n", 1)[1]
-    if not all(not line or line.startswith("            ") for line in script.splitlines()):
+    if not all(
+        not line or line.startswith("            ") for line in script.splitlines()
+    ):
         raise AssertionError("github-script block has unexpected indentation")
     return "\n".join(line[12:] for line in script.splitlines())
 
@@ -275,7 +276,9 @@ const context = {{ repo: {{ owner: "workflow", repo: "solar" }} }};
 class TriggerAndResolutionTests(unittest.TestCase):
     def test_only_exact_pr_conversation_commands_are_accepted(self) -> None:
         header = WORKFLOW.split("\npermissions:", 1)[0]
-        resolver = step_block(job_block("resolve"), "Validate request and freeze revisions")
+        resolver = step_block(
+            job_block("resolve"), "Validate request and freeze revisions"
+        )
 
         self.assertIn("  issue_comment:\n    types: [created]", header)
         self.assertNotIn("pull_request_target", WORKFLOW)
@@ -308,7 +311,7 @@ class TriggerAndResolutionTests(unittest.TestCase):
 
         self.assertIn("github.rest.pulls.get", resolver)
         self.assertIn('branch: "main"', resolver)
-        self.assertIn("pull.state !== \"open\"", resolver)
+        self.assertIn('pull.state !== "open"', resolver)
         self.assertIn('pull.base?.ref !== "main"', resolver)
         self.assertIn("const MERGEABLE_POLLS", resolver)
         self.assertIn("pull.mergeable === null", resolver)
@@ -344,9 +347,7 @@ class TriggerAndResolutionTests(unittest.TestCase):
         queue = job_block("queue-comment")
 
         self.assertIn("MAIN_SHA: ${{ needs.resolve.outputs.main_sha }}", queue)
-        self.assertIn(
-            "PR_HEAD_SHA: ${{ needs.resolve.outputs.pr_head_sha }}", queue
-        )
+        self.assertIn("PR_HEAD_SHA: ${{ needs.resolve.outputs.pr_head_sha }}", queue)
         self.assertIn(
             "MERGE_CANDIDATE_SHA: ${{ needs.resolve.outputs.merge_candidate_sha }}",
             queue,
@@ -359,7 +360,9 @@ class TriggerAndResolutionTests(unittest.TestCase):
 
     def test_manual_dispatch_cannot_execute_untrusted_code(self) -> None:
         header = WORKFLOW.split("\npermissions:", 1)[0]
-        resolver = step_block(job_block("resolve"), "Validate request and freeze revisions")
+        resolver = step_block(
+            job_block("resolve"), "Validate request and freeze revisions"
+        )
 
         self.assertNotIn("\n  workflow_dispatch:", header)
         self.assertNotIn("inputs.", WORKFLOW)
@@ -378,10 +381,13 @@ class TriggerAndResolutionTests(unittest.TestCase):
         script = step_block(arbitrate, "Keep only the latest accepted request")
 
         self.assertIn(
-            '.update(`${target.full_name.toLowerCase()}\\0${requestedNumber}`)', resolver
+            ".update(`${target.full_name.toLowerCase()}\\0${requestedNumber}`)",
+            resolver,
         )
         self.assertIn('core.setOutput("claim_key", claimKey)', resolver)
-        self.assertIn("name: lsp-bench-claim-${{ steps.resolve.outputs.claim_key }}", upload)
+        self.assertIn(
+            "name: lsp-bench-claim-${{ steps.resolve.outputs.claim_key }}", upload
+        )
         self.assertIn("overwrite: true", upload)
         self.assertIn("needs: resolve", arbitrate)
         self.assertIn("CLAIM_KEY: ${{ needs.resolve.outputs.claim_key }}", script)
@@ -399,7 +405,9 @@ class TriggerAndResolutionTests(unittest.TestCase):
             script.index("github.rest.actions.cancelWorkflowRun"),
         )
 
-    @unittest.skipUnless(shutil.which("node"), "Node.js is required for workflow contract tests")
+    @unittest.skipUnless(
+        shutil.which("node"), "Node.js is required for workflow contract tests"
+    )
     def test_resolver_freezes_exact_d_f_m_and_writes_minimal_claim(self) -> None:
         main_sha = "1" * 40
         pr_head_sha = "2" * 40
@@ -438,7 +446,9 @@ class TriggerAndResolutionTests(unittest.TestCase):
             },
         )
 
-    @unittest.skipUnless(shutil.which("node"), "Node.js is required for workflow contract tests")
+    @unittest.skipUnless(
+        shutil.which("node"), "Node.js is required for workflow contract tests"
+    )
     def test_resolver_retries_the_entire_group_when_main_moves(self) -> None:
         first_main = "1" * 40
         second_main = "2" * 40
@@ -460,7 +470,12 @@ class TriggerAndResolutionTests(unittest.TestCase):
 
         result = run_resolution_script(
             main_shas=[first_main, second_main, second_main, second_main],
-            pull_requests=[pull(first_merge), pull(first_merge), pull(second_merge), pull(second_merge)],
+            pull_requests=[
+                pull(first_merge),
+                pull(first_merge),
+                pull(second_merge),
+                pull(second_merge),
+            ],
             merge_commits={
                 first_merge: {
                     "sha": first_merge,
@@ -476,7 +491,9 @@ class TriggerAndResolutionTests(unittest.TestCase):
         self.assertEqual(result["outputs"]["main_sha"], second_main)
         self.assertEqual(result["outputs"]["merge_candidate_sha"], second_merge)
 
-    @unittest.skipUnless(shutil.which("node"), "Node.js is required for workflow contract tests")
+    @unittest.skipUnless(
+        shutil.which("node"), "Node.js is required for workflow contract tests"
+    )
     def test_resolver_rejects_invalid_test_merge_contracts(self) -> None:
         main_sha = "1" * 40
         pr_head_sha = "2" * 40
@@ -530,7 +547,9 @@ class TriggerAndResolutionTests(unittest.TestCase):
                 )
                 self.assertIn(message, result["error"])
 
-    @unittest.skipUnless(shutil.which("node"), "Node.js is required for workflow contract tests")
+    @unittest.skipUnless(
+        shutil.which("node"), "Node.js is required for workflow contract tests"
+    )
     def test_arbitration_is_independent_of_resolver_completion_order(self) -> None:
         older = run_arbitration_script(current_number=10, other_number=11)
         newer = run_arbitration_script(current_number=11, other_number=10)
@@ -612,7 +631,9 @@ class PermissionAndCheckoutTests(unittest.TestCase):
                 "path: lsp-bench/trusted",
             ),
         }
-        self.assertEqual(WORKFLOW.count("uses: actions/checkout@"), len(checkout_contracts))
+        self.assertEqual(
+            WORKFLOW.count("uses: actions/checkout@"), len(checkout_contracts)
+        )
         for name, (job, repository, ref, path) in checkout_contracts.items():
             with self.subTest(name=name):
                 checkout = step_block(job, name)
@@ -665,7 +686,9 @@ class PermissionAndCheckoutTests(unittest.TestCase):
             render.index("name: Validate and render benchmark"),
         )
         self.assertNotIn("cargo build", render)
-        self.assertNotIn("needs.resolve.outputs.pr_head_repository }}\n          ref:", render)
+        self.assertNotIn(
+            "needs.resolve.outputs.pr_head_repository }}\n          ref:", render
+        )
         self.assertIn("github.rest.repos.getBranch", current)
         self.assertIn("github.rest.pulls.get", current)
         self.assertIn("continue-on-error: true", current)
@@ -774,9 +797,7 @@ class ArtifactAndStatusTests(unittest.TestCase):
             'chmod 0755 "$RUNNER_TEMP/lsp-bench-bin/candidate-solar"', prepare
         )
         self.assertIn('test -x "$RUNNER_TEMP/lsp-bench-bin/base-solar"', prepare)
-        self.assertIn(
-            'test -x "$RUNNER_TEMP/lsp-bench-bin/candidate-solar"', prepare
-        )
+        self.assertIn('test -x "$RUNNER_TEMP/lsp-bench-bin/candidate-solar"', prepare)
         self.assertLess(
             compute.index("name: Download main compiler"),
             compute.index("name: Run LSP comparison"),
@@ -790,12 +811,8 @@ class ArtifactAndStatusTests(unittest.TestCase):
             compute.index("name: Run LSP comparison"),
         )
         run = step_block(compute, "Run LSP comparison")
-        self.assertIn(
-            '--base-binary "$RUNNER_TEMP/lsp-bench-bin/base-solar"', run
-        )
-        self.assertIn(
-            '--head-binary "$RUNNER_TEMP/lsp-bench-bin/candidate-solar"', run
-        )
+        self.assertIn('--base-binary "$RUNNER_TEMP/lsp-bench-bin/base-solar"', run)
+        self.assertIn('--head-binary "$RUNNER_TEMP/lsp-bench-bin/candidate-solar"', run)
 
     def test_compute_uploads_only_the_manifest_covered_raw_tree(self) -> None:
         upload = step_block(job_block("compute"), "Upload raw benchmark artifact")
@@ -837,7 +854,9 @@ class ArtifactAndStatusTests(unittest.TestCase):
         )
         self.assertIn('--report "$RUNNER_TEMP/lsp-bench-render/report.md"', validate)
 
-    def test_incomplete_runs_publish_versioned_inconclusive_outputs_and_fail(self) -> None:
+    def test_incomplete_runs_publish_versioned_inconclusive_outputs_and_fail(
+        self,
+    ) -> None:
         render = job_block("render")
         stage = step_block(render, "Stage trusted report")
         failure = step_block(render, "Fail incomplete benchmark")
@@ -865,7 +884,7 @@ class ArtifactAndStatusTests(unittest.TestCase):
         fallback = stage.index("python3 - <<'PY'")
         self.assertLess(success_gate, copy_report)
         self.assertLess(copy_report, fallback)
-        self.assertIn("staged_dir=\"$RUNNER_TEMP/lsp-bench-report.staged\"", stage)
+        self.assertIn('staged_dir="$RUNNER_TEMP/lsp-bench-report.staged"', stage)
         self.assertIn('mv "$staged_dir" "$report_dir"', stage)
         self.assertIn(
             "if: ${{ !cancelled() && steps.stage.outputs.conclusive != 'true' }}",
@@ -936,7 +955,9 @@ class ArtifactAndStatusTests(unittest.TestCase):
             self.assertEqual(comparison["threshold_percent"], 10.0)
             self.assertEqual(comparison["threshold_absolute_ms"], 1.0)
             self.assertEqual(comparison["confidence_level"], 0.95)
-            self.assertIn("**Overall:** `inconclusive`", (output / "report.md").read_text())
+            self.assertIn(
+                "**Overall:** `inconclusive`", (output / "report.md").read_text()
+            )
 
     def test_any_failed_stage_discards_partial_conclusive_outputs(self) -> None:
         stage = step_block(job_block("render"), "Stage trusted report")
@@ -962,7 +983,10 @@ class ArtifactAndStatusTests(unittest.TestCase):
             "current_state",
             "render",
         ):
-            with self.subTest(failed_stage=failed_stage), tempfile.TemporaryDirectory() as directory:
+            with (
+                self.subTest(failed_stage=failed_stage),
+                tempfile.TemporaryDirectory() as directory,
+            ):
                 root = Path(directory)
                 rendered = root / "lsp-bench-render"
                 rendered.mkdir()
@@ -1038,14 +1062,9 @@ class ArtifactAndStatusTests(unittest.TestCase):
             root = Path(directory)
             rendered = root / "lsp-bench-render"
             rendered.mkdir()
-            (rendered / "report.md").write_text(
-                "stale but valid\n", encoding="utf-8"
-            )
+            (rendered / "report.md").write_text("stale but valid\n", encoding="utf-8")
             (rendered / "comparison.json").write_text(
-                json.dumps(
-                    {"overall": "stable", "freshness": "main-advanced"}
-                )
-                + "\n",
+                json.dumps({"overall": "stable", "freshness": "main-advanced"}) + "\n",
                 encoding="utf-8",
             )
             output_path = root / "step-output"
@@ -1079,7 +1098,9 @@ class ArtifactAndStatusTests(unittest.TestCase):
         publish = step_block(render, "Publish sticky benchmark comment")
 
         self.assertIn("needs: [resolve, arbitrate, queue-comment, compute]", render)
-        self.assertIn("!cancelled() &&\n      needs.resolve.result == 'success'", render)
+        self.assertIn(
+            "!cancelled() &&\n      needs.resolve.result == 'success'", render
+        )
         self.assertNotIn("needs.compute.result == 'success'", render)
         self.assertNotIn("if: always()", WORKFLOW)
         self.assertIn(
@@ -1121,12 +1142,10 @@ class ExecutionAndRemovalTests(unittest.TestCase):
         compute = job_block("compute")
         upstream = json.loads((ROOT / "benches/lsp/upstream.json").read_text())
         adapter_path = ROOT / upstream["adapter"]["path"]
-        source_url = upstream["source"]["url"].replace(
-            upstream["commit"], "$commit"
-        )
+        source_url = upstream["source"]["url"].replace(upstream["commit"], "$commit")
         version = (
-            f'lsp-bench {upstream["version"]}+commit.'
-            f'{upstream["commit"][:7]}.linux.x86_64'
+            f"lsp-bench {upstream['version']}+commit."
+            f"{upstream['commit'][:7]}.linux.x86_64"
         )
 
         self.assertIn("needs: [resolve, arbitrate]", build_base)
@@ -1194,11 +1213,11 @@ class ExecutionAndRemovalTests(unittest.TestCase):
         self.assertIn(upstream["adapter"]["path"], compute)
         self.assertIn(version, compute)
         self.assertIn('CARGO_HOME="$RUNNER_TEMP/lsp-bench-cargo"', compute)
-        self.assertIn('CARGO_TARGET_DIR="$RUNNER_TEMP/lsp-bench-target/adapter"', compute)
-        self.assertIn('patch --batch --forward --directory="$source_dir"', compute)
         self.assertIn(
-            '--lsp-bench "$RUNNER_TEMP/lsp-bench-tool/lsp-bench"', compute
+            'CARGO_TARGET_DIR="$RUNNER_TEMP/lsp-bench-target/adapter"', compute
         )
+        self.assertIn('patch --batch --forward --directory="$source_dir"', compute)
+        self.assertIn('--lsp-bench "$RUNNER_TEMP/lsp-bench-tool/lsp-bench"', compute)
         self.assertNotIn("lsp_filter.py", WORKFLOW)
         self.assertIn("runs-on: ubuntu-latest", compute)
         self.assertNotIn("depot-ubuntu-latest", compute)
@@ -1215,7 +1234,9 @@ class ExecutionAndRemovalTests(unittest.TestCase):
         )
 
     def test_legacy_lsp_stack_is_absent(self) -> None:
-        workflow_names = {path.name for path in (ROOT / ".github/workflows").glob("lsp-bench*.yml")}
+        workflow_names = {
+            path.name for path in (ROOT / ".github/workflows").glob("lsp-bench*.yml")
+        }
 
         self.assertEqual(workflow_names, {"lsp-bench-command.yml"})
         self.assertFalse((ROOT / "tools/lsp-bench").exists())

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -10,6 +10,11 @@ both modes with `--mode runtime compile-time`.
 Keeping the inputs here makes the benchmark reproducible from this checkout and removes the CI
 dependency on a second repository and its recursive submodules.
 
+Use `--solar-only` for repeated local runs after recording a two-compiler baseline. This skips the
+reference solc compile for each case while retaining Solar compilation, gas measurements, and
+runtime failure checks. A one-compiler run cannot make differential runtime claims, so successful
+runtime comparisons are marked as skipped. CI does not use this option.
+
 The workload definitions and helper fixtures were imported from
 [`walnuthq/solidity-compiler-benchmarks`](https://github.com/walnuthq/solidity-compiler-benchmarks)
 at commit `01209d2b8ac81645b92e3ef801b5bcdfd61bfd69`. The benchmark still compiles each contract with

--- a/benches/runtime/README.md
+++ b/benches/runtime/README.md
@@ -13,13 +13,18 @@ dependency on a second repository and its recursive submodules.
 Use `--solar-only` for repeated local runs after recording a two-compiler baseline. This skips the
 reference solc compile for each case while retaining Solar compilation, gas measurements, and
 runtime failure checks. A one-compiler run cannot make differential runtime claims, so successful
-runtime comparisons are marked as skipped. CI does not use this option.
+runtime comparisons are marked as skipped unless a matching reference result is supplied.
+
+Pass `--reference-results PATH` with `--solar-only` to reuse matching solc results from a prior
+run. The benchmark copies solc compile, gas, and runtime data only when the input fingerprint
+matches, then performs the normal cross-compiler runtime checks. PR CI uses the exact-base result
+as the reference, so solc runs on the base revision instead of repeating unchanged work on the PR.
 
 The workload definitions and helper fixtures were imported from
 [`walnuthq/solidity-compiler-benchmarks`](https://github.com/walnuthq/solidity-compiler-benchmarks)
-at commit `01209d2b8ac81645b92e3ef801b5bcdfd61bfd69`. The benchmark still compiles each contract with
-both compilers, deploys both artifacts, executes the same ordered transactions, and requires their
-normalized runtime observations to match.
+at commit `01209d2b8ac81645b92e3ef801b5bcdfd61bfd69`. The combined profile still contains each contract
+from both compilers, both deployed artifacts, the same ordered transactions, and matching normalized
+runtime observations.
 
 | Case | Upstream source | Revision | Files |
 | --- | --- | --- | ---: |

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -13,29 +13,25 @@ import hashlib
 import json
 import re
 import shutil
-import subprocess
 import statistics
+import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
-from functools import lru_cache
+from functools import cache, lru_cache
 from pathlib import Path
-from typing import Dict, Optional, Sequence, Tuple
 
 from cases import (
     DEFAULT_FOURTH,
     DEFAULT_SENDER,
     DEFAULT_SPENDER,
     DEFAULT_THIRD,
-    EDGE_BYTES32,
-    MAX_UINT128,
     MAX_UINT256,
-    MIXED_BYTES32,
-    SIGNED_HASH,
     TEST_CASES,
-    TestCase,
     ZERO_ADDRESS,
+    TestCase,
     gas_calls,
     runtime_checks,
 )
@@ -110,7 +106,7 @@ def verbose_log(enabled: bool, message: str) -> None:
         print(message, flush=True)
 
 
-def find_binary(explicit: Optional[str], candidates: Sequence[str]) -> Optional[Path]:
+def find_binary(explicit: str | None, candidates: Sequence[str]) -> Path | None:
     if explicit:
         path = Path(explicit)
         if path.exists():
@@ -132,7 +128,7 @@ def find_binary(explicit: Optional[str], candidates: Sequence[str]) -> Optional[
     return None
 
 
-def binary_version(path: Path) -> Tuple[str, str]:
+def binary_version(path: Path) -> tuple[str, str]:
     result = run([str(path), "--version"], timeout=30)
     if result.returncode != 0:
         error = (result.stderr or result.stdout or "version command failed").strip()
@@ -143,22 +139,20 @@ def binary_version(path: Path) -> Tuple[str, str]:
     return version, ""
 
 
-def parse_version_tuple(version: str) -> Optional[Tuple[int, int, int]]:
+def parse_version_tuple(version: str) -> tuple[int, int, int] | None:
     match = re.match(r"(\d+)\.(\d+)\.(\d+)", version)
     if not match:
         return None
     return tuple(int(part) for part in match.groups())
 
 
-def version_in_range(version: str, minimum: Optional[str], maximum: Optional[str]) -> bool:
+def version_in_range(version: str, minimum: str | None, maximum: str | None) -> bool:
     parsed = parse_version_tuple(version)
     if parsed is None:
         return True
     if minimum and parsed < parse_version_tuple(minimum):
         return False
-    if maximum and parsed > parse_version_tuple(maximum):
-        return False
-    return True
+    return not (maximum and parsed > parse_version_tuple(maximum))
 
 
 @dataclass(frozen=True)
@@ -197,7 +191,7 @@ def standard_json_input(test_case: TestCase) -> str:
     return json.dumps(payload)
 
 
-@lru_cache(maxsize=None)
+@cache
 def project_full_standard_json_input(project_file: str) -> str:
     path = PROJECTS_ROOT / project_file
     with gzip.open(path, mode="rt", encoding="utf-8") as file:
@@ -244,7 +238,7 @@ LONG_COMPILE_CUTOFF_SECONDS = 10.0
 
 def compile_case(
     spec: CompilerSpec, test_case: TestCase, compile_repeats: int = 1
-) -> Dict[str, object]:
+) -> dict[str, object]:
     result = {
         "compiler_id": spec.compiler_id,
         "label": spec.label,
@@ -337,7 +331,7 @@ def compile_case(
     return result
 
 
-def parse_whole_project_output(stdout: str) -> Tuple[int, int, str]:
+def parse_whole_project_output(stdout: str) -> tuple[int, int, str]:
     """Returns contract entries, entries with nonempty bytecode, and an error."""
     try:
         output = json.loads(stdout)
@@ -362,14 +356,14 @@ def parse_whole_project_output(stdout: str) -> Tuple[int, int, str]:
     return compiled, objects, ""
 
 
-def parse_full_project_output(stdout: str, test_case: TestCase) -> Tuple[int, int, str]:
+def parse_full_project_output(stdout: str, test_case: TestCase) -> tuple[int, int, str]:
     del test_case
     return parse_whole_project_output(stdout)
 
 
 def parse_standard_json_output(
     stdout: str, test_case: TestCase
-) -> Tuple[Optional[str], Optional[str], str]:
+) -> tuple[str | None, str | None, str]:
     try:
         output = json.loads(stdout)
     except json.JSONDecodeError as exc:
@@ -395,17 +389,19 @@ def parse_standard_json_output(
                 return bytecode, deployed, ""
 
     available = [
-        name
-        for source_contracts in contracts.values()
-        for name in source_contracts.keys()
+        name for source_contracts in contracts.values() for name in source_contracts
     ]
-    return None, None, f"contract {test_case.contract_name} not found; available: {', '.join(available)}"
+    return (
+        None,
+        None,
+        f"contract {test_case.contract_name} not found; available: {', '.join(available)}",
+    )
 
 
-
-
-@lru_cache(maxsize=None)
-def compile_runtime_fixture(solc_path: str, contract_name: str) -> Tuple[Optional[str], str]:
+@cache
+def compile_runtime_fixture(
+    solc_path: str, contract_name: str
+) -> tuple[str | None, str]:
     source_name = str(RUNTIME_FIXTURES.relative_to(ROOT))
     payload = {
         "language": "Solidity",
@@ -415,7 +411,9 @@ def compile_runtime_fixture(solc_path: str, contract_name: str) -> Tuple[Optiona
             "outputSelection": {"*": {contract_name: ["evm.bytecode.object"]}},
         },
     }
-    proc = run([solc_path, "--standard-json"], input_text=json.dumps(payload), timeout=120)
+    proc = run(
+        [solc_path, "--standard-json"], input_text=json.dumps(payload), timeout=120
+    )
     if proc.returncode != 0:
         return None, (proc.stderr or proc.stdout or "fixture compiler failed")[:1000]
     try:
@@ -474,7 +472,9 @@ def start_anvil(rpc_url: str) -> subprocess.Popen[bytes]:
     raise RuntimeError("anvil did not accept RPC requests")
 
 
-def abi_encode_constructor(constructor_args: Sequence[str], constructor_sig: Optional[str]) -> Optional[str]:
+def abi_encode_constructor(
+    constructor_args: Sequence[str], constructor_sig: str | None
+) -> str | None:
     if not constructor_args:
         return ""
     if not constructor_sig:
@@ -483,7 +483,7 @@ def abi_encode_constructor(constructor_args: Sequence[str], constructor_sig: Opt
     if proc.returncode != 0:
         return None
     encoded = proc.stdout.strip()
-    return encoded[2:] if encoded.startswith("0x") else encoded
+    return encoded.removeprefix("0x")
 
 
 def deploy_contract(
@@ -491,7 +491,7 @@ def deploy_contract(
     test_case: TestCase,
     rpc_url: str,
     private_key: str,
-) -> Tuple[Optional[str], Optional[int], str]:
+) -> tuple[str | None, int | None, str]:
     return deploy_creation_code(
         bytecode,
         test_case.constructor_args,
@@ -504,10 +504,10 @@ def deploy_contract(
 def deploy_creation_code(
     bytecode: str,
     constructor_args: Sequence[str],
-    constructor_sig: Optional[str],
+    constructor_sig: str | None,
     rpc_url: str,
     private_key: str,
-) -> Tuple[Optional[str], Optional[int], str]:
+) -> tuple[str | None, int | None, str]:
     if not bytecode.startswith("0x"):
         bytecode = "0x" + bytecode
 
@@ -522,7 +522,7 @@ def deploy_creation_code_from_file(
     bytecode: str,
     rpc_url: str,
     private_key: str,
-) -> Tuple[Optional[str], Optional[int], str]:
+) -> tuple[str | None, int | None, str]:
     sender, error = private_key_address(private_key)
     if sender is None:
         return None, None, error
@@ -554,7 +554,7 @@ def deploy_creation_code_from_file(
 
 
 @lru_cache
-def private_key_address(private_key: str) -> Tuple[Optional[str], str]:
+def private_key_address(private_key: str) -> tuple[str | None, str]:
     if private_key == DEFAULT_PRIVATE_KEY:
         return DEFAULT_SENDER, ""
     proc = run(["cast", "wallet", "address", "--private-key", private_key], timeout=30)
@@ -565,16 +565,24 @@ def private_key_address(private_key: str) -> Tuple[Optional[str], str]:
 
 def parse_deploy_receipt(
     data: dict[str, object],
-) -> Tuple[Optional[str], Optional[int], str]:
+) -> tuple[str | None, int | None, str]:
     status = parse_receipt_int(data.get("status"))
     gas = data.get("gasUsed")
     deploy_gas = parse_receipt_int(gas)
     if status is not None and status != 1:
-        return None, deploy_gas, f"deploy transaction failed (status={status}, gasUsed={deploy_gas})"
+        return (
+            None,
+            deploy_gas,
+            f"deploy transaction failed (status={status}, gasUsed={deploy_gas})",
+        )
     if deploy_gas is None:
         return None, None, "deploy receipt missing gasUsed"
     contract_address = data.get("contractAddress")
-    return contract_address if isinstance(contract_address, str) else None, deploy_gas, ""
+    return (
+        contract_address if isinstance(contract_address, str) else None,
+        deploy_gas,
+        "",
+    )
 
 
 def rpc_request_from_file(
@@ -582,7 +590,7 @@ def rpc_request_from_file(
     params: Sequence[object],
     rpc_url: str,
     timeout: int = CAST_READ_TIMEOUT,
-) -> Tuple[Optional[object], str]:
+) -> tuple[object | None, str]:
     with tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
@@ -614,7 +622,7 @@ def call_contract(
     args: Sequence[str],
     rpc_url: str,
     private_key: str,
-) -> Tuple[Optional[int], str]:
+) -> tuple[int | None, str]:
     proc = run(
         [
             "cast",
@@ -656,7 +664,7 @@ def read_contract(
     signature: str,
     args: Sequence[str],
     rpc_url: str,
-) -> Tuple[Optional[str], str]:
+) -> tuple[str | None, str]:
     proc = run(
         [
             "cast",
@@ -681,7 +689,9 @@ def read_contract(
     return value, ""
 
 
-def rpc_request(method: str, params: Sequence[object], rpc_url: str) -> Tuple[Optional[object], str]:
+def rpc_request(
+    method: str, params: Sequence[object], rpc_url: str
+) -> tuple[object | None, str]:
     proc = run(
         ["cast", "rpc", "--rpc-url", rpc_url, "--raw", method],
         input_text=json.dumps(list(params)),
@@ -727,7 +737,7 @@ def send_value(address: str, amount: str, rpc_url: str, private_key: str) -> str
     return "" if status in (None, 1) else f"value transfer failed (status={status})"
 
 
-def encode_calldata(signature: str, args: Sequence[str]) -> Tuple[Optional[str], str]:
+def encode_calldata(signature: str, args: Sequence[str]) -> tuple[str | None, str]:
     proc = run(["cast", "calldata", signature, *args], timeout=30)
     if proc.returncode != 0:
         return None, proc.stderr[:1000]
@@ -739,7 +749,7 @@ def eth_call_raw(
     signature: str,
     args: Sequence[str],
     rpc_url: str,
-) -> Tuple[Optional[str], Optional[str], str]:
+) -> tuple[str | None, str | None, str]:
     calldata, error = encode_calldata(signature, args)
     if calldata is None:
         return None, None, error
@@ -769,15 +779,15 @@ def eth_call_raw(
     return None, None, message[:1000]
 
 
-def runtime_ok(label: str, value: object) -> Dict[str, object]:
+def runtime_ok(label: str, value: object) -> dict[str, object]:
     return {"label": label, "status": "ok", "value": str(value)}
 
 
-def runtime_error(label: str, error: str) -> Dict[str, object]:
+def runtime_error(label: str, error: str) -> dict[str, object]:
     return {"label": label, "status": "failed", "error": error}
 
 
-def checked_value(label: str, actual: object, expected: object) -> Dict[str, object]:
+def checked_value(label: str, actual: object, expected: object) -> dict[str, object]:
     actual_text = str(actual)
     expected_text = str(expected)
     if actual_text != expected_text:
@@ -790,7 +800,7 @@ def read_uint(
     signature: str,
     args: Sequence[str],
     rpc_url: str,
-) -> Tuple[Optional[int], str]:
+) -> tuple[int | None, str]:
     value, error = read_contract(address, signature, args, rpc_url)
     if value is None:
         return None, error
@@ -805,19 +815,23 @@ def read_address(
     signature: str,
     args: Sequence[str],
     rpc_url: str,
-) -> Tuple[Optional[str], str]:
+) -> tuple[str | None, str]:
     value, error = read_contract(address, signature, args, rpc_url)
     if value is None:
         return None, error
     match = re.search(r"0x[0-9a-fA-F]{40}", value)
-    return (match.group(0).lower(), "") if match else (None, f"invalid address result: {value}")
+    return (
+        (match.group(0).lower(), "")
+        if match
+        else (None, f"invalid address result: {value}")
+    )
 
 
-def decode_words(data: str) -> List[int]:
-    raw = data[2:] if data.startswith("0x") else data
+def decode_words(data: str) -> list[int]:
+    raw = data.removeprefix("0x")
     if len(raw) % 64 != 0:
         raise ValueError(f"ABI result has {len(raw)} hex digits")
-    return [int(raw[index:index + 64], 16) for index in range(0, len(raw), 64)]
+    return [int(raw[index : index + 64], 16) for index in range(0, len(raw), 64)]
 
 
 def run_vesting_cold_paths(
@@ -825,7 +839,7 @@ def run_vesting_cold_paths(
     solc_path: Path,
     rpc_url: str,
     private_key: str,
-) -> List[Dict[str, object]]:
+) -> list[dict[str, object]]:
     error = send_value(address, "1000", rpc_url, private_key)
     if error:
         return [runtime_error("cold-vesting-eth-setup", error)]
@@ -845,7 +859,9 @@ def run_vesting_cold_paths(
     )
     if token is None:
         return [runtime_error("cold-vesting-token-deploy", error)]
-    _, error = call_contract(address, "release(address)", (token,), rpc_url, private_key)
+    _, error = call_contract(
+        address, "release(address)", (token,), rpc_url, private_key
+    )
     if error:
         return [runtime_error("cold-vesting-token-release", error)]
 
@@ -853,19 +869,49 @@ def run_vesting_cold_paths(
     reads = (
         ("cold-vesting-released-eth", address, "released()(uint256)", (), 1000),
         ("cold-vesting-releasable-eth", address, "releasable()(uint256)", (), 0),
-        ("cold-vesting-released-token", address, "released(address)(uint256)", (token,), 2000),
-        ("cold-vesting-releasable-token", address, "releasable(address)(uint256)", (token,), 0),
-        ("cold-vesting-token-empty", token, "balanceOf(address)(uint256)", (address,), 0),
-        ("cold-vesting-owner-token", token, "balanceOf(address)(uint256)", (DEFAULT_SENDER,), 2000),
+        (
+            "cold-vesting-released-token",
+            address,
+            "released(address)(uint256)",
+            (token,),
+            2000,
+        ),
+        (
+            "cold-vesting-releasable-token",
+            address,
+            "releasable(address)(uint256)",
+            (token,),
+            0,
+        ),
+        (
+            "cold-vesting-token-empty",
+            token,
+            "balanceOf(address)(uint256)",
+            (address,),
+            0,
+        ),
+        (
+            "cold-vesting-owner-token",
+            token,
+            "balanceOf(address)(uint256)",
+            (DEFAULT_SENDER,),
+            2000,
+        ),
     )
     for label, target, signature, args, expected in reads:
         value, error = read_uint(target, signature, args, rpc_url)
-        observations.append(runtime_error(label, error) if value is None else checked_value(label, value, expected))
+        observations.append(
+            runtime_error(label, error)
+            if value is None
+            else checked_value(label, value, expected)
+        )
     balance, error = rpc_request("eth_getBalance", (address, "latest"), rpc_url)
     if balance is None:
         observations.append(runtime_error("cold-vesting-eth-empty", error))
     else:
-        observations.append(checked_value("cold-vesting-eth-empty", int(str(balance), 16), 0))
+        observations.append(
+            checked_value("cold-vesting-eth-empty", int(str(balance), 16), 0)
+        )
     return observations
 
 
@@ -874,14 +920,16 @@ def run_fractional_cold_paths(
     solc_path: Path,
     rpc_url: str,
     private_key: str,
-) -> List[Dict[str, object]]:
+) -> list[dict[str, object]]:
     nft_bytecode, error = compile_runtime_fixture(str(solc_path), "RuntimeNFT")
     if nft_bytecode is None:
         return [runtime_error("cold-fractional-nft-compile", error)]
     nft, _, error = deploy_creation_code(nft_bytecode, (), None, rpc_url, private_key)
     if nft is None:
         return [runtime_error("cold-fractional-nft-deploy", error)]
-    _, error = call_contract(nft, "setApprovalForAll(address,bool)", (address, "true"), rpc_url, private_key)
+    _, error = call_contract(
+        nft, "setApprovalForAll(address,bool)", (address, "true"), rpc_url, private_key
+    )
     if error:
         return [runtime_error("cold-fractional-approve-nft", error)]
     _, error = call_contract(
@@ -902,7 +950,11 @@ def run_fractional_cold_paths(
     except ValueError as exc:
         return [runtime_error("cold-fractional-vault", str(exc))]
     if len(vault) != 4:
-        return [runtime_error("cold-fractional-vault", f"expected 4 words, got {len(vault)}")]
+        return [
+            runtime_error(
+                "cold-fractional-vault", f"expected 4 words, got {len(vault)}"
+            )
+        ]
     token = "0x" + f"{vault[3]:040x}"
 
     observations = [
@@ -915,16 +967,22 @@ def run_fractional_cold_paths(
     observations.append(
         runtime_error("cold-fractional-nft-custody", error)
         if nft_owner is None
-        else checked_value("cold-fractional-nft-custody", nft_owner == address.lower(), True)
+        else checked_value(
+            "cold-fractional-nft-custody", nft_owner == address.lower(), True
+        )
     )
-    share_balance, error = read_uint(token, "balanceOf(address)(uint256)", (DEFAULT_SENDER,), rpc_url)
+    share_balance, error = read_uint(
+        token, "balanceOf(address)(uint256)", (DEFAULT_SENDER,), rpc_url
+    )
     observations.append(
         runtime_error("cold-fractional-share-minted", error)
         if share_balance is None
         else checked_value("cold-fractional-share-minted", share_balance, 1000)
     )
 
-    _, error = call_contract(token, "approve(address,uint256)", (address, MAX_UINT256), rpc_url, private_key)
+    _, error = call_contract(
+        token, "approve(address,uint256)", (address, MAX_UINT256), rpc_url, private_key
+    )
     if error:
         observations.append(runtime_error("cold-fractional-approve-share", error))
         return observations
@@ -935,16 +993,28 @@ def run_fractional_cold_paths(
 
     empty_vault, _, error = eth_call_raw(address, "getVault(uint256)", ("1",), rpc_url)
     if empty_vault is None:
-        observations.append(runtime_error("cold-fractional-vault-cleared", error or "getVault reverted"))
+        observations.append(
+            runtime_error("cold-fractional-vault-cleared", error or "getVault reverted")
+        )
     else:
-        observations.append(checked_value("cold-fractional-vault-cleared", all(word == 0 for word in decode_words(empty_vault)), True))
+        observations.append(
+            checked_value(
+                "cold-fractional-vault-cleared",
+                all(word == 0 for word in decode_words(empty_vault)),
+                True,
+            )
+        )
     nft_owner, error = read_address(nft, "ownerOf(uint256)(address)", ("1",), rpc_url)
     observations.append(
         runtime_error("cold-fractional-nft-returned", error)
         if nft_owner is None
-        else checked_value("cold-fractional-nft-returned", nft_owner, DEFAULT_SENDER.lower())
+        else checked_value(
+            "cold-fractional-nft-returned", nft_owner, DEFAULT_SENDER.lower()
+        )
     )
-    share_balance, error = read_uint(token, "balanceOf(address)(uint256)", (DEFAULT_SENDER,), rpc_url)
+    share_balance, error = read_uint(
+        token, "balanceOf(address)(uint256)", (DEFAULT_SENDER,), rpc_url
+    )
     observations.append(
         runtime_error("cold-fractional-share-burned", error)
         if share_balance is None
@@ -960,8 +1030,8 @@ def keccak256(data: bytes) -> bytes:
     return bytes.fromhex(proc.stdout.strip().removeprefix("0x"))
 
 
-@lru_cache(maxsize=None)
-def nitro_dispatch_vector(opcode: int) -> Tuple[str, str]:
+@cache
+def nitro_dispatch_vector(opcode: int) -> tuple[str, str]:
     zero = bytes(32)
     u32_zero = bytes(4)
     u64_zero = bytes(8)
@@ -971,20 +1041,27 @@ def nitro_dispatch_vector(opcode: int) -> Tuple[str, str]:
     functions_root = keccak256(b"Function:" + instructions_hash)
     memory_hash = keccak256(b"Memory:" + u64_zero + u64_zero + zero)
     module = zero + u64_zero + u64_zero + zero + zero + functions_root + zero + u32_zero
-    module_hash = keccak256(b"Module:" + zero + memory_hash + zero + functions_root + zero + u32_zero)
+    module_hash = keccak256(
+        b"Module:" + zero + memory_hash + zero + functions_root + zero + u32_zero
+    )
 
     inactive_multi = zero + zero
     multistack_hash = keccak256(b"multistack:" + zero + zero + zero)
-    recovery_pc = bytes([0xff]) * 32
+    recovery_pc = bytes([0xFF]) * 32
     machine = (
         b"\x00"
-        + zero + u256_zero
-        + inactive_multi
-        + zero + u256_zero
-        + zero + b"\x00"
+        + zero
+        + u256_zero
         + inactive_multi
         + zero
-        + u32_zero + u32_zero + u32_zero
+        + u256_zero
+        + zero
+        + b"\x00"
+        + inactive_multi
+        + zero
+        + u32_zero
+        + u32_zero
+        + u32_zero
         + recovery_pc
         + module_hash
     )
@@ -994,7 +1071,9 @@ def nitro_dispatch_vector(opcode: int) -> Tuple[str, str]:
         + zero
         + multistack_hash
         + zero
-        + u32_zero + u32_zero + u32_zero
+        + u32_zero
+        + u32_zero
+        + u32_zero
         + recovery_pc
         + module_hash
     )
@@ -1002,7 +1081,7 @@ def nitro_dispatch_vector(opcode: int) -> Tuple[str, str]:
     return "0x" + before_hash.hex(), "0x" + proof.hex()
 
 
-def run_nitro_cold_paths(address: str, rpc_url: str) -> List[Dict[str, object]]:
+def run_nitro_cold_paths(address: str, rpc_url: str) -> list[dict[str, object]]:
     dispatches = (
         ("prover0", 0x01, DEFAULT_SENDER, 1),
         ("prover-mem", 0x28, DEFAULT_SPENDER, 2),
@@ -1033,9 +1112,13 @@ def run_nitro_cold_paths(address: str, rpc_url: str) -> List[Dict[str, object]]:
             if error:
                 observations.append(runtime_error(f"cold-nitro-{label}", error))
             elif revert_data is None:
-                observations.append(runtime_error(f"cold-nitro-{label}", "expected mock-prover revert"))
+                observations.append(
+                    runtime_error(f"cold-nitro-{label}", "expected mock-prover revert")
+                )
             else:
-                observations.append(checked_value(f"cold-nitro-{label}", revert_data, expected))
+                observations.append(
+                    checked_value(f"cold-nitro-{label}", revert_data, expected)
+                )
     finally:
         for _, _, prover, _ in dispatches:
             rpc_request("anvil_setCode", (prover, "0x"), rpc_url)
@@ -1048,7 +1131,7 @@ def run_cold_path_checks(
     solc_path: Path,
     rpc_url: str,
     private_key: str,
-) -> List[Dict[str, object]]:
+) -> list[dict[str, object]]:
     if test_case.test_id == "openzeppelin-vesting-wallet":
         return run_vesting_cold_paths(address, solc_path, rpc_url, private_key)
     if test_case.test_id == "lilweb3-fractional":
@@ -1058,9 +1141,11 @@ def run_cold_path_checks(
     return []
 
 
-def compare_runtime_results(entry: Dict[str, object], specs: Sequence[CompilerSpec]) -> None:
+def compare_runtime_results(
+    entry: dict[str, object], specs: Sequence[CompilerSpec]
+) -> None:
     labels = []
-    values_by_compiler: Dict[str, Dict[str, str]] = {}
+    values_by_compiler: dict[str, dict[str, str]] = {}
     failed = False
 
     for spec in specs:
@@ -1108,46 +1193,46 @@ def compare_runtime_results(entry: Dict[str, object], specs: Sequence[CompilerSp
         entry["runtime_status"] = "ok"
 
 
-def result_key(result: Dict[str, object]) -> Tuple[str, str]:
+def result_key(result: dict[str, object]) -> tuple[str, str]:
     return str(result.get("suite", "repository")), str(result.get("test_id", ""))
 
 
-def load_reference_results(path: Path) -> Dict[Tuple[str, str], Dict[str, object]]:
+def load_reference_results(path: Path) -> dict[tuple[str, str], dict[str, object]]:
     document = json.loads(path.read_text())
     results = document.get("results") if isinstance(document, dict) else None
     if not isinstance(results, list):
         raise ValueError("expected a benchmark result document")
     return {
-        result_key(result): result
-        for result in results
-        if isinstance(result, dict)
+        result_key(result): result for result in results if isinstance(result, dict)
     }
 
 
-def workload_signature(data: Dict[str, object]) -> Tuple[object, ...]:
+def workload_signature(data: dict[str, object]) -> tuple[object, ...]:
     signature = []
     for field in ("gas_results", "runtime_results"):
         observations = data.get(field)
         if not isinstance(observations, list):
             continue
-        signature.append((
-            field,
-            tuple(
-                (
-                    observation.get("label"),
-                    observation.get("call"),
-                    tuple(observation.get("args") or ()),
-                )
-                for observation in observations
-                if isinstance(observation, dict)
-            ),
-        ))
+        signature.append(
+            (
+                field,
+                tuple(
+                    (
+                        observation.get("label"),
+                        observation.get("call"),
+                        tuple(observation.get("args") or ()),
+                    )
+                    for observation in observations
+                    if isinstance(observation, dict)
+                ),
+            )
+        )
     return tuple(signature)
 
 
 def merge_reference_compiler(
-    entry: Dict[str, object],
-    references: Dict[Tuple[str, str], Dict[str, object]],
+    entry: dict[str, object],
+    references: dict[tuple[str, str], dict[str, object]],
     compiler_id: str,
 ) -> bool:
     reference = references.get(result_key(entry))
@@ -1190,9 +1275,9 @@ def failed_test_result(
     specs: Sequence[CompilerSpec],
     gas_profile: str,
     error: Exception,
-) -> Dict[str, object]:
+) -> dict[str, object]:
     message = f"unexpected benchmark failure: {type(error).__name__}: {error}"[:1000]
-    entry: Dict[str, object] = {
+    entry: dict[str, object] = {
         "test_id": test_case.test_id,
         "description": test_case.description,
         "contract_name": test_case.contract_name,
@@ -1200,8 +1285,7 @@ def failed_test_result(
         "gas_profile": gas_profile,
         "benchmark_error": message,
         "compilers": {
-            spec.compiler_id: {"status": "failed", "error": message}
-            for spec in specs
+            spec.compiler_id: {"status": "failed", "error": message} for spec in specs
         },
     }
     if test_case.project_file is not None:
@@ -1219,9 +1303,9 @@ def run_test_case(
     private_key: str,
     verbose: bool = False,
     compile_repeats: int = 1,
-    reference_solc_path: Optional[Path] = None,
-) -> Dict[str, object]:
-    entry: Dict[str, object] = {
+    reference_solc_path: Path | None = None,
+) -> dict[str, object]:
+    entry: dict[str, object] = {
         "test_id": test_case.test_id,
         "description": test_case.description,
         "contract_name": test_case.contract_name,
@@ -1283,24 +1367,33 @@ def run_test_case(
         for call in calls:
             for index in range(call.repeat):
                 label = call.label if call.repeat == 1 else f"{call.label}#{index + 1}"
-                verbose_log(verbose, f"[{test_case.test_id}] {spec.compiler_id} tx {label}: {call.signature}")
-                gas, error = call_contract(address, call.signature, call.args, rpc_url, private_key)
+                verbose_log(
+                    verbose,
+                    f"[{test_case.test_id}] {spec.compiler_id} tx {label}: {call.signature}",
+                )
+                gas, error = call_contract(
+                    address, call.signature, call.args, rpc_url, private_key
+                )
                 if gas is None:
                     gas_failed = True
-                    gas_results.append({
+                    gas_results.append(
+                        {
+                            "label": label,
+                            "call": call.signature,
+                            "args": list(call.args),
+                            "gas": None,
+                            "error": error,
+                        }
+                    )
+                    continue
+                gas_results.append(
+                    {
                         "label": label,
                         "call": call.signature,
                         "args": list(call.args),
-                        "gas": None,
-                        "error": error,
-                    })
-                    continue
-                gas_results.append({
-                    "label": label,
-                    "call": call.signature,
-                    "args": list(call.args),
-                    "gas": gas,
-                })
+                        "gas": gas,
+                    }
+                )
                 total_gas += gas
         compiler_entry["gas_results"] = gas_results
         compiler_entry["gas_status"] = "failed" if gas_failed else "ok"
@@ -1309,30 +1402,42 @@ def run_test_case(
         runtime_results = []
         runtime_failed = False
         for check in checks:
-            verbose_log(verbose, f"[{test_case.test_id}] {spec.compiler_id} read {check.label}: {check.signature}")
+            verbose_log(
+                verbose,
+                f"[{test_case.test_id}] {spec.compiler_id} read {check.label}: {check.signature}",
+            )
             value, error = read_contract(address, check.signature, check.args, rpc_url)
             if value is None:
                 runtime_failed = True
-                runtime_results.append({
+                runtime_results.append(
+                    {
+                        "label": check.label,
+                        "call": check.signature,
+                        "args": list(check.args),
+                        "status": "failed",
+                        "error": error,
+                    }
+                )
+                continue
+            runtime_results.append(
+                {
                     "label": check.label,
                     "call": check.signature,
                     "args": list(check.args),
-                    "status": "failed",
-                    "error": error,
-                })
-                continue
-            runtime_results.append({
-                "label": check.label,
-                "call": check.signature,
-                "args": list(check.args),
-                "status": "ok",
-                "value": value,
-            })
+                    "status": "ok",
+                    "value": value,
+                }
+            )
         if has_cold_paths:
             if reference_solc is None:
-                cold_results = [runtime_error("cold-path-setup", "reference solc is required")]
+                cold_results = [
+                    runtime_error("cold-path-setup", "reference solc is required")
+                ]
             else:
-                verbose_log(verbose, f"[{test_case.test_id}] {spec.compiler_id} cold-path differential")
+                verbose_log(
+                    verbose,
+                    f"[{test_case.test_id}] {spec.compiler_id} cold-path differential",
+                )
                 cold_results = run_cold_path_checks(
                     test_case,
                     address,
@@ -1341,7 +1446,9 @@ def run_test_case(
                     private_key,
                 )
             runtime_results.extend(cold_results)
-            runtime_failed |= any(result.get("status") != "ok" for result in cold_results)
+            runtime_failed |= any(
+                result.get("status") != "ok" for result in cold_results
+            )
         if checks or has_cold_paths:
             compiler_entry["runtime_results"] = runtime_results
             compiler_entry["runtime_status"] = "failed" if runtime_failed else "ok"
@@ -1359,15 +1466,20 @@ def select_tests(modes: Sequence[str], suite: str) -> Sequence[TestCase]:
         test
         for test in TEST_CASES
         if (suite == "all" or test.suite == suite)
-        and ((test.whole_project and compile_time) or (not test.whole_project and runtime))
+        and (
+            (test.whole_project and compile_time)
+            or (not test.whole_project and runtime)
+        )
     ]
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Benchmark solc vs Solar codegen on inline and repository contracts"
     )
-    parser.add_argument("--solc", default="solc", help="Path to solc binary (default: solc)")
+    parser.add_argument(
+        "--solc", default="solc", help="Path to solc binary (default: solc)"
+    )
     parser.add_argument(
         "--solar",
         help="Path to solar binary (default: solar or target/{release,debug}/solar)",
@@ -1402,25 +1514,45 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help="Reuse matching solc results from another benchmark result document",
     )
     parser.add_argument("--tests", nargs="*", help="Subset of test IDs to run")
-    parser.add_argument("--projects", nargs="*", help="Subset of repository project names to run")
-    parser.add_argument("--list-tests", action="store_true", help="List available tests and exit")
+    parser.add_argument(
+        "--projects", nargs="*", help="Subset of repository project names to run"
+    )
+    parser.add_argument(
+        "--list-tests", action="store_true", help="List available tests and exit"
+    )
     parser.add_argument(
         "--include-incompatible",
         action="store_true",
         help="Run repository contracts even when their pragma is incompatible with the selected solc",
     )
-    parser.add_argument("--gas", action="store_true", help="Deploy, execute gas calls, and compare runtime results with cast/anvil")
+    parser.add_argument(
+        "--gas",
+        action="store_true",
+        help="Deploy, execute gas calls, and compare runtime results with cast/anvil",
+    )
     parser.add_argument(
         "--gas-profile",
         choices=("smoke", "hot"),
         default="smoke",
         help="Gas workload profile: smoke preserves the existing calls, hot runs a broader optimizer workload",
     )
-    parser.add_argument("--start-anvil", action="store_true", help="Start anvil automatically for --gas")
-    parser.add_argument("--rpc-url", default=DEFAULT_RPC_URL, help=f"RPC URL (default: {DEFAULT_RPC_URL})")
-    parser.add_argument("--private-key", default=DEFAULT_PRIVATE_KEY, help="Private key for transactions")
+    parser.add_argument(
+        "--start-anvil", action="store_true", help="Start anvil automatically for --gas"
+    )
+    parser.add_argument(
+        "--rpc-url",
+        default=DEFAULT_RPC_URL,
+        help=f"RPC URL (default: {DEFAULT_RPC_URL})",
+    )
+    parser.add_argument(
+        "--private-key",
+        default=DEFAULT_PRIVATE_KEY,
+        help="Private key for transactions",
+    )
     parser.add_argument("--output", help="Output JSON path")
-    parser.add_argument("--verbose", action="store_true", help="Print compiler errors for failed rows")
+    parser.add_argument(
+        "--verbose", action="store_true", help="Print compiler errors for failed rows"
+    )
     parser.add_argument(
         "--allow-failures",
         action="store_true",
@@ -1449,9 +1581,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.list_tests:
         for test in suite_tests:
             if test.project_file is not None:
-                print(f"{test.test_id}	{test.project}	{test.source}	{test.contract_name}")
+                print(
+                    f"{test.test_id}	{test.project}	{test.source}	{test.contract_name}"
+                )
             else:
-                print(f"{test.test_id}	{test.suite}	inline	{test.contract_name}")
+                print(
+                    f"{test.test_id}	{test.suite}	inline	{test.contract_name}"
+                )
         return 0
 
     solc = find_binary(args.solc, ["solc"])
@@ -1468,11 +1604,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ],
     )
     if not solar:
-        print(_color("solar binary not found; build Solar or pass --solar /path/to/solar", RED), file=sys.stderr)
+        print(
+            _color(
+                "solar binary not found; build Solar or pass --solar /path/to/solar",
+                RED,
+            ),
+            file=sys.stderr,
+        )
         return 1
 
     if args.gas and not check_tool("cast"):
-        print(_color("cast not found; install Foundry or omit --gas", RED), file=sys.stderr)
+        print(
+            _color("cast not found; install Foundry or omit --gas", RED),
+            file=sys.stderr,
+        )
         return 1
 
     use_reference_solc = bool(args.reference_results)
@@ -1497,7 +1642,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.tests:
         missing = [test_id for test_id in args.tests if test_id not in test_map]
         if missing:
-            print(_color(f"unknown test IDs: {', '.join(missing)}", RED), file=sys.stderr)
+            print(
+                _color(f"unknown test IDs: {', '.join(missing)}", RED), file=sys.stderr
+            )
             return 1
         tests = [test_map[test_id] for test_id in args.tests]
     else:
@@ -1522,10 +1669,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         and not runtime_checks(test)
         for test in tests
     ):
-        print(_color("repository contracts without gas calls or runtime checks will show N/A in the gas table", YELLOW), file=sys.stderr)
+        print(
+            _color(
+                "repository contracts without gas calls or runtime checks will show N/A in the gas table",
+                YELLOW,
+            ),
+            file=sys.stderr,
+        )
 
     if args.gas and args.start_anvil and not check_tool("anvil"):
-        print(_color("anvil not found; install Foundry or omit --start-anvil", RED), file=sys.stderr)
+        print(
+            _color("anvil not found; install Foundry or omit --start-anvil", RED),
+            file=sys.stderr,
+        )
         return 1
 
     for spec in specs:
@@ -1542,10 +1698,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             file=sys.stderr,
         )
     if solar_version_error:
-        print(_color(f"Warning: `solar --version` failed: {solar_version_error}", YELLOW), file=sys.stderr)
+        print(
+            _color(f"Warning: `solar --version` failed: {solar_version_error}", YELLOW),
+            file=sys.stderr,
+        )
     if skipped:
         skipped_ids = ", ".join(test.test_id for test in skipped)
-        print(_color(f"Skipping {len(skipped)} incompatible tests for solc {solc_version}: {skipped_ids}", YELLOW))
+        print(
+            _color(
+                f"Skipping {len(skipped)} incompatible tests for solc {solc_version}: {skipped_ids}",
+                YELLOW,
+            )
+        )
     print(f"Running {len(tests)} tests")
 
     results = []
@@ -1569,7 +1733,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             suite = test.suite
             if suite != current_suite:
                 if current_suite is not None and suite_started is not None:
-                    timings[current_suite] = timings.get(current_suite, 0.0) + time.monotonic() - suite_started
+                    timings[current_suite] = (
+                        timings.get(current_suite, 0.0)
+                        + time.monotonic()
+                        - suite_started
+                    )
                 current_suite = suite
                 suite_started = time.monotonic()
             try:
@@ -1586,7 +1754,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 )
             except Exception as exc:
                 print(
-                    _color(f"[{test.test_id}] Unexpected benchmark failure: {exc}", RED),
+                    _color(
+                        f"[{test.test_id}] Unexpected benchmark failure: {exc}", RED
+                    ),
                     file=sys.stderr,
                 )
                 result = failed_test_result(test, specs, args.gas_profile, exc)
@@ -1604,7 +1774,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     )
             results.append(result)
         if current_suite is not None and suite_started is not None:
-            timings[current_suite] = timings.get(current_suite, 0.0) + time.monotonic() - suite_started
+            timings[current_suite] = (
+                timings.get(current_suite, 0.0) + time.monotonic() - suite_started
+            )
     finally:
         if anvil_proc:
             print("Stopping anvil...")
@@ -1617,7 +1789,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         for result in results:
             for compiler_id, data in result["compilers"].items():
                 if data.get("status") != "ok":
-                    print(f"\n{result['test_id']} {compiler_id} error:\n{data.get('error', '')}")
+                    print(
+                        f"\n{result['test_id']} {compiler_id} error:\n{data.get('error', '')}"
+                    )
                 for check in data.get("runtime_results") or []:
                     if check.get("status") != "ok":
                         print(
@@ -1635,7 +1809,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     f"{compiler_id}={value}"
                     for compiler_id, value in mismatch.get("values", {}).items()
                 )
-                print(f"\n{result['test_id']} runtime mismatch {mismatch.get('label')}: {values}")
+                print(
+                    f"\n{result['test_id']} runtime mismatch {mismatch.get('label')}: {values}"
+                )
 
     RESULT_ROOT.mkdir(parents=True, exist_ok=True)
     output = Path(args.output) if args.output else RESULT_ROOT / "solar_latest.json"
@@ -1667,17 +1843,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if (failed or runtime_failed or gas_failed) and not args.allow_failures:
         if failed:
             print(
-                _color(f"{len(failed)} compiler runs failed; use --allow-failures to keep exit code 0", RED),
+                _color(
+                    f"{len(failed)} compiler runs failed; use --allow-failures to keep exit code 0",
+                    RED,
+                ),
                 file=sys.stderr,
             )
         if runtime_failed:
             print(
-                _color(f"{len(runtime_failed)} runtime checks failed; use --allow-failures to keep exit code 0", RED),
+                _color(
+                    f"{len(runtime_failed)} runtime checks failed; use --allow-failures to keep exit code 0",
+                    RED,
+                ),
                 file=sys.stderr,
             )
         if gas_failed:
             print(
-                _color(f"{len(gas_failed)} gas transaction runs failed; use --allow-failures to keep exit code 0", RED),
+                _color(
+                    f"{len(gas_failed)} gas transaction runs failed; use --allow-failures to keep exit code 0",
+                    RED,
+                ),
                 file=sys.stderr,
             )
         return 1

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -1080,6 +1080,10 @@ def compare_runtime_results(entry: Dict[str, object], specs: Sequence[CompilerSp
     if not labels:
         entry["runtime_status"] = "skipped"
         return
+    if len(specs) < 2:
+        entry["runtime_status"] = "failed" if failed else "skipped"
+        entry["runtime_mismatches"] = []
+        return
 
     mismatches = []
     for label in labels:
@@ -1137,6 +1141,7 @@ def run_test_case(
     private_key: str,
     verbose: bool = False,
     compile_repeats: int = 1,
+    reference_solc_path: Optional[Path] = None,
 ) -> Dict[str, object]:
     entry: Dict[str, object] = {
         "test_id": test_case.test_id,
@@ -1149,7 +1154,9 @@ def run_test_case(
     if test_case.project_file is not None:
         entry["project"] = test_case.project
         entry["source"] = test_case.source
-    reference_solc = next((spec for spec in specs if spec.kind == "solc"), None)
+    reference_solc = next(
+        (spec.path for spec in specs if spec.kind == "solc"), reference_solc_path
+    )
 
     for spec in specs:
         verbose_log(verbose, f"[{test_case.test_id}] compiling with {spec.compiler_id}")
@@ -1251,7 +1258,7 @@ def run_test_case(
                 cold_results = run_cold_path_checks(
                     test_case,
                     address,
-                    reference_solc.path,
+                    reference_solc,
                     rpc_url,
                     private_key,
                 )
@@ -1306,6 +1313,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         default=1,
         help="Compile each test this many times and record the median time (default: 1)",
     )
+    parser.add_argument(
+        "--solar-only",
+        action="store_true",
+        help="Benchmark Solar without compiling each case with solc",
+    )
     parser.add_argument("--tests", nargs="*", help="Subset of test IDs to run")
     parser.add_argument("--projects", nargs="*", help="Subset of repository project names to run")
     parser.add_argument("--list-tests", action="store_true", help="List available tests and exit")
@@ -1349,7 +1361,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 0
 
     solc = find_binary(args.solc, ["solc"])
-    if not solc:
+    if not solc and not args.solar_only:
         print(_color(f"solc not found: {args.solc}", RED), file=sys.stderr)
         return 1
 
@@ -1369,13 +1381,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(_color("cast not found; install Foundry or omit --gas", RED), file=sys.stderr)
         return 1
 
-    solc_version, solc_version_error = binary_version(solc)
+    solc_version, solc_version_error = (
+        binary_version(solc) if solc and not args.solar_only else ("unavailable", "")
+    )
     solar_version, solar_version_error = binary_version(solar)
 
-    specs = [
-        CompilerSpec("solc", f"solc {solc_version}", solc, "solc"),
-        CompilerSpec("solar", f"solar {solar_version}", solar, "solar"),
-    ]
+    specs = []
+    if not args.solar_only:
+        assert solc is not None
+        specs.append(CompilerSpec("solc", f"solc {solc_version}", solc, "solc"))
+    specs.append(CompilerSpec("solar", f"solar {solar_version}", solar, "solar"))
 
     if args.tests:
         missing = [test_id for test_id in args.tests if test_id not in test_map]
@@ -1387,7 +1402,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         tests = list(suite_tests)
 
     skipped = []
-    if not args.include_incompatible:
+    if not args.solar_only and not args.include_incompatible:
         compatible_tests = []
         for test in tests:
             if test.project_file is not None and not version_in_range(
@@ -1411,8 +1426,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(_color("anvil not found; install Foundry or omit --start-anvil", RED), file=sys.stderr)
         return 1
 
-    print(f"Using {specs[0].label}")
-    if solc_version_error:
+    for spec in specs:
+        print(f"Using {spec.label}")
+    if not args.solar_only and solc_version_error:
         print(
             _color(
                 "Warning: `solc --version` failed. If this is solc-select, run "
@@ -1421,7 +1437,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             ),
             file=sys.stderr,
         )
-    print(f"Using {specs[1].label}")
     if solar_version_error:
         print(_color(f"Warning: `solar --version` failed: {solar_version_error}", YELLOW), file=sys.stderr)
     if skipped:
@@ -1463,6 +1478,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     args.private_key,
                     args.verbose,
                     args.compile_repeats,
+                    solc,
                 )
             except Exception as exc:
                 print(

--- a/benches/runtime/benchmark.py
+++ b/benches/runtime/benchmark.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import argparse
+import copy
 import gzip
 import hashlib
 import json
@@ -1107,6 +1108,83 @@ def compare_runtime_results(entry: Dict[str, object], specs: Sequence[CompilerSp
         entry["runtime_status"] = "ok"
 
 
+def result_key(result: Dict[str, object]) -> Tuple[str, str]:
+    return str(result.get("suite", "repository")), str(result.get("test_id", ""))
+
+
+def load_reference_results(path: Path) -> Dict[Tuple[str, str], Dict[str, object]]:
+    document = json.loads(path.read_text())
+    results = document.get("results") if isinstance(document, dict) else None
+    if not isinstance(results, list):
+        raise ValueError("expected a benchmark result document")
+    return {
+        result_key(result): result
+        for result in results
+        if isinstance(result, dict)
+    }
+
+
+def workload_signature(data: Dict[str, object]) -> Tuple[object, ...]:
+    signature = []
+    for field in ("gas_results", "runtime_results"):
+        observations = data.get(field)
+        if not isinstance(observations, list):
+            continue
+        signature.append((
+            field,
+            tuple(
+                (
+                    observation.get("label"),
+                    observation.get("call"),
+                    tuple(observation.get("args") or ()),
+                )
+                for observation in observations
+                if isinstance(observation, dict)
+            ),
+        ))
+    return tuple(signature)
+
+
+def merge_reference_compiler(
+    entry: Dict[str, object],
+    references: Dict[Tuple[str, str], Dict[str, object]],
+    compiler_id: str,
+) -> bool:
+    reference = references.get(result_key(entry))
+    if reference is None:
+        return False
+    reference_compilers = reference.get("compilers")
+    if not isinstance(reference_compilers, dict):
+        return False
+    reference_data = reference_compilers.get(compiler_id)
+    compilers = entry.get("compilers") or {}
+    if not isinstance(reference_data, dict) or not isinstance(compilers, dict):
+        return False
+
+    reference_fingerprint = reference_data.get("input_fingerprint")
+    current_fingerprints = {
+        data.get("input_fingerprint")
+        for data in compilers.values()
+        if isinstance(data, dict) and data.get("input_fingerprint")
+    }
+    if not reference_fingerprint or reference_fingerprint not in current_fingerprints:
+        return False
+    if entry.get("gas_profile") != reference.get("gas_profile"):
+        return False
+    if not any(
+        workload_signature(data) == workload_signature(reference_data)
+        for data in compilers.values()
+        if isinstance(data, dict)
+    ):
+        return False
+
+    entry["compilers"] = {
+        compiler_id: copy.deepcopy(reference_data),
+        **compilers,
+    }
+    return True
+
+
 def failed_test_result(
     test_case: TestCase,
     specs: Sequence[CompilerSpec],
@@ -1318,6 +1396,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         action="store_true",
         help="Benchmark Solar without compiling each case with solc",
     )
+    parser.add_argument(
+        "--reference-results",
+        type=Path,
+        help="Reuse matching solc results from another benchmark result document",
+    )
     parser.add_argument("--tests", nargs="*", help="Subset of test IDs to run")
     parser.add_argument("--projects", nargs="*", help="Subset of repository project names to run")
     parser.add_argument("--list-tests", action="store_true", help="List available tests and exit")
@@ -1345,6 +1428,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.reference_results and not args.solar_only:
+        parser.error("--reference-results requires --solar-only")
+    try:
+        reference_results = (
+            load_reference_results(args.reference_results)
+            if args.reference_results
+            else {}
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        parser.error(f"failed to load reference results: {exc}")
+
     suite_tests = select_tests(args.mode, args.suite)
 
     if args.projects:
@@ -1361,7 +1455,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 0
 
     solc = find_binary(args.solc, ["solc"])
-    if not solc and not args.solar_only:
+    if not solc and (not args.solar_only or args.reference_results):
         print(_color(f"solc not found: {args.solc}", RED), file=sys.stderr)
         return 1
 
@@ -1381,8 +1475,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(_color("cast not found; install Foundry or omit --gas", RED), file=sys.stderr)
         return 1
 
+    use_reference_solc = bool(args.reference_results)
     solc_version, solc_version_error = (
-        binary_version(solc) if solc and not args.solar_only else ("unavailable", "")
+        binary_version(solc)
+        if solc and (not args.solar_only or use_reference_solc)
+        else ("unavailable", "")
     )
     solar_version, solar_version_error = binary_version(solar)
 
@@ -1391,6 +1488,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         assert solc is not None
         specs.append(CompilerSpec("solc", f"solc {solc_version}", solc, "solc"))
     specs.append(CompilerSpec("solar", f"solar {solar_version}", solar, "solar"))
+    reference_solc_spec = (
+        CompilerSpec("solc", f"solc {solc_version}", solc, "solc")
+        if use_reference_solc and solc is not None
+        else None
+    )
 
     if args.tests:
         missing = [test_id for test_id in args.tests if test_id not in test_map]
@@ -1402,7 +1504,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         tests = list(suite_tests)
 
     skipped = []
-    if not args.solar_only and not args.include_incompatible:
+    if (not args.solar_only or use_reference_solc) and not args.include_incompatible:
         compatible_tests = []
         for test in tests:
             if test.project_file is not None and not version_in_range(
@@ -1428,7 +1530,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     for spec in specs:
         print(f"Using {spec.label}")
-    if not args.solar_only and solc_version_error:
+    if args.reference_results:
+        print(f"Reusing solc results from {display_path(args.reference_results)}")
+    if (not args.solar_only or use_reference_solc) and solc_version_error:
         print(
             _color(
                 "Warning: `solc --version` failed. If this is solc-select, run "
@@ -1486,6 +1590,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     file=sys.stderr,
                 )
                 result = failed_test_result(test, specs, args.gas_profile, exc)
+            if reference_solc_spec:
+                if merge_reference_compiler(result, reference_results, "solc"):
+                    if args.gas:
+                        compare_runtime_results(result, (reference_solc_spec, *specs))
+                else:
+                    print(
+                        _color(
+                            f"[{test.test_id}] matching solc reference result not found",
+                            YELLOW,
+                        ),
+                        file=sys.stderr,
+                    )
             results.append(result)
         if current_suite is not None and suite_started is not None:
             timings[current_suite] = timings.get(current_suite, 0.0) + time.monotonic() - suite_started

--- a/benches/runtime/cases.py
+++ b/benches/runtime/cases.py
@@ -5,12 +5,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional, Sequence, Tuple
 
 from common import PROJECTS_ROOT, TESTDATA_ROOT
-
 
 DEFAULT_SENDER = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 DEFAULT_SPENDER = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
@@ -44,19 +43,19 @@ class TestCase:
     test_id: str
     description: str
     contract_name: str
-    test_calls: Sequence[Tuple[str, Sequence[str]]] = field(default_factory=tuple)
-    source_code: Optional[str] = None
+    test_calls: Sequence[tuple[str, Sequence[str]]] = field(default_factory=tuple)
+    source_code: str | None = None
     source_name: str = ""
     project: str = ""
-    project_file: Optional[str] = None
+    project_file: str | None = None
     settings_profile: str = ""
     source: str = ""
     gas_calls: Sequence[GasCall] = field(default_factory=tuple)
     constructor_args: Sequence[str] = field(default_factory=tuple)
-    constructor_sig: Optional[str] = None
+    constructor_sig: str | None = None
     runtime_checks: Sequence[RuntimeCheck] = field(default_factory=tuple)
-    min_solc: Optional[str] = None
-    max_solc: Optional[str] = None
+    min_solc: str | None = None
+    max_solc: str | None = None
     suite: str = "micro"
     # Compile every contract in the project input instead of one selected
     # contract. Compile-time only: no bytecode is extracted, so size, gas,
@@ -158,15 +157,39 @@ TEST_CASES: Sequence[TestCase] = (
             RuntimeCheck("symbol", "symbol()(string)"),
             RuntimeCheck("decimals", "decimals()(uint8)"),
             RuntimeCheck("balance", "balanceOf(address)(uint256)", (DEFAULT_SENDER,)),
-            RuntimeCheck("spender-balance", "balanceOf(address)(uint256)", (DEFAULT_SPENDER,)),
-            RuntimeCheck("third-balance", "balanceOf(address)(uint256)", (DEFAULT_THIRD,)),
-            RuntimeCheck("fourth-balance", "balanceOf(address)(uint256)", (DEFAULT_FOURTH,)),
-            RuntimeCheck("zero-balance", "balanceOf(address)(uint256)", (ZERO_ADDRESS,)),
+            RuntimeCheck(
+                "spender-balance", "balanceOf(address)(uint256)", (DEFAULT_SPENDER,)
+            ),
+            RuntimeCheck(
+                "third-balance", "balanceOf(address)(uint256)", (DEFAULT_THIRD,)
+            ),
+            RuntimeCheck(
+                "fourth-balance", "balanceOf(address)(uint256)", (DEFAULT_FOURTH,)
+            ),
+            RuntimeCheck(
+                "zero-balance", "balanceOf(address)(uint256)", (ZERO_ADDRESS,)
+            ),
             RuntimeCheck("supply", "totalSupply()(uint256)"),
-            RuntimeCheck("allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, DEFAULT_SPENDER)),
-            RuntimeCheck("third-allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, DEFAULT_THIRD)),
-            RuntimeCheck("fourth-allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, DEFAULT_FOURTH)),
-            RuntimeCheck("reverse-allowance", "allowance(address,address)(uint256)", (DEFAULT_SPENDER, DEFAULT_SENDER)),
+            RuntimeCheck(
+                "allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, DEFAULT_SPENDER),
+            ),
+            RuntimeCheck(
+                "third-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, DEFAULT_THIRD),
+            ),
+            RuntimeCheck(
+                "fourth-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, DEFAULT_FOURTH),
+            ),
+            RuntimeCheck(
+                "reverse-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SPENDER, DEFAULT_SENDER),
+            ),
         ),
     ),
     TestCase(
@@ -191,18 +214,32 @@ TEST_CASES: Sequence[TestCase] = (
             RuntimeCheck("duration", "duration()(uint256)"),
             RuntimeCheck("end", "end()(uint256)"),
             RuntimeCheck("released", "released()(uint256)"),
-            RuntimeCheck("released-token", "released(address)(uint256)", (DEFAULT_SPENDER,)),
+            RuntimeCheck(
+                "released-token", "released(address)(uint256)", (DEFAULT_SPENDER,)
+            ),
             RuntimeCheck("releasable", "releasable()(uint256)"),
-            RuntimeCheck("vested-before-start", "vestedAmount(uint64)(uint256)", ("999",)),
+            RuntimeCheck(
+                "vested-before-start", "vestedAmount(uint64)(uint256)", ("999",)
+            ),
             RuntimeCheck("vested-at-start", "vestedAmount(uint64)(uint256)", ("1000",)),
-            RuntimeCheck("vested-after-start", "vestedAmount(uint64)(uint256)", ("1001",)),
+            RuntimeCheck(
+                "vested-after-start", "vestedAmount(uint64)(uint256)", ("1001",)
+            ),
             RuntimeCheck("vested-quarter", "vestedAmount(uint64)(uint256)", ("1025",)),
             RuntimeCheck("vested-half", "vestedAmount(uint64)(uint256)", ("1050",)),
-            RuntimeCheck("vested-three-quarter", "vestedAmount(uint64)(uint256)", ("1075",)),
-            RuntimeCheck("vested-before-end", "vestedAmount(uint64)(uint256)", ("1099",)),
+            RuntimeCheck(
+                "vested-three-quarter", "vestedAmount(uint64)(uint256)", ("1075",)
+            ),
+            RuntimeCheck(
+                "vested-before-end", "vestedAmount(uint64)(uint256)", ("1099",)
+            ),
             RuntimeCheck("vested-end", "vestedAmount(uint64)(uint256)", ("1100",)),
-            RuntimeCheck("vested-after-end", "vestedAmount(uint64)(uint256)", ("1101",)),
-            RuntimeCheck("vested-far-future", "vestedAmount(uint64)(uint256)", ("999999",)),
+            RuntimeCheck(
+                "vested-after-end", "vestedAmount(uint64)(uint256)", ("1101",)
+            ),
+            RuntimeCheck(
+                "vested-far-future", "vestedAmount(uint64)(uint256)", ("999999",)
+            ),
         ),
     ),
     TestCase(
@@ -214,7 +251,12 @@ TEST_CASES: Sequence[TestCase] = (
         contract_name="OneStepProofEntry",
         suite="repository",
         settings_profile="runtime",
-        constructor_args=(DEFAULT_SENDER, DEFAULT_SPENDER, DEFAULT_THIRD, DEFAULT_FOURTH),
+        constructor_args=(
+            DEFAULT_SENDER,
+            DEFAULT_SPENDER,
+            DEFAULT_THIRD,
+            DEFAULT_FOURTH,
+        ),
         constructor_sig="constructor(address,address,address,address)",
         test_calls=(
             ("prover0()", ()),
@@ -285,21 +327,60 @@ TEST_CASES: Sequence[TestCase] = (
         settings_profile="runtime",
         test_calls=(
             ("POOL()", ()),
-            ("encodeSupplyParams(address,uint256,uint16)", (DEFAULT_SPENDER, "123456", "7")),
+            (
+                "encodeSupplyParams(address,uint256,uint16)",
+                (DEFAULT_SPENDER, "123456", "7"),
+            ),
             ("encodeWithdrawParams(address,uint256)", (DEFAULT_THIRD, MAX_UINT256)),
-            ("encodeBorrowParams(address,uint256,uint256,uint16)", (DEFAULT_SPENDER, "2222", "2", "9")),
-            ("encodeSetUserUseReserveAsCollateral(address,bool)", (DEFAULT_THIRD, "true")),
-            ("encodeRepayWithATokensParams(address,uint256,uint256)", (DEFAULT_FOURTH, MAX_UINT256, "2")),
+            (
+                "encodeBorrowParams(address,uint256,uint256,uint16)",
+                (DEFAULT_SPENDER, "2222", "2", "9"),
+            ),
+            (
+                "encodeSetUserUseReserveAsCollateral(address,bool)",
+                (DEFAULT_THIRD, "true"),
+            ),
+            (
+                "encodeRepayWithATokensParams(address,uint256,uint256)",
+                (DEFAULT_FOURTH, MAX_UINT256, "2"),
+            ),
             ("encodeSwapBorrowRateMode(address,uint256)", (DEFAULT_SENDER, "1")),
-            ("encodeRebalanceStableBorrowRate(address,address)", (DEFAULT_SPENDER, DEFAULT_THIRD)),
+            (
+                "encodeRebalanceStableBorrowRate(address,address)",
+                (DEFAULT_SPENDER, DEFAULT_THIRD),
+            ),
         ),
         runtime_checks=(
-            RuntimeCheck("supply", "encodeSupplyParams(address,uint256,uint16)(bytes32)", (DEFAULT_SPENDER, "123456", "7")),
-            RuntimeCheck("supply-zero", "encodeSupplyParams(address,uint256,uint16)(bytes32)", (DEFAULT_SENDER, "0", "0")),
-            RuntimeCheck("supply-max-u128", "encodeSupplyParams(address,uint256,uint16)(bytes32)", (DEFAULT_FOURTH, MAX_UINT128, "65535")),
-            RuntimeCheck("withdraw-zero", "encodeWithdrawParams(address,uint256)(bytes32)", (DEFAULT_SENDER, "0")),
-            RuntimeCheck("withdraw-small", "encodeWithdrawParams(address,uint256)(bytes32)", (DEFAULT_SENDER, "1")),
-            RuntimeCheck("withdraw-max", "encodeWithdrawParams(address,uint256)(bytes32)", (DEFAULT_THIRD, MAX_UINT256)),
+            RuntimeCheck(
+                "supply",
+                "encodeSupplyParams(address,uint256,uint16)(bytes32)",
+                (DEFAULT_SPENDER, "123456", "7"),
+            ),
+            RuntimeCheck(
+                "supply-zero",
+                "encodeSupplyParams(address,uint256,uint16)(bytes32)",
+                (DEFAULT_SENDER, "0", "0"),
+            ),
+            RuntimeCheck(
+                "supply-max-u128",
+                "encodeSupplyParams(address,uint256,uint16)(bytes32)",
+                (DEFAULT_FOURTH, MAX_UINT128, "65535"),
+            ),
+            RuntimeCheck(
+                "withdraw-zero",
+                "encodeWithdrawParams(address,uint256)(bytes32)",
+                (DEFAULT_SENDER, "0"),
+            ),
+            RuntimeCheck(
+                "withdraw-small",
+                "encodeWithdrawParams(address,uint256)(bytes32)",
+                (DEFAULT_SENDER, "1"),
+            ),
+            RuntimeCheck(
+                "withdraw-max",
+                "encodeWithdrawParams(address,uint256)(bytes32)",
+                (DEFAULT_THIRD, MAX_UINT256),
+            ),
             RuntimeCheck(
                 "borrow",
                 "encodeBorrowParams(address,uint256,uint256,uint16)(bytes32)",
@@ -435,9 +516,13 @@ TEST_CASES: Sequence[TestCase] = (
             RuntimeCheck("lookup-second", "lookup(string)(address)", ("second",)),
             RuntimeCheck("lookup-untouched", "lookup(string)(address)", ("untouched",)),
             RuntimeCheck("lookup-empty", "lookup(string)(address)", ("",)),
-            RuntimeCheck("lookup-long", "lookup(string)(address)", ("long-subdomain-name",)),
+            RuntimeCheck(
+                "lookup-long", "lookup(string)(address)", ("long-subdomain-name",)
+            ),
             RuntimeCheck("lookup-numeric", "lookup(string)(address)", ("numeric123",)),
-            RuntimeCheck("lookup-underscore", "lookup(string)(address)", ("under_score",)),
+            RuntimeCheck(
+                "lookup-underscore", "lookup(string)(address)", ("under_score",)
+            ),
             RuntimeCheck("missing", "lookup(string)(address)", ("missing",)),
         ),
     ),
@@ -464,18 +549,46 @@ TEST_CASES: Sequence[TestCase] = (
             RuntimeCheck("fee-fourth", "fees(address)(uint256)", (DEFAULT_FOURTH,)),
             RuntimeCheck("fee-sender", "fees(address)(uint256)", (DEFAULT_SENDER,)),
             RuntimeCheck("fee-missing", "fees(address)(uint256)", (ZERO_ADDRESS,)),
-            RuntimeCheck("computed-fee-zero", "getFee(address,uint256)(uint256)", (DEFAULT_SPENDER, "0")),
-            RuntimeCheck("computed-fee-spender", "getFee(address,uint256)(uint256)", (DEFAULT_SPENDER, "10000")),
-            RuntimeCheck("computed-fee-spender-small", "getFee(address,uint256)(uint256)", (DEFAULT_SPENDER, "1")),
+            RuntimeCheck(
+                "computed-fee-zero",
+                "getFee(address,uint256)(uint256)",
+                (DEFAULT_SPENDER, "0"),
+            ),
+            RuntimeCheck(
+                "computed-fee-spender",
+                "getFee(address,uint256)(uint256)",
+                (DEFAULT_SPENDER, "10000"),
+            ),
+            RuntimeCheck(
+                "computed-fee-spender-small",
+                "getFee(address,uint256)(uint256)",
+                (DEFAULT_SPENDER, "1"),
+            ),
             RuntimeCheck(
                 "computed-fee-spender-rounded",
                 "getFee(address,uint256)(uint256)",
                 (DEFAULT_SPENDER, "33333"),
             ),
-            RuntimeCheck("computed-fee-third", "getFee(address,uint256)(uint256)", (DEFAULT_THIRD, "12345")),
-            RuntimeCheck("computed-fee-fourth", "getFee(address,uint256)(uint256)", (DEFAULT_FOURTH, "12345")),
-            RuntimeCheck("computed-fee-sender", "getFee(address,uint256)(uint256)", (DEFAULT_SENDER, "999999")),
-            RuntimeCheck("computed-fee-missing", "getFee(address,uint256)(uint256)", (ZERO_ADDRESS, "10000")),
+            RuntimeCheck(
+                "computed-fee-third",
+                "getFee(address,uint256)(uint256)",
+                (DEFAULT_THIRD, "12345"),
+            ),
+            RuntimeCheck(
+                "computed-fee-fourth",
+                "getFee(address,uint256)(uint256)",
+                (DEFAULT_FOURTH, "12345"),
+            ),
+            RuntimeCheck(
+                "computed-fee-sender",
+                "getFee(address,uint256)(uint256)",
+                (DEFAULT_SENDER, "999999"),
+            ),
+            RuntimeCheck(
+                "computed-fee-missing",
+                "getFee(address,uint256)(uint256)",
+                (ZERO_ADDRESS, "10000"),
+            ),
         ),
     ),
     TestCase(
@@ -501,10 +614,26 @@ TEST_CASES: Sequence[TestCase] = (
             ),
         ),
         runtime_checks=(
-            RuntimeCheck("empty-vault-zero", "getVault(uint256)(address,uint256,uint256,address)", ("0",)),
-            RuntimeCheck("empty-vault-one", "getVault(uint256)(address,uint256,uint256,address)", ("1",)),
-            RuntimeCheck("empty-vault-forty-two", "getVault(uint256)(address,uint256,uint256,address)", ("42",)),
-            RuntimeCheck("empty-vault-max", "getVault(uint256)(address,uint256,uint256,address)", (MAX_UINT256,)),
+            RuntimeCheck(
+                "empty-vault-zero",
+                "getVault(uint256)(address,uint256,uint256,address)",
+                ("0",),
+            ),
+            RuntimeCheck(
+                "empty-vault-one",
+                "getVault(uint256)(address,uint256,uint256,address)",
+                ("1",),
+            ),
+            RuntimeCheck(
+                "empty-vault-forty-two",
+                "getVault(uint256)(address,uint256,uint256,address)",
+                ("42",),
+            ),
+            RuntimeCheck(
+                "empty-vault-max",
+                "getVault(uint256)(address,uint256,uint256,address)",
+                (MAX_UINT256,),
+            ),
             RuntimeCheck(
                 "erc721-receiver-empty-data",
                 "onERC721Received(address,address,uint256,bytes)(bytes4)",
@@ -549,16 +678,48 @@ TEST_CASES: Sequence[TestCase] = (
             RuntimeCheck("decimals", "decimals()(uint8)"),
             RuntimeCheck("total-supply", "totalSupply()(uint256)"),
             RuntimeCheck("balance", "balanceOf(address)(uint256)", (DEFAULT_SENDER,)),
-            RuntimeCheck("spender-balance", "balanceOf(address)(uint256)", (DEFAULT_SPENDER,)),
-            RuntimeCheck("allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, DEFAULT_SPENDER)),
-            RuntimeCheck("third-allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, DEFAULT_THIRD)),
-            RuntimeCheck("fourth-allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, DEFAULT_FOURTH)),
-            RuntimeCheck("zero-allowance", "allowance(address,address)(uint256)", (DEFAULT_SENDER, ZERO_ADDRESS)),
-            RuntimeCheck("reverse-allowance", "allowance(address,address)(uint256)", (DEFAULT_SPENDER, DEFAULT_SENDER)),
-            RuntimeCheck("third-reverse-allowance", "allowance(address,address)(uint256)", (DEFAULT_THIRD, DEFAULT_SENDER)),
-            RuntimeCheck("fourth-reverse-allowance", "allowance(address,address)(uint256)", (DEFAULT_FOURTH, DEFAULT_SENDER)),
+            RuntimeCheck(
+                "spender-balance", "balanceOf(address)(uint256)", (DEFAULT_SPENDER,)
+            ),
+            RuntimeCheck(
+                "allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, DEFAULT_SPENDER),
+            ),
+            RuntimeCheck(
+                "third-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, DEFAULT_THIRD),
+            ),
+            RuntimeCheck(
+                "fourth-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, DEFAULT_FOURTH),
+            ),
+            RuntimeCheck(
+                "zero-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SENDER, ZERO_ADDRESS),
+            ),
+            RuntimeCheck(
+                "reverse-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_SPENDER, DEFAULT_SENDER),
+            ),
+            RuntimeCheck(
+                "third-reverse-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_THIRD, DEFAULT_SENDER),
+            ),
+            RuntimeCheck(
+                "fourth-reverse-allowance",
+                "allowance(address,address)(uint256)",
+                (DEFAULT_FOURTH, DEFAULT_SENDER),
+            ),
             RuntimeCheck("nonce", "nonces(address)(uint256)", (DEFAULT_SENDER,)),
-            RuntimeCheck("spender-nonce", "nonces(address)(uint256)", (DEFAULT_SPENDER,)),
+            RuntimeCheck(
+                "spender-nonce", "nonces(address)(uint256)", (DEFAULT_SPENDER,)
+            ),
             RuntimeCheck("zero-nonce", "nonces(address)(uint256)", (ZERO_ADDRESS,)),
             RuntimeCheck("permit-typehash", "PERMIT_TYPEHASH()(bytes32)"),
         ),
@@ -650,7 +811,9 @@ TEST_CASES: Sequence[TestCase] = (
                 ("the quick brown fox jumps over the lazy dog",),
                 repeat=3,
             ),
-            GasCall("small-string", "toSmallString(string)", ("short string",), repeat=3),
+            GasCall(
+                "small-string", "toSmallString(string)", ("short string",), repeat=3
+            ),
             GasCall("replace-medium", "testStringReplaceMedium()", repeat=3),
             GasCall("replace-long", "testStringReplaceLong()", repeat=3),
         ),
@@ -662,7 +825,9 @@ TEST_CASES: Sequence[TestCase] = (
                 "returnString(string)(string)",
                 ("the quick brown fox jumps over the lazy dog",),
             ),
-            RuntimeCheck("small-string", "toSmallString(string)(bytes32)", ("short string",)),
+            RuntimeCheck(
+                "small-string", "toSmallString(string)(bytes32)", ("short string",)
+            ),
         ),
         suite="large",
     ),
@@ -750,7 +915,7 @@ TEST_CASES: Sequence[TestCase] = (
 )
 
 
-HOT_GAS_CALLS: Dict[str, Sequence[GasCall]] = {
+HOT_GAS_CALLS: dict[str, Sequence[GasCall]] = {
     "factorial": (
         GasCall("factorial-5", "computeFactorial(uint256)", ("5",)),
         GasCall("factorial-10", "computeFactorial(uint256)", ("10",)),
@@ -780,12 +945,20 @@ HOT_GAS_CALLS: Dict[str, Sequence[GasCall]] = {
     "openzeppelin-erc20-mock": (
         GasCall("mint-sender-1000", "mint(address,uint256)", (DEFAULT_SENDER, "1000")),
         GasCall("mint-spender-250", "mint(address,uint256)", (DEFAULT_SPENDER, "250")),
-        GasCall("transfer-third-125", "transfer(address,uint256)", (DEFAULT_THIRD, "125")),
-        GasCall("transfer-fourth-25", "transfer(address,uint256)", (DEFAULT_FOURTH, "25")),
-        GasCall("approve-spender-250", "approve(address,uint256)", (DEFAULT_SPENDER, "250")),
+        GasCall(
+            "transfer-third-125", "transfer(address,uint256)", (DEFAULT_THIRD, "125")
+        ),
+        GasCall(
+            "transfer-fourth-25", "transfer(address,uint256)", (DEFAULT_FOURTH, "25")
+        ),
+        GasCall(
+            "approve-spender-250", "approve(address,uint256)", (DEFAULT_SPENDER, "250")
+        ),
         GasCall("approve-third-77", "approve(address,uint256)", (DEFAULT_THIRD, "77")),
         GasCall("burn-sender-400", "burn(address,uint256)", (DEFAULT_SENDER, "400")),
-        GasCall("transfer-spender-50", "transfer(address,uint256)", (DEFAULT_SPENDER, "50")),
+        GasCall(
+            "transfer-spender-50", "transfer(address,uint256)", (DEFAULT_SPENDER, "50")
+        ),
     ),
     "openzeppelin-vesting-wallet": (
         GasCall("vested-before-start", "vestedAmount(uint64)", ("999",), repeat=2),
@@ -823,25 +996,86 @@ HOT_GAS_CALLS: Dict[str, Sequence[GasCall]] = {
         GasCall(
             "start-machine-mixed",
             "getStartMachineHash(bytes32,bytes32)",
-            (MIXED_BYTES32, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            (
+                MIXED_BYTES32,
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
             repeat=2,
         ),
     ),
     "aave-l2-encoder": (
         GasCall("pool", "POOL()", repeat=2),
-        GasCall("supply", "encodeSupplyParams(address,uint256,uint16)", (DEFAULT_SPENDER, "123456", "7"), repeat=2),
-        GasCall("supply-zero", "encodeSupplyParams(address,uint256,uint16)", (DEFAULT_SENDER, "0", "0"), repeat=2),
-        GasCall("supply-max", "encodeSupplyParams(address,uint256,uint16)", (DEFAULT_FOURTH, MAX_UINT128, "65535")),
-        GasCall("withdraw-zero", "encodeWithdrawParams(address,uint256)", (DEFAULT_SENDER, "0")),
-        GasCall("withdraw-max", "encodeWithdrawParams(address,uint256)", (DEFAULT_THIRD, MAX_UINT256), repeat=2),
-        GasCall("borrow", "encodeBorrowParams(address,uint256,uint256,uint16)", (DEFAULT_SPENDER, "2222", "2", "9"), repeat=2),
-        GasCall("borrow-zero", "encodeBorrowParams(address,uint256,uint256,uint16)", (DEFAULT_THIRD, "0", "1", "0")),
-        GasCall("repay", "encodeRepayParams(address,uint256,uint256)", (DEFAULT_THIRD, "3333", "1"), repeat=2),
-        GasCall("repay-max", "encodeRepayParams(address,uint256,uint256)", (DEFAULT_FOURTH, MAX_UINT256, "2")),
-        GasCall("repay-atokens", "encodeRepayWithATokensParams(address,uint256,uint256)", (DEFAULT_FOURTH, MAX_UINT256, "2")),
-        GasCall("swap-rate", "encodeSwapBorrowRateMode(address,uint256)", (DEFAULT_SENDER, "1"), repeat=2),
-        GasCall("collateral-true", "encodeSetUserUseReserveAsCollateral(address,bool)", (DEFAULT_THIRD, "true")),
-        GasCall("collateral-false", "encodeSetUserUseReserveAsCollateral(address,bool)", (DEFAULT_THIRD, "false")),
+        GasCall(
+            "supply",
+            "encodeSupplyParams(address,uint256,uint16)",
+            (DEFAULT_SPENDER, "123456", "7"),
+            repeat=2,
+        ),
+        GasCall(
+            "supply-zero",
+            "encodeSupplyParams(address,uint256,uint16)",
+            (DEFAULT_SENDER, "0", "0"),
+            repeat=2,
+        ),
+        GasCall(
+            "supply-max",
+            "encodeSupplyParams(address,uint256,uint16)",
+            (DEFAULT_FOURTH, MAX_UINT128, "65535"),
+        ),
+        GasCall(
+            "withdraw-zero",
+            "encodeWithdrawParams(address,uint256)",
+            (DEFAULT_SENDER, "0"),
+        ),
+        GasCall(
+            "withdraw-max",
+            "encodeWithdrawParams(address,uint256)",
+            (DEFAULT_THIRD, MAX_UINT256),
+            repeat=2,
+        ),
+        GasCall(
+            "borrow",
+            "encodeBorrowParams(address,uint256,uint256,uint16)",
+            (DEFAULT_SPENDER, "2222", "2", "9"),
+            repeat=2,
+        ),
+        GasCall(
+            "borrow-zero",
+            "encodeBorrowParams(address,uint256,uint256,uint16)",
+            (DEFAULT_THIRD, "0", "1", "0"),
+        ),
+        GasCall(
+            "repay",
+            "encodeRepayParams(address,uint256,uint256)",
+            (DEFAULT_THIRD, "3333", "1"),
+            repeat=2,
+        ),
+        GasCall(
+            "repay-max",
+            "encodeRepayParams(address,uint256,uint256)",
+            (DEFAULT_FOURTH, MAX_UINT256, "2"),
+        ),
+        GasCall(
+            "repay-atokens",
+            "encodeRepayWithATokensParams(address,uint256,uint256)",
+            (DEFAULT_FOURTH, MAX_UINT256, "2"),
+        ),
+        GasCall(
+            "swap-rate",
+            "encodeSwapBorrowRateMode(address,uint256)",
+            (DEFAULT_SENDER, "1"),
+            repeat=2,
+        ),
+        GasCall(
+            "collateral-true",
+            "encodeSetUserUseReserveAsCollateral(address,bool)",
+            (DEFAULT_THIRD, "true"),
+        ),
+        GasCall(
+            "collateral-false",
+            "encodeSetUserUseReserveAsCollateral(address,bool)",
+            (DEFAULT_THIRD, "false"),
+        ),
         GasCall(
             "liquidation",
             "encodeLiquidationCall(address,address,address,uint256,bool)",
@@ -855,29 +1089,69 @@ HOT_GAS_CALLS: Dict[str, Sequence[GasCall]] = {
     ),
     "lilweb3-ens": (
         GasCall("register-testname", "register(string)", ("testname",)),
-        GasCall("update-testname", "update(string,address)", ("testname", DEFAULT_SPENDER)),
+        GasCall(
+            "update-testname", "update(string,address)", ("testname", DEFAULT_SPENDER)
+        ),
         GasCall("register-second", "register(string)", ("second",)),
         GasCall("update-second", "update(string,address)", ("second", DEFAULT_THIRD)),
         GasCall("register-untouched", "register(string)", ("untouched",)),
         GasCall("register-empty", "register(string)", ("",)),
         GasCall("register-long", "register(string)", ("long-subdomain-name",)),
-        GasCall("update-long", "update(string,address)", ("long-subdomain-name", DEFAULT_FOURTH)),
+        GasCall(
+            "update-long",
+            "update(string,address)",
+            ("long-subdomain-name", DEFAULT_FOURTH),
+        ),
         GasCall("register-numeric", "register(string)", ("numeric123",)),
         GasCall("register-underscore", "register(string)", ("under_score",)),
-        GasCall("update-underscore", "update(string,address)", ("under_score", DEFAULT_SPENDER)),
-        GasCall("register-very-long", "register(string)", ("very-long-subdomain-name-with-more-bytes",)),
+        GasCall(
+            "update-underscore",
+            "update(string,address)",
+            ("under_score", DEFAULT_SPENDER),
+        ),
+        GasCall(
+            "register-very-long",
+            "register(string)",
+            ("very-long-subdomain-name-with-more-bytes",),
+        ),
     ),
     "lilweb3-flashloan": (
         GasCall("manager", "manager()", repeat=2),
-        GasCall("set-fee-spender", "setFees(address,uint256)", (DEFAULT_SPENDER, "250")),
+        GasCall(
+            "set-fee-spender", "setFees(address,uint256)", (DEFAULT_SPENDER, "250")
+        ),
         GasCall("set-fee-third", "setFees(address,uint256)", (DEFAULT_THIRD, "1000")),
-        GasCall("set-fee-fourth", "setFees(address,uint256)", (DEFAULT_FOURTH, "10000")),
+        GasCall(
+            "set-fee-fourth", "setFees(address,uint256)", (DEFAULT_FOURTH, "10000")
+        ),
         GasCall("set-fee-sender", "setFees(address,uint256)", (DEFAULT_SENDER, "1")),
-        GasCall("get-fee-zero", "getFee(address,uint256)", (DEFAULT_SPENDER, "0"), repeat=2),
-        GasCall("get-fee-spender", "getFee(address,uint256)", (DEFAULT_SPENDER, "10000"), repeat=2),
-        GasCall("get-fee-rounded", "getFee(address,uint256)", (DEFAULT_SPENDER, "33333"), repeat=2),
-        GasCall("get-fee-third", "getFee(address,uint256)", (DEFAULT_THIRD, "12345"), repeat=2),
-        GasCall("get-fee-fourth", "getFee(address,uint256)", (DEFAULT_FOURTH, "12345"), repeat=2),
+        GasCall(
+            "get-fee-zero", "getFee(address,uint256)", (DEFAULT_SPENDER, "0"), repeat=2
+        ),
+        GasCall(
+            "get-fee-spender",
+            "getFee(address,uint256)",
+            (DEFAULT_SPENDER, "10000"),
+            repeat=2,
+        ),
+        GasCall(
+            "get-fee-rounded",
+            "getFee(address,uint256)",
+            (DEFAULT_SPENDER, "33333"),
+            repeat=2,
+        ),
+        GasCall(
+            "get-fee-third",
+            "getFee(address,uint256)",
+            (DEFAULT_THIRD, "12345"),
+            repeat=2,
+        ),
+        GasCall(
+            "get-fee-fourth",
+            "getFee(address,uint256)",
+            (DEFAULT_FOURTH, "12345"),
+            repeat=2,
+        ),
         GasCall("get-fee-missing", "getFee(address,uint256)", (ZERO_ADDRESS, "10000")),
     ),
     "lilweb3-fractional": (
@@ -885,23 +1159,77 @@ HOT_GAS_CALLS: Dict[str, Sequence[GasCall]] = {
         GasCall("get-vault-one", "getVault(uint256)", ("1",), repeat=2),
         GasCall("get-vault-42", "getVault(uint256)", ("42",), repeat=2),
         GasCall("get-vault-max", "getVault(uint256)", (MAX_UINT256,)),
-        GasCall("erc721-empty", "onERC721Received(address,address,uint256,bytes)", (DEFAULT_SENDER, DEFAULT_SPENDER, "7", "0x"), repeat=2),
-        GasCall("erc721-nonempty", "onERC721Received(address,address,uint256,bytes)", (DEFAULT_THIRD, DEFAULT_FOURTH, "42", "0x123456"), repeat=2),
-        GasCall("erc721-word", "onERC721Received(address,address,uint256,bytes)", (ZERO_ADDRESS, ZERO_ADDRESS, "0", "0x" + "11" * 32)),
+        GasCall(
+            "erc721-empty",
+            "onERC721Received(address,address,uint256,bytes)",
+            (DEFAULT_SENDER, DEFAULT_SPENDER, "7", "0x"),
+            repeat=2,
+        ),
+        GasCall(
+            "erc721-nonempty",
+            "onERC721Received(address,address,uint256,bytes)",
+            (DEFAULT_THIRD, DEFAULT_FOURTH, "42", "0x123456"),
+            repeat=2,
+        ),
+        GasCall(
+            "erc721-word",
+            "onERC721Received(address,address,uint256,bytes)",
+            (ZERO_ADDRESS, ZERO_ADDRESS, "0", "0x" + "11" * 32),
+        ),
     ),
     "maple-erc20": (
-        GasCall("approve-spender-100", "approve(address,uint256)", (DEFAULT_SPENDER, "100")),
-        GasCall("increase-spender-50", "increaseAllowance(address,uint256)", (DEFAULT_SPENDER, "50")),
-        GasCall("decrease-spender-20", "decreaseAllowance(address,uint256)", (DEFAULT_SPENDER, "20")),
-        GasCall("increase-spender-70", "increaseAllowance(address,uint256)", (DEFAULT_SPENDER, "70")),
-        GasCall("decrease-spender-30", "decreaseAllowance(address,uint256)", (DEFAULT_SPENDER, "30")),
+        GasCall(
+            "approve-spender-100", "approve(address,uint256)", (DEFAULT_SPENDER, "100")
+        ),
+        GasCall(
+            "increase-spender-50",
+            "increaseAllowance(address,uint256)",
+            (DEFAULT_SPENDER, "50"),
+        ),
+        GasCall(
+            "decrease-spender-20",
+            "decreaseAllowance(address,uint256)",
+            (DEFAULT_SPENDER, "20"),
+        ),
+        GasCall(
+            "increase-spender-70",
+            "increaseAllowance(address,uint256)",
+            (DEFAULT_SPENDER, "70"),
+        ),
+        GasCall(
+            "decrease-spender-30",
+            "decreaseAllowance(address,uint256)",
+            (DEFAULT_SPENDER, "30"),
+        ),
         GasCall("approve-third-77", "approve(address,uint256)", (DEFAULT_THIRD, "77")),
-        GasCall("increase-third-23", "increaseAllowance(address,uint256)", (DEFAULT_THIRD, "23")),
-        GasCall("decrease-third-20", "decreaseAllowance(address,uint256)", (DEFAULT_THIRD, "20")),
-        GasCall("approve-fourth-900", "approve(address,uint256)", (DEFAULT_FOURTH, "900")),
-        GasCall("increase-fourth-100", "increaseAllowance(address,uint256)", (DEFAULT_FOURTH, "100")),
-        GasCall("decrease-fourth-50", "decreaseAllowance(address,uint256)", (DEFAULT_FOURTH, "50")),
-        GasCall("approve-fourth-max", "approve(address,uint256)", (DEFAULT_FOURTH, MAX_UINT256)),
+        GasCall(
+            "increase-third-23",
+            "increaseAllowance(address,uint256)",
+            (DEFAULT_THIRD, "23"),
+        ),
+        GasCall(
+            "decrease-third-20",
+            "decreaseAllowance(address,uint256)",
+            (DEFAULT_THIRD, "20"),
+        ),
+        GasCall(
+            "approve-fourth-900", "approve(address,uint256)", (DEFAULT_FOURTH, "900")
+        ),
+        GasCall(
+            "increase-fourth-100",
+            "increaseAllowance(address,uint256)",
+            (DEFAULT_FOURTH, "100"),
+        ),
+        GasCall(
+            "decrease-fourth-50",
+            "decreaseAllowance(address,uint256)",
+            (DEFAULT_FOURTH, "50"),
+        ),
+        GasCall(
+            "approve-fourth-max",
+            "approve(address,uint256)",
+            (DEFAULT_FOURTH, MAX_UINT256),
+        ),
         GasCall("approve-zero-1", "approve(address,uint256)", (ZERO_ADDRESS, "1")),
     ),
 }

--- a/benches/runtime/common.py
+++ b/benches/runtime/common.py
@@ -13,21 +13,21 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Sequence
-
+from typing import Any
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 TESTDATA_ROOT = REPOSITORY_ROOT / "testdata"
 PROJECTS_ROOT = TESTDATA_ROOT / "projects"
 RUNTIME_CORPUS_ROOT = Path(__file__).resolve().parent
 DEFAULT_RPC_URL = "http://127.0.0.1:8545"
-DEFAULT_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-
-IMPORT_RE = re.compile(
-    r"""\bimport\s+(?:(?:[^;]*?)\s+from\s+)?["']([^"']+)["']\s*;"""
+DEFAULT_PRIVATE_KEY = (
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 )
+
+IMPORT_RE = re.compile(r"""\bimport\s+(?:(?:[^;]*?)\s+from\s+)?["']([^"']+)["']\s*;""")
 
 
 @dataclass(frozen=True)
@@ -35,10 +35,10 @@ class CommandResult:
     returncode: int
     stdout: str
     stderr: str
-    peak_rss_bytes: Optional[int] = None
+    peak_rss_bytes: int | None = None
 
 
-def _read_peak_rss(path: Path) -> Optional[int]:
+def _read_peak_rss(path: Path) -> int | None:
     try:
         peak_rss_kib = int(path.read_text().strip())
     except (OSError, ValueError):
@@ -48,11 +48,11 @@ def _read_peak_rss(path: Path) -> Optional[int]:
 
 def run(
     cmd: Sequence[str],
-    input_text: Optional[str] = None,
+    input_text: str | None = None,
     timeout: int = 120,
-    cwd: Optional[Path] = None,
+    cwd: Path | None = None,
     measure_peak_rss: bool = False,
-    input_path: Optional[Path] = None,
+    input_path: Path | None = None,
 ) -> CommandResult:
     if input_text is not None and input_path is not None:
         raise ValueError("input_text and input_path are mutually exclusive")
@@ -110,7 +110,9 @@ def run(
             stdout, stderr = proc.communicate()
         elapsed = time.monotonic() - start
         stderr = (stderr or "").strip()
-        message = f"TIMEOUT after {elapsed:.1f}s: {shlex.join(str(part) for part in cmd)}"
+        message = (
+            f"TIMEOUT after {elapsed:.1f}s: {shlex.join(str(part) for part in cmd)}"
+        )
         if stderr:
             message = f"{message}\n{stderr}"
         result = CommandResult(-1, stdout or "", message)
@@ -120,11 +122,13 @@ def run(
     if peak_rss_path is not None:
         peak_rss_bytes = _read_peak_rss(peak_rss_path)
         peak_rss_path.unlink(missing_ok=True)
-        result = CommandResult(result.returncode, result.stdout, result.stderr, peak_rss_bytes)
+        result = CommandResult(
+            result.returncode, result.stdout, result.stderr, peak_rss_bytes
+        )
     return result
 
 
-def parse_receipt_int(value: object) -> Optional[int]:
+def parse_receipt_int(value: object) -> int | None:
     if isinstance(value, str):
         return int(value, 16) if value.startswith("0x") else int(value)
     if value is None:

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -42,9 +42,14 @@ def load_document(path: Path | None, label: str) -> dict[str, Any]:
     if isinstance(data, list):
         return {"results": data, "timings": {}}
     if not isinstance(data, dict) or not isinstance(data.get("results"), list):
-        warning(f"{label} benchmark results have unexpected shape: expected result document")
+        warning(
+            f"{label} benchmark results have unexpected shape: expected result document"
+        )
         return empty
-    return {"results": data["results"], "timings": normalize_timings(data.get("timings"))}
+    return {
+        "results": data["results"],
+        "timings": normalize_timings(data.get("timings")),
+    }
 
 
 def suite_name(result: dict[str, Any]) -> str:
@@ -84,7 +89,9 @@ def shorten(value: Any, limit: int = 160) -> str:
 
 
 def format_values(values: dict[str, Any]) -> str:
-    return ", ".join(f"{compiler}={shorten(value)}" for compiler, value in values.items())
+    return ", ".join(
+        f"{compiler}={shorten(value)}" for compiler, value in values.items()
+    )
 
 
 def runtime_issue_details(results: list[dict[str, Any]]) -> list[str]:
@@ -128,7 +135,11 @@ def baseline_regression_details(
 
         solar_gas = total_gas(result, "solar")
         base_solar_gas = total_gas(base, "solar")
-        if solar_gas is not None and base_solar_gas is not None and solar_gas > base_solar_gas:
+        if (
+            solar_gas is not None
+            and base_solar_gas is not None
+            and solar_gas > base_solar_gas
+        ):
             details.append(
                 f"{test_id} solar gas regressed vs previous Solar run: "
                 f"{base_solar_gas:,} -> {solar_gas:,} "
@@ -138,7 +149,11 @@ def baseline_regression_details(
 
         solar_size = runtime_size(result, "solar")
         base_solar_size = runtime_size(base, "solar")
-        if solar_size is not None and base_solar_size is not None and solar_size > base_solar_size:
+        if (
+            solar_size is not None
+            and base_solar_size is not None
+            and solar_size > base_solar_size
+        ):
             details.append(
                 f"{test_id} solar runtime size regressed vs previous Solar run: "
                 f"{base_solar_size:,}B -> {solar_size:,}B "
@@ -219,12 +234,20 @@ def has_codegen_changes(
 
         solar_gas = total_gas(result, "solar")
         base_solar_gas = total_gas(base, "solar")
-        if solar_gas is not None and base_solar_gas is not None and solar_gas != base_solar_gas:
+        if (
+            solar_gas is not None
+            and base_solar_gas is not None
+            and solar_gas != base_solar_gas
+        ):
             return True
 
         solar_size = runtime_size(result, "solar")
         base_solar_size = runtime_size(base, "solar")
-        if solar_size is not None and base_solar_size is not None and solar_size != base_solar_size:
+        if (
+            solar_size is not None
+            and base_solar_size is not None
+            and solar_size != base_solar_size
+        ):
             return True
 
     return False
@@ -326,7 +349,9 @@ def successful_compile_time(result: dict[str, Any], compiler: str) -> float | No
     return compile_time(result, compiler)
 
 
-def compiler_build_fingerprint(result: dict[str, Any], compiler: str) -> tuple[str, str]:
+def compiler_build_fingerprint(
+    result: dict[str, Any], compiler: str
+) -> tuple[str, str]:
     data = compiler_data(result, compiler)
     command = str(data.get("command") or "")
     if "target/release/" in command or "target\\release\\" in command:
@@ -368,7 +393,7 @@ def fmt_int(value: int | None, suffix: str = "") -> str:
     return f"{value:,}{suffix}"
 
 
-def fmt_bytes(value: int | float | None) -> str:
+def fmt_bytes(value: float | None) -> str:
     if value is None:
         return "n/a"
     return f"{value / (1024 * 1024):,.1f} MiB"
@@ -463,7 +488,9 @@ def benchmark_rows(
                     fmt_value_with_lower_is_better_delta(
                         solar_size, solar_size, base_solar_size, "B"
                     ),
-                    fmt_value_with_delta_vs_current(solc_size, solar_size, solc_size, "B"),
+                    fmt_value_with_delta_vs_current(
+                        solc_size, solar_size, solc_size, "B"
+                    ),
                 ]
             )
             + " |"
@@ -474,7 +501,7 @@ def benchmark_rows(
 def compiler_ids(results: list[dict[str, Any]]) -> list[str]:
     ids = []
     for result in results:
-        for compiler_id in (result.get("compilers") or {}).keys():
+        for compiler_id in result.get("compilers") or {}:
             if compiler_id not in ids:
                 ids.append(compiler_id)
     return ids
@@ -555,16 +582,16 @@ def compile_time_rows(
         solc_time = compile_time(result, "solc")
         solar_time = compile_time(result, "solar")
         base = baseline.get(suite_key(result), {})
-        base_solar_time = (
-            baseline_compile_time(result, base, "solar") if base else None
-        )
+        base_solar_time = baseline_compile_time(result, base, "solar") if base else None
         rows.append(
             "| "
             + " | ".join(
                 [
                     markdown_cell(test_id),
-                    f"{fmt_duration(solar_time)} "
-                    f"({fmt_pct_change_lower_is_better(solar_time, base_solar_time)})",
+                    (
+                        f"{fmt_duration(solar_time)} "
+                        f"({fmt_pct_change_lower_is_better(solar_time, base_solar_time)})"
+                    ),
                     f"{fmt_duration(solc_time)} ({fmt_pct_vs_current(solar_time, solc_time)})",
                 ]
             )
@@ -584,7 +611,11 @@ def compile_time_report(
         (compile_time(result, "solc"), compile_time(result, "solar"))
         for result in results
     ]
-    paired = [(solc, solar) for solc, solar in paired if solc is not None and solar is not None]
+    paired = [
+        (solc, solar)
+        for solc, solar in paired
+        if solc is not None and solar is not None
+    ]
     if not paired:
         return []
 
@@ -597,8 +628,10 @@ def compile_time_report(
         f"| bench | time (vs {baseline_label}) | solc |",
         "| ----- | --------------------- | ---- |",
         *compile_time_rows(results, baseline),
-        f"| **sum of medians** | **{fmt_duration(solar_sum)}** | "
-        f"**{fmt_duration(solc_sum)} ({fmt_pct_vs_current(solar_sum, solc_sum)})** |",
+        (
+            f"| **sum of medians** | **{fmt_duration(solar_sum)}** | "
+            f"**{fmt_duration(solc_sum)} ({fmt_pct_vs_current(solar_sum, solc_sum)})** |"
+        ),
         "",
     ]
 
@@ -645,7 +678,9 @@ def codegen_report(
     return report_section("Codegen benchmark", results, baseline_results, baseline_ref)
 
 
-def emit_warnings(results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]) -> None:
+def emit_warnings(
+    results: list[dict[str, Any]], baseline_results: list[dict[str, Any]]
+) -> None:
     for failure in compiler_failures(results):
         warning(f"compiler failure recorded: {failure}")
     for detail in runtime_issue_details(results):
@@ -692,8 +727,7 @@ def format_report(
         )
     if not has_changes:
         notices += (
-            "> [!NOTE]\n"
-            f"> Codegen benchmark output is unchanged from `{base_ref}`.\n\n"
+            f"> [!NOTE]\n> Codegen benchmark output is unchanged from `{base_ref}`.\n\n"
         )
     details = (
         "<details>\n"
@@ -704,14 +738,14 @@ def format_report(
     return notices + details
 
 
-def metric(value: int | float, unit: str, statistic: str) -> dict[str, Any]:
+def metric(value: float, unit: str, statistic: str) -> dict[str, Any]:
     return {"value": value, "unit": unit, "statistic": statistic}
 
 
 def common_benchmark(
     name: str,
     results: list[dict[str, Any]],
-    timing: int | float | None,
+    timing: float | None,
 ) -> dict[str, Any] | None:
     if not results or timing is None:
         return None
@@ -851,7 +885,9 @@ def main() -> int:
     should_comment = has_codegen_changes(results, baseline_results)
     if not args.ignore_compile_time_changes:
         should_comment |= has_compile_time_changes(results, baseline_results)
-    markdown = format_report(report, should_comment, branch_is_behind(base_ref), base_ref)
+    markdown = format_report(
+        report, should_comment, branch_is_behind(base_ref), base_ref
+    )
     print(markdown)
     append_github_output("report", markdown)
     append_github_output("should_comment", "true" if should_comment else "false")

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -226,6 +226,42 @@ class FailureHandlingTests(unittest.TestCase):
 
 
 class RuntimeComparisonTests(unittest.TestCase):
+    def test_single_compiler_is_not_a_semantic_oracle(self) -> None:
+        specs = (benchmark.CompilerSpec("solar", "solar", Path("solar"), "solar"),)
+        entry = {
+            "compilers": {
+                "solar": {
+                    "runtime_status": "ok",
+                    "runtime_results": [
+                        {"label": "value", "status": "ok", "value": "1"}
+                    ],
+                }
+            }
+        }
+
+        benchmark.compare_runtime_results(entry, specs)
+
+        self.assertEqual(entry["runtime_status"], "skipped")
+        self.assertEqual(entry["runtime_mismatches"], [])
+
+    def test_single_compiler_runtime_failure_still_fails(self) -> None:
+        specs = (benchmark.CompilerSpec("solar", "solar", Path("solar"), "solar"),)
+        entry = {
+            "compilers": {
+                "solar": {
+                    "runtime_status": "failed",
+                    "runtime_results": [
+                        {"label": "value", "status": "failed", "error": "reverted"}
+                    ],
+                }
+            }
+        }
+
+        benchmark.compare_runtime_results(entry, specs)
+
+        self.assertEqual(entry["runtime_status"], "failed")
+        self.assertEqual(entry["runtime_mismatches"], [])
+
     def test_reports_cross_compiler_mismatch(self) -> None:
         specs = (
             benchmark.CompilerSpec("solc", "solc", Path("solc"), "solc"),

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -6,7 +6,6 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-
 SCRIPT = Path(__file__).with_name("benchmark.py")
 sys.path.insert(0, str(SCRIPT.parent))
 SPEC = importlib.util.spec_from_file_location("codegen_benchmark", SCRIPT)
@@ -76,9 +75,7 @@ class CorpusTests(unittest.TestCase):
         heavy_cases = [case for case in benchmark.TEST_CASES if case.suite == "heavy"]
         self.assertEqual(len(heavy_cases), 9)
         self.assertTrue(all(case.whole_project for case in heavy_cases))
-        case = next(
-            case for case in heavy_cases if case.project == "solady-0.1.26"
-        )
+        case = next(case for case in heavy_cases if case.project == "solady-0.1.26")
         archive = benchmark.load_project(case.project_path)
         payload = json.loads(
             benchmark.full_project_standard_json_input(case.project_file)
@@ -186,18 +183,23 @@ class FailureHandlingTests(unittest.TestCase):
 
     def test_unexpected_test_error_is_written_as_a_failure(self) -> None:
         test_id = benchmark.TEST_CASES[0].test_id
-        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
-            benchmark,
-            "find_binary",
-            side_effect=lambda value, _fallbacks: Path(value),
-        ), mock.patch.object(
-            benchmark,
-            "binary_version",
-            return_value=("0.8.36", ""),
-        ), mock.patch.object(
-            benchmark,
-            "run_test_case",
-            side_effect=RuntimeError("unexpected"),
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(
+                benchmark,
+                "find_binary",
+                side_effect=lambda value, _fallbacks: Path(value),
+            ),
+            mock.patch.object(
+                benchmark,
+                "binary_version",
+                return_value=("0.8.36", ""),
+            ),
+            mock.patch.object(
+                benchmark,
+                "run_test_case",
+                side_effect=RuntimeError("unexpected"),
+            ),
         ):
             output = Path(directory) / "results.json"
             return_code = benchmark.main(
@@ -272,9 +274,7 @@ class RuntimeComparisonTests(unittest.TestCase):
             "compilers": {"solar": {"input_fingerprint": "new"}},
         }
         references = {
-            ("runtime", "test"): {
-                "compilers": {"solc": {"input_fingerprint": "old"}}
-            }
+            ("runtime", "test"): {"compilers": {"solc": {"input_fingerprint": "old"}}}
         }
 
         merged = benchmark.merge_reference_compiler(entry, references, "solc")

--- a/benches/runtime/test_benchmark.py
+++ b/benches/runtime/test_benchmark.py
@@ -226,6 +226,91 @@ class FailureHandlingTests(unittest.TestCase):
 
 
 class RuntimeComparisonTests(unittest.TestCase):
+    def test_merges_matching_reference_compiler_results(self) -> None:
+        entry = {
+            "test_id": "test",
+            "suite": "runtime",
+            "compilers": {
+                "solar": {
+                    "input_fingerprint": "input",
+                    "runtime_status": "ok",
+                    "runtime_results": [
+                        {"label": "value", "status": "ok", "value": "1"}
+                    ],
+                }
+            },
+        }
+        references = {
+            ("runtime", "test"): {
+                "compilers": {
+                    "solc": {
+                        "input_fingerprint": "input",
+                        "runtime_status": "ok",
+                        "runtime_results": [
+                            {"label": "value", "status": "ok", "value": "1"}
+                        ],
+                    }
+                }
+            }
+        }
+
+        merged = benchmark.merge_reference_compiler(entry, references, "solc")
+        specs = (
+            benchmark.CompilerSpec("solc", "solc", Path("solc"), "solc"),
+            benchmark.CompilerSpec("solar", "solar", Path("solar"), "solar"),
+        )
+        benchmark.compare_runtime_results(entry, specs)
+
+        self.assertTrue(merged)
+        self.assertEqual(entry["runtime_status"], "ok")
+        self.assertEqual(list(entry["compilers"]), ["solc", "solar"])
+
+    def test_rejects_reference_results_for_different_inputs(self) -> None:
+        entry = {
+            "test_id": "test",
+            "suite": "runtime",
+            "compilers": {"solar": {"input_fingerprint": "new"}},
+        }
+        references = {
+            ("runtime", "test"): {
+                "compilers": {"solc": {"input_fingerprint": "old"}}
+            }
+        }
+
+        merged = benchmark.merge_reference_compiler(entry, references, "solc")
+
+        self.assertFalse(merged)
+        self.assertNotIn("solc", entry["compilers"])
+
+    def test_rejects_reference_results_for_different_workloads(self) -> None:
+        entry = {
+            "test_id": "test",
+            "suite": "runtime",
+            "gas_profile": "hot",
+            "compilers": {
+                "solar": {
+                    "input_fingerprint": "input",
+                    "gas_results": [{"label": "new", "call": "new()"}],
+                }
+            },
+        }
+        references = {
+            ("runtime", "test"): {
+                "gas_profile": "hot",
+                "compilers": {
+                    "solc": {
+                        "input_fingerprint": "input",
+                        "gas_results": [{"label": "old", "call": "old()"}],
+                    }
+                },
+            }
+        }
+
+        merged = benchmark.merge_reference_compiler(entry, references, "solc")
+
+        self.assertFalse(merged)
+        self.assertNotIn("solc", entry["compilers"])
+
     def test_single_compiler_is_not_a_semantic_oracle(self) -> None:
         specs = (benchmark.CompilerSpec("solar", "solar", Path("solar"), "solar"),)
         entry = {

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -11,9 +11,11 @@ from jsonschema import Draft202012Validator
 sys.path.insert(0, str(Path(__file__).parent))
 import report as benchmark
 
-
 SCHEMA = json.loads(
-    (Path(__file__).resolve().parents[2] / "benches/schema/benchmark-result-v1.schema.json").read_text()
+    (
+        Path(__file__).resolve().parents[2]
+        / "benches/schema/benchmark-result-v1.schema.json"
+    ).read_text()
 )
 
 
@@ -35,7 +37,9 @@ class ReportFormattingTests(unittest.TestCase):
         )
 
     def test_changed_report_has_no_details(self):
-        self.assertEqual(benchmark.format_report("## Results", True, False), "## Results")
+        self.assertEqual(
+            benchmark.format_report("## Results", True, False), "## Results"
+        )
 
     def test_unchanged_report_uses_base_branch(self):
         report = benchmark.format_report("## Results", False, False, "feat/base")
@@ -120,9 +124,13 @@ class ReportFormattingTests(unittest.TestCase):
         )
 
     def test_codegen_report_combines_all_benches(self):
-        micro = result("micro", suite="micro", status="ok", total_gas=10, runtime_size=20)
+        micro = result(
+            "micro", suite="micro", status="ok", total_gas=10, runtime_size=20
+        )
         repository = result("repository", status="ok", total_gas=30, runtime_size=40)
-        large = result("large", suite="large", status="ok", total_gas=50, runtime_size=60)
+        large = result(
+            "large", suite="large", status="ok", total_gas=50, runtime_size=60
+        )
         report = benchmark.codegen_report(
             [micro, repository, large], [micro, repository, large]
         )
@@ -134,11 +142,13 @@ class ReportFormattingTests(unittest.TestCase):
             "| ----- | ------------- | ---- | -------------- | ---- |\n"
             "| micro | 10 (~0%) | n/a (n/a) | 20B (~0%) | n/a (n/a) |\n"
             "| repository | 30 (~0%) | n/a (n/a) | 40B (~0%) | n/a (n/a) |\n"
-            "| large | 50 (~0%) | n/a (n/a) | 60B (~0%) | n/a (n/a) |\n"
+            "| large | 50 (~0%) | n/a (n/a) | 60B (~0%) | n/a (n/a) |\n",
         )
 
     def test_codegen_report_uses_base_branch(self):
-        micro = result("micro", suite="micro", status="ok", total_gas=10, runtime_size=20)
+        micro = result(
+            "micro", suite="micro", status="ok", total_gas=10, runtime_size=20
+        )
         self.assertEqual(
             benchmark.codegen_report([micro], [micro], "feat/base"),
             "## Codegen benchmark\n"
@@ -188,9 +198,7 @@ class ReportFormattingTests(unittest.TestCase):
         self.assertIn(
             "| base-failed | 10.0 ms (n/a) | 100.0 ms (✅ +900.00%) |", report
         )
-        self.assertIn(
-            "| branch-failed | n/a (n/a) | 100.0 ms (n/a) |", report
-        )
+        self.assertIn("| branch-failed | n/a (n/a) | 100.0 ms (n/a) |", report)
 
         for index in range(2):
             self.assertTrue(
@@ -212,8 +220,10 @@ class ReportFormattingTests(unittest.TestCase):
         self.assertEqual(
             benchmark.compiler_failures([failure]),
             [
-                "repository/crashed: unexpected benchmark failure: "
-                "RuntimeError: broken"
+                (
+                    "repository/crashed: unexpected benchmark failure: "
+                    "RuntimeError: broken"
+                )
             ],
         )
 
@@ -222,17 +232,21 @@ class CommonBenchmarkResultTests(unittest.TestCase):
     def write_result(self, results, timings=None):
         if timings is None:
             timings = {"micro": 1.25}
-        with tempfile.TemporaryDirectory() as directory, patch.dict(
-            os.environ,
-            {
-                "GITHUB_REPOSITORY": "paradigmxyz/solar",
-                "GITHUB_SHA": "0123456789abcdef0123456789abcdef01234567",
-                "BENCHMARK_PR_NUMBER": "123",
-            },
-        ), patch.object(
-            benchmark,
-            "runner_metadata",
-            return_value={"os": "linux", "arch": "x86_64", "logical_cpus": 4},
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            patch.dict(
+                os.environ,
+                {
+                    "GITHUB_REPOSITORY": "paradigmxyz/solar",
+                    "GITHUB_SHA": "0123456789abcdef0123456789abcdef01234567",
+                    "BENCHMARK_PR_NUMBER": "123",
+                },
+            ),
+            patch.object(
+                benchmark,
+                "runner_metadata",
+                return_value={"os": "linux", "arch": "x86_64", "logical_cpus": 4},
+            ),
         ):
             output = Path(directory) / "common.json"
             benchmark.write_common_result(output, results, timings)
@@ -259,9 +273,7 @@ class CommonBenchmarkResultTests(unittest.TestCase):
                 peak_rss_bytes=200,
             ),
         ]
-        document = self.write_result(
-            [{**entry, "suite": "micro"} for entry in micro]
-        )
+        document = self.write_result([{**entry, "suite": "micro"} for entry in micro])
         self.assertEqual(
             document,
             {
@@ -279,7 +291,11 @@ class CommonBenchmarkResultTests(unittest.TestCase):
                             "statistic": "total",
                         },
                         "counters": {
-                            "tests": {"value": 2, "unit": "count", "statistic": "total"},
+                            "tests": {
+                                "value": 2,
+                                "unit": "count",
+                                "statistic": "total",
+                            },
                             "successful_compilations": {
                                 "value": 2,
                                 "unit": "count",
@@ -292,7 +308,11 @@ class CommonBenchmarkResultTests(unittest.TestCase):
                             },
                         },
                         "gas": {
-                            "runtime": {"value": 11, "unit": "gas", "statistic": "total"},
+                            "runtime": {
+                                "value": 11,
+                                "unit": "gas",
+                                "statistic": "total",
+                            },
                             "deployment": {
                                 "value": 22,
                                 "unit": "gas",
@@ -338,7 +358,9 @@ class CommonBenchmarkResultTests(unittest.TestCase):
         benchmark_result = document["benchmarks"][0]
         self.assertNotIn("gas", benchmark_result)
         self.assertNotIn("compiler", benchmark_result)
-        self.assertEqual(benchmark_result["counters"]["failed_compilations"]["value"], 1)
+        self.assertEqual(
+            benchmark_result["counters"]["failed_compilations"]["value"], 1
+        )
 
     def test_omits_each_incomplete_metric(self):
         complete = {
@@ -532,7 +554,13 @@ class CompileTimeReportTests(unittest.TestCase):
 
     def test_compile_time_bootstrap_triggers_comments(self):
         current = [self.timed_result("bench", 1.0, 0.1)]
-        base = [{"test_id": "bench", "suite": "repository", "compilers": {"solar": {"status": "ok"}}}]
+        base = [
+            {
+                "test_id": "bench",
+                "suite": "repository",
+                "compilers": {"solar": {"status": "ok"}},
+            }
+        ]
         self.assertTrue(benchmark.has_baseline_changes(current, base))
 
     def test_codegen_changes_trigger_comments(self):

--- a/fuzz/fandango/encode_abi_vectors.py
+++ b/fuzz/fandango/encode_abi_vectors.py
@@ -37,12 +37,14 @@ def main() -> int:
         calldata = evm.cast_calldata(args.cast, signature, values)
 
         out: dict[str, Any] = dict(vector)
-        out.update({
-            "index": index,
-            "signature": signature,
-            "args": vector.get("args", []),
-            "calldata": calldata,
-        })
+        out.update(
+            {
+                "index": index,
+                "signature": signature,
+                "args": vector.get("args", []),
+                "calldata": calldata,
+            }
+        )
         if args.seed is not None:
             out["seed"] = args.seed
         # `index` resets on each invocation (corpus + one run per seed), so build

--- a/fuzz/fandango/evm_runtime.py
+++ b/fuzz/fandango/evm_runtime.py
@@ -11,7 +11,6 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-
 SOLC_ADDRESS = "0x1000000000000000000000000000000000000001"
 SOLAR_ADDRESS = "0x1000000000000000000000000000000000000002"
 # Well-known anvil dev account 0; unlocked, so `eth_sendTransaction` needs no
@@ -40,20 +39,20 @@ def compile_solc(solc: str, source: pathlib.Path, contract: str, timeout: float)
         ],
         check=True,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=timeout,
     )
     return runtime_from_contracts(json.loads(result.stdout)["contracts"], contract)
 
 
-def compile_solar(solar: str, source: pathlib.Path, contract: str, timeout: float) -> str:
+def compile_solar(
+    solar: str, source: pathlib.Path, contract: str, timeout: float
+) -> str:
     result = subprocess.run(
         [solar, "--emit=bin-runtime", "--pretty-json", str(source)],
         check=True,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=timeout,
     )
     return runtime_from_contracts(json.loads(result.stdout)["contracts"], contract)
@@ -64,8 +63,7 @@ def cast_calldata(cast: str, signature: str, args: list[str]) -> str:
         [cast, "calldata", signature, *args],
         check=True,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
     return result.stdout.strip()
 
@@ -88,7 +86,9 @@ def rpc(
     timeout: float,
     retries: int = 2,
 ) -> dict[str, Any]:
-    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": method, "params": params})
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": 1, "method": method, "params": params}
+    )
     request = urllib.request.Request(
         url, data=payload.encode(), headers={"Content-Type": "application/json"}
     )
@@ -98,7 +98,9 @@ def rpc(
                 return json.loads(response.read().decode())
         except (urllib.error.URLError, TimeoutError) as err:
             if attempt >= retries:
-                raise InfraError(f"JSON-RPC transport error for {method}: {err}") from err
+                raise InfraError(
+                    f"JSON-RPC transport error for {method}: {err}"
+                ) from err
             time.sleep(0.1 * (attempt + 1))
 
     raise InfraError(f"JSON-RPC transport error for {method}")
@@ -171,7 +173,9 @@ def wait_for_receipt(url: str, tx_hash: str, timeout: float) -> dict[str, Any] |
     """
     deadline = time.monotonic() + timeout
     while True:
-        receipt = rpc(url, "eth_getTransactionReceipt", [tx_hash], timeout).get("result")
+        receipt = rpc(url, "eth_getTransactionReceipt", [tx_hash], timeout).get(
+            "result"
+        )
         if receipt:
             return receipt
         if time.monotonic() >= deadline:

--- a/fuzz/fandango/reduce_runtime_failure.py
+++ b/fuzz/fandango/reduce_runtime_failure.py
@@ -18,13 +18,13 @@ import tempfile
 from dataclasses import dataclass
 from typing import Any, Self
 
-
 RUN_RE = re.compile(
     r"(?P<prefix>function\s+run\s*\([^)]*\)\s+external\s+returns\s*\(uint256\s+r\)\s*\{\s*unchecked\s*\{\s*)"
     r"(?P<body>.*?)"
     r"(?P<suffix>\s*value\s*=\s*r\s*;\s*values\s*\[\s*a\s*&\s*7\s*\]\s*=\s*r\s*;\s*emit\s+Seen\s*\(\s*1\s*,\s*r\s*\)\s*;\s*return\s+r\s*;\s*\}\s*\})",
     re.DOTALL,
 )
+
 
 @dataclass
 class Stats:
@@ -99,9 +99,13 @@ class Reducer:
             chunk_size = max(1, len(items) // granularity)
             changed = False
             for start in range(0, len(items), chunk_size):
-                candidate_items = items[:start] + items[start + chunk_size:]
-                candidate = replace_body(source, parts.match, body_or_default(candidate_items))
-                if self.try_candidate(candidate, f"remove statement chunk {start}:{start + chunk_size}"):
+                candidate_items = items[:start] + items[start + chunk_size :]
+                candidate = replace_body(
+                    source, parts.match, body_or_default(candidate_items)
+                )
+                if self.try_candidate(
+                    candidate, f"remove statement chunk {start}:{start + chunk_size}"
+                ):
                     source = candidate
                     parts = RunParts.parse(source)
                     if parts is None:
@@ -127,7 +131,9 @@ class Reducer:
             for replacement in structured_replacements(item):
                 candidate_items = list(items)
                 candidate_items[index] = replacement
-                candidate = replace_body(source, parts.match, body_or_default(candidate_items))
+                candidate = replace_body(
+                    source, parts.match, body_or_default(candidate_items)
+                )
                 if self.try_candidate(candidate, f"simplify structured item {index}"):
                     return candidate
         return source
@@ -157,7 +163,9 @@ class Reducer:
                 return candidate
         return source
 
-    def apply_text_replacements(self, source: str, replacements: list[tuple[int, int, str, str]]) -> str:
+    def apply_text_replacements(
+        self, source: str, replacements: list[tuple[int, int, str, str]]
+    ) -> str:
         for start, end, replacement, label in replacements:
             candidate = source[:start] + replacement + source[end:]
             if candidate != source and self.try_candidate(candidate, label):
@@ -203,9 +211,9 @@ class Reducer:
                     "--timeout",
                     str(self.args.timeout),
                 ],
+                check=False,
                 text=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                capture_output=True,
                 timeout=self.args.timeout + 5,
             )
         try:
@@ -243,14 +251,21 @@ def main() -> int:
     args.out.write_text(reduced)
     reduced_failure = dict(failure)
     reduced_failure["source_text"] = reduced
-    args.out.with_suffix(".json").write_text(json.dumps(reduced_failure, indent=2, sort_keys=True) + "\n")
-    print(json.dumps({
-        "attempts": reducer.stats.attempts,
-        "accepted": reducer.stats.accepted,
-        "input_bytes": len(source),
-        "output_bytes": len(reduced),
-        "out": str(args.out),
-    }, separators=(",", ":")))
+    args.out.with_suffix(".json").write_text(
+        json.dumps(reduced_failure, indent=2, sort_keys=True) + "\n"
+    )
+    print(
+        json.dumps(
+            {
+                "attempts": reducer.stats.attempts,
+                "accepted": reducer.stats.accepted,
+                "input_bytes": len(source),
+                "output_bytes": len(reduced),
+                "out": str(args.out),
+            },
+            separators=(",", ":"),
+        )
+    )
     return 0
 
 
@@ -266,12 +281,12 @@ def split_top_level_items(body: str) -> list[str]:
         elif char == "}":
             depth = max(depth - 1, 0)
             if depth == 0 and not next_nonspace_starts_with(body, index + 1, "else"):
-                item = body[start:index + 1].strip()
+                item = body[start : index + 1].strip()
                 if item:
                     items.append(item)
                 start = index + 1
         elif char == ";" and depth == 0:
-            item = body[start:index + 1].strip()
+            item = body[start : index + 1].strip()
             if item:
                 items.append(item)
             start = index + 1
@@ -293,24 +308,28 @@ def structured_replacements(item: str) -> list[str]:
     replacements = []
     if_match = match_if_else(item)
     if if_match is not None:
-        replacements.extend([
-            if_match["then"].strip(),
-            if_match["else"].strip(),
-            "r = 0;",
-            "r = value;",
-        ])
+        replacements.extend(
+            [
+                if_match["then"].strip(),
+                if_match["else"].strip(),
+                "r = 0;",
+                "r = value;",
+            ]
+        )
 
     for_match = match_for(item)
     if for_match is not None:
         init = for_match["init"].strip()
         body = for_match["body"].strip()
-        replacements.extend([
-            body,
-            f"{init};",
-            f"{init}; r = value;",
-            re.sub(r"<\s*[^;]+", "< 1", item, count=1),
-            re.sub(r"<\s*[^;]+", "< 0", item, count=1),
-        ])
+        replacements.extend(
+            [
+                body,
+                f"{init};",
+                f"{init}; r = value;",
+                re.sub(r"<\s*[^;]+", "< 1", item, count=1),
+                re.sub(r"<\s*[^;]+", "< 0", item, count=1),
+            ]
+        )
 
     if "if (" in item and " else " not in item:
         simple = match_if(item)
@@ -336,9 +355,9 @@ def match_if_else(item: str) -> dict[str, str] | None:
     if else_start < 0 or else_end < 0:
         return None
     return {
-        "condition": item[cond_start + 1:cond_end],
-        "then": item[then_start + 1:then_end],
-        "else": item[else_start + 1:else_end],
+        "condition": item[cond_start + 1 : cond_end],
+        "then": item[then_start + 1 : then_end],
+        "else": item[else_start + 1 : else_end],
     }
 
 
@@ -351,8 +370,8 @@ def match_if(item: str) -> dict[str, str] | None:
     if min(start, cond_start, cond_end, then_start, then_end) < 0:
         return None
     return {
-        "condition": item[cond_start + 1:cond_end],
-        "then": item[then_start + 1:then_end],
+        "condition": item[cond_start + 1 : cond_end],
+        "then": item[then_start + 1 : then_end],
     }
 
 
@@ -364,7 +383,7 @@ def match_for(item: str) -> dict[str, str] | None:
     body_end = matching_delimiter(item, body_start, "{", "}")
     if min(start, header_start, header_end, body_start, body_end) < 0:
         return None
-    header = item[header_start + 1:header_end]
+    header = item[header_start + 1 : header_end]
     parts = header.split(";")
     if len(parts) != 3:
         return None
@@ -372,7 +391,7 @@ def match_for(item: str) -> dict[str, str] | None:
         "init": parts[0],
         "condition": parts[1],
         "step": parts[2],
-        "body": item[body_start + 1:body_end],
+        "body": item[body_start + 1 : body_end],
     }
 
 
@@ -381,19 +400,23 @@ def call_replacements(source: str) -> list[tuple[int, int, str, str]]:
     for name in ("helper", "mix"):
         for start, end, args in find_calls(source, name):
             if name == "helper" and len(args) == 1:
-                replacements.extend([
-                    (start, end, parenthesize(args[0]), "inline helper"),
-                    (start, end, "0", "helper to zero"),
-                    (start, end, "a", "helper to a"),
-                    (start, end, "value", "helper to value"),
-                ])
+                replacements.extend(
+                    [
+                        (start, end, parenthesize(args[0]), "inline helper"),
+                        (start, end, "0", "helper to zero"),
+                        (start, end, "a", "helper to a"),
+                        (start, end, "value", "helper to value"),
+                    ]
+                )
             elif name == "mix" and len(args) == 2:
-                replacements.extend([
-                    (start, end, parenthesize(args[0]), "mix to left"),
-                    (start, end, parenthesize(args[1]), "mix to right"),
-                    (start, end, f"({args[0]} ^ {args[1]})", "mix to xor"),
-                    (start, end, "0", "mix to zero"),
-                ])
+                replacements.extend(
+                    [
+                        (start, end, parenthesize(args[0]), "mix to left"),
+                        (start, end, parenthesize(args[1]), "mix to right"),
+                        (start, end, f"({args[0]} ^ {args[1]})", "mix to xor"),
+                        (start, end, "0", "mix to zero"),
+                    ]
+                )
     return replacements
 
 
@@ -402,15 +425,21 @@ def index_replacements(source: str) -> list[tuple[int, int, str, str]]:
     for match in re.finditer(r"values\s*\[(?P<index>[^\]]+)\]", source):
         index = match.group("index").strip()
         if index != "0":
-            replacements.append((match.start("index"), match.end("index"), "0", "mapping key to zero"))
+            replacements.append(
+                (match.start("index"), match.end("index"), "0", "mapping key to zero")
+            )
     for match in re.finditer(r"data\s*\[(?P<index>[^\]]+)\]", source):
         index = match.group("index").strip()
         if index != "0":
-            replacements.append((match.start("index"), match.end("index"), "0", "data index to zero"))
+            replacements.append(
+                (match.start("index"), match.end("index"), "0", "data index to zero")
+            )
     for match in re.finditer(r"xs\s*\[(?P<index>[^\]]+)\]", source):
         index = match.group("index").strip()
         if index != "0":
-            replacements.append((match.start("index"), match.end("index"), "0", "array index to zero"))
+            replacements.append(
+                (match.start("index"), match.end("index"), "0", "array index to zero")
+            )
     return replacements
 
 
@@ -420,10 +449,12 @@ def literal_replacements(source: str) -> list[tuple[int, int, str, str]]:
         literal = match.group(0)
         if literal in {"0", "1"}:
             continue
-        replacements.extend([
-            (match.start(), match.end(), "0", f"{literal} to zero"),
-            (match.start(), match.end(), "1", f"{literal} to one"),
-        ])
+        replacements.extend(
+            [
+                (match.start(), match.end(), "0", f"{literal} to zero"),
+                (match.start(), match.end(), "1", f"{literal} to one"),
+            ]
+        )
         if literal.startswith("0x") or int(literal) > 2:
             replacements.append((match.start(), match.end(), "2", f"{literal} to two"))
     return replacements
@@ -435,17 +466,35 @@ def assignment_replacements(source: str) -> list[tuple[int, int, str, str]]:
         expr = match.group("expr").strip()
         for replacement in ("0", "1", "a", "b", "value"):
             if expr != replacement:
-                replacements.append((match.start("expr"), match.end("expr"), replacement, f"r assignment to {replacement}"))
+                replacements.append(
+                    (
+                        match.start("expr"),
+                        match.end("expr"),
+                        replacement,
+                        f"r assignment to {replacement}",
+                    )
+                )
     for match in re.finditer(r"\br\s*\+=\s*(?P<expr>[^;{}]+);", source):
-        replacements.extend([
-            (match.start(), match.end(), "r += 0;", "remove r addend"),
-            (match.start("expr"), match.end("expr"), "1", "r addend to one"),
-        ])
-    for match in re.finditer(r"\buint256\s+(?P<name>limit|key)\s*=\s*(?P<expr>[^;{}]+);", source):
+        replacements.extend(
+            [
+                (match.start(), match.end(), "r += 0;", "remove r addend"),
+                (match.start("expr"), match.end("expr"), "1", "r addend to one"),
+            ]
+        )
+    for match in re.finditer(
+        r"\buint256\s+(?P<name>limit|key)\s*=\s*(?P<expr>[^;{}]+);", source
+    ):
         expr = match.group("expr").strip()
         for replacement in ("0", "1", "a & 7"):
             if expr != replacement:
-                replacements.append((match.start("expr"), match.end("expr"), replacement, f"{match.group('name')} to {replacement}"))
+                replacements.append(
+                    (
+                        match.start("expr"),
+                        match.end("expr"),
+                        replacement,
+                        f"{match.group('name')} to {replacement}",
+                    )
+                )
     return replacements
 
 
@@ -471,7 +520,7 @@ def find_calls(source: str, name: str) -> list[tuple[int, int, list[str]]]:
         close_index = matching_delimiter(source, open_index, "(", ")")
         if close_index < 0:
             continue
-        args = split_args(source[open_index + 1:close_index])
+        args = split_args(source[open_index + 1 : close_index])
         calls.append((match.start(), close_index + 1, args))
     return calls
 
@@ -520,7 +569,13 @@ def body_or_default(items: list[str]) -> str:
 
 
 def replace_body(source: str, match: re.Match[str], body: str) -> str:
-    return source[:match.start()] + match.group("prefix") + body + match.group("suffix") + source[match.end():]
+    return (
+        source[: match.start()]
+        + match.group("prefix")
+        + body
+        + match.group("suffix")
+        + source[match.end() :]
+    )
 
 
 def is_plausible_source(source: str) -> bool:

--- a/fuzz/fandango/run_abi_vectors.py
+++ b/fuzz/fandango/run_abi_vectors.py
@@ -66,7 +66,9 @@ def main() -> int:
 
         # Always exercise `eth_call` so the exact return/revert bytes are
         # compared, including for the panic/revert vectors.
-        call_envelope = {"from": args.sender, "gas": evm.TX_GAS} if mode == "tx" else None
+        call_envelope = (
+            {"from": args.sender, "gas": evm.TX_GAS} if mode == "tx" else None
+        )
         solc_result: dict[str, Any] = {
             "call": evm.eth_call(
                 args.rpc_url, evm.SOLC_ADDRESS, calldata, args.timeout, call_envelope

--- a/fuzz/fandango/run_foundry_target.py
+++ b/fuzz/fandango/run_foundry_target.py
@@ -27,11 +27,15 @@ def main() -> int:
     args = parser.parse_args()
 
     solc_runtime = evm.compile_solc(args.solc, args.source, args.contract, args.timeout)
-    solar_runtime = evm.compile_solar(args.solar, args.source, args.contract, args.timeout)
+    solar_runtime = evm.compile_solar(
+        args.solar, args.source, args.contract, args.timeout
+    )
 
     with tempfile.TemporaryDirectory(prefix="solar-foundry-fuzz-") as tmp:
         project = pathlib.Path(tmp)
-        write_foundry_target.write_target(args.source, project, solc_runtime, solar_runtime)
+        write_foundry_target.write_target(
+            args.source, project, solc_runtime, solar_runtime
+        )
         foundry = _forge_test(project, args.fuzz_runs, args.timeout)
 
     summary = {
@@ -43,16 +47,18 @@ def main() -> int:
     return 0 if summary["match"] else 1
 
 
-def _forge_test(project: pathlib.Path, fuzz_runs: int, timeout: float) -> dict[str, Any]:
+def _forge_test(
+    project: pathlib.Path, fuzz_runs: int, timeout: float
+) -> dict[str, Any]:
     env = os.environ.copy()
     try:
         result = subprocess.run(
             ["forge", "test", "--fuzz-runs", str(fuzz_runs)],
+            check=False,
             cwd=project,
             env=env,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as err:

--- a/fuzz/fandango/run_solidity_sources.py
+++ b/fuzz/fandango/run_solidity_sources.py
@@ -61,7 +61,9 @@ def main() -> int:
                 path = tmpdir / f"source_{index}.sol"
                 path.write_text(source)
 
-                solc_result, solar_result = _check_source(args, index, len(sources), path)
+                solc_result, solar_result = _check_source(
+                    args, index, len(sources), path
+                )
                 valid, invalid = _update_counts(valid, invalid, solc_result)
                 if solc_result["status"] != solar_result["status"]:
                     failure = _failure(index, source, solc_result, solar_result)
@@ -148,32 +150,38 @@ def _iter_sources(
 
 
 def _compile_solc(solc: str, source: pathlib.Path, timeout: float) -> dict[str, Any]:
-    return _run([
-        solc,
-        "--via-ir",
-        "--optimize",
-        "--metadata-hash",
-        "none",
-        "--bin-runtime",
-        str(source),
-    ], timeout)
+    return _run(
+        [
+            solc,
+            "--via-ir",
+            "--optimize",
+            "--metadata-hash",
+            "none",
+            "--bin-runtime",
+            str(source),
+        ],
+        timeout,
+    )
 
 
 def _compile_solar(solar: str, source: pathlib.Path, timeout: float) -> dict[str, Any]:
-    return _run([
-        solar,
-        "--emit=bin-runtime",
-        str(source),
-    ], timeout)
+    return _run(
+        [
+            solar,
+            "--emit=bin-runtime",
+            str(source),
+        ],
+        timeout,
+    )
 
 
 def _run(argv: list[str], timeout: float) -> dict[str, Any]:
     try:
         result = subprocess.run(
             argv,
+            check=False,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as err:
@@ -193,7 +201,9 @@ def _run(argv: list[str], timeout: float) -> dict[str, Any]:
     }
 
 
-def _write_failure(failure_dir: pathlib.Path, index: int, failure: dict[str, Any]) -> None:
+def _write_failure(
+    failure_dir: pathlib.Path, index: int, failure: dict[str, Any]
+) -> None:
     failure_dir.mkdir(parents=True, exist_ok=True)
     (failure_dir / f"source-{index}.json").write_text(
         json.dumps(failure, indent=2, sort_keys=True)

--- a/fuzz/fandango/run_source_runtime.py
+++ b/fuzz/fandango/run_source_runtime.py
@@ -64,7 +64,9 @@ def main() -> int:
     written_failures = 0
     for index, source in enumerate(sources):
         if args.verbose:
-            print(f"[runtime-source {index + 1}/{len(sources)}] {source}", file=sys.stderr)
+            print(
+                f"[runtime-source {index + 1}/{len(sources)}] {source}", file=sys.stderr
+            )
         result = _check_source_with_retry(args, source)
         if result is None:
             executed_cases += args.cases_per_source
@@ -134,7 +136,9 @@ def _check_replay(
     snapshot = _snapshot(args.rpc_url, args.timeout)
     try:
         solc_runtime = evm.compile_solc(args.solc, source, args.contract, args.timeout)
-        solar_runtime = evm.compile_solar(args.solar, source, args.contract, args.timeout)
+        solar_runtime = evm.compile_solar(
+            args.solar, source, args.contract, args.timeout
+        )
         evm.set_code(args.rpc_url, evm.SOLC_ADDRESS, solc_runtime, args.timeout)
         evm.set_code(args.rpc_url, evm.SOLAR_ADDRESS, solar_runtime, args.timeout)
 
@@ -178,11 +182,15 @@ def _check_replay(
         _revert(args.rpc_url, snapshot, args.timeout)
 
 
-def _check_source(args: argparse.Namespace, source: pathlib.Path) -> dict[str, Any] | None:
+def _check_source(
+    args: argparse.Namespace, source: pathlib.Path
+) -> dict[str, Any] | None:
     snapshot = _snapshot(args.rpc_url, args.timeout)
     try:
         try:
-            solc_runtime = evm.compile_solc(args.solc, source, args.contract, args.timeout)
+            solc_runtime = evm.compile_solc(
+                args.solc, source, args.contract, args.timeout
+            )
         except subprocess.CalledProcessError as err:
             return {
                 "kind": "solc-compile-error",
@@ -192,7 +200,9 @@ def _check_source(args: argparse.Namespace, source: pathlib.Path) -> dict[str, A
             }
 
         try:
-            solar_runtime = evm.compile_solar(args.solar, source, args.contract, args.timeout)
+            solar_runtime = evm.compile_solar(
+                args.solar, source, args.contract, args.timeout
+            )
         except subprocess.CalledProcessError as err:
             return {
                 "kind": "solar-compile-error",
@@ -250,16 +260,20 @@ def _check_case(
         if failure is not None:
             return failure
 
-    failure = _compare_call(args, source, case_index, case, "observe", observe_calldata, history)
+    failure = _compare_call(
+        args, source, case_index, case, "observe", observe_calldata, history
+    )
     if failure is not None:
         return failure
 
-    history.append({
-        "case": case_index,
-        "setup": setup_calldata,
-        "run": run_calldata,
-        "observe": observe_calldata,
-    })
+    history.append(
+        {
+            "case": case_index,
+            "setup": setup_calldata,
+            "run": run_calldata,
+            "observe": observe_calldata,
+        }
+    )
     return None
 
 
@@ -274,10 +288,14 @@ def _compare_tx(
 ) -> dict[str, Any] | None:
     call_envelope = {"from": args.sender, "gas": evm.TX_GAS}
     solc_result: dict[str, Any] = {
-        "call": evm.eth_call(args.rpc_url, evm.SOLC_ADDRESS, calldata, args.timeout, call_envelope)
+        "call": evm.eth_call(
+            args.rpc_url, evm.SOLC_ADDRESS, calldata, args.timeout, call_envelope
+        )
     }
     solar_result: dict[str, Any] = {
-        "call": evm.eth_call(args.rpc_url, evm.SOLAR_ADDRESS, calldata, args.timeout, call_envelope)
+        "call": evm.eth_call(
+            args.rpc_url, evm.SOLAR_ADDRESS, calldata, args.timeout, call_envelope
+        )
     }
     solc_result["receipt"] = evm.send_tx(
         args.rpc_url, args.sender, evm.SOLC_ADDRESS, calldata, args.timeout
@@ -299,8 +317,12 @@ def _compare_call(
     calldata: str,
     history: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    solc_result = {"call": evm.eth_call(args.rpc_url, evm.SOLC_ADDRESS, calldata, args.timeout)}
-    solar_result = {"call": evm.eth_call(args.rpc_url, evm.SOLAR_ADDRESS, calldata, args.timeout)}
+    solc_result = {
+        "call": evm.eth_call(args.rpc_url, evm.SOLC_ADDRESS, calldata, args.timeout)
+    }
+    solar_result = {
+        "call": evm.eth_call(args.rpc_url, evm.SOLAR_ADDRESS, calldata, args.timeout)
+    }
     return _failure_if_different(
         source, case_index, case, label, calldata, solc_result, solar_result, history
     )
@@ -351,7 +373,7 @@ def _cases(count: int) -> list[dict[str, Any]]:
         seed = ((index + 1) * 0x45D9F3B) & U256_MAX
         a = (seed ^ (index + 1) * 17) & U64_MAX
         b = ((seed >> 3) + index * 31 + 1) & U64_MAX
-        data = bytes(((seed + j * 13) & 0xFF for j in range(index % 34)))
+        data = bytes((seed + j * 13) & 0xFF for j in range(index % 34))
         cases.append(_case(seed, a, b, data))
     return cases
 
@@ -392,7 +414,9 @@ def _revert(url: str, snapshot: str, timeout: float) -> None:
         raise RuntimeError(f"evm_revert failed: {response.get('error')}")
 
 
-def _write_failure(directory: pathlib.Path, index: int, failure: dict[str, Any]) -> None:
+def _write_failure(
+    directory: pathlib.Path, index: int, failure: dict[str, Any]
+) -> None:
     directory.mkdir(parents=True, exist_ok=True)
     stem = pathlib.Path(failure["source"]).stem
     path = directory / f"runtime-{index}-{stem}.json"

--- a/fuzz/fandango/solsmith.py
+++ b/fuzz/fandango/solsmith.py
@@ -17,7 +17,6 @@ import random
 from dataclasses import dataclass
 from typing import Self
 
-
 U256_MASK = (1 << 256) - 1
 
 DEFAULT_REQUIRED_FEATURES = (
@@ -81,29 +80,39 @@ class Generator:
 
     def _u256_expr(self, depth: int = 0) -> Expr:
         if depth >= 2:
-            return self.rng.choice([
-                Expr("a"),
-                Expr("b"),
-                Expr("value", ("storage-read",)),
-                Expr("values[a & 7]", ("mapping-read",)),
-                Expr("values[b & 7]", ("mapping-read",)),
-            ])
+            return self.rng.choice(
+                [
+                    Expr("a"),
+                    Expr("b"),
+                    Expr("value", ("storage-read",)),
+                    Expr("values[a & 7]", ("mapping-read",)),
+                    Expr("values[b & 7]", ("mapping-read",)),
+                ]
+            )
 
         left = self._u256_expr(depth + 1)
         right = self._u256_expr(depth + 1)
         op = self.rng.choice(["+", "^", "&", "|"])
         if op == "&":
             right = self.rng.choice([Expr("15"), Expr("255"), right])
-        expr = Expr(f"({left.code} {op} {right.code})", (*left.features, *right.features, "arith"))
+        expr = Expr(
+            f"({left.code} {op} {right.code})",
+            (*left.features, *right.features, "arith"),
+        )
         if self.rng.random() < 0.35:
             expr = Expr(f"helper({expr.code})", (*expr.features, "internal-call"))
         return expr
 
     def _condition(self) -> Expr:
         lhs = self._u256_expr()
-        rhs = self.rng.choice([Expr("a"), Expr("b"), Expr("value", ("storage-read",)), Expr("7")])
+        rhs = self.rng.choice(
+            [Expr("a"), Expr("b"), Expr("value", ("storage-read",)), Expr("7")]
+        )
         op = self.rng.choice(["<", ">", "==", "!="])
-        return Expr(f"(({lhs.code}) & 255) {op} (({rhs.code}) & 255)", (*lhs.features, *rhs.features))
+        return Expr(
+            f"(({lhs.code}) & 255) {op} (({rhs.code}) & 255)",
+            (*lhs.features, *rhs.features),
+        )
 
     def _arithmetic_body(self) -> tuple[str, list[str]]:
         expr = self._u256_expr()
@@ -114,7 +123,12 @@ class Generator:
         then_expr = self._u256_expr()
         else_expr = self._u256_expr()
         body = f"if ({cond.code}) {{ r = {then_expr.code}; }} else {{ r = {else_expr.code}; }}"
-        return body, ["branch", *cond.features, *then_expr.features, *else_expr.features]
+        return body, [
+            "branch",
+            *cond.features,
+            *then_expr.features,
+            *else_expr.features,
+        ]
 
     def _loop_body(self) -> tuple[str, list[str]]:
         expr = self._u256_expr()
@@ -125,10 +139,12 @@ class Generator:
     def _mapping_body(self) -> tuple[str, list[str]]:
         expr = self._u256_expr()
         key = self.rng.choice(["a & 7", "b & 7", "(a + b) & 7", "(value + a) & 7"])
-        update = self.rng.choice([
-            f"values[key] = values[key] + ({expr.code}) + 1; r = values[key] + value;",
-            f"r = values[key] ^ ({expr.code}); values[(key + 1) & 7] = r;",
-        ])
+        update = self.rng.choice(
+            [
+                f"values[key] = values[key] + ({expr.code}) + 1; r = values[key] + value;",
+                f"r = values[key] ^ ({expr.code}); values[(key + 1) & 7] = r;",
+            ]
+        )
         return f"uint256 key = {key}; {update}", [
             "mapping-read",
             "mapping-write",
@@ -143,20 +159,24 @@ class Generator:
         return body, ["memory-array", "storage-read", *expr0.features, *expr1.features]
 
     def _bytes_body(self) -> tuple[str, list[str]]:
-        body = self.rng.choice([
-            "r = value + data.length; if (data.length != 0) { r += uint8(data[0]); }",
-            "uint256 limit = data.length < 5 ? data.length : 5; r = value; for (uint256 i = 0; i < limit; ++i) { r = (r << 1) + uint8(data[i]); }",
-            "r = data.length; if (data.length > 1) { r += uint8(data[1]) + value; }",
-        ])
+        body = self.rng.choice(
+            [
+                "r = value + data.length; if (data.length != 0) { r += uint8(data[0]); }",
+                "uint256 limit = data.length < 5 ? data.length : 5; r = value; for (uint256 i = 0; i < limit; ++i) { r = (r << 1) + uint8(data[i]); }",
+                "r = data.length; if (data.length > 1) { r += uint8(data[1]) + value; }",
+            ]
+        )
         return body, ["calldata-bytes", "storage-read"]
 
     def _combined_body(self) -> tuple[str, list[str]]:
         expr = self._u256_expr()
-        body = self.rng.choice([
-            f"uint256 key = a & 7; uint256[2] memory xs = [values[key], {expr.code}]; r = xs[0] + xs[1] + value;",
-            f"uint256 limit = (a & 3) + 1; r = values[b & 7]; for (uint256 i = 0; i < limit; ++i) {{ r += mix(i, {expr.code}); }}",
-            f"r = mix(a, b); if (data.length > 0) {{ values[uint8(data[0]) & 7] = {expr.code}; }} r += values[a & 7];",
-        ])
+        body = self.rng.choice(
+            [
+                f"uint256 key = a & 7; uint256[2] memory xs = [values[key], {expr.code}]; r = xs[0] + xs[1] + value;",
+                f"uint256 limit = (a & 3) + 1; r = values[b & 7]; for (uint256 i = 0; i < limit; ++i) {{ r += mix(i, {expr.code}); }}",
+                f"r = mix(a, b); if (data.length > 0) {{ values[uint8(data[0]) & 7] = {expr.code}; }} r += values[a & 7];",
+            ]
+        )
         return body, [
             "combined",
             "mapping-read",
@@ -240,7 +260,9 @@ def main() -> int:
     if args.require_default_features:
         required_features.update(DEFAULT_REQUIRED_FEATURES)
 
-    programs = _generate_batch(generator, args.count, required_features, args.max_attempts)
+    programs = _generate_batch(
+        generator, args.count, required_features, args.max_attempts
+    )
     metadata = []
     feature_counts: dict[str, int] = {}
     for index, program in enumerate(programs):
@@ -248,27 +270,41 @@ def main() -> int:
         path.write_text(program.source)
         for feature in program.features:
             feature_counts[feature] = feature_counts.get(feature, 0) + 1
-        metadata.append({
-            "path": str(path),
-            "seed": args.seed,
-            "index": index,
-            "features": list(program.features),
-        })
+        metadata.append(
+            {
+                "path": str(path),
+                "seed": args.seed,
+                "index": index,
+                "features": list(program.features),
+            }
+        )
 
     if args.metadata is not None:
         args.metadata.parent.mkdir(parents=True, exist_ok=True)
-        args.metadata.write_text(json.dumps({
-            "sources": metadata,
-            "feature_counts": feature_counts,
-            "required_features": sorted(required_features),
-        }, indent=2, sort_keys=True) + "\n")
+        args.metadata.write_text(
+            json.dumps(
+                {
+                    "sources": metadata,
+                    "feature_counts": feature_counts,
+                    "required_features": sorted(required_features),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n"
+        )
 
-    print(json.dumps({
-        "sources": len(programs),
-        "seed": args.seed,
-        "out_dir": str(args.out_dir),
-        "features": feature_counts,
-    }, separators=(",", ":")))
+    print(
+        json.dumps(
+            {
+                "sources": len(programs),
+                "seed": args.seed,
+                "out_dir": str(args.out_dir),
+                "features": feature_counts,
+            },
+            separators=(",", ":"),
+        )
+    )
     return 0
 
 
@@ -290,7 +326,7 @@ def _generate_batch(
 
         missing = required_features - covered
         if missing:
-            program = generator.program_for_feature(sorted(missing)[0])
+            program = generator.program_for_feature(min(missing))
         else:
             program = generator.program()
         if len(programs) < count:

--- a/fuzz/fandango/symbolic_differential.py
+++ b/fuzz/fandango/symbolic_differential.py
@@ -15,7 +15,6 @@ import subprocess
 import tempfile
 from typing import Any
 
-
 SCHEMA = "solar:solsymdiff@v1"
 TEST_NAME = "checkSymbolicDifferential"
 DEFAULT_DYNAMIC_LENGTHS = (0, 1, 2, 3)
@@ -47,12 +46,13 @@ def main(argv: list[str] | None = None) -> int:
         "--include-stateful",
         action="store_true",
         help=(
-            "allow a nonpayable target under the clean zero-storage, "
-            "single-call model"
+            "allow a nonpayable target under the clean zero-storage, single-call model"
         ),
     )
     parser.add_argument("--project-root", type=pathlib.Path)
-    parser.add_argument("--include-path", type=pathlib.Path, action="append", default=[])
+    parser.add_argument(
+        "--include-path", type=pathlib.Path, action="append", default=[]
+    )
     parser.add_argument("--remapping", action="append", default=[])
     parser.add_argument("--solc", default="solc")
     parser.add_argument("--solar", default="target/debug/solar")
@@ -132,7 +132,9 @@ def main(argv: list[str] | None = None) -> int:
     }[result["status"]]
 
 
-def run(args: argparse.Namespace, output_root: pathlib.Path | None = None) -> dict[str, Any]:
+def run(
+    args: argparse.Namespace, output_root: pathlib.Path | None = None
+) -> dict[str, Any]:
     source = args.source.resolve()
     if not source.is_file():
         raise ValueError(f"source file does not exist: {source}")
@@ -211,11 +213,11 @@ def run(args: argparse.Namespace, output_root: pathlib.Path | None = None) -> di
     }
 
     if output_root is None:
-        output_root = pathlib.Path(__file__).resolve().parents[2] / "target" / "solsymdiff"
+        output_root = (
+            pathlib.Path(__file__).resolve().parents[2] / "target" / "solsymdiff"
+        )
     output_root.mkdir(parents=True, exist_ok=True)
-    project = pathlib.Path(
-        tempfile.mkdtemp(prefix=f"{source.stem}-", dir=output_root)
-    )
+    project = pathlib.Path(tempfile.mkdtemp(prefix=f"{source.stem}-", dir=output_root))
     (project / "standard-input.json").write_text(
         serialized_input + "\n",
         encoding="utf-8",
@@ -389,11 +391,11 @@ def _standard_input(
     with tempfile.TemporaryDirectory(prefix="solar-solsymdiff-imports-") as cwd:
         result = subprocess.run(
             command,
+            check=False,
             input=json.dumps(discovery_input),
             cwd=cwd,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout,
         )
     output = _compiler_json(result, "Solc import discovery")
@@ -408,7 +410,9 @@ def _standard_input(
             path = source
         else:
             candidates = tuple((root / name).resolve() for root in roots)
-            path = next((candidate for candidate in candidates if candidate.is_file()), None)
+            path = next(
+                (candidate for candidate in candidates if candidate.is_file()), None
+            )
             if path is None:
                 raise ValueError(f"could not snapshot imported source unit: {name}")
         sources[name] = {"content": path.read_text(encoding="utf-8")}
@@ -432,7 +436,9 @@ def _standard_input(
         **({"remappings": list(remappings)} if remappings else {}),
     }
     value = {"language": "Solidity", "sources": sources, "settings": settings}
-    serialized = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    serialized = json.dumps(
+        value, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
     return {
         "input": value,
         "root_source": root_source,
@@ -453,21 +459,21 @@ def _compile(
     with tempfile.TemporaryDirectory(prefix="solar-solsymdiff-compile-") as cwd:
         result = subprocess.run(
             [compiler, "--standard-json"],
+            check=False,
             input=standard_input,
             cwd=cwd,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             timeout=timeout,
         )
     output = _compiler_json(result, label)
 
     contracts = output.get("contracts")
-    source_contracts = contracts.get(source_name) if isinstance(contracts, dict) else None
+    source_contracts = (
+        contracts.get(source_name) if isinstance(contracts, dict) else None
+    )
     artifact = (
-        source_contracts.get(contract)
-        if isinstance(source_contracts, dict)
-        else None
+        source_contracts.get(contract) if isinstance(source_contracts, dict) else None
     )
     if not isinstance(artifact, dict):
         raise ValueError(f"{label} did not emit {source_name}:{contract}")
@@ -548,7 +554,9 @@ def _select_function(
         allowed.add("nonpayable")
     if mutability not in allowed:
         choices = ", ".join(sorted(allowed))
-        raise ValueError(f"{signature} has mutability {mutability!r}; allowed: {choices}")
+        raise ValueError(
+            f"{signature} has mutability {mutability!r}; allowed: {choices}"
+        )
     if not all(_supported_input(item) for item in solc_entry["inputs"]):
         raise ValueError(f"{signature} uses an unsupported symbolic input")
 
@@ -606,7 +614,9 @@ def _canonical_type(item: dict[str, Any]) -> str:
     if not isinstance(components, list):
         raise ValueError("tuple ABI value has no components")
     suffix = abi_type[len("tuple") :]
-    return f"({','.join(_canonical_type(component) for component in components)}){suffix}"
+    return (
+        f"({','.join(_canonical_type(component) for component in components)}){suffix}"
+    )
 
 
 def _function_shape(entry: dict[str, Any]) -> tuple[Any, ...]:
@@ -631,9 +641,7 @@ def _selector(identifiers: dict[str, Any], signature: str, label: str) -> str:
     try:
         bytes.fromhex(payload)
     except ValueError as err:
-        raise ValueError(
-            f"{label} emitted a non-hex selector for {signature}"
-        ) from err
+        raise ValueError(f"{label} emitted a non-hex selector for {signature}") from err
     return "0x" + payload.lower()
 
 
@@ -668,7 +676,7 @@ def _supported_elementary(abi_type: str) -> bool:
 
     if abi_type in {"address", "bool", "bytes", "string"}:
         return True
-    if abi_type.startswith("uint") or abi_type.startswith("int"):
+    if abi_type.startswith(("uint", "int")):
         width = abi_type[4:] if abi_type.startswith("uint") else abi_type[3:]
         return not width or (width.isdigit() and int(width) in range(8, 257, 8))
     if abi_type.startswith("bytes"):
@@ -746,9 +754,7 @@ def _write_project(
     (project / "test").mkdir()
 
     definitions, declarations = _solidity_parameters(function["inputs"])
-    arguments = ", ".join(
-        f"arg{index}" for index in range(len(function["inputs"]))
-    )
+    arguments = ", ".join(f"arg{index}" for index in range(len(function["inputs"])))
     encode_arguments = f", {arguments}" if arguments else ""
     word_checks = "\n".join(
         (
@@ -811,9 +817,9 @@ def _run_forge(
 ) -> dict[str, Any]:
     help_output = subprocess.run(
         [forge, "test", "--help"],
+        check=False,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=args.timeout,
     ).stdout
     command = [
@@ -862,11 +868,11 @@ def _run_forge(
     )
     result = subprocess.run(
         command,
+        check=False,
         cwd=project,
         env=env,
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=args.timeout,
     )
     if not result.stdout.strip():
@@ -898,9 +904,7 @@ def _classify(
             if isinstance(symbolic, dict):
                 matches.append((test_name, result, symbolic))
     if len(matches) != 1:
-        raise ValueError(
-            f"expected one symbolic result, found {len(matches)}"
-        )
+        raise ValueError(f"expected one symbolic result, found {len(matches)}")
 
     test_name, result, symbolic = matches[0]
     if not test_name.startswith(TEST_NAME):

--- a/fuzz/fandango/test_symbolic_differential.py
+++ b/fuzz/fandango/test_symbolic_differential.py
@@ -239,9 +239,7 @@ class ProjectGenerationTests(unittest.TestCase):
                 max_dynamic_length=256,
             )
 
-            test_source = (
-                project / "test" / "SymbolicDifferential.t.sol"
-            ).read_text()
+            test_source = (project / "test" / "SymbolicDifferential.t.sol").read_text()
             config = (project / "foundry.toml").read_text()
 
         self.assertIn("checkSymbolicDifferential(uint256 arg0)", test_source)
@@ -273,9 +271,7 @@ class ProjectGenerationTests(unittest.TestCase):
                 max_dynamic_length=256,
             )
 
-            test_source = (
-                project / "test" / "SymbolicDifferential.t.sol"
-            ).read_text()
+            test_source = (project / "test" / "SymbolicDifferential.t.sol").read_text()
             config = (project / "foundry.toml").read_text()
 
         self.assertIn("vm.recordLogs()", test_source)
@@ -412,7 +408,7 @@ class CommandTests(unittest.TestCase):
                         },
                     }
                 }
-            }
+            },
         }
         script = (
             "#!/usr/bin/env python3\n"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+extend-exclude = ["testdata"]
+
+[lint]
+ignore = ["BLE001", "EXE001", "TRY004"]

--- a/scripts/analyze_evm_ir_peepholes.py
+++ b/scripts/analyze_evm_ir_peepholes.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 from tabulate import tabulate
 
-
 DEFAULT_RUST_LOG = (
     "solar::codegen::evm_ir::peephole=trace,"
     "solar::codegen::mir::inst_simplify=trace,"
@@ -73,7 +72,14 @@ def capture(args: argparse.Namespace) -> int:
 
 
 def markdown_table(headers: list[str], rows: list[list[object]]) -> None:
-    print(tabulate(rows, headers=headers, tablefmt="pipe", colalign=("left",) + ("right",) * (len(headers) - 1)))
+    print(
+        tabulate(
+            rows,
+            headers=headers,
+            tablefmt="pipe",
+            colalign=("left",) + ("right",) * (len(headers) - 1),
+        )
+    )
     print()
 
 
@@ -102,7 +108,9 @@ def analyze(args: argparse.Namespace) -> int:
             if "solar::codegen::evm_ir::peephole: rewrite" in line:
                 module_match = re.search(r"evm_codegen\{module=([^}]+)\}", line)
                 if module_match is None:
-                    module_match = re.search(r"evm_ir_pipeline\{program=([^}]+)\}", line)
+                    module_match = re.search(
+                        r"evm_ir_pipeline\{program=([^}]+)\}", line
+                    )
                 module = module_match.group(1) if module_match else "unknown"
                 input_sequence = field(line, "input") or ""
                 output_sequence = field(line, "output") or ""
@@ -112,9 +120,13 @@ def analyze(args: argparse.Namespace) -> int:
             elif "solar::codegen::evm_ir::peephole: input" in line:
                 blocks += 1
                 instructions = (field(line, "instructions") or "").split(",")
-                instructions = [instruction for instruction in instructions if instruction]
+                instructions = [
+                    instruction for instruction in instructions if instruction
+                ]
                 for size in range(2, args.max_pattern + 1):
-                    ngrams.update(zip(*(instructions[offset:] for offset in range(size))))
+                    ngrams.update(
+                        zip(*(instructions[offset:] for offset in range(size)))
+                    )
             elif "mir_inst_simplify_round" in line:
                 round_number = int(field(line, "round") or 0)
                 simplified = int(field(line, "simplified") or 0)
@@ -127,7 +139,9 @@ def analyze(args: argparse.Namespace) -> int:
         return 1
 
     total_rewrites = sum(rewrites.values())
-    print(f"Analyzed {blocks:,} eligible input blocks and {total_rewrites:,} rewrites.\n")
+    print(
+        f"Analyzed {blocks:,} eligible input blocks and {total_rewrites:,} rewrites.\n"
+    )
     markdown_table(
         ["Input → Output", "Hits", "Share", "Top modules"],
         [
@@ -143,7 +157,9 @@ def analyze(args: argparse.Namespace) -> int:
                 )
                 or "-",
             ]
-            for (input_sequence, output_sequence), count in rewrites.most_common(args.top)
+            for (input_sequence, output_sequence), count in rewrites.most_common(
+                args.top
+            )
         ],
     )
 
@@ -152,13 +168,21 @@ def analyze(args: argparse.Namespace) -> int:
         markdown_table(
             ["Round", "Runs", "Changed runs", "Simplifications"],
             [
-                [round_number, runs, mir_round_changed[round_number], mir_round_simplified[round_number]]
+                [
+                    round_number,
+                    runs,
+                    mir_round_changed[round_number],
+                    mir_round_simplified[round_number],
+                ]
                 for round_number, runs in sorted(mir_round_runs.items())
             ],
         )
 
     rewritten_inputs = {
-        tuple(normalize_instruction(instruction) for instruction in input_sequence.split(","))
+        tuple(
+            normalize_instruction(instruction)
+            for instruction in input_sequence.split(",")
+        )
         for input_sequence, _ in rewrites
     }
 
@@ -181,7 +205,9 @@ def analyze(args: argparse.Namespace) -> int:
         and any(STACK_OP_RE.match(instruction) for instruction in pattern)
         and not overlaps_rewrite(pattern)
     ][: args.top]
-    print("Frequent stack-instruction patterns not exactly matched by a recorded rewrite:\n")
+    print(
+        "Frequent stack-instruction patterns not exactly matched by a recorded rewrite:\n"
+    )
     markdown_table(
         ["Pattern", "Occurrences"],
         [[",".join(pattern), count] for pattern, count in candidates],
@@ -193,16 +219,24 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
-    capture_parser = subparsers.add_parser("capture", help="run a command and capture its trace")
+    capture_parser = subparsers.add_parser(
+        "capture", help="run a command and capture its trace"
+    )
     capture_parser.add_argument("--append", action="store_true")
-    capture_parser.add_argument("--cwd", default=str(Path(__file__).resolve().parent.parent))
+    capture_parser.add_argument(
+        "--cwd", default=str(Path(__file__).resolve().parent.parent)
+    )
     capture_parser.add_argument("--rust-log", default=DEFAULT_RUST_LOG)
     capture_parser.add_argument("log")
     capture_parser.add_argument("command", nargs=argparse.REMAINDER)
     capture_parser.set_defaults(func=capture)
 
-    analyze_parser = subparsers.add_parser("analyze", help="print Markdown hit and pattern tables")
-    analyze_parser.add_argument("--max-pattern", type=int, choices=range(2, 7), default=4)
+    analyze_parser = subparsers.add_parser(
+        "analyze", help="print Markdown hit and pattern tables"
+    )
+    analyze_parser.add_argument(
+        "--max-pattern", type=int, choices=range(2, 7), default=4
+    )
     analyze_parser.add_argument("--min-count", type=int, default=2)
     analyze_parser.add_argument("--top", type=int, default=30)
     analyze_parser.add_argument("log")

--- a/scripts/bench_switch_lowering.py
+++ b/scripts/bench_switch_lowering.py
@@ -19,10 +19,10 @@ import sys
 import tarfile
 import tempfile
 import time
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence, TextIO
-
+from typing import Any, TextIO
 
 DEFAULT_PIN = "01209d2b8ac81645b92e3ef801b5bcdfd61bfd69"
 DEFAULT_SOLC_VERSION = "0.8.36"
@@ -119,7 +119,9 @@ BIT_SLICE_GROWTH_SWEEP = GrowthSweep(
 
 
 def run(command: Sequence[str], cwd: Path | None = None) -> str:
-    result = subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        command, cwd=cwd, check=True, capture_output=True, text=True
+    )
     return result.stdout.strip()
 
 
@@ -224,7 +226,9 @@ def load_benchmark_module(root: Path) -> Any:
     sys.modules.pop("gas_bench", None)
     sys.modules.pop("switch_solar_bench", None)
     sys.path.insert(0, str(root))
-    spec = importlib.util.spec_from_file_location("switch_solar_bench", root / "solar_bench.py")
+    spec = importlib.util.spec_from_file_location(
+        "switch_solar_bench", root / "solar_bench.py"
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError("could not load solar_bench.py")
     module = importlib.util.module_from_spec(spec)
@@ -282,7 +286,9 @@ def verify_submodule(root: Path, revision: str, display: str) -> dict[str, str]:
         raise RuntimeError(f"benchmark submodule is missing: {display}")
     actual = run(["git", "rev-parse", "HEAD"], root)
     if actual != revision:
-        raise RuntimeError(f"benchmark submodule {display} is at {actual}, expected {revision}")
+        raise RuntimeError(
+            f"benchmark submodule {display} is at {actual}, expected {revision}"
+        )
     if run(["git", "status", "--porcelain", "--untracked-files=normal"], root):
         raise RuntimeError(f"benchmark submodule has local changes: {display}")
 
@@ -444,7 +450,10 @@ contract {name} {{
     }}
 }}
 """
-    calls = [(f"entry-{index:02}", "select(uint256)", (str(value),)) for index, value in enumerate(values)]
+    calls = [
+        (f"entry-{index:02}", "select(uint256)", (str(value),))
+        for index, value in enumerate(values)
+    ]
     calls.extend(
         (f"miss-{index:02}", "select(uint256)", (str(value),))
         for index, value in enumerate(misses)
@@ -472,7 +481,9 @@ def synthetic_cases(
     for count in (4, 5, 6, 7, 8, 16, 32, 64):
         case, checks = selector_case(bench, count)
         cases.append(case)
-        labels[case.test_id] = [f"entry-{index:02}" for index in range(count)] + ["miss-00"]
+        labels[case.test_id] = [f"entry-{index:02}" for index in range(count)] + [
+            "miss-00"
+        ]
         runtime_checks[case.test_id] = checks
 
     for count in (4, 5, 6, 7, 8, 16, 32, 64):
@@ -592,7 +603,7 @@ def compiler_specs(
                 *variant.flags,
             )
         )
-        wrapper.write_text(f"#!/bin/sh\nexec {command} \"$@\"\n")
+        wrapper.write_text(f'#!/bin/sh\nexec {command} "$@"\n')
         wrapper.chmod(0o755)
         specs.append(
             bench.CompilerSpec(
@@ -628,7 +639,9 @@ def parse_integer_ranges(value: str) -> list[int]:
                 start = int(start_text)
                 end = int(end_text.removeprefix("="))
             except ValueError as error:
-                raise argparse.ArgumentTypeError(f"invalid integer range: {item}") from error
+                raise argparse.ArgumentTypeError(
+                    f"invalid integer range: {item}"
+                ) from error
             if start < 0 or end < start:
                 raise argparse.ArgumentTypeError(f"invalid integer range: {item}")
             values.extend(range(start, end + 1))
@@ -729,9 +742,11 @@ def parse_solar_corpus_output(stdout: str) -> tuple[str | None, str | None, int,
     runtimes = []
     for contract in output["contracts"].values():
         bytecode = str(contract.get("bin") or "").strip().removeprefix("0x")
-        runtime = str(
-            contract.get("bin-runtime") or contract.get("bin_runtime") or ""
-        ).strip().removeprefix("0x")
+        runtime = (
+            str(contract.get("bin-runtime") or contract.get("bin_runtime") or "")
+            .strip()
+            .removeprefix("0x")
+        )
         if bytecode:
             bytecodes.append(bytecode)
             runtimes.append(runtime)
@@ -770,7 +785,9 @@ def run_ui_case(
             "error": "",
         }
         if process.returncode == 0:
-            bytecode, runtime, contracts, error = parse_solar_corpus_output(process.stdout)
+            bytecode, runtime, contracts, error = parse_solar_corpus_output(
+                process.stdout
+            )
             if bytecode:
                 bytecode_size, bytecode_hash = persist_bytecode(
                     artifact_dir,
@@ -795,9 +812,9 @@ def run_ui_case(
             else:
                 compiler["error"] = error
         else:
-            compiler["error"] = (
-                process.stderr or process.stdout or "compiler failed"
-            )[:1000]
+            compiler["error"] = (process.stderr or process.stdout or "compiler failed")[
+                :1000
+            ]
         compilers[spec.compiler_id] = compiler
     return {
         "test_id": case.test_id,
@@ -862,7 +879,9 @@ def write_text_atomic(path: Path, contents: str) -> None:
             temporary.unlink(missing_ok=True)
 
 
-def write_results(path: Path, metadata: dict[str, Any], results: Sequence[dict[str, Any]]) -> None:
+def write_results(
+    path: Path, metadata: dict[str, Any], results: Sequence[dict[str, Any]]
+) -> None:
     for result in results:
         strip_embedded_bytecode(result)
     write_text_atomic(
@@ -938,9 +957,8 @@ def apply_gas_schema(
         if not isinstance(gas_results, list) or len(gas_results) != len(runner_schema):
             raise RuntimeError(f"{compiler_id} returned the wrong number of gas calls")
         for gas_result, actual, expected in zip(gas_results, runner_schema, schema):
-            if (
-                not isinstance(gas_result, dict)
-                or any(gas_result.get(key) != value for key, value in actual.items())
+            if not isinstance(gas_result, dict) or any(
+                gas_result.get(key) != value for key, value in actual.items()
             ):
                 raise RuntimeError(f"{compiler_id} returned gas for an unexpected call")
             gas_result["label"] = expected["label"]
@@ -1053,14 +1071,20 @@ def run_cases(
                 gas_profile,
                 labels[case.test_id] if labels is not None else None,
             )
-        if case.test_id in previous and result_is_complete(
-            previous[case.test_id],
-            specs,
-            include_gas,
-            schema,
-            expected_status,
-            include_gas and expected_status == "ok",
-        ) and result_artifact_files_valid(previous[case.test_id], specs, output.parent):
+        if (
+            case.test_id in previous
+            and result_is_complete(
+                previous[case.test_id],
+                specs,
+                include_gas,
+                schema,
+                expected_status,
+                include_gas and expected_status == "ok",
+            )
+            and result_artifact_files_valid(
+                previous[case.test_id], specs, output.parent
+            )
+        ):
             print(f"[{index}/{len(cases)}] {case.test_id} (cached)", flush=True)
             results.append(strip_embedded_bytecode(previous[case.test_id]))
             continue
@@ -1131,10 +1155,14 @@ def run_cases(
                 compiler = partial["compilers"][spec.compiler_id]
                 for equivalent_spec in equivalent_specs:
                     equivalent = copy.deepcopy(compiler)
-                    equivalent.update(compiled["compilers"][equivalent_spec.compiler_id])
+                    equivalent.update(
+                        compiled["compilers"][equivalent_spec.compiler_id]
+                    )
                     result["compilers"][equivalent_spec.compiler_id] = equivalent
             if partial.get("runtime_status") != "ok" and expected_status == "ok":
-                raise RuntimeError(f"{case.test_id} did not match the reference compiler")
+                raise RuntimeError(
+                    f"{case.test_id} did not match the reference compiler"
+                )
             bench.compare_runtime_results(result, specs)
             if not result_is_complete(
                 result,
@@ -1144,7 +1172,9 @@ def run_cases(
                 expected_status,
                 expected_status == "ok",
             ):
-                raise RuntimeError(f"{case.test_id} has incomplete gas results after retries")
+                raise RuntimeError(
+                    f"{case.test_id} has incomplete gas results after retries"
+                )
         else:
             result = compile_specs(
                 bench,
@@ -1220,11 +1250,9 @@ def result_is_complete(
             or result.get("expected_gas_schema") != schema
         ):
             return False
-        if (
-            compiler.get("reference_runtime_status") != "ok"
-            or compiler.get("runtime_checks_sha256")
-            != compiler.get("reference_checks_sha256")
-        ):
+        if compiler.get("reference_runtime_status") != "ok" or compiler.get(
+            "runtime_checks_sha256"
+        ) != compiler.get("reference_checks_sha256"):
             return False
         if compiler.get("deploy_status") != "ok" or compiler.get("gas_status") != "ok":
             return False
@@ -1233,11 +1261,16 @@ def result_is_complete(
     return True
 
 
-def successful_intersection(results: Sequence[dict[str, Any]], methods: Sequence[str]) -> list[dict[str, Any]]:
+def successful_intersection(
+    results: Sequence[dict[str, Any]], methods: Sequence[str]
+) -> list[dict[str, Any]]:
     return [
         result
         for result in results
-        if all(result["compilers"].get(method, {}).get("status") == "ok" for method in methods)
+        if all(
+            result["compilers"].get(method, {}).get("status") == "ok"
+            for method in methods
+        )
     ]
 
 
@@ -1264,8 +1297,12 @@ def scope_rows(
             if gas_result.get("gas") is not None
         ]
         totals[method] = {
-            "deploy": sum(int(compiler.get("bytecode_size") or 0) for compiler in compilers),
-            "runtime": sum(int(compiler.get("runtime_size") or 0) for compiler in compilers),
+            "deploy": sum(
+                int(compiler.get("bytecode_size") or 0) for compiler in compilers
+            ),
+            "runtime": sum(
+                int(compiler.get("runtime_size") or 0) for compiler in compilers
+            ),
             "gas": sum(gas_values),
             "calls": len(gas_values),
         }
@@ -1323,7 +1360,9 @@ def render_markdown(
         if any(metadata.get(key) != value for key, value in metadata_base.items()):
             raise RuntimeError(f"{path} has mismatched benchmark provenance")
         if metadata.get("scope") != scope:
-            raise RuntimeError(f"{path} contains scope {metadata.get('scope')}, expected {scope}")
+            raise RuntimeError(
+                f"{path} contains scope {metadata.get('scope')}, expected {scope}"
+            )
         payloads.append(payload)
 
     for payload in payloads:
@@ -1344,7 +1383,9 @@ def render_markdown(
                 str(len(successful_intersection(results, methods))),
                 ", ".join(sorted(expected_failures)) or "none",
                 ", ".join(metadata.get("excluded_cases") or ()) or "none",
-                ", ".join(f"{key}: {value}" for key, value in sorted(runtime_statuses.items())),
+                ", ".join(
+                    f"{key}: {value}" for key, value in sorted(runtime_statuses.items())
+                ),
             ]
         )
         if include_details and metadata["scope"].startswith("ci-"):
@@ -1384,7 +1425,7 @@ def render_markdown(
                 row = [
                     metadata["scope"],
                     str(result["test_id"]),
-                    f'{auto["bytecode_size"]}/{auto["runtime_size"]}',
+                    f"{auto['bytecode_size']}/{auto['runtime_size']}",
                 ]
                 for method in methods:
                     if method == "auto":
@@ -1399,9 +1440,9 @@ def render_markdown(
                         and compiler["runtime_size"] == auto["runtime_size"]
                     )
                     row.append(
-                        f'{compiler["bytecode_size"]}/{compiler["runtime_size"]} '
-                        f'({percent_delta(compiler["runtime_size"], auto["runtime_size"])})'
-                        f'{"; code differs" if differs and same_sizes else ""}'
+                        f"{compiler['bytecode_size']}/{compiler['runtime_size']} "
+                        f"({percent_delta(compiler['runtime_size'], auto['runtime_size'])})"
+                        f"{'; code differs' if differs and same_sizes else ''}"
                     )
                 ui_rows.append(row)
         if not include_details or metadata["scope"] != "synthetic":
@@ -1413,12 +1454,14 @@ def render_markdown(
                 entries = [
                     int(item["gas"])
                     for item in gas_results
-                    if str(item["label"]).startswith("entry-") and item.get("gas") is not None
+                    if str(item["label"]).startswith("entry-")
+                    and item.get("gas") is not None
                 ]
                 misses = [
                     int(item["gas"])
                     for item in gas_results
-                    if str(item["label"]).startswith("miss-") and item.get("gas") is not None
+                    if str(item["label"]).startswith("miss-")
+                    and item.get("gas") is not None
                 ]
                 synthetic_rows.append(
                     [
@@ -1572,7 +1615,9 @@ def load_scope(output_dir: Path, scope: str) -> dict[str, Any]:
     return json.loads(path.read_text())
 
 
-def results_by_test_id(payload: dict[str, Any], scope: str) -> dict[str, dict[str, Any]]:
+def results_by_test_id(
+    payload: dict[str, Any], scope: str
+) -> dict[str, dict[str, Any]]:
     results = payload.get("results")
     if not isinstance(results, list):
         raise RuntimeError(f"{scope} results are missing")
@@ -1621,7 +1666,9 @@ def validate_growth_sweep_inputs(
         if key not in canonical or canonical[key] is None
     ]
     if missing:
-        raise RuntimeError(f"synthetic compile provenance is missing {', '.join(missing)}")
+        raise RuntimeError(
+            f"synthetic compile provenance is missing {', '.join(missing)}"
+        )
     if canonical.get("fixture_version") != SYNTHETIC_FIXTURE_VERSION:
         raise RuntimeError(
             "synthetic compile fixture version differs from the growth sweep manifest"
@@ -1643,7 +1690,9 @@ def validate_growth_sweep_inputs(
         if metadata.get("methods") != expected_methods:
             raise RuntimeError(f"{scope} methods differ from the growth sweep manifest")
         if metadata.get("variants") != expected_variants:
-            raise RuntimeError(f"{scope} variants differ from the growth sweep manifest")
+            raise RuntimeError(
+                f"{scope} variants differ from the growth sweep manifest"
+            )
         compile_results[scope] = results_by_test_id(payload, scope)
         for test_id, result in compile_results[scope].items():
             if list(result.get("compilers") or ()) != expected_methods:
@@ -1651,9 +1700,8 @@ def validate_growth_sweep_inputs(
                     f"{scope}/{test_id} compilers differ from the growth sweep manifest"
                 )
             for compiler_id, compiler in result["compilers"].items():
-                if (
-                    compiler.get("status") != "ok"
-                    or not artifact_files_valid(compile_dir, compiler)
+                if compiler.get("status") != "ok" or not artifact_files_valid(
+                    compile_dir, compiler
                 ):
                     raise RuntimeError(
                         f"{scope}/{test_id}/{compiler_id} artifact is invalid"
@@ -1704,9 +1752,8 @@ def validate_growth_sweep_inputs(
             if not valid_gas_schema(schema) or len(schema) != expected_calls:
                 raise RuntimeError(f"{scope}/{test_id} expected gas schema is invalid")
             for compiler_id, compiler in result["compilers"].items():
-                if (
-                    compiler.get("status") != "ok"
-                    or not artifact_files_valid(gas_dir, compiler)
+                if compiler.get("status") != "ok" or not artifact_files_valid(
+                    gas_dir, compiler
                 ):
                     raise RuntimeError(
                         f"{scope}/{test_id}/{compiler_id} artifact is invalid"
@@ -1720,9 +1767,13 @@ def validate_growth_sweep_inputs(
                     raise RuntimeError(f"{scope}/{test_id}/{compiler_id} checks failed")
                 checks = compiler.get("runtime_checks_sha256")
                 if not checks or checks != compiler.get("reference_checks_sha256"):
-                    raise RuntimeError(f"{scope}/{test_id}/{compiler_id} check digests differ")
+                    raise RuntimeError(
+                        f"{scope}/{test_id}/{compiler_id} check digests differ"
+                    )
                 if not complete_gas_results(compiler, schema):
-                    raise RuntimeError(f"{scope}/{test_id}/{compiler_id} gas calls are incomplete")
+                    raise RuntimeError(
+                        f"{scope}/{test_id}/{compiler_id} gas calls are incomplete"
+                    )
             default = result["compilers"]["auto"]
             policy = result["compilers"][policy_compiler_id]
             if (
@@ -1746,8 +1797,7 @@ def render_growth_sweep(
         for scope in ("synthetic", "ui-gas", "ci-gas")
     }
     gas_payloads = {
-        scope: load_scope(gas_dir, scope)
-        for scope in ("synthetic", "ci-gas")
+        scope: load_scope(gas_dir, scope) for scope in ("synthetic", "ci-gas")
     }
     validate_growth_sweep_inputs(
         compile_dir,
@@ -1781,7 +1831,9 @@ def render_growth_sweep(
                 )
                 previous = measured.setdefault(key, gas)
                 if previous != gas:
-                    raise RuntimeError(f"inconsistent gas for identical bytecode: {key}")
+                    raise RuntimeError(
+                        f"inconsistent gas for identical bytecode: {key}"
+                    )
 
     rows = []
     fingerprints = {}
@@ -1799,7 +1851,9 @@ def render_growth_sweep(
             for result in payload["results"]:
                 compiler = result["compilers"][compiler_id]
                 if compiler.get("status") != "ok":
-                    raise RuntimeError(f"{scope}/{result['test_id']}/{compiler_id} failed")
+                    raise RuntimeError(
+                        f"{scope}/{result['test_id']}/{compiler_id} failed"
+                    )
                 key = artifact_key(compiler)
                 fingerprint.append((scope, result["test_id"], *key))
                 deploy += compiler["bytecode_size"]
@@ -1837,7 +1891,9 @@ def render_growth_sweep(
             contract_regression = sum(calls.values()) - sum(baseline_calls.values())
             if contract_regression > 0:
                 regressing_contracts.append([test_id, contract_regression])
-                max_contract_regression = max(max_contract_regression, contract_regression)
+                max_contract_regression = max(
+                    max_contract_regression, contract_regression
+                )
             for label, gas in calls.items():
                 max_call_regression = max(
                     max_call_regression, gas - baseline_calls[label]
@@ -1874,7 +1930,9 @@ def render_growth_sweep(
             contract_regression = sum(calls.values()) - sum(reference_calls.values())
             if contract_regression > 0:
                 regressing_contracts.append([test_id, contract_regression])
-                max_contract_regression = max(max_contract_regression, contract_regression)
+                max_contract_regression = max(
+                    max_contract_regression, contract_regression
+                )
             for label, gas in calls.items():
                 max_call_regression = max(
                     max_call_regression, gas - reference_calls[label]
@@ -2069,7 +2127,9 @@ def validate_local_growth_sweep_provenance(
     for tool in ("anvil", "cast"):
         path = shutil.which(tool)
         if path is None:
-            raise RuntimeError(f"{tool} is required to validate growth sweep provenance")
+            raise RuntimeError(
+                f"{tool} is required to validate growth sweep provenance"
+            )
         tool_paths[tool] = Path(path).resolve()
 
     corpus_revisions = verify_corpus_pin(benchmark_repo, pin)
@@ -2128,8 +2188,12 @@ def main() -> int:
         / f".local/share/svm/{DEFAULT_SOLC_VERSION}/solc-{DEFAULT_SOLC_VERSION}",
     )
     parser.add_argument("--ui-corpus", type=Path, default=Path("tests/ui/codegen"))
-    parser.add_argument("--output-dir", type=Path, default=Path("target/codegen-bench/switch"))
-    parser.add_argument("--methods", nargs="+", choices=DEFAULT_METHODS, default=DEFAULT_METHODS)
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("target/codegen-bench/switch")
+    )
+    parser.add_argument(
+        "--methods", nargs="+", choices=DEFAULT_METHODS, default=DEFAULT_METHODS
+    )
     parser.add_argument(
         "--auto-growth-budgets",
         type=parse_integer_ranges,
@@ -2280,7 +2344,9 @@ def main() -> int:
             "solar_revision": built_revision,
             "source_tree": run(["git", "rev-parse", "HEAD^{tree}"], source_root),
             "benchmark_pin": args.pin,
-            "benchmark_tree": run(["git", "rev-parse", f"{args.pin}^{{tree}}"], benchmark_repo),
+            "benchmark_tree": run(
+                ["git", "rev-parse", f"{args.pin}^{{tree}}"], benchmark_repo
+            ),
             "benchmark_script_sha256": sha256(pinned_root / "solar_bench.py"),
             "gas_script_sha256": sha256(pinned_root / "gas_bench.py"),
             "benchmark_fixtures_sha256": benchmark_fixtures_sha256,
@@ -2368,9 +2434,7 @@ def main() -> int:
             run_cases(
                 bench,
                 cases,
-                compiler_specs(
-                    bench, solar, variants, "gas", wrapper_dir
-                ),
+                compiler_specs(bench, solar, variants, "gas", wrapper_dir),
                 output_dir / "synthetic.json",
                 metadata,
                 not args.compile_only,
@@ -2398,9 +2462,7 @@ def main() -> int:
                 run_cases(
                     bench,
                     ui_cases,
-                    compiler_specs(
-                        bench, solar, variants, optimization, wrapper_dir
-                    ),
+                    compiler_specs(bench, solar, variants, optimization, wrapper_dir),
                     output_dir / f"{scope}.json",
                     metadata,
                     False,
@@ -2434,9 +2496,7 @@ def main() -> int:
                 run_cases(
                     bench,
                     ci_cases,
-                    compiler_specs(
-                        bench, solar, variants, optimization, wrapper_dir
-                    ),
+                    compiler_specs(bench, solar, variants, optimization, wrapper_dir),
                     output_dir / f"{scope}.json",
                     metadata,
                     False,
@@ -2455,9 +2515,7 @@ def main() -> int:
             run_cases(
                 bench,
                 ci_cases,
-                compiler_specs(
-                    bench, solar, variants, "gas", wrapper_dir
-                ),
+                compiler_specs(bench, solar, variants, "gas", wrapper_dir),
                 output_dir / "ci-gas.json",
                 metadata,
                 not args.compile_only,

--- a/scripts/gen_compile_repros.py
+++ b/scripts/gen_compile_repros.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-
 HEADER = "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\n"
 
 SIZE_CONFIGS = {
@@ -24,9 +23,13 @@ def main() -> None:
     output_dir = Path(__file__).resolve().parents[1] / "testdata" / "repros"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    configs = SIZE_CONFIGS.values() if args.sizes == "all" else (SIZE_CONFIGS[args.sizes],)
+    configs = (
+        SIZE_CONFIGS.values() if args.sizes == "all" else (SIZE_CONFIGS[args.sizes],)
+    )
     for size_name, n_symbols, n_depth, n_types in configs:
-        print(f"Generating {size_name} repros (n={n_symbols}, depth={n_depth}, types={n_types})...")
+        print(
+            f"Generating {size_name} repros (n={n_symbols}, depth={n_depth}, types={n_types})..."
+        )
         generate_many_symbols(output_dir, size_name, n_symbols)
         generate_many_functions(output_dir, size_name, n_symbols)
         generate_deep_nesting(output_dir, size_name, n_depth)
@@ -57,7 +60,10 @@ def generate_many_symbols(directory: Path, size: str, n: int) -> None:
 
 def generate_many_functions(directory: Path, size: str, n: int) -> None:
     lines = ["contract C{"]
-    lines.extend(f"function f{i}(uint x)public pure returns(uint r){{r=x+{i};}}" for i in range(n))
+    lines.extend(
+        f"function f{i}(uint x)public pure returns(uint r){{r=x+{i};}}"
+        for i in range(n)
+    )
     lines.append("}")
     write_file(directory, f"many_functions_{size}.sol", source(lines))
 
@@ -75,7 +81,11 @@ def generate_deep_nesting(directory: Path, size: str, depth: int) -> None:
     loops.append("}" * loop_depth)
     loops.append("}")
 
-    write_file(directory, f"deep_nesting_{size}.sol", source(["contract C{", *nested, *loops, "}"]))
+    write_file(
+        directory,
+        f"deep_nesting_{size}.sol",
+        source(["contract C{", *nested, *loops, "}"]),
+    )
 
 
 def generate_many_types(directory: Path, size: str, n: int) -> None:
@@ -103,9 +113,12 @@ def generate_large_literals(directory: Path, size: str, n: int) -> None:
     lines.append("}")
 
     strings = ",".join(
-        f'"String literal number {i} with some content to make it longer"' for i in range(min(n, 50))
+        f'"String literal number {i} with some content to make it longer"'
+        for i in range(min(n, 50))
     )
-    lines.append(f"function g()public pure returns(string memory r){{r=string(abi.encodePacked({strings}));}}")
+    lines.append(
+        f"function g()public pure returns(string memory r){{r=string(abi.encodePacked({strings}));}}"
+    )
     lines.append("}")
     write_file(directory, f"large_literals_{size}.sol", source(lines))
 
@@ -145,9 +158,13 @@ def generate_many_storage(directory: Path, size: str, n: int) -> None:
 
 def generate_many_events(directory: Path, size: str, n: int) -> None:
     lines = ["contract C{"]
-    lines.extend(f"event E{i}(address indexed a,uint indexed b,bytes32 c);" for i in range(n))
+    lines.extend(
+        f"event E{i}(address indexed a,uint indexed b,bytes32 c);" for i in range(n)
+    )
     lines.append("function f()public{")
-    lines.extend(f"emit E{i}(msg.sender,{i},bytes32(uint({i})));" for i in range(min(n, 100)))
+    lines.extend(
+        f"emit E{i}(msg.sender,{i},bytes32(uint({i})));" for i in range(min(n, 100))
+    )
     lines.extend(("}", "}"))
     write_file(directory, f"many_events_{size}.sol", source(lines))
 


### PR DESCRIPTION
PR benchmark runs now reuse solc compile, gas, and runtime data from the exact-base profile and execute only the fresh Solar leg. The runner accepts cached solc data only when both the compiler input fingerprint and runtime workload match, then reruns the cross-compiler semantic comparison over the combined profile. Main and exact-base fallback runs still produce complete two-compiler profiles.

This also adds `--solar-only` for local iteration. In the measured nine-project compile-time workload, the two-compiler run took 288.445 seconds while Solar-only took 24.394 seconds, an 11.82x speedup. The skipped solc compiler samples accounted for 260.713 seconds; PR CI also avoids repeating the cached solc hot-runtime workload.
