### PR TITLE
fix(lsp): gate Unix-only test import

### DIFF
--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -278,8 +278,10 @@ async fn collect_pipe(pipe: JoinHandle<io::Result<Vec<u8>>>) -> io::Result<Vec<u
 mod tests {
     use super::*;
     #[cfg(unix)]
+    use crate::config::negotiate_capabilities;
+    use crate::test_support::TestProject;
+    #[cfg(unix)]
     use crate::test_support::process_exists;
-    use crate::{config::negotiate_capabilities, test_support::TestProject};
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- gate `negotiate_capabilities` behind `cfg(unix)` because only the Unix-only timeout test uses it
- eliminate the unused import warning on Windows test builds

## Testing

- `cargo check -p solar-lsp --tests --target x86_64-pc-windows-gnu`
- `cargo test -p solar-lsp --lib` (1,030 passed, 1 ignored)
- `cargo +nightly fmt --all --check`

Prompted by: @DaniPopes