### PR TITLE
feat(lsp): reload host Foundry config

### DIFF
--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -681,6 +681,13 @@ impl Config {
         &self,
         cancellation: &IndexingCancellation,
     ) -> Option<WorkspaceDiscoveryResult> {
+        self.try_discover_workspaces(cancellation).ok().flatten()
+    }
+
+    pub(crate) fn try_discover_workspaces(
+        &self,
+        cancellation: &IndexingCancellation,
+    ) -> Result<Option<WorkspaceDiscoveryResult>, WorkspaceError> {
         let start = std::time::Instant::now();
         let mut metrics = WorkspaceIndexMetrics::default();
         let mut workspaces = Vec::new();
@@ -693,9 +700,9 @@ impl Config {
         );
         for root in &self.workspace_roots {
             if cancellation.is_cancelled() {
-                return None;
+                return Ok(None);
             }
-            let (discovered, discovered_watch_roots, discovered_marker_watch_roots) =
+            let Some((discovered, discovered_watch_roots, discovered_marker_watch_roots)) =
                 ProjectManifest::discover_all_with_watch_roots(
                     std::slice::from_ref(root),
                     &self.workspace_roots,
@@ -703,7 +710,10 @@ impl Config {
                     cancellation,
                     &mut metrics,
                     &mut foundry_config,
-                )?;
+                )
+            else {
+                return Ok(None);
+            };
             manifest_watch_roots.extend(discovered_watch_roots);
             git_marker_watch_roots.extend(discovered_marker_watch_roots);
             info!(?root, ?discovered, "discovered projects");
@@ -713,21 +723,17 @@ impl Config {
                 continue;
             }
 
-            if load_discovered_workspaces(
+            load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
                 &mut foundry_config,
                 &mut seen_manifests,
                 &mut workspaces,
-            )
-            .is_err()
-            {
-                return None;
-            }
+            )?;
         }
         info!(workspaces = ?workspaces.iter().map(Workspace::kind).collect::<Vec<_>>(), "loaded workspaces");
         if cancellation.is_cancelled() {
-            return None;
+            return Ok(None);
         }
         loop {
             if !Workspace::refresh_all_source_files(
@@ -736,7 +742,7 @@ impl Config {
                 cancellation,
                 &mut metrics,
             ) {
-                return None;
+                return Ok(None);
             }
             let mut roots = workspaces
                 .iter()
@@ -748,11 +754,11 @@ impl Config {
                 .collect::<Vec<_>>();
             roots.sort_unstable();
             roots.dedup();
-            let discovered = ProjectManifest::discover_in_source_watch_roots(
-                &roots,
-                cancellation,
-                &mut metrics,
-            )?;
+            let Some(discovered) =
+                ProjectManifest::discover_in_source_watch_roots(&roots, cancellation, &mut metrics)
+            else {
+                return Ok(None);
+            };
             match load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
@@ -762,7 +768,7 @@ impl Config {
             ) {
                 Ok(0) => break,
                 Ok(_) => {}
-                Err(_) => return None,
+                Err(error) => return Err(error),
             }
         }
         WorkspacePathIndex::reconcile_source_files(
@@ -784,12 +790,12 @@ impl Config {
         manifest_watch_roots.dedup();
         git_marker_watch_roots.sort_unstable();
         git_marker_watch_roots.dedup();
-        Some(WorkspaceDiscoveryResult {
+        Ok(Some(WorkspaceDiscoveryResult {
             workspaces,
             manifest_watch_roots,
             git_marker_watch_roots,
             metrics,
-        })
+        }))
     }
 
     pub(crate) fn apply_workspace_discovery(

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -671,12 +671,22 @@ impl Config {
         self.flychecks.iter().map(FlycheckConfig::owner)
     }
 
+    #[cfg(test)]
     pub(crate) fn rediscover_workspaces(&mut self) -> Vec<DiagnosticOwner> {
-        let cancellation = IndexingCancellation::default();
-        let Some(result) = self.discover_workspaces(&cancellation) else { return Vec::new() };
-        self.apply_workspace_discovery(result)
+        self.try_rediscover_workspaces().unwrap_or_default()
     }
 
+    pub(crate) fn try_rediscover_workspaces(
+        &mut self,
+    ) -> Result<Vec<DiagnosticOwner>, WorkspaceError> {
+        let cancellation = IndexingCancellation::default();
+        let Some(result) = self.try_discover_workspaces(&cancellation)? else {
+            return Ok(Vec::new());
+        };
+        Ok(self.apply_workspace_discovery(result))
+    }
+
+    #[cfg(any(test, feature = "bench"))]
     pub(crate) fn discover_workspaces(
         &self,
         cancellation: &IndexingCancellation,
@@ -821,6 +831,10 @@ impl Config {
                 self.workspace_roots.push(path);
             }
         }
+    }
+
+    pub(crate) fn replace_workspace_roots(&mut self, roots: Vec<PathBuf>) {
+        self.workspace_roots = roots;
     }
 
     pub(crate) fn reconcile_workspace_roots(

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FoundryWorkspaceConfig, LaunchConfig, commands,
+    FoundryWorkspaceConfig, FoundryWorkspaceConfigLoader, LaunchConfig, commands,
     diagnostics::DiagnosticOwner,
     file_operations::FileMoveBatch,
     flycheck::{FlycheckConfig, FlycheckInitializationOptions},
@@ -49,6 +49,7 @@ pub(crate) struct Config {
     forge_path: PathBuf,
     selected_profile: Option<String>,
     foundry_workspace_configs: Vec<FoundryWorkspaceConfig>,
+    foundry_workspace_config_loader: Option<FoundryWorkspaceConfigLoader>,
     workspaces: Vec<Workspace>,
     manifest_watch_roots: Vec<SourceWatchRoot>,
     git_marker_watch_roots: Vec<PathBuf>,
@@ -133,6 +134,7 @@ impl Default for Config {
             forge_path: PathBuf::from("forge"),
             selected_profile: None,
             foundry_workspace_configs: Vec::new(),
+            foundry_workspace_config_loader: None,
             workspaces: Vec::new(),
             manifest_watch_roots: Vec::new(),
             git_marker_watch_roots: Vec::new(),
@@ -686,9 +688,12 @@ impl Config {
         let mut manifest_watch_roots = Vec::new();
         let mut git_marker_watch_roots = Vec::new();
         let mut seen_manifests = FxHashSet::default();
-        let foundry_config = FoundryConfigContext::new(
+        let (foundry_workspace_configs, foundry_workspace_config_errors) =
+            self.load_foundry_workspace_configs();
+        let foundry_config = FoundryConfigContext::with_errors(
             self.selected_profile.as_deref(),
-            &self.foundry_workspace_configs,
+            &foundry_workspace_configs,
+            &foundry_workspace_config_errors,
         );
         for root in &self.workspace_roots {
             if cancellation.is_cancelled() {
@@ -795,6 +800,38 @@ impl Config {
         self.git_marker_watch_roots = result.git_marker_watch_roots;
         self.index_metrics = result.metrics;
         self.refresh_flychecks()
+    }
+
+    fn load_foundry_workspace_configs(
+        &self,
+    ) -> (Vec<FoundryWorkspaceConfig>, Vec<(PathBuf, String)>) {
+        let Some(loader) = &self.foundry_workspace_config_loader else {
+            return (self.foundry_workspace_configs.clone(), Vec::new());
+        };
+        let mut configs = Vec::with_capacity(self.foundry_workspace_configs.len());
+        let mut errors = Vec::new();
+        for snapshot in &self.foundry_workspace_configs {
+            let root = snapshot.workspace_root();
+            match loader.load(root) {
+                Ok(config) => {
+                    let config = config.into_normalized();
+                    if config.workspace_root() == root {
+                        configs.push(config);
+                    } else {
+                        errors.push((
+                            root.to_path_buf(),
+                            format!(
+                                "host returned Foundry configuration for `{}` while loading `{}`",
+                                config.workspace_root().display(),
+                                root.display()
+                            ),
+                        ));
+                    }
+                }
+                Err(error) => errors.push((root.to_path_buf(), error)),
+            }
+        }
+        (configs, errors)
     }
 
     pub(crate) fn remove_workspace(&mut self, path: &Path) {
@@ -1199,6 +1236,9 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
             forge_path,
             selected_profile: launch_config.selected_profile().map(str::to_owned),
             foundry_workspace_configs: launch_config.foundry_workspace_configs().to_vec(),
+            foundry_workspace_config_loader: launch_config
+                .foundry_workspace_config_loader()
+                .cloned(),
             index_policy,
             flycheck_options,
             watched_file_dynamic_registration,

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,11 +1,12 @@
 use crate::{
-    FoundryWorkspaceConfig, FoundryWorkspaceConfigLoader, LaunchConfig, commands,
+    FoundryWorkspaceConfigSource, LaunchConfig, commands,
     diagnostics::DiagnosticOwner,
     file_operations::FileMoveBatch,
     flycheck::{FlycheckConfig, FlycheckInitializationOptions},
     import_resolution::ImportResolutionContext,
     workspace::{
-        FoundryConfigContext, SourceWatchRoot, Workspace, WorkspaceKind, WorkspacePathIndex,
+        FoundryConfigContext, SourceWatchRoot, Workspace, WorkspaceError, WorkspaceKind,
+        WorkspacePathIndex,
         index_policy::{
             IndexingCancellation, IndexingOptions, WorkspaceIndexMetrics, WorkspaceIndexPolicy,
         },
@@ -48,8 +49,7 @@ pub(crate) struct Config {
     workspace_roots: Vec<PathBuf>,
     forge_path: PathBuf,
     selected_profile: Option<String>,
-    foundry_workspace_configs: Vec<FoundryWorkspaceConfig>,
-    foundry_workspace_config_loader: Option<FoundryWorkspaceConfigLoader>,
+    foundry_workspace_config_source: FoundryWorkspaceConfigSource,
     workspaces: Vec<Workspace>,
     manifest_watch_roots: Vec<SourceWatchRoot>,
     git_marker_watch_roots: Vec<PathBuf>,
@@ -133,8 +133,7 @@ impl Default for Config {
             workspace_roots: Vec::new(),
             forge_path: PathBuf::from("forge"),
             selected_profile: None,
-            foundry_workspace_configs: Vec::new(),
-            foundry_workspace_config_loader: None,
+            foundry_workspace_config_source: FoundryWorkspaceConfigSource::default(),
             workspaces: Vec::new(),
             manifest_watch_roots: Vec::new(),
             git_marker_watch_roots: Vec::new(),
@@ -688,12 +687,9 @@ impl Config {
         let mut manifest_watch_roots = Vec::new();
         let mut git_marker_watch_roots = Vec::new();
         let mut seen_manifests = FxHashSet::default();
-        let (foundry_workspace_configs, foundry_workspace_config_errors) =
-            self.load_foundry_workspace_configs();
-        let foundry_config = FoundryConfigContext::with_errors(
+        let mut foundry_config = FoundryConfigContext::from_source(
             self.selected_profile.as_deref(),
-            &foundry_workspace_configs,
-            &foundry_workspace_config_errors,
+            &self.foundry_workspace_config_source,
         );
         for root in &self.workspace_roots {
             if cancellation.is_cancelled() {
@@ -706,7 +702,7 @@ impl Config {
                     &self.index_policy,
                     cancellation,
                     &mut metrics,
-                    foundry_config,
+                    &mut foundry_config,
                 )?;
             manifest_watch_roots.extend(discovered_watch_roots);
             git_marker_watch_roots.extend(discovered_marker_watch_roots);
@@ -717,13 +713,17 @@ impl Config {
                 continue;
             }
 
-            load_discovered_workspaces(
+            if load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
-                foundry_config,
+                &mut foundry_config,
                 &mut seen_manifests,
                 &mut workspaces,
-            );
+            )
+            .is_err()
+            {
+                return None;
+            }
         }
         info!(workspaces = ?workspaces.iter().map(Workspace::kind).collect::<Vec<_>>(), "loaded workspaces");
         if cancellation.is_cancelled() {
@@ -753,15 +753,16 @@ impl Config {
                 cancellation,
                 &mut metrics,
             )?;
-            if load_discovered_workspaces(
+            match load_discovered_workspaces(
                 discovered,
                 &self.workspace_roots,
-                foundry_config,
+                &mut foundry_config,
                 &mut seen_manifests,
                 &mut workspaces,
-            ) == 0
-            {
-                break;
+            ) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(_) => return None,
             }
         }
         WorkspacePathIndex::reconcile_source_files(
@@ -800,38 +801,6 @@ impl Config {
         self.git_marker_watch_roots = result.git_marker_watch_roots;
         self.index_metrics = result.metrics;
         self.refresh_flychecks()
-    }
-
-    fn load_foundry_workspace_configs(
-        &self,
-    ) -> (Vec<FoundryWorkspaceConfig>, Vec<(PathBuf, String)>) {
-        let Some(loader) = &self.foundry_workspace_config_loader else {
-            return (self.foundry_workspace_configs.clone(), Vec::new());
-        };
-        let mut configs = Vec::with_capacity(self.foundry_workspace_configs.len());
-        let mut errors = Vec::new();
-        for snapshot in &self.foundry_workspace_configs {
-            let root = snapshot.workspace_root();
-            match loader.load(root) {
-                Ok(config) => {
-                    let config = config.into_normalized();
-                    if config.workspace_root() == root {
-                        configs.push(config);
-                    } else {
-                        errors.push((
-                            root.to_path_buf(),
-                            format!(
-                                "host returned Foundry configuration for `{}` while loading `{}`",
-                                config.workspace_root().display(),
-                                root.display()
-                            ),
-                        ));
-                    }
-                }
-                Err(error) => errors.push((root.to_path_buf(), error)),
-            }
-        }
-        (configs, errors)
     }
 
     pub(crate) fn remove_workspace(&mut self, path: &Path) {
@@ -921,10 +890,10 @@ impl Config {
 fn load_discovered_workspaces(
     manifests: impl IntoIterator<Item = ProjectManifest>,
     workspace_roots: &[PathBuf],
-    foundry_config: FoundryConfigContext<'_>,
+    foundry_config: &mut FoundryConfigContext<'_>,
     seen_manifests: &mut FxHashSet<ProjectManifest>,
     workspaces: &mut Vec<Workspace>,
-) -> usize {
+) -> Result<usize, WorkspaceError> {
     let mut loaded = 0;
     for manifest in manifests {
         if !seen_manifests.insert(manifest.clone()) {
@@ -935,6 +904,10 @@ fn load_discovered_workspaces(
                 let fallback_root = path.parent().map(PathBuf::from);
                 match Workspace::load_foundry_bounded(path, workspace_roots, foundry_config) {
                     Ok(workspace) => workspaces.push(workspace),
+                    Err(error @ WorkspaceError::HostConfig { .. }) => {
+                        warn!(%error, "failed to load workspace");
+                        return Err(error);
+                    }
                     Err(error) => {
                         warn!(%error, "failed to load workspace");
                         if let Some(root) = fallback_root {
@@ -946,7 +919,7 @@ fn load_discovered_workspaces(
         }
         loaded += 1;
     }
-    loaded
+    Ok(loaded)
 }
 
 fn workspace_file_operation_options() -> FileOperationRegistrationOptions {
@@ -1235,10 +1208,9 @@ pub(crate) fn negotiate_capabilities_with_pull_diagnostic_data(
             workspace_roots,
             forge_path,
             selected_profile: launch_config.selected_profile().map(str::to_owned),
-            foundry_workspace_configs: launch_config.foundry_workspace_configs().to_vec(),
-            foundry_workspace_config_loader: launch_config
-                .foundry_workspace_config_loader()
-                .cloned(),
+            foundry_workspace_config_source: launch_config
+                .foundry_workspace_config_source()
+                .clone(),
             index_policy,
             flycheck_options,
             watched_file_dynamic_registration,

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -832,6 +832,7 @@ impl GlobalState {
 
                 commit.cache_invalidated = true;
                 commit.discovery_pending = false;
+                commit.workspace_roots_before_change = None;
                 commit.analysis_paths = AnalysisPathIndex::default();
                 commit.deferred_source_file_events.clear();
                 commit.symbol_tables_version = version;

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -15,7 +15,7 @@ use crate::{
     protocol_trace::ProtocolTrace,
     symbols::{SymbolTables, SymbolTablesAggregator},
     vfs::Vfs,
-    workspace::{WorkspacePathIndex, index_policy::IndexingCancellation},
+    workspace::{WorkspaceError, WorkspacePathIndex, index_policy::IndexingCancellation},
 };
 use async_lsp::{ClientSocket, LanguageClient, ResponseError};
 use lsp_types::{
@@ -51,7 +51,7 @@ use std::{
 };
 use tokio::{
     sync::{Mutex as AsyncMutex, Semaphore, oneshot, watch},
-    task::{AbortHandle, JoinError, JoinHandle},
+    task::{AbortHandle, JoinHandle},
 };
 
 #[derive(Clone, Copy)]
@@ -187,9 +187,12 @@ struct WorkspaceDiscoveryMonitor {
 }
 
 impl WorkspaceDiscoveryMonitor {
-    async fn finish(self, worker: JoinHandle<Option<WorkspaceDiscoveryResult>>) {
+    async fn finish(
+        self,
+        worker: JoinHandle<Result<Option<WorkspaceDiscoveryResult>, WorkspaceError>>,
+    ) {
         match worker.await {
-            Ok(Some(result))
+            Ok(Ok(Some(result)))
                 if !self.cancellation.is_cancelled()
                     && self.analysis_version.load(Ordering::Acquire) == self.version =>
             {
@@ -200,6 +203,24 @@ impl WorkspaceDiscoveryMonitor {
                     progress: self.progress,
                     cancellation: self.cancellation,
                 });
+            }
+            Ok(Err(error)) if !self.cancellation.is_cancelled() => {
+                if let Some(refresh_requests) = handle_analysis_failure(
+                    self.version,
+                    error,
+                    &self.analysis_version,
+                    &self.published_analysis_version,
+                    &self.analysis_commit,
+                ) {
+                    finish_analysis_progress_if_current(
+                        self.version,
+                        &self.analysis_version,
+                        &self.analysis_commit,
+                        &self.progress,
+                        "Workspace indexing failed",
+                    );
+                    request_pull_result_refreshes(&self.client, &self.config, refresh_requests);
+                }
             }
             Ok(_) => {}
             Err(error) => {
@@ -938,7 +959,7 @@ impl GlobalState {
             let discovery_config = config.clone();
             let worker = tokio::task::spawn_blocking(move || {
                 let _permit = permit;
-                discovery_config.discover_workspaces(&worker_cancellation)
+                discovery_config.try_discover_workspaces(&worker_cancellation)
             });
             task_scheduler.tasks.lock().worker = Some((task_key, worker.abort_handle()));
             WorkspaceDiscoveryMonitor {
@@ -1629,7 +1650,7 @@ fn finish_analysis_progress_if_current(
 
 fn handle_analysis_failure(
     version: usize,
-    error: JoinError,
+    error: impl std::fmt::Display,
     analysis_version: &Arc<AtomicUsize>,
     published_analysis_version: &watch::Sender<usize>,
     analysis_commit: &Arc<Mutex<AnalysisCommitState>>,

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -167,6 +167,12 @@ pub(crate) struct WorkspaceDiscoveryReady {
     cancellation: IndexingCancellation,
 }
 
+pub(crate) struct WorkspaceDiscoveryFailed {
+    version: usize,
+    error: String,
+    progress: ProgressTicket,
+}
+
 pub(crate) struct DeferredSourceFileEventsReady {
     version: usize,
     events: Vec<(PathBuf, FileChangeType)>,
@@ -180,10 +186,7 @@ struct WorkspaceDiscoveryMonitor {
     progress: ProgressTicket,
     cancellation: IndexingCancellation,
     analysis_version: Arc<AtomicUsize>,
-    published_analysis_version: watch::Sender<usize>,
-    analysis_commit: Arc<Mutex<AnalysisCommitState>>,
     client: ClientSocket,
-    config: Arc<Config>,
 }
 
 impl WorkspaceDiscoveryMonitor {
@@ -205,41 +208,19 @@ impl WorkspaceDiscoveryMonitor {
                 });
             }
             Ok(Err(error)) if !self.cancellation.is_cancelled() => {
-                if let Some(refresh_requests) = handle_analysis_failure(
-                    self.version,
-                    error,
-                    &self.analysis_version,
-                    &self.published_analysis_version,
-                    &self.analysis_commit,
-                ) {
-                    finish_analysis_progress_if_current(
-                        self.version,
-                        &self.analysis_version,
-                        &self.analysis_commit,
-                        &self.progress,
-                        "Workspace indexing failed",
-                    );
-                    request_pull_result_refreshes(&self.client, &self.config, refresh_requests);
-                }
+                let _ = self.client.emit(WorkspaceDiscoveryFailed {
+                    version: self.version,
+                    error: error.to_string(),
+                    progress: self.progress,
+                });
             }
             Ok(_) => {}
             Err(error) => {
-                if let Some(refresh_requests) = handle_analysis_failure(
-                    self.version,
-                    error,
-                    &self.analysis_version,
-                    &self.published_analysis_version,
-                    &self.analysis_commit,
-                ) {
-                    finish_analysis_progress_if_current(
-                        self.version,
-                        &self.analysis_version,
-                        &self.analysis_commit,
-                        &self.progress,
-                        "Workspace indexing failed",
-                    );
-                    request_pull_result_refreshes(&self.client, &self.config, refresh_requests);
-                }
+                let _ = self.client.emit(WorkspaceDiscoveryFailed {
+                    version: self.version,
+                    error: error.to_string(),
+                    progress: self.progress,
+                });
             }
         }
     }
@@ -261,6 +242,7 @@ struct PendingExternalRefresh {
 struct AnalysisCommitState {
     cache_invalidated: bool,
     discovery_pending: bool,
+    workspace_roots_before_change: Option<Vec<PathBuf>>,
     analysis_paths: AnalysisPathIndex,
     deferred_source_file_events: FxHashMap<PathBuf, FileChangeType>,
     external_refresh: Option<PendingExternalRefresh>,
@@ -794,6 +776,10 @@ impl GlobalState {
         );
     }
 
+    pub(crate) fn record_workspace_root_change(&mut self, previous_roots: Vec<PathBuf>) {
+        self.analysis_commit.lock().workspace_roots_before_change.get_or_insert(previous_roots);
+    }
+
     pub(crate) fn reindex_if_invalidated(&mut self) {
         self.request_analysis(
             AnalysisMode::IfInvalidated,
@@ -892,9 +878,18 @@ impl GlobalState {
             if self.background_discovery {
                 self.schedule_workspace_discovery(version, disk_paths, progress, delay);
             } else {
-                self.rediscover_workspaces();
-                self.analysis_commit.lock().discovery_pending = false;
-                self.schedule_analysis(version, disk_paths, progress, delay);
+                match self.rediscover_workspaces() {
+                    Ok(()) => {
+                        let mut commit = self.analysis_commit.lock();
+                        commit.discovery_pending = false;
+                        commit.workspace_roots_before_change = None;
+                        drop(commit);
+                        self.schedule_analysis(version, disk_paths, progress, delay);
+                    }
+                    Err(error) => {
+                        self.finish_workspace_discovery_failure(version, error, progress);
+                    }
+                }
             }
         } else {
             self.schedule_analysis(version, disk_paths, progress, delay);
@@ -930,8 +925,6 @@ impl GlobalState {
         let config = self.config.clone();
         let client = self.client.clone();
         let analysis_version = self.analysis_version.clone();
-        let published_analysis_version = self.published_analysis_version.clone();
-        let analysis_commit = self.analysis_commit.clone();
         let cancellation = IndexingCancellation::default();
         let task_key = AnalysisTaskKey { version, stage: AnalysisTaskStage::Discovery };
 
@@ -968,10 +961,7 @@ impl GlobalState {
                 progress,
                 cancellation,
                 analysis_version,
-                published_analysis_version,
-                analysis_commit,
                 client,
-                config,
             }
             .finish(worker)
             .await;
@@ -999,6 +989,7 @@ impl GlobalState {
         let deferred_source_file_events = {
             let mut commit = self.analysis_commit.lock();
             commit.discovery_pending = false;
+            commit.workspace_roots_before_change = None;
             mem::take(&mut commit.deferred_source_file_events)
         };
         let mut deferred_paths = Vec::new();
@@ -1034,6 +1025,17 @@ impl GlobalState {
             event.cancellation,
             false,
         );
+        ControlFlow::Continue(())
+    }
+
+    pub(crate) fn on_workspace_discovery_failed(
+        &mut self,
+        event: WorkspaceDiscoveryFailed,
+    ) -> NotifyResult {
+        if self.analysis_version.load(Ordering::Acquire) != event.version {
+            return ControlFlow::Continue(());
+        }
+        self.finish_workspace_discovery_failure(event.version, event.error, event.progress);
         ControlFlow::Continue(())
     }
 
@@ -1207,10 +1209,40 @@ impl GlobalState {
         self.analysis_version.load(Ordering::Relaxed).wrapping_add(1)
     }
 
-    fn rediscover_workspaces(&mut self) {
-        let removed_owners = Arc::make_mut(&mut self.config).rediscover_workspaces();
+    fn rediscover_workspaces(&mut self) -> Result<(), WorkspaceError> {
+        let removed_owners = Arc::make_mut(&mut self.config).try_rediscover_workspaces()?;
         self.clear_removed_flycheck_diagnostics(removed_owners);
         self.reregister_watched_files();
+        Ok(())
+    }
+
+    fn finish_workspace_discovery_failure(
+        &mut self,
+        version: usize,
+        error: impl std::fmt::Display,
+        progress: ProgressTicket,
+    ) {
+        let roots = self.analysis_commit.lock().workspace_roots_before_change.take();
+        if let Some(roots) = roots {
+            Arc::make_mut(&mut self.config).replace_workspace_roots(roots);
+            self.reregister_watched_files();
+        }
+        if let Some(refresh_requests) = handle_analysis_failure(
+            version,
+            error,
+            &self.analysis_version,
+            &self.published_analysis_version,
+            &self.analysis_commit,
+        ) {
+            finish_analysis_progress_if_current(
+                version,
+                &self.analysis_version,
+                &self.analysis_commit,
+                &progress,
+                "Workspace indexing failed",
+            );
+            request_pull_result_refreshes(&self.client, &self.config, refresh_requests);
+        }
     }
 
     #[cfg(test)]

--- a/crates/lsp/src/handlers/file_operations.rs
+++ b/crates/lsp/src/handlers/file_operations.rs
@@ -347,8 +347,12 @@ fn reconcile_workspace_file_operations(
         }
         vfs.remove_file_prefixes(&deleted_paths);
     }
+    let previous_workspace_roots = state.config.workspace_roots().to_vec();
     let workspace_roots_changed =
         Arc::make_mut(&mut state.config).reconcile_workspace_roots(&moves, &deleted_paths);
+    if workspace_roots_changed {
+        state.record_workspace_root_change(previous_workspace_roots);
+    }
     removed_paths.extend(removed_roots);
     removed_paths.sort();
     removed_paths.dedup();

--- a/crates/lsp/src/handlers/notifs.rs
+++ b/crates/lsp/src/handlers/notifs.rs
@@ -262,11 +262,17 @@ pub(crate) fn did_change_workspace_folders(
     let added_paths =
         params.event.added.into_iter().filter_map(|workspace| workspace.uri.to_file_path().ok());
 
-    let config = Arc::make_mut(&mut state.config);
-    for path in &removed_paths {
-        config.remove_workspace(path);
+    let previous_roots = state.config.workspace_roots().to_vec();
+    {
+        let config = Arc::make_mut(&mut state.config);
+        for path in &removed_paths {
+            config.remove_workspace(path);
+        }
+        config.add_workspaces(added_paths);
     }
-    config.add_workspaces(added_paths);
+    if state.config.workspace_roots() != previous_roots {
+        state.record_workspace_root_change(previous_roots);
+    }
 
     state.reindex_after_removing_paths(removed_paths);
     state.reregister_watched_files();

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -17,8 +17,10 @@ use normalize_path::NormalizePath;
 use serde_json as _;
 use solar_config::{EvmVersion, ImportRemapping, LspArgs};
 use std::{
+    fmt,
     ops::ControlFlow,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 use tower::ServiceBuilder;
 
@@ -30,6 +32,27 @@ pub struct LaunchConfig {
     selected_profile: Option<String>,
     /// Effective Foundry workspace configurations supplied by the embedding host.
     foundry_workspace_configs: Vec<FoundryWorkspaceConfig>,
+    /// Host callback used to refresh supplied Foundry workspace configurations.
+    foundry_workspace_config_loader: Option<FoundryWorkspaceConfigLoader>,
+}
+
+type FoundryWorkspaceConfigLoadResult = Result<FoundryWorkspaceConfig, String>;
+
+#[derive(Clone)]
+struct FoundryWorkspaceConfigLoader(
+    Arc<dyn Fn(&Path) -> FoundryWorkspaceConfigLoadResult + Send + Sync>,
+);
+
+impl FoundryWorkspaceConfigLoader {
+    fn load(&self, workspace_root: &Path) -> FoundryWorkspaceConfigLoadResult {
+        (self.0)(workspace_root)
+    }
+}
+
+impl fmt::Debug for FoundryWorkspaceConfigLoader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("FoundryWorkspaceConfigLoader(..)")
+    }
 }
 
 /// Effective Foundry configuration for one workspace supplied by an embedding host.
@@ -41,9 +64,10 @@ pub struct LaunchConfig {
 /// [`ImportRemapping`] values and are passed through unchanged. These values are already resolved
 /// by the host, including any inherited profiles and remappings. When this configuration matches a
 /// workspace, the language server uses these values as-is: it does not parse the local profile,
-/// read `remappings.txt`, or autodetect library remappings. The snapshot is captured when
-/// [`LaunchConfig`] is built and is reused for rediscovery during that LSP session; rebuild the
-/// launch configuration when Foundry configuration changes.
+/// read `remappings.txt`, or autodetect library remappings. By default, the snapshot is captured
+/// when [`LaunchConfig`] is built and reused for rediscovery during that LSP session. Embedding
+/// hosts that support configuration reloads can supply a fresh snapshot through
+/// [`LaunchConfig::with_foundry_workspace_config_loader`].
 #[derive(Clone, Debug)]
 pub struct FoundryWorkspaceConfig {
     /// Absolute directory containing the workspace manifest.
@@ -215,6 +239,25 @@ impl LaunchConfig {
         self
     }
 
+    /// Sets a callback that refreshes host-resolved Foundry workspace configurations.
+    ///
+    /// The callback runs once for every configuration supplied through
+    /// [`Self::with_foundry_workspace_config`] or [`Self::with_foundry_workspace_configs`] at the
+    /// start of initial workspace discovery and each later rediscovery. It receives the exact
+    /// normalized workspace root and must return an updated configuration for that same root.
+    /// Returning an error prevents that workspace from loading instead of reusing stale values.
+    pub fn with_foundry_workspace_config_loader<F, E>(mut self, loader: F) -> Self
+    where
+        F: Fn(&Path) -> Result<FoundryWorkspaceConfig, E> + Send + Sync + 'static,
+        E: fmt::Display,
+    {
+        self.foundry_workspace_config_loader =
+            Some(FoundryWorkspaceConfigLoader(Arc::new(move |workspace_root| {
+                loader(workspace_root).map_err(|error| error.to_string())
+            })));
+        self
+    }
+
     pub(crate) fn default_forge_path(&self) -> Option<&Path> {
         self.default_forge_path.as_deref()
     }
@@ -225,6 +268,10 @@ impl LaunchConfig {
 
     pub(crate) fn foundry_workspace_configs(&self) -> &[FoundryWorkspaceConfig] {
         &self.foundry_workspace_configs
+    }
+
+    pub(crate) fn foundry_workspace_config_loader(&self) -> Option<&FoundryWorkspaceConfigLoader> {
+        self.foundry_workspace_config_loader.as_ref()
     }
 }
 

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -30,16 +30,14 @@ pub struct LaunchConfig {
     default_forge_path: Option<PathBuf>,
     /// Foundry profile selected by the embedding host, if any.
     selected_profile: Option<String>,
-    /// Effective Foundry workspace configurations supplied by the embedding host.
-    foundry_workspace_configs: Vec<FoundryWorkspaceConfig>,
-    /// Host callback used to refresh supplied Foundry workspace configurations.
-    foundry_workspace_config_loader: Option<FoundryWorkspaceConfigLoader>,
+    /// Effective Foundry workspace configuration source supplied by the embedding host.
+    foundry_workspace_config_source: FoundryWorkspaceConfigSource,
 }
 
 type FoundryWorkspaceConfigLoadResult = Result<FoundryWorkspaceConfig, String>;
 
 #[derive(Clone)]
-struct FoundryWorkspaceConfigLoader(
+pub(crate) struct FoundryWorkspaceConfigLoader(
     Arc<dyn Fn(&Path) -> FoundryWorkspaceConfigLoadResult + Send + Sync>,
 );
 
@@ -55,6 +53,18 @@ impl fmt::Debug for FoundryWorkspaceConfigLoader {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum FoundryWorkspaceConfigSource {
+    Static(Vec<FoundryWorkspaceConfig>),
+    Loader(FoundryWorkspaceConfigLoader),
+}
+
+impl Default for FoundryWorkspaceConfigSource {
+    fn default() -> Self {
+        Self::Static(Vec::new())
+    }
+}
+
 /// Effective Foundry configuration for one workspace supplied by an embedding host.
 ///
 /// `workspace_root` is the absolute directory containing that workspace's `foundry.toml`. When the
@@ -66,7 +76,7 @@ impl fmt::Debug for FoundryWorkspaceConfigLoader {
 /// workspace, the language server uses these values as-is: it does not parse the local profile,
 /// read `remappings.txt`, or autodetect library remappings. By default, the snapshot is captured
 /// when [`LaunchConfig`] is built and reused for rediscovery during that LSP session. Embedding
-/// hosts that support configuration reloads can supply a fresh snapshot through
+/// hosts that support configuration reloads can supply a loader through
 /// [`LaunchConfig::with_foundry_workspace_config_loader`].
 #[derive(Clone, Debug)]
 pub struct FoundryWorkspaceConfig {
@@ -174,14 +184,24 @@ impl FoundryWorkspaceConfig {
         self.evm_version
     }
 
-    fn into_normalized(mut self) -> Self {
-        self.workspace_root = normalize_foundry_workspace_root(self.workspace_root);
+    fn into_normalized(self) -> Self {
+        self.try_into_normalized().unwrap_or_else(|error| panic!("{error}"))
+    }
+
+    fn try_into_normalized(mut self) -> Result<Self, String> {
+        if !self.workspace_root.is_absolute() {
+            return Err(format!(
+                "Foundry workspace config root must be absolute: `{}`",
+                self.workspace_root.display()
+            ));
+        }
+        self.workspace_root = self.workspace_root.normalize();
         let root = &self.workspace_root;
         self.source_roots = resolve_foundry_workspace_paths(root, self.source_roots);
         self.flycheck_source_roots =
             resolve_foundry_workspace_paths(root, self.flycheck_source_roots);
         self.include_paths = resolve_foundry_workspace_paths(root, self.include_paths);
-        self
+        Ok(self)
     }
 }
 
@@ -216,14 +236,19 @@ impl LaunchConfig {
     /// Panics if the workspace root is not absolute.
     pub fn with_foundry_workspace_config(mut self, config: FoundryWorkspaceConfig) -> Self {
         let config = config.into_normalized();
-        if let Some(existing) = self
-            .foundry_workspace_configs
-            .iter_mut()
-            .find(|existing| existing.workspace_root == config.workspace_root)
+        let FoundryWorkspaceConfigSource::Static(configs) =
+            &mut self.foundry_workspace_config_source
+        else {
+            self.foundry_workspace_config_source =
+                FoundryWorkspaceConfigSource::Static(vec![config]);
+            return self;
+        };
+        if let Some(existing) =
+            configs.iter_mut().find(|existing| existing.workspace_root == config.workspace_root)
         {
             *existing = config;
         } else {
-            self.foundry_workspace_configs.push(config);
+            configs.push(config);
         }
         self
     }
@@ -241,20 +266,22 @@ impl LaunchConfig {
 
     /// Sets a callback that refreshes host-resolved Foundry workspace configurations.
     ///
-    /// The callback runs once for every configuration supplied through
-    /// [`Self::with_foundry_workspace_config`] or [`Self::with_foundry_workspace_configs`] at the
-    /// start of initial workspace discovery and each later rediscovery. It receives the exact
-    /// normalized workspace root and must return an updated configuration for that same root.
-    /// Returning an error prevents that workspace from loading instead of reusing stale values.
+    /// The callback runs once for every Foundry workspace root encountered during initial
+    /// discovery and each later rediscovery. It receives the exact normalized workspace root and
+    /// must return a configuration for that same root. Returning an error aborts that discovery
+    /// pass so the last successfully discovered workspaces remain active.
+    ///
+    /// This replaces any static configurations previously supplied on this builder. Likewise,
+    /// supplying a static configuration after this method replaces the loader.
     pub fn with_foundry_workspace_config_loader<F, E>(mut self, loader: F) -> Self
     where
         F: Fn(&Path) -> Result<FoundryWorkspaceConfig, E> + Send + Sync + 'static,
         E: fmt::Display,
     {
-        self.foundry_workspace_config_loader =
-            Some(FoundryWorkspaceConfigLoader(Arc::new(move |workspace_root| {
-                loader(workspace_root).map_err(|error| error.to_string())
-            })));
+        self.foundry_workspace_config_source =
+            FoundryWorkspaceConfigSource::Loader(FoundryWorkspaceConfigLoader(Arc::new(
+                move |workspace_root| loader(workspace_root).map_err(|error| error.to_string()),
+            )));
         self
     }
 
@@ -266,23 +293,17 @@ impl LaunchConfig {
         self.selected_profile.as_deref()
     }
 
+    #[cfg(test)]
     pub(crate) fn foundry_workspace_configs(&self) -> &[FoundryWorkspaceConfig] {
-        &self.foundry_workspace_configs
+        match &self.foundry_workspace_config_source {
+            FoundryWorkspaceConfigSource::Static(configs) => configs,
+            FoundryWorkspaceConfigSource::Loader(_) => &[],
+        }
     }
 
-    pub(crate) fn foundry_workspace_config_loader(&self) -> Option<&FoundryWorkspaceConfigLoader> {
-        self.foundry_workspace_config_loader.as_ref()
+    pub(crate) fn foundry_workspace_config_source(&self) -> &FoundryWorkspaceConfigSource {
+        &self.foundry_workspace_config_source
     }
-}
-
-fn normalize_foundry_workspace_root(path: impl Into<PathBuf>) -> PathBuf {
-    let path = path.into();
-    assert!(
-        path.is_absolute(),
-        "Foundry workspace config root must be absolute: `{}`",
-        path.display()
-    );
-    path.normalize()
 }
 
 fn resolve_foundry_workspace_paths(root: &Path, paths: Vec<PathBuf>) -> Vec<PathBuf> {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -385,6 +385,7 @@ fn new_router_with_state(mut this: GlobalState) -> Router<GlobalState> {
         })
         .notification::<notif::Initialized>(GlobalState::on_initialized)
         .event::<global_state::WorkspaceDiscoveryReady>(GlobalState::on_workspace_discovery_ready)
+        .event::<global_state::WorkspaceDiscoveryFailed>(GlobalState::on_workspace_discovery_failed)
         .event::<global_state::DeferredSourceFileEventsReady>(
             GlobalState::on_deferred_source_file_events_ready,
         )

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::atomic::AtomicBool;
 
 #[test]
 fn analysis_tracks_excluded_transitive_dependencies_and_normalized_missing_candidates() {
@@ -595,9 +596,11 @@ async fn failed_current_workspace_discovery_terminates_the_analysis_epoch() {
         client: state.client.clone(),
         config: state.config.clone(),
     };
-    let worker = tokio::task::spawn_blocking(|| -> Option<WorkspaceDiscoveryResult> {
-        panic!("test workspace discovery failure")
-    });
+    let worker = tokio::task::spawn_blocking(
+        || -> Result<Option<WorkspaceDiscoveryResult>, WorkspaceError> {
+            panic!("test workspace discovery failure")
+        },
+    );
 
     monitor.finish(worker).await;
 
@@ -605,6 +608,70 @@ async fn failed_current_workspace_discovery_terminates_the_analysis_epoch() {
         .await
         .expect("failed discovery should publish its terminal version")
         .unwrap();
+    let commit = state.analysis_commit.lock();
+    assert!(commit.cache_invalidated);
+    assert!(!commit.discovery_pending);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_loader_failure_terminates_background_discovery_with_last_good_config() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /src/Existing.sol
+        contract Existing {}
+        "#,
+    );
+    let fail = Arc::new(AtomicBool::new(false));
+    let loader_fail = fail.clone();
+    let launch_config =
+        crate::LaunchConfig::default().with_foundry_workspace_config_loader(move |root| {
+            if loader_fail.load(Ordering::Relaxed) {
+                return Err("host config unavailable");
+            }
+            Ok(crate::FoundryWorkspaceConfig::new(root).with_source_roots(["src"]))
+        });
+    let (_, mut config) = crate::config::negotiate_capabilities_with_pull_diagnostic_data(
+        project.initialize_params(),
+        false,
+        &launch_config,
+    );
+    config.rediscover_workspaces();
+    assert_eq!(config.workspaces()[0].source_roots(), &[project.path("/src")]);
+
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(config);
+    fail.store(true, Ordering::Relaxed);
+    let (version, progress) = state
+        .begin_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new(), AnalysisTrigger::External)
+        .unwrap();
+    let cancellation = IndexingCancellation::default();
+    let monitor = WorkspaceDiscoveryMonitor {
+        version,
+        disk_paths: Vec::new(),
+        progress,
+        cancellation: cancellation.clone(),
+        analysis_version: state.analysis_version.clone(),
+        published_analysis_version: state.published_analysis_version.clone(),
+        analysis_commit: state.analysis_commit.clone(),
+        client: state.client.clone(),
+        config: state.config.clone(),
+    };
+    let discovery_config = state.config.clone();
+    let worker = tokio::task::spawn_blocking(move || {
+        discovery_config.try_discover_workspaces(&cancellation)
+    });
+
+    monitor.finish(worker).await;
+
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("host loader failure should publish its terminal version")
+        .unwrap();
+    assert_eq!(state.config.workspaces()[0].source_roots(), &[project.path("/src")]);
     let commit = state.analysis_commit.lock();
     assert!(commit.cache_invalidated);
     assert!(!commit.discovery_pending);

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -775,6 +775,57 @@ async fn synchronous_workspace_folder_loader_failure_rolls_back_roots() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn clearing_cache_discards_workspace_root_rollback_checkpoint() {
+    let (project, config) = workspace_folder_failure_fixture();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(config);
+
+    let old_root = project.path("/a");
+    let new_root = project.path("/b");
+    let previous_roots = state.config.workspace_roots().to_vec();
+    {
+        let config = Arc::make_mut(&mut state.config);
+        config.remove_workspace(&old_root);
+        config.add_workspaces([new_root.clone()]);
+    }
+    state.record_workspace_root_change(previous_roots);
+    let _ = state
+        .begin_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new(), AnalysisTrigger::External)
+        .unwrap();
+    assert_eq!(
+        state.analysis_commit.lock().workspace_roots_before_change.as_deref(),
+        Some(std::slice::from_ref(&old_root))
+    );
+
+    state.clear_analysis_cache();
+    assert!(state.analysis_commit.lock().workspace_roots_before_change.is_none());
+    assert_eq!(state.config.workspace_roots(), std::slice::from_ref(&new_root));
+
+    let (version, progress) = state
+        .begin_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new(), AnalysisTrigger::External)
+        .unwrap();
+    let cancellation = IndexingCancellation::default();
+    let Err(error) = state.config.try_discover_workspaces(&cancellation) else {
+        panic!("host loader should fail workspace discovery")
+    };
+    assert!(
+        state
+            .on_workspace_discovery_failed(WorkspaceDiscoveryFailed {
+                version,
+                error: error.to_string(),
+                progress,
+            })
+            .is_continue()
+    );
+
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("failed discovery should publish its terminal version")
+        .unwrap();
+    assert_eq!(state.config.workspace_roots(), [new_root]);
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn background_workspace_folder_loader_failure_rolls_back_roots() {
     struct WorkspaceStateProbe {
         old_root: PathBuf,

--- a/crates/lsp/src/tests/indexing.rs
+++ b/crates/lsp/src/tests/indexing.rs
@@ -1,4 +1,5 @@
 use super::*;
+use async_lsp::LanguageServer;
 use std::sync::atomic::AtomicBool;
 
 #[test]
@@ -585,24 +586,15 @@ async fn failed_current_workspace_discovery_terminates_the_analysis_epoch() {
         .begin_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new(), AnalysisTrigger::External)
         .unwrap();
     assert!(state.analysis_commit.lock().discovery_pending);
-    let monitor = WorkspaceDiscoveryMonitor {
-        version,
-        disk_paths: Vec::new(),
-        progress,
-        cancellation: IndexingCancellation::default(),
-        analysis_version: state.analysis_version.clone(),
-        published_analysis_version: state.published_analysis_version.clone(),
-        analysis_commit: state.analysis_commit.clone(),
-        client: state.client.clone(),
-        config: state.config.clone(),
-    };
-    let worker = tokio::task::spawn_blocking(
-        || -> Result<Option<WorkspaceDiscoveryResult>, WorkspaceError> {
-            panic!("test workspace discovery failure")
-        },
+    assert!(
+        state
+            .on_workspace_discovery_failed(WorkspaceDiscoveryFailed {
+                version,
+                error: "test workspace discovery failure".into(),
+                progress,
+            })
+            .is_continue()
     );
-
-    monitor.finish(worker).await;
 
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
         .await
@@ -649,23 +641,18 @@ async fn host_loader_failure_terminates_background_discovery_with_last_good_conf
         .begin_analysis(AnalysisMode::Rediscover, Vec::new(), Vec::new(), AnalysisTrigger::External)
         .unwrap();
     let cancellation = IndexingCancellation::default();
-    let monitor = WorkspaceDiscoveryMonitor {
-        version,
-        disk_paths: Vec::new(),
-        progress,
-        cancellation: cancellation.clone(),
-        analysis_version: state.analysis_version.clone(),
-        published_analysis_version: state.published_analysis_version.clone(),
-        analysis_commit: state.analysis_commit.clone(),
-        client: state.client.clone(),
-        config: state.config.clone(),
+    let Err(error) = state.config.try_discover_workspaces(&cancellation) else {
+        panic!("host loader should fail workspace discovery")
     };
-    let discovery_config = state.config.clone();
-    let worker = tokio::task::spawn_blocking(move || {
-        discovery_config.try_discover_workspaces(&cancellation)
-    });
-
-    monitor.finish(worker).await;
+    assert!(
+        state
+            .on_workspace_discovery_failed(WorkspaceDiscoveryFailed {
+                version,
+                error: error.to_string(),
+                progress,
+            })
+            .is_continue()
+    );
 
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
         .await
@@ -675,6 +662,183 @@ async fn host_loader_failure_terminates_background_discovery_with_last_good_conf
     let commit = state.analysis_commit.lock();
     assert!(commit.cache_invalidated);
     assert!(!commit.discovery_pending);
+}
+
+fn replace_workspace_folder(old_root: &Path, new_root: &Path) -> DidChangeWorkspaceFoldersParams {
+    DidChangeWorkspaceFoldersParams {
+        event: WorkspaceFoldersChangeEvent {
+            added: vec![WorkspaceFolder {
+                uri: Url::from_file_path(new_root).unwrap(),
+                name: "new".into(),
+            }],
+            removed: vec![WorkspaceFolder {
+                uri: Url::from_file_path(old_root).unwrap(),
+                name: "old".into(),
+            }],
+        },
+    }
+}
+
+fn workspace_folder_failure_fixture() -> (TestProject, Config) {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /a/foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /a/src/A.sol
+        contract A {}
+
+        //- /b/foundry.toml
+        [profile.default]
+        src = "src"
+
+        //- /b/src/B.sol
+        contract B {}
+        "#,
+    );
+    let rejected = project.path("/b");
+    let launch_config =
+        crate::LaunchConfig::default().with_foundry_workspace_config_loader(move |root| {
+            if root == rejected {
+                return Err("host config unavailable");
+            }
+            Ok(crate::FoundryWorkspaceConfig::new(root).with_source_roots(["src"]))
+        });
+    let (_, mut config) = crate::config::negotiate_capabilities_with_pull_diagnostic_data(
+        project.initialize_params_with_roots(&["/a"]),
+        false,
+        &launch_config,
+    );
+    config.rediscover_workspaces();
+    (project, config)
+}
+
+#[derive(Debug)]
+struct WorkspaceFolderState {
+    roots: Vec<PathBuf>,
+    workspace_base_paths: Vec<PathBuf>,
+    tracks_old_source: bool,
+    tracks_new_source: bool,
+    discovery_pending: bool,
+}
+
+fn workspace_folder_state(
+    state: &GlobalState,
+    old_root: &Path,
+    new_root: &Path,
+) -> WorkspaceFolderState {
+    WorkspaceFolderState {
+        roots: state.config.workspace_roots().to_vec(),
+        workspace_base_paths: state
+            .config
+            .workspaces()
+            .iter()
+            .filter_map(|workspace| workspace.compile_opts().base_path.clone())
+            .collect(),
+        tracks_old_source: state.config.tracks_source_file(&old_root.join("src/A.sol")),
+        tracks_new_source: state.config.tracks_source_file(&new_root.join("src/B.sol")),
+        discovery_pending: state.analysis_commit.lock().discovery_pending,
+    }
+}
+
+fn assert_failed_workspace_folder_change_rolled_back(state: WorkspaceFolderState, old_root: &Path) {
+    assert_eq!(state.roots, [old_root.to_path_buf()]);
+    assert_eq!(state.workspace_base_paths, [old_root.to_path_buf()]);
+    assert!(state.tracks_old_source);
+    assert!(!state.tracks_new_source);
+    assert!(!state.discovery_pending);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn synchronous_workspace_folder_loader_failure_rolls_back_roots() {
+    let (project, config) = workspace_folder_failure_fixture();
+    let mut state = GlobalState::new(ClientSocket::new_closed());
+    state.config = Arc::new(config);
+
+    assert!(
+        crate::handlers::did_change_workspace_folders(
+            &mut state,
+            replace_workspace_folder(&project.path("/a"), &project.path("/b")),
+        )
+        .is_continue()
+    );
+
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, state.latest_analysis())
+        .await
+        .expect("failed synchronous discovery should publish its terminal version")
+        .unwrap();
+    assert_failed_workspace_folder_change_rolled_back(
+        workspace_folder_state(&state, &project.path("/a"), &project.path("/b")),
+        &project.path("/a"),
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn background_workspace_folder_loader_failure_rolls_back_roots() {
+    struct WorkspaceStateProbe {
+        old_root: PathBuf,
+        new_root: PathBuf,
+        response: oneshot::Sender<WorkspaceFolderState>,
+    }
+
+    let (project, config) = workspace_folder_failure_fixture();
+    let (setup_tx, setup_rx) = std_mpsc::sync_channel(1);
+    let (server_main, internal_client) = async_lsp::MainLoop::new_server(move |client| {
+        let mut state = GlobalState::new(client);
+        state.config = Arc::new(config);
+        state.background_discovery = true;
+        setup_tx.send(state.published_analysis_version.subscribe()).unwrap();
+        let mut router = crate::new_router_with_state(state);
+        router.event::<WorkspaceStateProbe>(|state, probe| {
+            let snapshot = workspace_folder_state(state, &probe.old_root, &probe.new_root);
+            assert!(probe.response.send(snapshot).is_ok());
+            ControlFlow::Continue(())
+        });
+        router
+    });
+    let (client_main, mut server) = async_lsp::MainLoop::new_client(|_| {
+        let mut router = Router::new(());
+        router.notification::<notification::PublishDiagnostics>(|_, _| ControlFlow::Continue(()));
+        router.notification::<notification::LogMessage>(|_, _| ControlFlow::Continue(()));
+        router
+    });
+    let mut published = setup_rx.recv().unwrap();
+    let (server_stream, client_stream) = tokio::io::duplex(64 << 10);
+    let (server_rx, server_tx) = tokio::io::split(server_stream);
+    let server_task =
+        tokio::spawn(server_main.run_buffered(server_rx.compat(), server_tx.compat_write()));
+    let (client_rx, client_tx) = tokio::io::split(client_stream);
+    let client_task =
+        tokio::spawn(client_main.run_buffered(client_rx.compat(), client_tx.compat_write()));
+
+    server
+        .did_change_workspace_folders(replace_workspace_folder(
+            &project.path("/a"),
+            &project.path("/b"),
+        ))
+        .unwrap();
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, async {
+        while *published.borrow() == 0 {
+            published.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("failed background discovery should publish its terminal version");
+
+    let (probe_tx, probe_rx) = oneshot::channel();
+    internal_client
+        .emit(WorkspaceStateProbe {
+            old_root: project.path("/a"),
+            new_root: project.path("/b"),
+            response: probe_tx,
+        })
+        .unwrap();
+    assert_failed_workspace_folder_change_rolled_back(probe_rx.await.unwrap(), &project.path("/a"));
+    server.shutdown(()).await.unwrap();
+    server.exit(()).unwrap();
+    assert!(server_task.await.unwrap().is_ok());
+    assert!(matches!(client_task.await.unwrap(), Err(async_lsp::Error::Eof)));
 }
 
 #[test]

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -6,6 +6,7 @@ use async_lsp::{AnyRequest, ClientSocket, router::Router};
 use lsp_types::InitializeParams;
 use solar_config::{EvmVersion, LspArgs};
 use std::{
+    io::Read,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -274,6 +275,64 @@ async fn host_foundry_workspace_configs_match_their_own_roots() {
     assert_eq!(source_roots("/one"), [project.path("/one/host-one")]);
     assert_eq!(source_roots("/two"), [project.path("/two/host-two")]);
     assert_eq!(source_roots("/three"), [project.path("/three/local-three")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_foundry_workspace_config_loader_refreshes_after_manifest_change() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /old-src/Old.sol
+        contract OldContract {}
+
+        //- /new-src/New.sol
+        contract NewContract {}
+
+        //- /foundry.toml
+        [profile.default]
+        src = "old-src"
+        "#,
+    );
+    let snapshot = FoundryWorkspaceConfig::new(project.root())
+        .with_source_roots(["old-src"])
+        .with_flycheck_source_roots(["old-src"]);
+    let config = LaunchConfig::default()
+        .with_foundry_workspace_config(snapshot)
+        .with_foundry_workspace_config_loader(|root| {
+            let mut manifest = String::new();
+            std::fs::File::open(root.join("foundry.toml"))?.read_to_string(&mut manifest)?;
+            let source = if manifest.contains("new-src") { "new-src" } else { "old-src" };
+            Ok::<_, std::io::Error>(
+                FoundryWorkspaceConfig::new(root)
+                    .with_source_roots([source])
+                    .with_flycheck_source_roots([source]),
+            )
+        });
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params();
+    params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
+
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    let workspace = state
+        .config
+        .workspaces()
+        .iter()
+        .find(|workspace| workspace.compile_opts().base_path.as_deref() == Some(project.root()))
+        .unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/old-src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/old-src/Old.sol")]);
+
+    project.write_file("/foundry.toml", "[profile.default]\nsrc = \"new-src\"\n");
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    let workspace = state
+        .config
+        .workspaces()
+        .iter()
+        .find(|workspace| workspace.compile_opts().base_path.as_deref() == Some(project.root()))
+        .unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/new-src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/new-src/New.sol")]);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/launch.rs
+++ b/crates/lsp/src/tests/launch.rs
@@ -8,7 +8,10 @@ use solar_config::{EvmVersion, LspArgs};
 use std::{
     io::Read,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
 use tower::Service;
 
@@ -292,21 +295,16 @@ async fn host_foundry_workspace_config_loader_refreshes_after_manifest_change() 
         src = "old-src"
         "#,
     );
-    let snapshot = FoundryWorkspaceConfig::new(project.root())
-        .with_source_roots(["old-src"])
-        .with_flycheck_source_roots(["old-src"]);
-    let config = LaunchConfig::default()
-        .with_foundry_workspace_config(snapshot)
-        .with_foundry_workspace_config_loader(|root| {
-            let mut manifest = String::new();
-            std::fs::File::open(root.join("foundry.toml"))?.read_to_string(&mut manifest)?;
-            let source = if manifest.contains("new-src") { "new-src" } else { "old-src" };
-            Ok::<_, std::io::Error>(
-                FoundryWorkspaceConfig::new(root)
-                    .with_source_roots([source])
-                    .with_flycheck_source_roots([source]),
-            )
-        });
+    let config = LaunchConfig::default().with_foundry_workspace_config_loader(|root| {
+        let mut manifest = String::new();
+        std::fs::File::open(root.join("foundry.toml"))?.read_to_string(&mut manifest)?;
+        let source = if manifest.contains("new-src") { "new-src" } else { "old-src" };
+        Ok::<_, std::io::Error>(
+            FoundryWorkspaceConfig::new(root)
+                .with_source_roots([source])
+                .with_flycheck_source_roots([source]),
+        )
+    });
     let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
     let mut params = project.initialize_params();
     params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
@@ -333,6 +331,142 @@ async fn host_foundry_workspace_config_loader_refreshes_after_manifest_change() 
         .unwrap();
     assert_eq!(workspace.source_roots(), &[project.path("/new-src")]);
     assert_eq!(workspace.source_files(), &[project.path("/new-src/New.sol")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_foundry_workspace_config_loader_covers_new_nested_workspaces_once_per_pass() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /packages/Root.sol
+        contract RootContract {}
+
+        //- /foundry.toml
+        [profile.default]
+        src = "packages"
+        "#,
+    );
+    let loads = Arc::new(AtomicUsize::new(0));
+    let loader_loads = loads.clone();
+    let config = LaunchConfig::default().with_foundry_workspace_config_loader(move |root| {
+        loader_loads.fetch_add(1, Ordering::Relaxed);
+        let source = if root.ends_with("nested") { "host-src" } else { "packages" };
+        Ok::<_, String>(
+            FoundryWorkspaceConfig::new(root)
+                .with_source_roots([source])
+                .with_flycheck_source_roots([source]),
+        )
+    });
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params();
+    params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
+
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    assert_eq!(loads.load(Ordering::Relaxed), 1);
+
+    project.write_file("/packages/nested/foundry.toml", "[profile.default]\nsrc = \"local-src\"\n");
+    project.write_file("/packages/nested/host-src/Host.sol", "contract HostContract {}\n");
+    project.write_file("/packages/nested/local-src/Local.sol", "contract LocalContract {}\n");
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    assert_eq!(loads.load(Ordering::Relaxed), 3);
+    let nested = state
+        .config
+        .workspaces()
+        .iter()
+        .find(|workspace| {
+            workspace.compile_opts().base_path.as_deref()
+                == Some(project.path("/packages/nested").as_path())
+        })
+        .unwrap();
+    assert_eq!(nested.source_roots(), &[project.path("/packages/nested/host-src")]);
+    assert_eq!(nested.source_files(), &[project.path("/packages/nested/host-src/Host.sol")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_foundry_workspace_config_loader_failure_keeps_last_good_discovery() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /old-src/Old.sol
+        contract OldContract {}
+
+        //- /new-src/New.sol
+        contract NewContract {}
+
+        //- /foundry.toml
+        [profile.default]
+        src = "old-src"
+        "#,
+    );
+    let fail = Arc::new(AtomicBool::new(false));
+    let loader_fail = fail.clone();
+    let config = LaunchConfig::default().with_foundry_workspace_config_loader(move |root| {
+        if loader_fail.load(Ordering::Relaxed) {
+            return Err("host config unavailable");
+        }
+        let mut manifest = String::new();
+        std::fs::File::open(root.join("foundry.toml"))
+            .unwrap()
+            .read_to_string(&mut manifest)
+            .unwrap();
+        let source = if manifest.contains("new-src") { "new-src" } else { "old-src" };
+        Ok(FoundryWorkspaceConfig::new(root).with_source_roots([source]))
+    });
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+    let mut params = project.initialize_params();
+    params.initialization_options = Some(serde_json::json!({ "flychecks": [] }));
+
+    state.on_initialize(params).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    project.write_file("/foundry.toml", "[profile.default]\nsrc = \"new-src\"\n");
+    fail.store(true, Ordering::Relaxed);
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    let workspace = state.config.workspaces().first().unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/old-src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/old-src/Old.sol")]);
+
+    fail.store(false, Ordering::Relaxed);
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    let workspace = state.config.workspaces().first().unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/new-src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/new-src/New.sol")]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn host_foundry_workspace_config_loader_rejects_invalid_roots_without_panicking() {
+    let project = TestProject::from_fixture(
+        r#"
+        //- /src/Test.sol
+        contract TestContract {}
+
+        //- /foundry.toml
+        [profile.default]
+        src = "src"
+        "#,
+    );
+    let loads = Arc::new(AtomicUsize::new(0));
+    let loader_loads = loads.clone();
+    let wrong_root = project.path("/other");
+    let config = LaunchConfig::default().with_foundry_workspace_config_loader(move |root| {
+        let load = loader_loads.fetch_add(1, Ordering::Relaxed);
+        let root = match load {
+            0 => root.to_path_buf(),
+            1 => PathBuf::from("relative"),
+            _ => wrong_root.clone(),
+        };
+        Ok::<_, String>(FoundryWorkspaceConfig::new(root).with_source_roots(["src"]))
+    });
+    let mut state = GlobalState::new(ClientSocket::new_closed()).with_launch_config(config);
+
+    state.on_initialize(project.initialize_params()).await.unwrap();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+    let _ = Arc::make_mut(&mut state.config).rediscover_workspaces();
+
+    let workspace = state.config.workspaces().first().unwrap();
+    assert_eq!(workspace.source_roots(), &[project.path("/src")]);
+    assert_eq!(workspace.source_files(), &[project.path("/src/Test.sol")]);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/lsp/src/tests/watched_files.rs
+++ b/crates/lsp/src/tests/watched_files.rs
@@ -1284,7 +1284,7 @@ async fn synchronous_discovery_refreshes_watched_file_specs_before_analysis() {
     state.config = Arc::new(config);
     *state.watched_file_registration.desired_specs.lock() = Some(initial_specs);
 
-    state.rediscover_workspaces();
+    state.rediscover_workspaces().unwrap();
 
     let specs = state.watched_file_registration.desired_specs.lock();
     assert!(

--- a/crates/lsp/src/tests/watched_files.rs
+++ b/crates/lsp/src/tests/watched_files.rs
@@ -666,7 +666,7 @@ fn watched_file_specs_add_only_approved_dependency_parents() {
             crate::workspace::Workspace::load_foundry_bounded(
                 project.path("/workspace/foundry.toml"),
                 &[project.path("/workspace")],
-                crate::workspace::FoundryConfigContext::default(),
+                &mut crate::workspace::FoundryConfigContext::default(),
             )
             .unwrap(),
         ],

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -31,7 +31,7 @@ impl ProjectManifest {
         policy: &WorkspaceIndexPolicy,
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
-        foundry_config: FoundryConfigContext<'_>,
+        foundry_config: &mut FoundryConfigContext<'_>,
     ) -> io::Result<Option<ManifestDiscoveryResult>> {
         // Keep naked roots shallow, but recurse once a Foundry project boundary is known.
         let mut manifests = Vec::new();
@@ -124,7 +124,7 @@ impl ProjectManifest {
             policy,
             cancellation,
             metrics,
-            FoundryConfigContext::default(),
+            &mut FoundryConfigContext::default(),
         )
         .map(|(manifests, _, _)| manifests)
     }
@@ -135,7 +135,7 @@ impl ProjectManifest {
         policy: &WorkspaceIndexPolicy,
         cancellation: &IndexingCancellation,
         metrics: &mut WorkspaceIndexMetrics,
-        foundry_config: FoundryConfigContext<'_>,
+        foundry_config: &mut FoundryConfigContext<'_>,
     ) -> Option<ManifestDiscoveryResult> {
         let mut discovered = FxHashSet::default();
         let mut watch_roots = Vec::new();
@@ -236,7 +236,7 @@ fn find_in_parent_dirs(path: &Path, target_file_name: &str) -> Option<PathBuf> {
     None
 }
 
-struct ManifestDiscovery<'a> {
+struct ManifestDiscovery<'a, 'config> {
     manifests: &'a mut Vec<PathBuf>,
     approved_roots: &'a [PathBuf],
     watch_roots: &'a mut Vec<SourceWatchRoot>,
@@ -244,7 +244,7 @@ struct ManifestDiscovery<'a> {
     policy: &'a WorkspaceIndexPolicy,
     cancellation: &'a IndexingCancellation,
     metrics: &'a mut WorkspaceIndexMetrics,
-    foundry_config: FoundryConfigContext<'a>,
+    foundry_config: &'a mut FoundryConfigContext<'config>,
 }
 
 #[derive(Clone, Copy)]
@@ -265,7 +265,7 @@ enum ManifestTreeState {
     Cancelled,
 }
 
-impl ManifestDiscovery<'_> {
+impl ManifestDiscovery<'_, '_> {
     fn find_in_child_dirs(
         &mut self,
         entities: ReadDir,
@@ -391,23 +391,22 @@ impl ManifestDiscovery<'_> {
 fn foundry_index_roots(
     manifest: &Path,
     approved_roots: &[PathBuf],
-    foundry_config: FoundryConfigContext<'_>,
+    foundry_config: &mut FoundryConfigContext<'_>,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let Some(root) = manifest.parent() else { return Default::default() };
-    if foundry_config.workspace_config_error(root).is_some() {
+    let Ok(host_config) = foundry_config.workspace_config(root) else {
         return Default::default();
-    }
-    let (source_roots, import_only_roots) =
-        if let Some(config) = foundry_config.workspace_config(root) {
-            (config.source_roots().to_vec(), config.include_paths().to_vec())
-        } else {
-            let Ok(document) = load_foundry_document(manifest) else { return Default::default() };
-            let profile = document.profile_for(foundry_config.selected_profile());
-            let source_roots = profile.source_roots(root);
-            let import_only_roots =
-                profile.include_paths(root).into_iter().map(|path| path.normalize()).collect();
-            (source_roots, import_only_roots)
-        };
+    };
+    let (source_roots, import_only_roots) = if let Some(config) = host_config {
+        (config.source_roots().to_vec(), config.include_paths().to_vec())
+    } else {
+        let Ok(document) = load_foundry_document(manifest) else { return Default::default() };
+        let profile = document.profile_for(foundry_config.selected_profile());
+        let source_roots = profile.source_roots(root);
+        let import_only_roots =
+            profile.include_paths(root).into_iter().map(|path| path.normalize()).collect();
+        (source_roots, import_only_roots)
+    };
     (
         source_roots
             .into_iter()
@@ -635,7 +634,7 @@ mod tests {
             foundry_index_roots(
                 &project.path("/foundry.toml"),
                 &[project.root().to_path_buf()],
-                FoundryConfigContext::new(Some("custom"), &[]),
+                &mut FoundryConfigContext::new(Some("custom"), &[]),
             )
             .0,
             [project.path("/.hidden/custom-src")]
@@ -650,7 +649,7 @@ mod tests {
             &WorkspaceIndexPolicy::default(),
             &IndexingCancellation::default(),
             &mut WorkspaceIndexMetrics::default(),
-            FoundryConfigContext::new(Some("custom"), &[]),
+            &mut FoundryConfigContext::new(Some("custom"), &[]),
         )
         .unwrap()
         .0;
@@ -695,7 +694,7 @@ mod tests {
             foundry_index_roots(
                 &project.path("/workspace/foundry.toml"),
                 &[project.path("/workspace")],
-                FoundryConfigContext::new(None, &configs),
+                &mut FoundryConfigContext::new(None, &configs),
             ),
             (vec![project.path("/workspace/host-src")], vec![project.path("/workspace/host-lib")],)
         );

--- a/crates/lsp/src/workspace/manifest.rs
+++ b/crates/lsp/src/workspace/manifest.rs
@@ -394,6 +394,9 @@ fn foundry_index_roots(
     foundry_config: FoundryConfigContext<'_>,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let Some(root) = manifest.parent() else { return Default::default() };
+    if foundry_config.workspace_config_error(root).is_some() {
+        return Default::default();
+    }
     let (source_roots, import_only_roots) =
         if let Some(config) = foundry_config.workspace_config(root) {
             (config.source_roots().to_vec(), config.include_paths().to_vec())

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod manifest;
 pub(crate) struct FoundryConfigContext<'a> {
     selected_profile: Option<&'a str>,
     workspace_configs: &'a [FoundryWorkspaceConfig],
+    workspace_config_errors: &'a [(PathBuf, String)],
 }
 
 impl<'a> FoundryConfigContext<'a> {
@@ -39,7 +40,15 @@ impl<'a> FoundryConfigContext<'a> {
         selected_profile: Option<&'a str>,
         workspace_configs: &'a [FoundryWorkspaceConfig],
     ) -> Self {
-        Self { selected_profile, workspace_configs }
+        Self::with_errors(selected_profile, workspace_configs, &[])
+    }
+
+    pub(crate) fn with_errors(
+        selected_profile: Option<&'a str>,
+        workspace_configs: &'a [FoundryWorkspaceConfig],
+        workspace_config_errors: &'a [(PathBuf, String)],
+    ) -> Self {
+        Self { selected_profile, workspace_configs, workspace_config_errors }
     }
 
     pub(crate) fn selected_profile(self) -> Option<&'a str> {
@@ -49,6 +58,13 @@ impl<'a> FoundryConfigContext<'a> {
     pub(crate) fn workspace_config(self, root: &Path) -> Option<&'a FoundryWorkspaceConfig> {
         let root = root.normalize();
         self.workspace_configs.iter().find(|config| config.workspace_root() == root)
+    }
+
+    pub(crate) fn workspace_config_error(self, root: &Path) -> Option<&'a str> {
+        let root = root.normalize();
+        self.workspace_config_errors
+            .iter()
+            .find_map(|(candidate, error)| (*candidate == root).then_some(error.as_str()))
     }
 }
 
@@ -527,6 +543,9 @@ impl Workspace {
         foundry_config: FoundryConfigContext<'_>,
     ) -> Result<Self, WorkspaceError> {
         let root = manifest_root(&path)?.normalize();
+        if let Some(error) = foundry_config.workspace_config_error(&root) {
+            return Err(WorkspaceError::HostConfig { root, error: error.to_owned() });
+        }
         let approved = |path: &Path| {
             workspace_roots
                 .is_none_or(|workspace_roots| is_approved_index_root(path, &root, workspace_roots))
@@ -1005,6 +1024,8 @@ pub(crate) enum WorkspaceError {
         #[source]
         source: toml_edit::de::Error,
     },
+    #[error("failed to load host configuration for workspace `{}`: {error}", root.display())]
+    HostConfig { root: PathBuf, error: String },
 }
 
 fn manifest_root(path: &Path) -> Result<PathBuf, WorkspaceError> {

--- a/crates/lsp/src/workspace/mod.rs
+++ b/crates/lsp/src/workspace/mod.rs
@@ -10,7 +10,7 @@
 //! overall LSP config.
 
 use crate::{
-    FoundryWorkspaceConfig,
+    FoundryWorkspaceConfig, FoundryWorkspaceConfigLoader, FoundryWorkspaceConfigSource,
     workspace::{
         foundry::FoundryDocument,
         index_policy::{IndexingCancellation, WorkspaceIndexMetrics, WorkspaceIndexPolicy},
@@ -18,7 +18,10 @@ use crate::{
 };
 use normalize_path::NormalizePath;
 use solar_config::{CompileOpts, EvmVersion, ImportRemapping};
-use solar_interface::{data_structures::smallvec::SmallVec, source_map::SourceMap};
+use solar_interface::{
+    data_structures::{map::FxHashMap, smallvec::SmallVec},
+    source_map::SourceMap,
+};
 use std::{
     io,
     path::{Path, PathBuf},
@@ -28,11 +31,17 @@ mod foundry;
 pub(crate) mod index_policy;
 pub(crate) mod manifest;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 pub(crate) struct FoundryConfigContext<'a> {
     selected_profile: Option<&'a str>,
-    workspace_configs: &'a [FoundryWorkspaceConfig],
-    workspace_config_errors: &'a [(PathBuf, String)],
+    source: FoundryConfigSourceRef<'a>,
+    loaded: FxHashMap<PathBuf, Result<FoundryWorkspaceConfig, String>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FoundryConfigSourceRef<'a> {
+    Static(&'a [FoundryWorkspaceConfig]),
+    Loader(&'a FoundryWorkspaceConfigLoader),
 }
 
 impl<'a> FoundryConfigContext<'a> {
@@ -40,31 +49,61 @@ impl<'a> FoundryConfigContext<'a> {
         selected_profile: Option<&'a str>,
         workspace_configs: &'a [FoundryWorkspaceConfig],
     ) -> Self {
-        Self::with_errors(selected_profile, workspace_configs, &[])
+        Self {
+            selected_profile,
+            source: FoundryConfigSourceRef::Static(workspace_configs),
+            loaded: FxHashMap::default(),
+        }
     }
 
-    pub(crate) fn with_errors(
+    pub(crate) fn from_source(
         selected_profile: Option<&'a str>,
-        workspace_configs: &'a [FoundryWorkspaceConfig],
-        workspace_config_errors: &'a [(PathBuf, String)],
+        source: &'a FoundryWorkspaceConfigSource,
     ) -> Self {
-        Self { selected_profile, workspace_configs, workspace_config_errors }
+        let source = match source {
+            FoundryWorkspaceConfigSource::Static(configs) => {
+                FoundryConfigSourceRef::Static(configs)
+            }
+            FoundryWorkspaceConfigSource::Loader(loader) => FoundryConfigSourceRef::Loader(loader),
+        };
+        Self { selected_profile, source, loaded: FxHashMap::default() }
     }
 
-    pub(crate) fn selected_profile(self) -> Option<&'a str> {
+    pub(crate) fn selected_profile(&self) -> Option<&'a str> {
         self.selected_profile
     }
 
-    pub(crate) fn workspace_config(self, root: &Path) -> Option<&'a FoundryWorkspaceConfig> {
+    pub(crate) fn workspace_config(
+        &mut self,
+        root: &Path,
+    ) -> Result<Option<&FoundryWorkspaceConfig>, String> {
         let root = root.normalize();
-        self.workspace_configs.iter().find(|config| config.workspace_root() == root)
-    }
-
-    pub(crate) fn workspace_config_error(self, root: &Path) -> Option<&'a str> {
-        let root = root.normalize();
-        self.workspace_config_errors
-            .iter()
-            .find_map(|(candidate, error)| (*candidate == root).then_some(error.as_str()))
+        match self.source {
+            FoundryConfigSourceRef::Static(configs) => {
+                Ok(configs.iter().find(|config| config.workspace_root() == root))
+            }
+            FoundryConfigSourceRef::Loader(loader) => {
+                if !self.loaded.contains_key(&root) {
+                    let loaded = loader.load(&root).and_then(|config| {
+                        let config = config.try_into_normalized()?;
+                        if config.workspace_root() == root {
+                            Ok(config)
+                        } else {
+                            Err(format!(
+                                "host returned Foundry configuration for `{}` while loading `{}`",
+                                config.workspace_root().display(),
+                                root.display()
+                            ))
+                        }
+                    });
+                    self.loaded.insert(root.clone(), loaded);
+                }
+                match self.loaded.get(&root).expect("loaded Foundry configuration is cached") {
+                    Ok(config) => Ok(Some(config)),
+                    Err(error) => Err(error.clone()),
+                }
+            }
+        }
     }
 }
 
@@ -526,13 +565,13 @@ impl Workspace {
 
     #[cfg(any(test, feature = "bench"))]
     pub(crate) fn load_foundry(path: PathBuf) -> Result<Self, WorkspaceError> {
-        Self::load_foundry_inner(path, None, FoundryConfigContext::default())
+        Self::load_foundry_inner(path, None, &mut FoundryConfigContext::default())
     }
 
     pub(crate) fn load_foundry_bounded(
         path: PathBuf,
         workspace_roots: &[PathBuf],
-        foundry_config: FoundryConfigContext<'_>,
+        foundry_config: &mut FoundryConfigContext<'_>,
     ) -> Result<Self, WorkspaceError> {
         Self::load_foundry_inner(path, Some(workspace_roots), foundry_config)
     }
@@ -540,18 +579,18 @@ impl Workspace {
     fn load_foundry_inner(
         path: PathBuf,
         workspace_roots: Option<&[PathBuf]>,
-        foundry_config: FoundryConfigContext<'_>,
+        foundry_config: &mut FoundryConfigContext<'_>,
     ) -> Result<Self, WorkspaceError> {
         let root = manifest_root(&path)?.normalize();
-        if let Some(error) = foundry_config.workspace_config_error(&root) {
-            return Err(WorkspaceError::HostConfig { root, error: error.to_owned() });
-        }
         let approved = |path: &Path| {
             workspace_roots
                 .is_none_or(|workspace_roots| is_approved_index_root(path, &root, workspace_roots))
         };
+        let host_config = foundry_config
+            .workspace_config(&root)
+            .map_err(|error| WorkspaceError::HostConfig { root: root.clone(), error })?;
         let (source_roots, flycheck_source_roots, include_paths, import_remappings, evm_version) =
-            if let Some(config) = foundry_config.workspace_config(&root) {
+            if let Some(config) = host_config {
                 (
                     config.source_roots().to_vec(),
                     config.flycheck_source_roots().to_vec(),
@@ -1155,7 +1194,7 @@ mod tests {
         let workspace = Workspace::load_foundry_bounded(
             project.path("/foundry.toml"),
             &[project.root().to_path_buf()],
-            FoundryConfigContext::new(Some("custom"), &[]),
+            &mut FoundryConfigContext::new(Some("custom"), &[]),
         )
         .unwrap();
 
@@ -1178,19 +1217,21 @@ mod tests {
         let outer = FoundryWorkspaceConfig::new(project.path("/outer"));
         let nested = FoundryWorkspaceConfig::new(project.path("/outer/nested"));
         let configs = [outer, nested];
-        let foundry_config = FoundryConfigContext::new(None, &configs);
+        let mut foundry_config = FoundryConfigContext::new(None, &configs);
 
-        assert!(
+        let mut root_matches = |root: &Path, expected: &Path| {
             foundry_config
-                .workspace_config(&project.path("/outer"))
-                .is_some_and(|config| config.workspace_root() == project.path("/outer"))
-        );
-        assert!(
-            foundry_config
-                .workspace_config(&project.path("/outer/./nested/../nested"))
-                .is_some_and(|config| config.workspace_root() == project.path("/outer/nested"))
-        );
-        assert!(foundry_config.workspace_config(&project.path("/outer/other")).is_none());
+                .workspace_config(root)
+                .unwrap()
+                .is_some_and(|config| config.workspace_root() == expected)
+        };
+        assert!(root_matches(&project.path("/outer"), &project.path("/outer")));
+        assert!(root_matches(
+            &project.path("/outer/./nested/../nested"),
+            &project.path("/outer/nested")
+        ));
+        drop(root_matches);
+        assert!(foundry_config.workspace_config(&project.path("/outer/other")).unwrap().is_none());
     }
 
     #[test]
@@ -1215,7 +1256,7 @@ mod tests {
         let workspace = Workspace::load_foundry_bounded(
             project.path("/workspace/foundry.toml"),
             &[project.path("/workspace")],
-            FoundryConfigContext::new(None, &configs),
+            &mut FoundryConfigContext::new(None, &configs),
         )
         .unwrap();
 
@@ -1242,7 +1283,7 @@ mod tests {
         let workspace = Workspace::load_foundry_bounded(
             project.path("/workspace/foundry.toml"),
             &[project.path("/workspace")],
-            FoundryConfigContext::default(),
+            &mut FoundryConfigContext::default(),
         )
         .unwrap();
         let opts = workspace.compile_opts();


### PR DESCRIPTION
Foundry embeds the language server with host-resolved workspace configuration so inherited profiles and remappings match Forge. A launch-time snapshot was previously reused during every rediscovery, which meant a watched `foundry.toml` change could rediscover the workspace while retaining old source roots and compile settings.

This adds an optional host loader as an alternative to static snapshots. Solar resolves it lazily for every Foundry root encountered during a discovery pass and caches each root for that pass, so changed, newly created, renamed, and nested projects all receive host-resolved configuration. A loader error aborts the pass and retains the last successfully discovered workspace set, while invalid or mismatched returned roots are rejected without panicking. Background loader failures complete the current analysis epoch as failed rather than being mistaken for cancellation, keeping analysis requests responsive with the last-good configuration. If a workspace-folder or file operation changed the configured roots, a failed discovery restores the last committed roots and watcher registration so the root list and loaded workspace snapshot remain consistent. Clearing the analysis cache discards any pending root rollback checkpoint as it publishes the newer epoch, preventing a later discovery failure from restoring roots captured before the cache reset. Embedders that use static snapshots keep the existing behavior and avoid reload-time cloning.

This is the upstream API needed to resolve [foundry-rs/foundry#16397](https://github.com/foundry-rs/foundry/issues/16397). The coverage exercises live source-root changes, newly discovered nested projects, loader failure and recovery, synchronous and background workspace-folder rollback, cache-reset checkpoint invalidation, background failure completion, per-pass caching, and invalid returned roots. This change was developed with assistance from OpenAI Codex.
