### PR TITLE
test(tester): add codegen revision matrices

### DIFF
--- a/tests/ui/codegen/run-call/signed_literal_comparison.mir.stdout
+++ b/tests/ui/codegen/run-call/signed_literal_comparison.mir.stdout
@@ -1,0 +1,15 @@
+// === ROOT/tests/ui/codegen/run-call/signed_literal_comparison.sol:SignedLiteralComparison ===
+@module SignedLiteralComparison
+fn @literalLeft(arg0: i256) -> bool [abi_returns=[word]] {
+  bb0:
+    v0 = calldatasize
+    v1 = sub v0, 4
+    v2 = slt v1, 32
+    jumpi v2, bb1, bb2
+  bb2:
+    v3 = sgt 0, arg0
+    ret v3
+  bb1:
+    revert 0, 0
+}
+

--- a/tests/ui/codegen/run-call/signed_literal_comparison.sol
+++ b/tests/ui/codegen/run-call/signed_literal_comparison.sol
@@ -1,3 +1,4 @@
+//@ codegen-matrix: standard
 //@ run-call: SignedLiteralComparison::literalLeft(int256) -100 => true
 //@ run-call: SignedLiteralComparison::literalLeft(int256) 100 => false
 

--- a/tools/tester/src/codegen_matrix.rs
+++ b/tools/tester/src/codegen_matrix.rs
@@ -1,0 +1,124 @@
+use ui_test::{
+    CommentParser, Config, Revisioned,
+    spanned::{Span, Spanned},
+};
+
+pub(crate) const NAME: &str = "codegen-matrix";
+
+const STANDARD_REVISIONS: &[&str] = &["none", "gas", "size", "mir"];
+
+pub(crate) fn parse(parser: &mut CommentParser<&mut Revisioned>, args: Spanned<&str>, _span: Span) {
+    let mut revisions = args.split_whitespace();
+    parser.check(
+        args.span(),
+        revisions.next() == Some("standard"),
+        "`codegen-matrix` must start with `standard`",
+    );
+    for revision in revisions {
+        parser.check(
+            args.span(),
+            revision.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "invalid extra `codegen-matrix` revision",
+        );
+    }
+}
+
+pub(crate) fn is_standard(src: &str) -> bool {
+    directive(src).is_some_and(|args| args.split_whitespace().next() == Some("standard"))
+}
+
+fn directive(src: &str) -> Option<&str> {
+    src.lines().find_map(|line| {
+        let directive = line.trim_start().strip_prefix("//@")?;
+        directive.trim().strip_prefix("codegen-matrix:").map(str::trim)
+    })
+}
+
+pub(crate) fn apply(config: &mut Config, src: &str) -> bool {
+    if !is_standard(src) {
+        return false;
+    }
+
+    let extra_revisions = config.comment_defaults.revisions.take().unwrap_or_default();
+    let mut revisions = revisions(src).into_iter().map(str::to_owned).collect::<Vec<_>>();
+    for revision in extra_revisions {
+        if !revisions.contains(&revision) {
+            revisions.push(revision);
+        }
+    }
+    config.comment_defaults.revisions = Some(revisions);
+    for (revision, flags) in [
+        ("none", &["-O", "none", "--emit=abi,bin"] as &[&str]),
+        ("gas", &["-O", "gas", "--emit=abi,bin"]),
+        ("size", &["-O", "size", "--emit=abi,bin"]),
+        ("mir", &["-O", "none", "-Zdump=mir"]),
+    ] {
+        config
+            .comment_defaults
+            .revisioned
+            .entry(vec![revision.to_owned()])
+            .or_default()
+            .compile_flags
+            .extend(flags.iter().map(|flag| (*flag).to_owned()));
+    }
+    true
+}
+
+pub(crate) fn revisions(src: &str) -> Vec<&str> {
+    let mut revisions = STANDARD_REVISIONS.to_vec();
+    for revision in directive(src).into_iter().flat_map(|args| args.split_whitespace().skip(1)) {
+        if !revisions.contains(&revision) {
+            revisions.push(revision);
+        }
+    }
+    revisions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_standard_matrix() {
+        assert!(is_standard("//@ codegen-matrix: standard\n"));
+        assert!(is_standard("//@ codegen-matrix: standard unlinked\n"));
+        assert!(is_standard("  //@codegen-matrix: standard\n"));
+        assert!(!is_standard("//@ codegen-matrix: custom\n"));
+    }
+
+    #[test]
+    fn applies_standard_matrix() {
+        let mut config = Config::dummy();
+        assert!(apply(&mut config, "//@ codegen-matrix: standard\n"));
+        assert_eq!(
+            config.comment_defaults.revisions.as_deref(),
+            Some(&["none".to_owned(), "gas".to_owned(), "size".to_owned(), "mir".to_owned()][..])
+        );
+        assert_eq!(
+            config.comment_defaults.revisioned[&["mir".to_owned()][..]].compile_flags,
+            ["-O", "none", "-Zdump=mir"].map(str::to_owned)
+        );
+    }
+
+    #[test]
+    fn retains_extra_revisions() {
+        let mut config = Config::dummy();
+        assert!(apply(&mut config, "//@ codegen-matrix: standard unlinked mir\n"));
+        assert_eq!(
+            config.comment_defaults.revisions.as_deref(),
+            Some(
+                &[
+                    "none".to_owned(),
+                    "gas".to_owned(),
+                    "size".to_owned(),
+                    "mir".to_owned(),
+                    "unlinked".to_owned(),
+                ][..]
+            )
+        );
+        assert_eq!(
+            revisions("//@ codegen-matrix: standard unlinked\n"),
+            ["none", "gas", "size", "mir", "unlinked"]
+        );
+    }
+}

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -8,6 +8,7 @@
 use cfg_if as _;
 
 use eyre::{Result, eyre};
+use regex::bytes::Regex;
 use std::{
     ffi::{OsStr, OsString},
     io,
@@ -24,6 +25,10 @@ use ui_test::{
     spanned::{Span, Spanned},
 };
 
+const RUN_CALL_STDOUT_FILTER_PATTERN: &str = r"(?s).+";
+const RUN_CALL_MIR_STDOUT_FILTER_PATTERN: &str = r#"(?s)\{"contracts".*\}\n?$"#;
+
+mod codegen_matrix;
 mod errors;
 #[cfg(test)]
 mod foundry;
@@ -171,6 +176,7 @@ fn config(cmd: &'static Path, args: &ui_test::Args, mode: Mode) -> ui_test::Conf
         };
     }
     register_custom_flags![FileCheck, run_call::RunCall, run_call::RunCallFail];
+    config.custom_comments.insert(codegen_matrix::NAME, codegen_matrix::parse);
 
     config.comment_defaults.base().exit_status = None.into();
     config.infer_exit_status_from_annotations = !mode.is_solc();
@@ -337,9 +343,18 @@ fn per_file_config(config: &mut ui_test::Config, file: &Spanned<Vec<u8>>, cfg: M
     if is_codegen_test {
         config.program.args.push("--allow=2264".into());
     }
+    let has_codegen_matrix = codegen_matrix::apply(config, src);
+    let has_mir_dump = src.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("//@") && line.contains("-Zdump=mir")
+    }) || has_codegen_matrix;
     if matches!(cfg.mode, Mode::Ui) && src.lines().any(run_call::is_directive) {
-        config.program.args.push("--emit=abi,bin".into());
-        config.stdout_filter(r"(?s).+", "");
+        if has_mir_dump {
+            configure_run_call_stdout(config, src);
+        } else {
+            config.program.args.push("--emit=abi,bin".into());
+            config.stdout_filter(RUN_CALL_STDOUT_FILTER_PATTERN, "");
+        }
     }
     if src.lines().any(|line| {
         let line = line.trim_start();
@@ -349,6 +364,157 @@ fn per_file_config(config: &mut ui_test::Config, file: &Spanned<Vec<u8>>, cfg: M
     }) {
         config.program.args.retain(|arg| arg != "-j1");
     }
+}
+
+fn configure_run_call_stdout(config: &mut ui_test::Config, src: &str) {
+    let mut declared_revisions = Vec::new();
+    let mut dump_revisions = Vec::new();
+    let mut scoped_runtime_revisions = Vec::new();
+    let mut scoped_run_call_revisions = Vec::new();
+    let mut emitted_revisions = Vec::new();
+    let mut unscoped_run_call = false;
+    let mut base_mir_dump = false;
+    if codegen_matrix::is_standard(src) {
+        declared_revisions.extend(codegen_matrix::revisions(src).into_iter().map(str::to_owned));
+        dump_revisions.push("mir".to_owned());
+        emitted_revisions.extend(["none", "gas", "size"].map(str::to_owned));
+    }
+    for line in src.lines() {
+        let Some((directive, revisions)) = run_call::parse_directive(line) else {
+            continue;
+        };
+        if let Some(revision_list) = directive.strip_prefix("revisions:") {
+            declared_revisions.extend(revision_list.split_whitespace().map(str::to_owned));
+            continue;
+        }
+
+        if revisions.is_none() {
+            if run_call::is_directive(line) {
+                unscoped_run_call = true;
+            } else if directive.contains("compile-flags") && directive.contains("-Zdump=mir") {
+                base_mir_dump = true;
+            }
+            continue;
+        }
+        let Some(revisions) = revisions else { continue };
+        if run_call::is_directive(line) {
+            scoped_run_call_revisions
+                .extend(revisions.split(',').map(|revision| revision.trim().to_owned()));
+            continue;
+        }
+        if !directive.contains("compile-flags") {
+            continue;
+        }
+        let is_dump = directive.contains("-Zdump=");
+        let emits_artifacts = directive.split_whitespace().any(|arg| arg == "--emit=abi,bin");
+        for revision in revisions.split(',').map(|revision| revision.trim().to_owned()) {
+            if emits_artifacts {
+                emitted_revisions.push(revision.clone());
+            }
+            if is_dump {
+                dump_revisions.push(revision);
+            } else {
+                scoped_runtime_revisions.push(revision);
+            }
+        }
+    }
+
+    let mut runtime_revisions = if declared_revisions.is_empty() {
+        scoped_runtime_revisions
+    } else {
+        declared_revisions
+            .iter()
+            .filter(|revision| !dump_revisions.iter().any(|dump| dump == *revision))
+            .cloned()
+            .collect()
+    };
+    runtime_revisions.sort_unstable();
+    runtime_revisions.dedup();
+    let has_scoped_dump_call =
+        dump_revisions.iter().any(|revision| scoped_run_call_revisions.contains(revision));
+    if runtime_revisions.is_empty()
+        && (!unscoped_run_call || !base_mir_dump)
+        && !has_scoped_dump_call
+    {
+        return;
+    }
+
+    emitted_revisions.sort_unstable();
+    emitted_revisions.dedup();
+    let mut artifact_revisions = runtime_revisions.clone();
+    artifact_revisions.extend(scoped_run_call_revisions.iter().cloned());
+    if unscoped_run_call {
+        if declared_revisions.is_empty() {
+            if base_mir_dump {
+                config.comment_defaults.base().compile_flags.push("--emit=abi,bin".into());
+            }
+        } else {
+            artifact_revisions = declared_revisions.clone();
+        }
+    }
+    artifact_revisions.sort_unstable();
+    artifact_revisions.dedup();
+    let missing_emit = artifact_revisions
+        .iter()
+        .filter(|revision| !emitted_revisions.iter().any(|emitted| emitted == *revision))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing_emit.is_empty() {
+        config
+            .comment_defaults
+            .revisioned
+            .entry(missing_emit)
+            .or_default()
+            .compile_flags
+            .push("--emit=abi,bin".into());
+    }
+
+    if !runtime_revisions.is_empty() {
+        config
+            .comment_defaults
+            .revisioned
+            .entry(runtime_revisions)
+            .or_default()
+            .normalize_stdout
+            .push((run_call_stdout_regex().clone().into(), vec![]));
+    }
+    let mut run_call_dump_revisions = if unscoped_run_call {
+        dump_revisions.clone()
+    } else {
+        dump_revisions
+            .iter()
+            .filter(|revision| scoped_run_call_revisions.contains(revision))
+            .cloned()
+            .collect()
+    };
+    run_call_dump_revisions.sort_unstable();
+    run_call_dump_revisions.dedup();
+    if !run_call_dump_revisions.is_empty() {
+        config
+            .comment_defaults
+            .revisioned
+            .entry(run_call_dump_revisions)
+            .or_default()
+            .normalize_stdout
+            .push((run_call_mir_stdout_regex().clone().into(), vec![]));
+    }
+    if unscoped_run_call && base_mir_dump {
+        config
+            .comment_defaults
+            .base()
+            .normalize_stdout
+            .push((run_call_mir_stdout_regex().clone().into(), vec![]));
+    }
+}
+
+fn run_call_stdout_regex() -> &'static Regex {
+    static FILTER: OnceLock<Regex> = OnceLock::new();
+    FILTER.get_or_init(|| Regex::new(RUN_CALL_STDOUT_FILTER_PATTERN).unwrap())
+}
+
+fn run_call_mir_stdout_regex() -> &'static Regex {
+    static FILTER: OnceLock<Regex> = OnceLock::new();
+    FILTER.get_or_init(|| Regex::new(RUN_CALL_MIR_STDOUT_FILTER_PATTERN).unwrap())
 }
 
 // For solc tests, we can't expect errors normally since we have different diagnostics.

--- a/tools/tester/src/lib.rs
+++ b/tools/tester/src/lib.rs
@@ -489,6 +489,20 @@ fn configure_run_call_stdout(config: &mut ui_test::Config, src: &str) {
     };
     run_call_dump_revisions.sort_unstable();
     run_call_dump_revisions.dedup();
+    let dump_only_revisions = dump_revisions
+        .iter()
+        .filter(|revision| !run_call_dump_revisions.contains(revision))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !dump_only_revisions.is_empty() {
+        config
+            .comment_defaults
+            .revisioned
+            .entry(dump_only_revisions)
+            .or_default()
+            .normalize_stdout
+            .push((run_call_stdout_regex().clone().into(), vec![]));
+    }
     if !run_call_dump_revisions.is_empty() {
         config
             .comment_defaults

--- a/tools/tester/src/run_call.rs
+++ b/tools/tester/src/run_call.rs
@@ -72,17 +72,22 @@ struct ParsedCall<'a> {
     settings: CallSettings,
 }
 
-pub(crate) fn is_directive(line: &str) -> bool {
-    let Some(mut directive) = line.trim_start().strip_prefix("//@") else {
-        return false;
-    };
-    directive = directive.trim_start();
-    if let Some(revision) = directive.strip_prefix('[')
-        && let Some((_, rest)) = revision.split_once(']')
-    {
+pub(crate) fn parse_directive(line: &str) -> Option<(&str, Option<&str>)> {
+    let mut directive = line.trim_start().strip_prefix("//@")?.trim_start();
+    let revisions = if let Some(scoped) = directive.strip_prefix('[') {
+        let (revisions, rest) = scoped.split_once(']')?;
         directive = rest.trim_start();
-    }
-    directive.starts_with("run-call:") || directive.starts_with("run-call-fail:")
+        Some(revisions)
+    } else {
+        None
+    };
+    Some((directive, revisions))
+}
+
+pub(crate) fn is_directive(line: &str) -> bool {
+    parse_directive(line).is_some_and(|(directive, _)| {
+        directive.starts_with("run-call:") || directive.starts_with("run-call-fail:")
+    })
 }
 
 impl RunCall {
@@ -368,8 +373,25 @@ fn display_call(call: &str, function: Option<&Function>) -> String {
 }
 
 fn parse_artifacts(output: &[u8]) -> Result<Vec<Artifact>, String> {
-    let output: Value = serde_json::from_slice(output)
-        .map_err(|err| format!("failed to parse compiler output: {err}"))?;
+    let output: Value = match serde_json::from_slice(output) {
+        Ok(output) => output,
+        Err(err) => {
+            let marker = br#""contracts""#;
+            let Some(contracts) = output.windows(marker.len()).rposition(|window| window == marker)
+            else {
+                return Err(format!("failed to parse compiler output: {err}"));
+            };
+            let Some(start) = output[..contracts].iter().rposition(|&byte| byte == b'{') else {
+                return Err(format!("failed to parse compiler output: {err}"));
+            };
+            serde_json::Deserializer::from_slice(&output[start..])
+                .into_iter()
+                .next()
+                .transpose()
+                .map_err(|_| format!("failed to parse compiler output: {err}"))?
+                .ok_or_else(|| format!("failed to parse compiler output: {err}"))?
+        }
+    };
     let contracts = output
         .get("contracts")
         .and_then(Value::as_object)
@@ -752,6 +774,28 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn parses_artifacts_after_mir_dump() {
+        let output = br#"@module Test
+
+{"contracts":{"source.sol:Test":{"abi":[],"bin":"00"}}}"#;
+        let artifacts = parse_artifacts(output).unwrap();
+        assert_eq!(artifacts[0].name, "source.sol:Test");
+        assert_eq!(artifacts[0].bytecode, [0]);
+    }
+
+    #[test]
+    fn parses_artifacts_before_evm_ir_dump() {
+        let output = br#"{
+  "contracts": {"source.sol:Test": {"abi": [], "bin": "00"}}
+}
+
+@module runtime"#;
+        let artifacts = parse_artifacts(output).unwrap();
+        assert_eq!(artifacts[0].name, "source.sol:Test");
+        assert_eq!(artifacts[0].bytecode, [0]);
     }
 
     #[test]


### PR DESCRIPTION
Adds a shared codegen-matrix directive for the standard none, gas, size, and MIR revisions. Run-call fixtures can retain IR snapshots while the tester emits and parses ABI and bytecode artifacts for each runtime revision, including dump-only revisions. This extracts the reusable tester support from #1161 so other codegen PRs can build on it without taking the lowering rewrite.