### PR TITLE
fix(ci): repair main workflow failures

### DIFF
--- a/.github/workflows/bench-comment.yml
+++ b/.github/workflows/bench-comment.yml
@@ -29,7 +29,7 @@ jobs:
             const head = `${run.head_repository.owner.login}:${run.head_branch}`;
             const { data: pulls } = await github.rest.pulls.list({
               ...context.repo,
-              state: "open",
+              state: "all",
               head,
             });
             const pull = pulls.find((candidate) => candidate.head.sha === run.head_sha);

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -9,21 +9,6 @@ on:
         required: false
         type: string
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".cargo/**"
-      - ".github/workflows/build-release-binaries.yml"
-      - ".github/workflows/release.yml"
-      - "benches/runtime/**"
-      - "crates/**"
-      - "testdata/projects/**"
-      - "testdata/repros/**"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "dist-workspace.toml"
-      - "rust-toolchain*"
-      - "scripts/pgo/**"
-      - "scripts/wasm/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -146,28 +146,6 @@ jobs:
             echo "solar requires glibc $max_glibc_version, above the configured $MIN_GLIBC_VERSION" >&2
             exit 1
           fi
-      - name: Build benchmark baseline
-        if: github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu'
-        shell: bash
-        run: |
-          python scripts/pgo/build.py \
-            --target "${{ matrix.target }}" \
-            --target-dir "${{ github.workspace }}/target/solar-baseline" \
-            --baseline-only
-      - name: Compare baseline and PGO
-        if: github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu'
-        shell: bash
-        run: |
-          python scripts/pgo/compare.py \
-            --baseline "${{ github.workspace }}/target/solar-baseline/${{ matrix.target }}/dist/solar" \
-            --pgo "$SOLAR_BINARY" \
-            --output-dir "${{ github.workspace }}/target/pgo-comparison"
-      - name: Upload PGO comparison
-        if: always() && github.event_name == 'pull_request' && matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: pgo-comparison
-          path: target/pgo-comparison
       - name: Package release binary
         shell: bash
         run: |

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -452,7 +452,7 @@ mod tests {
             command: "/bin/sh".into(),
             args: vec![
                 "-c".into(),
-                "printf '%s' 'contract Test { uint256 temporary; }' > \"$1\"; printf '%s\\n' \"$2\"; printf '%s' \"$3\" > \"$1\"; touch -t 200001010000 \"$1\""
+                "printf '%s' 'contract Test { uint256 temporary; }' > \"$1\"; printf '%s\\n' \"$2\"; printf '%s' \"$3\" > \"$1.tmp\"; mv \"$1.tmp\" \"$1\""
                     .into(),
                 "sh".into(),
                 path.display().to_string(),

--- a/crates/lsp/src/flycheck/runner.rs
+++ b/crates/lsp/src/flycheck/runner.rs
@@ -452,7 +452,7 @@ mod tests {
             command: "/bin/sh".into(),
             args: vec![
                 "-c".into(),
-                "printf '%s' 'contract Test { uint256 temporary; }' > \"$1\"; printf '%s\\n' \"$2\"; printf '%s' \"$3\" > \"$1\""
+                "printf '%s' 'contract Test { uint256 temporary; }' > \"$1\"; printf '%s\\n' \"$2\"; printf '%s' \"$3\" > \"$1\"; touch -t 200001010000 \"$1\""
                     .into(),
                 "sh".into(),
                 path.display().to_string(),


### PR DESCRIPTION
Fix the main CI failures and remove automatic release-binary builds from pull requests:

- Resolve benchmark PRs across all states so a merge racing the trusted `workflow_run` follow-up does not fail the comment job. The exact benchmark head SHA is still required.
- Make the restored-source flycheck test force a deterministic file revision change instead of relying on sub-second filesystem timestamp resolution. This is the test failing in both the MSRV and nightly matrix jobs.
- Keep release-binary builds available to the release workflow and manual dispatch, but stop running them automatically for pull requests. The workflow had no push trigger.

Validation:
- Parsed the modified workflow YAML with PyYAML
- Confirmed failed benchmark head SHAs resolve when querying all PR states
- `cargo +nightly fmt --all --check`
- Targeted LSP test on stable and nightly

Prompted by: @DaniPopes