### PR TITLE
fix(codegen): clear packed array copy tails

### DIFF
--- a/crates/codegen/src/lower/function/storage_values.rs
+++ b/crates/codegen/src/lower/function/storage_values.rs
@@ -83,19 +83,7 @@ fn load_packed_storage_array_element(
     // storage_slot = data_slot + index / per_slot
     // shift = (index % per_slot) * bytes * 8
     // value = decode(sload(storage_slot), shift, encoding)
-    let per_slot = u64::from(32 / bytes);
-    let per_slot_value = builder.imm_u64(per_slot);
-    let (slot_index, index_in_slot) = if per_slot.is_power_of_two() {
-        let slot_shift = builder.imm_u64(u64::from(per_slot.trailing_zeros()));
-        let slot_index = builder.shr(slot_shift, index);
-        let slot_mask = builder.imm_u64(per_slot - 1);
-        let index_in_slot = builder.and(index, slot_mask);
-        (slot_index, index_in_slot)
-    } else {
-        let slot_index = builder.div(index, per_slot_value);
-        let index_in_slot = builder.mod_(index, per_slot_value);
-        (slot_index, index_in_slot)
-    };
+    let (slot_index, index_in_slot) = packed_storage_array_position(builder, index, bytes);
     let storage_slot = builder.add(data_slot, slot_index);
     let word = builder.sload(storage_slot);
     let byte_shift = u64::from(bytes) * 8;
@@ -108,6 +96,26 @@ fn load_packed_storage_array_element(
     };
     let size = TypeSize::new_int_bits(u16::from(bytes) * 8);
     StorageLocation::packed_word(size, encoding).load_word(builder, word, Some(shift))
+}
+
+fn packed_storage_array_position(
+    builder: &mut FunctionBuilder<'_>,
+    index: ValueId,
+    bytes: u8,
+) -> (ValueId, ValueId) {
+    let per_slot = u64::from(32 / bytes);
+    if per_slot.is_power_of_two() {
+        let slot_shift = builder.imm_u64(u64::from(per_slot.trailing_zeros()));
+        let slot_index = builder.shr(slot_shift, index);
+        let slot_mask = builder.imm_u64(per_slot - 1);
+        let index_in_slot = builder.and(index, slot_mask);
+        (slot_index, index_in_slot)
+    } else {
+        let per_slot_value = builder.imm_u64(per_slot);
+        let slot_index = builder.div(index, per_slot_value);
+        let index_in_slot = builder.mod_(index, per_slot_value);
+        (slot_index, index_in_slot)
+    }
 }
 
 /// Builds the helper for clearing the data words of a storage bytes value.
@@ -1317,13 +1325,13 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         // for i < new_length { store(source_element[i], element[i]) }
         let source_ty = source_ty.peel_refs();
         let source_layout = self.types.memory_layout(source_ty)?;
-        let (source_element, length) = match source_ty.kind {
+        let (source_element, length, fixed_length) = match source_ty.kind {
             TyKind::DynArray(source_element) | TyKind::Slice(source_element) => {
-                (source_element, self.builder.memory_object_len(object, source_layout.kind()))
+                (source_element, self.builder.memory_object_len(object, source_layout.kind()), None)
             }
             TyKind::Array(source_element, source_len) => {
-                let source_len = self.builder.imm_u64(u64::try_from(source_len).ok()?);
-                (source_element, source_len)
+                let source_len = u64::try_from(source_len).ok()?;
+                (source_element, self.builder.imm_u64(source_len), Some(source_len))
             }
             _ => return report_unsupported(self.context.gcx, span, "storage array conversion"),
         };
@@ -1383,7 +1391,56 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
         self.builder.jump(header);
         self.builder.add_phi_incoming(index, backedge, next);
         self.builder.switch_to_block(exit);
+
+        if let Some((size, _)) = self.context.storage.packed_encoding(element)
+            && 32 / size.bytes() > 1
+        {
+            // Packed element stores preserve neighboring bits, including stale values past the
+            // logical length.
+            let per_slot = u64::from(32 / size.bytes());
+            if let Some(length) = fixed_length {
+                let remainder = length % per_slot;
+                if remainder != 0 {
+                    let slot_index = self.builder.imm_u64(length / per_slot);
+                    let used_bits = u64::from(size.bits()) * remainder;
+                    let mask = (U256::from(1) << used_bits) - U256::from(1);
+                    let mask = self.builder.imm_u256(mask);
+                    self.clear_unused_packed_array_elements(slot, slot_index, mask);
+                }
+            } else {
+                let (slot_index, remainder) =
+                    packed_storage_array_position(&mut self.builder, length, size.bytes());
+                let no_partial_slot = self.builder.iszero(remainder);
+                let cleanup_block = self.builder.create_block();
+                let merge_block = self.builder.create_block();
+                self.builder.branch(no_partial_slot, merge_block, cleanup_block);
+
+                self.builder.switch_to_block(cleanup_block);
+                let element_bits = self.builder.imm_u64(u64::from(size.bits()));
+                let used_bits = self.builder.mul(remainder, element_bits);
+                let one = self.builder.imm_u64(1);
+                let high_bit = self.builder.shl(used_bits, one);
+                let mask = self.builder.sub(high_bit, one);
+                self.clear_unused_packed_array_elements(slot, slot_index, mask);
+                self.builder.jump(merge_block);
+
+                self.builder.switch_to_block(merge_block);
+            }
+        }
         Some(())
+    }
+
+    fn clear_unused_packed_array_elements(
+        &mut self,
+        slot: ValueId,
+        slot_index: ValueId,
+        mask: ValueId,
+    ) {
+        let data_slot = self.builder.storage_array_data_slot(slot);
+        let partial_slot = self.builder.add(data_slot, slot_index);
+        let word = self.builder.sload(partial_slot);
+        let word = self.builder.and(word, mask);
+        self.builder.sstore(partial_slot, word);
     }
 
     fn store_storage_struct_fields_with_source(

--- a/crates/codegen/src/lower/function/storage_values.rs
+++ b/crates/codegen/src/lower/function/storage_values.rs
@@ -1399,10 +1399,10 @@ impl<'gcx, 'ctx> FunctionLowerer<'gcx, 'ctx> {
             // logical length.
             let per_slot = u64::from(32 / size.bytes());
             if let Some(length) = fixed_length {
-                let remainder = length % per_slot;
+                let remainder = (length % per_slot) as u16;
                 if remainder != 0 {
                     let slot_index = self.builder.imm_u64(length / per_slot);
-                    let used_bits = u64::from(size.bits()) * remainder;
+                    let used_bits = size.bits() * remainder;
                     let mask = (U256::from(1) << used_bits) - U256::from(1);
                     let mask = self.builder.imm_u256(mask);
                     self.clear_unused_packed_array_elements(slot, slot_index, mask);

--- a/tests/ui/codegen/lowering/run-call/array_copy_cleanup_uint40.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/array_copy_cleanup_uint40.mir.stdout
@@ -431,525 +431,540 @@ fn @f() -> bool [selector=0x26121ff0, abi_params=[], abi_returns=[word<bool>]] {
     v345 = lt v344, v325
     jumpi v345, bb49, bb50
   bb50:
-    sstore 0, 20 !metadata(storage=slot(0))
-    v361 = sload 0 !metadata(storage=slot(0))
-    v362 = lt 0, v361
+    v361 = div v325, 6
+    v362 = mod v325, 6
     v363 = iszero v362
-    jumpi v363, bb51, bb52
+    jumpi v363, bb52, bb51
+  bb51:
+    v364 = mul v362, 40
+    v365 = shl v364, 1
+    v366 = sub v365, 1
+    v367 = storage_array_data_slot 0
+    v368 = add v367, v361
+    v369 = sload v368 !metadata(storage=symbolic(v368))
+    v370 = and v369, v366
+    sstore v368, v370 !metadata(storage=symbolic(v368))
+    jump bb52
   bb52:
-    v364 = storage_array_data_slot 0
-    v365 = div 0, 6
-    v366 = add v364, v365
-    v367 = mod 0, 6
-    v368 = mul v367, 5
-    v369 = sload v366 !metadata(storage=symbolic(v366))
-    v370 = mul v368, 8
-    v371 = shr v370, v369
-    v372 = and v371, 0xffffffffff
-    v373 = eq v372, 23
-    v374 = iszero v373
-    jumpi v374, bb53, bb54
+    sstore 0, 20 !metadata(storage=slot(0))
+    v371 = sload 0 !metadata(storage=slot(0))
+    v372 = lt 0, v371
+    v373 = iszero v372
+    jumpi v373, bb53, bb54
   bb54:
-    v375 = sload 0 !metadata(storage=slot(0))
-    v376 = lt 1, v375
-    v377 = iszero v376
-    jumpi v377, bb55, bb56
+    v374 = storage_array_data_slot 0
+    v375 = div 0, 6
+    v376 = add v374, v375
+    v377 = mod 0, 6
+    v378 = mul v377, 5
+    v379 = sload v376 !metadata(storage=symbolic(v376))
+    v380 = mul v378, 8
+    v381 = shr v380, v379
+    v382 = and v381, 0xffffffffff
+    v383 = eq v382, 23
+    v384 = iszero v383
+    jumpi v384, bb55, bb56
   bb56:
-    v378 = storage_array_data_slot 0
-    v379 = div 1, 6
-    v380 = add v378, v379
-    v381 = mod 1, 6
-    v382 = mul v381, 5
-    v383 = sload v380 !metadata(storage=symbolic(v380))
-    v384 = mul v382, 8
-    v385 = shr v384, v383
-    v386 = and v385, 0xffffffffff
-    v387 = eq v386, 0
-    v388 = iszero v387
-    jumpi v388, bb57, bb58
+    v385 = sload 0 !metadata(storage=slot(0))
+    v386 = lt 1, v385
+    v387 = iszero v386
+    jumpi v387, bb57, bb58
   bb58:
-    v389 = sload 0 !metadata(storage=slot(0))
-    v390 = lt 2, v389
-    v391 = iszero v390
-    jumpi v391, bb59, bb60
+    v388 = storage_array_data_slot 0
+    v389 = div 1, 6
+    v390 = add v388, v389
+    v391 = mod 1, 6
+    v392 = mul v391, 5
+    v393 = sload v390 !metadata(storage=symbolic(v390))
+    v394 = mul v392, 8
+    v395 = shr v394, v393
+    v396 = and v395, 0xffffffffff
+    v397 = eq v396, 0
+    v398 = iszero v397
+    jumpi v398, bb59, bb60
   bb60:
-    v392 = storage_array_data_slot 0
-    v393 = div 2, 6
-    v394 = add v392, v393
-    v395 = mod 2, 6
-    v396 = mul v395, 5
-    v397 = sload v394 !metadata(storage=symbolic(v394))
-    v398 = mul v396, 8
-    v399 = shr v398, v397
-    v400 = and v399, 0xffffffffff
-    v401 = eq v400, 0
-    v402 = iszero v401
-    jumpi v402, bb61, bb62
+    v399 = sload 0 !metadata(storage=slot(0))
+    v400 = lt 2, v399
+    v401 = iszero v400
+    jumpi v401, bb61, bb62
   bb62:
-    v403 = sload 0 !metadata(storage=slot(0))
-    v404 = lt 3, v403
-    v405 = iszero v404
-    jumpi v405, bb63, bb64
+    v402 = storage_array_data_slot 0
+    v403 = div 2, 6
+    v404 = add v402, v403
+    v405 = mod 2, 6
+    v406 = mul v405, 5
+    v407 = sload v404 !metadata(storage=symbolic(v404))
+    v408 = mul v406, 8
+    v409 = shr v408, v407
+    v410 = and v409, 0xffffffffff
+    v411 = eq v410, 0
+    v412 = iszero v411
+    jumpi v412, bb63, bb64
   bb64:
-    v406 = storage_array_data_slot 0
-    v407 = div 3, 6
-    v408 = add v406, v407
-    v409 = mod 3, 6
-    v410 = mul v409, 5
-    v411 = sload v408 !metadata(storage=symbolic(v408))
-    v412 = mul v410, 8
-    v413 = shr v412, v411
-    v414 = and v413, 0xffffffffff
-    v415 = eq v414, 0
-    v416 = iszero v415
-    jumpi v416, bb65, bb66
+    v413 = sload 0 !metadata(storage=slot(0))
+    v414 = lt 3, v413
+    v415 = iszero v414
+    jumpi v415, bb65, bb66
   bb66:
-    v417 = sload 0 !metadata(storage=slot(0))
-    v418 = lt 4, v417
-    v419 = iszero v418
-    jumpi v419, bb67, bb68
+    v416 = storage_array_data_slot 0
+    v417 = div 3, 6
+    v418 = add v416, v417
+    v419 = mod 3, 6
+    v420 = mul v419, 5
+    v421 = sload v418 !metadata(storage=symbolic(v418))
+    v422 = mul v420, 8
+    v423 = shr v422, v421
+    v424 = and v423, 0xffffffffff
+    v425 = eq v424, 0
+    v426 = iszero v425
+    jumpi v426, bb67, bb68
   bb68:
-    v420 = storage_array_data_slot 0
-    v421 = div 4, 6
-    v422 = add v420, v421
-    v423 = mod 4, 6
-    v424 = mul v423, 5
-    v425 = sload v422 !metadata(storage=symbolic(v422))
-    v426 = mul v424, 8
-    v427 = shr v426, v425
-    v428 = and v427, 0xffffffffff
-    v429 = eq v428, 0
-    v430 = iszero v429
-    jumpi v430, bb69, bb70
+    v427 = sload 0 !metadata(storage=slot(0))
+    v428 = lt 4, v427
+    v429 = iszero v428
+    jumpi v429, bb69, bb70
   bb70:
-    v431 = sload 0 !metadata(storage=slot(0))
-    v432 = lt 5, v431
-    v433 = iszero v432
-    jumpi v433, bb71, bb72
+    v430 = storage_array_data_slot 0
+    v431 = div 4, 6
+    v432 = add v430, v431
+    v433 = mod 4, 6
+    v434 = mul v433, 5
+    v435 = sload v432 !metadata(storage=symbolic(v432))
+    v436 = mul v434, 8
+    v437 = shr v436, v435
+    v438 = and v437, 0xffffffffff
+    v439 = eq v438, 0
+    v440 = iszero v439
+    jumpi v440, bb71, bb72
   bb72:
-    v434 = storage_array_data_slot 0
-    v435 = div 5, 6
-    v436 = add v434, v435
-    v437 = mod 5, 6
-    v438 = mul v437, 5
-    v439 = sload v436 !metadata(storage=symbolic(v436))
-    v440 = mul v438, 8
-    v441 = shr v440, v439
-    v442 = and v441, 0xffffffffff
-    v443 = eq v442, 0
-    v444 = iszero v443
-    jumpi v444, bb73, bb74
+    v441 = sload 0 !metadata(storage=slot(0))
+    v442 = lt 5, v441
+    v443 = iszero v442
+    jumpi v443, bb73, bb74
   bb74:
-    v445 = sload 0 !metadata(storage=slot(0))
-    v446 = lt 6, v445
-    v447 = iszero v446
-    jumpi v447, bb75, bb76
+    v444 = storage_array_data_slot 0
+    v445 = div 5, 6
+    v446 = add v444, v445
+    v447 = mod 5, 6
+    v448 = mul v447, 5
+    v449 = sload v446 !metadata(storage=symbolic(v446))
+    v450 = mul v448, 8
+    v451 = shr v450, v449
+    v452 = and v451, 0xffffffffff
+    v453 = eq v452, 0
+    v454 = iszero v453
+    jumpi v454, bb75, bb76
   bb76:
-    v448 = storage_array_data_slot 0
-    v449 = div 6, 6
-    v450 = add v448, v449
-    v451 = mod 6, 6
-    v452 = mul v451, 5
-    v453 = sload v450 !metadata(storage=symbolic(v450))
-    v454 = mul v452, 8
-    v455 = shr v454, v453
-    v456 = and v455, 0xffffffffff
-    v457 = eq v456, 0
-    v458 = iszero v457
-    jumpi v458, bb77, bb78
+    v455 = sload 0 !metadata(storage=slot(0))
+    v456 = lt 6, v455
+    v457 = iszero v456
+    jumpi v457, bb77, bb78
   bb78:
-    v459 = sload 0 !metadata(storage=slot(0))
-    v460 = lt 7, v459
-    v461 = iszero v460
-    jumpi v461, bb79, bb80
+    v458 = storage_array_data_slot 0
+    v459 = div 6, 6
+    v460 = add v458, v459
+    v461 = mod 6, 6
+    v462 = mul v461, 5
+    v463 = sload v460 !metadata(storage=symbolic(v460))
+    v464 = mul v462, 8
+    v465 = shr v464, v463
+    v466 = and v465, 0xffffffffff
+    v467 = eq v466, 0
+    v468 = iszero v467
+    jumpi v468, bb79, bb80
   bb80:
-    v462 = storage_array_data_slot 0
-    v463 = div 7, 6
-    v464 = add v462, v463
-    v465 = mod 7, 6
-    v466 = mul v465, 5
-    v467 = sload v464 !metadata(storage=symbolic(v464))
-    v468 = mul v466, 8
-    v469 = shr v468, v467
-    v470 = and v469, 0xffffffffff
-    v471 = eq v470, 0
-    v472 = iszero v471
-    jumpi v472, bb81, bb82
+    v469 = sload 0 !metadata(storage=slot(0))
+    v470 = lt 7, v469
+    v471 = iszero v470
+    jumpi v471, bb81, bb82
   bb82:
-    v473 = sload 0 !metadata(storage=slot(0))
-    v474 = lt 8, v473
-    v475 = iszero v474
-    jumpi v475, bb83, bb84
+    v472 = storage_array_data_slot 0
+    v473 = div 7, 6
+    v474 = add v472, v473
+    v475 = mod 7, 6
+    v476 = mul v475, 5
+    v477 = sload v474 !metadata(storage=symbolic(v474))
+    v478 = mul v476, 8
+    v479 = shr v478, v477
+    v480 = and v479, 0xffffffffff
+    v481 = eq v480, 0
+    v482 = iszero v481
+    jumpi v482, bb83, bb84
   bb84:
-    v476 = storage_array_data_slot 0
-    v477 = div 8, 6
-    v478 = add v476, v477
-    v479 = mod 8, 6
-    v480 = mul v479, 5
-    v481 = sload v478 !metadata(storage=symbolic(v478))
-    v482 = mul v480, 8
-    v483 = shr v482, v481
-    v484 = and v483, 0xffffffffff
-    v485 = eq v484, 0
-    v486 = iszero v485
-    jumpi v486, bb85, bb86
+    v483 = sload 0 !metadata(storage=slot(0))
+    v484 = lt 8, v483
+    v485 = iszero v484
+    jumpi v485, bb85, bb86
   bb86:
-    v487 = sload 0 !metadata(storage=slot(0))
-    v488 = lt 9, v487
-    v489 = iszero v488
-    jumpi v489, bb87, bb88
+    v486 = storage_array_data_slot 0
+    v487 = div 8, 6
+    v488 = add v486, v487
+    v489 = mod 8, 6
+    v490 = mul v489, 5
+    v491 = sload v488 !metadata(storage=symbolic(v488))
+    v492 = mul v490, 8
+    v493 = shr v492, v491
+    v494 = and v493, 0xffffffffff
+    v495 = eq v494, 0
+    v496 = iszero v495
+    jumpi v496, bb87, bb88
   bb88:
-    v490 = storage_array_data_slot 0
-    v491 = div 9, 6
-    v492 = add v490, v491
-    v493 = mod 9, 6
-    v494 = mul v493, 5
-    v495 = sload v492 !metadata(storage=symbolic(v492))
-    v496 = mul v494, 8
-    v497 = shr v496, v495
-    v498 = and v497, 0xffffffffff
-    v499 = eq v498, 0
-    v500 = iszero v499
-    jumpi v500, bb89, bb90
+    v497 = sload 0 !metadata(storage=slot(0))
+    v498 = lt 9, v497
+    v499 = iszero v498
+    jumpi v499, bb89, bb90
   bb90:
-    v501 = sload 0 !metadata(storage=slot(0))
-    v502 = lt 10, v501
-    v503 = iszero v502
-    jumpi v503, bb91, bb92
+    v500 = storage_array_data_slot 0
+    v501 = div 9, 6
+    v502 = add v500, v501
+    v503 = mod 9, 6
+    v504 = mul v503, 5
+    v505 = sload v502 !metadata(storage=symbolic(v502))
+    v506 = mul v504, 8
+    v507 = shr v506, v505
+    v508 = and v507, 0xffffffffff
+    v509 = eq v508, 0
+    v510 = iszero v509
+    jumpi v510, bb91, bb92
   bb92:
-    v504 = storage_array_data_slot 0
-    v505 = div 10, 6
-    v506 = add v504, v505
-    v507 = mod 10, 6
-    v508 = mul v507, 5
-    v509 = sload v506 !metadata(storage=symbolic(v506))
-    v510 = mul v508, 8
-    v511 = shr v510, v509
-    v512 = and v511, 0xffffffffff
-    v513 = eq v512, 0
-    v514 = iszero v513
-    jumpi v514, bb93, bb94
+    v511 = sload 0 !metadata(storage=slot(0))
+    v512 = lt 10, v511
+    v513 = iszero v512
+    jumpi v513, bb93, bb94
   bb94:
-    v515 = sload 0 !metadata(storage=slot(0))
-    v516 = lt 11, v515
-    v517 = iszero v516
-    jumpi v517, bb95, bb96
+    v514 = storage_array_data_slot 0
+    v515 = div 10, 6
+    v516 = add v514, v515
+    v517 = mod 10, 6
+    v518 = mul v517, 5
+    v519 = sload v516 !metadata(storage=symbolic(v516))
+    v520 = mul v518, 8
+    v521 = shr v520, v519
+    v522 = and v521, 0xffffffffff
+    v523 = eq v522, 0
+    v524 = iszero v523
+    jumpi v524, bb95, bb96
   bb96:
-    v518 = storage_array_data_slot 0
-    v519 = div 11, 6
-    v520 = add v518, v519
-    v521 = mod 11, 6
-    v522 = mul v521, 5
-    v523 = sload v520 !metadata(storage=symbolic(v520))
-    v524 = mul v522, 8
-    v525 = shr v524, v523
-    v526 = and v525, 0xffffffffff
-    v527 = eq v526, 0
-    v528 = iszero v527
-    jumpi v528, bb97, bb98
+    v525 = sload 0 !metadata(storage=slot(0))
+    v526 = lt 11, v525
+    v527 = iszero v526
+    jumpi v527, bb97, bb98
   bb98:
-    v529 = sload 0 !metadata(storage=slot(0))
-    v530 = lt 12, v529
-    v531 = iszero v530
-    jumpi v531, bb99, bb100
+    v528 = storage_array_data_slot 0
+    v529 = div 11, 6
+    v530 = add v528, v529
+    v531 = mod 11, 6
+    v532 = mul v531, 5
+    v533 = sload v530 !metadata(storage=symbolic(v530))
+    v534 = mul v532, 8
+    v535 = shr v534, v533
+    v536 = and v535, 0xffffffffff
+    v537 = eq v536, 0
+    v538 = iszero v537
+    jumpi v538, bb99, bb100
   bb100:
-    v532 = storage_array_data_slot 0
-    v533 = div 12, 6
-    v534 = add v532, v533
-    v535 = mod 12, 6
-    v536 = mul v535, 5
-    v537 = sload v534 !metadata(storage=symbolic(v534))
-    v538 = mul v536, 8
-    v539 = shr v538, v537
-    v540 = and v539, 0xffffffffff
-    v541 = eq v540, 0
-    v542 = iszero v541
-    jumpi v542, bb101, bb102
+    v539 = sload 0 !metadata(storage=slot(0))
+    v540 = lt 12, v539
+    v541 = iszero v540
+    jumpi v541, bb101, bb102
   bb102:
-    v543 = sload 0 !metadata(storage=slot(0))
-    v544 = lt 13, v543
-    v545 = iszero v544
-    jumpi v545, bb103, bb104
+    v542 = storage_array_data_slot 0
+    v543 = div 12, 6
+    v544 = add v542, v543
+    v545 = mod 12, 6
+    v546 = mul v545, 5
+    v547 = sload v544 !metadata(storage=symbolic(v544))
+    v548 = mul v546, 8
+    v549 = shr v548, v547
+    v550 = and v549, 0xffffffffff
+    v551 = eq v550, 0
+    v552 = iszero v551
+    jumpi v552, bb103, bb104
   bb104:
-    v546 = storage_array_data_slot 0
-    v547 = div 13, 6
-    v548 = add v546, v547
-    v549 = mod 13, 6
-    v550 = mul v549, 5
-    v551 = sload v548 !metadata(storage=symbolic(v548))
-    v552 = mul v550, 8
-    v553 = shr v552, v551
-    v554 = and v553, 0xffffffffff
-    v555 = eq v554, 0
-    v556 = iszero v555
-    jumpi v556, bb105, bb106
+    v553 = sload 0 !metadata(storage=slot(0))
+    v554 = lt 13, v553
+    v555 = iszero v554
+    jumpi v555, bb105, bb106
   bb106:
-    v557 = sload 0 !metadata(storage=slot(0))
-    v558 = lt 14, v557
-    v559 = iszero v558
-    jumpi v559, bb107, bb108
+    v556 = storage_array_data_slot 0
+    v557 = div 13, 6
+    v558 = add v556, v557
+    v559 = mod 13, 6
+    v560 = mul v559, 5
+    v561 = sload v558 !metadata(storage=symbolic(v558))
+    v562 = mul v560, 8
+    v563 = shr v562, v561
+    v564 = and v563, 0xffffffffff
+    v565 = eq v564, 0
+    v566 = iszero v565
+    jumpi v566, bb107, bb108
   bb108:
-    v560 = storage_array_data_slot 0
-    v561 = div 14, 6
-    v562 = add v560, v561
-    v563 = mod 14, 6
-    v564 = mul v563, 5
-    v565 = sload v562 !metadata(storage=symbolic(v562))
-    v566 = mul v564, 8
-    v567 = shr v566, v565
-    v568 = and v567, 0xffffffffff
-    v569 = eq v568, 0
-    v570 = iszero v569
-    jumpi v570, bb109, bb110
+    v567 = sload 0 !metadata(storage=slot(0))
+    v568 = lt 14, v567
+    v569 = iszero v568
+    jumpi v569, bb109, bb110
   bb110:
-    v571 = sload 0 !metadata(storage=slot(0))
-    v572 = lt 15, v571
-    v573 = iszero v572
-    jumpi v573, bb111, bb112
+    v570 = storage_array_data_slot 0
+    v571 = div 14, 6
+    v572 = add v570, v571
+    v573 = mod 14, 6
+    v574 = mul v573, 5
+    v575 = sload v572 !metadata(storage=symbolic(v572))
+    v576 = mul v574, 8
+    v577 = shr v576, v575
+    v578 = and v577, 0xffffffffff
+    v579 = eq v578, 0
+    v580 = iszero v579
+    jumpi v580, bb111, bb112
   bb112:
-    v574 = storage_array_data_slot 0
-    v575 = div 15, 6
-    v576 = add v574, v575
-    v577 = mod 15, 6
-    v578 = mul v577, 5
-    v579 = sload v576 !metadata(storage=symbolic(v576))
-    v580 = mul v578, 8
-    v581 = shr v580, v579
-    v582 = and v581, 0xffffffffff
-    v583 = eq v582, 0
-    v584 = iszero v583
-    jumpi v584, bb113, bb114
+    v581 = sload 0 !metadata(storage=slot(0))
+    v582 = lt 15, v581
+    v583 = iszero v582
+    jumpi v583, bb113, bb114
   bb114:
-    v585 = sload 0 !metadata(storage=slot(0))
-    v586 = lt 16, v585
-    v587 = iszero v586
-    jumpi v587, bb115, bb116
+    v584 = storage_array_data_slot 0
+    v585 = div 15, 6
+    v586 = add v584, v585
+    v587 = mod 15, 6
+    v588 = mul v587, 5
+    v589 = sload v586 !metadata(storage=symbolic(v586))
+    v590 = mul v588, 8
+    v591 = shr v590, v589
+    v592 = and v591, 0xffffffffff
+    v593 = eq v592, 0
+    v594 = iszero v593
+    jumpi v594, bb115, bb116
   bb116:
-    v588 = storage_array_data_slot 0
-    v589 = div 16, 6
-    v590 = add v588, v589
-    v591 = mod 16, 6
-    v592 = mul v591, 5
-    v593 = sload v590 !metadata(storage=symbolic(v590))
-    v594 = mul v592, 8
-    v595 = shr v594, v593
-    v596 = and v595, 0xffffffffff
-    v597 = eq v596, 0
-    v598 = iszero v597
-    jumpi v598, bb117, bb118
+    v595 = sload 0 !metadata(storage=slot(0))
+    v596 = lt 16, v595
+    v597 = iszero v596
+    jumpi v597, bb117, bb118
   bb118:
-    v599 = sload 0 !metadata(storage=slot(0))
-    v600 = lt 17, v599
-    v601 = iszero v600
-    jumpi v601, bb119, bb120
+    v598 = storage_array_data_slot 0
+    v599 = div 16, 6
+    v600 = add v598, v599
+    v601 = mod 16, 6
+    v602 = mul v601, 5
+    v603 = sload v600 !metadata(storage=symbolic(v600))
+    v604 = mul v602, 8
+    v605 = shr v604, v603
+    v606 = and v605, 0xffffffffff
+    v607 = eq v606, 0
+    v608 = iszero v607
+    jumpi v608, bb119, bb120
   bb120:
-    v602 = storage_array_data_slot 0
-    v603 = div 17, 6
-    v604 = add v602, v603
-    v605 = mod 17, 6
-    v606 = mul v605, 5
-    v607 = sload v604 !metadata(storage=symbolic(v604))
-    v608 = mul v606, 8
-    v609 = shr v608, v607
-    v610 = and v609, 0xffffffffff
-    v611 = eq v610, 0
-    v612 = iszero v611
-    jumpi v612, bb121, bb122
+    v609 = sload 0 !metadata(storage=slot(0))
+    v610 = lt 17, v609
+    v611 = iszero v610
+    jumpi v611, bb121, bb122
   bb122:
-    v613 = sload 0 !metadata(storage=slot(0))
-    v614 = lt 18, v613
-    v615 = iszero v614
-    jumpi v615, bb123, bb124
+    v612 = storage_array_data_slot 0
+    v613 = div 17, 6
+    v614 = add v612, v613
+    v615 = mod 17, 6
+    v616 = mul v615, 5
+    v617 = sload v614 !metadata(storage=symbolic(v614))
+    v618 = mul v616, 8
+    v619 = shr v618, v617
+    v620 = and v619, 0xffffffffff
+    v621 = eq v620, 0
+    v622 = iszero v621
+    jumpi v622, bb123, bb124
   bb124:
-    v616 = storage_array_data_slot 0
-    v617 = div 18, 6
-    v618 = add v616, v617
-    v619 = mod 18, 6
-    v620 = mul v619, 5
-    v621 = sload v618 !metadata(storage=symbolic(v618))
-    v622 = mul v620, 8
-    v623 = shr v622, v621
-    v624 = and v623, 0xffffffffff
-    v625 = eq v624, 0
-    v626 = iszero v625
-    jumpi v626, bb125, bb126
+    v623 = sload 0 !metadata(storage=slot(0))
+    v624 = lt 18, v623
+    v625 = iszero v624
+    jumpi v625, bb125, bb126
   bb126:
-    v627 = sload 0 !metadata(storage=slot(0))
-    v628 = lt 19, v627
-    v629 = iszero v628
-    jumpi v629, bb127, bb128
+    v626 = storage_array_data_slot 0
+    v627 = div 18, 6
+    v628 = add v626, v627
+    v629 = mod 18, 6
+    v630 = mul v629, 5
+    v631 = sload v628 !metadata(storage=symbolic(v628))
+    v632 = mul v630, 8
+    v633 = shr v632, v631
+    v634 = and v633, 0xffffffffff
+    v635 = eq v634, 0
+    v636 = iszero v635
+    jumpi v636, bb127, bb128
   bb128:
-    v630 = storage_array_data_slot 0
-    v631 = div 19, 6
-    v632 = add v630, v631
-    v633 = mod 19, 6
-    v634 = mul v633, 5
-    v635 = sload v632 !metadata(storage=symbolic(v632))
-    v636 = mul v634, 8
-    v637 = shr v636, v635
-    v638 = and v637, 0xffffffffff
-    v639 = eq v638, 0
-    v640 = iszero v639
-    jumpi v640, bb129, bb130
+    v637 = sload 0 !metadata(storage=slot(0))
+    v638 = lt 19, v637
+    v639 = iszero v638
+    jumpi v639, bb129, bb130
   bb130:
+    v640 = storage_array_data_slot 0
+    v641 = div 19, 6
+    v642 = add v640, v641
+    v643 = mod 19, 6
+    v644 = mul v643, 5
+    v645 = sload v642 !metadata(storage=symbolic(v642))
+    v646 = mul v644, 8
+    v647 = shr v646, v645
+    v648 = and v647, 0xffffffffff
+    v649 = eq v648, 0
+    v650 = iszero v649
+    jumpi v650, bb131, bb132
+  bb132:
     ret 1
-  bb129:
+  bb131:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
+    revert 0, 36
+  bb129:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb127:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb125:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb123:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb121:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb119:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb117:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb115:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb113:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb111:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb109:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb107:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb105:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb103:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb101:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb99:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb97:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb95:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb93:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb91:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb89:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb87:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb85:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb83:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb81:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb79:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb77:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb75:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb73:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb71:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb69:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb67:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb65:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb63:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb61:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb59:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb57:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb55:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb53:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
-  bb51:
+  bb53:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/array_copy_clear_storage_packed.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/array_copy_clear_storage_packed.mir.stdout
@@ -111,101 +111,116 @@ fn @f() -> u128 [selector=0x26121ff0, abi_params=[], abi_returns=[word<u128>]] {
     v89 = lt v88, v69
     jumpi v89, bb17, bb18
   bb18:
-    sstore 0, 4 !metadata(storage=slot(0))
-    v105 = sload 0 !metadata(storage=slot(0))
-    v106 = lt 0, v105
+    v105 = shr 1, v69
+    v106 = and v69, 1
     v107 = iszero v106
-    jumpi v107, bb19, bb20
+    jumpi v107, bb20, bb19
+  bb19:
+    v108 = mul v106, 128
+    v109 = shl v108, 1
+    v110 = sub v109, 1
+    v111 = storage_array_data_slot 0
+    v112 = add v111, v105
+    v113 = sload v112 !metadata(storage=symbolic(v112))
+    v114 = and v113, v110
+    sstore v112, v114 !metadata(storage=symbolic(v112))
+    jump bb20
   bb20:
-    v108 = storage_array_data_slot 0
-    v109 = div 0, 2
-    v110 = add v108, v109
-    v111 = mod 0, 2
-    v112 = mul v111, 16
-    v113 = sload v110 !metadata(storage=symbolic(v110))
-    v114 = mul v112, 8
-    v115 = shr v114, v113
-    v116 = and v115, 0xffffffffffffffffffffffffffffffff
-    v117 = eq v116, 23
-    v118 = iszero v117
-    jumpi v118, bb21, bb22
+    sstore 0, 4 !metadata(storage=slot(0))
+    v115 = sload 0 !metadata(storage=slot(0))
+    v116 = lt 0, v115
+    v117 = iszero v116
+    jumpi v117, bb21, bb22
   bb22:
-    v119 = sload 0 !metadata(storage=slot(0))
-    v120 = lt 2, v119
-    v121 = iszero v120
-    jumpi v121, bb23, bb24
+    v118 = storage_array_data_slot 0
+    v119 = div 0, 2
+    v120 = add v118, v119
+    v121 = mod 0, 2
+    v122 = mul v121, 16
+    v123 = sload v120 !metadata(storage=symbolic(v120))
+    v124 = mul v122, 8
+    v125 = shr v124, v123
+    v126 = and v125, 0xffffffffffffffffffffffffffffffff
+    v127 = eq v126, 23
+    v128 = iszero v127
+    jumpi v128, bb23, bb24
   bb24:
-    v122 = storage_array_data_slot 0
-    v123 = div 2, 2
-    v124 = add v122, v123
-    v125 = mod 2, 2
-    v126 = mul v125, 16
-    v127 = sload v124 !metadata(storage=symbolic(v124))
-    v128 = mul v126, 8
-    v129 = shr v128, v127
-    v130 = and v129, 0xffffffffffffffffffffffffffffffff
-    v131 = eq v130, 0
-    v132 = iszero v131
-    jumpi v132, bb25, bb26
+    v129 = sload 0 !metadata(storage=slot(0))
+    v130 = lt 2, v129
+    v131 = iszero v130
+    jumpi v131, bb25, bb26
   bb26:
-    v133 = sload 0 !metadata(storage=slot(0))
-    v134 = lt 3, v133
-    v135 = iszero v134
-    jumpi v135, bb27, bb28
+    v132 = storage_array_data_slot 0
+    v133 = div 2, 2
+    v134 = add v132, v133
+    v135 = mod 2, 2
+    v136 = mul v135, 16
+    v137 = sload v134 !metadata(storage=symbolic(v134))
+    v138 = mul v136, 8
+    v139 = shr v138, v137
+    v140 = and v139, 0xffffffffffffffffffffffffffffffff
+    v141 = eq v140, 0
+    v142 = iszero v141
+    jumpi v142, bb27, bb28
   bb28:
-    v136 = storage_array_data_slot 0
-    v137 = div 3, 2
-    v138 = add v136, v137
-    v139 = mod 3, 2
-    v140 = mul v139, 16
-    v141 = sload v138 !metadata(storage=symbolic(v138))
-    v142 = mul v140, 8
-    v143 = shr v142, v141
-    v144 = and v143, 0xffffffffffffffffffffffffffffffff
-    v145 = eq v144, 0
-    v146 = iszero v145
-    jumpi v146, bb29, bb30
+    v143 = sload 0 !metadata(storage=slot(0))
+    v144 = lt 3, v143
+    v145 = iszero v144
+    jumpi v145, bb29, bb30
   bb30:
-    v147 = sload 0 !metadata(storage=slot(0))
-    v148 = lt 1, v147
-    v149 = iszero v148
-    jumpi v149, bb31, bb32
+    v146 = storage_array_data_slot 0
+    v147 = div 3, 2
+    v148 = add v146, v147
+    v149 = mod 3, 2
+    v150 = mul v149, 16
+    v151 = sload v148 !metadata(storage=symbolic(v148))
+    v152 = mul v150, 8
+    v153 = shr v152, v151
+    v154 = and v153, 0xffffffffffffffffffffffffffffffff
+    v155 = eq v154, 0
+    v156 = iszero v155
+    jumpi v156, bb31, bb32
   bb32:
-    v150 = storage_array_data_slot 0
-    v151 = div 1, 2
-    v152 = add v150, v151
-    v153 = mod 1, 2
-    v154 = mul v153, 16
-    v155 = sload v152 !metadata(storage=symbolic(v152))
-    v156 = mul v154, 8
-    v157 = shr v156, v155
-    v158 = and v157, 0xffffffffffffffffffffffffffffffff
-    ret v158
-  bb31:
+    v157 = sload 0 !metadata(storage=slot(0))
+    v158 = lt 1, v157
+    v159 = iszero v158
+    jumpi v159, bb33, bb34
+  bb34:
+    v160 = storage_array_data_slot 0
+    v161 = div 1, 2
+    v162 = add v160, v161
+    v163 = mod 1, 2
+    v164 = mul v163, 16
+    v165 = sload v162 !metadata(storage=symbolic(v162))
+    v166 = mul v164, 8
+    v167 = shr v166, v165
+    v168 = and v167, 0xffffffffffffffffffffffffffffffff
+    ret v168
+  bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb31:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb29:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb27:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb25:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb21:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
-  bb19:
+  bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -377,101 +392,116 @@ fn @g() -> u64 [selector=0xe2179b8e, abi_params=[], abi_returns=[word<u64>]] {
     v89 = lt v88, v69
     jumpi v89, bb17, bb18
   bb18:
-    sstore 1, 4 !metadata(storage=slot(1))
-    v105 = sload 1 !metadata(storage=slot(1))
-    v106 = lt 0, v105
+    v105 = shr 2, v69
+    v106 = and v69, 3
     v107 = iszero v106
-    jumpi v107, bb19, bb20
+    jumpi v107, bb20, bb19
+  bb19:
+    v108 = mul v106, 64
+    v109 = shl v108, 1
+    v110 = sub v109, 1
+    v111 = storage_array_data_slot 1
+    v112 = add v111, v105
+    v113 = sload v112 !metadata(storage=symbolic(v112))
+    v114 = and v113, v110
+    sstore v112, v114 !metadata(storage=symbolic(v112))
+    jump bb20
   bb20:
-    v108 = storage_array_data_slot 1
-    v109 = div 0, 4
-    v110 = add v108, v109
-    v111 = mod 0, 4
-    v112 = mul v111, 8
-    v113 = sload v110 !metadata(storage=symbolic(v110))
-    v114 = mul v112, 8
-    v115 = shr v114, v113
-    v116 = and v115, 0xffffffffffffffff
-    v117 = eq v116, 23
-    v118 = iszero v117
-    jumpi v118, bb21, bb22
+    sstore 1, 4 !metadata(storage=slot(1))
+    v115 = sload 1 !metadata(storage=slot(1))
+    v116 = lt 0, v115
+    v117 = iszero v116
+    jumpi v117, bb21, bb22
   bb22:
-    v119 = sload 1 !metadata(storage=slot(1))
-    v120 = lt 2, v119
-    v121 = iszero v120
-    jumpi v121, bb23, bb24
+    v118 = storage_array_data_slot 1
+    v119 = div 0, 4
+    v120 = add v118, v119
+    v121 = mod 0, 4
+    v122 = mul v121, 8
+    v123 = sload v120 !metadata(storage=symbolic(v120))
+    v124 = mul v122, 8
+    v125 = shr v124, v123
+    v126 = and v125, 0xffffffffffffffff
+    v127 = eq v126, 23
+    v128 = iszero v127
+    jumpi v128, bb23, bb24
   bb24:
-    v122 = storage_array_data_slot 1
-    v123 = div 2, 4
-    v124 = add v122, v123
-    v125 = mod 2, 4
-    v126 = mul v125, 8
-    v127 = sload v124 !metadata(storage=symbolic(v124))
-    v128 = mul v126, 8
-    v129 = shr v128, v127
-    v130 = and v129, 0xffffffffffffffff
-    v131 = eq v130, 0
-    v132 = iszero v131
-    jumpi v132, bb25, bb26
+    v129 = sload 1 !metadata(storage=slot(1))
+    v130 = lt 2, v129
+    v131 = iszero v130
+    jumpi v131, bb25, bb26
   bb26:
-    v133 = sload 1 !metadata(storage=slot(1))
-    v134 = lt 3, v133
-    v135 = iszero v134
-    jumpi v135, bb27, bb28
+    v132 = storage_array_data_slot 1
+    v133 = div 2, 4
+    v134 = add v132, v133
+    v135 = mod 2, 4
+    v136 = mul v135, 8
+    v137 = sload v134 !metadata(storage=symbolic(v134))
+    v138 = mul v136, 8
+    v139 = shr v138, v137
+    v140 = and v139, 0xffffffffffffffff
+    v141 = eq v140, 0
+    v142 = iszero v141
+    jumpi v142, bb27, bb28
   bb28:
-    v136 = storage_array_data_slot 1
-    v137 = div 3, 4
-    v138 = add v136, v137
-    v139 = mod 3, 4
-    v140 = mul v139, 8
-    v141 = sload v138 !metadata(storage=symbolic(v138))
-    v142 = mul v140, 8
-    v143 = shr v142, v141
-    v144 = and v143, 0xffffffffffffffff
-    v145 = eq v144, 0
-    v146 = iszero v145
-    jumpi v146, bb29, bb30
+    v143 = sload 1 !metadata(storage=slot(1))
+    v144 = lt 3, v143
+    v145 = iszero v144
+    jumpi v145, bb29, bb30
   bb30:
-    v147 = sload 1 !metadata(storage=slot(1))
-    v148 = lt 1, v147
-    v149 = iszero v148
-    jumpi v149, bb31, bb32
+    v146 = storage_array_data_slot 1
+    v147 = div 3, 4
+    v148 = add v146, v147
+    v149 = mod 3, 4
+    v150 = mul v149, 8
+    v151 = sload v148 !metadata(storage=symbolic(v148))
+    v152 = mul v150, 8
+    v153 = shr v152, v151
+    v154 = and v153, 0xffffffffffffffff
+    v155 = eq v154, 0
+    v156 = iszero v155
+    jumpi v156, bb31, bb32
   bb32:
-    v150 = storage_array_data_slot 1
-    v151 = div 1, 4
-    v152 = add v150, v151
-    v153 = mod 1, 4
-    v154 = mul v153, 8
-    v155 = sload v152 !metadata(storage=symbolic(v152))
-    v156 = mul v154, 8
-    v157 = shr v156, v155
-    v158 = and v157, 0xffffffffffffffff
-    ret v158
-  bb31:
+    v157 = sload 1 !metadata(storage=slot(1))
+    v158 = lt 1, v157
+    v159 = iszero v158
+    jumpi v159, bb33, bb34
+  bb34:
+    v160 = storage_array_data_slot 1
+    v161 = div 1, 4
+    v162 = add v160, v161
+    v163 = mod 1, 4
+    v164 = mul v163, 8
+    v165 = sload v162 !metadata(storage=symbolic(v162))
+    v166 = mul v164, 8
+    v167 = shr v166, v165
+    v168 = and v167, 0xffffffffffffffff
+    ret v168
+  bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb31:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb29:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb27:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb25:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb21:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
-  bb19:
+  bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -643,101 +673,116 @@ fn @h() -> u120 [selector=0xb8c9d365, abi_params=[], abi_returns=[word<u120>]] {
     v89 = lt v88, v69
     jumpi v89, bb17, bb18
   bb18:
-    sstore 2, 4 !metadata(storage=slot(2))
-    v105 = sload 2 !metadata(storage=slot(2))
-    v106 = lt 0, v105
+    v105 = shr 1, v69
+    v106 = and v69, 1
     v107 = iszero v106
-    jumpi v107, bb19, bb20
+    jumpi v107, bb20, bb19
+  bb19:
+    v108 = mul v106, 120
+    v109 = shl v108, 1
+    v110 = sub v109, 1
+    v111 = storage_array_data_slot 2
+    v112 = add v111, v105
+    v113 = sload v112 !metadata(storage=symbolic(v112))
+    v114 = and v113, v110
+    sstore v112, v114 !metadata(storage=symbolic(v112))
+    jump bb20
   bb20:
-    v108 = storage_array_data_slot 2
-    v109 = div 0, 2
-    v110 = add v108, v109
-    v111 = mod 0, 2
-    v112 = mul v111, 15
-    v113 = sload v110 !metadata(storage=symbolic(v110))
-    v114 = mul v112, 8
-    v115 = shr v114, v113
-    v116 = and v115, 0xffffffffffffffffffffffffffffff
-    v117 = eq v116, 23
-    v118 = iszero v117
-    jumpi v118, bb21, bb22
+    sstore 2, 4 !metadata(storage=slot(2))
+    v115 = sload 2 !metadata(storage=slot(2))
+    v116 = lt 0, v115
+    v117 = iszero v116
+    jumpi v117, bb21, bb22
   bb22:
-    v119 = sload 2 !metadata(storage=slot(2))
-    v120 = lt 2, v119
-    v121 = iszero v120
-    jumpi v121, bb23, bb24
+    v118 = storage_array_data_slot 2
+    v119 = div 0, 2
+    v120 = add v118, v119
+    v121 = mod 0, 2
+    v122 = mul v121, 15
+    v123 = sload v120 !metadata(storage=symbolic(v120))
+    v124 = mul v122, 8
+    v125 = shr v124, v123
+    v126 = and v125, 0xffffffffffffffffffffffffffffff
+    v127 = eq v126, 23
+    v128 = iszero v127
+    jumpi v128, bb23, bb24
   bb24:
-    v122 = storage_array_data_slot 2
-    v123 = div 2, 2
-    v124 = add v122, v123
-    v125 = mod 2, 2
-    v126 = mul v125, 15
-    v127 = sload v124 !metadata(storage=symbolic(v124))
-    v128 = mul v126, 8
-    v129 = shr v128, v127
-    v130 = and v129, 0xffffffffffffffffffffffffffffff
-    v131 = eq v130, 0
-    v132 = iszero v131
-    jumpi v132, bb25, bb26
+    v129 = sload 2 !metadata(storage=slot(2))
+    v130 = lt 2, v129
+    v131 = iszero v130
+    jumpi v131, bb25, bb26
   bb26:
-    v133 = sload 2 !metadata(storage=slot(2))
-    v134 = lt 3, v133
-    v135 = iszero v134
-    jumpi v135, bb27, bb28
+    v132 = storage_array_data_slot 2
+    v133 = div 2, 2
+    v134 = add v132, v133
+    v135 = mod 2, 2
+    v136 = mul v135, 15
+    v137 = sload v134 !metadata(storage=symbolic(v134))
+    v138 = mul v136, 8
+    v139 = shr v138, v137
+    v140 = and v139, 0xffffffffffffffffffffffffffffff
+    v141 = eq v140, 0
+    v142 = iszero v141
+    jumpi v142, bb27, bb28
   bb28:
-    v136 = storage_array_data_slot 2
-    v137 = div 3, 2
-    v138 = add v136, v137
-    v139 = mod 3, 2
-    v140 = mul v139, 15
-    v141 = sload v138 !metadata(storage=symbolic(v138))
-    v142 = mul v140, 8
-    v143 = shr v142, v141
-    v144 = and v143, 0xffffffffffffffffffffffffffffff
-    v145 = eq v144, 0
-    v146 = iszero v145
-    jumpi v146, bb29, bb30
+    v143 = sload 2 !metadata(storage=slot(2))
+    v144 = lt 3, v143
+    v145 = iszero v144
+    jumpi v145, bb29, bb30
   bb30:
-    v147 = sload 2 !metadata(storage=slot(2))
-    v148 = lt 1, v147
-    v149 = iszero v148
-    jumpi v149, bb31, bb32
+    v146 = storage_array_data_slot 2
+    v147 = div 3, 2
+    v148 = add v146, v147
+    v149 = mod 3, 2
+    v150 = mul v149, 15
+    v151 = sload v148 !metadata(storage=symbolic(v148))
+    v152 = mul v150, 8
+    v153 = shr v152, v151
+    v154 = and v153, 0xffffffffffffffffffffffffffffff
+    v155 = eq v154, 0
+    v156 = iszero v155
+    jumpi v156, bb31, bb32
   bb32:
-    v150 = storage_array_data_slot 2
-    v151 = div 1, 2
-    v152 = add v150, v151
-    v153 = mod 1, 2
-    v154 = mul v153, 15
-    v155 = sload v152 !metadata(storage=symbolic(v152))
-    v156 = mul v154, 8
-    v157 = shr v156, v155
-    v158 = and v157, 0xffffffffffffffffffffffffffffff
-    ret v158
-  bb31:
+    v157 = sload 2 !metadata(storage=slot(2))
+    v158 = lt 1, v157
+    v159 = iszero v158
+    jumpi v159, bb33, bb34
+  bb34:
+    v160 = storage_array_data_slot 2
+    v161 = div 1, 2
+    v162 = add v160, v161
+    v163 = mod 1, 2
+    v164 = mul v163, 15
+    v165 = sload v162 !metadata(storage=symbolic(v162))
+    v166 = mul v164, 8
+    v167 = shr v166, v165
+    v168 = and v167, 0xffffffffffffffffffffffffffffff
+    ret v168
+  bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb31:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb29:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb27:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
   bb25:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 1 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb21:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 1 !metadata(memory=scratch)
     revert 0, 36
-  bb19:
+  bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/array_copy_memory_storage.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/array_copy_memory_storage.mir.stdout
@@ -45,22 +45,37 @@ fn @copyDynamic() -> u32 [selector=0x902a0a84, abi_params=[], abi_returns=[word<
     v33 = lt v32, v13
     jumpi v33, bb13, bb14
   bb14:
-    v49 = sload 0 !metadata(storage=slot(0))
-    v50 = lt 0, v49
+    v49 = shr 3, v13
+    v50 = and v13, 7
     v51 = iszero v50
-    jumpi v51, bb15, bb16
-  bb16:
-    v52 = storage_array_data_slot 0
-    v53 = div 0, 8
-    v54 = add v52, v53
-    v55 = mod 0, 8
-    v56 = mul v55, 4
-    v57 = sload v54 !metadata(storage=symbolic(v54))
-    v58 = mul v56, 8
-    v59 = shr v58, v57
-    v60 = and v59, 0xffffffff
-    ret v60
+    jumpi v51, bb16, bb15
   bb15:
+    v52 = mul v50, 32
+    v53 = shl v52, 1
+    v54 = sub v53, 1
+    v55 = storage_array_data_slot 0
+    v56 = add v55, v49
+    v57 = sload v56 !metadata(storage=symbolic(v56))
+    v58 = and v57, v54
+    sstore v56, v58 !metadata(storage=symbolic(v56))
+    jump bb16
+  bb16:
+    v59 = sload 0 !metadata(storage=slot(0))
+    v60 = lt 0, v59
+    v61 = iszero v60
+    jumpi v61, bb17, bb18
+  bb18:
+    v62 = storage_array_data_slot 0
+    v63 = div 0, 8
+    v64 = add v62, v63
+    v65 = mod 0, 8
+    v66 = mul v65, 4
+    v67 = sload v64 !metadata(storage=symbolic(v64))
+    v68 = mul v66, 8
+    v69 = shr v68, v67
+    v70 = and v69, 0xffffffff
+    ret v70
+  bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -154,97 +169,102 @@ fn @copyFixed() -> u32 [selector=0x23235673, abi_params=[], abi_returns=[word<u3
     v29 = lt v28, 3
     jumpi v29, bb13, bb14
   bb14:
-    v45 = div 0, 8
-    v46 = add 1, v45
-    v47 = mod 0, 8
-    v48 = mul v47, 4
-    v49 = memory_object_load_element memoryfixedarray<3, 1>, v0, 0
-    v50 = mul v48, 8
-    v51 = shl v50, 0xffffffff
-    v52 = sload v46 !metadata(storage=offset(v45, 1))
-    v53 = not v51
-    v54 = and v52, v53
-    v55 = and v49, 0xffffffff
-    v56 = shl v50, v55
-    v57 = or v54, v56
-    sstore v46, v57 !metadata(storage=offset(v45, 1))
-    v58 = div 1, 8
-    v59 = add 1, v58
-    v60 = mod 1, 8
-    v61 = mul v60, 4
-    v62 = memory_object_load_element memoryfixedarray<3, 1>, v0, 1
-    v63 = mul v61, 8
-    v64 = shl v63, 0xffffffff
-    v65 = sload v59 !metadata(storage=offset(v58, 1))
-    v66 = not v64
-    v67 = and v65, v66
-    v68 = and v62, 0xffffffff
-    v69 = shl v63, v68
-    v70 = or v67, v69
-    sstore v59, v70 !metadata(storage=offset(v58, 1))
-    v71 = div 2, 8
-    v72 = add 1, v71
-    v73 = mod 2, 8
-    v74 = mul v73, 4
-    v75 = memory_object_load_element memoryfixedarray<3, 1>, v0, 2
-    v76 = mul v74, 8
-    v77 = shl v76, 0xffffffff
-    v78 = sload v72 !metadata(storage=offset(v71, 1))
-    v79 = not v77
-    v80 = and v78, v79
-    v81 = and v75, 0xffffffff
-    v82 = shl v76, v81
-    v83 = or v80, v82
-    sstore v72, v83 !metadata(storage=offset(v71, 1))
-    v84 = sload 0 !metadata(storage=slot(0))
-    v85 = lt 0, v84
-    v86 = iszero v85
-    jumpi v86, bb15, bb16
+    v45 = storage_array_data_slot 0
+    v46 = add v45, 0
+    v47 = sload v46 !metadata(storage=symbolic(v45))
+    v48 = and v47, 0xffffffffffffffffffffffff
+    sstore v46, v48 !metadata(storage=symbolic(v45))
+    v49 = div 0, 8
+    v50 = add 1, v49
+    v51 = mod 0, 8
+    v52 = mul v51, 4
+    v53 = memory_object_load_element memoryfixedarray<3, 1>, v0, 0
+    v54 = mul v52, 8
+    v55 = shl v54, 0xffffffff
+    v56 = sload v50 !metadata(storage=offset(v49, 1))
+    v57 = not v55
+    v58 = and v56, v57
+    v59 = and v53, 0xffffffff
+    v60 = shl v54, v59
+    v61 = or v58, v60
+    sstore v50, v61 !metadata(storage=offset(v49, 1))
+    v62 = div 1, 8
+    v63 = add 1, v62
+    v64 = mod 1, 8
+    v65 = mul v64, 4
+    v66 = memory_object_load_element memoryfixedarray<3, 1>, v0, 1
+    v67 = mul v65, 8
+    v68 = shl v67, 0xffffffff
+    v69 = sload v63 !metadata(storage=offset(v62, 1))
+    v70 = not v68
+    v71 = and v69, v70
+    v72 = and v66, 0xffffffff
+    v73 = shl v67, v72
+    v74 = or v71, v73
+    sstore v63, v74 !metadata(storage=offset(v62, 1))
+    v75 = div 2, 8
+    v76 = add 1, v75
+    v77 = mod 2, 8
+    v78 = mul v77, 4
+    v79 = memory_object_load_element memoryfixedarray<3, 1>, v0, 2
+    v80 = mul v78, 8
+    v81 = shl v80, 0xffffffff
+    v82 = sload v76 !metadata(storage=offset(v75, 1))
+    v83 = not v81
+    v84 = and v82, v83
+    v85 = and v79, 0xffffffff
+    v86 = shl v80, v85
+    v87 = or v84, v86
+    sstore v76, v87 !metadata(storage=offset(v75, 1))
+    v88 = sload 0 !metadata(storage=slot(0))
+    v89 = lt 0, v88
+    v90 = iszero v89
+    jumpi v90, bb15, bb16
   bb16:
-    v87 = storage_array_data_slot 0
-    v88 = div 0, 8
-    v89 = add v87, v88
-    v90 = mod 0, 8
-    v91 = mul v90, 4
-    v92 = sload v89 !metadata(storage=symbolic(v89))
-    v93 = mul v91, 8
-    v94 = shr v93, v92
-    v95 = and v94, 0xffffffff
-    v96 = lt 1, 3
-    v97 = iszero v96
-    jumpi v97, bb17, bb18
+    v91 = storage_array_data_slot 0
+    v92 = div 0, 8
+    v93 = add v91, v92
+    v94 = mod 0, 8
+    v95 = mul v94, 4
+    v96 = sload v93 !metadata(storage=symbolic(v93))
+    v97 = mul v95, 8
+    v98 = shr v97, v96
+    v99 = and v98, 0xffffffff
+    v100 = lt 1, 3
+    v101 = iszero v100
+    jumpi v101, bb17, bb18
   bb18:
-    v98 = div 1, 8
-    v99 = add 1, v98
-    v100 = mod 1, 8
-    v101 = mul v100, 4
-    v102 = sload v99 !metadata(storage=offset(v98, 1))
-    v103 = mul v101, 8
-    v104 = shr v103, v102
-    v105 = and v104, 0xffffffff
-    v106 = add v95, v105
-    v107 = gt v106, 0xffffffff
-    jumpi v107, bb19, bb20
+    v102 = div 1, 8
+    v103 = add 1, v102
+    v104 = mod 1, 8
+    v105 = mul v104, 4
+    v106 = sload v103 !metadata(storage=offset(v102, 1))
+    v107 = mul v105, 8
+    v108 = shr v107, v106
+    v109 = and v108, 0xffffffff
+    v110 = add v99, v109
+    v111 = gt v110, 0xffffffff
+    jumpi v111, bb19, bb20
   bb20:
-    v108 = sload 0 !metadata(storage=slot(0))
-    v109 = lt 2, v108
-    v110 = iszero v109
-    jumpi v110, bb21, bb22
+    v112 = sload 0 !metadata(storage=slot(0))
+    v113 = lt 2, v112
+    v114 = iszero v113
+    jumpi v114, bb21, bb22
   bb22:
-    v111 = storage_array_data_slot 0
-    v112 = div 2, 8
-    v113 = add v111, v112
-    v114 = mod 2, 8
-    v115 = mul v114, 4
-    v116 = sload v113 !metadata(storage=symbolic(v113))
-    v117 = mul v115, 8
-    v118 = shr v117, v116
-    v119 = and v118, 0xffffffff
-    v120 = add v106, v119
-    v121 = gt v120, 0xffffffff
-    jumpi v121, bb23, bb24
+    v115 = storage_array_data_slot 0
+    v116 = div 2, 8
+    v117 = add v115, v116
+    v118 = mod 2, 8
+    v119 = mul v118, 4
+    v120 = sload v117 !metadata(storage=symbolic(v117))
+    v121 = mul v119, 8
+    v122 = shr v121, v120
+    v123 = and v122, 0xffffffff
+    v124 = add v110, v123
+    v125 = gt v124, 0xffffffff
+    jumpi v125, bb23, bb24
   bb24:
-    ret v120
+    ret v124
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/array_struct_memory_storage.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/array_struct_memory_storage.mir.stdout
@@ -127,89 +127,93 @@ fn @copy() -> u256 [selector=0x60726abb, abi_params=[], abi_returns=[word]] {
     sstore 0, v53 !metadata(storage=slot(0))
     jump bb29
   bb29:
-    v76 = phi [bb22: 0], [bb41: v172]
+    v76 = phi [bb22: 0], [bb43: v182]
     v77 = lt v76, v53
     jumpi v77, bb30, bb31
   bb31:
-    v173 = sload 0 !metadata(storage=slot(0))
-    v174 = lt 1, v173
-    v175 = iszero v174
-    jumpi v175, bb42, bb43
-  bb43:
-    v176 = storage_array_data_slot 0
-    v177 = mul 1, 4
-    v178 = add v176, v177
-    v179 = add v178, 1
-    v180 = sload 0 !metadata(storage=slot(0))
-    v181 = lt 1, v180
-    v182 = iszero v181
-    jumpi v182, bb44, bb45
+    v183 = sload 0 !metadata(storage=slot(0))
+    v184 = lt 1, v183
+    v185 = iszero v184
+    jumpi v185, bb44, bb45
   bb45:
-    v183 = storage_array_data_slot 0
-    v184 = mul 1, 4
-    v185 = add v183, v184
-    v186 = add v185, 3
-    v187 = sload v186 !metadata(storage=offset(v185, 3))
-    v188 = add 3, v187
-    v189 = lt v188, 3
-    jumpi v189, bb46, bb47
-  bb47:
+    v186 = storage_array_data_slot 0
+    v187 = mul 1, 4
+    v188 = add v186, v187
+    v189 = add v188, 1
     v190 = sload 0 !metadata(storage=slot(0))
     v191 = lt 1, v190
     v192 = iszero v191
-    jumpi v192, bb48, bb49
-  bb49:
+    jumpi v192, bb46, bb47
+  bb47:
     v193 = storage_array_data_slot 0
     v194 = mul 1, 4
     v195 = add v193, v194
-    v196 = add v195, 1
-    v197 = lt 2, 3
-    v198 = iszero v197
-    jumpi v198, bb50, bb51
+    v196 = add v195, 3
+    v197 = sload v196 !metadata(storage=offset(v195, 3))
+    v198 = add 3, v197
+    v199 = lt v198, 3
+    jumpi v199, bb48, bb49
+  bb49:
+    v200 = sload 0 !metadata(storage=slot(0))
+    v201 = lt 1, v200
+    v202 = iszero v201
+    jumpi v202, bb50, bb51
   bb51:
-    v199 = div 2, 2
-    v200 = add v196, v199
-    v201 = mod 2, 2
-    v202 = mul v201, 16
-    v203 = sload v200 !metadata(storage=symbolic(v200))
-    v204 = mul v202, 8
-    v205 = shr v204, v203
-    v206 = and v205, 0xffffffffffffffffffffffffffffffff
-    v207 = add v188, v206
-    v208 = lt v207, v188
+    v203 = storage_array_data_slot 0
+    v204 = mul 1, 4
+    v205 = add v203, v204
+    v206 = add v205, 1
+    v207 = lt 2, 3
+    v208 = iszero v207
     jumpi v208, bb52, bb53
   bb53:
-    v209 = sload 0 !metadata(storage=slot(0))
-    v210 = lt 1, v209
-    v211 = iszero v210
-    jumpi v211, bb54, bb55
+    v209 = div 2, 2
+    v210 = add v206, v209
+    v211 = mod 2, 2
+    v212 = mul v211, 16
+    v213 = sload v210 !metadata(storage=symbolic(v210))
+    v214 = mul v212, 8
+    v215 = shr v214, v213
+    v216 = and v215, 0xffffffffffffffffffffffffffffffff
+    v217 = add v198, v216
+    v218 = lt v217, v198
+    jumpi v218, bb54, bb55
   bb55:
-    v212 = storage_array_data_slot 0
-    v213 = mul 1, 4
-    v214 = add v212, v213
-    v215 = add v214, 3
-    v216 = sload v215 !metadata(storage=offset(v214, 3))
-    v217 = lt 0, v216
-    v218 = iszero v217
-    jumpi v218, bb56, bb57
+    v219 = sload 0 !metadata(storage=slot(0))
+    v220 = lt 1, v219
+    v221 = iszero v220
+    jumpi v221, bb56, bb57
   bb57:
-    v219 = storage_array_data_slot v215
-    v220 = div 0, 2
-    v221 = add v219, v220
-    v222 = mod 0, 2
-    v223 = mul v222, 16
-    v224 = sload v221 !metadata(storage=symbolic(v221))
-    v225 = mul v223, 8
-    v226 = shr v225, v224
-    v227 = and v226, 0xffffffffffffffffffffffffffffffff
-    v228 = add v207, v227
-    v229 = lt v228, v207
-    jumpi v229, bb58, bb59
+    v222 = storage_array_data_slot 0
+    v223 = mul 1, 4
+    v224 = add v222, v223
+    v225 = add v224, 3
+    v226 = sload v225 !metadata(storage=offset(v224, 3))
+    v227 = lt 0, v226
+    v228 = iszero v227
+    jumpi v228, bb58, bb59
   bb59:
-    ret v228
-  bb58:
+    v229 = storage_array_data_slot v225
+    v230 = div 0, 2
+    v231 = add v229, v230
+    v232 = mod 0, 2
+    v233 = mul v232, 16
+    v234 = sload v231 !metadata(storage=symbolic(v231))
+    v235 = mul v233, 8
+    v236 = shr v235, v234
+    v237 = and v236, 0xffffffffffffffffffffffffffffffff
+    v238 = add v217, v237
+    v239 = lt v238, v217
+    jumpi v239, bb60, bb61
+  bb61:
+    ret v238
+  bb60:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb58:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb56:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -217,11 +221,11 @@ fn @copy() -> u256 [selector=0x60726abb, abi_params=[], abi_returns=[word]] {
     revert 0, 36
   bb54:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb52:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb50:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -229,17 +233,13 @@ fn @copy() -> u256 [selector=0x60726abb, abi_params=[], abi_returns=[word]] {
     revert 0, 36
   bb48:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb46:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb44:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb42:
+  bb44:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -336,7 +336,22 @@ fn @copy() -> u256 [selector=0x60726abb, abi_params=[], abi_returns=[word]] {
     v156 = lt v155, v136
     jumpi v156, bb40, bb41
   bb41:
-    v172 = add v76, 1
+    v172 = shr 1, v136
+    v173 = and v136, 1
+    v174 = iszero v173
+    jumpi v174, bb43, bb42
+  bb42:
+    v175 = mul v173, 128
+    v176 = shl v175, 1
+    v177 = sub v176, 1
+    v178 = storage_array_data_slot v134
+    v179 = add v178, v172
+    v180 = sload v179 !metadata(storage=symbolic(v179))
+    v181 = and v180, v177
+    sstore v179, v181 !metadata(storage=symbolic(v179))
+    jump bb43
+  bb43:
+    v182 = add v76, 1
     jump bb29
   bb40:
     v157 = memory_object_load_element memoryarray<1>, v135, v155

--- a/tests/ui/codegen/lowering/run-call/internal_function_pointer_dynamic_storage_copy.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/internal_function_pointer_dynamic_storage_copy.mir.stdout
@@ -24,102 +24,132 @@ fn @test() -> u256 [selector=0xf8a8fd6d, abi_params=[], abi_returns=[word]] {
     v21 = lt v20, v1
     jumpi v21, bb7, bb8
   bb8:
-    v37 = sload 0 !metadata(storage=slot(0))
-    v38 = lt 9, v37
+    v37 = shr 2, v1
+    v38 = and v1, 3
     v39 = iszero v38
-    jumpi v39, bb9, bb10
+    jumpi v39, bb10, bb9
+  bb9:
+    v40 = mul v38, 64
+    v41 = shl v40, 1
+    v42 = sub v41, 1
+    v43 = storage_array_data_slot 0
+    v44 = add v43, v37
+    v45 = sload v44 !metadata(storage=symbolic(v44))
+    v46 = and v45, v42
+    sstore v44, v46 !metadata(storage=symbolic(v44))
+    jump bb10
   bb10:
-    v40 = storage_array_data_slot 0
-    v41 = div 9, 4
-    v42 = add v40, v41
-    v43 = mod 9, 4
-    v44 = mul v43, 8
-    v45 = mul v44, 8
-    v46 = shl v45, 0xffffffffffffffff
-    v47 = sload v42 !metadata(storage=symbolic(v42))
-    v48 = not v46
-    v49 = and v47, v48
-    v50 = and 2, 0xffffffffffffffff
-    v51 = shl v45, v50
-    v52 = or v49, v51
-    sstore v42, v52 !metadata(storage=symbolic(v42))
-    v53 = internal_call @load_storage_packed_array_8_0, 1, 0
-    v54 = memory_object_len memoryarray, v53
-    v55 = sload 1 !metadata(storage=slot(1))
-    v56 = gt v55, v54
-    jumpi v56, bb11, bb12
-  bb11:
-    jump bb13
-  bb13:
-    v57 = phi [bb11: v54], [bb14: v72]
-    v58 = lt v57, v55
-    jumpi v58, bb14, bb15
-  bb15:
-    jump bb12
+    v47 = sload 0 !metadata(storage=slot(0))
+    v48 = lt 9, v47
+    v49 = iszero v48
+    jumpi v49, bb11, bb12
   bb12:
-    sstore 1, v54 !metadata(storage=slot(1))
-    jump bb16
-  bb16:
-    v73 = phi [bb12: 0], [bb17: v89]
-    v74 = lt v73, v54
-    jumpi v74, bb17, bb18
+    v50 = storage_array_data_slot 0
+    v51 = div 9, 4
+    v52 = add v50, v51
+    v53 = mod 9, 4
+    v54 = mul v53, 8
+    v55 = mul v54, 8
+    v56 = shl v55, 0xffffffffffffffff
+    v57 = sload v52 !metadata(storage=symbolic(v52))
+    v58 = not v56
+    v59 = and v57, v58
+    v60 = and 2, 0xffffffffffffffff
+    v61 = shl v55, v60
+    v62 = or v59, v61
+    sstore v52, v62 !metadata(storage=symbolic(v52))
+    v63 = internal_call @load_storage_packed_array_8_0, 1, 0
+    v64 = memory_object_len memoryarray, v63
+    v65 = sload 1 !metadata(storage=slot(1))
+    v66 = gt v65, v64
+    jumpi v66, bb13, bb14
+  bb13:
+    jump bb15
+  bb15:
+    v67 = phi [bb13: v64], [bb16: v82]
+    v68 = lt v67, v65
+    jumpi v68, bb16, bb17
+  bb17:
+    jump bb14
+  bb14:
+    sstore 1, v64 !metadata(storage=slot(1))
+    jump bb18
   bb18:
-    v90 = sload 1 !metadata(storage=slot(1))
-    v91 = lt 9, v90
-    v92 = iszero v91
-    jumpi v92, bb19, bb20
+    v83 = phi [bb14: 0], [bb19: v99]
+    v84 = lt v83, v64
+    jumpi v84, bb19, bb20
   bb20:
-    v93 = storage_array_data_slot 1
-    v94 = div 9, 4
-    v95 = add v93, v94
-    v96 = mod 9, 4
-    v97 = mul v96, 8
-    v98 = sload v95 !metadata(storage=symbolic(v95))
-    v99 = mul v97, 8
-    v100 = shr v99, v98
-    v101 = and v100, 0xffffffffffffffff
-    v102 = internal_call @internal_dispatcher_p_none_r_u256, 1, v101
-    ret v102
-  bb19:
+    v100 = shr 2, v64
+    v101 = and v64, 3
+    v102 = iszero v101
+    jumpi v102, bb22, bb21
+  bb21:
+    v103 = mul v101, 64
+    v104 = shl v103, 1
+    v105 = sub v104, 1
+    v106 = storage_array_data_slot 1
+    v107 = add v106, v100
+    v108 = sload v107 !metadata(storage=symbolic(v107))
+    v109 = and v108, v105
+    sstore v107, v109 !metadata(storage=symbolic(v107))
+    jump bb22
+  bb22:
+    v110 = sload 1 !metadata(storage=slot(1))
+    v111 = lt 9, v110
+    v112 = iszero v111
+    jumpi v112, bb23, bb24
+  bb24:
+    v113 = storage_array_data_slot 1
+    v114 = div 9, 4
+    v115 = add v113, v114
+    v116 = mod 9, 4
+    v117 = mul v116, 8
+    v118 = sload v115 !metadata(storage=symbolic(v115))
+    v119 = mul v117, 8
+    v120 = shr v119, v118
+    v121 = and v120, 0xffffffffffffffff
+    v122 = internal_call @internal_dispatcher_p_none_r_u256, 1, v121
+    ret v122
+  bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb17:
-    v75 = memory_object_load_element memoryarray<1>, v53, v73
-    v76 = storage_array_data_slot 1
-    v77 = div v73, 4
-    v78 = add v76, v77
-    v79 = mod v73, 4
-    v80 = mul v79, 8
-    v81 = mul v80, 8
-    v82 = shl v81, 0xffffffffffffffff
-    v83 = sload v78 !metadata(storage=symbolic(v78))
-    v84 = not v82
-    v85 = and v83, v84
-    v86 = and v75, 0xffffffffffffffff
-    v87 = shl v81, v86
-    v88 = or v85, v87
-    sstore v78, v88 !metadata(storage=symbolic(v78))
-    v89 = add v73, 1
-    jump bb16
-  bb14:
-    v59 = storage_array_data_slot 1
-    v60 = div v57, 4
-    v61 = add v59, v60
-    v62 = mod v57, 4
-    v63 = mul v62, 8
-    v64 = mul v63, 8
-    v65 = shl v64, 0xffffffffffffffff
-    v66 = sload v61 !metadata(storage=symbolic(v61))
-    v67 = not v65
-    v68 = and v66, v67
-    v69 = and 0, 0xffffffffffffffff
-    v70 = shl v64, v69
-    v71 = or v68, v70
-    sstore v61, v71 !metadata(storage=symbolic(v61))
-    v72 = add v57, 1
-    jump bb13
-  bb9:
+  bb19:
+    v85 = memory_object_load_element memoryarray<1>, v63, v83
+    v86 = storage_array_data_slot 1
+    v87 = div v83, 4
+    v88 = add v86, v87
+    v89 = mod v83, 4
+    v90 = mul v89, 8
+    v91 = mul v90, 8
+    v92 = shl v91, 0xffffffffffffffff
+    v93 = sload v88 !metadata(storage=symbolic(v88))
+    v94 = not v92
+    v95 = and v93, v94
+    v96 = and v85, 0xffffffffffffffff
+    v97 = shl v91, v96
+    v98 = or v95, v97
+    sstore v88, v98 !metadata(storage=symbolic(v88))
+    v99 = add v83, 1
+    jump bb18
+  bb16:
+    v69 = storage_array_data_slot 1
+    v70 = div v67, 4
+    v71 = add v69, v70
+    v72 = mod v67, 4
+    v73 = mul v72, 8
+    v74 = mul v73, 8
+    v75 = shl v74, 0xffffffffffffffff
+    v76 = sload v71 !metadata(storage=symbolic(v71))
+    v77 = not v75
+    v78 = and v76, v77
+    v79 = and 0, 0xffffffffffffffff
+    v80 = shl v74, v79
+    v81 = or v78, v80
+    sstore v71, v81 !metadata(storage=symbolic(v71))
+    v82 = add v67, 1
+    jump bb15
+  bb11:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/std_invariant_shapes.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/std_invariant_shapes.mir.stdout
@@ -68,6 +68,21 @@ fn @targetSelector(arg0: memorystruct) {
     v35 = lt v34, v14
     jumpi v35, bb9, bb10
   bb10:
+    v52 = shr 3, v14
+    v53 = and v14, 7
+    v54 = iszero v53
+    jumpi v54, bb12, bb11
+  bb11:
+    v55 = mul v53, 32
+    v56 = shl v55, 1
+    v57 = sub v56, 1
+    v58 = storage_array_data_slot v12
+    v59 = add v58, v52
+    v60 = sload v59 !metadata(storage=symbolic(v59))
+    v61 = and v60, v57
+    sstore v59, v61 !metadata(storage=symbolic(v59))
+    jump bb12
+  bb12:
     sstore 1, v1 !metadata(storage=slot(1))
     stop
   bb9:

--- a/tests/ui/codegen/lowering/run-call/storage_array_assignment_packed_tail.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_array_assignment_packed_tail.mir.stdout
@@ -1,0 +1,707 @@
+// === ROOT/tests/ui/codegen/lowering/run-call/storage_array_assignment_packed_tail.sol:StorageArrayAssignmentPackedTail ===
+@module StorageArrayAssignmentPackedTail
+fn @_anonymous() [constructor] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    v1 = add v0, 1
+    v2 = lt v1, v0
+    jumpi v2, bb1, bb2
+  bb2:
+    v3 = storage_array_data_slot 0
+    v4 = div v0, 8
+    v5 = add v3, v4
+    v6 = mod v0, 8
+    v7 = mul v6, 4
+    sstore 0, v1 !metadata(storage=slot(0))
+    v8 = sload 0 !metadata(storage=slot(0))
+    v9 = add v8, 1
+    v10 = lt v9, v8
+    jumpi v10, bb3, bb4
+  bb4:
+    v11 = storage_array_data_slot 0
+    v12 = div v8, 8
+    v13 = add v11, v12
+    v14 = mod v8, 8
+    v15 = mul v14, 4
+    sstore 0, v9 !metadata(storage=slot(0))
+    stop
+  bb3:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @fixedLength() -> u256 [selector=0x47f1a57f, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = alloc memoryfixedarray<1, 1>, exact, uninitialized, infallible, 32
+    v1 = and 0, 0xffffffff
+    memory_object_store_element memoryfixedarray<1, 1>, v0, 0, v1
+    v2 = sload 0 !metadata(storage=slot(0))
+    v3 = lt 1, v2
+    v4 = iszero v3
+    jumpi v4, bb1, bb2
+  bb2:
+    v5 = storage_array_data_slot 0
+    v6 = div 1, 8
+    v7 = add v5, v6
+    v8 = mod 1, 8
+    v9 = mul v8, 4
+    v10 = sload 0 !metadata(storage=slot(0))
+    v11 = gt v10, 1
+    jumpi v11, bb3, bb4
+  bb3:
+    jump bb5
+  bb5:
+    v12 = phi [bb3: 1], [bb6: v27]
+    v13 = lt v12, v10
+    jumpi v13, bb6, bb7
+  bb7:
+    jump bb4
+  bb4:
+    sstore 0, 1 !metadata(storage=slot(0))
+    jump bb8
+  bb8:
+    v28 = phi [bb4: 0], [bb9: v44]
+    v29 = lt v28, 1
+    jumpi v29, bb9, bb10
+  bb10:
+    v45 = storage_array_data_slot 0
+    v46 = add v45, 0
+    v47 = sload v46 !metadata(storage=symbolic(v45))
+    v48 = and v47, 0xffffffff
+    sstore v46, v48 !metadata(storage=symbolic(v45))
+    v49 = mul v9, 8
+    v50 = shl v49, 0xffffffff
+    v51 = sload v7 !metadata(storage=symbolic(v7))
+    v52 = not v50
+    v53 = and v51, v52
+    v54 = and 4, 0xffffffff
+    v55 = shl v49, v54
+    v56 = or v53, v55
+    sstore v7, v56 !metadata(storage=symbolic(v7))
+    v57 = alloc memoryfixedarray<1, 1>, exact, uninitialized, infallible, 32
+    v58 = and 0, 0xffffffff
+    memory_object_store_element memoryfixedarray<1, 1>, v57, 0, v58
+    v59 = sload 0 !metadata(storage=slot(0))
+    v60 = gt v59, 1
+    jumpi v60, bb11, bb12
+  bb11:
+    jump bb13
+  bb13:
+    v61 = phi [bb11: 1], [bb14: v76]
+    v62 = lt v61, v59
+    jumpi v62, bb14, bb15
+  bb15:
+    jump bb12
+  bb12:
+    sstore 0, 1 !metadata(storage=slot(0))
+    jump bb16
+  bb16:
+    v77 = phi [bb12: 0], [bb17: v93]
+    v78 = lt v77, 1
+    jumpi v78, bb17, bb18
+  bb18:
+    v94 = storage_array_data_slot 0
+    v95 = add v94, 0
+    v96 = sload v95 !metadata(storage=symbolic(v94))
+    v97 = and v96, 0xffffffff
+    sstore v95, v97 !metadata(storage=symbolic(v94))
+    v98 = sload 0 !metadata(storage=slot(0))
+    v99 = add v98, 1
+    v100 = lt v99, v98
+    jumpi v100, bb19, bb20
+  bb20:
+    v101 = storage_array_data_slot 0
+    v102 = div v98, 8
+    v103 = add v101, v102
+    v104 = mod v98, 8
+    v105 = mul v104, 4
+    sstore 0, v99 !metadata(storage=slot(0))
+    v106 = sload 0 !metadata(storage=slot(0))
+    v107 = lt 1, v106
+    v108 = iszero v107
+    jumpi v108, bb21, bb22
+  bb22:
+    v109 = storage_array_data_slot 0
+    v110 = div 1, 8
+    v111 = add v109, v110
+    v112 = mod 1, 8
+    v113 = mul v112, 4
+    v114 = sload v111 !metadata(storage=symbolic(v111))
+    v115 = mul v113, 8
+    v116 = shr v115, v114
+    v117 = and v116, 0xffffffff
+    ret v117
+  bb21:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb19:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb17:
+    v79 = memory_object_load_element memoryfixedarray<1, 1>, v57, v77
+    v80 = storage_array_data_slot 0
+    v81 = div v77, 8
+    v82 = add v80, v81
+    v83 = mod v77, 8
+    v84 = mul v83, 4
+    v85 = mul v84, 8
+    v86 = shl v85, 0xffffffff
+    v87 = sload v82 !metadata(storage=symbolic(v82))
+    v88 = not v86
+    v89 = and v87, v88
+    v90 = and v79, 0xffffffff
+    v91 = shl v85, v90
+    v92 = or v89, v91
+    sstore v82, v92 !metadata(storage=symbolic(v82))
+    v93 = add v77, 1
+    jump bb16
+  bb14:
+    v63 = storage_array_data_slot 0
+    v64 = div v61, 8
+    v65 = add v63, v64
+    v66 = mod v61, 8
+    v67 = mul v66, 4
+    v68 = mul v67, 8
+    v69 = shl v68, 0xffffffff
+    v70 = sload v65 !metadata(storage=symbolic(v65))
+    v71 = not v69
+    v72 = and v70, v71
+    v73 = and 0, 0xffffffff
+    v74 = shl v68, v73
+    v75 = or v72, v74
+    sstore v65, v75 !metadata(storage=symbolic(v65))
+    v76 = add v61, 1
+    jump bb13
+  bb9:
+    v30 = memory_object_load_element memoryfixedarray<1, 1>, v0, v28
+    v31 = storage_array_data_slot 0
+    v32 = div v28, 8
+    v33 = add v31, v32
+    v34 = mod v28, 8
+    v35 = mul v34, 4
+    v36 = mul v35, 8
+    v37 = shl v36, 0xffffffff
+    v38 = sload v33 !metadata(storage=symbolic(v33))
+    v39 = not v37
+    v40 = and v38, v39
+    v41 = and v30, 0xffffffff
+    v42 = shl v36, v41
+    v43 = or v40, v42
+    sstore v33, v43 !metadata(storage=symbolic(v33))
+    v44 = add v28, 1
+    jump bb8
+  bb6:
+    v14 = storage_array_data_slot 0
+    v15 = div v12, 8
+    v16 = add v14, v15
+    v17 = mod v12, 8
+    v18 = mul v17, 4
+    v19 = mul v18, 8
+    v20 = shl v19, 0xffffffff
+    v21 = sload v16 !metadata(storage=symbolic(v16))
+    v22 = not v20
+    v23 = and v21, v22
+    v24 = and 0, 0xffffffff
+    v25 = shl v19, v24
+    v26 = or v23, v25
+    sstore v16, v26 !metadata(storage=symbolic(v16))
+    v27 = add v12, 1
+    jump bb5
+  bb1:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @dynamicLength(arg0: u256) -> u256 [selector=0x3e3319e9, abi_params=[u256], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    jump bb1
+  bb1:
+    v1 = phi [bb0: arg0], [bb10: v1]
+    v2 = phi [bb0: v0], [bb10: v14]
+    v3 = phi [bb0: 0], [bb10: v3]
+    v4 = gt v2, v1
+    v5 = iszero v4
+    jumpi v5, bb4, bb5
+  bb5:
+    jump bb2
+  bb2:
+    v16 = mul v1, 1
+    v17 = iszero 1
+    v18 = div v16, 1
+    v19 = eq v18, v1
+    v20 = or v17, v19
+    v21 = iszero v20
+    jumpi v21, bb11, bb12
+  bb12:
+    v22 = add v16, 1
+    v23 = lt v22, v16
+    jumpi v23, bb13, bb14
+  bb14:
+    v24 = mul v22, 32
+    v25 = iszero 32
+    v26 = div v24, 32
+    v27 = eq v26, v22
+    v28 = or v25, v27
+    v29 = iszero v28
+    jumpi v29, bb15, bb16
+  bb16:
+    v30 = alloc memoryarray<1>, exact, zeroed, panic, v24
+    set_memory_object_len memoryarray, v30, v1
+    v31 = sload 0 !metadata(storage=slot(0))
+    v32 = lt v1, v31
+    v33 = iszero v32
+    jumpi v33, bb17, bb18
+  bb18:
+    v34 = storage_array_data_slot 0
+    v35 = div v1, 8
+    v36 = add v34, v35
+    v37 = mod v1, 8
+    v38 = mul v37, 4
+    v39 = memory_object_len memoryarray, v30
+    v40 = sload 0 !metadata(storage=slot(0))
+    v41 = gt v40, v39
+    jumpi v41, bb19, bb20
+  bb19:
+    jump bb21
+  bb21:
+    v42 = phi [bb19: v39], [bb22: v57]
+    v43 = lt v42, v40
+    jumpi v43, bb22, bb23
+  bb23:
+    jump bb20
+  bb20:
+    sstore 0, v39 !metadata(storage=slot(0))
+    jump bb24
+  bb24:
+    v58 = phi [bb20: 0], [bb25: v74]
+    v59 = lt v58, v39
+    jumpi v59, bb25, bb26
+  bb26:
+    v75 = shr 3, v39
+    v76 = and v39, 7
+    v77 = iszero v76
+    jumpi v77, bb28, bb27
+  bb27:
+    v78 = mul v76, 32
+    v79 = shl v78, 1
+    v80 = sub v79, 1
+    v81 = storage_array_data_slot 0
+    v82 = add v81, v75
+    v83 = sload v82 !metadata(storage=symbolic(v82))
+    v84 = and v83, v80
+    sstore v82, v84 !metadata(storage=symbolic(v82))
+    jump bb28
+  bb28:
+    v85 = mul v38, 8
+    v86 = shl v85, 0xffffffff
+    v87 = sload v36 !metadata(storage=symbolic(v36))
+    v88 = not v86
+    v89 = and v87, v88
+    v90 = and 4, 0xffffffff
+    v91 = shl v85, v90
+    v92 = or v89, v91
+    sstore v36, v92 !metadata(storage=symbolic(v36))
+    v93 = memory_object_len memoryarray, v30
+    v94 = sload 0 !metadata(storage=slot(0))
+    v95 = gt v94, v93
+    jumpi v95, bb29, bb30
+  bb29:
+    jump bb31
+  bb31:
+    v96 = phi [bb29: v93], [bb32: v111]
+    v97 = lt v96, v94
+    jumpi v97, bb32, bb33
+  bb33:
+    jump bb30
+  bb30:
+    sstore 0, v93 !metadata(storage=slot(0))
+    jump bb34
+  bb34:
+    v112 = phi [bb30: 0], [bb35: v128]
+    v113 = lt v112, v93
+    jumpi v113, bb35, bb36
+  bb36:
+    v129 = shr 3, v93
+    v130 = and v93, 7
+    v131 = iszero v130
+    jumpi v131, bb38, bb37
+  bb37:
+    v132 = mul v130, 32
+    v133 = shl v132, 1
+    v134 = sub v133, 1
+    v135 = storage_array_data_slot 0
+    v136 = add v135, v129
+    v137 = sload v136 !metadata(storage=symbolic(v136))
+    v138 = and v137, v134
+    sstore v136, v138 !metadata(storage=symbolic(v136))
+    jump bb38
+  bb38:
+    v139 = sload 0 !metadata(storage=slot(0))
+    v140 = add v139, 1
+    v141 = lt v140, v139
+    jumpi v141, bb39, bb40
+  bb40:
+    v142 = storage_array_data_slot 0
+    v143 = div v139, 8
+    v144 = add v142, v143
+    v145 = mod v139, 8
+    v146 = mul v145, 4
+    sstore 0, v140 !metadata(storage=slot(0))
+    v147 = sload 0 !metadata(storage=slot(0))
+    v148 = lt v1, v147
+    v149 = iszero v148
+    jumpi v149, bb41, bb42
+  bb42:
+    v150 = storage_array_data_slot 0
+    v151 = div v1, 8
+    v152 = add v150, v151
+    v153 = mod v1, 8
+    v154 = mul v153, 4
+    v155 = sload v152 !metadata(storage=symbolic(v152))
+    v156 = mul v154, 8
+    v157 = shr v156, v155
+    v158 = and v157, 0xffffffff
+    ret v158
+  bb41:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb39:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb35:
+    v114 = memory_object_load_element memoryarray<1>, v30, v112
+    v115 = storage_array_data_slot 0
+    v116 = div v112, 8
+    v117 = add v115, v116
+    v118 = mod v112, 8
+    v119 = mul v118, 4
+    v120 = mul v119, 8
+    v121 = shl v120, 0xffffffff
+    v122 = sload v117 !metadata(storage=symbolic(v117))
+    v123 = not v121
+    v124 = and v122, v123
+    v125 = and v114, 0xffffffff
+    v126 = shl v120, v125
+    v127 = or v124, v126
+    sstore v117, v127 !metadata(storage=symbolic(v117))
+    v128 = add v112, 1
+    jump bb34
+  bb32:
+    v98 = storage_array_data_slot 0
+    v99 = div v96, 8
+    v100 = add v98, v99
+    v101 = mod v96, 8
+    v102 = mul v101, 4
+    v103 = mul v102, 8
+    v104 = shl v103, 0xffffffff
+    v105 = sload v100 !metadata(storage=symbolic(v100))
+    v106 = not v104
+    v107 = and v105, v106
+    v108 = and 0, 0xffffffff
+    v109 = shl v103, v108
+    v110 = or v107, v109
+    sstore v100, v110 !metadata(storage=symbolic(v100))
+    v111 = add v96, 1
+    jump bb31
+  bb25:
+    v60 = memory_object_load_element memoryarray<1>, v30, v58
+    v61 = storage_array_data_slot 0
+    v62 = div v58, 8
+    v63 = add v61, v62
+    v64 = mod v58, 8
+    v65 = mul v64, 4
+    v66 = mul v65, 8
+    v67 = shl v66, 0xffffffff
+    v68 = sload v63 !metadata(storage=symbolic(v63))
+    v69 = not v67
+    v70 = and v68, v69
+    v71 = and v60, 0xffffffff
+    v72 = shl v66, v71
+    v73 = or v70, v72
+    sstore v63, v73 !metadata(storage=symbolic(v63))
+    v74 = add v58, 1
+    jump bb24
+  bb22:
+    v44 = storage_array_data_slot 0
+    v45 = div v42, 8
+    v46 = add v44, v45
+    v47 = mod v42, 8
+    v48 = mul v47, 4
+    v49 = mul v48, 8
+    v50 = shl v49, 0xffffffff
+    v51 = sload v46 !metadata(storage=symbolic(v46))
+    v52 = not v50
+    v53 = and v51, v52
+    v54 = and 0, 0xffffffff
+    v55 = shl v49, v54
+    v56 = or v53, v55
+    sstore v46, v56 !metadata(storage=symbolic(v46))
+    v57 = add v42, 1
+    jump bb21
+  bb17:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb15:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb13:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    v6 = sload 0 !metadata(storage=slot(0))
+    v7 = add v6, 1
+    v8 = lt v7, v6
+    jumpi v8, bb7, bb8
+  bb8:
+    v9 = storage_array_data_slot 0
+    v10 = div v6, 8
+    v11 = add v9, v10
+    v12 = mod v6, 8
+    v13 = mul v12, 4
+    sstore 0, v7 !metadata(storage=slot(0))
+    jump bb6
+  bb6:
+    jump bb3
+  bb3:
+    v14 = add v2, 1
+    v15 = lt v14, v2
+    jumpi v15, bb9, bb10
+  bb10:
+    jump bb1
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}
+
+fn @exactSlotBoundary() -> u256 [selector=0xe55d27b8, abi_params=[], abi_returns=[word]] {
+  bb0:
+    v0 = sload 0 !metadata(storage=slot(0))
+    jump bb1
+  bb1:
+    v1 = phi [bb0: v0], [bb10: v12]
+    v2 = phi [bb0: 0], [bb10: v2]
+    v3 = lt v1, 9
+    jumpi v3, bb4, bb5
+  bb5:
+    jump bb2
+  bb2:
+    v14 = alloc memoryfixedarray<8, 1>, exact, uninitialized, infallible, 256
+    memory_zero v14, 256
+    v15 = sload 0 !metadata(storage=slot(0))
+    v16 = lt 8, v15
+    v17 = iszero v16
+    jumpi v17, bb11, bb12
+  bb12:
+    v18 = storage_array_data_slot 0
+    v19 = div 8, 8
+    v20 = add v18, v19
+    v21 = mod 8, 8
+    v22 = mul v21, 4
+    v23 = sload 0 !metadata(storage=slot(0))
+    v24 = gt v23, 8
+    jumpi v24, bb13, bb14
+  bb13:
+    jump bb15
+  bb15:
+    v25 = phi [bb13: 8], [bb16: v40]
+    v26 = lt v25, v23
+    jumpi v26, bb16, bb17
+  bb17:
+    jump bb14
+  bb14:
+    sstore 0, 8 !metadata(storage=slot(0))
+    jump bb18
+  bb18:
+    v41 = phi [bb14: 0], [bb19: v57]
+    v42 = lt v41, 8
+    jumpi v42, bb19, bb20
+  bb20:
+    v58 = mul v22, 8
+    v59 = shl v58, 0xffffffff
+    v60 = sload v20 !metadata(storage=symbolic(v20))
+    v61 = not v59
+    v62 = and v60, v61
+    v63 = and 4, 0xffffffff
+    v64 = shl v58, v63
+    v65 = or v62, v64
+    sstore v20, v65 !metadata(storage=symbolic(v20))
+    v66 = sload 0 !metadata(storage=slot(0))
+    v67 = gt v66, 8
+    jumpi v67, bb21, bb22
+  bb21:
+    jump bb23
+  bb23:
+    v68 = phi [bb21: 8], [bb24: v83]
+    v69 = lt v68, v66
+    jumpi v69, bb24, bb25
+  bb25:
+    jump bb22
+  bb22:
+    sstore 0, 8 !metadata(storage=slot(0))
+    jump bb26
+  bb26:
+    v84 = phi [bb22: 0], [bb27: v100]
+    v85 = lt v84, 8
+    jumpi v85, bb27, bb28
+  bb28:
+    v101 = sload 0 !metadata(storage=slot(0))
+    v102 = add v101, 1
+    v103 = lt v102, v101
+    jumpi v103, bb29, bb30
+  bb30:
+    v104 = storage_array_data_slot 0
+    v105 = div v101, 8
+    v106 = add v104, v105
+    v107 = mod v101, 8
+    v108 = mul v107, 4
+    sstore 0, v102 !metadata(storage=slot(0))
+    v109 = sload 0 !metadata(storage=slot(0))
+    v110 = lt 8, v109
+    v111 = iszero v110
+    jumpi v111, bb31, bb32
+  bb32:
+    v112 = storage_array_data_slot 0
+    v113 = div 8, 8
+    v114 = add v112, v113
+    v115 = mod 8, 8
+    v116 = mul v115, 4
+    v117 = sload v114 !metadata(storage=symbolic(v114))
+    v118 = mul v116, 8
+    v119 = shr v118, v117
+    v120 = and v119, 0xffffffff
+    ret v120
+  bb31:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb29:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb27:
+    v86 = memory_object_load_element memoryfixedarray<8, 1>, v14, v84
+    v87 = storage_array_data_slot 0
+    v88 = div v84, 8
+    v89 = add v87, v88
+    v90 = mod v84, 8
+    v91 = mul v90, 4
+    v92 = mul v91, 8
+    v93 = shl v92, 0xffffffff
+    v94 = sload v89 !metadata(storage=symbolic(v89))
+    v95 = not v93
+    v96 = and v94, v95
+    v97 = and v86, 0xffffffff
+    v98 = shl v92, v97
+    v99 = or v96, v98
+    sstore v89, v99 !metadata(storage=symbolic(v89))
+    v100 = add v84, 1
+    jump bb26
+  bb24:
+    v70 = storage_array_data_slot 0
+    v71 = div v68, 8
+    v72 = add v70, v71
+    v73 = mod v68, 8
+    v74 = mul v73, 4
+    v75 = mul v74, 8
+    v76 = shl v75, 0xffffffff
+    v77 = sload v72 !metadata(storage=symbolic(v72))
+    v78 = not v76
+    v79 = and v77, v78
+    v80 = and 0, 0xffffffff
+    v81 = shl v75, v80
+    v82 = or v79, v81
+    sstore v72, v82 !metadata(storage=symbolic(v72))
+    v83 = add v68, 1
+    jump bb23
+  bb19:
+    v43 = memory_object_load_element memoryfixedarray<8, 1>, v14, v41
+    v44 = storage_array_data_slot 0
+    v45 = div v41, 8
+    v46 = add v44, v45
+    v47 = mod v41, 8
+    v48 = mul v47, 4
+    v49 = mul v48, 8
+    v50 = shl v49, 0xffffffff
+    v51 = sload v46 !metadata(storage=symbolic(v46))
+    v52 = not v50
+    v53 = and v51, v52
+    v54 = and v43, 0xffffffff
+    v55 = shl v49, v54
+    v56 = or v53, v55
+    sstore v46, v56 !metadata(storage=symbolic(v46))
+    v57 = add v41, 1
+    jump bb18
+  bb16:
+    v27 = storage_array_data_slot 0
+    v28 = div v25, 8
+    v29 = add v27, v28
+    v30 = mod v25, 8
+    v31 = mul v30, 4
+    v32 = mul v31, 8
+    v33 = shl v32, 0xffffffff
+    v34 = sload v29 !metadata(storage=symbolic(v29))
+    v35 = not v33
+    v36 = and v34, v35
+    v37 = and 0, 0xffffffff
+    v38 = shl v32, v37
+    v39 = or v36, v38
+    sstore v29, v39 !metadata(storage=symbolic(v29))
+    v40 = add v25, 1
+    jump bb15
+  bb11:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb4:
+    v4 = sload 0 !metadata(storage=slot(0))
+    v5 = add v4, 1
+    v6 = lt v5, v4
+    jumpi v6, bb7, bb8
+  bb8:
+    v7 = storage_array_data_slot 0
+    v8 = div v4, 8
+    v9 = add v7, v8
+    v10 = mod v4, 8
+    v11 = mul v10, 4
+    sstore 0, v5 !metadata(storage=slot(0))
+    jump bb6
+  bb6:
+    jump bb3
+  bb3:
+    v12 = add v1, 1
+    v13 = lt v12, v1
+    jumpi v13, bb9, bb10
+  bb10:
+    jump bb1
+  bb9:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb7:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+}

--- a/tests/ui/codegen/lowering/run-call/storage_array_assignment_packed_tail.sol
+++ b/tests/ui/codegen/lowering/run-call/storage_array_assignment_packed_tail.sol
@@ -1,0 +1,48 @@
+//@ filecheck:
+// CHECK: @module
+//@ codegen-matrix: standard
+//@ run-call: fixedLength() => 0
+//@ run-call: dynamicLength(uint256) 8 => 4
+//@ run-call: dynamicLength(uint256) 9 => 0
+//@ run-call: exactSlotBoundary() => 4
+// ported-from: test/libsolidity/semanticTests/array/copying/cleanup_during_multi_element_per_slot_copy.sol
+
+contract StorageArrayAssignmentPackedTail {
+    uint32[] private values;
+
+    constructor() {
+        values.push();
+        values.push();
+    }
+
+    function fixedLength() external returns (uint256) {
+        (values[1], values) = (4, [uint32(0)]);
+        values = [uint32(0)];
+        values.push();
+        return values[1];
+    }
+
+    function dynamicLength(uint256 length) external returns (uint256) {
+        for (uint256 i = values.length; i <= length; ++i) {
+            values.push();
+        }
+
+        uint32[] memory replacement = new uint32[](length);
+        (values[length], values) = (4, replacement);
+        values = replacement;
+        values.push();
+        return values[length];
+    }
+
+    function exactSlotBoundary() external returns (uint256) {
+        for (uint256 i = values.length; i < 9; ++i) {
+            values.push();
+        }
+
+        uint32[8] memory replacement;
+        (values[8], values) = (4, replacement);
+        values = replacement;
+        values.push();
+        return values[8];
+    }
+}

--- a/tests/ui/codegen/lowering/run-call/storage_array_different_packing.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_array_different_packing.mir.stdout
@@ -24,117 +24,155 @@ fn @test() -> (bytes10, bytes10, bytes10, bytes10, bytes10) [selector=0xf8a8fd6d
     v22 = lt v21, v1
     jumpi v22, bb7, bb8
   bb8:
-    jump bb9
+    v39 = shr 2, v1
+    v40 = and v1, 3
+    v41 = iszero v40
+    jumpi v41, bb10, bb9
   bb9:
-    v39 = phi [bb8: 0], [bb18: v39]
-    v40 = phi [bb8: 0], [bb18: v66]
-    v41 = phi [bb8: 0], [bb18: v41]
-    v42 = phi [bb8: 0], [bb18: v42]
-    v43 = phi [bb8: 0], [bb18: v43]
-    v44 = phi [bb8: 0], [bb18: v44]
-    v45 = sload 0 !metadata(storage=slot(0))
-    v46 = lt v40, v45
-    jumpi v46, bb12, bb13
-  bb13:
+    v42 = mul v40, 64
+    v43 = shl v42, 1
+    v44 = sub v43, 1
+    v45 = storage_array_data_slot 0
+    v46 = add v45, v39
+    v47 = sload v46 !metadata(storage=symbolic(v46))
+    v48 = and v47, v44
+    sstore v46, v48 !metadata(storage=symbolic(v46))
     jump bb10
   bb10:
-    v68 = internal_call @load_storage_packed_array_8_2, 1, 0
-    v69 = memory_object_len memoryarray, v68
-    v70 = sload 1 !metadata(storage=slot(1))
-    v71 = gt v70, v69
-    jumpi v71, bb19, bb20
-  bb19:
-    jump bb21
+    jump bb11
+  bb11:
+    v49 = phi [bb10: 0], [bb20: v49]
+    v50 = phi [bb10: 0], [bb20: v76]
+    v51 = phi [bb10: 0], [bb20: v51]
+    v52 = phi [bb10: 0], [bb20: v52]
+    v53 = phi [bb10: 0], [bb20: v53]
+    v54 = phi [bb10: 0], [bb20: v54]
+    v55 = sload 0 !metadata(storage=slot(0))
+    v56 = lt v50, v55
+    jumpi v56, bb14, bb15
+  bb15:
+    jump bb12
+  bb12:
+    v78 = internal_call @load_storage_packed_array_8_2, 1, 0
+    v79 = memory_object_len memoryarray, v78
+    v80 = sload 1 !metadata(storage=slot(1))
+    v81 = gt v80, v79
+    jumpi v81, bb21, bb22
   bb21:
-    v72 = phi [bb19: v69], [bb22: v88]
-    v73 = lt v72, v70
-    jumpi v73, bb22, bb23
+    jump bb23
   bb23:
-    jump bb20
-  bb20:
-    sstore 1, v69 !metadata(storage=slot(1))
-    jump bb24
-  bb24:
-    v89 = phi [bb20: 0], [bb25: v106]
-    v90 = lt v89, v69
-    jumpi v90, bb25, bb26
+    v82 = phi [bb21: v79], [bb24: v98]
+    v83 = lt v82, v80
+    jumpi v83, bb24, bb25
+  bb25:
+    jump bb22
+  bb22:
+    sstore 1, v79 !metadata(storage=slot(1))
+    jump bb26
   bb26:
-    v107 = sload 1 !metadata(storage=slot(1))
-    v108 = lt 1, v107
-    v109 = iszero v108
-    jumpi v109, bb27, bb28
+    v99 = phi [bb22: 0], [bb27: v116]
+    v100 = lt v99, v79
+    jumpi v100, bb27, bb28
   bb28:
-    v110 = storage_array_data_slot 1
-    v111 = div 1, 3
-    v112 = add v110, v111
-    v113 = mod 1, 3
-    v114 = mul v113, 10
-    v115 = sload v112 !metadata(storage=symbolic(v112))
-    v116 = mul v114, 8
-    v117 = shr v116, v115
-    v118 = and v117, 0xffffffffffffffffffff
-    v119 = shl 176, v118
-    v120 = sload 1 !metadata(storage=slot(1))
-    v121 = lt 2, v120
-    v122 = iszero v121
-    jumpi v122, bb29, bb30
-  bb30:
+    v117 = div v79, 3
+    v118 = mod v79, 3
+    v119 = iszero v118
+    jumpi v119, bb30, bb29
+  bb29:
+    v120 = mul v118, 80
+    v121 = shl v120, 1
+    v122 = sub v121, 1
     v123 = storage_array_data_slot 1
-    v124 = div 2, 3
-    v125 = add v123, v124
-    v126 = mod 2, 3
-    v127 = mul v126, 10
-    v128 = sload v125 !metadata(storage=symbolic(v125))
-    v129 = mul v127, 8
-    v130 = shr v129, v128
-    v131 = and v130, 0xffffffffffffffffffff
-    v132 = shl 176, v131
-    v133 = sload 1 !metadata(storage=slot(1))
-    v134 = lt 3, v133
-    v135 = iszero v134
-    jumpi v135, bb31, bb32
+    v124 = add v123, v117
+    v125 = sload v124 !metadata(storage=symbolic(v124))
+    v126 = and v125, v122
+    sstore v124, v126 !metadata(storage=symbolic(v124))
+    jump bb30
+  bb30:
+    v127 = sload 1 !metadata(storage=slot(1))
+    v128 = lt 1, v127
+    v129 = iszero v128
+    jumpi v129, bb31, bb32
   bb32:
-    v136 = storage_array_data_slot 1
-    v137 = div 3, 3
-    v138 = add v136, v137
-    v139 = mod 3, 3
-    v140 = mul v139, 10
-    v141 = sload v138 !metadata(storage=symbolic(v138))
-    v142 = mul v140, 8
-    v143 = shr v142, v141
-    v144 = and v143, 0xffffffffffffffffffff
-    v145 = shl 176, v144
-    v146 = sload 1 !metadata(storage=slot(1))
-    v147 = lt 4, v146
-    v148 = iszero v147
-    jumpi v148, bb33, bb34
+    v130 = storage_array_data_slot 1
+    v131 = div 1, 3
+    v132 = add v130, v131
+    v133 = mod 1, 3
+    v134 = mul v133, 10
+    v135 = sload v132 !metadata(storage=symbolic(v132))
+    v136 = mul v134, 8
+    v137 = shr v136, v135
+    v138 = and v137, 0xffffffffffffffffffff
+    v139 = shl 176, v138
+    v140 = sload 1 !metadata(storage=slot(1))
+    v141 = lt 2, v140
+    v142 = iszero v141
+    jumpi v142, bb33, bb34
   bb34:
-    v149 = storage_array_data_slot 1
-    v150 = div 4, 3
-    v151 = add v149, v150
-    v152 = mod 4, 3
-    v153 = mul v152, 10
-    v154 = sload v151 !metadata(storage=symbolic(v151))
-    v155 = mul v153, 8
-    v156 = shr v155, v154
-    v157 = and v156, 0xffffffffffffffffffff
-    v158 = shl 176, v157
-    v159 = sload 1 !metadata(storage=slot(1))
-    v160 = lt 5, v159
-    v161 = iszero v160
-    jumpi v161, bb35, bb36
+    v143 = storage_array_data_slot 1
+    v144 = div 2, 3
+    v145 = add v143, v144
+    v146 = mod 2, 3
+    v147 = mul v146, 10
+    v148 = sload v145 !metadata(storage=symbolic(v145))
+    v149 = mul v147, 8
+    v150 = shr v149, v148
+    v151 = and v150, 0xffffffffffffffffffff
+    v152 = shl 176, v151
+    v153 = sload 1 !metadata(storage=slot(1))
+    v154 = lt 3, v153
+    v155 = iszero v154
+    jumpi v155, bb35, bb36
   bb36:
-    v162 = storage_array_data_slot 1
-    v163 = div 5, 3
-    v164 = add v162, v163
-    v165 = mod 5, 3
-    v166 = mul v165, 10
-    v167 = sload v164 !metadata(storage=symbolic(v164))
-    v168 = mul v166, 8
-    v169 = shr v168, v167
-    v170 = and v169, 0xffffffffffffffffffff
-    v171 = shl 176, v170
-    ret v119, v132, v145, v158, v171
+    v156 = storage_array_data_slot 1
+    v157 = div 3, 3
+    v158 = add v156, v157
+    v159 = mod 3, 3
+    v160 = mul v159, 10
+    v161 = sload v158 !metadata(storage=symbolic(v158))
+    v162 = mul v160, 8
+    v163 = shr v162, v161
+    v164 = and v163, 0xffffffffffffffffffff
+    v165 = shl 176, v164
+    v166 = sload 1 !metadata(storage=slot(1))
+    v167 = lt 4, v166
+    v168 = iszero v167
+    jumpi v168, bb37, bb38
+  bb38:
+    v169 = storage_array_data_slot 1
+    v170 = div 4, 3
+    v171 = add v169, v170
+    v172 = mod 4, 3
+    v173 = mul v172, 10
+    v174 = sload v171 !metadata(storage=symbolic(v171))
+    v175 = mul v173, 8
+    v176 = shr v175, v174
+    v177 = and v176, 0xffffffffffffffffffff
+    v178 = shl 176, v177
+    v179 = sload 1 !metadata(storage=slot(1))
+    v180 = lt 5, v179
+    v181 = iszero v180
+    jumpi v181, bb39, bb40
+  bb40:
+    v182 = storage_array_data_slot 1
+    v183 = div 5, 3
+    v184 = add v182, v183
+    v185 = mod 5, 3
+    v186 = mul v185, 10
+    v187 = sload v184 !metadata(storage=symbolic(v184))
+    v188 = mul v186, 8
+    v189 = shr v188, v187
+    v190 = and v189, 0xffffffffffffffffffff
+    v191 = shl 176, v190
+    ret v139, v152, v165, v178, v191
+  bb39:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb37:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -147,88 +185,80 @@ fn @test() -> (bytes10, bytes10, bytes10, bytes10, bytes10) [selector=0xf8a8fd6d
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb29:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
   bb27:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb25:
-    v91 = memory_object_load_element memoryarray<1>, v68, v89
-    v92 = storage_array_data_slot 1
-    v93 = div v89, 3
-    v94 = add v92, v93
-    v95 = mod v89, 3
-    v96 = mul v95, 10
-    v97 = mul v96, 8
-    v98 = shl v97, 0xffffffffffffffffffff
-    v99 = sload v94 !metadata(storage=symbolic(v94))
-    v100 = not v98
-    v101 = and v99, v100
-    v102 = shr 176, v91
-    v103 = and v102, 0xffffffffffffffffffff
-    v104 = shl v97, v103
-    v105 = or v101, v104
-    sstore v94, v105 !metadata(storage=symbolic(v94))
-    v106 = add v89, 1
-    jump bb24
-  bb22:
-    v74 = storage_array_data_slot 1
-    v75 = div v72, 3
-    v76 = add v74, v75
-    v77 = mod v72, 3
-    v78 = mul v77, 10
-    v79 = mul v78, 8
-    v80 = shl v79, 0xffffffffffffffffffff
-    v81 = sload v76 !metadata(storage=symbolic(v76))
-    v82 = not v80
-    v83 = and v81, v82
-    v84 = shr 176, 0
-    v85 = and v84, 0xffffffffffffffffffff
-    v86 = shl v79, v85
-    v87 = or v83, v86
-    sstore v76, v87 !metadata(storage=symbolic(v76))
-    v88 = add v72, 1
-    jump bb21
-  bb12:
-    v47 = and v40, 0xffffffffffffffff
-    v48 = shl 192, v47
-    v49 = sload 0 !metadata(storage=slot(0))
-    v50 = lt v40, v49
-    v51 = iszero v50
-    jumpi v51, bb15, bb16
-  bb16:
-    v52 = storage_array_data_slot 0
-    v53 = div v40, 4
-    v54 = add v52, v53
-    v55 = mod v40, 4
-    v56 = mul v55, 8
-    v57 = mul v56, 8
-    v58 = shl v57, 0xffffffffffffffff
-    v59 = sload v54 !metadata(storage=symbolic(v54))
-    v60 = not v58
-    v61 = and v59, v60
-    v62 = shr 192, v48
-    v63 = and v62, 0xffffffffffffffff
-    v64 = shl v57, v63
-    v65 = or v61, v64
-    sstore v54, v65 !metadata(storage=symbolic(v54))
-    jump bb14
+    v101 = memory_object_load_element memoryarray<1>, v78, v99
+    v102 = storage_array_data_slot 1
+    v103 = div v99, 3
+    v104 = add v102, v103
+    v105 = mod v99, 3
+    v106 = mul v105, 10
+    v107 = mul v106, 8
+    v108 = shl v107, 0xffffffffffffffffffff
+    v109 = sload v104 !metadata(storage=symbolic(v104))
+    v110 = not v108
+    v111 = and v109, v110
+    v112 = shr 176, v101
+    v113 = and v112, 0xffffffffffffffffffff
+    v114 = shl v107, v113
+    v115 = or v111, v114
+    sstore v104, v115 !metadata(storage=symbolic(v104))
+    v116 = add v99, 1
+    jump bb26
+  bb24:
+    v84 = storage_array_data_slot 1
+    v85 = div v82, 3
+    v86 = add v84, v85
+    v87 = mod v82, 3
+    v88 = mul v87, 10
+    v89 = mul v88, 8
+    v90 = shl v89, 0xffffffffffffffffffff
+    v91 = sload v86 !metadata(storage=symbolic(v86))
+    v92 = not v90
+    v93 = and v91, v92
+    v94 = shr 176, 0
+    v95 = and v94, 0xffffffffffffffffffff
+    v96 = shl v89, v95
+    v97 = or v93, v96
+    sstore v86, v97 !metadata(storage=symbolic(v86))
+    v98 = add v82, 1
+    jump bb23
   bb14:
-    jump bb11
-  bb11:
-    v66 = add v40, 1
-    v67 = lt v66, v40
-    jumpi v67, bb17, bb18
+    v57 = and v50, 0xffffffffffffffff
+    v58 = shl 192, v57
+    v59 = sload 0 !metadata(storage=slot(0))
+    v60 = lt v50, v59
+    v61 = iszero v60
+    jumpi v61, bb17, bb18
   bb18:
-    jump bb9
-  bb17:
+    v62 = storage_array_data_slot 0
+    v63 = div v50, 4
+    v64 = add v62, v63
+    v65 = mod v50, 4
+    v66 = mul v65, 8
+    v67 = mul v66, 8
+    v68 = shl v67, 0xffffffffffffffff
+    v69 = sload v64 !metadata(storage=symbolic(v64))
+    v70 = not v68
+    v71 = and v69, v70
+    v72 = shr 192, v58
+    v73 = and v72, 0xffffffffffffffff
+    v74 = shl v67, v73
+    v75 = or v71, v74
+    sstore v64, v75 !metadata(storage=symbolic(v64))
+    jump bb16
+  bb16:
+    jump bb13
+  bb13:
+    v76 = add v50, 1
+    v77 = lt v76, v50
+    jumpi v77, bb19, bb20
+  bb20:
+    jump bb11
+  bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb15:
+  bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/storage_array_push_calldata.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_array_push_calldata.mir.stdout
@@ -64,34 +64,49 @@ fn @pushArray(arg0: calldataslice) -> u120 [selector=0xac513f44, abi_params=[arr
     v60 = lt v59, v40
     jumpi v60, bb24, bb25
   bb25:
-    sstore 0, v36 !metadata(storage=slot(0))
-    v76 = sload 0 !metadata(storage=slot(0))
-    v77 = lt 0, v76
+    v76 = shr 1, v40
+    v77 = and v40, 1
     v78 = iszero v77
-    jumpi v78, bb26, bb27
+    jumpi v78, bb27, bb26
+  bb26:
+    v79 = mul v77, 120
+    v80 = shl v79, 1
+    v81 = sub v80, 1
+    v82 = storage_array_data_slot v39
+    v83 = add v82, v76
+    v84 = sload v83 !metadata(storage=symbolic(v83))
+    v85 = and v84, v81
+    sstore v83, v85 !metadata(storage=symbolic(v83))
+    jump bb27
   bb27:
-    v79 = storage_array_data_slot 0
-    v80 = add v79, 0
-    v81 = sload v80 !metadata(storage=symbolic(v79))
-    v82 = lt 0, v81
-    v83 = iszero v82
-    jumpi v83, bb28, bb29
+    sstore 0, v36 !metadata(storage=slot(0))
+    v86 = sload 0 !metadata(storage=slot(0))
+    v87 = lt 0, v86
+    v88 = iszero v87
+    jumpi v88, bb28, bb29
   bb29:
-    v84 = storage_array_data_slot v80
-    v85 = div 0, 2
-    v86 = add v84, v85
-    v87 = mod 0, 2
-    v88 = mul v87, 15
-    v89 = sload v86 !metadata(storage=symbolic(v86))
-    v90 = mul v88, 8
-    v91 = shr v90, v89
-    v92 = and v91, 0xffffffffffffffffffffffffffffff
-    ret v92
-  bb28:
+    v89 = storage_array_data_slot 0
+    v90 = add v89, 0
+    v91 = sload v90 !metadata(storage=symbolic(v89))
+    v92 = lt 0, v91
+    v93 = iszero v92
+    jumpi v93, bb30, bb31
+  bb31:
+    v94 = storage_array_data_slot v90
+    v95 = div 0, 2
+    v96 = add v94, v95
+    v97 = mod 0, 2
+    v98 = mul v97, 15
+    v99 = sload v96 !metadata(storage=symbolic(v96))
+    v100 = mul v98, 8
+    v101 = shr v100, v99
+    v102 = and v101, 0xffffffffffffffffffffffffffffff
+    ret v102
+  bb30:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb26:
+  bb28:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -380,112 +395,131 @@ fn @pushStruct(arg0: calldataslice) -> u256 [selector=0x1696eca8, abi_params=[tu
     v168 = lt v167, v148
     jumpi v168, bb44, bb45
   bb45:
-    sstore 1, v86 !metadata(storage=slot(1))
-    v184 = sload 1 !metadata(storage=slot(1))
-    v185 = lt 0, v184
+    v184 = shr 4, v148
+    v185 = and v148, 15
     v186 = iszero v185
-    jumpi v186, bb46, bb47
+    jumpi v186, bb47, bb46
+  bb46:
+    v187 = mul v185, 16
+    v188 = shl v187, 1
+    v189 = sub v188, 1
+    v190 = storage_array_data_slot v146
+    v191 = add v190, v184
+    v192 = sload v191 !metadata(storage=symbolic(v191))
+    v193 = and v192, v189
+    sstore v191, v193 !metadata(storage=symbolic(v191))
+    jump bb47
   bb47:
-    v187 = storage_array_data_slot 1
-    v188 = mul 0, 3
-    v189 = add v187, v188
-    v190 = sload v189 !metadata(storage=symbolic(v189))
-    v191 = and v190, 0xffff
-    v192 = mul v191, 0x3e8
-    v193 = iszero 0x3e8
-    v194 = div v192, 0x3e8
-    v195 = eq v194, v191
-    v196 = or v193, v195
-    v197 = iszero v196
-    jumpi v197, bb48, bb49
+    sstore 1, v86 !metadata(storage=slot(1))
+    v194 = sload 1 !metadata(storage=slot(1))
+    v195 = lt 0, v194
+    v196 = iszero v195
+    jumpi v196, bb48, bb49
   bb49:
-    v198 = sload 1 !metadata(storage=slot(1))
-    v199 = lt 0, v198
-    v200 = iszero v199
-    jumpi v200, bb50, bb51
+    v197 = storage_array_data_slot 1
+    v198 = mul 0, 3
+    v199 = add v197, v198
+    v200 = sload v199 !metadata(storage=symbolic(v199))
+    v201 = and v200, 0xffff
+    v202 = mul v201, 0x3e8
+    v203 = iszero 0x3e8
+    v204 = div v202, 0x3e8
+    v205 = eq v204, v201
+    v206 = or v203, v205
+    v207 = iszero v206
+    jumpi v207, bb50, bb51
   bb51:
-    v201 = storage_array_data_slot 1
-    v202 = mul 0, 3
-    v203 = add v201, v202
-    v204 = sload v203 !metadata(storage=symbolic(v203))
-    v205 = shr 16, v204
-    v206 = and v205, 0xffff
-    v207 = mul v206, 100
-    v208 = iszero 100
-    v209 = div v207, 100
-    v210 = eq v209, v206
-    v211 = or v208, v210
-    v212 = iszero v211
-    jumpi v212, bb52, bb53
+    v208 = sload 1 !metadata(storage=slot(1))
+    v209 = lt 0, v208
+    v210 = iszero v209
+    jumpi v210, bb52, bb53
   bb53:
-    v213 = add v192, v207
-    v214 = lt v213, v192
-    jumpi v214, bb54, bb55
+    v211 = storage_array_data_slot 1
+    v212 = mul 0, 3
+    v213 = add v211, v212
+    v214 = sload v213 !metadata(storage=symbolic(v213))
+    v215 = shr 16, v214
+    v216 = and v215, 0xffff
+    v217 = mul v216, 100
+    v218 = iszero 100
+    v219 = div v217, 100
+    v220 = eq v219, v216
+    v221 = or v218, v220
+    v222 = iszero v221
+    jumpi v222, bb54, bb55
   bb55:
-    v215 = sload 1 !metadata(storage=slot(1))
-    v216 = lt 0, v215
-    v217 = iszero v216
-    jumpi v217, bb56, bb57
+    v223 = add v202, v217
+    v224 = lt v223, v202
+    jumpi v224, bb56, bb57
   bb57:
-    v218 = storage_array_data_slot 1
-    v219 = mul 0, 3
-    v220 = add v218, v219
-    v221 = add v220, 1
-    v222 = lt 2, 3
-    v223 = iszero v222
-    jumpi v223, bb58, bb59
+    v225 = sload 1 !metadata(storage=slot(1))
+    v226 = lt 0, v225
+    v227 = iszero v226
+    jumpi v227, bb58, bb59
   bb59:
-    v224 = div 2, 16
-    v225 = add v221, v224
-    v226 = mod 2, 16
-    v227 = mul v226, 2
-    v228 = sload v225 !metadata(storage=symbolic(v225))
-    v229 = mul v227, 8
-    v230 = shr v229, v228
-    v231 = and v230, 0xffff
-    v232 = mul v231, 10
-    v233 = iszero 10
-    v234 = div v232, 10
-    v235 = eq v234, v231
-    v236 = or v233, v235
-    v237 = iszero v236
-    jumpi v237, bb60, bb61
+    v228 = storage_array_data_slot 1
+    v229 = mul 0, 3
+    v230 = add v228, v229
+    v231 = add v230, 1
+    v232 = lt 2, 3
+    v233 = iszero v232
+    jumpi v233, bb60, bb61
   bb61:
-    v238 = add v213, v232
-    v239 = lt v238, v213
-    jumpi v239, bb62, bb63
+    v234 = div 2, 16
+    v235 = add v231, v234
+    v236 = mod 2, 16
+    v237 = mul v236, 2
+    v238 = sload v235 !metadata(storage=symbolic(v235))
+    v239 = mul v237, 8
+    v240 = shr v239, v238
+    v241 = and v240, 0xffff
+    v242 = mul v241, 10
+    v243 = iszero 10
+    v244 = div v242, 10
+    v245 = eq v244, v241
+    v246 = or v243, v245
+    v247 = iszero v246
+    jumpi v247, bb62, bb63
   bb63:
-    v240 = sload 1 !metadata(storage=slot(1))
-    v241 = lt 0, v240
-    v242 = iszero v241
-    jumpi v242, bb64, bb65
+    v248 = add v223, v242
+    v249 = lt v248, v223
+    jumpi v249, bb64, bb65
   bb65:
-    v243 = storage_array_data_slot 1
-    v244 = mul 0, 3
-    v245 = add v243, v244
-    v246 = add v245, 2
-    v247 = sload v246 !metadata(storage=offset(v245, 2))
-    v248 = lt 2, v247
-    v249 = iszero v248
-    jumpi v249, bb66, bb67
+    v250 = sload 1 !metadata(storage=slot(1))
+    v251 = lt 0, v250
+    v252 = iszero v251
+    jumpi v252, bb66, bb67
   bb67:
-    v250 = storage_array_data_slot v246
-    v251 = div 2, 16
-    v252 = add v250, v251
-    v253 = mod 2, 16
-    v254 = mul v253, 2
-    v255 = sload v252 !metadata(storage=symbolic(v252))
-    v256 = mul v254, 8
-    v257 = shr v256, v255
-    v258 = and v257, 0xffff
-    v259 = add v238, v258
-    v260 = lt v259, v238
-    jumpi v260, bb68, bb69
+    v253 = storage_array_data_slot 1
+    v254 = mul 0, 3
+    v255 = add v253, v254
+    v256 = add v255, 2
+    v257 = sload v256 !metadata(storage=offset(v255, 2))
+    v258 = lt 2, v257
+    v259 = iszero v258
+    jumpi v259, bb68, bb69
   bb69:
-    ret v259
-  bb68:
+    v260 = storage_array_data_slot v256
+    v261 = div 2, 16
+    v262 = add v260, v261
+    v263 = mod 2, 16
+    v264 = mul v263, 2
+    v265 = sload v262 !metadata(storage=symbolic(v262))
+    v266 = mul v264, 8
+    v267 = shr v266, v265
+    v268 = and v267, 0xffff
+    v269 = add v248, v268
+    v270 = lt v269, v248
+    jumpi v270, bb70, bb71
+  bb71:
+    ret v269
+  bb70:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb68:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb66:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -493,7 +527,7 @@ fn @pushStruct(arg0: calldataslice) -> u256 [selector=0x1696eca8, abi_params=[tu
     revert 0, 36
   bb64:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb62:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -501,7 +535,7 @@ fn @pushStruct(arg0: calldataslice) -> u256 [selector=0x1696eca8, abi_params=[tu
     revert 0, 36
   bb60:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb58:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -509,7 +543,7 @@ fn @pushStruct(arg0: calldataslice) -> u256 [selector=0x1696eca8, abi_params=[tu
     revert 0, 36
   bb56:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb54:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -517,17 +551,13 @@ fn @pushStruct(arg0: calldataslice) -> u256 [selector=0x1696eca8, abi_params=[tu
     revert 0, 36
   bb52:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb50:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb48:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb46:
+  bb48:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/storage_array_push_nested.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_array_push_nested.mir.stdout
@@ -110,34 +110,49 @@ fn @pushMemory() -> u256 [selector=0x4d735002, abi_params=[], abi_returns=[word]
     v30 = lt v29, v10
     jumpi v30, bb11, bb12
   bb12:
-    sstore 0, v6 !metadata(storage=slot(0))
-    v46 = sload 0 !metadata(storage=slot(0))
-    v47 = lt 0, v46
+    v46 = shr 1, v10
+    v47 = and v10, 1
     v48 = iszero v47
-    jumpi v48, bb13, bb14
+    jumpi v48, bb14, bb13
+  bb13:
+    v49 = mul v47, 120
+    v50 = shl v49, 1
+    v51 = sub v50, 1
+    v52 = storage_array_data_slot v9
+    v53 = add v52, v46
+    v54 = sload v53 !metadata(storage=symbolic(v53))
+    v55 = and v54, v51
+    sstore v53, v55 !metadata(storage=symbolic(v53))
+    jump bb14
   bb14:
-    v49 = storage_array_data_slot 0
-    v50 = add v49, 0
-    v51 = sload v50 !metadata(storage=symbolic(v49))
-    v52 = lt 0, v51
-    v53 = iszero v52
-    jumpi v53, bb15, bb16
+    sstore 0, v6 !metadata(storage=slot(0))
+    v56 = sload 0 !metadata(storage=slot(0))
+    v57 = lt 0, v56
+    v58 = iszero v57
+    jumpi v58, bb15, bb16
   bb16:
-    v54 = storage_array_data_slot v50
-    v55 = div 0, 2
-    v56 = add v54, v55
-    v57 = mod 0, 2
-    v58 = mul v57, 15
-    v59 = sload v56 !metadata(storage=symbolic(v56))
-    v60 = mul v58, 8
-    v61 = shr v60, v59
-    v62 = and v61, 0xffffffffffffffffffffffffffffff
-    ret v62
-  bb15:
+    v59 = storage_array_data_slot 0
+    v60 = add v59, 0
+    v61 = sload v60 !metadata(storage=symbolic(v59))
+    v62 = lt 0, v61
+    v63 = iszero v62
+    jumpi v63, bb17, bb18
+  bb18:
+    v64 = storage_array_data_slot v60
+    v65 = div 0, 2
+    v66 = add v64, v65
+    v67 = mod 0, 2
+    v68 = mul v67, 15
+    v69 = sload v66 !metadata(storage=symbolic(v66))
+    v70 = mul v68, 8
+    v71 = shr v70, v69
+    v72 = and v71, 0xffffffffffffffffffffffffffffff
+    ret v72
+  bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb13:
+  bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -306,112 +321,131 @@ fn @pushStruct() -> u256 [selector=0x7f91da62, abi_params=[], abi_returns=[word]
     v97 = lt v96, v77
     jumpi v97, bb13, bb14
   bb14:
-    sstore 1, v15 !metadata(storage=slot(1))
-    v113 = sload 1 !metadata(storage=slot(1))
-    v114 = lt 0, v113
+    v113 = shr 4, v77
+    v114 = and v77, 15
     v115 = iszero v114
-    jumpi v115, bb15, bb16
+    jumpi v115, bb16, bb15
+  bb15:
+    v116 = mul v114, 16
+    v117 = shl v116, 1
+    v118 = sub v117, 1
+    v119 = storage_array_data_slot v75
+    v120 = add v119, v113
+    v121 = sload v120 !metadata(storage=symbolic(v120))
+    v122 = and v121, v118
+    sstore v120, v122 !metadata(storage=symbolic(v120))
+    jump bb16
   bb16:
-    v116 = storage_array_data_slot 1
-    v117 = mul 0, 3
-    v118 = add v116, v117
-    v119 = sload v118 !metadata(storage=symbolic(v118))
-    v120 = and v119, 0xffff
-    v121 = mul v120, 0x3e8
-    v122 = iszero 0x3e8
-    v123 = div v121, 0x3e8
-    v124 = eq v123, v120
-    v125 = or v122, v124
-    v126 = iszero v125
-    jumpi v126, bb17, bb18
+    sstore 1, v15 !metadata(storage=slot(1))
+    v123 = sload 1 !metadata(storage=slot(1))
+    v124 = lt 0, v123
+    v125 = iszero v124
+    jumpi v125, bb17, bb18
   bb18:
-    v127 = sload 1 !metadata(storage=slot(1))
-    v128 = lt 0, v127
-    v129 = iszero v128
-    jumpi v129, bb19, bb20
+    v126 = storage_array_data_slot 1
+    v127 = mul 0, 3
+    v128 = add v126, v127
+    v129 = sload v128 !metadata(storage=symbolic(v128))
+    v130 = and v129, 0xffff
+    v131 = mul v130, 0x3e8
+    v132 = iszero 0x3e8
+    v133 = div v131, 0x3e8
+    v134 = eq v133, v130
+    v135 = or v132, v134
+    v136 = iszero v135
+    jumpi v136, bb19, bb20
   bb20:
-    v130 = storage_array_data_slot 1
-    v131 = mul 0, 3
-    v132 = add v130, v131
-    v133 = sload v132 !metadata(storage=symbolic(v132))
-    v134 = shr 16, v133
-    v135 = and v134, 0xffff
-    v136 = mul v135, 100
-    v137 = iszero 100
-    v138 = div v136, 100
-    v139 = eq v138, v135
-    v140 = or v137, v139
-    v141 = iszero v140
-    jumpi v141, bb21, bb22
+    v137 = sload 1 !metadata(storage=slot(1))
+    v138 = lt 0, v137
+    v139 = iszero v138
+    jumpi v139, bb21, bb22
   bb22:
-    v142 = add v121, v136
-    v143 = lt v142, v121
-    jumpi v143, bb23, bb24
+    v140 = storage_array_data_slot 1
+    v141 = mul 0, 3
+    v142 = add v140, v141
+    v143 = sload v142 !metadata(storage=symbolic(v142))
+    v144 = shr 16, v143
+    v145 = and v144, 0xffff
+    v146 = mul v145, 100
+    v147 = iszero 100
+    v148 = div v146, 100
+    v149 = eq v148, v145
+    v150 = or v147, v149
+    v151 = iszero v150
+    jumpi v151, bb23, bb24
   bb24:
-    v144 = sload 1 !metadata(storage=slot(1))
-    v145 = lt 0, v144
-    v146 = iszero v145
-    jumpi v146, bb25, bb26
+    v152 = add v131, v146
+    v153 = lt v152, v131
+    jumpi v153, bb25, bb26
   bb26:
-    v147 = storage_array_data_slot 1
-    v148 = mul 0, 3
-    v149 = add v147, v148
-    v150 = add v149, 1
-    v151 = lt 2, 3
-    v152 = iszero v151
-    jumpi v152, bb27, bb28
+    v154 = sload 1 !metadata(storage=slot(1))
+    v155 = lt 0, v154
+    v156 = iszero v155
+    jumpi v156, bb27, bb28
   bb28:
-    v153 = div 2, 16
-    v154 = add v150, v153
-    v155 = mod 2, 16
-    v156 = mul v155, 2
-    v157 = sload v154 !metadata(storage=symbolic(v154))
-    v158 = mul v156, 8
-    v159 = shr v158, v157
-    v160 = and v159, 0xffff
-    v161 = mul v160, 10
-    v162 = iszero 10
-    v163 = div v161, 10
-    v164 = eq v163, v160
-    v165 = or v162, v164
-    v166 = iszero v165
-    jumpi v166, bb29, bb30
+    v157 = storage_array_data_slot 1
+    v158 = mul 0, 3
+    v159 = add v157, v158
+    v160 = add v159, 1
+    v161 = lt 2, 3
+    v162 = iszero v161
+    jumpi v162, bb29, bb30
   bb30:
-    v167 = add v142, v161
-    v168 = lt v167, v142
-    jumpi v168, bb31, bb32
+    v163 = div 2, 16
+    v164 = add v160, v163
+    v165 = mod 2, 16
+    v166 = mul v165, 2
+    v167 = sload v164 !metadata(storage=symbolic(v164))
+    v168 = mul v166, 8
+    v169 = shr v168, v167
+    v170 = and v169, 0xffff
+    v171 = mul v170, 10
+    v172 = iszero 10
+    v173 = div v171, 10
+    v174 = eq v173, v170
+    v175 = or v172, v174
+    v176 = iszero v175
+    jumpi v176, bb31, bb32
   bb32:
-    v169 = sload 1 !metadata(storage=slot(1))
-    v170 = lt 0, v169
-    v171 = iszero v170
-    jumpi v171, bb33, bb34
+    v177 = add v152, v171
+    v178 = lt v177, v152
+    jumpi v178, bb33, bb34
   bb34:
-    v172 = storage_array_data_slot 1
-    v173 = mul 0, 3
-    v174 = add v172, v173
-    v175 = add v174, 2
-    v176 = sload v175 !metadata(storage=offset(v174, 2))
-    v177 = lt 2, v176
-    v178 = iszero v177
-    jumpi v178, bb35, bb36
+    v179 = sload 1 !metadata(storage=slot(1))
+    v180 = lt 0, v179
+    v181 = iszero v180
+    jumpi v181, bb35, bb36
   bb36:
-    v179 = storage_array_data_slot v175
-    v180 = div 2, 16
-    v181 = add v179, v180
-    v182 = mod 2, 16
-    v183 = mul v182, 2
-    v184 = sload v181 !metadata(storage=symbolic(v181))
-    v185 = mul v183, 8
-    v186 = shr v185, v184
-    v187 = and v186, 0xffff
-    v188 = add v167, v187
-    v189 = lt v188, v167
-    jumpi v189, bb37, bb38
+    v182 = storage_array_data_slot 1
+    v183 = mul 0, 3
+    v184 = add v182, v183
+    v185 = add v184, 2
+    v186 = sload v185 !metadata(storage=offset(v184, 2))
+    v187 = lt 2, v186
+    v188 = iszero v187
+    jumpi v188, bb37, bb38
   bb38:
-    ret v188
-  bb37:
+    v189 = storage_array_data_slot v185
+    v190 = div 2, 16
+    v191 = add v189, v190
+    v192 = mod 2, 16
+    v193 = mul v192, 2
+    v194 = sload v191 !metadata(storage=symbolic(v191))
+    v195 = mul v193, 8
+    v196 = shr v195, v194
+    v197 = and v196, 0xffff
+    v198 = add v177, v197
+    v199 = lt v198, v177
+    jumpi v199, bb39, bb40
+  bb40:
+    ret v198
+  bb39:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb37:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -419,7 +453,7 @@ fn @pushStruct() -> u256 [selector=0x7f91da62, abi_params=[], abi_returns=[word]
     revert 0, 36
   bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb31:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -427,7 +461,7 @@ fn @pushStruct() -> u256 [selector=0x7f91da62, abi_params=[], abi_returns=[word]
     revert 0, 36
   bb29:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb27:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -435,7 +469,7 @@ fn @pushStruct() -> u256 [selector=0x7f91da62, abi_params=[], abi_returns=[word]
     revert 0, 36
   bb25:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb23:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -443,17 +477,13 @@ fn @pushStruct() -> u256 [selector=0x7f91da62, abi_params=[], abi_returns=[word]
     revert 0, 36
   bb21:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb17:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb15:
+  bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/storage_array_to_mapping.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_array_to_mapping.mir.stdout
@@ -20,246 +20,288 @@ fn @_anonymous() [constructor] {
     sstore 1, v1 !metadata(storage=slot(1))
     jump bb9
   bb9:
-    v20 = phi [bb2: 0], [bb21: v64]
+    v20 = phi [bb2: 0], [bb23: v74]
     v21 = lt v20, v1
     jumpi v21, bb10, bb11
   bb11:
-    v65 = alloc memoryarray<1>, exact, zeroed, panic, 96
-    set_memory_object_len memoryarray, v65, 2
-    v66 = sload 1 !metadata(storage=slot(1))
-    v67 = lt 0, v66
-    v68 = iszero v67
-    jumpi v68, bb22, bb23
-  bb23:
-    v69 = storage_array_data_slot 1
-    v70 = add v69, 0
-    v71 = memory_object_len memoryarray, v65
-    v72 = sload v70 !metadata(storage=symbolic(v69))
-    v73 = gt v72, v71
-    jumpi v73, bb24, bb25
-  bb24:
-    jump bb26
-  bb26:
-    v74 = phi [bb24: v71], [bb27: v89]
-    v75 = lt v74, v72
-    jumpi v75, bb27, bb28
-  bb28:
-    jump bb25
+    v75 = alloc memoryarray<1>, exact, zeroed, panic, 96
+    set_memory_object_len memoryarray, v75, 2
+    v76 = sload 1 !metadata(storage=slot(1))
+    v77 = lt 0, v76
+    v78 = iszero v77
+    jumpi v78, bb24, bb25
   bb25:
-    sstore v70, v71 !metadata(storage=symbolic(v69))
-    jump bb29
-  bb29:
-    v90 = phi [bb25: 0], [bb30: v106]
-    v91 = lt v90, v71
-    jumpi v91, bb30, bb31
+    v79 = storage_array_data_slot 1
+    v80 = add v79, 0
+    v81 = memory_object_len memoryarray, v75
+    v82 = sload v80 !metadata(storage=symbolic(v79))
+    v83 = gt v82, v81
+    jumpi v83, bb26, bb27
+  bb26:
+    jump bb28
+  bb28:
+    v84 = phi [bb26: v81], [bb29: v99]
+    v85 = lt v84, v82
+    jumpi v85, bb29, bb30
+  bb30:
+    jump bb27
+  bb27:
+    sstore v80, v81 !metadata(storage=symbolic(v79))
+    jump bb31
   bb31:
-    v107 = sload 1 !metadata(storage=slot(1))
-    v108 = lt 0, v107
-    v109 = iszero v108
-    jumpi v109, bb32, bb33
+    v100 = phi [bb27: 0], [bb32: v116]
+    v101 = lt v100, v81
+    jumpi v101, bb32, bb33
   bb33:
-    v110 = storage_array_data_slot 1
-    v111 = add v110, 0
-    v112 = sload v111 !metadata(storage=symbolic(v110))
-    v113 = lt 0, v112
-    v114 = iszero v113
-    jumpi v114, bb34, bb35
+    v117 = shr 5, v81
+    v118 = and v81, 31
+    v119 = iszero v118
+    jumpi v119, bb35, bb34
+  bb34:
+    v120 = mul v118, 8
+    v121 = shl v120, 1
+    v122 = sub v121, 1
+    v123 = storage_array_data_slot v80
+    v124 = add v123, v117
+    v125 = sload v124 !metadata(storage=symbolic(v124))
+    v126 = and v125, v122
+    sstore v124, v126 !metadata(storage=symbolic(v124))
+    jump bb35
   bb35:
-    v115 = storage_array_data_slot v111
-    v116 = div 0, 32
-    v117 = add v115, v116
-    v118 = mod 0, 32
-    v119 = mul v118, 1
-    v120 = mul v119, 8
-    v121 = shl v120, 255
-    v122 = sload v117 !metadata(storage=symbolic(v117))
-    v123 = not v121
-    v124 = and v122, v123
-    v125 = and 10, 255
-    v126 = shl v120, v125
-    v127 = or v124, v126
-    sstore v117, v127 !metadata(storage=symbolic(v117))
-    v128 = sload 1 !metadata(storage=slot(1))
-    v129 = lt 0, v128
-    v130 = iszero v129
-    jumpi v130, bb36, bb37
+    v127 = sload 1 !metadata(storage=slot(1))
+    v128 = lt 0, v127
+    v129 = iszero v128
+    jumpi v129, bb36, bb37
   bb37:
-    v131 = storage_array_data_slot 1
-    v132 = add v131, 0
-    v133 = sload v132 !metadata(storage=symbolic(v131))
-    v134 = lt 1, v133
-    v135 = iszero v134
-    jumpi v135, bb38, bb39
+    v130 = storage_array_data_slot 1
+    v131 = add v130, 0
+    v132 = sload v131 !metadata(storage=symbolic(v130))
+    v133 = lt 0, v132
+    v134 = iszero v133
+    jumpi v134, bb38, bb39
   bb39:
-    v136 = storage_array_data_slot v132
-    v137 = div 1, 32
-    v138 = add v136, v137
-    v139 = mod 1, 32
-    v140 = mul v139, 1
-    v141 = mul v140, 8
-    v142 = shl v141, 255
-    v143 = sload v138 !metadata(storage=symbolic(v138))
-    v144 = not v142
-    v145 = and v143, v144
-    v146 = and 11, 255
-    v147 = shl v141, v146
-    v148 = or v145, v147
-    sstore v138, v148 !metadata(storage=symbolic(v138))
-    v149 = alloc memoryarray<1>, exact, zeroed, panic, 128
-    set_memory_object_len memoryarray, v149, 3
-    v150 = sload 1 !metadata(storage=slot(1))
-    v151 = lt 1, v150
-    v152 = iszero v151
-    jumpi v152, bb40, bb41
+    v135 = storage_array_data_slot v131
+    v136 = div 0, 32
+    v137 = add v135, v136
+    v138 = mod 0, 32
+    v139 = mul v138, 1
+    v140 = mul v139, 8
+    v141 = shl v140, 255
+    v142 = sload v137 !metadata(storage=symbolic(v137))
+    v143 = not v141
+    v144 = and v142, v143
+    v145 = and 10, 255
+    v146 = shl v140, v145
+    v147 = or v144, v146
+    sstore v137, v147 !metadata(storage=symbolic(v137))
+    v148 = sload 1 !metadata(storage=slot(1))
+    v149 = lt 0, v148
+    v150 = iszero v149
+    jumpi v150, bb40, bb41
   bb41:
-    v153 = storage_array_data_slot 1
-    v154 = add v153, 1
-    v155 = memory_object_len memoryarray, v149
-    v156 = sload v154 !metadata(storage=offset(v153, 1))
-    v157 = gt v156, v155
-    jumpi v157, bb42, bb43
-  bb42:
-    jump bb44
-  bb44:
-    v158 = phi [bb42: v155], [bb45: v173]
-    v159 = lt v158, v156
-    jumpi v159, bb45, bb46
-  bb46:
-    jump bb43
+    v151 = storage_array_data_slot 1
+    v152 = add v151, 0
+    v153 = sload v152 !metadata(storage=symbolic(v151))
+    v154 = lt 1, v153
+    v155 = iszero v154
+    jumpi v155, bb42, bb43
   bb43:
-    sstore v154, v155 !metadata(storage=offset(v153, 1))
+    v156 = storage_array_data_slot v152
+    v157 = div 1, 32
+    v158 = add v156, v157
+    v159 = mod 1, 32
+    v160 = mul v159, 1
+    v161 = mul v160, 8
+    v162 = shl v161, 255
+    v163 = sload v158 !metadata(storage=symbolic(v158))
+    v164 = not v162
+    v165 = and v163, v164
+    v166 = and 11, 255
+    v167 = shl v161, v166
+    v168 = or v165, v167
+    sstore v158, v168 !metadata(storage=symbolic(v158))
+    v169 = alloc memoryarray<1>, exact, zeroed, panic, 128
+    set_memory_object_len memoryarray, v169, 3
+    v170 = sload 1 !metadata(storage=slot(1))
+    v171 = lt 1, v170
+    v172 = iszero v171
+    jumpi v172, bb44, bb45
+  bb45:
+    v173 = storage_array_data_slot 1
+    v174 = add v173, 1
+    v175 = memory_object_len memoryarray, v169
+    v176 = sload v174 !metadata(storage=offset(v173, 1))
+    v177 = gt v176, v175
+    jumpi v177, bb46, bb47
+  bb46:
+    jump bb48
+  bb48:
+    v178 = phi [bb46: v175], [bb49: v193]
+    v179 = lt v178, v176
+    jumpi v179, bb49, bb50
+  bb50:
     jump bb47
   bb47:
-    v174 = phi [bb43: 0], [bb48: v190]
-    v175 = lt v174, v155
-    jumpi v175, bb48, bb49
-  bb49:
-    v191 = sload 1 !metadata(storage=slot(1))
-    v192 = lt 1, v191
-    v193 = iszero v192
-    jumpi v193, bb50, bb51
+    sstore v174, v175 !metadata(storage=offset(v173, 1))
+    jump bb51
   bb51:
-    v194 = storage_array_data_slot 1
-    v195 = add v194, 1
-    v196 = sload v195 !metadata(storage=offset(v194, 1))
-    v197 = lt 0, v196
-    v198 = iszero v197
-    jumpi v198, bb52, bb53
+    v194 = phi [bb47: 0], [bb52: v210]
+    v195 = lt v194, v175
+    jumpi v195, bb52, bb53
   bb53:
-    v199 = storage_array_data_slot v195
-    v200 = div 0, 32
-    v201 = add v199, v200
-    v202 = mod 0, 32
-    v203 = mul v202, 1
-    v204 = mul v203, 8
-    v205 = shl v204, 255
-    v206 = sload v201 !metadata(storage=symbolic(v201))
-    v207 = not v205
-    v208 = and v206, v207
-    v209 = and 12, 255
-    v210 = shl v204, v209
-    v211 = or v208, v210
-    sstore v201, v211 !metadata(storage=symbolic(v201))
-    v212 = sload 1 !metadata(storage=slot(1))
-    v213 = lt 1, v212
-    v214 = iszero v213
-    jumpi v214, bb54, bb55
+    v211 = shr 5, v175
+    v212 = and v175, 31
+    v213 = iszero v212
+    jumpi v213, bb55, bb54
+  bb54:
+    v214 = mul v212, 8
+    v215 = shl v214, 1
+    v216 = sub v215, 1
+    v217 = storage_array_data_slot v174
+    v218 = add v217, v211
+    v219 = sload v218 !metadata(storage=symbolic(v218))
+    v220 = and v219, v216
+    sstore v218, v220 !metadata(storage=symbolic(v218))
+    jump bb55
   bb55:
-    v215 = storage_array_data_slot 1
-    v216 = add v215, 1
-    v217 = sload v216 !metadata(storage=offset(v215, 1))
-    v218 = lt 1, v217
-    v219 = iszero v218
-    jumpi v219, bb56, bb57
+    v221 = sload 1 !metadata(storage=slot(1))
+    v222 = lt 1, v221
+    v223 = iszero v222
+    jumpi v223, bb56, bb57
   bb57:
-    v220 = storage_array_data_slot v216
-    v221 = div 1, 32
-    v222 = add v220, v221
-    v223 = mod 1, 32
-    v224 = mul v223, 1
-    v225 = mul v224, 8
-    v226 = shl v225, 255
-    v227 = sload v222 !metadata(storage=symbolic(v222))
-    v228 = not v226
-    v229 = and v227, v228
-    v230 = and 13, 255
-    v231 = shl v225, v230
-    v232 = or v229, v231
-    sstore v222, v232 !metadata(storage=symbolic(v222))
-    v233 = sload 1 !metadata(storage=slot(1))
-    v234 = lt 1, v233
-    v235 = iszero v234
-    jumpi v235, bb58, bb59
+    v224 = storage_array_data_slot 1
+    v225 = add v224, 1
+    v226 = sload v225 !metadata(storage=offset(v224, 1))
+    v227 = lt 0, v226
+    v228 = iszero v227
+    jumpi v228, bb58, bb59
   bb59:
-    v236 = storage_array_data_slot 1
-    v237 = add v236, 1
-    v238 = sload v237 !metadata(storage=offset(v236, 1))
-    v239 = lt 2, v238
-    v240 = iszero v239
-    jumpi v240, bb60, bb61
+    v229 = storage_array_data_slot v225
+    v230 = div 0, 32
+    v231 = add v229, v230
+    v232 = mod 0, 32
+    v233 = mul v232, 1
+    v234 = mul v233, 8
+    v235 = shl v234, 255
+    v236 = sload v231 !metadata(storage=symbolic(v231))
+    v237 = not v235
+    v238 = and v236, v237
+    v239 = and 12, 255
+    v240 = shl v234, v239
+    v241 = or v238, v240
+    sstore v231, v241 !metadata(storage=symbolic(v231))
+    v242 = sload 1 !metadata(storage=slot(1))
+    v243 = lt 1, v242
+    v244 = iszero v243
+    jumpi v244, bb60, bb61
   bb61:
-    v241 = storage_array_data_slot v237
-    v242 = div 2, 32
-    v243 = add v241, v242
-    v244 = mod 2, 32
-    v245 = mul v244, 1
-    v246 = mul v245, 8
-    v247 = shl v246, 255
-    v248 = sload v243 !metadata(storage=symbolic(v243))
-    v249 = not v247
-    v250 = and v248, v249
-    v251 = and 14, 255
-    v252 = shl v246, v251
-    v253 = or v250, v252
-    sstore v243, v253 !metadata(storage=symbolic(v243))
-    v254 = sload 2 !metadata(storage=slot(2))
-    v255 = add v254, 1
-    v256 = lt v255, v254
-    jumpi v256, bb62, bb63
+    v245 = storage_array_data_slot 1
+    v246 = add v245, 1
+    v247 = sload v246 !metadata(storage=offset(v245, 1))
+    v248 = lt 1, v247
+    v249 = iszero v248
+    jumpi v249, bb62, bb63
   bb63:
-    v257 = storage_array_data_slot 2
-    v258 = div v254, 1
-    v259 = add v257, v258
-    v260 = mod v254, 1
-    v261 = mul v260, 20
-    v262 = mul v261, 8
-    v263 = shl v262, 0xffffffffffffffffffffffffffffffffffffffff
-    v264 = sload v259 !metadata(storage=symbolic(v259))
-    v265 = not v263
-    v266 = and v264, v265
-    v267 = and 1, 0xffffffffffffffffffffffffffffffffffffffff
-    v268 = shl v262, v267
-    v269 = or v266, v268
-    sstore v259, v269 !metadata(storage=symbolic(v259))
-    sstore 2, v255 !metadata(storage=slot(2))
-    v270 = sload 2 !metadata(storage=slot(2))
-    v271 = add v270, 1
-    v272 = lt v271, v270
-    jumpi v272, bb64, bb65
+    v250 = storage_array_data_slot v246
+    v251 = div 1, 32
+    v252 = add v250, v251
+    v253 = mod 1, 32
+    v254 = mul v253, 1
+    v255 = mul v254, 8
+    v256 = shl v255, 255
+    v257 = sload v252 !metadata(storage=symbolic(v252))
+    v258 = not v256
+    v259 = and v257, v258
+    v260 = and 13, 255
+    v261 = shl v255, v260
+    v262 = or v259, v261
+    sstore v252, v262 !metadata(storage=symbolic(v252))
+    v263 = sload 1 !metadata(storage=slot(1))
+    v264 = lt 1, v263
+    v265 = iszero v264
+    jumpi v265, bb64, bb65
   bb65:
-    v273 = storage_array_data_slot 2
-    v274 = div v270, 1
-    v275 = add v273, v274
-    v276 = mod v270, 1
-    v277 = mul v276, 20
-    v278 = mul v277, 8
-    v279 = shl v278, 0xffffffffffffffffffffffffffffffffffffffff
-    v280 = sload v275 !metadata(storage=symbolic(v275))
-    v281 = not v279
-    v282 = and v280, v281
-    v283 = and 2, 0xffffffffffffffffffffffffffffffffffffffff
-    v284 = shl v278, v283
-    v285 = or v282, v284
-    sstore v275, v285 !metadata(storage=symbolic(v275))
-    sstore 2, v271 !metadata(storage=slot(2))
+    v266 = storage_array_data_slot 1
+    v267 = add v266, 1
+    v268 = sload v267 !metadata(storage=offset(v266, 1))
+    v269 = lt 2, v268
+    v270 = iszero v269
+    jumpi v270, bb66, bb67
+  bb67:
+    v271 = storage_array_data_slot v267
+    v272 = div 2, 32
+    v273 = add v271, v272
+    v274 = mod 2, 32
+    v275 = mul v274, 1
+    v276 = mul v275, 8
+    v277 = shl v276, 255
+    v278 = sload v273 !metadata(storage=symbolic(v273))
+    v279 = not v277
+    v280 = and v278, v279
+    v281 = and 14, 255
+    v282 = shl v276, v281
+    v283 = or v280, v282
+    sstore v273, v283 !metadata(storage=symbolic(v273))
+    v284 = sload 2 !metadata(storage=slot(2))
+    v285 = add v284, 1
+    v286 = lt v285, v284
+    jumpi v286, bb68, bb69
+  bb69:
+    v287 = storage_array_data_slot 2
+    v288 = div v284, 1
+    v289 = add v287, v288
+    v290 = mod v284, 1
+    v291 = mul v290, 20
+    v292 = mul v291, 8
+    v293 = shl v292, 0xffffffffffffffffffffffffffffffffffffffff
+    v294 = sload v289 !metadata(storage=symbolic(v289))
+    v295 = not v293
+    v296 = and v294, v295
+    v297 = and 1, 0xffffffffffffffffffffffffffffffffffffffff
+    v298 = shl v292, v297
+    v299 = or v296, v298
+    sstore v289, v299 !metadata(storage=symbolic(v289))
+    sstore 2, v285 !metadata(storage=slot(2))
+    v300 = sload 2 !metadata(storage=slot(2))
+    v301 = add v300, 1
+    v302 = lt v301, v300
+    jumpi v302, bb70, bb71
+  bb71:
+    v303 = storage_array_data_slot 2
+    v304 = div v300, 1
+    v305 = add v303, v304
+    v306 = mod v300, 1
+    v307 = mul v306, 20
+    v308 = mul v307, 8
+    v309 = shl v308, 0xffffffffffffffffffffffffffffffffffffffff
+    v310 = sload v305 !metadata(storage=symbolic(v305))
+    v311 = not v309
+    v312 = and v310, v311
+    v313 = and 2, 0xffffffffffffffffffffffffffffffffffffffff
+    v314 = shl v308, v313
+    v315 = or v312, v314
+    sstore v305, v315 !metadata(storage=symbolic(v305))
+    sstore 2, v301 !metadata(storage=slot(2))
     stop
-  bb64:
+  bb70:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb62:
+  bb68:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb66:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb64:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb62:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb60:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -273,53 +315,49 @@ fn @_anonymous() [constructor] {
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb54:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
   bb52:
+    v196 = memory_object_load_element memoryarray<1>, v169, v194
+    v197 = storage_array_data_slot v174
+    v198 = div v194, 32
+    v199 = add v197, v198
+    v200 = mod v194, 32
+    v201 = mul v200, 1
+    v202 = mul v201, 8
+    v203 = shl v202, 255
+    v204 = sload v199 !metadata(storage=symbolic(v199))
+    v205 = not v203
+    v206 = and v204, v205
+    v207 = and v196, 255
+    v208 = shl v202, v207
+    v209 = or v206, v208
+    sstore v199, v209 !metadata(storage=symbolic(v199))
+    v210 = add v194, 1
+    jump bb51
+  bb49:
+    v180 = storage_array_data_slot v174
+    v181 = div v178, 32
+    v182 = add v180, v181
+    v183 = mod v178, 32
+    v184 = mul v183, 1
+    v185 = mul v184, 8
+    v186 = shl v185, 255
+    v187 = sload v182 !metadata(storage=symbolic(v182))
+    v188 = not v186
+    v189 = and v187, v188
+    v190 = and 0, 255
+    v191 = shl v185, v190
+    v192 = or v189, v191
+    sstore v182, v192 !metadata(storage=symbolic(v182))
+    v193 = add v178, 1
+    jump bb48
+  bb44:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb50:
+  bb42:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb48:
-    v176 = memory_object_load_element memoryarray<1>, v149, v174
-    v177 = storage_array_data_slot v154
-    v178 = div v174, 32
-    v179 = add v177, v178
-    v180 = mod v174, 32
-    v181 = mul v180, 1
-    v182 = mul v181, 8
-    v183 = shl v182, 255
-    v184 = sload v179 !metadata(storage=symbolic(v179))
-    v185 = not v183
-    v186 = and v184, v185
-    v187 = and v176, 255
-    v188 = shl v182, v187
-    v189 = or v186, v188
-    sstore v179, v189 !metadata(storage=symbolic(v179))
-    v190 = add v174, 1
-    jump bb47
-  bb45:
-    v160 = storage_array_data_slot v154
-    v161 = div v158, 32
-    v162 = add v160, v161
-    v163 = mod v158, 32
-    v164 = mul v163, 1
-    v165 = mul v164, 8
-    v166 = shl v165, 255
-    v167 = sload v162 !metadata(storage=symbolic(v162))
-    v168 = not v166
-    v169 = and v167, v168
-    v170 = and 0, 255
-    v171 = shl v165, v170
-    v172 = or v169, v171
-    sstore v162, v172 !metadata(storage=symbolic(v162))
-    v173 = add v158, 1
-    jump bb44
   bb40:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
@@ -332,50 +370,42 @@ fn @_anonymous() [constructor] {
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb34:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
   bb32:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb30:
-    v92 = memory_object_load_element memoryarray<1>, v65, v90
-    v93 = storage_array_data_slot v70
-    v94 = div v90, 32
-    v95 = add v93, v94
-    v96 = mod v90, 32
-    v97 = mul v96, 1
-    v98 = mul v97, 8
-    v99 = shl v98, 255
-    v100 = sload v95 !metadata(storage=symbolic(v95))
-    v101 = not v99
-    v102 = and v100, v101
-    v103 = and v92, 255
-    v104 = shl v98, v103
-    v105 = or v102, v104
-    sstore v95, v105 !metadata(storage=symbolic(v95))
-    v106 = add v90, 1
-    jump bb29
-  bb27:
-    v76 = storage_array_data_slot v70
-    v77 = div v74, 32
-    v78 = add v76, v77
-    v79 = mod v74, 32
-    v80 = mul v79, 1
-    v81 = mul v80, 8
-    v82 = shl v81, 255
-    v83 = sload v78 !metadata(storage=symbolic(v78))
-    v84 = not v82
-    v85 = and v83, v84
-    v86 = and 0, 255
-    v87 = shl v81, v86
-    v88 = or v85, v87
-    sstore v78, v88 !metadata(storage=symbolic(v78))
-    v89 = add v74, 1
-    jump bb26
-  bb22:
+    v102 = memory_object_load_element memoryarray<1>, v75, v100
+    v103 = storage_array_data_slot v80
+    v104 = div v100, 32
+    v105 = add v103, v104
+    v106 = mod v100, 32
+    v107 = mul v106, 1
+    v108 = mul v107, 8
+    v109 = shl v108, 255
+    v110 = sload v105 !metadata(storage=symbolic(v105))
+    v111 = not v109
+    v112 = and v110, v111
+    v113 = and v102, 255
+    v114 = shl v108, v113
+    v115 = or v112, v114
+    sstore v105, v115 !metadata(storage=symbolic(v105))
+    v116 = add v100, 1
+    jump bb31
+  bb29:
+    v86 = storage_array_data_slot v80
+    v87 = div v84, 32
+    v88 = add v86, v87
+    v89 = mod v84, 32
+    v90 = mul v89, 1
+    v91 = mul v90, 8
+    v92 = shl v91, 255
+    v93 = sload v88 !metadata(storage=symbolic(v88))
+    v94 = not v92
+    v95 = and v93, v94
+    v96 = and 0, 255
+    v97 = shl v91, v96
+    v98 = or v95, v97
+    sstore v88, v98 !metadata(storage=symbolic(v88))
+    v99 = add v84, 1
+    jump bb28
+  bb24:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -412,7 +442,22 @@ fn @_anonymous() [constructor] {
     v48 = lt v47, v28
     jumpi v48, bb20, bb21
   bb21:
-    v64 = add v20, 1
+    v64 = shr 5, v28
+    v65 = and v28, 31
+    v66 = iszero v65
+    jumpi v66, bb23, bb22
+  bb22:
+    v67 = mul v65, 8
+    v68 = shl v67, 1
+    v69 = sub v68, 1
+    v70 = storage_array_data_slot v27
+    v71 = add v70, v64
+    v72 = sload v71 !metadata(storage=symbolic(v71))
+    v73 = and v72, v69
+    sstore v71, v73 !metadata(storage=symbolic(v71))
+    jump bb23
+  bb23:
+    v74 = add v20, 1
     jump bb9
   bb20:
     v49 = memory_object_load_element memoryarray<1>, v25, v47
@@ -523,57 +568,57 @@ fn @from_storage() -> memoryarray [selector=0x904f60db, abi_params=[], abi_retur
     sstore v22, v23 !metadata(storage=symbolic(v22))
     jump bb18
   bb18:
-    v42 = phi [bb11: 0], [bb30: v86]
+    v42 = phi [bb11: 0], [bb32: v96]
     v43 = lt v42, v23
     jumpi v43, bb19, bb20
   bb20:
-    v87 = mapping_slot 0, 0
-    v88 = sload v87 !metadata(storage=symbolic(v87))
-    v89 = mul v88, 1
-    v90 = iszero 1
-    v91 = div v89, 1
-    v92 = eq v91, v88
-    v93 = or v90, v92
-    v94 = iszero v93
-    jumpi v94, bb31, bb32
-  bb32:
-    v95 = add v89, 1
-    v96 = lt v95, v89
-    jumpi v96, bb33, bb34
+    v97 = mapping_slot 0, 0
+    v98 = sload v97 !metadata(storage=symbolic(v97))
+    v99 = mul v98, 1
+    v100 = iszero 1
+    v101 = div v99, 1
+    v102 = eq v101, v98
+    v103 = or v100, v102
+    v104 = iszero v103
+    jumpi v104, bb33, bb34
   bb34:
-    v97 = mul v95, 32
-    v98 = iszero 32
-    v99 = div v97, 32
-    v100 = eq v99, v95
-    v101 = or v98, v100
-    v102 = iszero v101
-    jumpi v102, bb35, bb36
+    v105 = add v99, 1
+    v106 = lt v105, v99
+    jumpi v106, bb35, bb36
   bb36:
-    v103 = alloc memoryarray<1>, exact, uninitialized, panic, v97
-    set_memory_object_len memoryarray, v103, v88
-    jump bb37
-  bb37:
-    v104 = phi [bb36: 0], [bb38: v109]
-    v105 = lt v104, v88
-    jumpi v105, bb38, bb39
-  bb39:
-    ret v103
+    v107 = mul v105, 32
+    v108 = iszero 32
+    v109 = div v107, 32
+    v110 = eq v109, v105
+    v111 = or v108, v110
+    v112 = iszero v111
+    jumpi v112, bb37, bb38
   bb38:
-    v106 = storage_array_data_slot v87
-    v107 = add v106, v104
-    v108 = internal_call @load_storage_packed_array_1_0, 1, v107
-    memory_object_store_element memoryarray<1>, v103, v104, v108
-    v109 = add v104, 1
-    jump bb37
+    v113 = alloc memoryarray<1>, exact, uninitialized, panic, v107
+    set_memory_object_len memoryarray, v113, v98
+    jump bb39
+  bb39:
+    v114 = phi [bb38: 0], [bb40: v119]
+    v115 = lt v114, v98
+    jumpi v115, bb40, bb41
+  bb41:
+    ret v113
+  bb40:
+    v116 = storage_array_data_slot v97
+    v117 = add v116, v114
+    v118 = internal_call @load_storage_packed_array_1_0, 1, v117
+    memory_object_store_element memoryarray<1>, v113, v114, v118
+    v119 = add v114, 1
+    jump bb39
+  bb37:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb33:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb31:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -610,7 +655,22 @@ fn @from_storage() -> memoryarray [selector=0x904f60db, abi_params=[], abi_retur
     v70 = lt v69, v50
     jumpi v70, bb29, bb30
   bb30:
-    v86 = add v42, 1
+    v86 = shr 5, v50
+    v87 = and v50, 31
+    v88 = iszero v87
+    jumpi v88, bb32, bb31
+  bb31:
+    v89 = mul v87, 8
+    v90 = shl v89, 1
+    v91 = sub v90, 1
+    v92 = storage_array_data_slot v49
+    v93 = add v92, v86
+    v94 = sload v93 !metadata(storage=symbolic(v93))
+    v95 = and v94, v91
+    sstore v93, v95 !metadata(storage=symbolic(v93))
+    jump bb32
+  bb32:
+    v96 = add v42, 1
     jump bb18
   bb29:
     v71 = memory_object_load_element memoryarray<1>, v47, v69
@@ -740,57 +800,57 @@ fn @from_storage_ptr() -> memoryarray [selector=0x764eb525, abi_params=[], abi_r
     sstore v22, v23 !metadata(storage=symbolic(v22))
     jump bb18
   bb18:
-    v42 = phi [bb11: 0], [bb30: v86]
+    v42 = phi [bb11: 0], [bb32: v96]
     v43 = lt v42, v23
     jumpi v43, bb19, bb20
   bb20:
-    v87 = mapping_slot 0, 0
-    v88 = sload v87 !metadata(storage=symbolic(v87))
-    v89 = mul v88, 1
-    v90 = iszero 1
-    v91 = div v89, 1
-    v92 = eq v91, v88
-    v93 = or v90, v92
-    v94 = iszero v93
-    jumpi v94, bb31, bb32
-  bb32:
-    v95 = add v89, 1
-    v96 = lt v95, v89
-    jumpi v96, bb33, bb34
+    v97 = mapping_slot 0, 0
+    v98 = sload v97 !metadata(storage=symbolic(v97))
+    v99 = mul v98, 1
+    v100 = iszero 1
+    v101 = div v99, 1
+    v102 = eq v101, v98
+    v103 = or v100, v102
+    v104 = iszero v103
+    jumpi v104, bb33, bb34
   bb34:
-    v97 = mul v95, 32
-    v98 = iszero 32
-    v99 = div v97, 32
-    v100 = eq v99, v95
-    v101 = or v98, v100
-    v102 = iszero v101
-    jumpi v102, bb35, bb36
+    v105 = add v99, 1
+    v106 = lt v105, v99
+    jumpi v106, bb35, bb36
   bb36:
-    v103 = alloc memoryarray<1>, exact, uninitialized, panic, v97
-    set_memory_object_len memoryarray, v103, v88
-    jump bb37
-  bb37:
-    v104 = phi [bb36: 0], [bb38: v109]
-    v105 = lt v104, v88
-    jumpi v105, bb38, bb39
-  bb39:
-    ret v103
+    v107 = mul v105, 32
+    v108 = iszero 32
+    v109 = div v107, 32
+    v110 = eq v109, v105
+    v111 = or v108, v110
+    v112 = iszero v111
+    jumpi v112, bb37, bb38
   bb38:
-    v106 = storage_array_data_slot v87
-    v107 = add v106, v104
-    v108 = internal_call @load_storage_packed_array_1_0, 1, v107
-    memory_object_store_element memoryarray<1>, v103, v104, v108
-    v109 = add v104, 1
-    jump bb37
+    v113 = alloc memoryarray<1>, exact, uninitialized, panic, v107
+    set_memory_object_len memoryarray, v113, v98
+    jump bb39
+  bb39:
+    v114 = phi [bb38: 0], [bb40: v119]
+    v115 = lt v114, v98
+    jumpi v115, bb40, bb41
+  bb41:
+    ret v113
+  bb40:
+    v116 = storage_array_data_slot v97
+    v117 = add v116, v114
+    v118 = internal_call @load_storage_packed_array_1_0, 1, v117
+    memory_object_store_element memoryarray<1>, v113, v114, v118
+    v119 = add v114, 1
+    jump bb39
+  bb37:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb33:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb31:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -827,7 +887,22 @@ fn @from_storage_ptr() -> memoryarray [selector=0x764eb525, abi_params=[], abi_r
     v70 = lt v69, v50
     jumpi v70, bb29, bb30
   bb30:
-    v86 = add v42, 1
+    v86 = shr 5, v50
+    v87 = and v50, 31
+    v88 = iszero v87
+    jumpi v88, bb32, bb31
+  bb31:
+    v89 = mul v87, 8
+    v90 = shl v89, 1
+    v91 = sub v90, 1
+    v92 = storage_array_data_slot v49
+    v93 = add v92, v86
+    v94 = sload v93 !metadata(storage=symbolic(v93))
+    v95 = and v94, v91
+    sstore v93, v95 !metadata(storage=symbolic(v93))
+    jump bb32
+  bb32:
+    v96 = add v42, 1
     jump bb18
   bb29:
     v71 = memory_object_load_element memoryarray<1>, v47, v69
@@ -957,57 +1032,57 @@ fn @from_memory() -> memoryarray [selector=0x841ae8f5, abi_params=[], abi_return
     sstore v22, v23 !metadata(storage=symbolic(v22))
     jump bb18
   bb18:
-    v42 = phi [bb11: 0], [bb30: v86]
+    v42 = phi [bb11: 0], [bb32: v96]
     v43 = lt v42, v23
     jumpi v43, bb19, bb20
   bb20:
-    v87 = mapping_slot 0, 0
-    v88 = sload v87 !metadata(storage=symbolic(v87))
-    v89 = mul v88, 1
-    v90 = iszero 1
-    v91 = div v89, 1
-    v92 = eq v91, v88
-    v93 = or v90, v92
-    v94 = iszero v93
-    jumpi v94, bb31, bb32
-  bb32:
-    v95 = add v89, 1
-    v96 = lt v95, v89
-    jumpi v96, bb33, bb34
+    v97 = mapping_slot 0, 0
+    v98 = sload v97 !metadata(storage=symbolic(v97))
+    v99 = mul v98, 1
+    v100 = iszero 1
+    v101 = div v99, 1
+    v102 = eq v101, v98
+    v103 = or v100, v102
+    v104 = iszero v103
+    jumpi v104, bb33, bb34
   bb34:
-    v97 = mul v95, 32
-    v98 = iszero 32
-    v99 = div v97, 32
-    v100 = eq v99, v95
-    v101 = or v98, v100
-    v102 = iszero v101
-    jumpi v102, bb35, bb36
+    v105 = add v99, 1
+    v106 = lt v105, v99
+    jumpi v106, bb35, bb36
   bb36:
-    v103 = alloc memoryarray<1>, exact, uninitialized, panic, v97
-    set_memory_object_len memoryarray, v103, v88
-    jump bb37
-  bb37:
-    v104 = phi [bb36: 0], [bb38: v109]
-    v105 = lt v104, v88
-    jumpi v105, bb38, bb39
-  bb39:
-    ret v103
+    v107 = mul v105, 32
+    v108 = iszero 32
+    v109 = div v107, 32
+    v110 = eq v109, v105
+    v111 = or v108, v110
+    v112 = iszero v111
+    jumpi v112, bb37, bb38
   bb38:
-    v106 = storage_array_data_slot v87
-    v107 = add v106, v104
-    v108 = internal_call @load_storage_packed_array_1_0, 1, v107
-    memory_object_store_element memoryarray<1>, v103, v104, v108
-    v109 = add v104, 1
-    jump bb37
+    v113 = alloc memoryarray<1>, exact, uninitialized, panic, v107
+    set_memory_object_len memoryarray, v113, v98
+    jump bb39
+  bb39:
+    v114 = phi [bb38: 0], [bb40: v119]
+    v115 = lt v114, v98
+    jumpi v115, bb40, bb41
+  bb41:
+    ret v113
+  bb40:
+    v116 = storage_array_data_slot v97
+    v117 = add v116, v114
+    v118 = internal_call @load_storage_packed_array_1_0, 1, v117
+    memory_object_store_element memoryarray<1>, v113, v114, v118
+    v119 = add v114, 1
+    jump bb39
+  bb37:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb33:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb31:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -1044,7 +1119,22 @@ fn @from_memory() -> memoryarray [selector=0x841ae8f5, abi_params=[], abi_return
     v70 = lt v69, v50
     jumpi v70, bb29, bb30
   bb30:
-    v86 = add v42, 1
+    v86 = shr 5, v50
+    v87 = and v50, 31
+    v88 = iszero v87
+    jumpi v88, bb32, bb31
+  bb31:
+    v89 = mul v87, 8
+    v90 = shl v89, 1
+    v91 = sub v90, 1
+    v92 = storage_array_data_slot v49
+    v93 = add v92, v86
+    v94 = sload v93 !metadata(storage=symbolic(v93))
+    v95 = and v94, v91
+    sstore v93, v95 !metadata(storage=symbolic(v93))
+    jump bb32
+  bb32:
+    v96 = add v42, 1
     jump bb18
   bb29:
     v71 = memory_object_load_element memoryarray<1>, v47, v69
@@ -1180,57 +1270,57 @@ fn @from_calldata(arg0: calldataslice) -> memoryarray [selector=0xbc57f638, abi_
     sstore v72, v73 !metadata(storage=symbolic(v72))
     jump bb41
   bb41:
-    v92 = phi [bb34: 0], [bb53: v136]
+    v92 = phi [bb34: 0], [bb55: v146]
     v93 = lt v92, v73
     jumpi v93, bb42, bb43
   bb43:
-    v137 = mapping_slot 0, 0
-    v138 = sload v137 !metadata(storage=symbolic(v137))
-    v139 = mul v138, 1
-    v140 = iszero 1
-    v141 = div v139, 1
-    v142 = eq v141, v138
-    v143 = or v140, v142
-    v144 = iszero v143
-    jumpi v144, bb54, bb55
-  bb55:
-    v145 = add v139, 1
-    v146 = lt v145, v139
-    jumpi v146, bb56, bb57
+    v147 = mapping_slot 0, 0
+    v148 = sload v147 !metadata(storage=symbolic(v147))
+    v149 = mul v148, 1
+    v150 = iszero 1
+    v151 = div v149, 1
+    v152 = eq v151, v148
+    v153 = or v150, v152
+    v154 = iszero v153
+    jumpi v154, bb56, bb57
   bb57:
-    v147 = mul v145, 32
-    v148 = iszero 32
-    v149 = div v147, 32
-    v150 = eq v149, v145
-    v151 = or v148, v150
-    v152 = iszero v151
-    jumpi v152, bb58, bb59
+    v155 = add v149, 1
+    v156 = lt v155, v149
+    jumpi v156, bb58, bb59
   bb59:
-    v153 = alloc memoryarray<1>, exact, uninitialized, panic, v147
-    set_memory_object_len memoryarray, v153, v138
-    jump bb60
-  bb60:
-    v154 = phi [bb59: 0], [bb61: v159]
-    v155 = lt v154, v138
-    jumpi v155, bb61, bb62
-  bb62:
-    ret v153
+    v157 = mul v155, 32
+    v158 = iszero 32
+    v159 = div v157, 32
+    v160 = eq v159, v155
+    v161 = or v158, v160
+    v162 = iszero v161
+    jumpi v162, bb60, bb61
   bb61:
-    v156 = storage_array_data_slot v137
-    v157 = add v156, v154
-    v158 = internal_call @load_storage_packed_array_1_0, 1, v157
-    memory_object_store_element memoryarray<1>, v153, v154, v158
-    v159 = add v154, 1
-    jump bb60
+    v163 = alloc memoryarray<1>, exact, uninitialized, panic, v157
+    set_memory_object_len memoryarray, v163, v148
+    jump bb62
+  bb62:
+    v164 = phi [bb61: 0], [bb63: v169]
+    v165 = lt v164, v148
+    jumpi v165, bb63, bb64
+  bb64:
+    ret v163
+  bb63:
+    v166 = storage_array_data_slot v147
+    v167 = add v166, v164
+    v168 = internal_call @load_storage_packed_array_1_0, 1, v167
+    memory_object_store_element memoryarray<1>, v163, v164, v168
+    v169 = add v164, 1
+    jump bb62
+  bb60:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
   bb58:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb56:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb54:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -1267,7 +1357,22 @@ fn @from_calldata(arg0: calldataslice) -> memoryarray [selector=0xbc57f638, abi_
     v120 = lt v119, v100
     jumpi v120, bb52, bb53
   bb53:
-    v136 = add v92, 1
+    v136 = shr 5, v100
+    v137 = and v100, 31
+    v138 = iszero v137
+    jumpi v138, bb55, bb54
+  bb54:
+    v139 = mul v137, 8
+    v140 = shl v139, 1
+    v141 = sub v140, 1
+    v142 = storage_array_data_slot v99
+    v143 = add v142, v136
+    v144 = sload v143 !metadata(storage=symbolic(v143))
+    v145 = and v144, v141
+    sstore v143, v145 !metadata(storage=symbolic(v143))
+    jump bb55
+  bb55:
+    v146 = add v92, 1
     jump bb41
   bb52:
     v121 = memory_object_load_element memoryarray<1>, v97, v119

--- a/tests/ui/codegen/lowering/run-call/storage_dynamic_array_from_fixed.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_dynamic_array_from_fixed.mir.stdout
@@ -26,44 +26,49 @@ fn @assign() -> (u256, u8, u8) [selector=0x12ae6397, abi_params=[], abi_returns=
     v22 = lt v21, 2
     jumpi v22, bb7, bb8
   bb8:
-    v40 = sload 0 !metadata(storage=slot(0))
-    v41 = sload 0 !metadata(storage=slot(0))
-    v42 = lt 0, v41
-    v43 = iszero v42
-    jumpi v43, bb11, bb12
+    v40 = storage_array_data_slot 0
+    v41 = add v40, 0
+    v42 = sload v41 !metadata(storage=symbolic(v40))
+    v43 = and v42, 0xffff
+    sstore v41, v43 !metadata(storage=symbolic(v40))
+    v44 = sload 0 !metadata(storage=slot(0))
+    v45 = sload 0 !metadata(storage=slot(0))
+    v46 = lt 0, v45
+    v47 = iszero v46
+    jumpi v47, bb11, bb12
   bb12:
-    v44 = storage_array_data_slot 0
-    v45 = div 0, 32
-    v46 = add v44, v45
-    v47 = mod 0, 32
-    v48 = mul v47, 1
-    v49 = sload v46 !metadata(storage=symbolic(v46))
-    v50 = mul v48, 8
-    v51 = shr v50, v49
-    v52 = and v51, 255
-    v53 = lt v52, 6
-    v54 = iszero v53
-    jumpi v54, bb13, bb14
+    v48 = storage_array_data_slot 0
+    v49 = div 0, 32
+    v50 = add v48, v49
+    v51 = mod 0, 32
+    v52 = mul v51, 1
+    v53 = sload v50 !metadata(storage=symbolic(v50))
+    v54 = mul v52, 8
+    v55 = shr v54, v53
+    v56 = and v55, 255
+    v57 = lt v56, 6
+    v58 = iszero v57
+    jumpi v58, bb13, bb14
   bb14:
-    v55 = sload 0 !metadata(storage=slot(0))
-    v56 = lt 1, v55
-    v57 = iszero v56
-    jumpi v57, bb15, bb16
+    v59 = sload 0 !metadata(storage=slot(0))
+    v60 = lt 1, v59
+    v61 = iszero v60
+    jumpi v61, bb15, bb16
   bb16:
-    v58 = storage_array_data_slot 0
-    v59 = div 1, 32
-    v60 = add v58, v59
-    v61 = mod 1, 32
-    v62 = mul v61, 1
-    v63 = sload v60 !metadata(storage=symbolic(v60))
-    v64 = mul v62, 8
-    v65 = shr v64, v63
-    v66 = and v65, 255
-    v67 = lt v66, 6
-    v68 = iszero v67
-    jumpi v68, bb17, bb18
+    v62 = storage_array_data_slot 0
+    v63 = div 1, 32
+    v64 = add v62, v63
+    v65 = mod 1, 32
+    v66 = mul v65, 1
+    v67 = sload v64 !metadata(storage=symbolic(v64))
+    v68 = mul v66, 8
+    v69 = shr v68, v67
+    v70 = and v69, 255
+    v71 = lt v70, 6
+    v72 = iszero v71
+    jumpi v72, bb17, bb18
   bb18:
-    ret v40, v52, v66
+    ret v44, v56, v70
   bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 33 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/run-call/storage_nested_array_pop.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_nested_array_pop.mir.stdout
@@ -4,216 +4,220 @@ fn @test() -> (u256, u256, u256) [selector=0xf8a8fd6d, abi_params=[], abi_return
   bb0:
     jump bb1
   bb1:
-    v0 = phi [bb0: 0], [bb18: v0]
-    v1 = phi [bb0: 1], [bb18: v48]
-    v2 = phi [bb0: 0], [bb18: v2]
-    v3 = phi [bb0: 0], [bb18: v3]
+    v0 = phi [bb0: 0], [bb20: v0]
+    v1 = phi [bb0: 1], [bb20: v58]
+    v2 = phi [bb0: 0], [bb20: v2]
+    v3 = phi [bb0: 0], [bb20: v3]
     v4 = gt v1, 48
     v5 = iszero v4
     jumpi v5, bb4, bb5
   bb5:
     jump bb2
   bb2:
-    jump bb19
-  bb19:
-    v50 = phi [bb2: v0], [bb31: v50]
-    v51 = phi [bb2: v1], [bb31: v51]
-    v52 = phi [bb2: v2], [bb31: v52]
-    v53 = phi [bb2: v3], [bb31: v53]
-    v54 = phi [bb2: 1], [bb31: v73]
-    v55 = gt v54, 10
-    v56 = iszero v55
-    jumpi v56, bb22, bb23
-  bb23:
-    jump bb20
-  bb20:
-    v75 = sload 1 !metadata(storage=slot(1))
-    v76 = sub v75, 1
-    v77 = lt v75, 1
-    jumpi v77, bb32, bb33
-  bb33:
-    v78 = sload 1 !metadata(storage=slot(1))
-    v79 = lt v76, v78
-    v80 = iszero v79
-    jumpi v80, bb34, bb35
+    jump bb21
+  bb21:
+    v60 = phi [bb2: v0], [bb33: v60]
+    v61 = phi [bb2: v1], [bb33: v61]
+    v62 = phi [bb2: v2], [bb33: v62]
+    v63 = phi [bb2: v3], [bb33: v63]
+    v64 = phi [bb2: 1], [bb33: v83]
+    v65 = gt v64, 10
+    v66 = iszero v65
+    jumpi v66, bb24, bb25
+  bb25:
+    jump bb22
+  bb22:
+    v85 = sload 1 !metadata(storage=slot(1))
+    v86 = sub v85, 1
+    v87 = lt v85, 1
+    jumpi v87, bb34, bb35
   bb35:
-    v81 = storage_array_data_slot 1
-    v82 = add v81, v76
-    v83 = sload v82 !metadata(storage=symbolic(v82))
-    v84 = lt 0, v83
-    v85 = iszero v84
-    jumpi v85, bb36, bb37
+    v88 = sload 1 !metadata(storage=slot(1))
+    v89 = lt v86, v88
+    v90 = iszero v89
+    jumpi v90, bb36, bb37
   bb37:
-    v86 = storage_array_data_slot v82
-    v87 = div 0, 16
-    v88 = add v86, v87
-    v89 = mod 0, 16
-    v90 = mul v89, 2
-    v91 = sload v88 !metadata(storage=symbolic(v88))
-    v92 = mul v90, 8
-    v93 = shr v92, v91
-    v94 = and v93, 0xffff
-    jump bb38
-  bb38:
-    v95 = phi [bb37: v50], [bb50: v95]
-    v96 = phi [bb37: v51], [bb50: v96]
-    v97 = phi [bb37: 1], [bb50: v119]
-    v98 = phi [bb37: v94], [bb50: v98]
-    v99 = phi [bb37: v53], [bb50: v99]
-    v100 = phi [bb37: v54], [bb50: v100]
-    v101 = gt v97, 10
-    v102 = iszero v101
-    jumpi v102, bb41, bb42
-  bb42:
-    jump bb39
+    v91 = storage_array_data_slot 1
+    v92 = add v91, v86
+    v93 = sload v92 !metadata(storage=symbolic(v92))
+    v94 = lt 0, v93
+    v95 = iszero v94
+    jumpi v95, bb38, bb39
   bb39:
-    v121 = sload 1 !metadata(storage=slot(1))
-    v122 = sub v121, 1
-    v123 = lt v121, 1
-    jumpi v123, bb51, bb52
-  bb52:
-    v124 = sload 1 !metadata(storage=slot(1))
-    v125 = lt v122, v124
-    v126 = iszero v125
-    jumpi v126, bb53, bb54
+    v96 = storage_array_data_slot v92
+    v97 = div 0, 16
+    v98 = add v96, v97
+    v99 = mod 0, 16
+    v100 = mul v99, 2
+    v101 = sload v98 !metadata(storage=symbolic(v98))
+    v102 = mul v100, 8
+    v103 = shr v102, v101
+    v104 = and v103, 0xffff
+    jump bb40
+  bb40:
+    v105 = phi [bb39: v60], [bb52: v105]
+    v106 = phi [bb39: v61], [bb52: v106]
+    v107 = phi [bb39: 1], [bb52: v129]
+    v108 = phi [bb39: v104], [bb52: v108]
+    v109 = phi [bb39: v63], [bb52: v109]
+    v110 = phi [bb39: v64], [bb52: v110]
+    v111 = gt v107, 10
+    v112 = iszero v111
+    jumpi v112, bb43, bb44
+  bb44:
+    jump bb41
+  bb41:
+    v131 = sload 1 !metadata(storage=slot(1))
+    v132 = sub v131, 1
+    v133 = lt v131, 1
+    jumpi v133, bb53, bb54
   bb54:
-    v127 = storage_array_data_slot 1
-    v128 = add v127, v122
-    v129 = sload v128 !metadata(storage=symbolic(v128))
-    v130 = lt 1, v129
-    v131 = iszero v130
-    jumpi v131, bb55, bb56
+    v134 = sload 1 !metadata(storage=slot(1))
+    v135 = lt v132, v134
+    v136 = iszero v135
+    jumpi v136, bb55, bb56
   bb56:
-    v132 = storage_array_data_slot v128
-    v133 = div 1, 16
-    v134 = add v132, v133
-    v135 = mod 1, 16
-    v136 = mul v135, 2
-    v137 = sload v134 !metadata(storage=symbolic(v134))
-    v138 = mul v136, 8
-    v139 = shr v138, v137
-    v140 = and v139, 0xffff
-    jump bb57
-  bb57:
-    v141 = phi [bb56: v140], [bb69: v141]
-    v142 = phi [bb56: v96], [bb69: v142]
-    v143 = phi [bb56: v97], [bb69: v143]
-    v144 = phi [bb56: v98], [bb69: v144]
-    v145 = phi [bb56: v99], [bb69: v145]
-    v146 = phi [bb56: v100], [bb69: v146]
-    v147 = phi [bb56: 1], [bb69: v166]
-    v148 = gt v147, 10
-    v149 = iszero v148
-    jumpi v149, bb60, bb61
-  bb61:
-    jump bb58
+    v137 = storage_array_data_slot 1
+    v138 = add v137, v132
+    v139 = sload v138 !metadata(storage=symbolic(v138))
+    v140 = lt 1, v139
+    v141 = iszero v140
+    jumpi v141, bb57, bb58
   bb58:
-    v168 = sload 1 !metadata(storage=slot(1))
-    v169 = sub v168, 1
-    v170 = lt v168, 1
-    jumpi v170, bb70, bb71
-  bb71:
-    v171 = sload 1 !metadata(storage=slot(1))
-    v172 = lt v169, v171
-    v173 = iszero v172
-    jumpi v173, bb72, bb73
+    v142 = storage_array_data_slot v138
+    v143 = div 1, 16
+    v144 = add v142, v143
+    v145 = mod 1, 16
+    v146 = mul v145, 2
+    v147 = sload v144 !metadata(storage=symbolic(v144))
+    v148 = mul v146, 8
+    v149 = shr v148, v147
+    v150 = and v149, 0xffff
+    jump bb59
+  bb59:
+    v151 = phi [bb58: v150], [bb71: v151]
+    v152 = phi [bb58: v106], [bb71: v152]
+    v153 = phi [bb58: v107], [bb71: v153]
+    v154 = phi [bb58: v108], [bb71: v154]
+    v155 = phi [bb58: v109], [bb71: v155]
+    v156 = phi [bb58: v110], [bb71: v156]
+    v157 = phi [bb58: 1], [bb71: v176]
+    v158 = gt v157, 10
+    v159 = iszero v158
+    jumpi v159, bb62, bb63
+  bb63:
+    jump bb60
+  bb60:
+    v178 = sload 1 !metadata(storage=slot(1))
+    v179 = sub v178, 1
+    v180 = lt v178, 1
+    jumpi v180, bb72, bb73
   bb73:
-    v174 = storage_array_data_slot 1
-    v175 = add v174, v169
-    v176 = sload v175 !metadata(storage=symbolic(v175))
-    v177 = lt 2, v176
-    v178 = iszero v177
-    jumpi v178, bb74, bb75
+    v181 = sload 1 !metadata(storage=slot(1))
+    v182 = lt v179, v181
+    v183 = iszero v182
+    jumpi v183, bb74, bb75
   bb75:
-    v179 = storage_array_data_slot v175
-    v180 = div 2, 16
-    v181 = add v179, v180
-    v182 = mod 2, 16
-    v183 = mul v182, 2
-    v184 = sload v181 !metadata(storage=symbolic(v181))
-    v185 = mul v183, 8
-    v186 = shr v185, v184
-    v187 = and v186, 0xffff
-    jump bb76
-  bb76:
-    v188 = phi [bb75: v142], [bb88: v188]
-    v189 = phi [bb75: 1], [bb88: v214]
-    v190 = phi [bb75: v144], [bb88: v190]
-    v191 = phi [bb75: v146], [bb88: v191]
-    v192 = phi [bb75: v141], [bb88: v192]
-    v193 = phi [bb75: v143], [bb88: v193]
-    v194 = phi [bb75: v187], [bb88: v194]
-    v195 = phi [bb75: v147], [bb88: v195]
-    v196 = gt v189, 18
-    v197 = iszero v196
-    jumpi v197, bb79, bb80
-  bb80:
-    jump bb77
+    v184 = storage_array_data_slot 1
+    v185 = add v184, v179
+    v186 = sload v185 !metadata(storage=symbolic(v185))
+    v187 = lt 2, v186
+    v188 = iszero v187
+    jumpi v188, bb76, bb77
   bb77:
-    v216 = sload 0 !metadata(storage=slot(0))
-    sstore 0, 0 !metadata(storage=slot(0))
-    v217 = div v216, 16
-    v218 = mod v216, 16
-    v219 = iszero v218
-    v220 = iszero v219
-    v221 = add v217, v220
-    v222 = storage_array_data_slot 0
-    jump bb89
-  bb89:
-    v223 = phi [bb77: 0], [bb90: v226]
-    v224 = lt v223, v221
-    jumpi v224, bb90, bb91
-  bb91:
-    ret v190, v192, v194
-  bb90:
-    v225 = add v222, v223
-    sstore v225, 0 !metadata(storage=symbolic(v225))
-    v226 = add v223, 1
-    jump bb89
-  bb79:
-    v198 = sload 1 !metadata(storage=slot(1))
-    v199 = eq v198, 0
-    jumpi v199, bb82, bb83
-  bb83:
-    v200 = sub v198, 1
-    sstore 1, v200 !metadata(storage=slot(1))
-    v201 = storage_array_data_slot 1
-    v202 = add v201, v200
-    v203 = sload v202 !metadata(storage=symbolic(v202))
-    sstore v202, 0 !metadata(storage=symbolic(v202))
-    v204 = div v203, 16
-    v205 = mod v203, 16
-    v206 = iszero v205
-    v207 = iszero v206
-    v208 = add v204, v207
-    v209 = storage_array_data_slot v202
-    jump bb84
-  bb84:
-    v210 = phi [bb83: 0], [bb85: v213]
-    v211 = lt v210, v208
-    jumpi v211, bb85, bb86
-  bb86:
-    jump bb81
-  bb81:
+    v189 = storage_array_data_slot v185
+    v190 = div 2, 16
+    v191 = add v189, v190
+    v192 = mod 2, 16
+    v193 = mul v192, 2
+    v194 = sload v191 !metadata(storage=symbolic(v191))
+    v195 = mul v193, 8
+    v196 = shr v195, v194
+    v197 = and v196, 0xffff
     jump bb78
   bb78:
-    v214 = add v189, 1
-    v215 = lt v214, v189
-    jumpi v215, bb87, bb88
+    v198 = phi [bb77: v152], [bb90: v198]
+    v199 = phi [bb77: 1], [bb90: v224]
+    v200 = phi [bb77: v154], [bb90: v200]
+    v201 = phi [bb77: v156], [bb90: v201]
+    v202 = phi [bb77: v151], [bb90: v202]
+    v203 = phi [bb77: v153], [bb90: v203]
+    v204 = phi [bb77: v197], [bb90: v204]
+    v205 = phi [bb77: v157], [bb90: v205]
+    v206 = gt v199, 18
+    v207 = iszero v206
+    jumpi v207, bb81, bb82
+  bb82:
+    jump bb79
+  bb79:
+    v226 = sload 0 !metadata(storage=slot(0))
+    sstore 0, 0 !metadata(storage=slot(0))
+    v227 = div v226, 16
+    v228 = mod v226, 16
+    v229 = iszero v228
+    v230 = iszero v229
+    v231 = add v227, v230
+    v232 = storage_array_data_slot 0
+    jump bb91
+  bb91:
+    v233 = phi [bb79: 0], [bb92: v236]
+    v234 = lt v233, v231
+    jumpi v234, bb92, bb93
+  bb93:
+    ret v200, v202, v204
+  bb92:
+    v235 = add v232, v233
+    sstore v235, 0 !metadata(storage=symbolic(v235))
+    v236 = add v233, 1
+    jump bb91
+  bb81:
+    v208 = sload 1 !metadata(storage=slot(1))
+    v209 = eq v208, 0
+    jumpi v209, bb84, bb85
+  bb85:
+    v210 = sub v208, 1
+    sstore 1, v210 !metadata(storage=slot(1))
+    v211 = storage_array_data_slot 1
+    v212 = add v211, v210
+    v213 = sload v212 !metadata(storage=symbolic(v212))
+    sstore v212, 0 !metadata(storage=symbolic(v212))
+    v214 = div v213, 16
+    v215 = mod v213, 16
+    v216 = iszero v215
+    v217 = iszero v216
+    v218 = add v214, v217
+    v219 = storage_array_data_slot v212
+    jump bb86
+  bb86:
+    v220 = phi [bb85: 0], [bb87: v223]
+    v221 = lt v220, v218
+    jumpi v221, bb87, bb88
   bb88:
-    jump bb76
-  bb87:
+    jump bb83
+  bb83:
+    jump bb80
+  bb80:
+    v224 = add v199, 1
+    v225 = lt v224, v199
+    jumpi v225, bb89, bb90
+  bb90:
+    jump bb78
+  bb89:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb85:
-    v212 = add v209, v210
-    sstore v212, 0 !metadata(storage=symbolic(v212))
-    v213 = add v210, 1
-    jump bb84
-  bb82:
+  bb87:
+    v222 = add v219, v220
+    sstore v222, 0 !metadata(storage=symbolic(v222))
+    v223 = add v220, 1
+    jump bb86
+  bb84:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 49 !metadata(memory=scratch)
+    revert 0, 36
+  bb76:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb74:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -221,56 +225,56 @@ fn @test() -> (u256, u256, u256) [selector=0xf8a8fd6d, abi_params=[], abi_return
     revert 0, 36
   bb72:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb62:
+    v160 = sload 1 !metadata(storage=slot(1))
+    v161 = eq v160, 0
+    jumpi v161, bb65, bb66
+  bb66:
+    v162 = sub v160, 1
+    sstore 1, v162 !metadata(storage=slot(1))
+    v163 = storage_array_data_slot 1
+    v164 = add v163, v162
+    v165 = sload v164 !metadata(storage=symbolic(v164))
+    sstore v164, 0 !metadata(storage=symbolic(v164))
+    v166 = div v165, 16
+    v167 = mod v165, 16
+    v168 = iszero v167
+    v169 = iszero v168
+    v170 = add v166, v169
+    v171 = storage_array_data_slot v164
+    jump bb67
+  bb67:
+    v172 = phi [bb66: 0], [bb68: v175]
+    v173 = lt v172, v170
+    jumpi v173, bb68, bb69
+  bb69:
+    jump bb64
+  bb64:
+    jump bb61
+  bb61:
+    v176 = add v157, 1
+    v177 = lt v176, v157
+    jumpi v177, bb70, bb71
+  bb71:
+    jump bb59
   bb70:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb60:
-    v150 = sload 1 !metadata(storage=slot(1))
-    v151 = eq v150, 0
-    jumpi v151, bb63, bb64
-  bb64:
-    v152 = sub v150, 1
-    sstore 1, v152 !metadata(storage=slot(1))
-    v153 = storage_array_data_slot 1
-    v154 = add v153, v152
-    v155 = sload v154 !metadata(storage=symbolic(v154))
-    sstore v154, 0 !metadata(storage=symbolic(v154))
-    v156 = div v155, 16
-    v157 = mod v155, 16
-    v158 = iszero v157
-    v159 = iszero v158
-    v160 = add v156, v159
-    v161 = storage_array_data_slot v154
-    jump bb65
-  bb65:
-    v162 = phi [bb64: 0], [bb66: v165]
-    v163 = lt v162, v160
-    jumpi v163, bb66, bb67
-  bb67:
-    jump bb62
-  bb62:
-    jump bb59
-  bb59:
-    v166 = add v147, 1
-    v167 = lt v166, v147
-    jumpi v167, bb68, bb69
-  bb69:
-    jump bb57
   bb68:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb66:
-    v164 = add v161, v162
-    sstore v164, 0 !metadata(storage=symbolic(v164))
-    v165 = add v162, 1
-    jump bb65
-  bb63:
+    v174 = add v171, v172
+    sstore v174, 0 !metadata(storage=symbolic(v174))
+    v175 = add v172, 1
+    jump bb67
+  bb65:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 49 !metadata(memory=scratch)
+    revert 0, 36
+  bb57:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb55:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -278,56 +282,56 @@ fn @test() -> (u256, u256, u256) [selector=0xf8a8fd6d, abi_params=[], abi_return
     revert 0, 36
   bb53:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb43:
+    v113 = sload 1 !metadata(storage=slot(1))
+    v114 = eq v113, 0
+    jumpi v114, bb46, bb47
+  bb47:
+    v115 = sub v113, 1
+    sstore 1, v115 !metadata(storage=slot(1))
+    v116 = storage_array_data_slot 1
+    v117 = add v116, v115
+    v118 = sload v117 !metadata(storage=symbolic(v117))
+    sstore v117, 0 !metadata(storage=symbolic(v117))
+    v119 = div v118, 16
+    v120 = mod v118, 16
+    v121 = iszero v120
+    v122 = iszero v121
+    v123 = add v119, v122
+    v124 = storage_array_data_slot v117
+    jump bb48
+  bb48:
+    v125 = phi [bb47: 0], [bb49: v128]
+    v126 = lt v125, v123
+    jumpi v126, bb49, bb50
+  bb50:
+    jump bb45
+  bb45:
+    jump bb42
+  bb42:
+    v129 = add v107, 1
+    v130 = lt v129, v107
+    jumpi v130, bb51, bb52
+  bb52:
+    jump bb40
   bb51:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb41:
-    v103 = sload 1 !metadata(storage=slot(1))
-    v104 = eq v103, 0
-    jumpi v104, bb44, bb45
-  bb45:
-    v105 = sub v103, 1
-    sstore 1, v105 !metadata(storage=slot(1))
-    v106 = storage_array_data_slot 1
-    v107 = add v106, v105
-    v108 = sload v107 !metadata(storage=symbolic(v107))
-    sstore v107, 0 !metadata(storage=symbolic(v107))
-    v109 = div v108, 16
-    v110 = mod v108, 16
-    v111 = iszero v110
-    v112 = iszero v111
-    v113 = add v109, v112
-    v114 = storage_array_data_slot v107
-    jump bb46
-  bb46:
-    v115 = phi [bb45: 0], [bb47: v118]
-    v116 = lt v115, v113
-    jumpi v116, bb47, bb48
-  bb48:
-    jump bb43
-  bb43:
-    jump bb40
-  bb40:
-    v119 = add v97, 1
-    v120 = lt v119, v97
-    jumpi v120, bb49, bb50
-  bb50:
-    jump bb38
   bb49:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb47:
-    v117 = add v114, v115
-    sstore v117, 0 !metadata(storage=symbolic(v117))
-    v118 = add v115, 1
-    jump bb46
-  bb44:
+    v127 = add v124, v125
+    sstore v127, 0 !metadata(storage=symbolic(v127))
+    v128 = add v125, 1
+    jump bb48
+  bb46:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 49 !metadata(memory=scratch)
+    revert 0, 36
+  bb38:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb36:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -335,54 +339,50 @@ fn @test() -> (u256, u256, u256) [selector=0xf8a8fd6d, abi_params=[], abi_return
     revert 0, 36
   bb34:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
+  bb24:
+    v67 = sload 1 !metadata(storage=slot(1))
+    v68 = eq v67, 0
+    jumpi v68, bb27, bb28
+  bb28:
+    v69 = sub v67, 1
+    sstore 1, v69 !metadata(storage=slot(1))
+    v70 = storage_array_data_slot 1
+    v71 = add v70, v69
+    v72 = sload v71 !metadata(storage=symbolic(v71))
+    sstore v71, 0 !metadata(storage=symbolic(v71))
+    v73 = div v72, 16
+    v74 = mod v72, 16
+    v75 = iszero v74
+    v76 = iszero v75
+    v77 = add v73, v76
+    v78 = storage_array_data_slot v71
+    jump bb29
+  bb29:
+    v79 = phi [bb28: 0], [bb30: v82]
+    v80 = lt v79, v77
+    jumpi v80, bb30, bb31
+  bb31:
+    jump bb26
+  bb26:
+    jump bb23
+  bb23:
+    v83 = add v64, 1
+    v84 = lt v83, v64
+    jumpi v84, bb32, bb33
+  bb33:
+    jump bb21
   bb32:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb22:
-    v57 = sload 1 !metadata(storage=slot(1))
-    v58 = eq v57, 0
-    jumpi v58, bb25, bb26
-  bb26:
-    v59 = sub v57, 1
-    sstore 1, v59 !metadata(storage=slot(1))
-    v60 = storage_array_data_slot 1
-    v61 = add v60, v59
-    v62 = sload v61 !metadata(storage=symbolic(v61))
-    sstore v61, 0 !metadata(storage=symbolic(v61))
-    v63 = div v62, 16
-    v64 = mod v62, 16
-    v65 = iszero v64
-    v66 = iszero v65
-    v67 = add v63, v66
-    v68 = storage_array_data_slot v61
-    jump bb27
-  bb27:
-    v69 = phi [bb26: 0], [bb28: v72]
-    v70 = lt v69, v67
-    jumpi v70, bb28, bb29
-  bb29:
-    jump bb24
-  bb24:
-    jump bb21
-  bb21:
-    v73 = add v54, 1
-    v74 = lt v73, v54
-    jumpi v74, bb30, bb31
-  bb31:
-    jump bb19
   bb30:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
-    revert 0, 36
-  bb28:
-    v71 = add v68, v69
-    sstore v71, 0 !metadata(storage=symbolic(v71))
-    v72 = add v69, 1
-    jump bb27
-  bb25:
+    v81 = add v78, v79
+    sstore v81, 0 !metadata(storage=symbolic(v81))
+    v82 = add v79, 1
+    jump bb29
+  bb27:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 49 !metadata(memory=scratch)
     revert 0, 36
@@ -415,17 +415,32 @@ fn @test() -> (u256, u256, u256) [selector=0xf8a8fd6d, abi_params=[], abi_return
     v32 = lt v31, v12
     jumpi v32, bb15, bb16
   bb16:
+    v48 = shr 4, v12
+    v49 = and v12, 15
+    v50 = iszero v49
+    jumpi v50, bb18, bb17
+  bb17:
+    v51 = mul v49, 16
+    v52 = shl v51, 1
+    v53 = sub v52, 1
+    v54 = storage_array_data_slot v11
+    v55 = add v54, v48
+    v56 = sload v55 !metadata(storage=symbolic(v55))
+    v57 = and v56, v53
+    sstore v55, v57 !metadata(storage=symbolic(v55))
+    jump bb18
+  bb18:
     sstore 1, v8 !metadata(storage=slot(1))
     jump bb6
   bb6:
     jump bb3
   bb3:
-    v48 = add v1, 1
-    v49 = lt v48, v1
-    jumpi v49, bb17, bb18
-  bb18:
+    v58 = add v1, 1
+    v59 = lt v58, v1
+    jumpi v59, bb19, bb20
+  bb20:
     jump bb1
-  bb17:
+  bb19:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/run-call/storage_nested_dynamic_calldata_to_storage.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_nested_dynamic_calldata_to_storage.mir.stdout
@@ -87,158 +87,158 @@ fn @test(arg0: calldataslice) [selector=0x787210b9, abi_params=[array<_, array<_
     sstore 0, v96 !metadata(storage=slot(0))
     jump bb51
   bb51:
-    v115 = phi [bb44: 0], [bb63: v159]
+    v115 = phi [bb44: 0], [bb65: v169]
     v116 = lt v115, v96
     jumpi v116, bb52, bb53
   bb53:
-    v160 = sload 0 !metadata(storage=slot(0))
-    v161 = eq v160, 2
-    v162 = iszero v161
-    jumpi v162, bb64, bb65
-  bb65:
-    v163 = sload 0 !metadata(storage=slot(0))
-    v164 = lt 0, v163
-    v165 = iszero v164
-    jumpi v165, bb66, bb67
+    v170 = sload 0 !metadata(storage=slot(0))
+    v171 = eq v170, 2
+    v172 = iszero v171
+    jumpi v172, bb66, bb67
   bb67:
-    v166 = storage_array_data_slot 0
-    v167 = add v166, 0
-    v168 = sload v167 !metadata(storage=symbolic(v166))
-    v169 = eq v168, 1
-    v170 = iszero v169
-    jumpi v170, bb68, bb69
+    v173 = sload 0 !metadata(storage=slot(0))
+    v174 = lt 0, v173
+    v175 = iszero v174
+    jumpi v175, bb68, bb69
   bb69:
-    v171 = sload 0 !metadata(storage=slot(0))
-    v172 = lt 0, v171
-    v173 = iszero v172
-    jumpi v173, bb70, bb71
+    v176 = storage_array_data_slot 0
+    v177 = add v176, 0
+    v178 = sload v177 !metadata(storage=symbolic(v176))
+    v179 = eq v178, 1
+    v180 = iszero v179
+    jumpi v180, bb70, bb71
   bb71:
-    v174 = storage_array_data_slot 0
-    v175 = add v174, 0
-    v176 = sload v175 !metadata(storage=symbolic(v174))
-    v177 = lt 0, v176
-    v178 = iszero v177
-    jumpi v178, bb72, bb73
+    v181 = sload 0 !metadata(storage=slot(0))
+    v182 = lt 0, v181
+    v183 = iszero v182
+    jumpi v183, bb72, bb73
   bb73:
-    v179 = storage_array_data_slot v175
-    v180 = div 0, 32
-    v181 = add v179, v180
-    v182 = mod 0, 32
-    v183 = mul v182, 1
-    v184 = sload v181 !metadata(storage=symbolic(v181))
-    v185 = mul v183, 8
-    v186 = shr v185, v184
-    v187 = and v186, 255
-    v188 = eq v187, 7
-    v189 = iszero v188
-    jumpi v189, bb74, bb75
+    v184 = storage_array_data_slot 0
+    v185 = add v184, 0
+    v186 = sload v185 !metadata(storage=symbolic(v184))
+    v187 = lt 0, v186
+    v188 = iszero v187
+    jumpi v188, bb74, bb75
   bb75:
-    v190 = sload 0 !metadata(storage=slot(0))
-    v191 = lt 1, v190
-    v192 = iszero v191
-    jumpi v192, bb76, bb77
+    v189 = storage_array_data_slot v185
+    v190 = div 0, 32
+    v191 = add v189, v190
+    v192 = mod 0, 32
+    v193 = mul v192, 1
+    v194 = sload v191 !metadata(storage=symbolic(v191))
+    v195 = mul v193, 8
+    v196 = shr v195, v194
+    v197 = and v196, 255
+    v198 = eq v197, 7
+    v199 = iszero v198
+    jumpi v199, bb76, bb77
   bb77:
-    v193 = storage_array_data_slot 0
-    v194 = add v193, 1
-    v195 = sload v194 !metadata(storage=offset(v193, 1))
-    v196 = eq v195, 2
-    v197 = iszero v196
-    jumpi v197, bb78, bb79
+    v200 = sload 0 !metadata(storage=slot(0))
+    v201 = lt 1, v200
+    v202 = iszero v201
+    jumpi v202, bb78, bb79
   bb79:
-    v198 = sload 0 !metadata(storage=slot(0))
-    v199 = lt 1, v198
-    v200 = iszero v199
-    jumpi v200, bb80, bb81
+    v203 = storage_array_data_slot 0
+    v204 = add v203, 1
+    v205 = sload v204 !metadata(storage=offset(v203, 1))
+    v206 = eq v205, 2
+    v207 = iszero v206
+    jumpi v207, bb80, bb81
   bb81:
-    v201 = storage_array_data_slot 0
-    v202 = add v201, 1
-    v203 = sload v202 !metadata(storage=offset(v201, 1))
-    v204 = lt 0, v203
-    v205 = iszero v204
-    jumpi v205, bb82, bb83
+    v208 = sload 0 !metadata(storage=slot(0))
+    v209 = lt 1, v208
+    v210 = iszero v209
+    jumpi v210, bb82, bb83
   bb83:
-    v206 = storage_array_data_slot v202
-    v207 = div 0, 32
-    v208 = add v206, v207
-    v209 = mod 0, 32
-    v210 = mul v209, 1
-    v211 = sload v208 !metadata(storage=symbolic(v208))
-    v212 = mul v210, 8
-    v213 = shr v212, v211
-    v214 = and v213, 255
-    v215 = eq v214, 8
-    v216 = iszero v215
-    jumpi v216, bb84, bb85
+    v211 = storage_array_data_slot 0
+    v212 = add v211, 1
+    v213 = sload v212 !metadata(storage=offset(v211, 1))
+    v214 = lt 0, v213
+    v215 = iszero v214
+    jumpi v215, bb84, bb85
   bb85:
-    v217 = sload 0 !metadata(storage=slot(0))
-    v218 = lt 1, v217
-    v219 = iszero v218
-    jumpi v219, bb86, bb87
+    v216 = storage_array_data_slot v212
+    v217 = div 0, 32
+    v218 = add v216, v217
+    v219 = mod 0, 32
+    v220 = mul v219, 1
+    v221 = sload v218 !metadata(storage=symbolic(v218))
+    v222 = mul v220, 8
+    v223 = shr v222, v221
+    v224 = and v223, 255
+    v225 = eq v224, 8
+    v226 = iszero v225
+    jumpi v226, bb86, bb87
   bb87:
-    v220 = storage_array_data_slot 0
-    v221 = add v220, 1
-    v222 = sload v221 !metadata(storage=offset(v220, 1))
-    v223 = lt 1, v222
-    v224 = iszero v223
-    jumpi v224, bb88, bb89
+    v227 = sload 0 !metadata(storage=slot(0))
+    v228 = lt 1, v227
+    v229 = iszero v228
+    jumpi v229, bb88, bb89
   bb89:
-    v225 = storage_array_data_slot v221
-    v226 = div 1, 32
-    v227 = add v225, v226
-    v228 = mod 1, 32
-    v229 = mul v228, 1
-    v230 = sload v227 !metadata(storage=symbolic(v227))
-    v231 = mul v229, 8
-    v232 = shr v231, v230
-    v233 = and v232, 255
-    v234 = eq v233, 9
-    v235 = iszero v234
-    jumpi v235, bb90, bb91
+    v230 = storage_array_data_slot 0
+    v231 = add v230, 1
+    v232 = sload v231 !metadata(storage=offset(v230, 1))
+    v233 = lt 1, v232
+    v234 = iszero v233
+    jumpi v234, bb90, bb91
   bb91:
+    v235 = storage_array_data_slot v231
+    v236 = div 1, 32
+    v237 = add v235, v236
+    v238 = mod 1, 32
+    v239 = mul v238, 1
+    v240 = sload v237 !metadata(storage=symbolic(v237))
+    v241 = mul v239, 8
+    v242 = shr v241, v240
+    v243 = and v242, 255
+    v244 = eq v243, 9
+    v245 = iszero v244
+    jumpi v245, bb92, bb93
+  bb93:
     stop
-  bb90:
+  bb92:
     revert 0, 0
+  bb90:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb88:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb86:
+    revert 0, 0
+  bb84:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb84:
-    revert 0, 0
   bb82:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb80:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
+    revert 0, 0
   bb78:
-    revert 0, 0
-  bb76:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb74:
+  bb76:
     revert 0, 0
+  bb74:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb72:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb70:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb68:
     revert 0, 0
-  bb66:
+  bb68:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb64:
+  bb66:
     revert 0, 0
   bb52:
     v117 = memory_object_load_element memoryarray<1>, v43, v115
@@ -273,7 +273,22 @@ fn @test(arg0: calldataslice) [selector=0x787210b9, abi_params=[array<_, array<_
     v143 = lt v142, v123
     jumpi v143, bb62, bb63
   bb63:
-    v159 = add v115, 1
+    v159 = shr 5, v123
+    v160 = and v123, 31
+    v161 = iszero v160
+    jumpi v161, bb65, bb64
+  bb64:
+    v162 = mul v160, 8
+    v163 = shl v162, 1
+    v164 = sub v163, 1
+    v165 = storage_array_data_slot v122
+    v166 = add v165, v159
+    v167 = sload v166 !metadata(storage=symbolic(v166))
+    v168 = and v167, v164
+    sstore v166, v168 !metadata(storage=symbolic(v166))
+    jump bb65
+  bb65:
+    v169 = add v115, 1
     jump bb51
   bb62:
     v144 = memory_object_load_element memoryarray<1>, v120, v142
@@ -487,231 +502,237 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
     sstore 1, v1 !metadata(storage=slot(1))
     jump bb12
   bb12:
-    v26 = phi [bb2: 0], [bb27: v98]
+    v26 = phi [bb2: 0], [bb27: v108]
     v27 = lt v26, v1
     jumpi v27, bb13, bb14
   bb14:
-    v99 = slice_len arg0
-    v100 = slice_ptr arg0
-    v101 = mul v99, 32
-    v102 = iszero 32
-    v103 = div v101, 32
-    v104 = eq v103, v99
-    v105 = or v102, v104
-    v106 = iszero v105
-    jumpi v106, bb38, bb39
-  bb39:
-    v107 = calldatasize
-    v108 = sub v107, v100
-    v109 = slt v108, v101
-    jumpi v109, bb40, bb41
+    v109 = slice_len arg0
+    v110 = slice_ptr arg0
+    v111 = mul v109, 32
+    v112 = iszero 32
+    v113 = div v111, 32
+    v114 = eq v113, v109
+    v115 = or v112, v114
+    v116 = iszero v115
+    jumpi v116, bb40, bb41
   bb41:
-    v110 = mul v99, 32
-    v111 = iszero 32
-    v112 = div v110, 32
-    v113 = eq v112, v99
-    v114 = or v111, v113
-    v115 = iszero v114
-    jumpi v115, bb42, bb43
+    v117 = calldatasize
+    v118 = sub v117, v110
+    v119 = slt v118, v111
+    jumpi v119, bb42, bb43
   bb43:
-    v116 = add 32, v110
-    v117 = lt v116, 32
-    jumpi v117, bb44, bb45
+    v120 = mul v109, 32
+    v121 = iszero 32
+    v122 = div v120, 32
+    v123 = eq v122, v109
+    v124 = or v121, v123
+    v125 = iszero v124
+    jumpi v125, bb44, bb45
   bb45:
-    v118 = alloc memoryarray<1>, exact, uninitialized, infallible, v116
-    set_memory_object_len memoryarray, v118, v99
-    jump bb46
-  bb46:
-    v119 = phi [bb45: 0], [bb65: v170]
-    v120 = lt v119, v99
-    jumpi v120, bb47, bb48
+    v126 = add 32, v120
+    v127 = lt v126, 32
+    jumpi v127, bb46, bb47
+  bb47:
+    v128 = alloc memoryarray<1>, exact, uninitialized, infallible, v126
+    set_memory_object_len memoryarray, v128, v109
+    jump bb48
   bb48:
-    v171 = sload 1 !metadata(storage=slot(1))
-    v172 = lt 0, v171
-    v173 = iszero v172
-    jumpi v173, bb70, bb71
-  bb71:
-    v174 = storage_array_data_slot 1
-    v175 = add v174, 0
-    v176 = memory_object_len memoryarray, v118
-    v177 = sload v175 !metadata(storage=symbolic(v174))
-    v178 = gt v177, v176
-    jumpi v178, bb72, bb73
-  bb72:
-    jump bb74
-  bb74:
-    v179 = phi [bb72: v176], [bb79: v194]
-    v180 = lt v179, v177
-    jumpi v180, bb75, bb76
-  bb76:
-    jump bb73
+    v129 = phi [bb47: 0], [bb67: v180]
+    v130 = lt v129, v109
+    jumpi v130, bb49, bb50
+  bb50:
+    v181 = sload 1 !metadata(storage=slot(1))
+    v182 = lt 0, v181
+    v183 = iszero v182
+    jumpi v183, bb72, bb73
   bb73:
-    sstore v175, v176 !metadata(storage=symbolic(v174))
-    jump bb80
-  bb80:
-    v195 = phi [bb73: 0], [bb92: v239]
-    v196 = lt v195, v176
-    jumpi v196, bb81, bb82
+    v184 = storage_array_data_slot 1
+    v185 = add v184, 0
+    v186 = memory_object_len memoryarray, v128
+    v187 = sload v185 !metadata(storage=symbolic(v184))
+    v188 = gt v187, v186
+    jumpi v188, bb74, bb75
+  bb74:
+    jump bb76
+  bb76:
+    v189 = phi [bb74: v186], [bb81: v204]
+    v190 = lt v189, v187
+    jumpi v190, bb77, bb78
+  bb78:
+    jump bb75
+  bb75:
+    sstore v185, v186 !metadata(storage=symbolic(v184))
+    jump bb82
   bb82:
-    v240 = sload 1 !metadata(storage=slot(1))
-    v241 = lt 0, v240
-    v242 = iszero v241
-    jumpi v242, bb93, bb94
-  bb94:
-    v243 = storage_array_data_slot 1
-    v244 = add v243, 0
-    v245 = sload v244 !metadata(storage=symbolic(v243))
-    v246 = eq v245, 2
-    v247 = iszero v246
-    jumpi v247, bb95, bb96
-  bb96:
-    v248 = sload 1 !metadata(storage=slot(1))
-    v249 = lt 0, v248
-    v250 = iszero v249
-    jumpi v250, bb97, bb98
+    v205 = phi [bb75: 0], [bb96: v259]
+    v206 = lt v205, v186
+    jumpi v206, bb83, bb84
+  bb84:
+    v260 = sload 1 !metadata(storage=slot(1))
+    v261 = lt 0, v260
+    v262 = iszero v261
+    jumpi v262, bb97, bb98
   bb98:
-    v251 = storage_array_data_slot 1
-    v252 = add v251, 0
-    v253 = sload v252 !metadata(storage=symbolic(v251))
-    v254 = lt 0, v253
-    v255 = iszero v254
-    jumpi v255, bb99, bb100
+    v263 = storage_array_data_slot 1
+    v264 = add v263, 0
+    v265 = sload v264 !metadata(storage=symbolic(v263))
+    v266 = eq v265, 2
+    v267 = iszero v266
+    jumpi v267, bb99, bb100
   bb100:
-    v256 = storage_array_data_slot v252
-    v257 = add v256, 0
-    v258 = sload v257 !metadata(storage=symbolic(v256))
-    v259 = eq v258, 1
-    v260 = iszero v259
-    jumpi v260, bb101, bb102
+    v268 = sload 1 !metadata(storage=slot(1))
+    v269 = lt 0, v268
+    v270 = iszero v269
+    jumpi v270, bb101, bb102
   bb102:
-    v261 = sload 1 !metadata(storage=slot(1))
-    v262 = lt 0, v261
-    v263 = iszero v262
-    jumpi v263, bb103, bb104
+    v271 = storage_array_data_slot 1
+    v272 = add v271, 0
+    v273 = sload v272 !metadata(storage=symbolic(v271))
+    v274 = lt 0, v273
+    v275 = iszero v274
+    jumpi v275, bb103, bb104
   bb104:
-    v264 = storage_array_data_slot 1
-    v265 = add v264, 0
-    v266 = sload v265 !metadata(storage=symbolic(v264))
-    v267 = lt 0, v266
-    v268 = iszero v267
-    jumpi v268, bb105, bb106
+    v276 = storage_array_data_slot v272
+    v277 = add v276, 0
+    v278 = sload v277 !metadata(storage=symbolic(v276))
+    v279 = eq v278, 1
+    v280 = iszero v279
+    jumpi v280, bb105, bb106
   bb106:
-    v269 = storage_array_data_slot v265
-    v270 = add v269, 0
-    v271 = sload v270 !metadata(storage=symbolic(v269))
-    v272 = lt 0, v271
-    v273 = iszero v272
-    jumpi v273, bb107, bb108
+    v281 = sload 1 !metadata(storage=slot(1))
+    v282 = lt 0, v281
+    v283 = iszero v282
+    jumpi v283, bb107, bb108
   bb108:
-    v274 = storage_array_data_slot v270
-    v275 = div 0, 32
-    v276 = add v274, v275
-    v277 = mod 0, 32
-    v278 = mul v277, 1
-    v279 = sload v276 !metadata(storage=symbolic(v276))
-    v280 = mul v278, 8
-    v281 = shr v280, v279
-    v282 = and v281, 255
-    v283 = eq v282, 7
-    v284 = iszero v283
-    jumpi v284, bb109, bb110
+    v284 = storage_array_data_slot 1
+    v285 = add v284, 0
+    v286 = sload v285 !metadata(storage=symbolic(v284))
+    v287 = lt 0, v286
+    v288 = iszero v287
+    jumpi v288, bb109, bb110
   bb110:
-    v285 = sload 1 !metadata(storage=slot(1))
-    v286 = lt 0, v285
-    v287 = iszero v286
-    jumpi v287, bb111, bb112
+    v289 = storage_array_data_slot v285
+    v290 = add v289, 0
+    v291 = sload v290 !metadata(storage=symbolic(v289))
+    v292 = lt 0, v291
+    v293 = iszero v292
+    jumpi v293, bb111, bb112
   bb112:
-    v288 = storage_array_data_slot 1
-    v289 = add v288, 0
-    v290 = sload v289 !metadata(storage=symbolic(v288))
-    v291 = lt 1, v290
-    v292 = iszero v291
-    jumpi v292, bb113, bb114
+    v294 = storage_array_data_slot v290
+    v295 = div 0, 32
+    v296 = add v294, v295
+    v297 = mod 0, 32
+    v298 = mul v297, 1
+    v299 = sload v296 !metadata(storage=symbolic(v296))
+    v300 = mul v298, 8
+    v301 = shr v300, v299
+    v302 = and v301, 255
+    v303 = eq v302, 7
+    v304 = iszero v303
+    jumpi v304, bb113, bb114
   bb114:
-    v293 = storage_array_data_slot v289
-    v294 = add v293, 1
-    v295 = sload v294 !metadata(storage=offset(v293, 1))
-    v296 = eq v295, 2
-    v297 = iszero v296
-    jumpi v297, bb115, bb116
+    v305 = sload 1 !metadata(storage=slot(1))
+    v306 = lt 0, v305
+    v307 = iszero v306
+    jumpi v307, bb115, bb116
   bb116:
-    v298 = sload 1 !metadata(storage=slot(1))
-    v299 = lt 0, v298
-    v300 = iszero v299
-    jumpi v300, bb117, bb118
+    v308 = storage_array_data_slot 1
+    v309 = add v308, 0
+    v310 = sload v309 !metadata(storage=symbolic(v308))
+    v311 = lt 1, v310
+    v312 = iszero v311
+    jumpi v312, bb117, bb118
   bb118:
-    v301 = storage_array_data_slot 1
-    v302 = add v301, 0
-    v303 = sload v302 !metadata(storage=symbolic(v301))
-    v304 = lt 1, v303
-    v305 = iszero v304
-    jumpi v305, bb119, bb120
+    v313 = storage_array_data_slot v309
+    v314 = add v313, 1
+    v315 = sload v314 !metadata(storage=offset(v313, 1))
+    v316 = eq v315, 2
+    v317 = iszero v316
+    jumpi v317, bb119, bb120
   bb120:
-    v306 = storage_array_data_slot v302
-    v307 = add v306, 1
-    v308 = sload v307 !metadata(storage=offset(v306, 1))
-    v309 = lt 0, v308
-    v310 = iszero v309
-    jumpi v310, bb121, bb122
+    v318 = sload 1 !metadata(storage=slot(1))
+    v319 = lt 0, v318
+    v320 = iszero v319
+    jumpi v320, bb121, bb122
   bb122:
-    v311 = storage_array_data_slot v307
-    v312 = div 0, 32
-    v313 = add v311, v312
-    v314 = mod 0, 32
-    v315 = mul v314, 1
-    v316 = sload v313 !metadata(storage=symbolic(v313))
-    v317 = mul v315, 8
-    v318 = shr v317, v316
-    v319 = and v318, 255
-    v320 = eq v319, 8
-    v321 = iszero v320
-    jumpi v321, bb123, bb124
+    v321 = storage_array_data_slot 1
+    v322 = add v321, 0
+    v323 = sload v322 !metadata(storage=symbolic(v321))
+    v324 = lt 1, v323
+    v325 = iszero v324
+    jumpi v325, bb123, bb124
   bb124:
-    v322 = sload 1 !metadata(storage=slot(1))
-    v323 = lt 0, v322
-    v324 = iszero v323
-    jumpi v324, bb125, bb126
+    v326 = storage_array_data_slot v322
+    v327 = add v326, 1
+    v328 = sload v327 !metadata(storage=offset(v326, 1))
+    v329 = lt 0, v328
+    v330 = iszero v329
+    jumpi v330, bb125, bb126
   bb126:
-    v325 = storage_array_data_slot 1
-    v326 = add v325, 0
-    v327 = sload v326 !metadata(storage=symbolic(v325))
-    v328 = lt 1, v327
-    v329 = iszero v328
-    jumpi v329, bb127, bb128
+    v331 = storage_array_data_slot v327
+    v332 = div 0, 32
+    v333 = add v331, v332
+    v334 = mod 0, 32
+    v335 = mul v334, 1
+    v336 = sload v333 !metadata(storage=symbolic(v333))
+    v337 = mul v335, 8
+    v338 = shr v337, v336
+    v339 = and v338, 255
+    v340 = eq v339, 8
+    v341 = iszero v340
+    jumpi v341, bb127, bb128
   bb128:
-    v330 = storage_array_data_slot v326
-    v331 = add v330, 1
-    v332 = sload v331 !metadata(storage=offset(v330, 1))
-    v333 = lt 1, v332
-    v334 = iszero v333
-    jumpi v334, bb129, bb130
+    v342 = sload 1 !metadata(storage=slot(1))
+    v343 = lt 0, v342
+    v344 = iszero v343
+    jumpi v344, bb129, bb130
   bb130:
-    v335 = storage_array_data_slot v331
-    v336 = div 1, 32
-    v337 = add v335, v336
-    v338 = mod 1, 32
-    v339 = mul v338, 1
-    v340 = sload v337 !metadata(storage=symbolic(v337))
-    v341 = mul v339, 8
-    v342 = shr v341, v340
-    v343 = and v342, 255
-    v344 = eq v343, 9
-    v345 = iszero v344
-    jumpi v345, bb131, bb132
+    v345 = storage_array_data_slot 1
+    v346 = add v345, 0
+    v347 = sload v346 !metadata(storage=symbolic(v345))
+    v348 = lt 1, v347
+    v349 = iszero v348
+    jumpi v349, bb131, bb132
   bb132:
-    v346 = sload 1 !metadata(storage=slot(1))
-    v347 = lt 1, v346
-    v348 = iszero v347
-    jumpi v348, bb133, bb134
+    v350 = storage_array_data_slot v346
+    v351 = add v350, 1
+    v352 = sload v351 !metadata(storage=offset(v350, 1))
+    v353 = lt 1, v352
+    v354 = iszero v353
+    jumpi v354, bb133, bb134
   bb134:
-    v349 = storage_array_data_slot 1
-    v350 = add v349, 1
-    v351 = sload v350 !metadata(storage=offset(v349, 1))
-    v352 = eq v351, 0
-    v353 = iszero v352
-    jumpi v353, bb135, bb136
+    v355 = storage_array_data_slot v351
+    v356 = div 1, 32
+    v357 = add v355, v356
+    v358 = mod 1, 32
+    v359 = mul v358, 1
+    v360 = sload v357 !metadata(storage=symbolic(v357))
+    v361 = mul v359, 8
+    v362 = shr v361, v360
+    v363 = and v362, 255
+    v364 = eq v363, 9
+    v365 = iszero v364
+    jumpi v365, bb135, bb136
   bb136:
+    v366 = sload 1 !metadata(storage=slot(1))
+    v367 = lt 1, v366
+    v368 = iszero v367
+    jumpi v368, bb137, bb138
+  bb138:
+    v369 = storage_array_data_slot 1
+    v370 = add v369, 1
+    v371 = sload v370 !metadata(storage=offset(v369, 1))
+    v372 = eq v371, 0
+    v373 = iszero v372
+    jumpi v373, bb139, bb140
+  bb140:
     stop
+  bb139:
+    revert 0, 0
+  bb137:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb135:
     revert 0, 0
   bb133:
@@ -719,253 +740,266 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb131:
-    revert 0, 0
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb129:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb127:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
+    revert 0, 0
   bb125:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb123:
-    revert 0, 0
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb121:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb119:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
+    revert 0, 0
   bb117:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb115:
-    revert 0, 0
-  bb113:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
+  bb113:
+    revert 0, 0
   bb111:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb109:
-    revert 0, 0
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb107:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb105:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
+    revert 0, 0
   bb103:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb101:
-    revert 0, 0
-  bb99:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
+  bb99:
+    revert 0, 0
   bb97:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb95:
-    revert 0, 0
-  bb93:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb81:
-    v197 = memory_object_load_element memoryarray<1>, v118, v195
-    v198 = eq v197, 0
-    jumpi v198, bb83, bb84
   bb83:
-    v199 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
-    set_memory_object_len memoryarray, v199, 0
-    memory_object_store_element memoryarray<1>, v118, v195, v199
-    jump bb84
-  bb84:
-    v200 = phi [bb81: v197], [bb83: v199]
-    v201 = storage_array_data_slot v175
-    v202 = add v201, v195
-    v203 = memory_object_len memoryarray, v200
-    v204 = sload v202 !metadata(storage=symbolic(v202))
-    v205 = gt v204, v203
-    jumpi v205, bb85, bb86
+    v207 = memory_object_load_element memoryarray<1>, v128, v205
+    v208 = eq v207, 0
+    jumpi v208, bb85, bb86
   bb85:
-    jump bb87
-  bb87:
-    v206 = phi [bb85: v203], [bb88: v221]
-    v207 = lt v206, v204
-    jumpi v207, bb88, bb89
-  bb89:
+    v209 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
+    set_memory_object_len memoryarray, v209, 0
+    memory_object_store_element memoryarray<1>, v128, v205, v209
     jump bb86
   bb86:
-    sstore v202, v203 !metadata(storage=symbolic(v202))
-    jump bb90
-  bb90:
-    v222 = phi [bb86: 0], [bb91: v238]
-    v223 = lt v222, v203
-    jumpi v223, bb91, bb92
-  bb92:
-    v239 = add v195, 1
-    jump bb80
+    v210 = phi [bb83: v207], [bb85: v209]
+    v211 = storage_array_data_slot v185
+    v212 = add v211, v205
+    v213 = memory_object_len memoryarray, v210
+    v214 = sload v212 !metadata(storage=symbolic(v212))
+    v215 = gt v214, v213
+    jumpi v215, bb87, bb88
+  bb87:
+    jump bb89
+  bb89:
+    v216 = phi [bb87: v213], [bb90: v231]
+    v217 = lt v216, v214
+    jumpi v217, bb90, bb91
   bb91:
-    v224 = memory_object_load_element memoryarray<1>, v200, v222
-    v225 = storage_array_data_slot v202
-    v226 = div v222, 32
-    v227 = add v225, v226
-    v228 = mod v222, 32
-    v229 = mul v228, 1
-    v230 = mul v229, 8
-    v231 = shl v230, 255
-    v232 = sload v227 !metadata(storage=symbolic(v227))
-    v233 = not v231
-    v234 = and v232, v233
-    v235 = and v224, 255
-    v236 = shl v230, v235
-    v237 = or v234, v236
-    sstore v227, v237 !metadata(storage=symbolic(v227))
-    v238 = add v222, 1
-    jump bb90
+    jump bb88
   bb88:
-    v208 = storage_array_data_slot v202
-    v209 = div v206, 32
-    v210 = add v208, v209
-    v211 = mod v206, 32
-    v212 = mul v211, 1
-    v213 = mul v212, 8
-    v214 = shl v213, 255
-    v215 = sload v210 !metadata(storage=symbolic(v210))
-    v216 = not v214
-    v217 = and v215, v216
-    v218 = and 0, 255
-    v219 = shl v213, v218
-    v220 = or v217, v219
-    sstore v210, v220 !metadata(storage=symbolic(v210))
-    v221 = add v206, 1
-    jump bb87
-  bb75:
-    v181 = storage_array_data_slot v175
-    v182 = add v181, v179
-    v183 = sload v182 !metadata(storage=symbolic(v182))
-    sstore v182, 0 !metadata(storage=symbolic(v182))
-    v184 = div v183, 32
-    v185 = mod v183, 32
-    v186 = iszero v185
-    v187 = iszero v186
-    v188 = add v184, v187
-    v189 = storage_array_data_slot v182
-    jump bb77
+    sstore v212, v213 !metadata(storage=symbolic(v212))
+    jump bb92
+  bb92:
+    v232 = phi [bb88: 0], [bb93: v248]
+    v233 = lt v232, v213
+    jumpi v233, bb93, bb94
+  bb94:
+    v249 = shr 5, v213
+    v250 = and v213, 31
+    v251 = iszero v250
+    jumpi v251, bb96, bb95
+  bb95:
+    v252 = mul v250, 8
+    v253 = shl v252, 1
+    v254 = sub v253, 1
+    v255 = storage_array_data_slot v212
+    v256 = add v255, v249
+    v257 = sload v256 !metadata(storage=symbolic(v256))
+    v258 = and v257, v254
+    sstore v256, v258 !metadata(storage=symbolic(v256))
+    jump bb96
+  bb96:
+    v259 = add v205, 1
+    jump bb82
+  bb93:
+    v234 = memory_object_load_element memoryarray<1>, v210, v232
+    v235 = storage_array_data_slot v212
+    v236 = div v232, 32
+    v237 = add v235, v236
+    v238 = mod v232, 32
+    v239 = mul v238, 1
+    v240 = mul v239, 8
+    v241 = shl v240, 255
+    v242 = sload v237 !metadata(storage=symbolic(v237))
+    v243 = not v241
+    v244 = and v242, v243
+    v245 = and v234, 255
+    v246 = shl v240, v245
+    v247 = or v244, v246
+    sstore v237, v247 !metadata(storage=symbolic(v237))
+    v248 = add v232, 1
+    jump bb92
+  bb90:
+    v218 = storage_array_data_slot v212
+    v219 = div v216, 32
+    v220 = add v218, v219
+    v221 = mod v216, 32
+    v222 = mul v221, 1
+    v223 = mul v222, 8
+    v224 = shl v223, 255
+    v225 = sload v220 !metadata(storage=symbolic(v220))
+    v226 = not v224
+    v227 = and v225, v226
+    v228 = and 0, 255
+    v229 = shl v223, v228
+    v230 = or v227, v229
+    sstore v220, v230 !metadata(storage=symbolic(v220))
+    v231 = add v216, 1
+    jump bb89
   bb77:
-    v190 = phi [bb75: 0], [bb78: v193]
-    v191 = lt v190, v188
-    jumpi v191, bb78, bb79
-  bb79:
-    v194 = add v179, 1
-    jump bb74
-  bb78:
-    v192 = add v189, v190
+    v191 = storage_array_data_slot v185
+    v192 = add v191, v189
+    v193 = sload v192 !metadata(storage=symbolic(v192))
     sstore v192, 0 !metadata(storage=symbolic(v192))
-    v193 = add v190, 1
-    jump bb77
-  bb70:
+    v194 = div v193, 32
+    v195 = mod v193, 32
+    v196 = iszero v195
+    v197 = iszero v196
+    v198 = add v194, v197
+    v199 = storage_array_data_slot v192
+    jump bb79
+  bb79:
+    v200 = phi [bb77: 0], [bb80: v203]
+    v201 = lt v200, v198
+    jumpi v201, bb80, bb81
+  bb81:
+    v204 = add v189, 1
+    jump bb76
+  bb80:
+    v202 = add v199, v200
+    sstore v202, 0 !metadata(storage=symbolic(v202))
+    v203 = add v200, 1
+    jump bb79
+  bb72:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb47:
-    v121 = mul v119, 32
-    v122 = iszero 32
-    v123 = div v121, 32
-    v124 = eq v123, v119
-    v125 = or v122, v124
-    v126 = iszero v125
-    jumpi v126, bb49, bb50
-  bb50:
-    v127 = add v100, v121
-    v128 = calldatasize
-    v129 = sub v128, v127
-    v130 = slt v129, 32
-    jumpi v130, bb51, bb52
+  bb49:
+    v131 = mul v129, 32
+    v132 = iszero 32
+    v133 = div v131, 32
+    v134 = eq v133, v129
+    v135 = or v132, v134
+    v136 = iszero v135
+    jumpi v136, bb51, bb52
   bb52:
-    v131 = calldataload v127
-    v132 = add v100, v131
-    v133 = calldatasize
-    v134 = sub v133, v100
-    v135 = sub v134, 31
-    v136 = slt v131, v135
-    v137 = iszero v136
-    jumpi v137, bb53, bb54
+    v137 = add v110, v131
+    v138 = calldatasize
+    v139 = sub v138, v137
+    v140 = slt v139, 32
+    jumpi v140, bb53, bb54
   bb54:
-    v138 = calldataload v132
-    v139 = gt v138, 0xffffffffffffffff
-    jumpi v139, bb55, bb56
+    v141 = calldataload v137
+    v142 = add v110, v141
+    v143 = calldatasize
+    v144 = sub v143, v110
+    v145 = sub v144, 31
+    v146 = slt v141, v145
+    v147 = iszero v146
+    jumpi v147, bb55, bb56
   bb56:
-    v140 = mul v138, 32
-    v141 = add v132, 32
-    v142 = calldatasize
-    v143 = sub v142, v140
-    v144 = sgt v141, v143
-    jumpi v144, bb57, bb58
+    v148 = calldataload v142
+    v149 = gt v148, 0xffffffffffffffff
+    jumpi v149, bb57, bb58
   bb58:
-    v145 = add v132, 32
-    v146 = mul v138, 32
-    v147 = iszero 32
-    v148 = div v146, 32
-    v149 = eq v148, v138
-    v150 = or v147, v149
-    v151 = iszero v150
-    jumpi v151, bb59, bb60
+    v150 = mul v148, 32
+    v151 = add v142, 32
+    v152 = calldatasize
+    v153 = sub v152, v150
+    v154 = sgt v151, v153
+    jumpi v154, bb59, bb60
   bb60:
-    v152 = add 32, v146
-    v153 = lt v152, 32
-    jumpi v153, bb61, bb62
+    v155 = add v142, 32
+    v156 = mul v148, 32
+    v157 = iszero 32
+    v158 = div v156, 32
+    v159 = eq v158, v148
+    v160 = or v157, v159
+    v161 = iszero v160
+    jumpi v161, bb61, bb62
   bb62:
-    v154 = alloc memoryarray<1>, exact, uninitialized, infallible, v152
-    set_memory_object_len memoryarray, v154, v138
-    jump bb63
-  bb63:
-    v155 = phi [bb62: 0], [bb69: v169]
-    v156 = lt v155, v138
-    jumpi v156, bb64, bb65
-  bb65:
-    memory_object_store_element memoryarray<1>, v118, v119, v154
-    v170 = add v119, 1
-    jump bb46
+    v162 = add 32, v156
+    v163 = lt v162, 32
+    jumpi v163, bb63, bb64
   bb64:
-    v157 = mul v155, 32
-    v158 = iszero 32
-    v159 = div v157, 32
-    v160 = eq v159, v155
-    v161 = or v158, v160
-    v162 = iszero v161
-    jumpi v162, bb66, bb67
+    v164 = alloc memoryarray<1>, exact, uninitialized, infallible, v162
+    set_memory_object_len memoryarray, v164, v148
+    jump bb65
+  bb65:
+    v165 = phi [bb64: 0], [bb71: v179]
+    v166 = lt v165, v148
+    jumpi v166, bb66, bb67
   bb67:
-    v163 = add v145, v157
-    v164 = calldataload v163
-    v165 = and v164, 255
-    v166 = eq v164, v165
-    v167 = iszero v166
-    jumpi v167, bb68, bb69
-  bb69:
-    v168 = and v164, 255
-    memory_object_store_element memoryarray<1>, v154, v155, v168
-    v169 = add v155, 1
-    jump bb63
-  bb68:
-    revert 0, 0
+    memory_object_store_element memoryarray<1>, v128, v129, v164
+    v180 = add v129, 1
+    jump bb48
   bb66:
+    v167 = mul v165, 32
+    v168 = iszero 32
+    v169 = div v167, 32
+    v170 = eq v169, v165
+    v171 = or v168, v170
+    v172 = iszero v171
+    jumpi v172, bb68, bb69
+  bb69:
+    v173 = add v155, v167
+    v174 = calldataload v173
+    v175 = and v174, 255
+    v176 = eq v174, v175
+    v177 = iszero v176
+    jumpi v177, bb70, bb71
+  bb71:
+    v178 = and v174, 255
+    memory_object_store_element memoryarray<1>, v164, v165, v178
+    v179 = add v165, 1
+    jump bb65
+  bb70:
+    revert 0, 0
+  bb68:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb63:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -974,9 +1008,7 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb59:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
+    revert 0, 0
   bb57:
     revert 0, 0
   bb55:
@@ -984,8 +1016,10 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
   bb53:
     revert 0, 0
   bb51:
-    revert 0, 0
-  bb49:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb46:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -994,12 +1028,8 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb42:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb40:
     revert 0, 0
-  bb38:
+  bb40:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
@@ -1032,11 +1062,11 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
     sstore v33, v34 !metadata(storage=symbolic(v33))
     jump bb25
   bb25:
-    v53 = phi [bb18: 0], [bb37: v97]
+    v53 = phi [bb18: 0], [bb39: v107]
     v54 = lt v53, v34
     jumpi v54, bb26, bb27
   bb27:
-    v98 = add v26, 1
+    v108 = add v26, 1
     jump bb12
   bb26:
     v55 = memory_object_load_element memoryarray<1>, v31, v53
@@ -1071,7 +1101,22 @@ fn @test2(arg0: calldataslice) [selector=0x56647b67, abi_params=[array<_, array<
     v81 = lt v80, v61
     jumpi v81, bb36, bb37
   bb37:
-    v97 = add v53, 1
+    v97 = shr 5, v61
+    v98 = and v61, 31
+    v99 = iszero v98
+    jumpi v99, bb39, bb38
+  bb38:
+    v100 = mul v98, 8
+    v101 = shl v100, 1
+    v102 = sub v101, 1
+    v103 = storage_array_data_slot v60
+    v104 = add v103, v97
+    v105 = sload v104 !metadata(storage=symbolic(v104))
+    v106 = and v105, v102
+    sstore v104, v106 !metadata(storage=symbolic(v104))
+    jump bb39
+  bb39:
+    v107 = add v53, 1
     jump bb25
   bb36:
     v82 = memory_object_load_element memoryarray<1>, v58, v80

--- a/tests/ui/codegen/lowering/run-call/storage_nested_element_copy.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_nested_element_copy.mir.stdout
@@ -20,403 +20,337 @@ fn @_anonymous() [constructor] {
     sstore 3, v1 !metadata(storage=slot(3))
     jump bb12
   bb12:
-    v34 = phi [bb2: 0], [bb32: v121]
+    v34 = phi [bb2: 0], [bb36: v141]
     v35 = lt v34, v1
     jumpi v35, bb13, bb14
   bb14:
-    v122 = alloc memoryarray<1>, exact, zeroed, panic, 96
-    set_memory_object_len memoryarray, v122, 2
-    v123 = memory_object_len memoryarray, v122
-    v124 = sload 0 !metadata(storage=slot(0))
-    v125 = gt v124, v123
-    jumpi v125, bb33, bb34
-  bb33:
-    jump bb35
-  bb35:
-    v126 = phi [bb33: v123], [bb40: v147]
-    v127 = lt v126, v124
-    jumpi v127, bb36, bb37
+    v142 = alloc memoryarray<1>, exact, zeroed, panic, 96
+    set_memory_object_len memoryarray, v142, 2
+    v143 = memory_object_len memoryarray, v142
+    v144 = sload 0 !metadata(storage=slot(0))
+    v145 = gt v144, v143
+    jumpi v145, bb37, bb38
   bb37:
-    jump bb34
-  bb34:
-    sstore 0, v123 !metadata(storage=slot(0))
-    jump bb44
-  bb44:
-    v148 = phi [bb34: 0], [bb59: v220]
-    v149 = lt v148, v123
-    jumpi v149, bb45, bb46
-  bb46:
-    v221 = alloc memoryarray<1>, exact, zeroed, panic, 96
-    set_memory_object_len memoryarray, v221, 2
-    v222 = sload 0 !metadata(storage=slot(0))
-    v223 = lt 1, v222
-    v224 = iszero v223
-    jumpi v224, bb70, bb71
-  bb71:
-    v225 = storage_array_data_slot 0
-    v226 = add v225, 1
-    v227 = memory_object_len memoryarray, v221
-    v228 = sload v226 !metadata(storage=offset(v225, 1))
-    v229 = gt v228, v227
-    jumpi v229, bb72, bb73
-  bb72:
-    jump bb74
-  bb74:
-    v230 = phi [bb72: v227], [bb79: v245]
-    v231 = lt v230, v228
-    jumpi v231, bb75, bb76
-  bb76:
-    jump bb73
-  bb73:
-    sstore v226, v227 !metadata(storage=offset(v225, 1))
+    jump bb39
+  bb39:
+    v146 = phi [bb37: v143], [bb44: v167]
+    v147 = lt v146, v144
+    jumpi v147, bb40, bb41
+  bb41:
+    jump bb38
+  bb38:
+    sstore 0, v143 !metadata(storage=slot(0))
+    jump bb48
+  bb48:
+    v168 = phi [bb38: 0], [bb63: v250]
+    v169 = lt v168, v143
+    jumpi v169, bb49, bb50
+  bb50:
+    v251 = alloc memoryarray<1>, exact, zeroed, panic, 96
+    set_memory_object_len memoryarray, v251, 2
+    v252 = sload 0 !metadata(storage=slot(0))
+    v253 = lt 1, v252
+    v254 = iszero v253
+    jumpi v254, bb76, bb77
+  bb77:
+    v255 = storage_array_data_slot 0
+    v256 = add v255, 1
+    v257 = memory_object_len memoryarray, v251
+    v258 = sload v256 !metadata(storage=offset(v255, 1))
+    v259 = gt v258, v257
+    jumpi v259, bb78, bb79
+  bb78:
     jump bb80
   bb80:
-    v246 = phi [bb73: 0], [bb92: v290]
-    v247 = lt v246, v227
-    jumpi v247, bb81, bb82
+    v260 = phi [bb78: v257], [bb85: v275]
+    v261 = lt v260, v258
+    jumpi v261, bb81, bb82
   bb82:
-    v291 = sload 0 !metadata(storage=slot(0))
-    v292 = lt 1, v291
-    v293 = iszero v292
-    jumpi v293, bb93, bb94
-  bb94:
-    v294 = storage_array_data_slot 0
-    v295 = add v294, 1
-    v296 = sload v295 !metadata(storage=offset(v294, 1))
-    v297 = lt 0, v296
-    v298 = iszero v297
-    jumpi v298, bb95, bb96
-  bb96:
-    v299 = storage_array_data_slot v295
-    v300 = add v299, 0
-    v301 = sload v300 !metadata(storage=symbolic(v299))
-    v302 = add v301, 1
-    v303 = lt v302, v301
-    jumpi v303, bb97, bb98
-  bb98:
-    v304 = storage_array_data_slot v300
-    v305 = div v301, 32
-    v306 = add v304, v305
-    v307 = mod v301, 32
-    v308 = mul v307, 1
-    v309 = mul v308, 8
-    v310 = shl v309, 255
-    v311 = sload v306 !metadata(storage=symbolic(v306))
-    v312 = not v310
-    v313 = and v311, v312
-    v314 = and 3, 255
-    v315 = shl v309, v314
-    v316 = or v313, v315
-    sstore v306, v316 !metadata(storage=symbolic(v306))
-    sstore v300, v302 !metadata(storage=symbolic(v299))
-    v317 = sload 0 !metadata(storage=slot(0))
-    v318 = lt 1, v317
-    v319 = iszero v318
-    jumpi v319, bb99, bb100
-  bb100:
-    v320 = storage_array_data_slot 0
-    v321 = add v320, 1
-    v322 = sload v321 !metadata(storage=offset(v320, 1))
-    v323 = lt 0, v322
-    v324 = iszero v323
-    jumpi v324, bb101, bb102
+    jump bb79
+  bb79:
+    sstore v256, v257 !metadata(storage=offset(v255, 1))
+    jump bb86
+  bb86:
+    v276 = phi [bb79: 0], [bb100: v330]
+    v277 = lt v276, v257
+    jumpi v277, bb87, bb88
+  bb88:
+    v331 = sload 0 !metadata(storage=slot(0))
+    v332 = lt 1, v331
+    v333 = iszero v332
+    jumpi v333, bb101, bb102
   bb102:
-    v325 = storage_array_data_slot v321
-    v326 = add v325, 0
-    v327 = sload v326 !metadata(storage=symbolic(v325))
-    v328 = add v327, 1
-    v329 = lt v328, v327
-    jumpi v329, bb103, bb104
+    v334 = storage_array_data_slot 0
+    v335 = add v334, 1
+    v336 = sload v335 !metadata(storage=offset(v334, 1))
+    v337 = lt 0, v336
+    v338 = iszero v337
+    jumpi v338, bb103, bb104
   bb104:
-    v330 = storage_array_data_slot v326
-    v331 = div v327, 32
-    v332 = add v330, v331
-    v333 = mod v327, 32
-    v334 = mul v333, 1
-    v335 = mul v334, 8
-    v336 = shl v335, 255
-    v337 = sload v332 !metadata(storage=symbolic(v332))
-    v338 = not v336
-    v339 = and v337, v338
-    v340 = and 4, 255
-    v341 = shl v335, v340
-    v342 = or v339, v341
-    sstore v332, v342 !metadata(storage=symbolic(v332))
-    sstore v326, v328 !metadata(storage=symbolic(v325))
-    v343 = sload 0 !metadata(storage=slot(0))
-    v344 = lt 1, v343
-    v345 = iszero v344
-    jumpi v345, bb105, bb106
+    v339 = storage_array_data_slot v335
+    v340 = add v339, 0
+    v341 = sload v340 !metadata(storage=symbolic(v339))
+    v342 = add v341, 1
+    v343 = lt v342, v341
+    jumpi v343, bb105, bb106
   bb106:
-    v346 = storage_array_data_slot 0
-    v347 = add v346, 1
-    v348 = sload v347 !metadata(storage=offset(v346, 1))
-    v349 = lt 1, v348
-    v350 = iszero v349
-    jumpi v350, bb107, bb108
+    v344 = storage_array_data_slot v340
+    v345 = div v341, 32
+    v346 = add v344, v345
+    v347 = mod v341, 32
+    v348 = mul v347, 1
+    v349 = mul v348, 8
+    v350 = shl v349, 255
+    v351 = sload v346 !metadata(storage=symbolic(v346))
+    v352 = not v350
+    v353 = and v351, v352
+    v354 = and 3, 255
+    v355 = shl v349, v354
+    v356 = or v353, v355
+    sstore v346, v356 !metadata(storage=symbolic(v346))
+    sstore v340, v342 !metadata(storage=symbolic(v339))
+    v357 = sload 0 !metadata(storage=slot(0))
+    v358 = lt 1, v357
+    v359 = iszero v358
+    jumpi v359, bb107, bb108
   bb108:
-    v351 = storage_array_data_slot v347
-    v352 = add v351, 1
-    v353 = sload v352 !metadata(storage=offset(v351, 1))
-    v354 = add v353, 1
-    v355 = lt v354, v353
-    jumpi v355, bb109, bb110
+    v360 = storage_array_data_slot 0
+    v361 = add v360, 1
+    v362 = sload v361 !metadata(storage=offset(v360, 1))
+    v363 = lt 0, v362
+    v364 = iszero v363
+    jumpi v364, bb109, bb110
   bb110:
-    v356 = storage_array_data_slot v352
-    v357 = div v353, 32
-    v358 = add v356, v357
-    v359 = mod v353, 32
-    v360 = mul v359, 1
-    v361 = mul v360, 8
-    v362 = shl v361, 255
-    v363 = sload v358 !metadata(storage=symbolic(v358))
-    v364 = not v362
-    v365 = and v363, v364
-    v366 = and 5, 255
-    v367 = shl v361, v366
-    v368 = or v365, v367
-    sstore v358, v368 !metadata(storage=symbolic(v358))
-    sstore v352, v354 !metadata(storage=offset(v351, 1))
-    v369 = sload 0 !metadata(storage=slot(0))
-    v370 = lt 1, v369
-    v371 = iszero v370
-    jumpi v371, bb111, bb112
+    v365 = storage_array_data_slot v361
+    v366 = add v365, 0
+    v367 = sload v366 !metadata(storage=symbolic(v365))
+    v368 = add v367, 1
+    v369 = lt v368, v367
+    jumpi v369, bb111, bb112
   bb112:
-    v372 = storage_array_data_slot 0
-    v373 = add v372, 1
-    v374 = sload v373 !metadata(storage=offset(v372, 1))
-    v375 = lt 1, v374
-    v376 = iszero v375
-    jumpi v376, bb113, bb114
+    v370 = storage_array_data_slot v366
+    v371 = div v367, 32
+    v372 = add v370, v371
+    v373 = mod v367, 32
+    v374 = mul v373, 1
+    v375 = mul v374, 8
+    v376 = shl v375, 255
+    v377 = sload v372 !metadata(storage=symbolic(v372))
+    v378 = not v376
+    v379 = and v377, v378
+    v380 = and 4, 255
+    v381 = shl v375, v380
+    v382 = or v379, v381
+    sstore v372, v382 !metadata(storage=symbolic(v372))
+    sstore v366, v368 !metadata(storage=symbolic(v365))
+    v383 = sload 0 !metadata(storage=slot(0))
+    v384 = lt 1, v383
+    v385 = iszero v384
+    jumpi v385, bb113, bb114
   bb114:
-    v377 = storage_array_data_slot v373
-    v378 = add v377, 1
-    v379 = sload v378 !metadata(storage=offset(v377, 1))
-    v380 = add v379, 1
-    v381 = lt v380, v379
-    jumpi v381, bb115, bb116
+    v386 = storage_array_data_slot 0
+    v387 = add v386, 1
+    v388 = sload v387 !metadata(storage=offset(v386, 1))
+    v389 = lt 1, v388
+    v390 = iszero v389
+    jumpi v390, bb115, bb116
   bb116:
-    v382 = storage_array_data_slot v378
-    v383 = div v379, 32
-    v384 = add v382, v383
-    v385 = mod v379, 32
-    v386 = mul v385, 1
-    v387 = mul v386, 8
-    v388 = shl v387, 255
-    v389 = sload v384 !metadata(storage=symbolic(v384))
-    v390 = not v388
-    v391 = and v389, v390
-    v392 = and 6, 255
-    v393 = shl v387, v392
-    v394 = or v391, v393
-    sstore v384, v394 !metadata(storage=symbolic(v384))
-    sstore v378, v380 !metadata(storage=offset(v377, 1))
-    v395 = alloc memoryarray<1>, exact, zeroed, panic, 96
-    set_memory_object_len memoryarray, v395, 2
-    v396 = lt 0, 2
-    v397 = iszero v396
-    jumpi v397, bb117, bb118
+    v391 = storage_array_data_slot v387
+    v392 = add v391, 1
+    v393 = sload v392 !metadata(storage=offset(v391, 1))
+    v394 = add v393, 1
+    v395 = lt v394, v393
+    jumpi v395, bb117, bb118
   bb118:
-    v398 = add 1, 0
-    v399 = memory_object_len memoryarray, v395
-    v400 = sload v398 !metadata(storage=slot(1))
-    v401 = gt v400, v399
-    jumpi v401, bb119, bb120
-  bb119:
-    jump bb121
-  bb121:
-    v402 = phi [bb119: v399], [bb126: v417]
-    v403 = lt v402, v400
-    jumpi v403, bb122, bb123
-  bb123:
-    jump bb120
+    v396 = storage_array_data_slot v392
+    v397 = div v393, 32
+    v398 = add v396, v397
+    v399 = mod v393, 32
+    v400 = mul v399, 1
+    v401 = mul v400, 8
+    v402 = shl v401, 255
+    v403 = sload v398 !metadata(storage=symbolic(v398))
+    v404 = not v402
+    v405 = and v403, v404
+    v406 = and 5, 255
+    v407 = shl v401, v406
+    v408 = or v405, v407
+    sstore v398, v408 !metadata(storage=symbolic(v398))
+    sstore v392, v394 !metadata(storage=offset(v391, 1))
+    v409 = sload 0 !metadata(storage=slot(0))
+    v410 = lt 1, v409
+    v411 = iszero v410
+    jumpi v411, bb119, bb120
   bb120:
-    sstore v398, v399 !metadata(storage=slot(1))
-    jump bb127
+    v412 = storage_array_data_slot 0
+    v413 = add v412, 1
+    v414 = sload v413 !metadata(storage=offset(v412, 1))
+    v415 = lt 1, v414
+    v416 = iszero v415
+    jumpi v416, bb121, bb122
+  bb122:
+    v417 = storage_array_data_slot v413
+    v418 = add v417, 1
+    v419 = sload v418 !metadata(storage=offset(v417, 1))
+    v420 = add v419, 1
+    v421 = lt v420, v419
+    jumpi v421, bb123, bb124
+  bb124:
+    v422 = storage_array_data_slot v418
+    v423 = div v419, 32
+    v424 = add v422, v423
+    v425 = mod v419, 32
+    v426 = mul v425, 1
+    v427 = mul v426, 8
+    v428 = shl v427, 255
+    v429 = sload v424 !metadata(storage=symbolic(v424))
+    v430 = not v428
+    v431 = and v429, v430
+    v432 = and 6, 255
+    v433 = shl v427, v432
+    v434 = or v431, v433
+    sstore v424, v434 !metadata(storage=symbolic(v424))
+    sstore v418, v420 !metadata(storage=offset(v417, 1))
+    v435 = alloc memoryarray<1>, exact, zeroed, panic, 96
+    set_memory_object_len memoryarray, v435, 2
+    v436 = lt 0, 2
+    v437 = iszero v436
+    jumpi v437, bb125, bb126
+  bb126:
+    v438 = add 1, 0
+    v439 = memory_object_len memoryarray, v435
+    v440 = sload v438 !metadata(storage=slot(1))
+    v441 = gt v440, v439
+    jumpi v441, bb127, bb128
   bb127:
-    v418 = phi [bb120: 0], [bb139: v462]
-    v419 = lt v418, v399
-    jumpi v419, bb128, bb129
+    jump bb129
   bb129:
-    v463 = lt 0, 2
-    v464 = iszero v463
-    jumpi v464, bb140, bb141
-  bb141:
-    v465 = add 1, 0
-    v466 = sload v465 !metadata(storage=slot(1))
-    v467 = lt 0, v466
-    v468 = iszero v467
-    jumpi v468, bb142, bb143
-  bb143:
-    v469 = storage_array_data_slot v465
-    v470 = add v469, 0
-    v471 = sload v470 !metadata(storage=symbolic(v469))
-    v472 = add v471, 1
-    v473 = lt v472, v471
-    jumpi v473, bb144, bb145
-  bb145:
-    v474 = storage_array_data_slot v470
-    v475 = div v471, 32
-    v476 = add v474, v475
-    v477 = mod v471, 32
-    v478 = mul v477, 1
-    v479 = mul v478, 8
-    v480 = shl v479, 255
-    v481 = sload v476 !metadata(storage=symbolic(v476))
-    v482 = not v480
-    v483 = and v481, v482
-    v484 = and 6, 255
-    v485 = shl v479, v484
-    v486 = or v483, v485
-    sstore v476, v486 !metadata(storage=symbolic(v476))
-    sstore v470, v472 !metadata(storage=symbolic(v469))
-    v487 = lt 0, 2
-    v488 = iszero v487
-    jumpi v488, bb146, bb147
-  bb147:
-    v489 = add 1, 0
-    v490 = sload v489 !metadata(storage=slot(1))
-    v491 = lt 0, v490
-    v492 = iszero v491
-    jumpi v492, bb148, bb149
-  bb149:
-    v493 = storage_array_data_slot v489
-    v494 = add v493, 0
-    v495 = sload v494 !metadata(storage=symbolic(v493))
-    v496 = add v495, 1
-    v497 = lt v496, v495
-    jumpi v497, bb150, bb151
+    v442 = phi [bb127: v439], [bb134: v457]
+    v443 = lt v442, v440
+    jumpi v443, bb130, bb131
+  bb131:
+    jump bb128
+  bb128:
+    sstore v438, v439 !metadata(storage=slot(1))
+    jump bb135
+  bb135:
+    v458 = phi [bb128: 0], [bb149: v512]
+    v459 = lt v458, v439
+    jumpi v459, bb136, bb137
+  bb137:
+    v513 = lt 0, 2
+    v514 = iszero v513
+    jumpi v514, bb150, bb151
   bb151:
-    v498 = storage_array_data_slot v494
-    v499 = div v495, 32
-    v500 = add v498, v499
-    v501 = mod v495, 32
-    v502 = mul v501, 1
-    v503 = mul v502, 8
-    v504 = shl v503, 255
-    v505 = sload v500 !metadata(storage=symbolic(v500))
-    v506 = not v504
-    v507 = and v505, v506
-    v508 = and 7, 255
-    v509 = shl v503, v508
-    v510 = or v507, v509
-    sstore v500, v510 !metadata(storage=symbolic(v500))
-    sstore v494, v496 !metadata(storage=symbolic(v493))
-    v511 = lt 0, 2
-    v512 = iszero v511
-    jumpi v512, bb152, bb153
+    v515 = add 1, 0
+    v516 = sload v515 !metadata(storage=slot(1))
+    v517 = lt 0, v516
+    v518 = iszero v517
+    jumpi v518, bb152, bb153
   bb153:
-    v513 = add 1, 0
-    v514 = sload v513 !metadata(storage=slot(1))
-    v515 = lt 1, v514
-    v516 = iszero v515
-    jumpi v516, bb154, bb155
+    v519 = storage_array_data_slot v515
+    v520 = add v519, 0
+    v521 = sload v520 !metadata(storage=symbolic(v519))
+    v522 = add v521, 1
+    v523 = lt v522, v521
+    jumpi v523, bb154, bb155
   bb155:
-    v517 = storage_array_data_slot v513
-    v518 = add v517, 1
-    v519 = sload v518 !metadata(storage=offset(v517, 1))
-    v520 = add v519, 1
-    v521 = lt v520, v519
-    jumpi v521, bb156, bb157
+    v524 = storage_array_data_slot v520
+    v525 = div v521, 32
+    v526 = add v524, v525
+    v527 = mod v521, 32
+    v528 = mul v527, 1
+    v529 = mul v528, 8
+    v530 = shl v529, 255
+    v531 = sload v526 !metadata(storage=symbolic(v526))
+    v532 = not v530
+    v533 = and v531, v532
+    v534 = and 6, 255
+    v535 = shl v529, v534
+    v536 = or v533, v535
+    sstore v526, v536 !metadata(storage=symbolic(v526))
+    sstore v520, v522 !metadata(storage=symbolic(v519))
+    v537 = lt 0, 2
+    v538 = iszero v537
+    jumpi v538, bb156, bb157
   bb157:
-    v522 = storage_array_data_slot v518
-    v523 = div v519, 32
-    v524 = add v522, v523
-    v525 = mod v519, 32
-    v526 = mul v525, 1
-    v527 = mul v526, 8
-    v528 = shl v527, 255
-    v529 = sload v524 !metadata(storage=symbolic(v524))
-    v530 = not v528
-    v531 = and v529, v530
-    v532 = and 8, 255
-    v533 = shl v527, v532
-    v534 = or v531, v533
-    sstore v524, v534 !metadata(storage=symbolic(v524))
-    sstore v518, v520 !metadata(storage=offset(v517, 1))
-    v535 = lt 0, 2
-    v536 = iszero v535
-    jumpi v536, bb158, bb159
+    v539 = add 1, 0
+    v540 = sload v539 !metadata(storage=slot(1))
+    v541 = lt 0, v540
+    v542 = iszero v541
+    jumpi v542, bb158, bb159
   bb159:
-    v537 = add 1, 0
-    v538 = sload v537 !metadata(storage=slot(1))
-    v539 = lt 1, v538
-    v540 = iszero v539
-    jumpi v540, bb160, bb161
+    v543 = storage_array_data_slot v539
+    v544 = add v543, 0
+    v545 = sload v544 !metadata(storage=symbolic(v543))
+    v546 = add v545, 1
+    v547 = lt v546, v545
+    jumpi v547, bb160, bb161
   bb161:
-    v541 = storage_array_data_slot v537
-    v542 = add v541, 1
-    v543 = sload v542 !metadata(storage=offset(v541, 1))
-    v544 = add v543, 1
-    v545 = lt v544, v543
-    jumpi v545, bb162, bb163
+    v548 = storage_array_data_slot v544
+    v549 = div v545, 32
+    v550 = add v548, v549
+    v551 = mod v545, 32
+    v552 = mul v551, 1
+    v553 = mul v552, 8
+    v554 = shl v553, 255
+    v555 = sload v550 !metadata(storage=symbolic(v550))
+    v556 = not v554
+    v557 = and v555, v556
+    v558 = and 7, 255
+    v559 = shl v553, v558
+    v560 = or v557, v559
+    sstore v550, v560 !metadata(storage=symbolic(v550))
+    sstore v544, v546 !metadata(storage=symbolic(v543))
+    v561 = lt 0, 2
+    v562 = iszero v561
+    jumpi v562, bb162, bb163
   bb163:
-    v546 = storage_array_data_slot v542
-    v547 = div v543, 32
-    v548 = add v546, v547
-    v549 = mod v543, 32
-    v550 = mul v549, 1
-    v551 = mul v550, 8
-    v552 = shl v551, 255
-    v553 = sload v548 !metadata(storage=symbolic(v548))
-    v554 = not v552
-    v555 = and v553, v554
-    v556 = and 9, 255
-    v557 = shl v551, v556
-    v558 = or v555, v557
-    sstore v548, v558 !metadata(storage=symbolic(v548))
-    sstore v542, v544 !metadata(storage=offset(v541, 1))
-    v559 = sload 3 !metadata(storage=slot(3))
-    v560 = lt 0, v559
-    v561 = iszero v560
-    jumpi v561, bb164, bb165
-  bb165:
-    v562 = storage_array_data_slot 3
-    v563 = mul 0, 2
-    v564 = add v562, v563
-    v565 = lt 0, 2
+    v563 = add 1, 0
+    v564 = sload v563 !metadata(storage=slot(1))
+    v565 = lt 1, v564
     v566 = iszero v565
-    jumpi v566, bb166, bb167
+    jumpi v566, bb164, bb165
+  bb165:
+    v567 = storage_array_data_slot v563
+    v568 = add v567, 1
+    v569 = sload v568 !metadata(storage=offset(v567, 1))
+    v570 = add v569, 1
+    v571 = lt v570, v569
+    jumpi v571, bb166, bb167
   bb167:
-    v567 = add v564, 0
-    v568 = sload v567 !metadata(storage=symbolic(v564))
-    v569 = add v568, 1
-    v570 = lt v569, v568
-    jumpi v570, bb168, bb169
-  bb169:
-    v571 = storage_array_data_slot v567
-    v572 = div v568, 32
-    v573 = add v571, v572
-    v574 = mod v568, 32
-    v575 = mul v574, 1
-    v576 = mul v575, 8
-    v577 = shl v576, 255
-    v578 = sload v573 !metadata(storage=symbolic(v573))
-    v579 = not v577
-    v580 = and v578, v579
-    v581 = and 3, 255
-    v582 = shl v576, v581
-    v583 = or v580, v582
-    sstore v573, v583 !metadata(storage=symbolic(v573))
-    sstore v567, v569 !metadata(storage=symbolic(v564))
-    v584 = sload 3 !metadata(storage=slot(3))
-    v585 = lt 0, v584
+    v572 = storage_array_data_slot v568
+    v573 = div v569, 32
+    v574 = add v572, v573
+    v575 = mod v569, 32
+    v576 = mul v575, 1
+    v577 = mul v576, 8
+    v578 = shl v577, 255
+    v579 = sload v574 !metadata(storage=symbolic(v574))
+    v580 = not v578
+    v581 = and v579, v580
+    v582 = and 8, 255
+    v583 = shl v577, v582
+    v584 = or v581, v583
+    sstore v574, v584 !metadata(storage=symbolic(v574))
+    sstore v568, v570 !metadata(storage=offset(v567, 1))
+    v585 = lt 0, 2
     v586 = iszero v585
-    jumpi v586, bb170, bb171
+    jumpi v586, bb168, bb169
+  bb169:
+    v587 = add 1, 0
+    v588 = sload v587 !metadata(storage=slot(1))
+    v589 = lt 1, v588
+    v590 = iszero v589
+    jumpi v590, bb170, bb171
   bb171:
-    v587 = storage_array_data_slot 3
-    v588 = mul 0, 2
-    v589 = add v587, v588
-    v590 = lt 0, 2
-    v591 = iszero v590
-    jumpi v591, bb172, bb173
-  bb173:
-    v592 = add v589, 0
-    v593 = sload v592 !metadata(storage=symbolic(v589))
+    v591 = storage_array_data_slot v587
+    v592 = add v591, 1
+    v593 = sload v592 !metadata(storage=offset(v591, 1))
     v594 = add v593, 1
     v595 = lt v594, v593
-    jumpi v595, bb174, bb175
-  bb175:
+    jumpi v595, bb172, bb173
+  bb173:
     v596 = storage_array_data_slot v592
     v597 = div v593, 32
     v598 = add v596, v597
@@ -427,29 +361,29 @@ fn @_anonymous() [constructor] {
     v603 = sload v598 !metadata(storage=symbolic(v598))
     v604 = not v602
     v605 = and v603, v604
-    v606 = and 4, 255
+    v606 = and 9, 255
     v607 = shl v601, v606
     v608 = or v605, v607
     sstore v598, v608 !metadata(storage=symbolic(v598))
-    sstore v592, v594 !metadata(storage=symbolic(v589))
+    sstore v592, v594 !metadata(storage=offset(v591, 1))
     v609 = sload 3 !metadata(storage=slot(3))
     v610 = lt 0, v609
     v611 = iszero v610
-    jumpi v611, bb176, bb177
-  bb177:
+    jumpi v611, bb174, bb175
+  bb175:
     v612 = storage_array_data_slot 3
     v613 = mul 0, 2
     v614 = add v612, v613
-    v615 = lt 1, 2
+    v615 = lt 0, 2
     v616 = iszero v615
-    jumpi v616, bb178, bb179
-  bb179:
-    v617 = add v614, 1
-    v618 = sload v617 !metadata(storage=offset(v614, 1))
+    jumpi v616, bb176, bb177
+  bb177:
+    v617 = add v614, 0
+    v618 = sload v617 !metadata(storage=symbolic(v614))
     v619 = add v618, 1
     v620 = lt v619, v618
-    jumpi v620, bb180, bb181
-  bb181:
+    jumpi v620, bb178, bb179
+  bb179:
     v621 = storage_array_data_slot v617
     v622 = div v618, 32
     v623 = add v621, v622
@@ -460,29 +394,29 @@ fn @_anonymous() [constructor] {
     v628 = sload v623 !metadata(storage=symbolic(v623))
     v629 = not v627
     v630 = and v628, v629
-    v631 = and 5, 255
+    v631 = and 3, 255
     v632 = shl v626, v631
     v633 = or v630, v632
     sstore v623, v633 !metadata(storage=symbolic(v623))
-    sstore v617, v619 !metadata(storage=offset(v614, 1))
+    sstore v617, v619 !metadata(storage=symbolic(v614))
     v634 = sload 3 !metadata(storage=slot(3))
     v635 = lt 0, v634
     v636 = iszero v635
-    jumpi v636, bb182, bb183
-  bb183:
+    jumpi v636, bb180, bb181
+  bb181:
     v637 = storage_array_data_slot 3
     v638 = mul 0, 2
     v639 = add v637, v638
-    v640 = lt 1, 2
+    v640 = lt 0, 2
     v641 = iszero v640
-    jumpi v641, bb184, bb185
-  bb185:
-    v642 = add v639, 1
-    v643 = sload v642 !metadata(storage=offset(v639, 1))
+    jumpi v641, bb182, bb183
+  bb183:
+    v642 = add v639, 0
+    v643 = sload v642 !metadata(storage=symbolic(v639))
     v644 = add v643, 1
     v645 = lt v644, v643
-    jumpi v645, bb186, bb187
-  bb187:
+    jumpi v645, bb184, bb185
+  bb185:
     v646 = storage_array_data_slot v642
     v647 = div v643, 32
     v648 = add v646, v647
@@ -493,19 +427,105 @@ fn @_anonymous() [constructor] {
     v653 = sload v648 !metadata(storage=symbolic(v648))
     v654 = not v652
     v655 = and v653, v654
-    v656 = and 6, 255
+    v656 = and 4, 255
     v657 = shl v651, v656
     v658 = or v655, v657
     sstore v648, v658 !metadata(storage=symbolic(v648))
-    sstore v642, v644 !metadata(storage=offset(v639, 1))
+    sstore v642, v644 !metadata(storage=symbolic(v639))
+    v659 = sload 3 !metadata(storage=slot(3))
+    v660 = lt 0, v659
+    v661 = iszero v660
+    jumpi v661, bb186, bb187
+  bb187:
+    v662 = storage_array_data_slot 3
+    v663 = mul 0, 2
+    v664 = add v662, v663
+    v665 = lt 1, 2
+    v666 = iszero v665
+    jumpi v666, bb188, bb189
+  bb189:
+    v667 = add v664, 1
+    v668 = sload v667 !metadata(storage=offset(v664, 1))
+    v669 = add v668, 1
+    v670 = lt v669, v668
+    jumpi v670, bb190, bb191
+  bb191:
+    v671 = storage_array_data_slot v667
+    v672 = div v668, 32
+    v673 = add v671, v672
+    v674 = mod v668, 32
+    v675 = mul v674, 1
+    v676 = mul v675, 8
+    v677 = shl v676, 255
+    v678 = sload v673 !metadata(storage=symbolic(v673))
+    v679 = not v677
+    v680 = and v678, v679
+    v681 = and 5, 255
+    v682 = shl v676, v681
+    v683 = or v680, v682
+    sstore v673, v683 !metadata(storage=symbolic(v673))
+    sstore v667, v669 !metadata(storage=offset(v664, 1))
+    v684 = sload 3 !metadata(storage=slot(3))
+    v685 = lt 0, v684
+    v686 = iszero v685
+    jumpi v686, bb192, bb193
+  bb193:
+    v687 = storage_array_data_slot 3
+    v688 = mul 0, 2
+    v689 = add v687, v688
+    v690 = lt 1, 2
+    v691 = iszero v690
+    jumpi v691, bb194, bb195
+  bb195:
+    v692 = add v689, 1
+    v693 = sload v692 !metadata(storage=offset(v689, 1))
+    v694 = add v693, 1
+    v695 = lt v694, v693
+    jumpi v695, bb196, bb197
+  bb197:
+    v696 = storage_array_data_slot v692
+    v697 = div v693, 32
+    v698 = add v696, v697
+    v699 = mod v693, 32
+    v700 = mul v699, 1
+    v701 = mul v700, 8
+    v702 = shl v701, 255
+    v703 = sload v698 !metadata(storage=symbolic(v698))
+    v704 = not v702
+    v705 = and v703, v704
+    v706 = and 6, 255
+    v707 = shl v701, v706
+    v708 = or v705, v707
+    sstore v698, v708 !metadata(storage=symbolic(v698))
+    sstore v692, v694 !metadata(storage=offset(v689, 1))
     stop
-  bb186:
+  bb196:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb184:
+  bb194:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb192:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb190:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb188:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb186:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb184:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb182:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -513,11 +533,11 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb180:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb178:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb176:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -525,11 +545,11 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb174:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb172:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb170:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -537,11 +557,11 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb168:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb166:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb164:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -549,11 +569,11 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb162:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb160:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb158:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -561,11 +581,11 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb156:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb154:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb152:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -573,129 +593,140 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb150:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb148:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb146:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb144:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb142:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb140:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb128:
-    v420 = memory_object_load_element memoryarray<1>, v395, v418
-    v421 = eq v420, 0
-    jumpi v421, bb130, bb131
-  bb130:
-    v422 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
-    set_memory_object_len memoryarray, v422, 0
-    memory_object_store_element memoryarray<1>, v395, v418, v422
-    jump bb131
-  bb131:
-    v423 = phi [bb128: v420], [bb130: v422]
-    v424 = storage_array_data_slot v398
-    v425 = add v424, v418
-    v426 = memory_object_len memoryarray, v423
-    v427 = sload v425 !metadata(storage=symbolic(v425))
-    v428 = gt v427, v426
-    jumpi v428, bb132, bb133
-  bb132:
-    jump bb134
-  bb134:
-    v429 = phi [bb132: v426], [bb135: v444]
-    v430 = lt v429, v427
-    jumpi v430, bb135, bb136
   bb136:
-    jump bb133
-  bb133:
-    sstore v425, v426 !metadata(storage=symbolic(v425))
-    jump bb137
-  bb137:
-    v445 = phi [bb133: 0], [bb138: v461]
-    v446 = lt v445, v426
-    jumpi v446, bb138, bb139
-  bb139:
-    v462 = add v418, 1
-    jump bb127
+    v460 = memory_object_load_element memoryarray<1>, v435, v458
+    v461 = eq v460, 0
+    jumpi v461, bb138, bb139
   bb138:
-    v447 = memory_object_load_element memoryarray<1>, v423, v445
-    v448 = storage_array_data_slot v425
-    v449 = div v445, 32
-    v450 = add v448, v449
-    v451 = mod v445, 32
-    v452 = mul v451, 1
-    v453 = mul v452, 8
-    v454 = shl v453, 255
-    v455 = sload v450 !metadata(storage=symbolic(v450))
-    v456 = not v454
-    v457 = and v455, v456
-    v458 = and v447, 255
-    v459 = shl v453, v458
-    v460 = or v457, v459
-    sstore v450, v460 !metadata(storage=symbolic(v450))
-    v461 = add v445, 1
-    jump bb137
-  bb135:
-    v431 = storage_array_data_slot v425
-    v432 = div v429, 32
-    v433 = add v431, v432
-    v434 = mod v429, 32
-    v435 = mul v434, 1
-    v436 = mul v435, 8
-    v437 = shl v436, 255
-    v438 = sload v433 !metadata(storage=symbolic(v433))
-    v439 = not v437
-    v440 = and v438, v439
-    v441 = and 0, 255
-    v442 = shl v436, v441
-    v443 = or v440, v442
-    sstore v433, v443 !metadata(storage=symbolic(v433))
-    v444 = add v429, 1
-    jump bb134
-  bb122:
-    v404 = storage_array_data_slot v398
-    v405 = add v404, v402
-    v406 = sload v405 !metadata(storage=symbolic(v405))
-    sstore v405, 0 !metadata(storage=symbolic(v405))
-    v407 = div v406, 32
-    v408 = mod v406, 32
-    v409 = iszero v408
-    v410 = iszero v409
-    v411 = add v407, v410
-    v412 = storage_array_data_slot v405
-    jump bb124
-  bb124:
-    v413 = phi [bb122: 0], [bb125: v416]
-    v414 = lt v413, v411
-    jumpi v414, bb125, bb126
-  bb126:
-    v417 = add v402, 1
-    jump bb121
+    v462 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
+    set_memory_object_len memoryarray, v462, 0
+    memory_object_store_element memoryarray<1>, v435, v458, v462
+    jump bb139
+  bb139:
+    v463 = phi [bb136: v460], [bb138: v462]
+    v464 = storage_array_data_slot v438
+    v465 = add v464, v458
+    v466 = memory_object_len memoryarray, v463
+    v467 = sload v465 !metadata(storage=symbolic(v465))
+    v468 = gt v467, v466
+    jumpi v468, bb140, bb141
+  bb140:
+    jump bb142
+  bb142:
+    v469 = phi [bb140: v466], [bb143: v484]
+    v470 = lt v469, v467
+    jumpi v470, bb143, bb144
+  bb144:
+    jump bb141
+  bb141:
+    sstore v465, v466 !metadata(storage=symbolic(v465))
+    jump bb145
+  bb145:
+    v485 = phi [bb141: 0], [bb146: v501]
+    v486 = lt v485, v466
+    jumpi v486, bb146, bb147
+  bb147:
+    v502 = shr 5, v466
+    v503 = and v466, 31
+    v504 = iszero v503
+    jumpi v504, bb149, bb148
+  bb148:
+    v505 = mul v503, 8
+    v506 = shl v505, 1
+    v507 = sub v506, 1
+    v508 = storage_array_data_slot v465
+    v509 = add v508, v502
+    v510 = sload v509 !metadata(storage=symbolic(v509))
+    v511 = and v510, v507
+    sstore v509, v511 !metadata(storage=symbolic(v509))
+    jump bb149
+  bb149:
+    v512 = add v458, 1
+    jump bb135
+  bb146:
+    v487 = memory_object_load_element memoryarray<1>, v463, v485
+    v488 = storage_array_data_slot v465
+    v489 = div v485, 32
+    v490 = add v488, v489
+    v491 = mod v485, 32
+    v492 = mul v491, 1
+    v493 = mul v492, 8
+    v494 = shl v493, 255
+    v495 = sload v490 !metadata(storage=symbolic(v490))
+    v496 = not v494
+    v497 = and v495, v496
+    v498 = and v487, 255
+    v499 = shl v493, v498
+    v500 = or v497, v499
+    sstore v490, v500 !metadata(storage=symbolic(v490))
+    v501 = add v485, 1
+    jump bb145
+  bb143:
+    v471 = storage_array_data_slot v465
+    v472 = div v469, 32
+    v473 = add v471, v472
+    v474 = mod v469, 32
+    v475 = mul v474, 1
+    v476 = mul v475, 8
+    v477 = shl v476, 255
+    v478 = sload v473 !metadata(storage=symbolic(v473))
+    v479 = not v477
+    v480 = and v478, v479
+    v481 = and 0, 255
+    v482 = shl v476, v481
+    v483 = or v480, v482
+    sstore v473, v483 !metadata(storage=symbolic(v473))
+    v484 = add v469, 1
+    jump bb142
+  bb130:
+    v444 = storage_array_data_slot v438
+    v445 = add v444, v442
+    v446 = sload v445 !metadata(storage=symbolic(v445))
+    sstore v445, 0 !metadata(storage=symbolic(v445))
+    v447 = div v446, 32
+    v448 = mod v446, 32
+    v449 = iszero v448
+    v450 = iszero v449
+    v451 = add v447, v450
+    v452 = storage_array_data_slot v445
+    jump bb132
+  bb132:
+    v453 = phi [bb130: 0], [bb133: v456]
+    v454 = lt v453, v451
+    jumpi v454, bb133, bb134
+  bb134:
+    v457 = add v442, 1
+    jump bb129
+  bb133:
+    v455 = add v452, v453
+    sstore v455, 0 !metadata(storage=symbolic(v455))
+    v456 = add v453, 1
+    jump bb132
   bb125:
-    v415 = add v412, v413
-    sstore v415, 0 !metadata(storage=symbolic(v415))
-    v416 = add v413, 1
-    jump bb124
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb123:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
+    revert 0, 36
+  bb121:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb119:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
   bb117:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb115:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb113:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -703,11 +734,11 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb111:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb109:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb107:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -715,296 +746,310 @@ fn @_anonymous() [constructor] {
     revert 0, 36
   bb105:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
   bb103:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb101:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb99:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb97:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 65 !metadata(memory=scratch)
-    revert 0, 36
-  bb95:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb93:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb81:
-    v248 = memory_object_load_element memoryarray<1>, v221, v246
-    v249 = eq v248, 0
-    jumpi v249, bb83, bb84
-  bb83:
-    v250 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
-    set_memory_object_len memoryarray, v250, 0
-    memory_object_store_element memoryarray<1>, v221, v246, v250
-    jump bb84
-  bb84:
-    v251 = phi [bb81: v248], [bb83: v250]
-    v252 = storage_array_data_slot v226
-    v253 = add v252, v246
-    v254 = memory_object_len memoryarray, v251
-    v255 = sload v253 !metadata(storage=symbolic(v253))
-    v256 = gt v255, v254
-    jumpi v256, bb85, bb86
-  bb85:
-    jump bb87
   bb87:
-    v257 = phi [bb85: v254], [bb88: v272]
-    v258 = lt v257, v255
-    jumpi v258, bb88, bb89
+    v278 = memory_object_load_element memoryarray<1>, v251, v276
+    v279 = eq v278, 0
+    jumpi v279, bb89, bb90
   bb89:
-    jump bb86
-  bb86:
-    sstore v253, v254 !metadata(storage=symbolic(v253))
+    v280 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
+    set_memory_object_len memoryarray, v280, 0
+    memory_object_store_element memoryarray<1>, v251, v276, v280
     jump bb90
   bb90:
-    v273 = phi [bb86: 0], [bb91: v289]
-    v274 = lt v273, v254
-    jumpi v274, bb91, bb92
-  bb92:
-    v290 = add v246, 1
-    jump bb80
+    v281 = phi [bb87: v278], [bb89: v280]
+    v282 = storage_array_data_slot v256
+    v283 = add v282, v276
+    v284 = memory_object_len memoryarray, v281
+    v285 = sload v283 !metadata(storage=symbolic(v283))
+    v286 = gt v285, v284
+    jumpi v286, bb91, bb92
   bb91:
-    v275 = memory_object_load_element memoryarray<1>, v251, v273
-    v276 = storage_array_data_slot v253
-    v277 = div v273, 32
-    v278 = add v276, v277
-    v279 = mod v273, 32
-    v280 = mul v279, 1
-    v281 = mul v280, 8
-    v282 = shl v281, 255
-    v283 = sload v278 !metadata(storage=symbolic(v278))
-    v284 = not v282
-    v285 = and v283, v284
-    v286 = and v275, 255
-    v287 = shl v281, v286
-    v288 = or v285, v287
-    sstore v278, v288 !metadata(storage=symbolic(v278))
-    v289 = add v273, 1
-    jump bb90
-  bb88:
-    v259 = storage_array_data_slot v253
-    v260 = div v257, 32
-    v261 = add v259, v260
-    v262 = mod v257, 32
-    v263 = mul v262, 1
-    v264 = mul v263, 8
-    v265 = shl v264, 255
-    v266 = sload v261 !metadata(storage=symbolic(v261))
-    v267 = not v265
-    v268 = and v266, v267
-    v269 = and 0, 255
-    v270 = shl v264, v269
-    v271 = or v268, v270
-    sstore v261, v271 !metadata(storage=symbolic(v261))
-    v272 = add v257, 1
-    jump bb87
-  bb75:
-    v232 = storage_array_data_slot v226
-    v233 = add v232, v230
-    v234 = sload v233 !metadata(storage=symbolic(v233))
-    sstore v233, 0 !metadata(storage=symbolic(v233))
-    v235 = div v234, 32
-    v236 = mod v234, 32
-    v237 = iszero v236
-    v238 = iszero v237
-    v239 = add v235, v238
-    v240 = storage_array_data_slot v233
-    jump bb77
-  bb77:
-    v241 = phi [bb75: 0], [bb78: v244]
-    v242 = lt v241, v239
-    jumpi v242, bb78, bb79
-  bb79:
-    v245 = add v230, 1
-    jump bb74
-  bb78:
-    v243 = add v240, v241
-    sstore v243, 0 !metadata(storage=symbolic(v243))
-    v244 = add v241, 1
-    jump bb77
-  bb70:
+    jump bb93
+  bb93:
+    v287 = phi [bb91: v284], [bb94: v302]
+    v288 = lt v287, v285
+    jumpi v288, bb94, bb95
+  bb95:
+    jump bb92
+  bb92:
+    sstore v283, v284 !metadata(storage=symbolic(v283))
+    jump bb96
+  bb96:
+    v303 = phi [bb92: 0], [bb97: v319]
+    v304 = lt v303, v284
+    jumpi v304, bb97, bb98
+  bb98:
+    v320 = shr 5, v284
+    v321 = and v284, 31
+    v322 = iszero v321
+    jumpi v322, bb100, bb99
+  bb99:
+    v323 = mul v321, 8
+    v324 = shl v323, 1
+    v325 = sub v324, 1
+    v326 = storage_array_data_slot v283
+    v327 = add v326, v320
+    v328 = sload v327 !metadata(storage=symbolic(v327))
+    v329 = and v328, v325
+    sstore v327, v329 !metadata(storage=symbolic(v327))
+    jump bb100
+  bb100:
+    v330 = add v276, 1
+    jump bb86
+  bb97:
+    v305 = memory_object_load_element memoryarray<1>, v281, v303
+    v306 = storage_array_data_slot v283
+    v307 = div v303, 32
+    v308 = add v306, v307
+    v309 = mod v303, 32
+    v310 = mul v309, 1
+    v311 = mul v310, 8
+    v312 = shl v311, 255
+    v313 = sload v308 !metadata(storage=symbolic(v308))
+    v314 = not v312
+    v315 = and v313, v314
+    v316 = and v305, 255
+    v317 = shl v311, v316
+    v318 = or v315, v317
+    sstore v308, v318 !metadata(storage=symbolic(v308))
+    v319 = add v303, 1
+    jump bb96
+  bb94:
+    v289 = storage_array_data_slot v283
+    v290 = div v287, 32
+    v291 = add v289, v290
+    v292 = mod v287, 32
+    v293 = mul v292, 1
+    v294 = mul v293, 8
+    v295 = shl v294, 255
+    v296 = sload v291 !metadata(storage=symbolic(v291))
+    v297 = not v295
+    v298 = and v296, v297
+    v299 = and 0, 255
+    v300 = shl v294, v299
+    v301 = or v298, v300
+    sstore v291, v301 !metadata(storage=symbolic(v291))
+    v302 = add v287, 1
+    jump bb93
+  bb81:
+    v262 = storage_array_data_slot v256
+    v263 = add v262, v260
+    v264 = sload v263 !metadata(storage=symbolic(v263))
+    sstore v263, 0 !metadata(storage=symbolic(v263))
+    v265 = div v264, 32
+    v266 = mod v264, 32
+    v267 = iszero v266
+    v268 = iszero v267
+    v269 = add v265, v268
+    v270 = storage_array_data_slot v263
+    jump bb83
+  bb83:
+    v271 = phi [bb81: 0], [bb84: v274]
+    v272 = lt v271, v269
+    jumpi v272, bb84, bb85
+  bb85:
+    v275 = add v260, 1
+    jump bb80
+  bb84:
+    v273 = add v270, v271
+    sstore v273, 0 !metadata(storage=symbolic(v273))
+    v274 = add v271, 1
+    jump bb83
+  bb76:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb45:
-    v150 = memory_object_load_element memoryarray<1>, v122, v148
-    v151 = eq v150, 0
-    jumpi v151, bb47, bb48
-  bb47:
-    v152 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
-    set_memory_object_len memoryarray, v152, 0
-    memory_object_store_element memoryarray<1>, v122, v148, v152
-    jump bb48
-  bb48:
-    v153 = phi [bb45: v150], [bb47: v152]
-    v154 = storage_array_data_slot 0
-    v155 = add v154, v148
-    v156 = memory_object_len memoryarray, v153
-    v157 = sload v155 !metadata(storage=symbolic(v155))
-    v158 = gt v157, v156
-    jumpi v158, bb49, bb50
   bb49:
-    jump bb51
+    v170 = memory_object_load_element memoryarray<1>, v142, v168
+    v171 = eq v170, 0
+    jumpi v171, bb51, bb52
   bb51:
-    v159 = phi [bb49: v156], [bb56: v174]
-    v160 = lt v159, v157
-    jumpi v160, bb52, bb53
-  bb53:
-    jump bb50
-  bb50:
-    sstore v155, v156 !metadata(storage=symbolic(v155))
-    jump bb57
-  bb57:
-    v175 = phi [bb50: 0], [bb69: v219]
-    v176 = lt v175, v156
-    jumpi v176, bb58, bb59
-  bb59:
-    v220 = add v148, 1
-    jump bb44
-  bb58:
-    v177 = memory_object_load_element memoryarray<1>, v153, v175
-    v178 = eq v177, 0
-    jumpi v178, bb60, bb61
-  bb60:
-    v179 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
-    set_memory_object_len memoryarray, v179, 0
-    memory_object_store_element memoryarray<1>, v153, v175, v179
-    jump bb61
-  bb61:
-    v180 = phi [bb58: v177], [bb60: v179]
-    v181 = storage_array_data_slot v155
-    v182 = add v181, v175
-    v183 = memory_object_len memoryarray, v180
-    v184 = sload v182 !metadata(storage=symbolic(v182))
-    v185 = gt v184, v183
-    jumpi v185, bb62, bb63
-  bb62:
-    jump bb64
-  bb64:
-    v186 = phi [bb62: v183], [bb65: v201]
-    v187 = lt v186, v184
-    jumpi v187, bb65, bb66
-  bb66:
-    jump bb63
-  bb63:
-    sstore v182, v183 !metadata(storage=symbolic(v182))
-    jump bb67
-  bb67:
-    v202 = phi [bb63: 0], [bb68: v218]
-    v203 = lt v202, v183
-    jumpi v203, bb68, bb69
-  bb69:
-    v219 = add v175, 1
-    jump bb57
-  bb68:
-    v204 = memory_object_load_element memoryarray<1>, v180, v202
-    v205 = storage_array_data_slot v182
-    v206 = div v202, 32
-    v207 = add v205, v206
-    v208 = mod v202, 32
-    v209 = mul v208, 1
-    v210 = mul v209, 8
-    v211 = shl v210, 255
-    v212 = sload v207 !metadata(storage=symbolic(v207))
-    v213 = not v211
-    v214 = and v212, v213
-    v215 = and v204, 255
-    v216 = shl v210, v215
-    v217 = or v214, v216
-    sstore v207, v217 !metadata(storage=symbolic(v207))
-    v218 = add v202, 1
-    jump bb67
-  bb65:
-    v188 = storage_array_data_slot v182
-    v189 = div v186, 32
-    v190 = add v188, v189
-    v191 = mod v186, 32
-    v192 = mul v191, 1
-    v193 = mul v192, 8
-    v194 = shl v193, 255
-    v195 = sload v190 !metadata(storage=symbolic(v190))
-    v196 = not v194
-    v197 = and v195, v196
-    v198 = and 0, 255
-    v199 = shl v193, v198
-    v200 = or v197, v199
-    sstore v190, v200 !metadata(storage=symbolic(v190))
-    v201 = add v186, 1
-    jump bb64
+    v172 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
+    set_memory_object_len memoryarray, v172, 0
+    memory_object_store_element memoryarray<1>, v142, v168, v172
+    jump bb52
   bb52:
-    v161 = storage_array_data_slot v155
-    v162 = add v161, v159
-    v163 = sload v162 !metadata(storage=symbolic(v162))
-    sstore v162, 0 !metadata(storage=symbolic(v162))
-    v164 = div v163, 32
-    v165 = mod v163, 32
-    v166 = iszero v165
-    v167 = iszero v166
-    v168 = add v164, v167
-    v169 = storage_array_data_slot v162
+    v173 = phi [bb49: v170], [bb51: v172]
+    v174 = storage_array_data_slot 0
+    v175 = add v174, v168
+    v176 = memory_object_len memoryarray, v173
+    v177 = sload v175 !metadata(storage=symbolic(v175))
+    v178 = gt v177, v176
+    jumpi v178, bb53, bb54
+  bb53:
+    jump bb55
+  bb55:
+    v179 = phi [bb53: v176], [bb60: v194]
+    v180 = lt v179, v177
+    jumpi v180, bb56, bb57
+  bb57:
     jump bb54
   bb54:
-    v170 = phi [bb52: 0], [bb55: v173]
-    v171 = lt v170, v168
-    jumpi v171, bb55, bb56
+    sstore v175, v176 !metadata(storage=symbolic(v175))
+    jump bb61
+  bb61:
+    v195 = phi [bb54: 0], [bb75: v249]
+    v196 = lt v195, v176
+    jumpi v196, bb62, bb63
+  bb63:
+    v250 = add v168, 1
+    jump bb48
+  bb62:
+    v197 = memory_object_load_element memoryarray<1>, v173, v195
+    v198 = eq v197, 0
+    jumpi v198, bb64, bb65
+  bb64:
+    v199 = alloc memoryarray<1>, exact, uninitialized, infallible, 32
+    set_memory_object_len memoryarray, v199, 0
+    memory_object_store_element memoryarray<1>, v173, v195, v199
+    jump bb65
+  bb65:
+    v200 = phi [bb62: v197], [bb64: v199]
+    v201 = storage_array_data_slot v175
+    v202 = add v201, v195
+    v203 = memory_object_len memoryarray, v200
+    v204 = sload v202 !metadata(storage=symbolic(v202))
+    v205 = gt v204, v203
+    jumpi v205, bb66, bb67
+  bb66:
+    jump bb68
+  bb68:
+    v206 = phi [bb66: v203], [bb69: v221]
+    v207 = lt v206, v204
+    jumpi v207, bb69, bb70
+  bb70:
+    jump bb67
+  bb67:
+    sstore v202, v203 !metadata(storage=symbolic(v202))
+    jump bb71
+  bb71:
+    v222 = phi [bb67: 0], [bb72: v238]
+    v223 = lt v222, v203
+    jumpi v223, bb72, bb73
+  bb73:
+    v239 = shr 5, v203
+    v240 = and v203, 31
+    v241 = iszero v240
+    jumpi v241, bb75, bb74
+  bb74:
+    v242 = mul v240, 8
+    v243 = shl v242, 1
+    v244 = sub v243, 1
+    v245 = storage_array_data_slot v202
+    v246 = add v245, v239
+    v247 = sload v246 !metadata(storage=symbolic(v246))
+    v248 = and v247, v244
+    sstore v246, v248 !metadata(storage=symbolic(v246))
+    jump bb75
+  bb75:
+    v249 = add v195, 1
+    jump bb61
+  bb72:
+    v224 = memory_object_load_element memoryarray<1>, v200, v222
+    v225 = storage_array_data_slot v202
+    v226 = div v222, 32
+    v227 = add v225, v226
+    v228 = mod v222, 32
+    v229 = mul v228, 1
+    v230 = mul v229, 8
+    v231 = shl v230, 255
+    v232 = sload v227 !metadata(storage=symbolic(v227))
+    v233 = not v231
+    v234 = and v232, v233
+    v235 = and v224, 255
+    v236 = shl v230, v235
+    v237 = or v234, v236
+    sstore v227, v237 !metadata(storage=symbolic(v227))
+    v238 = add v222, 1
+    jump bb71
+  bb69:
+    v208 = storage_array_data_slot v202
+    v209 = div v206, 32
+    v210 = add v208, v209
+    v211 = mod v206, 32
+    v212 = mul v211, 1
+    v213 = mul v212, 8
+    v214 = shl v213, 255
+    v215 = sload v210 !metadata(storage=symbolic(v210))
+    v216 = not v214
+    v217 = and v215, v216
+    v218 = and 0, 255
+    v219 = shl v213, v218
+    v220 = or v217, v219
+    sstore v210, v220 !metadata(storage=symbolic(v210))
+    v221 = add v206, 1
+    jump bb68
   bb56:
-    v174 = add v159, 1
-    jump bb51
-  bb55:
-    v172 = add v169, v170
-    sstore v172, 0 !metadata(storage=symbolic(v172))
-    v173 = add v170, 1
-    jump bb54
-  bb36:
-    v128 = storage_array_data_slot 0
-    v129 = add v128, v126
-    v130 = sload v129 !metadata(storage=symbolic(v129))
-    sstore v129, 0 !metadata(storage=symbolic(v129))
-    jump bb38
-  bb38:
-    v131 = phi [bb36: 0], [bb43: v146]
-    v132 = lt v131, v130
-    jumpi v132, bb39, bb40
+    v181 = storage_array_data_slot v175
+    v182 = add v181, v179
+    v183 = sload v182 !metadata(storage=symbolic(v182))
+    sstore v182, 0 !metadata(storage=symbolic(v182))
+    v184 = div v183, 32
+    v185 = mod v183, 32
+    v186 = iszero v185
+    v187 = iszero v186
+    v188 = add v184, v187
+    v189 = storage_array_data_slot v182
+    jump bb58
+  bb58:
+    v190 = phi [bb56: 0], [bb59: v193]
+    v191 = lt v190, v188
+    jumpi v191, bb59, bb60
+  bb60:
+    v194 = add v179, 1
+    jump bb55
+  bb59:
+    v192 = add v189, v190
+    sstore v192, 0 !metadata(storage=symbolic(v192))
+    v193 = add v190, 1
+    jump bb58
   bb40:
-    v147 = add v126, 1
-    jump bb35
-  bb39:
-    v133 = storage_array_data_slot v129
-    v134 = add v133, v131
-    v135 = sload v134 !metadata(storage=symbolic(v134))
-    sstore v134, 0 !metadata(storage=symbolic(v134))
-    v136 = div v135, 32
-    v137 = mod v135, 32
-    v138 = iszero v137
-    v139 = iszero v138
-    v140 = add v136, v139
-    v141 = storage_array_data_slot v134
-    jump bb41
-  bb41:
-    v142 = phi [bb39: 0], [bb42: v145]
-    v143 = lt v142, v140
-    jumpi v143, bb42, bb43
-  bb43:
-    v146 = add v131, 1
-    jump bb38
+    v148 = storage_array_data_slot 0
+    v149 = add v148, v146
+    v150 = sload v149 !metadata(storage=symbolic(v149))
+    sstore v149, 0 !metadata(storage=symbolic(v149))
+    jump bb42
   bb42:
-    v144 = add v141, v142
-    sstore v144, 0 !metadata(storage=symbolic(v144))
-    v145 = add v142, 1
-    jump bb41
+    v151 = phi [bb40: 0], [bb47: v166]
+    v152 = lt v151, v150
+    jumpi v152, bb43, bb44
+  bb44:
+    v167 = add v146, 1
+    jump bb39
+  bb43:
+    v153 = storage_array_data_slot v149
+    v154 = add v153, v151
+    v155 = sload v154 !metadata(storage=symbolic(v154))
+    sstore v154, 0 !metadata(storage=symbolic(v154))
+    v156 = div v155, 32
+    v157 = mod v155, 32
+    v158 = iszero v157
+    v159 = iszero v158
+    v160 = add v156, v159
+    v161 = storage_array_data_slot v154
+    jump bb45
+  bb45:
+    v162 = phi [bb43: 0], [bb46: v165]
+    v163 = lt v162, v160
+    jumpi v163, bb46, bb47
+  bb47:
+    v166 = add v151, 1
+    jump bb42
+  bb46:
+    v164 = add v161, v162
+    sstore v164, 0 !metadata(storage=symbolic(v164))
+    v165 = add v162, 1
+    jump bb45
   bb13:
     v36 = memory_object_load_element memoryarray<1>, v0, v34
     v37 = eq v36, 0
@@ -1046,65 +1091,95 @@ fn @_anonymous() [constructor] {
     v67 = lt v66, v47
     jumpi v67, bb23, bb24
   bb24:
-    v83 = add v44, 1
-    v84 = memory_object_load_element memoryfixedarray<2, 1>, v41, 1
-    v85 = memory_object_len memoryarray, v84
-    v86 = sload v83 !metadata(storage=offset(v44, 1))
-    v87 = gt v86, v85
-    jumpi v87, bb25, bb26
+    v83 = shr 5, v47
+    v84 = and v47, 31
+    v85 = iszero v84
+    jumpi v85, bb26, bb25
   bb25:
-    jump bb27
-  bb27:
-    v88 = phi [bb25: v85], [bb28: v103]
-    v89 = lt v88, v86
-    jumpi v89, bb28, bb29
-  bb29:
+    v86 = mul v84, 8
+    v87 = shl v86, 1
+    v88 = sub v87, 1
+    v89 = storage_array_data_slot v45
+    v90 = add v89, v83
+    v91 = sload v90 !metadata(storage=symbolic(v90))
+    v92 = and v91, v88
+    sstore v90, v92 !metadata(storage=symbolic(v90))
     jump bb26
   bb26:
-    sstore v83, v85 !metadata(storage=offset(v44, 1))
-    jump bb30
-  bb30:
-    v104 = phi [bb26: 0], [bb31: v120]
-    v105 = lt v104, v85
-    jumpi v105, bb31, bb32
-  bb32:
-    v121 = add v34, 1
-    jump bb12
+    v93 = add v44, 1
+    v94 = memory_object_load_element memoryfixedarray<2, 1>, v41, 1
+    v95 = memory_object_len memoryarray, v94
+    v96 = sload v93 !metadata(storage=offset(v44, 1))
+    v97 = gt v96, v95
+    jumpi v97, bb27, bb28
+  bb27:
+    jump bb29
+  bb29:
+    v98 = phi [bb27: v95], [bb30: v113]
+    v99 = lt v98, v96
+    jumpi v99, bb30, bb31
   bb31:
-    v106 = memory_object_load_element memoryarray<1>, v84, v104
-    v107 = storage_array_data_slot v83
-    v108 = div v104, 32
-    v109 = add v107, v108
-    v110 = mod v104, 32
-    v111 = mul v110, 1
-    v112 = mul v111, 8
-    v113 = shl v112, 255
-    v114 = sload v109 !metadata(storage=symbolic(v109))
-    v115 = not v113
-    v116 = and v114, v115
-    v117 = and v106, 255
-    v118 = shl v112, v117
-    v119 = or v116, v118
-    sstore v109, v119 !metadata(storage=symbolic(v109))
-    v120 = add v104, 1
-    jump bb30
+    jump bb28
   bb28:
-    v90 = storage_array_data_slot v83
-    v91 = div v88, 32
-    v92 = add v90, v91
-    v93 = mod v88, 32
-    v94 = mul v93, 1
-    v95 = mul v94, 8
-    v96 = shl v95, 255
-    v97 = sload v92 !metadata(storage=symbolic(v92))
-    v98 = not v96
-    v99 = and v97, v98
-    v100 = and 0, 255
-    v101 = shl v95, v100
-    v102 = or v99, v101
-    sstore v92, v102 !metadata(storage=symbolic(v92))
-    v103 = add v88, 1
-    jump bb27
+    sstore v93, v95 !metadata(storage=offset(v44, 1))
+    jump bb32
+  bb32:
+    v114 = phi [bb28: 0], [bb33: v130]
+    v115 = lt v114, v95
+    jumpi v115, bb33, bb34
+  bb34:
+    v131 = shr 5, v95
+    v132 = and v95, 31
+    v133 = iszero v132
+    jumpi v133, bb36, bb35
+  bb35:
+    v134 = mul v132, 8
+    v135 = shl v134, 1
+    v136 = sub v135, 1
+    v137 = storage_array_data_slot v93
+    v138 = add v137, v131
+    v139 = sload v138 !metadata(storage=symbolic(v138))
+    v140 = and v139, v136
+    sstore v138, v140 !metadata(storage=symbolic(v138))
+    jump bb36
+  bb36:
+    v141 = add v34, 1
+    jump bb12
+  bb33:
+    v116 = memory_object_load_element memoryarray<1>, v94, v114
+    v117 = storage_array_data_slot v93
+    v118 = div v114, 32
+    v119 = add v117, v118
+    v120 = mod v114, 32
+    v121 = mul v120, 1
+    v122 = mul v121, 8
+    v123 = shl v122, 255
+    v124 = sload v119 !metadata(storage=symbolic(v119))
+    v125 = not v123
+    v126 = and v124, v125
+    v127 = and v116, 255
+    v128 = shl v122, v127
+    v129 = or v126, v128
+    sstore v119, v129 !metadata(storage=symbolic(v119))
+    v130 = add v114, 1
+    jump bb32
+  bb30:
+    v100 = storage_array_data_slot v93
+    v101 = div v98, 32
+    v102 = add v100, v101
+    v103 = mod v98, 32
+    v104 = mul v103, 1
+    v105 = mul v104, 8
+    v106 = shl v105, 255
+    v107 = sload v102 !metadata(storage=symbolic(v102))
+    v108 = not v106
+    v109 = and v107, v108
+    v110 = and 0, 255
+    v111 = shl v105, v110
+    v112 = or v109, v111
+    sstore v102, v112 !metadata(storage=symbolic(v102))
+    v113 = add v98, 1
+    jump bb29
   bb23:
     v68 = memory_object_load_element memoryarray<1>, v46, v66
     v69 = storage_array_data_slot v45
@@ -1242,110 +1317,114 @@ fn @copyDynamic() -> u256 [selector=0x902a0a84, abi_params=[], abi_returns=[word
     sstore 4, v27 !metadata(storage=slot(4))
     jump bb20
   bb20:
-    v46 = phi [bb13: 0], [bb32: v90]
+    v46 = phi [bb13: 0], [bb34: v100]
     v47 = lt v46, v27
     jumpi v47, bb21, bb22
   bb22:
-    v91 = sload 4 !metadata(storage=slot(4))
-    v92 = lt 0, v91
-    v93 = iszero v92
-    jumpi v93, bb33, bb34
-  bb34:
-    v94 = storage_array_data_slot 4
-    v95 = add v94, 0
-    v96 = sload v95 !metadata(storage=symbolic(v94))
-    v97 = lt 0, v96
-    v98 = iszero v97
-    jumpi v98, bb35, bb36
+    v101 = sload 4 !metadata(storage=slot(4))
+    v102 = lt 0, v101
+    v103 = iszero v102
+    jumpi v103, bb35, bb36
   bb36:
-    v99 = storage_array_data_slot v95
-    v100 = div 0, 32
-    v101 = add v99, v100
-    v102 = mod 0, 32
-    v103 = mul v102, 1
-    v104 = sload v101 !metadata(storage=symbolic(v101))
-    v105 = mul v103, 8
-    v106 = shr v105, v104
-    v107 = and v106, 255
-    v108 = sload 4 !metadata(storage=slot(4))
-    v109 = lt 0, v108
-    v110 = iszero v109
-    jumpi v110, bb37, bb38
+    v104 = storage_array_data_slot 4
+    v105 = add v104, 0
+    v106 = sload v105 !metadata(storage=symbolic(v104))
+    v107 = lt 0, v106
+    v108 = iszero v107
+    jumpi v108, bb37, bb38
   bb38:
-    v111 = storage_array_data_slot 4
-    v112 = add v111, 0
-    v113 = sload v112 !metadata(storage=symbolic(v111))
-    v114 = lt 1, v113
-    v115 = iszero v114
-    jumpi v115, bb39, bb40
+    v109 = storage_array_data_slot v105
+    v110 = div 0, 32
+    v111 = add v109, v110
+    v112 = mod 0, 32
+    v113 = mul v112, 1
+    v114 = sload v111 !metadata(storage=symbolic(v111))
+    v115 = mul v113, 8
+    v116 = shr v115, v114
+    v117 = and v116, 255
+    v118 = sload 4 !metadata(storage=slot(4))
+    v119 = lt 0, v118
+    v120 = iszero v119
+    jumpi v120, bb39, bb40
   bb40:
-    v116 = storage_array_data_slot v112
-    v117 = div 1, 32
-    v118 = add v116, v117
-    v119 = mod 1, 32
-    v120 = mul v119, 1
-    v121 = sload v118 !metadata(storage=symbolic(v118))
-    v122 = mul v120, 8
-    v123 = shr v122, v121
-    v124 = and v123, 255
-    v125 = add v107, v124
-    v126 = gt v125, 255
-    jumpi v126, bb41, bb42
+    v121 = storage_array_data_slot 4
+    v122 = add v121, 0
+    v123 = sload v122 !metadata(storage=symbolic(v121))
+    v124 = lt 1, v123
+    v125 = iszero v124
+    jumpi v125, bb41, bb42
   bb42:
-    v127 = sload 4 !metadata(storage=slot(4))
-    v128 = lt 1, v127
-    v129 = iszero v128
-    jumpi v129, bb43, bb44
+    v126 = storage_array_data_slot v122
+    v127 = div 1, 32
+    v128 = add v126, v127
+    v129 = mod 1, 32
+    v130 = mul v129, 1
+    v131 = sload v128 !metadata(storage=symbolic(v128))
+    v132 = mul v130, 8
+    v133 = shr v132, v131
+    v134 = and v133, 255
+    v135 = add v117, v134
+    v136 = gt v135, 255
+    jumpi v136, bb43, bb44
   bb44:
-    v130 = storage_array_data_slot 4
-    v131 = add v130, 1
-    v132 = sload v131 !metadata(storage=offset(v130, 1))
-    v133 = lt 0, v132
-    v134 = iszero v133
-    jumpi v134, bb45, bb46
+    v137 = sload 4 !metadata(storage=slot(4))
+    v138 = lt 1, v137
+    v139 = iszero v138
+    jumpi v139, bb45, bb46
   bb46:
-    v135 = storage_array_data_slot v131
-    v136 = div 0, 32
-    v137 = add v135, v136
-    v138 = mod 0, 32
-    v139 = mul v138, 1
-    v140 = sload v137 !metadata(storage=symbolic(v137))
-    v141 = mul v139, 8
-    v142 = shr v141, v140
-    v143 = and v142, 255
-    v144 = add v125, v143
-    v145 = gt v144, 255
-    jumpi v145, bb47, bb48
+    v140 = storage_array_data_slot 4
+    v141 = add v140, 1
+    v142 = sload v141 !metadata(storage=offset(v140, 1))
+    v143 = lt 0, v142
+    v144 = iszero v143
+    jumpi v144, bb47, bb48
   bb48:
-    v146 = sload 4 !metadata(storage=slot(4))
-    v147 = lt 1, v146
-    v148 = iszero v147
-    jumpi v148, bb49, bb50
+    v145 = storage_array_data_slot v141
+    v146 = div 0, 32
+    v147 = add v145, v146
+    v148 = mod 0, 32
+    v149 = mul v148, 1
+    v150 = sload v147 !metadata(storage=symbolic(v147))
+    v151 = mul v149, 8
+    v152 = shr v151, v150
+    v153 = and v152, 255
+    v154 = add v135, v153
+    v155 = gt v154, 255
+    jumpi v155, bb49, bb50
   bb50:
-    v149 = storage_array_data_slot 4
-    v150 = add v149, 1
-    v151 = sload v150 !metadata(storage=offset(v149, 1))
-    v152 = lt 1, v151
-    v153 = iszero v152
-    jumpi v153, bb51, bb52
+    v156 = sload 4 !metadata(storage=slot(4))
+    v157 = lt 1, v156
+    v158 = iszero v157
+    jumpi v158, bb51, bb52
   bb52:
-    v154 = storage_array_data_slot v150
-    v155 = div 1, 32
-    v156 = add v154, v155
-    v157 = mod 1, 32
-    v158 = mul v157, 1
-    v159 = sload v156 !metadata(storage=symbolic(v156))
-    v160 = mul v158, 8
-    v161 = shr v160, v159
-    v162 = and v161, 255
-    v163 = add v144, v162
-    v164 = gt v163, 255
-    jumpi v164, bb53, bb54
+    v159 = storage_array_data_slot 4
+    v160 = add v159, 1
+    v161 = sload v160 !metadata(storage=offset(v159, 1))
+    v162 = lt 1, v161
+    v163 = iszero v162
+    jumpi v163, bb53, bb54
   bb54:
-    ret v163
-  bb53:
+    v164 = storage_array_data_slot v160
+    v165 = div 1, 32
+    v166 = add v164, v165
+    v167 = mod 1, 32
+    v168 = mul v167, 1
+    v169 = sload v166 !metadata(storage=symbolic(v166))
+    v170 = mul v168, 8
+    v171 = shr v170, v169
+    v172 = and v171, 255
+    v173 = add v154, v172
+    v174 = gt v173, 255
+    jumpi v174, bb55, bb56
+  bb56:
+    ret v173
+  bb55:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb53:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb51:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1353,11 +1432,11 @@ fn @copyDynamic() -> u256 [selector=0x902a0a84, abi_params=[], abi_returns=[word
     revert 0, 36
   bb49:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb47:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb45:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1365,11 +1444,11 @@ fn @copyDynamic() -> u256 [selector=0x902a0a84, abi_params=[], abi_returns=[word
     revert 0, 36
   bb43:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb41:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb39:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1380,10 +1459,6 @@ fn @copyDynamic() -> u256 [selector=0x902a0a84, abi_params=[], abi_returns=[word
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb35:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -1420,7 +1495,22 @@ fn @copyDynamic() -> u256 [selector=0x902a0a84, abi_params=[], abi_returns=[word
     v74 = lt v73, v54
     jumpi v74, bb31, bb32
   bb32:
-    v90 = add v46, 1
+    v90 = shr 5, v54
+    v91 = and v54, 31
+    v92 = iszero v91
+    jumpi v92, bb34, bb33
+  bb33:
+    v93 = mul v91, 8
+    v94 = shl v93, 1
+    v95 = sub v94, 1
+    v96 = storage_array_data_slot v53
+    v97 = add v96, v90
+    v98 = sload v97 !metadata(storage=symbolic(v97))
+    v99 = and v98, v95
+    sstore v97, v99 !metadata(storage=symbolic(v97))
+    jump bb34
+  bb34:
+    v100 = add v46, 1
     jump bb20
   bb31:
     v75 = memory_object_load_element memoryarray<1>, v51, v73
@@ -1558,110 +1648,114 @@ fn @copyFixed() -> u256 [selector=0x23235673, abi_params=[], abi_returns=[word]]
     sstore 4, v25 !metadata(storage=slot(4))
     jump bb20
   bb20:
-    v44 = phi [bb13: 0], [bb32: v88]
+    v44 = phi [bb13: 0], [bb34: v98]
     v45 = lt v44, v25
     jumpi v45, bb21, bb22
   bb22:
-    v89 = sload 4 !metadata(storage=slot(4))
-    v90 = lt 0, v89
-    v91 = iszero v90
-    jumpi v91, bb33, bb34
-  bb34:
-    v92 = storage_array_data_slot 4
-    v93 = add v92, 0
-    v94 = sload v93 !metadata(storage=symbolic(v92))
-    v95 = lt 0, v94
-    v96 = iszero v95
-    jumpi v96, bb35, bb36
+    v99 = sload 4 !metadata(storage=slot(4))
+    v100 = lt 0, v99
+    v101 = iszero v100
+    jumpi v101, bb35, bb36
   bb36:
-    v97 = storage_array_data_slot v93
-    v98 = div 0, 32
-    v99 = add v97, v98
-    v100 = mod 0, 32
-    v101 = mul v100, 1
-    v102 = sload v99 !metadata(storage=symbolic(v99))
-    v103 = mul v101, 8
-    v104 = shr v103, v102
-    v105 = and v104, 255
-    v106 = sload 4 !metadata(storage=slot(4))
-    v107 = lt 0, v106
-    v108 = iszero v107
-    jumpi v108, bb37, bb38
+    v102 = storage_array_data_slot 4
+    v103 = add v102, 0
+    v104 = sload v103 !metadata(storage=symbolic(v102))
+    v105 = lt 0, v104
+    v106 = iszero v105
+    jumpi v106, bb37, bb38
   bb38:
-    v109 = storage_array_data_slot 4
-    v110 = add v109, 0
-    v111 = sload v110 !metadata(storage=symbolic(v109))
-    v112 = lt 1, v111
-    v113 = iszero v112
-    jumpi v113, bb39, bb40
+    v107 = storage_array_data_slot v103
+    v108 = div 0, 32
+    v109 = add v107, v108
+    v110 = mod 0, 32
+    v111 = mul v110, 1
+    v112 = sload v109 !metadata(storage=symbolic(v109))
+    v113 = mul v111, 8
+    v114 = shr v113, v112
+    v115 = and v114, 255
+    v116 = sload 4 !metadata(storage=slot(4))
+    v117 = lt 0, v116
+    v118 = iszero v117
+    jumpi v118, bb39, bb40
   bb40:
-    v114 = storage_array_data_slot v110
-    v115 = div 1, 32
-    v116 = add v114, v115
-    v117 = mod 1, 32
-    v118 = mul v117, 1
-    v119 = sload v116 !metadata(storage=symbolic(v116))
-    v120 = mul v118, 8
-    v121 = shr v120, v119
-    v122 = and v121, 255
-    v123 = add v105, v122
-    v124 = gt v123, 255
-    jumpi v124, bb41, bb42
+    v119 = storage_array_data_slot 4
+    v120 = add v119, 0
+    v121 = sload v120 !metadata(storage=symbolic(v119))
+    v122 = lt 1, v121
+    v123 = iszero v122
+    jumpi v123, bb41, bb42
   bb42:
-    v125 = sload 4 !metadata(storage=slot(4))
-    v126 = lt 1, v125
-    v127 = iszero v126
-    jumpi v127, bb43, bb44
+    v124 = storage_array_data_slot v120
+    v125 = div 1, 32
+    v126 = add v124, v125
+    v127 = mod 1, 32
+    v128 = mul v127, 1
+    v129 = sload v126 !metadata(storage=symbolic(v126))
+    v130 = mul v128, 8
+    v131 = shr v130, v129
+    v132 = and v131, 255
+    v133 = add v115, v132
+    v134 = gt v133, 255
+    jumpi v134, bb43, bb44
   bb44:
-    v128 = storage_array_data_slot 4
-    v129 = add v128, 1
-    v130 = sload v129 !metadata(storage=offset(v128, 1))
-    v131 = lt 0, v130
-    v132 = iszero v131
-    jumpi v132, bb45, bb46
+    v135 = sload 4 !metadata(storage=slot(4))
+    v136 = lt 1, v135
+    v137 = iszero v136
+    jumpi v137, bb45, bb46
   bb46:
-    v133 = storage_array_data_slot v129
-    v134 = div 0, 32
-    v135 = add v133, v134
-    v136 = mod 0, 32
-    v137 = mul v136, 1
-    v138 = sload v135 !metadata(storage=symbolic(v135))
-    v139 = mul v137, 8
-    v140 = shr v139, v138
-    v141 = and v140, 255
-    v142 = add v123, v141
-    v143 = gt v142, 255
-    jumpi v143, bb47, bb48
+    v138 = storage_array_data_slot 4
+    v139 = add v138, 1
+    v140 = sload v139 !metadata(storage=offset(v138, 1))
+    v141 = lt 0, v140
+    v142 = iszero v141
+    jumpi v142, bb47, bb48
   bb48:
-    v144 = sload 4 !metadata(storage=slot(4))
-    v145 = lt 1, v144
-    v146 = iszero v145
-    jumpi v146, bb49, bb50
+    v143 = storage_array_data_slot v139
+    v144 = div 0, 32
+    v145 = add v143, v144
+    v146 = mod 0, 32
+    v147 = mul v146, 1
+    v148 = sload v145 !metadata(storage=symbolic(v145))
+    v149 = mul v147, 8
+    v150 = shr v149, v148
+    v151 = and v150, 255
+    v152 = add v133, v151
+    v153 = gt v152, 255
+    jumpi v153, bb49, bb50
   bb50:
-    v147 = storage_array_data_slot 4
-    v148 = add v147, 1
-    v149 = sload v148 !metadata(storage=offset(v147, 1))
-    v150 = lt 1, v149
-    v151 = iszero v150
-    jumpi v151, bb51, bb52
+    v154 = sload 4 !metadata(storage=slot(4))
+    v155 = lt 1, v154
+    v156 = iszero v155
+    jumpi v156, bb51, bb52
   bb52:
-    v152 = storage_array_data_slot v148
-    v153 = div 1, 32
-    v154 = add v152, v153
-    v155 = mod 1, 32
-    v156 = mul v155, 1
-    v157 = sload v154 !metadata(storage=symbolic(v154))
-    v158 = mul v156, 8
-    v159 = shr v158, v157
-    v160 = and v159, 255
-    v161 = add v142, v160
-    v162 = gt v161, 255
-    jumpi v162, bb53, bb54
+    v157 = storage_array_data_slot 4
+    v158 = add v157, 1
+    v159 = sload v158 !metadata(storage=offset(v157, 1))
+    v160 = lt 1, v159
+    v161 = iszero v160
+    jumpi v161, bb53, bb54
   bb54:
-    ret v161
-  bb53:
+    v162 = storage_array_data_slot v158
+    v163 = div 1, 32
+    v164 = add v162, v163
+    v165 = mod 1, 32
+    v166 = mul v165, 1
+    v167 = sload v164 !metadata(storage=symbolic(v164))
+    v168 = mul v166, 8
+    v169 = shr v168, v167
+    v170 = and v169, 255
+    v171 = add v152, v170
+    v172 = gt v171, 255
+    jumpi v172, bb55, bb56
+  bb56:
+    ret v171
+  bb55:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb53:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb51:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1669,11 +1763,11 @@ fn @copyFixed() -> u256 [selector=0x23235673, abi_params=[], abi_returns=[word]]
     revert 0, 36
   bb49:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb47:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb45:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1681,11 +1775,11 @@ fn @copyFixed() -> u256 [selector=0x23235673, abi_params=[], abi_returns=[word]]
     revert 0, 36
   bb43:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb41:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb39:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1696,10 +1790,6 @@ fn @copyFixed() -> u256 [selector=0x23235673, abi_params=[], abi_returns=[word]]
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb35:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -1736,7 +1826,22 @@ fn @copyFixed() -> u256 [selector=0x23235673, abi_params=[], abi_returns=[word]]
     v72 = lt v71, v52
     jumpi v72, bb31, bb32
   bb32:
-    v88 = add v44, 1
+    v88 = shr 5, v52
+    v89 = and v52, 31
+    v90 = iszero v89
+    jumpi v90, bb34, bb33
+  bb33:
+    v91 = mul v89, 8
+    v92 = shl v91, 1
+    v93 = sub v92, 1
+    v94 = storage_array_data_slot v51
+    v95 = add v94, v88
+    v96 = sload v95 !metadata(storage=symbolic(v95))
+    v97 = and v96, v93
+    sstore v95, v97 !metadata(storage=symbolic(v95))
+    jump bb34
+  bb34:
+    v98 = add v44, 1
     jump bb20
   bb31:
     v73 = memory_object_load_element memoryarray<1>, v49, v71
@@ -1861,124 +1966,162 @@ fn @copyMixed() -> u256 [selector=0x0eb8f89e, abi_params=[], abi_returns=[word]]
     v33 = lt v32, v13
     jumpi v33, bb9, bb10
   bb10:
-    v49 = add 5, 1
-    v50 = memory_object_load_element memoryfixedarray<2, 1>, v6, 1
-    v51 = memory_object_len memoryarray, v50
-    v52 = sload v49 !metadata(storage=slot(6))
-    v53 = gt v52, v51
-    jumpi v53, bb11, bb12
+    v49 = shr 5, v13
+    v50 = and v13, 31
+    v51 = iszero v50
+    jumpi v51, bb12, bb11
   bb11:
-    jump bb13
-  bb13:
-    v54 = phi [bb11: v51], [bb14: v69]
-    v55 = lt v54, v52
-    jumpi v55, bb14, bb15
-  bb15:
+    v52 = mul v50, 8
+    v53 = shl v52, 1
+    v54 = sub v53, 1
+    v55 = storage_array_data_slot v11
+    v56 = add v55, v49
+    v57 = sload v56 !metadata(storage=symbolic(v56))
+    v58 = and v57, v54
+    sstore v56, v58 !metadata(storage=symbolic(v56))
     jump bb12
   bb12:
-    sstore v49, v51 !metadata(storage=slot(6))
-    jump bb16
-  bb16:
-    v70 = phi [bb12: 0], [bb17: v86]
-    v71 = lt v70, v51
-    jumpi v71, bb17, bb18
+    v59 = add 5, 1
+    v60 = memory_object_load_element memoryfixedarray<2, 1>, v6, 1
+    v61 = memory_object_len memoryarray, v60
+    v62 = sload v59 !metadata(storage=slot(6))
+    v63 = gt v62, v61
+    jumpi v63, bb13, bb14
+  bb13:
+    jump bb15
+  bb15:
+    v64 = phi [bb13: v61], [bb16: v79]
+    v65 = lt v64, v62
+    jumpi v65, bb16, bb17
+  bb17:
+    jump bb14
+  bb14:
+    sstore v59, v61 !metadata(storage=slot(6))
+    jump bb18
   bb18:
-    v87 = lt 0, 2
-    v88 = iszero v87
-    jumpi v88, bb19, bb20
+    v80 = phi [bb14: 0], [bb19: v96]
+    v81 = lt v80, v61
+    jumpi v81, bb19, bb20
   bb20:
-    v89 = add 5, 0
-    v90 = sload v89 !metadata(storage=slot(5))
-    v91 = lt 0, v90
-    v92 = iszero v91
-    jumpi v92, bb21, bb22
+    v97 = shr 5, v61
+    v98 = and v61, 31
+    v99 = iszero v98
+    jumpi v99, bb22, bb21
+  bb21:
+    v100 = mul v98, 8
+    v101 = shl v100, 1
+    v102 = sub v101, 1
+    v103 = storage_array_data_slot v59
+    v104 = add v103, v97
+    v105 = sload v104 !metadata(storage=symbolic(v104))
+    v106 = and v105, v102
+    sstore v104, v106 !metadata(storage=symbolic(v104))
+    jump bb22
   bb22:
-    v93 = storage_array_data_slot v89
-    v94 = div 0, 32
-    v95 = add v93, v94
-    v96 = mod 0, 32
-    v97 = mul v96, 1
-    v98 = sload v95 !metadata(storage=symbolic(v95))
-    v99 = mul v97, 8
-    v100 = shr v99, v98
-    v101 = and v100, 255
-    v102 = lt 0, 2
-    v103 = iszero v102
-    jumpi v103, bb23, bb24
+    v107 = lt 0, 2
+    v108 = iszero v107
+    jumpi v108, bb23, bb24
   bb24:
-    v104 = add 5, 0
-    v105 = sload v104 !metadata(storage=slot(5))
-    v106 = lt 1, v105
-    v107 = iszero v106
-    jumpi v107, bb25, bb26
+    v109 = add 5, 0
+    v110 = sload v109 !metadata(storage=slot(5))
+    v111 = lt 0, v110
+    v112 = iszero v111
+    jumpi v112, bb25, bb26
   bb26:
-    v108 = storage_array_data_slot v104
-    v109 = div 1, 32
-    v110 = add v108, v109
-    v111 = mod 1, 32
-    v112 = mul v111, 1
-    v113 = sload v110 !metadata(storage=symbolic(v110))
-    v114 = mul v112, 8
-    v115 = shr v114, v113
-    v116 = and v115, 255
-    v117 = add v101, v116
-    v118 = gt v117, 255
-    jumpi v118, bb27, bb28
+    v113 = storage_array_data_slot v109
+    v114 = div 0, 32
+    v115 = add v113, v114
+    v116 = mod 0, 32
+    v117 = mul v116, 1
+    v118 = sload v115 !metadata(storage=symbolic(v115))
+    v119 = mul v117, 8
+    v120 = shr v119, v118
+    v121 = and v120, 255
+    v122 = lt 0, 2
+    v123 = iszero v122
+    jumpi v123, bb27, bb28
   bb28:
-    v119 = lt 1, 2
-    v120 = iszero v119
-    jumpi v120, bb29, bb30
+    v124 = add 5, 0
+    v125 = sload v124 !metadata(storage=slot(5))
+    v126 = lt 1, v125
+    v127 = iszero v126
+    jumpi v127, bb29, bb30
   bb30:
-    v121 = add 5, 1
-    v122 = sload v121 !metadata(storage=slot(6))
-    v123 = lt 0, v122
-    v124 = iszero v123
-    jumpi v124, bb31, bb32
+    v128 = storage_array_data_slot v124
+    v129 = div 1, 32
+    v130 = add v128, v129
+    v131 = mod 1, 32
+    v132 = mul v131, 1
+    v133 = sload v130 !metadata(storage=symbolic(v130))
+    v134 = mul v132, 8
+    v135 = shr v134, v133
+    v136 = and v135, 255
+    v137 = add v121, v136
+    v138 = gt v137, 255
+    jumpi v138, bb31, bb32
   bb32:
-    v125 = storage_array_data_slot v121
-    v126 = div 0, 32
-    v127 = add v125, v126
-    v128 = mod 0, 32
-    v129 = mul v128, 1
-    v130 = sload v127 !metadata(storage=symbolic(v127))
-    v131 = mul v129, 8
-    v132 = shr v131, v130
-    v133 = and v132, 255
-    v134 = add v117, v133
-    v135 = gt v134, 255
-    jumpi v135, bb33, bb34
+    v139 = lt 1, 2
+    v140 = iszero v139
+    jumpi v140, bb33, bb34
   bb34:
-    v136 = lt 1, 2
-    v137 = iszero v136
-    jumpi v137, bb35, bb36
+    v141 = add 5, 1
+    v142 = sload v141 !metadata(storage=slot(6))
+    v143 = lt 0, v142
+    v144 = iszero v143
+    jumpi v144, bb35, bb36
   bb36:
-    v138 = add 5, 1
-    v139 = sload v138 !metadata(storage=slot(6))
-    v140 = lt 1, v139
-    v141 = iszero v140
-    jumpi v141, bb37, bb38
+    v145 = storage_array_data_slot v141
+    v146 = div 0, 32
+    v147 = add v145, v146
+    v148 = mod 0, 32
+    v149 = mul v148, 1
+    v150 = sload v147 !metadata(storage=symbolic(v147))
+    v151 = mul v149, 8
+    v152 = shr v151, v150
+    v153 = and v152, 255
+    v154 = add v137, v153
+    v155 = gt v154, 255
+    jumpi v155, bb37, bb38
   bb38:
-    v142 = storage_array_data_slot v138
-    v143 = div 1, 32
-    v144 = add v142, v143
-    v145 = mod 1, 32
-    v146 = mul v145, 1
-    v147 = sload v144 !metadata(storage=symbolic(v144))
-    v148 = mul v146, 8
-    v149 = shr v148, v147
-    v150 = and v149, 255
-    v151 = add v134, v150
-    v152 = gt v151, 255
-    jumpi v152, bb39, bb40
+    v156 = lt 1, 2
+    v157 = iszero v156
+    jumpi v157, bb39, bb40
   bb40:
-    ret v151
-  bb39:
+    v158 = add 5, 1
+    v159 = sload v158 !metadata(storage=slot(6))
+    v160 = lt 1, v159
+    v161 = iszero v160
+    jumpi v161, bb41, bb42
+  bb42:
+    v162 = storage_array_data_slot v158
+    v163 = div 1, 32
+    v164 = add v162, v163
+    v165 = mod 1, 32
+    v166 = mul v165, 1
+    v167 = sload v164 !metadata(storage=symbolic(v164))
+    v168 = mul v166, 8
+    v169 = shr v168, v167
+    v170 = and v169, 255
+    v171 = add v154, v170
+    v172 = gt v171, 255
+    jumpi v172, bb43, bb44
+  bb44:
+    ret v171
+  bb43:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
-  bb37:
+  bb41:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb39:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
+    revert 0, 36
+  bb37:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb35:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1986,11 +2129,11 @@ fn @copyMixed() -> u256 [selector=0x0eb8f89e, abi_params=[], abi_returns=[word]]
     revert 0, 36
   bb33:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb31:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb29:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1998,7 +2141,7 @@ fn @copyMixed() -> u256 [selector=0x0eb8f89e, abi_params=[], abi_returns=[word]]
     revert 0, 36
   bb27:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb25:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -2008,49 +2151,41 @@ fn @copyMixed() -> u256 [selector=0x0eb8f89e, abi_params=[], abi_returns=[word]]
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
-  bb21:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
   bb19:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb17:
-    v72 = memory_object_load_element memoryarray<1>, v50, v70
-    v73 = storage_array_data_slot v49
-    v74 = div v70, 32
-    v75 = add v73, v74
-    v76 = mod v70, 32
-    v77 = mul v76, 1
-    v78 = mul v77, 8
-    v79 = shl v78, 255
-    v80 = sload v75 !metadata(storage=symbolic(v75))
-    v81 = not v79
-    v82 = and v80, v81
-    v83 = and v72, 255
-    v84 = shl v78, v83
-    v85 = or v82, v84
-    sstore v75, v85 !metadata(storage=symbolic(v75))
-    v86 = add v70, 1
-    jump bb16
-  bb14:
-    v56 = storage_array_data_slot v49
-    v57 = div v54, 32
-    v58 = add v56, v57
-    v59 = mod v54, 32
-    v60 = mul v59, 1
-    v61 = mul v60, 8
-    v62 = shl v61, 255
-    v63 = sload v58 !metadata(storage=symbolic(v58))
-    v64 = not v62
-    v65 = and v63, v64
-    v66 = and 0, 255
-    v67 = shl v61, v66
-    v68 = or v65, v67
-    sstore v58, v68 !metadata(storage=symbolic(v58))
-    v69 = add v54, 1
-    jump bb13
+    v82 = memory_object_load_element memoryarray<1>, v60, v80
+    v83 = storage_array_data_slot v59
+    v84 = div v80, 32
+    v85 = add v83, v84
+    v86 = mod v80, 32
+    v87 = mul v86, 1
+    v88 = mul v87, 8
+    v89 = shl v88, 255
+    v90 = sload v85 !metadata(storage=symbolic(v85))
+    v91 = not v89
+    v92 = and v90, v91
+    v93 = and v82, 255
+    v94 = shl v88, v93
+    v95 = or v92, v94
+    sstore v85, v95 !metadata(storage=symbolic(v85))
+    v96 = add v80, 1
+    jump bb18
+  bb16:
+    v66 = storage_array_data_slot v59
+    v67 = div v64, 32
+    v68 = add v66, v67
+    v69 = mod v64, 32
+    v70 = mul v69, 1
+    v71 = mul v70, 8
+    v72 = shl v71, 255
+    v73 = sload v68 !metadata(storage=symbolic(v68))
+    v74 = not v72
+    v75 = and v73, v74
+    v76 = and 0, 255
+    v77 = shl v71, v76
+    v78 = or v75, v77
+    sstore v68, v78 !metadata(storage=symbolic(v68))
+    v79 = add v64, 1
+    jump bb15
   bb9:
     v34 = memory_object_load_element memoryarray<1>, v12, v32
     v35 = storage_array_data_slot v11

--- a/tests/ui/codegen/lowering/run-call/storage_nested_struct_calldata.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_nested_struct_calldata.mir.stdout
@@ -53,107 +53,111 @@ fn @copy(arg0: calldataslice) -> u256 [selector=0xc58b68ae, abi_params=[array<_,
     sstore 0, v137 !metadata(storage=slot(0))
     jump bb71
   bb71:
-    v164 = phi [bb61: 0], [bb86: v270]
+    v164 = phi [bb61: 0], [bb86: v280]
     v165 = lt v164, v137
     jumpi v165, bb72, bb73
   bb73:
-    v271 = sload 0 !metadata(storage=slot(0))
-    v272 = lt 0, v271
-    v273 = iszero v272
-    jumpi v273, bb97, bb98
-  bb98:
-    v274 = storage_array_data_slot 0
-    v275 = add v274, 0
-    v276 = sload v275 !metadata(storage=symbolic(v274))
-    v277 = lt 1, v276
-    v278 = iszero v277
-    jumpi v278, bb99, bb100
+    v281 = sload 0 !metadata(storage=slot(0))
+    v282 = lt 0, v281
+    v283 = iszero v282
+    jumpi v283, bb99, bb100
   bb100:
-    v279 = storage_array_data_slot v275
-    v280 = mul 1, 2
-    v281 = add v279, v280
-    v282 = sload v281 !metadata(storage=symbolic(v281))
-    v283 = lt 1, v282
-    v284 = iszero v283
-    jumpi v284, bb101, bb102
+    v284 = storage_array_data_slot 0
+    v285 = add v284, 0
+    v286 = sload v285 !metadata(storage=symbolic(v284))
+    v287 = lt 1, v286
+    v288 = iszero v287
+    jumpi v288, bb101, bb102
   bb102:
-    v285 = storage_array_data_slot v281
-    v286 = div 1, 32
-    v287 = add v285, v286
-    v288 = mod 1, 32
-    v289 = mul v288, 1
-    v290 = sload v287 !metadata(storage=symbolic(v287))
-    v291 = mul v289, 8
-    v292 = shr v291, v290
-    v293 = and v292, 255
-    v294 = sload 0 !metadata(storage=slot(0))
-    v295 = lt 0, v294
-    v296 = iszero v295
-    jumpi v296, bb103, bb104
+    v289 = storage_array_data_slot v285
+    v290 = mul 1, 2
+    v291 = add v289, v290
+    v292 = sload v291 !metadata(storage=symbolic(v291))
+    v293 = lt 1, v292
+    v294 = iszero v293
+    jumpi v294, bb103, bb104
   bb104:
-    v297 = storage_array_data_slot 0
-    v298 = add v297, 0
-    v299 = sload v298 !metadata(storage=symbolic(v297))
-    v300 = lt 0, v299
-    v301 = iszero v300
-    jumpi v301, bb105, bb106
+    v295 = storage_array_data_slot v291
+    v296 = div 1, 32
+    v297 = add v295, v296
+    v298 = mod 1, 32
+    v299 = mul v298, 1
+    v300 = sload v297 !metadata(storage=symbolic(v297))
+    v301 = mul v299, 8
+    v302 = shr v301, v300
+    v303 = and v302, 255
+    v304 = sload 0 !metadata(storage=slot(0))
+    v305 = lt 0, v304
+    v306 = iszero v305
+    jumpi v306, bb105, bb106
   bb106:
-    v302 = storage_array_data_slot v298
-    v303 = mul 0, 2
-    v304 = add v302, v303
-    v305 = add v304, 1
-    v306 = lt 0, 2
-    v307 = iszero v306
-    jumpi v307, bb107, bb108
+    v307 = storage_array_data_slot 0
+    v308 = add v307, 0
+    v309 = sload v308 !metadata(storage=symbolic(v307))
+    v310 = lt 0, v309
+    v311 = iszero v310
+    jumpi v311, bb107, bb108
   bb108:
-    v308 = div 0, 32
-    v309 = add v305, v308
-    v310 = mod 0, 32
-    v311 = mul v310, 1
-    v312 = sload v309 !metadata(storage=symbolic(v309))
-    v313 = mul v311, 8
-    v314 = shr v313, v312
-    v315 = and v314, 255
-    v316 = add v293, v315
-    v317 = gt v316, 255
+    v312 = storage_array_data_slot v308
+    v313 = mul 0, 2
+    v314 = add v312, v313
+    v315 = add v314, 1
+    v316 = lt 0, 2
+    v317 = iszero v316
     jumpi v317, bb109, bb110
   bb110:
-    v318 = sload 0 !metadata(storage=slot(0))
-    v319 = lt 0, v318
-    v320 = iszero v319
-    jumpi v320, bb111, bb112
+    v318 = div 0, 32
+    v319 = add v315, v318
+    v320 = mod 0, 32
+    v321 = mul v320, 1
+    v322 = sload v319 !metadata(storage=symbolic(v319))
+    v323 = mul v321, 8
+    v324 = shr v323, v322
+    v325 = and v324, 255
+    v326 = add v303, v325
+    v327 = gt v326, 255
+    jumpi v327, bb111, bb112
   bb112:
-    v321 = storage_array_data_slot 0
-    v322 = add v321, 0
-    v323 = sload v322 !metadata(storage=symbolic(v321))
-    v324 = lt 1, v323
-    v325 = iszero v324
-    jumpi v325, bb113, bb114
+    v328 = sload 0 !metadata(storage=slot(0))
+    v329 = lt 0, v328
+    v330 = iszero v329
+    jumpi v330, bb113, bb114
   bb114:
-    v326 = storage_array_data_slot v322
-    v327 = mul 1, 2
-    v328 = add v326, v327
-    v329 = add v328, 1
-    v330 = lt 1, 2
-    v331 = iszero v330
-    jumpi v331, bb115, bb116
+    v331 = storage_array_data_slot 0
+    v332 = add v331, 0
+    v333 = sload v332 !metadata(storage=symbolic(v331))
+    v334 = lt 1, v333
+    v335 = iszero v334
+    jumpi v335, bb115, bb116
   bb116:
-    v332 = div 1, 32
-    v333 = add v329, v332
-    v334 = mod 1, 32
-    v335 = mul v334, 1
-    v336 = sload v333 !metadata(storage=symbolic(v333))
-    v337 = mul v335, 8
-    v338 = shr v337, v336
-    v339 = and v338, 255
-    v340 = add v316, v339
-    v341 = gt v340, 255
+    v336 = storage_array_data_slot v332
+    v337 = mul 1, 2
+    v338 = add v336, v337
+    v339 = add v338, 1
+    v340 = lt 1, 2
+    v341 = iszero v340
     jumpi v341, bb117, bb118
   bb118:
-    ret v340
-  bb117:
+    v342 = div 1, 32
+    v343 = add v339, v342
+    v344 = mod 1, 32
+    v345 = mul v344, 1
+    v346 = sload v343 !metadata(storage=symbolic(v343))
+    v347 = mul v345, 8
+    v348 = shr v347, v346
+    v349 = and v348, 255
+    v350 = add v326, v349
+    v351 = gt v350, 255
+    jumpi v351, bb119, bb120
+  bb120:
+    ret v350
+  bb119:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb117:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb115:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -165,11 +169,11 @@ fn @copy(arg0: calldataslice) -> u256 [selector=0xc58b68ae, abi_params=[array<_,
     revert 0, 36
   bb111:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb109:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb107:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -188,10 +192,6 @@ fn @copy(arg0: calldataslice) -> u256 [selector=0xc58b68ae, abi_params=[array<_,
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb99:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb97:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -224,11 +224,11 @@ fn @copy(arg0: calldataslice) -> u256 [selector=0xc58b68ae, abi_params=[array<_,
     sstore v171, v172 !metadata(storage=symbolic(v171))
     jump bb84
   bb84:
-    v193 = phi [bb77: 0], [bb96: v269]
+    v193 = phi [bb77: 0], [bb98: v279]
     v194 = lt v193, v172
     jumpi v194, bb85, bb86
   bb86:
-    v270 = add v164, 1
+    v280 = add v164, 1
     jump bb71
   bb85:
     v195 = memory_object_load_element memoryarray<1>, v169, v193
@@ -270,37 +270,52 @@ fn @copy(arg0: calldataslice) -> u256 [selector=0xc58b68ae, abi_params=[array<_,
     v225 = lt v224, v205
     jumpi v225, bb95, bb96
   bb96:
-    v241 = add v203, 1
-    v242 = memory_object_load_field memorystruct<2>, v200, 1
-    v243 = div 0, 32
-    v244 = add v241, v243
-    v245 = mod 0, 32
-    v246 = mul v245, 1
-    v247 = memory_object_load_element memoryfixedarray<2, 1>, v242, 0
-    v248 = mul v246, 8
-    v249 = shl v248, 255
-    v250 = sload v244 !metadata(storage=symbolic(v244))
-    v251 = not v249
-    v252 = and v250, v251
-    v253 = and v247, 255
-    v254 = shl v248, v253
-    v255 = or v252, v254
-    sstore v244, v255 !metadata(storage=symbolic(v244))
-    v256 = div 1, 32
-    v257 = add v241, v256
-    v258 = mod 1, 32
-    v259 = mul v258, 1
-    v260 = memory_object_load_element memoryfixedarray<2, 1>, v242, 1
-    v261 = mul v259, 8
-    v262 = shl v261, 255
-    v263 = sload v257 !metadata(storage=symbolic(v257))
-    v264 = not v262
-    v265 = and v263, v264
-    v266 = and v260, 255
-    v267 = shl v261, v266
-    v268 = or v265, v267
-    sstore v257, v268 !metadata(storage=symbolic(v257))
-    v269 = add v193, 1
+    v241 = shr 5, v205
+    v242 = and v205, 31
+    v243 = iszero v242
+    jumpi v243, bb98, bb97
+  bb97:
+    v244 = mul v242, 8
+    v245 = shl v244, 1
+    v246 = sub v245, 1
+    v247 = storage_array_data_slot v203
+    v248 = add v247, v241
+    v249 = sload v248 !metadata(storage=symbolic(v248))
+    v250 = and v249, v246
+    sstore v248, v250 !metadata(storage=symbolic(v248))
+    jump bb98
+  bb98:
+    v251 = add v203, 1
+    v252 = memory_object_load_field memorystruct<2>, v200, 1
+    v253 = div 0, 32
+    v254 = add v251, v253
+    v255 = mod 0, 32
+    v256 = mul v255, 1
+    v257 = memory_object_load_element memoryfixedarray<2, 1>, v252, 0
+    v258 = mul v256, 8
+    v259 = shl v258, 255
+    v260 = sload v254 !metadata(storage=symbolic(v254))
+    v261 = not v259
+    v262 = and v260, v261
+    v263 = and v257, 255
+    v264 = shl v258, v263
+    v265 = or v262, v264
+    sstore v254, v265 !metadata(storage=symbolic(v254))
+    v266 = div 1, 32
+    v267 = add v251, v266
+    v268 = mod 1, 32
+    v269 = mul v268, 1
+    v270 = memory_object_load_element memoryfixedarray<2, 1>, v252, 1
+    v271 = mul v269, 8
+    v272 = shl v271, 255
+    v273 = sload v267 !metadata(storage=symbolic(v267))
+    v274 = not v272
+    v275 = and v273, v274
+    v276 = and v270, 255
+    v277 = shl v271, v276
+    v278 = or v275, v277
+    sstore v267, v278 !metadata(storage=symbolic(v267))
+    v279 = add v193, 1
     jump bb84
   bb95:
     v226 = memory_object_load_element memoryarray<1>, v204, v224
@@ -731,101 +746,105 @@ fn @copyFixed(arg0: calldataslice) -> u256 [selector=0x39bd9a66, abi_params=[arr
     sstore v113, v115 !metadata(storage=slot(1))
     jump bb57
   bb57:
-    v136 = phi [bb50: 0], [bb69: v212]
+    v136 = phi [bb50: 0], [bb71: v222]
     v137 = lt v136, v115
     jumpi v137, bb58, bb59
   bb59:
-    v213 = lt 0, 1
-    v214 = iszero v213
-    jumpi v214, bb70, bb71
-  bb71:
-    v215 = add 1, 0
-    v216 = sload v215 !metadata(storage=slot(1))
-    v217 = lt 1, v216
-    v218 = iszero v217
-    jumpi v218, bb72, bb73
-  bb73:
-    v219 = storage_array_data_slot v215
-    v220 = mul 1, 2
-    v221 = add v219, v220
-    v222 = sload v221 !metadata(storage=symbolic(v221))
-    v223 = lt 1, v222
+    v223 = lt 0, 1
     v224 = iszero v223
-    jumpi v224, bb74, bb75
+    jumpi v224, bb72, bb73
+  bb73:
+    v225 = add 1, 0
+    v226 = sload v225 !metadata(storage=slot(1))
+    v227 = lt 1, v226
+    v228 = iszero v227
+    jumpi v228, bb74, bb75
   bb75:
-    v225 = storage_array_data_slot v221
-    v226 = div 1, 32
-    v227 = add v225, v226
-    v228 = mod 1, 32
-    v229 = mul v228, 1
-    v230 = sload v227 !metadata(storage=symbolic(v227))
-    v231 = mul v229, 8
-    v232 = shr v231, v230
-    v233 = and v232, 255
-    v234 = lt 0, 1
-    v235 = iszero v234
-    jumpi v235, bb76, bb77
+    v229 = storage_array_data_slot v225
+    v230 = mul 1, 2
+    v231 = add v229, v230
+    v232 = sload v231 !metadata(storage=symbolic(v231))
+    v233 = lt 1, v232
+    v234 = iszero v233
+    jumpi v234, bb76, bb77
   bb77:
-    v236 = add 1, 0
-    v237 = sload v236 !metadata(storage=slot(1))
-    v238 = lt 0, v237
-    v239 = iszero v238
-    jumpi v239, bb78, bb79
-  bb79:
-    v240 = storage_array_data_slot v236
-    v241 = mul 0, 2
-    v242 = add v240, v241
-    v243 = add v242, 1
-    v244 = lt 0, 2
+    v235 = storage_array_data_slot v231
+    v236 = div 1, 32
+    v237 = add v235, v236
+    v238 = mod 1, 32
+    v239 = mul v238, 1
+    v240 = sload v237 !metadata(storage=symbolic(v237))
+    v241 = mul v239, 8
+    v242 = shr v241, v240
+    v243 = and v242, 255
+    v244 = lt 0, 1
     v245 = iszero v244
-    jumpi v245, bb80, bb81
+    jumpi v245, bb78, bb79
+  bb79:
+    v246 = add 1, 0
+    v247 = sload v246 !metadata(storage=slot(1))
+    v248 = lt 0, v247
+    v249 = iszero v248
+    jumpi v249, bb80, bb81
   bb81:
-    v246 = div 0, 32
-    v247 = add v243, v246
-    v248 = mod 0, 32
-    v249 = mul v248, 1
-    v250 = sload v247 !metadata(storage=symbolic(v247))
-    v251 = mul v249, 8
-    v252 = shr v251, v250
-    v253 = and v252, 255
-    v254 = add v233, v253
-    v255 = gt v254, 255
+    v250 = storage_array_data_slot v246
+    v251 = mul 0, 2
+    v252 = add v250, v251
+    v253 = add v252, 1
+    v254 = lt 0, 2
+    v255 = iszero v254
     jumpi v255, bb82, bb83
   bb83:
-    v256 = lt 0, 1
-    v257 = iszero v256
-    jumpi v257, bb84, bb85
+    v256 = div 0, 32
+    v257 = add v253, v256
+    v258 = mod 0, 32
+    v259 = mul v258, 1
+    v260 = sload v257 !metadata(storage=symbolic(v257))
+    v261 = mul v259, 8
+    v262 = shr v261, v260
+    v263 = and v262, 255
+    v264 = add v243, v263
+    v265 = gt v264, 255
+    jumpi v265, bb84, bb85
   bb85:
-    v258 = add 1, 0
-    v259 = sload v258 !metadata(storage=slot(1))
-    v260 = lt 1, v259
-    v261 = iszero v260
-    jumpi v261, bb86, bb87
-  bb87:
-    v262 = storage_array_data_slot v258
-    v263 = mul 1, 2
-    v264 = add v262, v263
-    v265 = add v264, 1
-    v266 = lt 1, 2
+    v266 = lt 0, 1
     v267 = iszero v266
-    jumpi v267, bb88, bb89
+    jumpi v267, bb86, bb87
+  bb87:
+    v268 = add 1, 0
+    v269 = sload v268 !metadata(storage=slot(1))
+    v270 = lt 1, v269
+    v271 = iszero v270
+    jumpi v271, bb88, bb89
   bb89:
-    v268 = div 1, 32
-    v269 = add v265, v268
-    v270 = mod 1, 32
-    v271 = mul v270, 1
-    v272 = sload v269 !metadata(storage=symbolic(v269))
-    v273 = mul v271, 8
-    v274 = shr v273, v272
-    v275 = and v274, 255
-    v276 = add v254, v275
-    v277 = gt v276, 255
+    v272 = storage_array_data_slot v268
+    v273 = mul 1, 2
+    v274 = add v272, v273
+    v275 = add v274, 1
+    v276 = lt 1, 2
+    v277 = iszero v276
     jumpi v277, bb90, bb91
   bb91:
-    ret v276
-  bb90:
+    v278 = div 1, 32
+    v279 = add v275, v278
+    v280 = mod 1, 32
+    v281 = mul v280, 1
+    v282 = sload v279 !metadata(storage=symbolic(v279))
+    v283 = mul v281, 8
+    v284 = shr v283, v282
+    v285 = and v284, 255
+    v286 = add v264, v285
+    v287 = gt v286, 255
+    jumpi v287, bb92, bb93
+  bb93:
+    ret v286
+  bb92:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb90:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb88:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -837,11 +856,11 @@ fn @copyFixed(arg0: calldataslice) -> u256 [selector=0x39bd9a66, abi_params=[arr
     revert 0, 36
   bb84:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb82:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb80:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -860,10 +879,6 @@ fn @copyFixed(arg0: calldataslice) -> u256 [selector=0x39bd9a66, abi_params=[arr
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb72:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb70:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -907,37 +922,52 @@ fn @copyFixed(arg0: calldataslice) -> u256 [selector=0x39bd9a66, abi_params=[arr
     v168 = lt v167, v148
     jumpi v168, bb68, bb69
   bb69:
-    v184 = add v146, 1
-    v185 = memory_object_load_field memorystruct<2>, v143, 1
-    v186 = div 0, 32
-    v187 = add v184, v186
-    v188 = mod 0, 32
-    v189 = mul v188, 1
-    v190 = memory_object_load_element memoryfixedarray<2, 1>, v185, 0
-    v191 = mul v189, 8
-    v192 = shl v191, 255
-    v193 = sload v187 !metadata(storage=symbolic(v187))
-    v194 = not v192
-    v195 = and v193, v194
-    v196 = and v190, 255
-    v197 = shl v191, v196
-    v198 = or v195, v197
-    sstore v187, v198 !metadata(storage=symbolic(v187))
-    v199 = div 1, 32
-    v200 = add v184, v199
-    v201 = mod 1, 32
-    v202 = mul v201, 1
-    v203 = memory_object_load_element memoryfixedarray<2, 1>, v185, 1
-    v204 = mul v202, 8
-    v205 = shl v204, 255
-    v206 = sload v200 !metadata(storage=symbolic(v200))
-    v207 = not v205
-    v208 = and v206, v207
-    v209 = and v203, 255
-    v210 = shl v204, v209
-    v211 = or v208, v210
-    sstore v200, v211 !metadata(storage=symbolic(v200))
-    v212 = add v136, 1
+    v184 = shr 5, v148
+    v185 = and v148, 31
+    v186 = iszero v185
+    jumpi v186, bb71, bb70
+  bb70:
+    v187 = mul v185, 8
+    v188 = shl v187, 1
+    v189 = sub v188, 1
+    v190 = storage_array_data_slot v146
+    v191 = add v190, v184
+    v192 = sload v191 !metadata(storage=symbolic(v191))
+    v193 = and v192, v189
+    sstore v191, v193 !metadata(storage=symbolic(v191))
+    jump bb71
+  bb71:
+    v194 = add v146, 1
+    v195 = memory_object_load_field memorystruct<2>, v143, 1
+    v196 = div 0, 32
+    v197 = add v194, v196
+    v198 = mod 0, 32
+    v199 = mul v198, 1
+    v200 = memory_object_load_element memoryfixedarray<2, 1>, v195, 0
+    v201 = mul v199, 8
+    v202 = shl v201, 255
+    v203 = sload v197 !metadata(storage=symbolic(v197))
+    v204 = not v202
+    v205 = and v203, v204
+    v206 = and v200, 255
+    v207 = shl v201, v206
+    v208 = or v205, v207
+    sstore v197, v208 !metadata(storage=symbolic(v197))
+    v209 = div 1, 32
+    v210 = add v194, v209
+    v211 = mod 1, 32
+    v212 = mul v211, 1
+    v213 = memory_object_load_element memoryfixedarray<2, 1>, v195, 1
+    v214 = mul v212, 8
+    v215 = shl v214, 255
+    v216 = sload v210 !metadata(storage=symbolic(v210))
+    v217 = not v215
+    v218 = and v216, v217
+    v219 = and v213, 255
+    v220 = shl v214, v219
+    v221 = or v218, v220
+    sstore v210, v221 !metadata(storage=symbolic(v210))
+    v222 = add v136, 1
     jump bb57
   bb68:
     v169 = memory_object_load_element memoryarray<1>, v147, v167
@@ -1231,104 +1261,108 @@ fn @copyDynamicFixed(arg0: calldataslice) -> u256 [selector=0x62d70355, abi_para
     sstore 2, v115 !metadata(storage=slot(2))
     jump bb57
   bb57:
-    v138 = phi [bb50: 0], [bb69: v218]
+    v138 = phi [bb50: 0], [bb71: v228]
     v139 = lt v138, v115
     jumpi v139, bb58, bb59
   bb59:
-    v219 = sload 2 !metadata(storage=slot(2))
-    v220 = lt 1, v219
-    v221 = iszero v220
-    jumpi v221, bb70, bb71
-  bb71:
-    v222 = storage_array_data_slot 2
-    v223 = mul 1, 2
-    v224 = add v222, v223
-    v225 = lt 0, 1
-    v226 = iszero v225
-    jumpi v226, bb72, bb73
-  bb73:
-    v227 = mul 0, 2
-    v228 = add v224, v227
-    v229 = sload v228 !metadata(storage=symbolic(v228))
+    v229 = sload 2 !metadata(storage=slot(2))
     v230 = lt 1, v229
     v231 = iszero v230
-    jumpi v231, bb74, bb75
-  bb75:
-    v232 = storage_array_data_slot v228
-    v233 = div 1, 32
+    jumpi v231, bb72, bb73
+  bb73:
+    v232 = storage_array_data_slot 2
+    v233 = mul 1, 2
     v234 = add v232, v233
-    v235 = mod 1, 32
-    v236 = mul v235, 1
-    v237 = sload v234 !metadata(storage=symbolic(v234))
-    v238 = mul v236, 8
-    v239 = shr v238, v237
-    v240 = and v239, 255
-    v241 = sload 2 !metadata(storage=slot(2))
-    v242 = lt 0, v241
-    v243 = iszero v242
-    jumpi v243, bb76, bb77
+    v235 = lt 0, 1
+    v236 = iszero v235
+    jumpi v236, bb74, bb75
+  bb75:
+    v237 = mul 0, 2
+    v238 = add v234, v237
+    v239 = sload v238 !metadata(storage=symbolic(v238))
+    v240 = lt 1, v239
+    v241 = iszero v240
+    jumpi v241, bb76, bb77
   bb77:
-    v244 = storage_array_data_slot 2
-    v245 = mul 0, 2
-    v246 = add v244, v245
-    v247 = lt 0, 1
-    v248 = iszero v247
-    jumpi v248, bb78, bb79
-  bb79:
-    v249 = mul 0, 2
-    v250 = add v246, v249
-    v251 = add v250, 1
-    v252 = lt 0, 2
+    v242 = storage_array_data_slot v238
+    v243 = div 1, 32
+    v244 = add v242, v243
+    v245 = mod 1, 32
+    v246 = mul v245, 1
+    v247 = sload v244 !metadata(storage=symbolic(v244))
+    v248 = mul v246, 8
+    v249 = shr v248, v247
+    v250 = and v249, 255
+    v251 = sload 2 !metadata(storage=slot(2))
+    v252 = lt 0, v251
     v253 = iszero v252
-    jumpi v253, bb80, bb81
+    jumpi v253, bb78, bb79
+  bb79:
+    v254 = storage_array_data_slot 2
+    v255 = mul 0, 2
+    v256 = add v254, v255
+    v257 = lt 0, 1
+    v258 = iszero v257
+    jumpi v258, bb80, bb81
   bb81:
-    v254 = div 0, 32
-    v255 = add v251, v254
-    v256 = mod 0, 32
-    v257 = mul v256, 1
-    v258 = sload v255 !metadata(storage=symbolic(v255))
-    v259 = mul v257, 8
-    v260 = shr v259, v258
-    v261 = and v260, 255
-    v262 = add v240, v261
-    v263 = gt v262, 255
+    v259 = mul 0, 2
+    v260 = add v256, v259
+    v261 = add v260, 1
+    v262 = lt 0, 2
+    v263 = iszero v262
     jumpi v263, bb82, bb83
   bb83:
-    v264 = sload 2 !metadata(storage=slot(2))
-    v265 = lt 1, v264
-    v266 = iszero v265
-    jumpi v266, bb84, bb85
+    v264 = div 0, 32
+    v265 = add v261, v264
+    v266 = mod 0, 32
+    v267 = mul v266, 1
+    v268 = sload v265 !metadata(storage=symbolic(v265))
+    v269 = mul v267, 8
+    v270 = shr v269, v268
+    v271 = and v270, 255
+    v272 = add v250, v271
+    v273 = gt v272, 255
+    jumpi v273, bb84, bb85
   bb85:
-    v267 = storage_array_data_slot 2
-    v268 = mul 1, 2
-    v269 = add v267, v268
-    v270 = lt 0, 1
-    v271 = iszero v270
-    jumpi v271, bb86, bb87
-  bb87:
-    v272 = mul 0, 2
-    v273 = add v269, v272
-    v274 = add v273, 1
-    v275 = lt 1, 2
+    v274 = sload 2 !metadata(storage=slot(2))
+    v275 = lt 1, v274
     v276 = iszero v275
-    jumpi v276, bb88, bb89
+    jumpi v276, bb86, bb87
+  bb87:
+    v277 = storage_array_data_slot 2
+    v278 = mul 1, 2
+    v279 = add v277, v278
+    v280 = lt 0, 1
+    v281 = iszero v280
+    jumpi v281, bb88, bb89
   bb89:
-    v277 = div 1, 32
-    v278 = add v274, v277
-    v279 = mod 1, 32
-    v280 = mul v279, 1
-    v281 = sload v278 !metadata(storage=symbolic(v278))
-    v282 = mul v280, 8
-    v283 = shr v282, v281
-    v284 = and v283, 255
-    v285 = add v262, v284
-    v286 = gt v285, 255
+    v282 = mul 0, 2
+    v283 = add v279, v282
+    v284 = add v283, 1
+    v285 = lt 1, 2
+    v286 = iszero v285
     jumpi v286, bb90, bb91
   bb91:
-    ret v285
-  bb90:
+    v287 = div 1, 32
+    v288 = add v284, v287
+    v289 = mod 1, 32
+    v290 = mul v289, 1
+    v291 = sload v288 !metadata(storage=symbolic(v288))
+    v292 = mul v290, 8
+    v293 = shr v292, v291
+    v294 = and v293, 255
+    v295 = add v272, v294
+    v296 = gt v295, 255
+    jumpi v296, bb92, bb93
+  bb93:
+    ret v295
+  bb92:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb90:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb88:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1340,11 +1374,11 @@ fn @copyDynamicFixed(arg0: calldataslice) -> u256 [selector=0x62d70355, abi_para
     revert 0, 36
   bb84:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb82:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb80:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -1363,10 +1397,6 @@ fn @copyDynamicFixed(arg0: calldataslice) -> u256 [selector=0x62d70355, abi_para
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb72:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb70:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -1415,37 +1445,52 @@ fn @copyDynamicFixed(arg0: calldataslice) -> u256 [selector=0x62d70355, abi_para
     v174 = lt v173, v154
     jumpi v174, bb68, bb69
   bb69:
-    v190 = add v151, 1
-    v191 = memory_object_load_field memorystruct<2>, v152, 1
-    v192 = div 0, 32
-    v193 = add v190, v192
-    v194 = mod 0, 32
-    v195 = mul v194, 1
-    v196 = memory_object_load_element memoryfixedarray<2, 1>, v191, 0
-    v197 = mul v195, 8
-    v198 = shl v197, 255
-    v199 = sload v193 !metadata(storage=symbolic(v193))
-    v200 = not v198
-    v201 = and v199, v200
-    v202 = and v196, 255
-    v203 = shl v197, v202
-    v204 = or v201, v203
-    sstore v193, v204 !metadata(storage=symbolic(v193))
-    v205 = div 1, 32
-    v206 = add v190, v205
-    v207 = mod 1, 32
-    v208 = mul v207, 1
-    v209 = memory_object_load_element memoryfixedarray<2, 1>, v191, 1
-    v210 = mul v208, 8
-    v211 = shl v210, 255
-    v212 = sload v206 !metadata(storage=symbolic(v206))
-    v213 = not v211
-    v214 = and v212, v213
-    v215 = and v209, 255
-    v216 = shl v210, v215
-    v217 = or v214, v216
-    sstore v206, v217 !metadata(storage=symbolic(v206))
-    v218 = add v138, 1
+    v190 = shr 5, v154
+    v191 = and v154, 31
+    v192 = iszero v191
+    jumpi v192, bb71, bb70
+  bb70:
+    v193 = mul v191, 8
+    v194 = shl v193, 1
+    v195 = sub v194, 1
+    v196 = storage_array_data_slot v151
+    v197 = add v196, v190
+    v198 = sload v197 !metadata(storage=symbolic(v197))
+    v199 = and v198, v195
+    sstore v197, v199 !metadata(storage=symbolic(v197))
+    jump bb71
+  bb71:
+    v200 = add v151, 1
+    v201 = memory_object_load_field memorystruct<2>, v152, 1
+    v202 = div 0, 32
+    v203 = add v200, v202
+    v204 = mod 0, 32
+    v205 = mul v204, 1
+    v206 = memory_object_load_element memoryfixedarray<2, 1>, v201, 0
+    v207 = mul v205, 8
+    v208 = shl v207, 255
+    v209 = sload v203 !metadata(storage=symbolic(v203))
+    v210 = not v208
+    v211 = and v209, v210
+    v212 = and v206, 255
+    v213 = shl v207, v212
+    v214 = or v211, v213
+    sstore v203, v214 !metadata(storage=symbolic(v203))
+    v215 = div 1, 32
+    v216 = add v200, v215
+    v217 = mod 1, 32
+    v218 = mul v217, 1
+    v219 = memory_object_load_element memoryfixedarray<2, 1>, v201, 1
+    v220 = mul v218, 8
+    v221 = shl v220, 255
+    v222 = sload v216 !metadata(storage=symbolic(v216))
+    v223 = not v221
+    v224 = and v222, v223
+    v225 = and v219, 255
+    v226 = shl v220, v225
+    v227 = or v224, v226
+    sstore v216, v227 !metadata(storage=symbolic(v216))
+    v228 = add v138, 1
     jump bb57
   bb68:
     v175 = memory_object_load_element memoryarray<1>, v153, v173

--- a/tests/ui/codegen/lowering/run-call/storage_nested_struct_memory.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/storage_nested_struct_memory.mir.stdout
@@ -18,107 +18,111 @@ fn @copy(arg0: memoryarray) -> u256 [selector=0xc58b68ae, abi_params=[array<_, a
     sstore 0, v0 !metadata(storage=slot(0))
     jump bb12
   bb12:
-    v27 = phi [bb2: 0], [bb27: v133]
+    v27 = phi [bb2: 0], [bb27: v143]
     v28 = lt v27, v0
     jumpi v28, bb13, bb14
   bb14:
-    v134 = sload 0 !metadata(storage=slot(0))
-    v135 = lt 0, v134
-    v136 = iszero v135
-    jumpi v136, bb38, bb39
-  bb39:
-    v137 = storage_array_data_slot 0
-    v138 = add v137, 0
-    v139 = sload v138 !metadata(storage=symbolic(v137))
-    v140 = lt 1, v139
-    v141 = iszero v140
-    jumpi v141, bb40, bb41
+    v144 = sload 0 !metadata(storage=slot(0))
+    v145 = lt 0, v144
+    v146 = iszero v145
+    jumpi v146, bb40, bb41
   bb41:
-    v142 = storage_array_data_slot v138
-    v143 = mul 1, 2
-    v144 = add v142, v143
-    v145 = sload v144 !metadata(storage=symbolic(v144))
-    v146 = lt 1, v145
-    v147 = iszero v146
-    jumpi v147, bb42, bb43
+    v147 = storage_array_data_slot 0
+    v148 = add v147, 0
+    v149 = sload v148 !metadata(storage=symbolic(v147))
+    v150 = lt 1, v149
+    v151 = iszero v150
+    jumpi v151, bb42, bb43
   bb43:
-    v148 = storage_array_data_slot v144
-    v149 = div 1, 32
-    v150 = add v148, v149
-    v151 = mod 1, 32
-    v152 = mul v151, 1
-    v153 = sload v150 !metadata(storage=symbolic(v150))
-    v154 = mul v152, 8
-    v155 = shr v154, v153
-    v156 = and v155, 255
-    v157 = sload 0 !metadata(storage=slot(0))
-    v158 = lt 0, v157
-    v159 = iszero v158
-    jumpi v159, bb44, bb45
+    v152 = storage_array_data_slot v148
+    v153 = mul 1, 2
+    v154 = add v152, v153
+    v155 = sload v154 !metadata(storage=symbolic(v154))
+    v156 = lt 1, v155
+    v157 = iszero v156
+    jumpi v157, bb44, bb45
   bb45:
-    v160 = storage_array_data_slot 0
-    v161 = add v160, 0
-    v162 = sload v161 !metadata(storage=symbolic(v160))
-    v163 = lt 0, v162
-    v164 = iszero v163
-    jumpi v164, bb46, bb47
+    v158 = storage_array_data_slot v154
+    v159 = div 1, 32
+    v160 = add v158, v159
+    v161 = mod 1, 32
+    v162 = mul v161, 1
+    v163 = sload v160 !metadata(storage=symbolic(v160))
+    v164 = mul v162, 8
+    v165 = shr v164, v163
+    v166 = and v165, 255
+    v167 = sload 0 !metadata(storage=slot(0))
+    v168 = lt 0, v167
+    v169 = iszero v168
+    jumpi v169, bb46, bb47
   bb47:
-    v165 = storage_array_data_slot v161
-    v166 = mul 0, 2
-    v167 = add v165, v166
-    v168 = add v167, 1
-    v169 = lt 0, 2
-    v170 = iszero v169
-    jumpi v170, bb48, bb49
+    v170 = storage_array_data_slot 0
+    v171 = add v170, 0
+    v172 = sload v171 !metadata(storage=symbolic(v170))
+    v173 = lt 0, v172
+    v174 = iszero v173
+    jumpi v174, bb48, bb49
   bb49:
-    v171 = div 0, 32
-    v172 = add v168, v171
-    v173 = mod 0, 32
-    v174 = mul v173, 1
-    v175 = sload v172 !metadata(storage=symbolic(v172))
-    v176 = mul v174, 8
-    v177 = shr v176, v175
-    v178 = and v177, 255
-    v179 = add v156, v178
-    v180 = gt v179, 255
+    v175 = storage_array_data_slot v171
+    v176 = mul 0, 2
+    v177 = add v175, v176
+    v178 = add v177, 1
+    v179 = lt 0, 2
+    v180 = iszero v179
     jumpi v180, bb50, bb51
   bb51:
-    v181 = sload 0 !metadata(storage=slot(0))
-    v182 = lt 0, v181
-    v183 = iszero v182
-    jumpi v183, bb52, bb53
+    v181 = div 0, 32
+    v182 = add v178, v181
+    v183 = mod 0, 32
+    v184 = mul v183, 1
+    v185 = sload v182 !metadata(storage=symbolic(v182))
+    v186 = mul v184, 8
+    v187 = shr v186, v185
+    v188 = and v187, 255
+    v189 = add v166, v188
+    v190 = gt v189, 255
+    jumpi v190, bb52, bb53
   bb53:
-    v184 = storage_array_data_slot 0
-    v185 = add v184, 0
-    v186 = sload v185 !metadata(storage=symbolic(v184))
-    v187 = lt 1, v186
-    v188 = iszero v187
-    jumpi v188, bb54, bb55
+    v191 = sload 0 !metadata(storage=slot(0))
+    v192 = lt 0, v191
+    v193 = iszero v192
+    jumpi v193, bb54, bb55
   bb55:
-    v189 = storage_array_data_slot v185
-    v190 = mul 1, 2
-    v191 = add v189, v190
-    v192 = add v191, 1
-    v193 = lt 1, 2
-    v194 = iszero v193
-    jumpi v194, bb56, bb57
+    v194 = storage_array_data_slot 0
+    v195 = add v194, 0
+    v196 = sload v195 !metadata(storage=symbolic(v194))
+    v197 = lt 1, v196
+    v198 = iszero v197
+    jumpi v198, bb56, bb57
   bb57:
-    v195 = div 1, 32
-    v196 = add v192, v195
-    v197 = mod 1, 32
-    v198 = mul v197, 1
-    v199 = sload v196 !metadata(storage=symbolic(v196))
-    v200 = mul v198, 8
-    v201 = shr v200, v199
-    v202 = and v201, 255
-    v203 = add v179, v202
-    v204 = gt v203, 255
+    v199 = storage_array_data_slot v195
+    v200 = mul 1, 2
+    v201 = add v199, v200
+    v202 = add v201, 1
+    v203 = lt 1, 2
+    v204 = iszero v203
     jumpi v204, bb58, bb59
   bb59:
-    ret v203
-  bb58:
+    v205 = div 1, 32
+    v206 = add v202, v205
+    v207 = mod 1, 32
+    v208 = mul v207, 1
+    v209 = sload v206 !metadata(storage=symbolic(v206))
+    v210 = mul v208, 8
+    v211 = shr v210, v209
+    v212 = and v211, 255
+    v213 = add v189, v212
+    v214 = gt v213, 255
+    jumpi v214, bb60, bb61
+  bb61:
+    ret v213
+  bb60:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb58:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb56:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -130,11 +134,11 @@ fn @copy(arg0: memoryarray) -> u256 [selector=0xc58b68ae, abi_params=[array<_, a
     revert 0, 36
   bb52:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb50:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb48:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -153,10 +157,6 @@ fn @copy(arg0: memoryarray) -> u256 [selector=0xc58b68ae, abi_params=[array<_, a
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb40:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb38:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -189,11 +189,11 @@ fn @copy(arg0: memoryarray) -> u256 [selector=0xc58b68ae, abi_params=[array<_, a
     sstore v34, v35 !metadata(storage=symbolic(v34))
     jump bb25
   bb25:
-    v56 = phi [bb18: 0], [bb37: v132]
+    v56 = phi [bb18: 0], [bb39: v142]
     v57 = lt v56, v35
     jumpi v57, bb26, bb27
   bb27:
-    v133 = add v27, 1
+    v143 = add v27, 1
     jump bb12
   bb26:
     v58 = memory_object_load_element memoryarray<1>, v32, v56
@@ -235,37 +235,52 @@ fn @copy(arg0: memoryarray) -> u256 [selector=0xc58b68ae, abi_params=[array<_, a
     v88 = lt v87, v68
     jumpi v88, bb36, bb37
   bb37:
-    v104 = add v66, 1
-    v105 = memory_object_load_field memorystruct<2>, v63, 1
-    v106 = div 0, 32
-    v107 = add v104, v106
-    v108 = mod 0, 32
-    v109 = mul v108, 1
-    v110 = memory_object_load_element memoryfixedarray<2, 1>, v105, 0
-    v111 = mul v109, 8
-    v112 = shl v111, 255
-    v113 = sload v107 !metadata(storage=symbolic(v107))
-    v114 = not v112
-    v115 = and v113, v114
-    v116 = and v110, 255
-    v117 = shl v111, v116
-    v118 = or v115, v117
-    sstore v107, v118 !metadata(storage=symbolic(v107))
-    v119 = div 1, 32
-    v120 = add v104, v119
-    v121 = mod 1, 32
-    v122 = mul v121, 1
-    v123 = memory_object_load_element memoryfixedarray<2, 1>, v105, 1
-    v124 = mul v122, 8
-    v125 = shl v124, 255
-    v126 = sload v120 !metadata(storage=symbolic(v120))
-    v127 = not v125
-    v128 = and v126, v127
-    v129 = and v123, 255
-    v130 = shl v124, v129
-    v131 = or v128, v130
-    sstore v120, v131 !metadata(storage=symbolic(v120))
-    v132 = add v56, 1
+    v104 = shr 5, v68
+    v105 = and v68, 31
+    v106 = iszero v105
+    jumpi v106, bb39, bb38
+  bb38:
+    v107 = mul v105, 8
+    v108 = shl v107, 1
+    v109 = sub v108, 1
+    v110 = storage_array_data_slot v66
+    v111 = add v110, v104
+    v112 = sload v111 !metadata(storage=symbolic(v111))
+    v113 = and v112, v109
+    sstore v111, v113 !metadata(storage=symbolic(v111))
+    jump bb39
+  bb39:
+    v114 = add v66, 1
+    v115 = memory_object_load_field memorystruct<2>, v63, 1
+    v116 = div 0, 32
+    v117 = add v114, v116
+    v118 = mod 0, 32
+    v119 = mul v118, 1
+    v120 = memory_object_load_element memoryfixedarray<2, 1>, v115, 0
+    v121 = mul v119, 8
+    v122 = shl v121, 255
+    v123 = sload v117 !metadata(storage=symbolic(v117))
+    v124 = not v122
+    v125 = and v123, v124
+    v126 = and v120, 255
+    v127 = shl v121, v126
+    v128 = or v125, v127
+    sstore v117, v128 !metadata(storage=symbolic(v117))
+    v129 = div 1, 32
+    v130 = add v114, v129
+    v131 = mod 1, 32
+    v132 = mul v131, 1
+    v133 = memory_object_load_element memoryfixedarray<2, 1>, v115, 1
+    v134 = mul v132, 8
+    v135 = shl v134, 255
+    v136 = sload v130 !metadata(storage=symbolic(v130))
+    v137 = not v135
+    v138 = and v136, v137
+    v139 = and v133, 255
+    v140 = shl v134, v139
+    v141 = or v138, v140
+    sstore v130, v141 !metadata(storage=symbolic(v130))
+    v142 = add v56, 1
     jump bb25
   bb36:
     v89 = memory_object_load_element memoryarray<1>, v67, v87
@@ -391,101 +406,105 @@ fn @copyFixed(arg0: memoryfixedarray) -> u256 [selector=0x39bd9a66, abi_params=[
     sstore v0, v2 !metadata(storage=slot(1))
     jump bb9
   bb9:
-    v23 = phi [bb2: 0], [bb21: v99]
+    v23 = phi [bb2: 0], [bb23: v109]
     v24 = lt v23, v2
     jumpi v24, bb10, bb11
   bb11:
-    v100 = lt 0, 1
-    v101 = iszero v100
-    jumpi v101, bb22, bb23
-  bb23:
-    v102 = add 1, 0
-    v103 = sload v102 !metadata(storage=slot(1))
-    v104 = lt 1, v103
-    v105 = iszero v104
-    jumpi v105, bb24, bb25
-  bb25:
-    v106 = storage_array_data_slot v102
-    v107 = mul 1, 2
-    v108 = add v106, v107
-    v109 = sload v108 !metadata(storage=symbolic(v108))
-    v110 = lt 1, v109
+    v110 = lt 0, 1
     v111 = iszero v110
-    jumpi v111, bb26, bb27
+    jumpi v111, bb24, bb25
+  bb25:
+    v112 = add 1, 0
+    v113 = sload v112 !metadata(storage=slot(1))
+    v114 = lt 1, v113
+    v115 = iszero v114
+    jumpi v115, bb26, bb27
   bb27:
-    v112 = storage_array_data_slot v108
-    v113 = div 1, 32
-    v114 = add v112, v113
-    v115 = mod 1, 32
-    v116 = mul v115, 1
-    v117 = sload v114 !metadata(storage=symbolic(v114))
-    v118 = mul v116, 8
-    v119 = shr v118, v117
-    v120 = and v119, 255
-    v121 = lt 0, 1
-    v122 = iszero v121
-    jumpi v122, bb28, bb29
+    v116 = storage_array_data_slot v112
+    v117 = mul 1, 2
+    v118 = add v116, v117
+    v119 = sload v118 !metadata(storage=symbolic(v118))
+    v120 = lt 1, v119
+    v121 = iszero v120
+    jumpi v121, bb28, bb29
   bb29:
-    v123 = add 1, 0
-    v124 = sload v123 !metadata(storage=slot(1))
-    v125 = lt 0, v124
-    v126 = iszero v125
-    jumpi v126, bb30, bb31
-  bb31:
-    v127 = storage_array_data_slot v123
-    v128 = mul 0, 2
-    v129 = add v127, v128
-    v130 = add v129, 1
-    v131 = lt 0, 2
+    v122 = storage_array_data_slot v118
+    v123 = div 1, 32
+    v124 = add v122, v123
+    v125 = mod 1, 32
+    v126 = mul v125, 1
+    v127 = sload v124 !metadata(storage=symbolic(v124))
+    v128 = mul v126, 8
+    v129 = shr v128, v127
+    v130 = and v129, 255
+    v131 = lt 0, 1
     v132 = iszero v131
-    jumpi v132, bb32, bb33
+    jumpi v132, bb30, bb31
+  bb31:
+    v133 = add 1, 0
+    v134 = sload v133 !metadata(storage=slot(1))
+    v135 = lt 0, v134
+    v136 = iszero v135
+    jumpi v136, bb32, bb33
   bb33:
-    v133 = div 0, 32
-    v134 = add v130, v133
-    v135 = mod 0, 32
-    v136 = mul v135, 1
-    v137 = sload v134 !metadata(storage=symbolic(v134))
-    v138 = mul v136, 8
-    v139 = shr v138, v137
-    v140 = and v139, 255
-    v141 = add v120, v140
-    v142 = gt v141, 255
+    v137 = storage_array_data_slot v133
+    v138 = mul 0, 2
+    v139 = add v137, v138
+    v140 = add v139, 1
+    v141 = lt 0, 2
+    v142 = iszero v141
     jumpi v142, bb34, bb35
   bb35:
-    v143 = lt 0, 1
-    v144 = iszero v143
-    jumpi v144, bb36, bb37
+    v143 = div 0, 32
+    v144 = add v140, v143
+    v145 = mod 0, 32
+    v146 = mul v145, 1
+    v147 = sload v144 !metadata(storage=symbolic(v144))
+    v148 = mul v146, 8
+    v149 = shr v148, v147
+    v150 = and v149, 255
+    v151 = add v130, v150
+    v152 = gt v151, 255
+    jumpi v152, bb36, bb37
   bb37:
-    v145 = add 1, 0
-    v146 = sload v145 !metadata(storage=slot(1))
-    v147 = lt 1, v146
-    v148 = iszero v147
-    jumpi v148, bb38, bb39
-  bb39:
-    v149 = storage_array_data_slot v145
-    v150 = mul 1, 2
-    v151 = add v149, v150
-    v152 = add v151, 1
-    v153 = lt 1, 2
+    v153 = lt 0, 1
     v154 = iszero v153
-    jumpi v154, bb40, bb41
+    jumpi v154, bb38, bb39
+  bb39:
+    v155 = add 1, 0
+    v156 = sload v155 !metadata(storage=slot(1))
+    v157 = lt 1, v156
+    v158 = iszero v157
+    jumpi v158, bb40, bb41
   bb41:
-    v155 = div 1, 32
-    v156 = add v152, v155
-    v157 = mod 1, 32
-    v158 = mul v157, 1
-    v159 = sload v156 !metadata(storage=symbolic(v156))
-    v160 = mul v158, 8
-    v161 = shr v160, v159
-    v162 = and v161, 255
-    v163 = add v141, v162
-    v164 = gt v163, 255
+    v159 = storage_array_data_slot v155
+    v160 = mul 1, 2
+    v161 = add v159, v160
+    v162 = add v161, 1
+    v163 = lt 1, 2
+    v164 = iszero v163
     jumpi v164, bb42, bb43
   bb43:
-    ret v163
-  bb42:
+    v165 = div 1, 32
+    v166 = add v162, v165
+    v167 = mod 1, 32
+    v168 = mul v167, 1
+    v169 = sload v166 !metadata(storage=symbolic(v166))
+    v170 = mul v168, 8
+    v171 = shr v170, v169
+    v172 = and v171, 255
+    v173 = add v151, v172
+    v174 = gt v173, 255
+    jumpi v174, bb44, bb45
+  bb45:
+    ret v173
+  bb44:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb42:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb40:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -497,11 +516,11 @@ fn @copyFixed(arg0: memoryfixedarray) -> u256 [selector=0x39bd9a66, abi_params=[
     revert 0, 36
   bb36:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb34:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb32:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -520,10 +539,6 @@ fn @copyFixed(arg0: memoryfixedarray) -> u256 [selector=0x39bd9a66, abi_params=[
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb24:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb22:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -567,37 +582,52 @@ fn @copyFixed(arg0: memoryfixedarray) -> u256 [selector=0x39bd9a66, abi_params=[
     v55 = lt v54, v35
     jumpi v55, bb20, bb21
   bb21:
-    v71 = add v33, 1
-    v72 = memory_object_load_field memorystruct<2>, v30, 1
-    v73 = div 0, 32
-    v74 = add v71, v73
-    v75 = mod 0, 32
-    v76 = mul v75, 1
-    v77 = memory_object_load_element memoryfixedarray<2, 1>, v72, 0
-    v78 = mul v76, 8
-    v79 = shl v78, 255
-    v80 = sload v74 !metadata(storage=symbolic(v74))
-    v81 = not v79
-    v82 = and v80, v81
-    v83 = and v77, 255
-    v84 = shl v78, v83
-    v85 = or v82, v84
-    sstore v74, v85 !metadata(storage=symbolic(v74))
-    v86 = div 1, 32
-    v87 = add v71, v86
-    v88 = mod 1, 32
-    v89 = mul v88, 1
-    v90 = memory_object_load_element memoryfixedarray<2, 1>, v72, 1
-    v91 = mul v89, 8
-    v92 = shl v91, 255
-    v93 = sload v87 !metadata(storage=symbolic(v87))
-    v94 = not v92
-    v95 = and v93, v94
-    v96 = and v90, 255
-    v97 = shl v91, v96
-    v98 = or v95, v97
-    sstore v87, v98 !metadata(storage=symbolic(v87))
-    v99 = add v23, 1
+    v71 = shr 5, v35
+    v72 = and v35, 31
+    v73 = iszero v72
+    jumpi v73, bb23, bb22
+  bb22:
+    v74 = mul v72, 8
+    v75 = shl v74, 1
+    v76 = sub v75, 1
+    v77 = storage_array_data_slot v33
+    v78 = add v77, v71
+    v79 = sload v78 !metadata(storage=symbolic(v78))
+    v80 = and v79, v76
+    sstore v78, v80 !metadata(storage=symbolic(v78))
+    jump bb23
+  bb23:
+    v81 = add v33, 1
+    v82 = memory_object_load_field memorystruct<2>, v30, 1
+    v83 = div 0, 32
+    v84 = add v81, v83
+    v85 = mod 0, 32
+    v86 = mul v85, 1
+    v87 = memory_object_load_element memoryfixedarray<2, 1>, v82, 0
+    v88 = mul v86, 8
+    v89 = shl v88, 255
+    v90 = sload v84 !metadata(storage=symbolic(v84))
+    v91 = not v89
+    v92 = and v90, v91
+    v93 = and v87, 255
+    v94 = shl v88, v93
+    v95 = or v92, v94
+    sstore v84, v95 !metadata(storage=symbolic(v84))
+    v96 = div 1, 32
+    v97 = add v81, v96
+    v98 = mod 1, 32
+    v99 = mul v98, 1
+    v100 = memory_object_load_element memoryfixedarray<2, 1>, v82, 1
+    v101 = mul v99, 8
+    v102 = shl v101, 255
+    v103 = sload v97 !metadata(storage=symbolic(v97))
+    v104 = not v102
+    v105 = and v103, v104
+    v106 = and v100, 255
+    v107 = shl v101, v106
+    v108 = or v105, v107
+    sstore v97, v108 !metadata(storage=symbolic(v97))
+    v109 = add v23, 1
     jump bb9
   bb20:
     v56 = memory_object_load_element memoryarray<1>, v34, v54
@@ -681,104 +711,108 @@ fn @copyDynamicFixed(arg0: memoryarray) -> u256 [selector=0x62d70355, abi_params
     sstore 2, v0 !metadata(storage=slot(2))
     jump bb9
   bb9:
-    v23 = phi [bb2: 0], [bb21: v103]
+    v23 = phi [bb2: 0], [bb23: v113]
     v24 = lt v23, v0
     jumpi v24, bb10, bb11
   bb11:
-    v104 = sload 2 !metadata(storage=slot(2))
-    v105 = lt 1, v104
-    v106 = iszero v105
-    jumpi v106, bb22, bb23
-  bb23:
-    v107 = storage_array_data_slot 2
-    v108 = mul 1, 2
-    v109 = add v107, v108
-    v110 = lt 0, 1
-    v111 = iszero v110
-    jumpi v111, bb24, bb25
-  bb25:
-    v112 = mul 0, 2
-    v113 = add v109, v112
-    v114 = sload v113 !metadata(storage=symbolic(v113))
+    v114 = sload 2 !metadata(storage=slot(2))
     v115 = lt 1, v114
     v116 = iszero v115
-    jumpi v116, bb26, bb27
-  bb27:
-    v117 = storage_array_data_slot v113
-    v118 = div 1, 32
+    jumpi v116, bb24, bb25
+  bb25:
+    v117 = storage_array_data_slot 2
+    v118 = mul 1, 2
     v119 = add v117, v118
-    v120 = mod 1, 32
-    v121 = mul v120, 1
-    v122 = sload v119 !metadata(storage=symbolic(v119))
-    v123 = mul v121, 8
-    v124 = shr v123, v122
-    v125 = and v124, 255
-    v126 = sload 2 !metadata(storage=slot(2))
-    v127 = lt 0, v126
-    v128 = iszero v127
-    jumpi v128, bb28, bb29
+    v120 = lt 0, 1
+    v121 = iszero v120
+    jumpi v121, bb26, bb27
+  bb27:
+    v122 = mul 0, 2
+    v123 = add v119, v122
+    v124 = sload v123 !metadata(storage=symbolic(v123))
+    v125 = lt 1, v124
+    v126 = iszero v125
+    jumpi v126, bb28, bb29
   bb29:
-    v129 = storage_array_data_slot 2
-    v130 = mul 0, 2
-    v131 = add v129, v130
-    v132 = lt 0, 1
-    v133 = iszero v132
-    jumpi v133, bb30, bb31
-  bb31:
-    v134 = mul 0, 2
-    v135 = add v131, v134
-    v136 = add v135, 1
-    v137 = lt 0, 2
+    v127 = storage_array_data_slot v123
+    v128 = div 1, 32
+    v129 = add v127, v128
+    v130 = mod 1, 32
+    v131 = mul v130, 1
+    v132 = sload v129 !metadata(storage=symbolic(v129))
+    v133 = mul v131, 8
+    v134 = shr v133, v132
+    v135 = and v134, 255
+    v136 = sload 2 !metadata(storage=slot(2))
+    v137 = lt 0, v136
     v138 = iszero v137
-    jumpi v138, bb32, bb33
+    jumpi v138, bb30, bb31
+  bb31:
+    v139 = storage_array_data_slot 2
+    v140 = mul 0, 2
+    v141 = add v139, v140
+    v142 = lt 0, 1
+    v143 = iszero v142
+    jumpi v143, bb32, bb33
   bb33:
-    v139 = div 0, 32
-    v140 = add v136, v139
-    v141 = mod 0, 32
-    v142 = mul v141, 1
-    v143 = sload v140 !metadata(storage=symbolic(v140))
-    v144 = mul v142, 8
-    v145 = shr v144, v143
-    v146 = and v145, 255
-    v147 = add v125, v146
-    v148 = gt v147, 255
+    v144 = mul 0, 2
+    v145 = add v141, v144
+    v146 = add v145, 1
+    v147 = lt 0, 2
+    v148 = iszero v147
     jumpi v148, bb34, bb35
   bb35:
-    v149 = sload 2 !metadata(storage=slot(2))
-    v150 = lt 1, v149
-    v151 = iszero v150
-    jumpi v151, bb36, bb37
+    v149 = div 0, 32
+    v150 = add v146, v149
+    v151 = mod 0, 32
+    v152 = mul v151, 1
+    v153 = sload v150 !metadata(storage=symbolic(v150))
+    v154 = mul v152, 8
+    v155 = shr v154, v153
+    v156 = and v155, 255
+    v157 = add v135, v156
+    v158 = gt v157, 255
+    jumpi v158, bb36, bb37
   bb37:
-    v152 = storage_array_data_slot 2
-    v153 = mul 1, 2
-    v154 = add v152, v153
-    v155 = lt 0, 1
-    v156 = iszero v155
-    jumpi v156, bb38, bb39
-  bb39:
-    v157 = mul 0, 2
-    v158 = add v154, v157
-    v159 = add v158, 1
-    v160 = lt 1, 2
+    v159 = sload 2 !metadata(storage=slot(2))
+    v160 = lt 1, v159
     v161 = iszero v160
-    jumpi v161, bb40, bb41
+    jumpi v161, bb38, bb39
+  bb39:
+    v162 = storage_array_data_slot 2
+    v163 = mul 1, 2
+    v164 = add v162, v163
+    v165 = lt 0, 1
+    v166 = iszero v165
+    jumpi v166, bb40, bb41
   bb41:
-    v162 = div 1, 32
-    v163 = add v159, v162
-    v164 = mod 1, 32
-    v165 = mul v164, 1
-    v166 = sload v163 !metadata(storage=symbolic(v163))
-    v167 = mul v165, 8
-    v168 = shr v167, v166
-    v169 = and v168, 255
-    v170 = add v147, v169
-    v171 = gt v170, 255
+    v167 = mul 0, 2
+    v168 = add v164, v167
+    v169 = add v168, 1
+    v170 = lt 1, 2
+    v171 = iszero v170
     jumpi v171, bb42, bb43
   bb43:
-    ret v170
-  bb42:
+    v172 = div 1, 32
+    v173 = add v169, v172
+    v174 = mod 1, 32
+    v175 = mul v174, 1
+    v176 = sload v173 !metadata(storage=symbolic(v173))
+    v177 = mul v175, 8
+    v178 = shr v177, v176
+    v179 = and v178, 255
+    v180 = add v157, v179
+    v181 = gt v180, 255
+    jumpi v181, bb44, bb45
+  bb45:
+    ret v180
+  bb44:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 17 !metadata(memory=scratch)
+    revert 0, 36
+  bb42:
+    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb40:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -790,11 +824,11 @@ fn @copyDynamicFixed(arg0: memoryarray) -> u256 [selector=0x62d70355, abi_params
     revert 0, 36
   bb36:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
+    mstore 4, 17 !metadata(memory=scratch)
     revert 0, 36
   bb34:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 17 !metadata(memory=scratch)
+    mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb32:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
@@ -813,10 +847,6 @@ fn @copyDynamicFixed(arg0: memoryarray) -> u256 [selector=0x62d70355, abi_params
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
   bb24:
-    mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
-    mstore 4, 50 !metadata(memory=scratch)
-    revert 0, 36
-  bb22:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -865,37 +895,52 @@ fn @copyDynamicFixed(arg0: memoryarray) -> u256 [selector=0x62d70355, abi_params
     v59 = lt v58, v39
     jumpi v59, bb20, bb21
   bb21:
-    v75 = add v36, 1
-    v76 = memory_object_load_field memorystruct<2>, v37, 1
-    v77 = div 0, 32
-    v78 = add v75, v77
-    v79 = mod 0, 32
-    v80 = mul v79, 1
-    v81 = memory_object_load_element memoryfixedarray<2, 1>, v76, 0
-    v82 = mul v80, 8
-    v83 = shl v82, 255
-    v84 = sload v78 !metadata(storage=symbolic(v78))
-    v85 = not v83
-    v86 = and v84, v85
-    v87 = and v81, 255
-    v88 = shl v82, v87
-    v89 = or v86, v88
-    sstore v78, v89 !metadata(storage=symbolic(v78))
-    v90 = div 1, 32
-    v91 = add v75, v90
-    v92 = mod 1, 32
-    v93 = mul v92, 1
-    v94 = memory_object_load_element memoryfixedarray<2, 1>, v76, 1
-    v95 = mul v93, 8
-    v96 = shl v95, 255
-    v97 = sload v91 !metadata(storage=symbolic(v91))
-    v98 = not v96
-    v99 = and v97, v98
-    v100 = and v94, 255
-    v101 = shl v95, v100
-    v102 = or v99, v101
-    sstore v91, v102 !metadata(storage=symbolic(v91))
-    v103 = add v23, 1
+    v75 = shr 5, v39
+    v76 = and v39, 31
+    v77 = iszero v76
+    jumpi v77, bb23, bb22
+  bb22:
+    v78 = mul v76, 8
+    v79 = shl v78, 1
+    v80 = sub v79, 1
+    v81 = storage_array_data_slot v36
+    v82 = add v81, v75
+    v83 = sload v82 !metadata(storage=symbolic(v82))
+    v84 = and v83, v80
+    sstore v82, v84 !metadata(storage=symbolic(v82))
+    jump bb23
+  bb23:
+    v85 = add v36, 1
+    v86 = memory_object_load_field memorystruct<2>, v37, 1
+    v87 = div 0, 32
+    v88 = add v85, v87
+    v89 = mod 0, 32
+    v90 = mul v89, 1
+    v91 = memory_object_load_element memoryfixedarray<2, 1>, v86, 0
+    v92 = mul v90, 8
+    v93 = shl v92, 255
+    v94 = sload v88 !metadata(storage=symbolic(v88))
+    v95 = not v93
+    v96 = and v94, v95
+    v97 = and v91, 255
+    v98 = shl v92, v97
+    v99 = or v96, v98
+    sstore v88, v99 !metadata(storage=symbolic(v88))
+    v100 = div 1, 32
+    v101 = add v85, v100
+    v102 = mod 1, 32
+    v103 = mul v102, 1
+    v104 = memory_object_load_element memoryfixedarray<2, 1>, v86, 1
+    v105 = mul v103, 8
+    v106 = shl v105, 255
+    v107 = sload v101 !metadata(storage=symbolic(v101))
+    v108 = not v106
+    v109 = and v107, v108
+    v110 = and v104, 255
+    v111 = shl v105, v110
+    v112 = or v109, v111
+    sstore v101, v112 !metadata(storage=symbolic(v101))
+    v113 = add v23, 1
     jump bb9
   bb20:
     v60 = memory_object_load_element memoryarray<1>, v38, v58

--- a/tests/ui/codegen/lowering/run-call/user_defined_storage_conversion.mir.stdout
+++ b/tests/ui/codegen/lowering/run-call/user_defined_storage_conversion.mir.stdout
@@ -313,22 +313,37 @@ fn @storeSmall(arg0: calldataslice) -> u256 [selector=0x48de48f7, abi_params=[ar
     v55 = lt v54, v35
     jumpi v55, bb22, bb23
   bb23:
-    v71 = sload 1 !metadata(storage=slot(1))
-    v72 = lt 1, v71
+    v71 = shr 4, v35
+    v72 = and v35, 15
     v73 = iszero v72
-    jumpi v73, bb24, bb25
-  bb25:
-    v74 = storage_array_data_slot 1
-    v75 = div 1, 16
-    v76 = add v74, v75
-    v77 = mod 1, 16
-    v78 = mul v77, 2
-    v79 = sload v76 !metadata(storage=symbolic(v76))
-    v80 = mul v78, 8
-    v81 = shr v80, v79
-    v82 = and v81, 0xffff
-    ret v82
+    jumpi v73, bb25, bb24
   bb24:
+    v74 = mul v72, 16
+    v75 = shl v74, 1
+    v76 = sub v75, 1
+    v77 = storage_array_data_slot 1
+    v78 = add v77, v71
+    v79 = sload v78 !metadata(storage=symbolic(v78))
+    v80 = and v79, v76
+    sstore v78, v80 !metadata(storage=symbolic(v78))
+    jump bb25
+  bb25:
+    v81 = sload 1 !metadata(storage=slot(1))
+    v82 = lt 1, v81
+    v83 = iszero v82
+    jumpi v83, bb26, bb27
+  bb27:
+    v84 = storage_array_data_slot 1
+    v85 = div 1, 16
+    v86 = add v84, v85
+    v87 = mod 1, 16
+    v88 = mul v87, 2
+    v89 = sload v86 !metadata(storage=symbolic(v86))
+    v90 = mul v88, 8
+    v91 = shr v90, v89
+    v92 = and v91, 0xffff
+    ret v92
+  bb26:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36
@@ -466,25 +481,40 @@ fn @storeLeft(arg0: calldataslice) -> u256 [selector=0x2d92e508, abi_params=[arr
     v56 = lt v55, v35
     jumpi v56, bb22, bb23
   bb23:
-    v73 = sload 2 !metadata(storage=slot(2))
-    v74 = lt 1, v73
+    v73 = shr 4, v35
+    v74 = and v35, 15
     v75 = iszero v74
-    jumpi v75, bb24, bb25
-  bb25:
-    v76 = storage_array_data_slot 2
-    v77 = div 1, 16
-    v78 = add v76, v77
-    v79 = mod 1, 16
-    v80 = mul v79, 2
-    v81 = sload v78 !metadata(storage=symbolic(v78))
-    v82 = mul v80, 8
-    v83 = shr v82, v81
-    v84 = and v83, 0xffff
-    v85 = shl 240, v84
-    v86 = and v85, 0xff00000000000000000000000000000000000000000000000000000000000000
-    v87 = shr 248, v86
-    ret v87
+    jumpi v75, bb25, bb24
   bb24:
+    v76 = mul v74, 16
+    v77 = shl v76, 1
+    v78 = sub v77, 1
+    v79 = storage_array_data_slot 2
+    v80 = add v79, v73
+    v81 = sload v80 !metadata(storage=symbolic(v80))
+    v82 = and v81, v78
+    sstore v80, v82 !metadata(storage=symbolic(v80))
+    jump bb25
+  bb25:
+    v83 = sload 2 !metadata(storage=slot(2))
+    v84 = lt 1, v83
+    v85 = iszero v84
+    jumpi v85, bb26, bb27
+  bb27:
+    v86 = storage_array_data_slot 2
+    v87 = div 1, 16
+    v88 = add v86, v87
+    v89 = mod 1, 16
+    v90 = mul v89, 2
+    v91 = sload v88 !metadata(storage=symbolic(v88))
+    v92 = mul v90, 8
+    v93 = shr v92, v91
+    v94 = and v93, 0xffff
+    v95 = shl 240, v94
+    v96 = and v95, 0xff00000000000000000000000000000000000000000000000000000000000000
+    v97 = shr 248, v96
+    ret v97
+  bb26:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 50 !metadata(memory=scratch)
     revert 0, 36

--- a/tests/ui/codegen/lowering/storage_struct_deep_copy.stdout
+++ b/tests/ui/codegen/lowering/storage_struct_deep_copy.stdout
@@ -3,44 +3,44 @@
 @phase evm-shaped
 fn @assign() [selector=0x4bd0273c] {
   bb0:
-    v53 = calldatasize
-    v54 = lt v53, 68
-    jumpi v54, bb8, bb9
-  bb9:
-    v55 = calldataload 4
-    v56 = shr 160, v55
-    jumpi v56, bb8, bb10
-  bb10:
-    v58 = calldataload 36
-    v59 = shl 32, v58
-    jumpi v59, bb8, bb11
+    v63 = calldatasize
+    v64 = lt v63, 68
+    jumpi v64, bb10, bb11
   bb11:
-    v0 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v69 = add v0, 64
-    v70 = lt v69, v0
-    v71 = gt v69, 0xffffffffffffffff
-    v72 = or v70, v71
-    jumpi v72, bb13, bb12
+    v65 = calldataload 4
+    v66 = shr 160, v65
+    jumpi v66, bb10, bb12
   bb12:
-    mstore 64, v69 !metadata(memory=scratch)
-    v73 = calldatasize
-    calldatacopy v0, v73, 64
+    v68 = calldataload 36
+    v69 = shl 32, v68
+    jumpi v69, bb10, bb13
+  bb13:
+    v0 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v80 = add v0, 64
+    v81 = lt v80, v0
+    v82 = gt v80, 0xffffffffffffffff
+    v83 = or v81, v82
+    jumpi v83, bb15, bb14
+  bb14:
+    mstore 64, v80 !metadata(memory=scratch)
+    v84 = calldatasize
+    calldatacopy v0, v84, 64
     mstore v0, 1
     v4 = and arg1, 0xffffffff00000000000000000000000000000000000000000000000000000000
-    v66 = add v0, 32
-    mstore v66, v4
+    v77 = add v0, 32
+    mstore v77, v4
     v5 = alloc raw, exact, uninitialized, infallible, 64 !metadata(deferred_alloc)
     v6 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
     mstore v5, v6
-    v67 = add v5, 32
-    mstore v67, v0
+    v78 = add v5, 32
+    mstore v78, v0
     v7 = mload v5
     v8 = sload 0 !metadata(storage=slot(0))
     v10 = and v8, 0xffffffffffffffffffffffff0000000000000000000000000000000000000000
     v11 = and v7, 0xffffffffffffffffffffffffffffffffffffffff
     v12 = or v10, v11
     sstore 0, v12 !metadata(storage=slot(0))
-    v14 = mload v67
+    v14 = mload v78
     v15 = mload v14
     v16 = sload 1 !metadata(storage=slot(1))
     v17 = gt v16, v15
@@ -59,16 +59,31 @@ fn @assign() [selector=0x4bd0273c] {
     v36 = lt v35, v15
     jumpi v36, bb6, bb7
   bb7:
+    v53 = shr 3, v15
+    v54 = and v15, 7
+    jumpi v54, bb8, bb9
+  bb8:
+    v56 = shl 5, v54
+    v57 = shl v56, 1
+    v58 = sub v57, 1
+    mstore 0, 1 !metadata(memory=scratch)
+    v73 = keccak256 0, 32 !metadata(memory=scratch)
+    v60 = add v73, v53
+    v61 = sload v60 !metadata(storage=symbolic(v60))
+    v62 = and v61, v58
+    sstore v60, v62 !metadata(storage=symbolic(v60))
+    jump bb9
+  bb9:
     stop
   bb6:
-    v63 = add v14, 32
-    v64 = mul v35, 32
-    v65 = add v63, v64
-    v37 = mload v65
+    v74 = add v14, 32
+    v75 = mul v35, 32
+    v76 = add v74, v75
+    v37 = mload v76
     mstore 0, 1 !metadata(memory=scratch)
     v39 = shr 3, v35
-    v62 = keccak256 0, 32 !metadata(memory=scratch)
-    v40 = add v62, v39
+    v72 = keccak256 0, 32 !metadata(memory=scratch)
+    v40 = add v72, v39
     v41 = and v35, 7
     v42 = shl 2, v41
     v43 = shl 3, v42
@@ -86,8 +101,8 @@ fn @assign() [selector=0x4bd0273c] {
   bb4:
     mstore 0, 1 !metadata(memory=scratch)
     v21 = shr 3, v18
-    v61 = keccak256 0, 32 !metadata(memory=scratch)
-    v22 = add v61, v21
+    v71 = keccak256 0, 32 !metadata(memory=scratch)
+    v22 = add v71, v21
     v23 = and v18, 7
     v24 = shl 2, v23
     v25 = shl 3, v24
@@ -98,47 +113,47 @@ fn @assign() [selector=0x4bd0273c] {
     sstore v22, v29 !metadata(storage=symbolic(v22))
     v34 = add v18, 1
     jump bb3
-  bb13:
+  bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
+  bb10:
     revert 0, 0
 }
 
 fn @push() [selector=0xa60249a3] {
   bb0:
-    v59 = calldatasize
-    v60 = lt v59, 68
-    jumpi v60, bb10, bb11
-  bb11:
-    v61 = calldataload 4
-    v62 = shr 160, v61
-    jumpi v62, bb10, bb12
-  bb12:
-    v64 = calldataload 36
-    v65 = shl 32, v64
-    jumpi v65, bb10, bb13
+    v69 = calldatasize
+    v70 = lt v69, 68
+    jumpi v70, bb12, bb13
   bb13:
-    v0 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v76 = add v0, 64
-    v77 = lt v76, v0
-    v78 = gt v76, 0xffffffffffffffff
-    v79 = or v77, v78
-    jumpi v79, bb15, bb14
+    v71 = calldataload 4
+    v72 = shr 160, v71
+    jumpi v72, bb12, bb14
   bb14:
-    mstore 64, v76 !metadata(memory=scratch)
-    v80 = calldatasize
-    calldatacopy v0, v80, 64
+    v74 = calldataload 36
+    v75 = shl 32, v74
+    jumpi v75, bb12, bb15
+  bb15:
+    v0 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v87 = add v0, 64
+    v88 = lt v87, v0
+    v89 = gt v87, 0xffffffffffffffff
+    v90 = or v88, v89
+    jumpi v90, bb17, bb16
+  bb16:
+    mstore 64, v87 !metadata(memory=scratch)
+    v91 = calldatasize
+    calldatacopy v0, v91, 64
     mstore v0, 1
     v4 = and arg1, 0xffffffff00000000000000000000000000000000000000000000000000000000
-    v74 = add v0, 32
-    mstore v74, v4
+    v85 = add v0, 32
+    mstore v85, v4
     v5 = alloc raw, exact, uninitialized, infallible, 64 !metadata(deferred_alloc)
     v6 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
     mstore v5, v6
-    v75 = add v5, 32
-    mstore v75, v0
+    v86 = add v5, 32
+    mstore v86, v0
     v7 = sload 2 !metadata(storage=slot(2))
     v8 = add v7, 1
     v9 = lt v8, v7
@@ -146,8 +161,8 @@ fn @push() [selector=0xa60249a3] {
   bb2:
     mstore 0, 2 !metadata(memory=scratch)
     v11 = shl 1, v7
-    v67 = keccak256 0, 32 !metadata(memory=scratch)
-    v12 = add v67, v11
+    v77 = keccak256 0, 32 !metadata(memory=scratch)
+    v12 = add v77, v11
     v13 = mload v5
     v14 = sload v12 !metadata(storage=symbolic(v12))
     v16 = and v14, 0xffffffffffffffffffffffff0000000000000000000000000000000000000000
@@ -155,7 +170,7 @@ fn @push() [selector=0xa60249a3] {
     v18 = or v16, v17
     sstore v12, v18 !metadata(storage=symbolic(v12))
     v19 = add v12, 1
-    v20 = mload v75
+    v20 = mload v86
     v21 = mload v20
     v22 = sload v19 !metadata(storage=offset(v12, 1))
     v23 = gt v22, v21
@@ -174,17 +189,32 @@ fn @push() [selector=0xa60249a3] {
     v42 = lt v41, v21
     jumpi v42, bb8, bb9
   bb9:
+    v59 = shr 3, v21
+    v60 = and v21, 7
+    jumpi v60, bb10, bb11
+  bb10:
+    v62 = shl 5, v60
+    v63 = shl v62, 1
+    v64 = sub v63, 1
+    mstore 0, v19 !metadata(memory=scratch)
+    v80 = keccak256 0, 32 !metadata(memory=scratch)
+    v66 = add v80, v59
+    v67 = sload v66 !metadata(storage=symbolic(v66))
+    v68 = and v67, v64
+    sstore v66, v68 !metadata(storage=symbolic(v66))
+    jump bb11
+  bb11:
     sstore 2, v8 !metadata(storage=slot(2))
     stop
   bb8:
-    v71 = add v20, 32
-    v72 = mul v41, 32
-    v73 = add v71, v72
-    v43 = mload v73
+    v82 = add v20, 32
+    v83 = mul v41, 32
+    v84 = add v82, v83
+    v43 = mload v84
     mstore 0, v19 !metadata(memory=scratch)
     v45 = shr 3, v41
-    v69 = keccak256 0, 32 !metadata(memory=scratch)
-    v46 = add v69, v45
+    v79 = keccak256 0, 32 !metadata(memory=scratch)
+    v46 = add v79, v45
     v47 = and v41, 7
     v48 = shl 2, v47
     v49 = shl 3, v48
@@ -202,8 +232,8 @@ fn @push() [selector=0xa60249a3] {
   bb6:
     mstore 0, v19 !metadata(memory=scratch)
     v27 = shr 3, v24
-    v68 = keccak256 0, 32 !metadata(memory=scratch)
-    v28 = add v68, v27
+    v78 = keccak256 0, 32 !metadata(memory=scratch)
+    v28 = add v78, v27
     v29 = and v24, 7
     v30 = shl 2, v29
     v31 = shl 3, v30
@@ -218,11 +248,11 @@ fn @push() [selector=0xa60249a3] {
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb15:
+  bb17:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb10:
+  bb12:
     revert 0, 0
 }
 
@@ -269,44 +299,44 @@ fn @pop() [selector=0xa4ece52c] {
 
 fn @assignFixed() [selector=0xb7ffd825] {
   bb0:
-    v57 = calldatasize
-    v58 = lt v57, 68
-    jumpi v58, bb8, bb9
-  bb9:
-    v59 = calldataload 4
-    v60 = shr 160, v59
-    jumpi v60, bb8, bb10
-  bb10:
-    v62 = calldataload 36
-    v63 = shl 32, v62
-    jumpi v63, bb8, bb11
+    v67 = calldatasize
+    v68 = lt v67, 68
+    jumpi v68, bb10, bb11
   bb11:
-    v0 = mload 64 !metadata(memory=scratch, effect=memory_write)
-    v73 = add v0, 64
-    v74 = lt v73, v0
-    v75 = gt v73, 0xffffffffffffffff
-    v76 = or v74, v75
-    jumpi v76, bb13, bb12
+    v69 = calldataload 4
+    v70 = shr 160, v69
+    jumpi v70, bb10, bb12
   bb12:
-    mstore 64, v73 !metadata(memory=scratch)
-    v77 = calldatasize
-    calldatacopy v0, v77, 64
+    v72 = calldataload 36
+    v73 = shl 32, v72
+    jumpi v73, bb10, bb13
+  bb13:
+    v0 = mload 64 !metadata(memory=scratch, effect=memory_write)
+    v84 = add v0, 64
+    v85 = lt v84, v0
+    v86 = gt v84, 0xffffffffffffffff
+    v87 = or v85, v86
+    jumpi v87, bb15, bb14
+  bb14:
+    mstore 64, v84 !metadata(memory=scratch)
+    v88 = calldatasize
+    calldatacopy v0, v88, 64
     mstore v0, 1
     v4 = and arg1, 0xffffffff00000000000000000000000000000000000000000000000000000000
-    v70 = add v0, 32
-    mstore v70, v4
+    v81 = add v0, 32
+    mstore v81, v4
     v5 = alloc raw, exact, uninitialized, infallible, 64 !metadata(deferred_alloc)
     v6 = and arg0, 0xffffffffffffffffffffffffffffffffffffffff
     mstore v5, v6
-    v71 = add v5, 32
-    mstore v71, v0
+    v82 = add v5, 32
+    mstore v82, v0
     v11 = mload v5
     v12 = sload 3 !metadata(storage=slot(3))
     v14 = and v12, 0xffffffffffffffffffffffff0000000000000000000000000000000000000000
     v15 = and v11, 0xffffffffffffffffffffffffffffffffffffffff
     v16 = or v14, v15
     sstore 3, v16 !metadata(storage=slot(3))
-    v18 = mload v71
+    v18 = mload v82
     v19 = mload v18
     v20 = sload 4 !metadata(storage=slot(4))
     v21 = gt v20, v19
@@ -325,16 +355,31 @@ fn @assignFixed() [selector=0xb7ffd825] {
     v40 = lt v39, v19
     jumpi v40, bb6, bb7
   bb7:
+    v57 = shr 3, v19
+    v58 = and v19, 7
+    jumpi v58, bb8, bb9
+  bb8:
+    v60 = shl 5, v58
+    v61 = shl v60, 1
+    v62 = sub v61, 1
+    mstore 0, 4 !metadata(memory=scratch)
+    v77 = keccak256 0, 32 !metadata(memory=scratch)
+    v64 = add v77, v57
+    v65 = sload v64 !metadata(storage=symbolic(v64))
+    v66 = and v65, v62
+    sstore v64, v66 !metadata(storage=symbolic(v64))
+    jump bb9
+  bb9:
     stop
   bb6:
-    v67 = add v18, 32
-    v68 = mul v39, 32
-    v69 = add v67, v68
-    v41 = mload v69
+    v78 = add v18, 32
+    v79 = mul v39, 32
+    v80 = add v78, v79
+    v41 = mload v80
     mstore 0, 4 !metadata(memory=scratch)
     v43 = shr 3, v39
-    v66 = keccak256 0, 32 !metadata(memory=scratch)
-    v44 = add v66, v43
+    v76 = keccak256 0, 32 !metadata(memory=scratch)
+    v44 = add v76, v43
     v45 = and v39, 7
     v46 = shl 2, v45
     v47 = shl 3, v46
@@ -352,8 +397,8 @@ fn @assignFixed() [selector=0xb7ffd825] {
   bb4:
     mstore 0, 4 !metadata(memory=scratch)
     v25 = shr 3, v22
-    v65 = keccak256 0, 32 !metadata(memory=scratch)
-    v26 = add v65, v25
+    v75 = keccak256 0, 32 !metadata(memory=scratch)
+    v26 = add v75, v25
     v27 = and v22, 7
     v28 = shl 2, v27
     v29 = shl 3, v28
@@ -364,11 +409,11 @@ fn @assignFixed() [selector=0xb7ffd825] {
     sstore v26, v33 !metadata(storage=symbolic(v26))
     v38 = add v22, 1
     jump bb3
-  bb13:
+  bb15:
     mstore 0, 0x4e487b7100000000000000000000000000000000000000000000000000000000 !metadata(memory=scratch)
     mstore 4, 65 !metadata(memory=scratch)
     revert 0, 36
-  bb8:
+  bb10:
     revert 0, 0
 }
 


### PR DESCRIPTION
A fixed-prestate `solsymdiff` campaign replayed Solidity's upstream `cleanup_during_multi_element_per_slot_copy` case and found that a packed dynamic-array copy preserved a value outside its logical length. Solc returned zero after the next `push()`, while the rewrite returned the stale value `4`.

This masks unused logical elements in the final partial storage word after packed array copies. Fixed and dynamic sources are covered, and exact-slot-boundary copies retain the existing next-slot behavior. The adapted regression and boundary control reach bounded agreement in optimized and unoptimized legacy and via-IR builds.

The minimized optimized runtime grows from 498 to 518 bytes, while the failing transaction drops from 47,490 to 40,572 gas. Packed-copy-heavy UI fixtures grow roughly 5–10%; the 15-case hot benchmark suite is unchanged in bytecode, deploy/call gas, and runtime results.

This targets #1161.

AI assistance: Codex assisted with differential discovery, implementation, and validation.