### PR TITLE
fix(sema): defer ternary branch coercion

### DIFF
--- a/crates/sema/src/typeck/checker/mod.rs
+++ b/crates/sema/src/typeck/checker/mod.rs
@@ -661,8 +661,8 @@ impl<'gcx> TypeChecker<'gcx> {
             hir::ExprKind::Ternary(cond, true_, false_) => {
                 let _ = self.expect_ty(cond, self.gcx.types.bool);
                 // TODO: Does mobile need to return None?
-                let true_ty = self.check_expr_with(true_, expected).mobile(self.gcx);
-                let false_ty = self.check_expr_with(false_, expected).mobile(self.gcx);
+                let true_ty = self.check_expr_with_noexpect(true_, expected).mobile(self.gcx);
+                let false_ty = self.check_expr_with_noexpect(false_, expected).mobile(self.gcx);
                 match (true_ty, false_ty) {
                     (Some(true_ty), Some(false_ty)) => {
                         true_ty.common_type(false_ty, self.gcx).unwrap_or_else(|| {

--- a/tests/ui/codegen/run-call/ternary_storage_copy.sol
+++ b/tests/ui/codegen/run-call/ternary_storage_copy.sol
@@ -1,0 +1,79 @@
+//@ run-call: TernaryStorageCopy::bytesCopy(bool) true => 0xaabb
+//@ run-call: TernaryStorageCopy::bytesCopy(bool) false => 0xcc
+//@ run-call: TernaryStorageCopy::dynamicCopy(bool) true => 2, 11
+//@ run-call: TernaryStorageCopy::dynamicCopy(bool) false => 1, 22
+//@ run-call: TernaryStorageCopy::fixedCopy(bool) true => 1, 2
+//@ run-call: TernaryStorageCopy::fixedCopy(bool) false => 3, 4
+//@ run-call: TernaryStorageCopy::structCopy(bool) true => 1, 0xaa
+//@ run-call: TernaryStorageCopy::structCopy(bool) false => 2, 0xbbcc
+//@ run-call: TernaryStorageCopy::nestedCopy(bool,bool) true, false => 3
+//@ run-call: TernaryStorageCopy::nestedCopy(bool,bool) false, true => 5
+//@ run-call: TernaryStorageCopy::memoryCalldata(bool,uint256[]) true, [6] => 6
+//@ run-call: TernaryStorageCopy::memoryCalldata(bool,uint256[]) false, [6] => 7
+//@ run-call: TernaryStorageCopy::storageMemory(bool) true => 8
+//@ run-call: TernaryStorageCopy::storageMemory(bool) false => 9
+contract TernaryStorageCopy {
+    struct Item {
+        uint256 value;
+        bytes data;
+    }
+
+    bytes private blob;
+    uint256[] private dynamicArray;
+    uint256[2] private fixedArray;
+    Item private item;
+    uint256[] private leftStorage;
+
+    function bytesCopy(bool condition) external returns (bytes memory) {
+        bytes memory a = hex"aabb";
+        bytes memory b = hex"cc";
+        blob = condition ? a : b;
+        return blob;
+    }
+
+    function dynamicCopy(bool condition) external returns (uint256, uint256) {
+        uint256[] memory a = new uint256[](2);
+        uint256[] memory b = new uint256[](1);
+        a[1] = 11;
+        b[0] = 22;
+        dynamicArray = condition ? a : b;
+        return (dynamicArray.length, dynamicArray[dynamicArray.length - 1]);
+    }
+
+    function fixedCopy(bool condition) external returns (uint256, uint256) {
+        uint256[2] memory a = [uint256(1), 2];
+        uint256[2] memory b = [uint256(3), 4];
+        fixedArray = condition ? a : b;
+        return (fixedArray[0], fixedArray[1]);
+    }
+
+    function structCopy(bool condition) external returns (uint256, bytes memory) {
+        Item memory a = Item(1, hex"aa");
+        Item memory b = Item(2, hex"bbcc");
+        item = condition ? a : b;
+        return (item.value, item.data);
+    }
+
+    function nestedCopy(bool outer, bool inner) external returns (uint256) {
+        uint256[2] memory a = [uint256(1), 2];
+        uint256[2] memory b = [uint256(3), 4];
+        uint256[2] memory c = [uint256(5), 6];
+        fixedArray = outer ? (inner ? a : b) : c;
+        return fixedArray[0];
+    }
+
+    function memoryCalldata(bool condition, uint256[] calldata a) external returns (uint256) {
+        uint256[] memory b = new uint256[](1);
+        b[0] = 7;
+        dynamicArray = condition ? a : b;
+        return dynamicArray[0];
+    }
+
+    function storageMemory(bool condition) external returns (uint256) {
+        leftStorage.push(8);
+        uint256[] memory b = new uint256[](1);
+        b[0] = 9;
+        dynamicArray = condition ? leftStorage : b;
+        return dynamicArray[0];
+    }
+}

--- a/tests/ui/typeck/function_calls/event_error/nested_contexts.sol
+++ b/tests/ui/typeck/function_calls/event_error/nested_contexts.sol
@@ -40,9 +40,7 @@ contract EventErrorNestedContexts {
     function eventInTernary() public {
         uint x = true ? EmptyEvent() : EmptyEvent();
         //~^ ERROR: event invocations have to be prefixed by `emit`
-        //~| ERROR: mismatched types
         //~| ERROR: event invocations have to be prefixed by `emit`
-        //~| ERROR: mismatched types
         //~| ERROR: mismatched number of components
     }
 

--- a/tests/ui/typeck/function_calls/event_error/nested_contexts.stderr
+++ b/tests/ui/typeck/function_calls/event_error/nested_contexts.stderr
@@ -86,23 +86,11 @@ error: event invocations have to be prefixed by `emit`
 LL │         uint x = true ? EmptyEvent() : EmptyEvent();
    ╰╴                        ━━━━━━━━━━━━
 
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/function_calls/event_error/nested_contexts.sol:LL:CC
-   │
-LL │         uint x = true ? EmptyEvent() : EmptyEvent();
-   ╰╴                        ━━━━━━━━━━━━ expected `uint256`, found `tuple()`
-
 error: event invocations have to be prefixed by `emit`
    ╭▸ ROOT/tests/ui/typeck/function_calls/event_error/nested_contexts.sol:LL:CC
    │
 LL │         uint x = true ? EmptyEvent() : EmptyEvent();
    ╰╴                                       ━━━━━━━━━━━━
-
-error: mismatched types
-   ╭▸ ROOT/tests/ui/typeck/function_calls/event_error/nested_contexts.sol:LL:CC
-   │
-LL │         uint x = true ? EmptyEvent() : EmptyEvent();
-   ╰╴                                       ━━━━━━━━━━━━ expected `uint256`, found `tuple()`
 
 error: mismatched number of components
    ╭▸ ROOT/tests/ui/typeck/function_calls/event_error/nested_contexts.sol:LL:CC
@@ -168,5 +156,5 @@ LL │         uint x = EmptyEvent() + EmptyEvent();
    │                  │
    ╰╴                 tuple()
 
-error: aborting due to 27 previous errors
+error: aborting due to 25 previous errors
 

--- a/tests/ui/typeck/ternary_data_locations.sol
+++ b/tests/ui/typeck/ternary_data_locations.sol
@@ -1,0 +1,24 @@
+contract TernaryDataLocations {
+    uint256[] private words;
+
+    function incompatibleReferences(bool condition) external {
+        uint256[] memory a = new uint256[](1);
+        bytes memory b = hex"aa";
+        words = condition ? a : b; //~ ERROR: incompatible conditional types
+    }
+
+    function memoryToStoragePointer(bool condition) external {
+        uint256[] memory a = new uint256[](1);
+        uint256[] storage pointer = condition ? words : a; //~ ERROR: mismatched types
+        pointer;
+    }
+
+    function incompatibleScalars(bool condition) external {
+        uint256 value = condition ? 1 : true; //~ ERROR: incompatible conditional types
+        value;
+    }
+
+    function storageCalldata(bool condition, uint256[] calldata a) external {
+        words = condition ? words : a; //~ ERROR: incompatible conditional types
+    }
+}

--- a/tests/ui/typeck/ternary_data_locations.stderr
+++ b/tests/ui/typeck/ternary_data_locations.stderr
@@ -1,0 +1,26 @@
+error: incompatible conditional types
+   ╭▸ ROOT/tests/ui/typeck/ternary_data_locations.sol:LL:CC
+   │
+LL │         words = condition ? a : b;
+   ╰╴                ━━━━━━━━━━━━━━━━━
+
+error: mismatched types
+   ╭▸ ROOT/tests/ui/typeck/ternary_data_locations.sol:LL:CC
+   │
+LL │         uint256[] storage pointer = condition ? words : a;
+   ╰╴                                    ━━━━━━━━━━━━━━━━━━━━━ expected `uint256[] storage`, found `uint256[] memory`
+
+error: incompatible conditional types
+   ╭▸ ROOT/tests/ui/typeck/ternary_data_locations.sol:LL:CC
+   │
+LL │         uint256 value = condition ? 1 : true;
+   ╰╴                        ━━━━━━━━━━━━━━━━━━━━
+
+error: incompatible conditional types
+   ╭▸ ROOT/tests/ui/typeck/ternary_data_locations.sol:LL:CC
+   │
+LL │         words = condition ? words : a;
+   ╰╴                ━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
`solsymdiff` found that Solar rejects Solidity's valid conditional memory-to-storage copy pattern, including the upstream `conditional_expression_storage_memory_1.sol` fixture. Both branches were checked directly against the storage destination before the conditional could infer their common memory type, so the enclosing assignment never reached Solar's existing storage-copy path.

This keeps the expected type available for branch inference but defers validation until after the conditional selects its common type. Bytes, dynamic and fixed arrays, structs with dynamic members, nested conditionals, and mixed memory/calldata or storage/memory branches now agree with solc. Invalid location and incompatible-type combinations remain rejected.

Concrete replay and bounded differential checks agree with solc across optimized and unoptimized legacy and via-IR modes.

AI assistance: Codex assisted with differential discovery, implementation, and validation.
