### PR TITLE
fix(codegen): bound fixed-array ABI encoding

### DIFF
--- a/crates/codegen/src/transform/lower_abi_encode.rs
+++ b/crates/codegen/src/transform/lower_abi_encode.rs
@@ -14,6 +14,17 @@ use solar_data_structures::map::{FxHashMap, FxHashSet};
 use solar_interface::{Ident, sym};
 use solar_sema::Gcx;
 
+// Unrolling large fixed arrays leaves at least one value live per element until it is encoded,
+// eventually exhausting the EVM stack. 116 is the latest general gas crossover among the
+// representative layouts: isolated wider structs save less than 0.12% at 119 to 121 but add roughly
+// 15 KiB of code, so larger arrays use a bounded loop instead.
+const MAX_UNROLLED_FIXED_ARRAY_LEN: u64 = 116;
+
+// Dynamic elements make each unrolled iteration substantially larger. Unrolling wins through eight
+// for bytes and strings and through seventeen for nested dynamic arrays; using the wider cutoff
+// preserves every measured small-array gas win, while the loop is smaller and cheaper above it.
+const MAX_UNROLLED_DYNAMIC_FIXED_ARRAY_LEN: u64 = 17;
+
 /// Lowers `abi_encode` after the main optimization pipeline.
 pub(crate) struct LowerAbiEncode;
 
@@ -421,28 +432,15 @@ fn encode_static_impl(
             }
         }
         AbiType::FixedArray { element, len } => {
-            let (child_source, non_null) = source.descend_memory(builder, value);
-            let mut element_head = head_addr;
-            for index in 0..*len {
-                let index = builder.imm_u64(index);
-                let mut element_value = builder.memory_object_load_element(
-                    value,
-                    MemoryObjectLayout::word_fixed_array(*len),
-                    index,
-                );
-                if let Some(non_null) = non_null {
-                    element_value = builder.mul(element_value, non_null);
-                }
-                encode_static_impl(
-                    builder,
-                    element,
-                    element_value,
-                    element_head,
-                    allow_slice_fast_path,
-                    child_source,
-                );
-                element_head = offset_ptr(builder, element_head, element.head_size());
-            }
+            encode_static_array(
+                builder,
+                element,
+                *len,
+                value,
+                head_addr,
+                allow_slice_fast_path,
+                source,
+            );
         }
         AbiType::Function => {
             let value = if source == AbiValueSource::Scalar {
@@ -468,6 +466,86 @@ fn encode_static_impl(
             unreachable!("dynamic ABI values are not static")
         }
     }
+}
+
+fn encode_static_array(
+    builder: &mut FunctionBuilder<'_>,
+    element: &AbiType,
+    len: u64,
+    value: ValueId,
+    head_addr: ValueId,
+    allow_slice_fast_path: bool,
+    source: AbiValueSource,
+) {
+    let (child_source, non_null) = source.descend_memory(builder, value);
+    if len <= MAX_UNROLLED_FIXED_ARRAY_LEN {
+        let mut element_head = head_addr;
+        for index in 0..len {
+            let index = builder.imm_u64(index);
+            let mut element_value = builder.memory_object_load_element(
+                value,
+                MemoryObjectLayout::word_fixed_array(len),
+                index,
+            );
+            if let Some(non_null) = non_null {
+                element_value = builder.mul(element_value, non_null);
+            }
+            encode_static_impl(
+                builder,
+                element,
+                element_value,
+                element_head,
+                allow_slice_fast_path,
+                child_source,
+            );
+            element_head = offset_ptr(builder, element_head, element.head_size());
+        }
+        return;
+    }
+
+    let preheader = builder.current_block();
+    let cond = builder.create_block();
+    let body = builder.create_block();
+    let done = builder.create_block();
+    if let Some(non_null) = non_null {
+        let encode_zero = builder.create_block();
+        builder.branch(non_null, cond, encode_zero);
+
+        builder.switch_to_block(encode_zero);
+        let size = builder.imm_u64(element.head_size() * len);
+        builder.memory_zero(head_addr, size);
+        builder.jump(done);
+    } else {
+        builder.jump(cond);
+    }
+
+    builder.switch_to_block(cond);
+    let zero = builder.imm_u64(0);
+    let index = builder.phi(vec![(preheader, zero)]);
+    let element_head = builder.phi(vec![(preheader, head_addr)]);
+    let length = builder.imm_u64(len);
+    let more = builder.lt(index, length);
+    builder.branch(more, body, done);
+
+    builder.switch_to_block(body);
+    let element_value =
+        builder.memory_object_load_element(value, MemoryObjectLayout::word_fixed_array(len), index);
+    encode_static_impl(
+        builder,
+        element,
+        element_value,
+        element_head,
+        allow_slice_fast_path,
+        child_source,
+    );
+    let next_index = builder.add_u64_offset(index, 1);
+    let next_head = offset_ptr(builder, element_head, element.head_size());
+    let backedge = builder.current_block();
+    builder.jump(cond);
+    builder.add_phi_incoming(index, backedge, next_index);
+    builder.add_phi_incoming(element_head, backedge, next_head);
+
+    builder.switch_to_block(done);
 }
 
 fn encode_tuple(
@@ -666,22 +744,33 @@ fn encode_dynamic_body(
         }
         AbiType::FixedArray { element, len } => {
             let (child_source, non_null) = source.descend_memory(builder, value);
-            let mut values = Vec::with_capacity(*len as usize);
-            for index in 0..*len {
-                let index_value = builder.imm_u64(index);
-                let mut element_value = builder.memory_object_load_element(
-                    value,
-                    crate::mir::MemoryObjectLayout::word_fixed_array(*len),
-                    index_value,
-                );
-                if let Some(non_null) = non_null {
-                    element_value = builder.mul(element_value, non_null);
+            if *len <= MAX_UNROLLED_DYNAMIC_FIXED_ARRAY_LEN {
+                let mut values = Vec::with_capacity(*len as usize);
+                for index in 0..*len {
+                    let index_value = builder.imm_u64(index);
+                    let mut element_value = builder.memory_object_load_element(
+                        value,
+                        MemoryObjectLayout::word_fixed_array(*len),
+                        index_value,
+                    );
+                    if let Some(non_null) = non_null {
+                        element_value = builder.mul(element_value, non_null);
+                    }
+                    values.push(element_value);
                 }
-                values.push(element_value);
+                let types = vec![element.as_ref().clone(); *len as usize];
+                let size = encode_tuple_impl(builder, &values, &types, dest, child_source, helpers);
+                return builder.add(dest, size);
             }
-            let types = vec![element.as_ref().clone(); *len as usize];
-            let size = encode_tuple_impl(builder, &values, &types, dest, child_source, helpers);
-            builder.add(dest, size)
+            encode_memory_array_elements(
+                builder,
+                element,
+                value,
+                dest,
+                MemoryObjectLayout::word_fixed_array(*len),
+                non_null,
+                helpers,
+            )
         }
         AbiType::Tuple(fields) => {
             let (child_source, non_null) = source.descend_memory(builder, value);
@@ -748,29 +837,47 @@ fn encode_memory_array(
     helpers: &EncodeHelpers,
 ) -> ValueId {
     match array_loop_element(element) {
-        Some(None) => encode_dynamic_array(builder, element, value, dest, helpers),
+        Some(None) => encode_memory_array_elements(
+            builder,
+            element,
+            value,
+            dest,
+            MemoryObjectLayout::WORD_ARRAY,
+            None,
+            helpers,
+        ),
         cleanup => {
             encode_word_array(builder, value, dest, SliceLocation::Memory, cleanup.flatten())
         }
     }
 }
 
-fn encode_dynamic_array(
+fn encode_memory_array_elements(
     builder: &mut FunctionBuilder<'_>,
     element: &AbiType,
     value: ValueId,
     dest: ValueId,
+    layout: MemoryObjectLayout,
+    non_null: Option<ValueId>,
     helpers: &EncodeHelpers,
 ) -> ValueId {
-    let len = memory_object_len(builder, value, MemoryObjectKind::DynamicArray);
-    builder.mstore(dest, len);
-
-    let word = builder.imm_u64(32);
-    let element_area = builder.add(dest, word);
+    let (len, element_area) = match layout {
+        MemoryObjectLayout::DynamicArray { .. } => {
+            let len = memory_object_len(builder, value, MemoryObjectKind::DynamicArray);
+            builder.mstore(dest, len);
+            let word = builder.imm_u64(32);
+            (len, builder.add(dest, word))
+        }
+        MemoryObjectLayout::FixedArray { len, .. } => (builder.imm_u64(len), dest),
+        MemoryObjectLayout::Bytes | MemoryObjectLayout::Struct { .. } => {
+            unreachable!("ABI array encoding requires an array memory layout")
+        }
+    };
     let element_head_size = builder.imm_u64(element.head_size());
     let head_bytes = builder.mul(len, element_head_size);
     let initial_tail = builder.add(element_area, head_bytes);
-    let source_cursor = builder.memory_object_data(value, MemoryObjectKind::DynamicArray);
+    let source_cursor = builder.memory_object_data(value, layout.kind());
+    let word = builder.imm_u64(32);
 
     let preheader = builder.current_block();
     let cond = builder.create_block();
@@ -788,7 +895,10 @@ fn encode_dynamic_array(
     builder.branch(has_next, body, done);
 
     builder.switch_to_block(body);
-    let element_value = builder.mload(source);
+    let mut element_value = builder.mload(source);
+    if let Some(non_null) = non_null {
+        element_value = builder.mul(element_value, non_null);
+    }
     let new_tail = encode_value(
         builder,
         element,

--- a/tests/ui/codegen/run-call/large_fixed_array_abi.sol
+++ b/tests/ui/codegen/run-call/large_fixed_array_abi.sol
@@ -1,0 +1,113 @@
+//@ revisions: gas size
+//@[gas] compile-flags: -O gas
+//@[size] compile-flags: -O size
+//@ run-call: LargeWordArray::hash() => 0xa41eebc34ef4a2bef7c4463ad5d47685d5cf475712be997e19818707e2e36b43
+//@ run-call: UnrolledWordArray::hash() => 0x413fb8809e5063fd99860bceb9963617ce9a04f9001f7825ffacb57e3d64f140
+//@ run-call: NestedStructArray::hash() => 0x267950286dfa1667d06ecbbef2341c0ff0300e2241889da8186dbbc3256b3dbe
+//@ run-call: NullableFixedArray::hash(bool) false => 0xbd25874911abf23663dfdb4f360566b8be904042a4b73297ff91a2ed4b0b9290
+//@ run-call: NullableFixedArray::hash(bool) true => 0xe024dd41efb1448109e8a893545763be3cc16bbcff9d3c3d657db8f3e979d391
+//@ run-call: DynamicFixedArray::returnHash() => 0xae64e4c9ef2c7ec4a51aeb6980efa4df8e8a81def13fea38f8d4a8a76d8607d0
+//@ run-call: DynamicFixedArray::encodeHash() => 0xfce20023d5be7adf99be05833ee5b1be38219ef1f717ced202a7139e09572597
+//@ run-call: DynamicFixedArray::nestedHash(bool) false => 0xdb666b204e126b7c16cba7510b7a045fd85861c6aff50723985ef5e1198fa055
+//@ run-call: DynamicFixedArray::nestedHash(bool) true => 0x81657b39d8099a2aef988f9d70cdb30bcea35a4a9fa1e8ad829ea6a89c1dc354
+//@ run-call: DynamicFixedArray::unrolledHash() => 0x8712a90fa925ee5615802a9a69f58ddcf7da5d8c7eb43a4acb9f0627ef040cbf
+
+contract LargeWordArray {
+    function values() external pure returns (bool[989] memory result) {}
+
+    function hash() external view returns (bytes32) {
+        (bool success, bytes memory output) =
+            address(this).staticcall(abi.encodeCall(this.values, ()));
+        require(success);
+        return keccak256(output);
+    }
+}
+
+contract UnrolledWordArray {
+    function values() external pure returns (bool[116] memory result) {
+        result[0] = true;
+        result[115] = true;
+    }
+
+    function hash() external view returns (bytes32) {
+        (bool success, bytes memory output) =
+            address(this).staticcall(abi.encodeCall(this.values, ()));
+        require(success);
+        return keccak256(output);
+    }
+}
+
+contract NestedStructArray {
+    struct Value {
+        uint256 id;
+        bool enabled;
+        bytes32[3] words;
+    }
+
+    function values() external pure returns (Value[129] memory result) {
+        result[0].id = 1;
+        result[0].enabled = true;
+        result[0].words[2] = bytes32(uint256(2));
+        result[128].id = 3;
+        result[128].words[0] = bytes32(uint256(4));
+    }
+
+    function hash() external view returns (bytes32) {
+        (bool success, bytes memory output) =
+            address(this).staticcall(abi.encodeCall(this.values, ()));
+        require(success);
+        return keccak256(output);
+    }
+}
+
+contract NullableFixedArray {
+    function hash(bool populate) external pure returns (bytes32) {
+        bool[989][] memory values = new bool[989][](1);
+        if (populate) {
+            bool[989] memory inner;
+            inner[0] = true;
+            inner[988] = true;
+            values[0] = inner;
+        }
+        return keccak256(abi.encode(values));
+    }
+}
+
+contract DynamicFixedArray {
+    function values() external pure returns (string[510] memory result) {
+        result[0] = "first";
+        result[509] = "last";
+    }
+
+    function returnHash() external view returns (bytes32) {
+        (bool success, bytes memory output) =
+            address(this).staticcall(abi.encodeCall(this.values, ()));
+        require(success);
+        return keccak256(output);
+    }
+
+    function encodeHash() external pure returns (bytes32) {
+        string[510] memory items;
+        items[1] = "one";
+        items[508] = "near-last";
+        return keccak256(abi.encode(items));
+    }
+
+    function nestedHash(bool populate) external pure returns (bytes32) {
+        string[510][] memory items = new string[510][](1);
+        if (populate) {
+            string[510] memory inner;
+            inner[0] = "first";
+            inner[509] = "last";
+            items[0] = inner;
+        }
+        return keccak256(abi.encode(items));
+    }
+
+    function unrolledHash() external pure returns (bytes32) {
+        string[17] memory items;
+        items[0] = "first";
+        items[16] = "last";
+        return keccak256(abi.encode(items));
+    }
+}


### PR DESCRIPTION
Stacks on #1161.

That rewrite currently expands every fixed-array element into MIR before ABI encoding. `bool[989]` consequently emits a 110,006-byte optimized runtime that overflows the EVM stack, while dynamic-element arrays such as `string[512]` reach 100,736 bytes and fail the same way.

This keeps the measured small-array unrolled paths, then encodes larger static arrays with a bounded cursor loop and reuses the existing memory-array loop for dynamic elements. Nullable/default aggregates retain their canonical zero encoding.

The `bool[989]` runtime falls to 13,920 bytes and `string[512]` to 4,801 bytes; the pathological compile is 19.1x faster with 56.8% lower peak RSS. Runtime hashes match Solc across legacy/viaIR and optimized/unoptimized settings, while the 15-contract hot corpus remains byte-for-byte and gas-identical.

Developed with AI assistance.
