### PR TITLE
refactor: centralize function naming

### DIFF
--- a/crates/codegen/src/lower/mod.rs
+++ b/crates/codegen/src/lower/mod.rs
@@ -1306,7 +1306,7 @@ impl<'gcx> Lowerer<'gcx> {
         let check_expr_errors = std::mem::replace(&mut self.check_expr_errors, self.hir_has_errors);
         let hir_func = self.gcx.hir.function(func_id);
 
-        let func_name = hir_func.name.unwrap_or_else(|| Ident::new(sym::_anonymous, Span::DUMMY));
+        let func_name = Ident::new(hir_func.name_or_kind(), Span::DUMMY);
 
         // Reserve and register the MIR id before lowering the body so recursive
         // self-calls can resolve to this function.

--- a/crates/lsp/src/type_hierarchy.rs
+++ b/crates/lsp/src/type_hierarchy.rs
@@ -304,11 +304,7 @@ fn node_name(gcx: Gcx<'_>, item_id: ItemId) -> Option<String> {
                 name.push_str(gcx.hir.contract(contract_id).name.as_str());
                 name.push('.');
             }
-            if let Some(function_name) = function.name {
-                name.push_str(function_name.as_str());
-            } else {
-                name.push_str(function.kind.to_str());
-            }
+            name.push_str(function.name_or_kind().as_str());
 
             if function.kind != FunctionKind::Modifier {
                 name.push('(');

--- a/crates/sema/src/hir/mod.rs
+++ b/crates/sema/src/hir/mod.rs
@@ -10,7 +10,9 @@ use solar_data_structures::{
     index::{Idx, IndexVec},
     newtype_index,
 };
-use solar_interface::{Ident, Span, Symbol, diagnostics::ErrorGuaranteed, source_map::SourceFile};
+use solar_interface::{
+    Ident, Span, Symbol, diagnostics::ErrorGuaranteed, kw, source_map::SourceFile,
+};
 use std::{cell::Cell, fmt, ops::ControlFlow, sync::Arc};
 use strum::EnumIs;
 
@@ -1059,6 +1061,20 @@ pub struct Function<'hir> {
 }
 
 impl Function<'_> {
+    /// Returns the function name or its kind when unnamed.
+    pub fn name_or_kind(&self) -> Symbol {
+        self.name.map_or_else(
+            || match self.kind {
+                FunctionKind::Constructor => kw::Constructor,
+                FunctionKind::Function => kw::Function,
+                FunctionKind::Fallback => kw::Fallback,
+                FunctionKind::Receive => kw::Receive,
+                FunctionKind::Modifier => kw::Modifier,
+            },
+            |name| name.name,
+        )
+    }
+
     /// Returns the span of the `kind` keyword.
     pub fn keyword_span(&self) -> Span {
         self.span.with_hi(self.span.lo() + self.kind.to_str().len() as u32)

--- a/tests/ui/codegen/lowering/base_constructor.sol
+++ b/tests/ui/codegen/lowering/base_constructor.sol
@@ -6,7 +6,7 @@ contract Base {
     // CHECK: {{v[0-9]+}} = sload 0
     uint256 public value;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: sstore 0, arg0
     constructor(uint256 initialValue) {
         value = initialValue;
@@ -14,7 +14,7 @@ contract Base {
 }
 
 contract Derived is Base {
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: sstore 0, arg0
     // CHECK-LABEL: fn @value{{[( ]}}
     // CHECK: sload 0

--- a/tests/ui/codegen/lowering/base_constructor.stdout
+++ b/tests/ui/codegen/lowering/base_constructor.stdout
@@ -6,7 +6,7 @@ fn @value() -> u256 [abi_returns=[word]] {
     ret v0
 }
 
-fn @_anonymous(arg0: u256) {
+fn @constructor(arg0: u256) {
   bb0:
     sstore 0, arg0 !metadata(storage=slot(0))
     stop
@@ -14,7 +14,7 @@ fn @_anonymous(arg0: u256) {
 
 // === ROOT/tests/ui/codegen/lowering/base_constructor.sol:Derived ===
 @module Derived
-fn @_anonymous(arg0: u256) {
+fn @constructor(arg0: u256) {
   bb0:
     sstore 0, arg0 !metadata(storage=slot(0))
     jump bb1

--- a/tests/ui/codegen/lowering/constructor_abi_validation.sol
+++ b/tests/ui/codegen/lowering/constructor_abi_validation.sol
@@ -11,7 +11,7 @@ contract ConstructorAbiValidation {
     // CHECK: and {{v[0-9]+}}, 255
     bool public second;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: [[BASE:v[0-9]+]] = constructor_args_base
     // CHECK: [[FIRST:v[0-9]+]] = add [[BASE]], 0
     // CHECK-NEXT: {{v[0-9]+}} = mload [[FIRST]]

--- a/tests/ui/codegen/lowering/constructor_abi_validation.stdout
+++ b/tests/ui/codegen/lowering/constructor_abi_validation.stdout
@@ -15,7 +15,7 @@ fn @second() -> bool [abi_returns=[word]] {
     ret v2
 }
 
-fn @_anonymous(arg0: bool, arg1: u256, arg2: u256) {
+fn @constructor(arg0: bool, arg1: u256, arg2: u256) {
   bb0:
     v0 = constructor_args_base
     v1 = add v0, 0

--- a/tests/ui/codegen/lowering/constructor_internal_call.mir.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_call.mir.stdout
@@ -6,7 +6,7 @@ fn @value() -> u256 [abi_returns=[word]] {
     ret v0
 }
 
-fn @_anonymous(arg0: u256) {
+fn @constructor(arg0: u256) {
   bb0:
     v0 = and arg0, 7
     v1 = internal_call @helper, 1, v0

--- a/tests/ui/codegen/lowering/constructor_internal_call.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_call.sol
@@ -9,7 +9,7 @@ contract ConstructorInternalCall {
     // MIR: sload 0
     uint256 public value;
 
-    // MIR-LABEL: fn @_anonymous{{[( ]}}
+    // MIR-LABEL: fn @constructor{{[( ]}}
     // MIR: [[MASKED:v[0-9]+]] = and arg0, 7
     // MIR: [[VALUE:v[0-9]+]] = internal_call @helper, 1, [[MASKED]]
     // MIR: sstore 0, [[VALUE]]

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.sol
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.sol
@@ -15,7 +15,7 @@ contract ConstructorInternalLibraryCall {
     // CHECK: sload 0
     uint256 public value;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: [[MASKED:v[0-9]+]] = and arg0, 7
     // CHECK: [[VALUE:v[0-9]+]] = internal_call @helper, 1, [[MASKED]]
     // CHECK: sstore 0, [[VALUE]]

--- a/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
+++ b/tests/ui/codegen/lowering/constructor_internal_library_call.stdout
@@ -9,7 +9,7 @@ fn @value() -> u256 [abi_returns=[word]] {
     ret v0
 }
 
-fn @_anonymous(arg0: u256) {
+fn @constructor(arg0: u256) {
   bb0:
     v0 = and arg0, 7
     v1 = internal_call @helper, 1, v0

--- a/tests/ui/codegen/lowering/immutable_getter.sol
+++ b/tests/ui/codegen/lowering/immutable_getter.sol
@@ -6,7 +6,7 @@ contract C {
     // CHECK: {{v[0-9]+}} = loadimmutable owner
     address public immutable owner;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: storeimmutable owner, arg0
     constructor(address value) {
         owner = value;

--- a/tests/ui/codegen/lowering/immutable_getter.stdout
+++ b/tests/ui/codegen/lowering/immutable_getter.stdout
@@ -9,7 +9,7 @@ fn @owner() -> address [abi_returns=[word]] {
     ret v0
 }
 
-fn @_anonymous(arg0: address) {
+fn @constructor(arg0: address) {
   bb0:
     v0 = constructor_args_base
     v1 = add v0, 0

--- a/tests/ui/codegen/lowering/immutable_reads.sol
+++ b/tests/ui/codegen/lowering/immutable_reads.sol
@@ -10,7 +10,7 @@ contract C {
     // CHECK: loadimmutable duration
     uint256 public immutable duration;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: storeimmutable start, arg0
     // CHECK: [[START:v[0-9]+]] = loadimmutable start
     // CHECK: [[DURATION:v[0-9]+]] = add [[START]], 1

--- a/tests/ui/codegen/lowering/immutable_reads.stdout
+++ b/tests/ui/codegen/lowering/immutable_reads.stdout
@@ -16,7 +16,7 @@ fn @duration() -> u256 [abi_returns=[word]] {
     ret v0
 }
 
-fn @_anonymous(arg0: u256) {
+fn @constructor(arg0: u256) {
   bb0:
     storeimmutable start, arg0
     v0 = loadimmutable start

--- a/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.sol
+++ b/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.sol
@@ -5,7 +5,7 @@
 
 // The 8-byte function pointer packs into slot 0: the constructor
 // read-modify-writes its bytes and readers mask them back out.
-// CHECK-LABEL: fn @_anonymous(
+// CHECK-LABEL: fn @constructor(
 // CHECK: and [[ONLY_STORED:[0-9]+]], 0xffffffffffffffff
 // CHECK: sstore 0, {{v[0-9]+}}
 contract ConstructorStoredFunctionPointer {

--- a/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.stdout
+++ b/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/internal-function-pointer/constructor_storage_mir.sol:ConstructorStoredFunctionPointer ===
 @module ConstructorStoredFunctionPointer
-fn @_anonymous() {
+fn @constructor() {
   bb0:
     v0 = sload 0 !metadata(storage=slot(0))
     v1 = and v0, 0xffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000

--- a/tests/ui/codegen/lowering/storage_bytes_elements.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.sol
@@ -45,7 +45,7 @@ contract StorageStringConstructor {
     // CHECK: internal_call @__load_storage_bytes, 1, 1
     string public symbol;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK-COUNT-2: mcopy {{.*}} !metadata(memory=heap)
     // CHECK: sstore 0,
     // CHECK: sstore 1,
@@ -64,7 +64,7 @@ contract StorageStringBase {
     // CHECK: internal_call @__load_storage_bytes, 1, 1
     string public symbol;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: sstore 0,
     // CHECK: sstore 1,
     constructor(string memory name_, string memory symbol_) {
@@ -74,7 +74,7 @@ contract StorageStringBase {
 }
 
 contract StorageStringDerived is StorageStringBase {
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: set_memory_object_len memorybytes, {{v[0-9]+}}, 9
     // CHECK: set_memory_object_len memorybytes, {{v[0-9]+}}, 4
     // CHECK: sstore 0,

--- a/tests/ui/codegen/lowering/storage_bytes_elements.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_elements.stdout
@@ -305,7 +305,7 @@ fn @symbol() -> memorybytes [abi_returns=[memory_bytes]] {
     ret v0
 }
 
-fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
+fn @constructor(arg0: memorybytes, arg1: memorybytes) {
   bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = constructor_args_base
@@ -610,7 +610,7 @@ fn @symbol() -> memorybytes [abi_returns=[memory_bytes]] {
     ret v0
 }
 
-fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
+fn @constructor(arg0: memorybytes, arg1: memorybytes) {
   bb0:
     v0 = mload 64 !metadata(memory=scratch)
     v1 = constructor_args_base
@@ -857,7 +857,7 @@ fn @_anonymous(arg0: memorybytes, arg1: memorybytes) {
 
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_elements.sol:StorageStringDerived ===
 @module StorageStringDerived
-fn @_anonymous() {
+fn @constructor() {
   bb0:
     v0 = alloc memorybytes, exact, uninitialized, infallible, 64
     set_memory_object_len memorybytes, v0, 9

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.sol
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.sol
@@ -4,7 +4,7 @@
 contract StorageBytesPushPop {
     bytes data;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: [[FIRST:v[0-9]+]] = internal_call @__load_storage_bytes, 1, 0
     // CHECK: {{v[0-9]+}} = memory_object_len memorybytes, [[FIRST]]
     // CHECK: mcopy

--- a/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
+++ b/tests/ui/codegen/lowering/storage_bytes_push_pop.stdout
@@ -1,6 +1,6 @@
 // === ROOT/tests/ui/codegen/lowering/storage_bytes_push_pop.sol:StorageBytesPushPop ===
 @module StorageBytesPushPop
-fn @_anonymous() {
+fn @constructor() {
   bb0:
     v0 = internal_call @__load_storage_bytes, 1, 0
     v1 = memory_object_len memorybytes, v0

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.sol
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.sol
@@ -12,7 +12,7 @@ contract StorageLongBytesReturn {
     // CHECK: ret [[VALUE]]
     bytes public b;
 
-    // CHECK-LABEL: fn @_anonymous{{[( ]}}
+    // CHECK-LABEL: fn @constructor{{[( ]}}
     // CHECK: sstore 0, 65
     // CHECK: [[S_DATA:v[0-9]+]] = keccak256 0, 32
     // CHECK: sstore [[S_DATA]], 0x6162636465666768696a6b6c6d6e6f707172737475767778797a414243444546

--- a/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
+++ b/tests/ui/codegen/lowering/storage_long_bytes_return.stdout
@@ -58,7 +58,7 @@ fn @b() -> memorybytes [abi_returns=[memory_bytes]] {
     ret v0
 }
 
-fn @_anonymous() {
+fn @constructor() {
   bb0:
     sstore 0, 65 !metadata(storage=slot(0))
     mstore 0, 0 !metadata(memory=scratch)

--- a/tests/ui/codegen/lowering/store_immutable_requires_lowering.stderr
+++ b/tests/ui/codegen/lowering/store_immutable_requires_lowering.stderr
@@ -4,7 +4,7 @@ error: immutable assignments must be lowered before EVM codegen
 LL │ contract StoreImmutableRequiresLowering {
    │          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
-   ╰ note: remaining MIR slice is in function `_anonymous`
+   ╰ note: remaining MIR slice is in function `constructor`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Add `Function::name_or_kind` to return a pre-interned symbol for named and special functions. Use it in the LSP type hierarchy and MIR lowering so constructors keep their kind instead of becoming `_anonymous`.