### PR TITLE
perf(codegen): optimize physical stack peepholes

### DIFF
--- a/crates/codegen/src/backend/evm/ir/passes/peephole.rs
+++ b/crates/codegen/src/backend/evm/ir/passes/peephole.rs
@@ -33,6 +33,7 @@ use crate::{
     utils::eval,
 };
 use alloy_primitives::U256;
+use smallvec::SmallVec;
 use solar_config::EvmVersion;
 use solar_sema::Gcx;
 use std::fmt;
@@ -163,6 +164,14 @@ fn try_peephole(gcx: Gcx<'_>, instructions: &mut Vec<Instruction>, block: u32) -
         ($skip:expr, $edit:expr) => {
             rewrite(instructions, $skip, $edit, block)
         };
+    }
+
+    // `... PUSH0 ... DUPn -> ... PUSH0 ... PUSH0` when the duplicate reads that zero.
+    //
+    // `PUSH0` is one byte and costs two gas, so it dominates every `DUPn` on targets that support
+    // it.
+    if gcx.sess.opts.evm_version.has_push0() && duplicates_known_zero(instructions) {
+        return rewrite!(1, Edit::OverwritePush0);
     }
 
     // `PUSH x PUSH 0 OP -> PUSH 0`.
@@ -469,6 +478,10 @@ fn try_peephole(gcx: Gcx<'_>, instructions: &mut Vec<Instruction>, block: u32) -
         return rewrite!(4, Edit::EqIszeroJumpi);
     }
 
+    if let Some(len) = noop_stack_suffix_len(instructions) {
+        return rewrite!(len, Edit::Keep(0));
+    }
+
     // `EXCHANGE n, m SWAPn -> SWAPn SWAPm`.
     // `EXCHANGE n, m SWAPm -> SWAPm SWAPn`.
     // `SWAPn EXCHANGE n, m -> SWAPm SWAPn`.
@@ -512,6 +525,119 @@ fn try_peephole(gcx: Gcx<'_>, instructions: &mut Vec<Instruction>, block: u32) -
     false
 }
 
+const MAX_STACK_PEEPHOLE_WINDOW: usize = 24;
+
+#[derive(Clone, Copy)]
+enum SymbolicStackOp {
+    Push,
+    Physical(PhysicalStackOp),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum KnownStackWord {
+    Other,
+    Zero,
+}
+
+fn duplicates_known_zero(instructions: &[Instruction]) -> bool {
+    let Some(op::StackOp::Dup(depth)) = instructions.last().and_then(Instruction::as_stack_op)
+    else {
+        return false;
+    };
+    let end = instructions.len() - 1;
+    let start = instructions[..end]
+        .iter()
+        .rposition(|inst| !(inst.is_encoded_push() || inst.as_stack_op().is_some()))
+        .map_or(end.saturating_sub(MAX_STACK_PEEPHOLE_WINDOW), |index| index + 1)
+        .max(end.saturating_sub(MAX_STACK_PEEPHOLE_WINDOW));
+    if !instructions[start..end].iter().any(|inst| inst.concrete_immediate() == Some(U256::ZERO)) {
+        return false;
+    }
+    let mut stack = SmallVec::<[KnownStackWord; MAX_STACK_PEEPHOLE_WINDOW + 16]>::from_elem(
+        KnownStackWord::Other,
+        usize::from(depth),
+    );
+    for inst in &instructions[start..end] {
+        if !inst.has_canonical_stack_effect() {
+            return false;
+        }
+        if inst.is_encoded_push() {
+            stack.push(if inst.concrete_immediate() == Some(U256::ZERO) {
+                KnownStackWord::Zero
+            } else {
+                KnownStackWord::Other
+            });
+            continue;
+        }
+        let Some(op) = inst.as_stack_op() else { return false };
+        let required = op.required_depth();
+        if stack.len() < required {
+            for _ in stack.len()..required {
+                stack.insert(0, KnownStackWord::Other);
+            }
+        }
+        let top = stack.len() - 1;
+        match op {
+            op::StackOp::Dup(depth) => stack.push(stack[top - usize::from(depth - 1)]),
+            op::StackOp::Swap(depth) => stack.swap(top, top - usize::from(depth)),
+            op::StackOp::Exchange(n, m) => {
+                stack.swap(top - usize::from(n), top - usize::from(m));
+            }
+            op::StackOp::Pop => {
+                stack.pop();
+            }
+        }
+    }
+    let depth = usize::from(depth);
+    if stack.len() < depth {
+        return false;
+    }
+    stack[stack.len() - depth] == KnownStackWord::Zero
+}
+
+fn noop_stack_suffix_len(instructions: &[Instruction]) -> Option<usize> {
+    let end = instructions.len();
+    let last = stack_op(instructions.last()?)?;
+    if end < 2 || !matches!(last, SymbolicStackOp::Physical(PhysicalStackOp::Pop)) {
+        return None;
+    }
+    let floor = end.saturating_sub(MAX_STACK_PEEPHOLE_WINDOW);
+    let start = instructions[floor..end - 1]
+        .iter()
+        .rposition(|inst| stack_op(inst).is_none())
+        .map_or(floor, |index| floor + index + 1);
+    let last_push =
+        instructions[start..end].iter().rposition(is_removable_push).map(|index| start + index)?;
+    (start..=last_push)
+        .find(|&start| is_noop_stack_sequence(&instructions[start..]))
+        .map(|start| end - start)
+}
+
+fn is_noop_stack_sequence(instructions: &[Instruction]) -> bool {
+    let mut depth = 0usize;
+    for inst in instructions {
+        match stack_op(inst) {
+            Some(SymbolicStackOp::Push) => depth += 1,
+            Some(SymbolicStackOp::Physical(op)) => {
+                if depth < op.required_depth() {
+                    return false;
+                }
+                let Some(next) = depth.checked_add_signed(op.net_growth()) else { return false };
+                depth = next;
+            }
+            None => return false,
+        }
+    }
+    depth == 0
+}
+
+fn stack_op(inst: &Instruction) -> Option<SymbolicStackOp> {
+    if is_removable_push(inst) {
+        return Some(SymbolicStackOp::Push);
+    }
+    inst.as_stack_op().map(SymbolicStackOp::Physical)
+}
+
 // Keep trace formatting out of the hot matcher's stack frame.
 #[inline(never)]
 fn rewrite(instructions: &mut Vec<Instruction>, skip: usize, edit: Edit, block: u32) -> bool {
@@ -534,6 +660,7 @@ fn rewrite(instructions: &mut Vec<Instruction>, skip: usize, edit: Edit, block: 
 #[derive(Clone, Copy)]
 enum Edit {
     Keep(u8),
+    OverwritePush0,
     RemoveFirstKeep(u8),
     RemoveFirstOverwrite(u8),
     SwapOverwrite(u8),
@@ -553,6 +680,11 @@ impl Edit {
     fn apply(self, instructions: &mut Vec<Instruction>, start: usize) {
         match self {
             Self::Keep(len) => instructions.truncate(start + usize::from(len)),
+            Self::OverwritePush0 => {
+                let metadata = std::mem::take(&mut instructions[start].metadata);
+                instructions[start] = Instruction::push_value(U256::ZERO);
+                instructions[start].metadata = metadata;
+            }
             Self::RemoveFirstKeep(len) => {
                 instructions.remove(start);
                 instructions.truncate(start + usize::from(len));

--- a/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.evmir
@@ -138,3 +138,95 @@ bb10:
   push 0
   mstore
   stop
+
+// Remove a longer identity shuffle without matching its exact opcode sequence.
+// CHECK-LABEL: {{^[ +].*}}bb11:
+// CHECK-NEXT: {{^[ +].*}}push 1
+// CHECK-NEXT: {{^[ +].*}}push 2
+// CHECK-NEXT: {{^[ +].*}}push 3
+// CHECK-NEXT: {{^[ +].*}}push 4
+// CHECK-NEXT: {{^[ +].*}}push 5
+// CHECK-NEXT: {{^[ +].*}}swap 3
+// CHECK: {{^[ +].*}}swap 4
+bb11:
+  push 1
+  push 2
+  push 3
+  push 4
+  push 5
+  swap 3
+  push 0
+  push 1
+  swap 1
+  swap 2
+  swap 1
+  pop
+  swap 1
+  pop
+  swap 4
+  push 0
+  mstore
+  stop
+
+// PUSH0 participates in symbolic cleanup.
+// CHECK-LABEL: {{^[ +].*}}bb12:
+// CHECK: {{^[ +].*}}push 0
+// CHECK-NEXT: -   pop
+// CHECK-NEXT: -   push 0
+bb12:
+  calldatasize
+  push0
+  pop
+  push0
+  mstore
+  stop
+
+// Deferred pushes cannot be removed before assembly resolves them.
+// CHECK-LABEL: {{^[ +].*}}bb13:
+// CHECK-NEXT: {{^[ +].*}}calldatasize
+// CHECK-NEXT: {{^    push_deferred 0}}
+// CHECK-NEXT: {{^    pop}}
+// CHECK-NEXT: {{^    push 0}}
+bb13:
+  calldatasize
+  push_deferred 0
+  pop
+  push0
+  mstore
+  stop
+
+// Do not remove an identity that only holds with an unavailable stack prefix.
+// CHECK-LABEL: {{^[ +].*}}bb14:
+// CHECK: +   exchange 1, 2
+// CHECK-NEXT: {{^[ +].*}}pop
+// CHECK-NEXT: {{^[ +].*}}swap 1
+// CHECK-NEXT: {{^[ +].*}}pop
+bb14:
+  push 0
+  push 1
+  swap 1
+  swap 2
+  swap 1
+  pop
+  swap 1
+  pop
+  stop
+
+// PUSH0 is cheaper than duplicating it at any depth.
+// CHECK-LABEL: {{^[ +].*}}bb15:
+// CHECK-NEXT: {{^[ +].*}}push 0
+// CHECK-NEXT: {{^[ +].*}}push 1
+// CHECK-NEXT: -   dup 2
+// CHECK-NEXT: -   dup 1
+// CHECK-NEXT: +   push 0
+// CHECK-NEXT: +   push 0
+// CHECK-NEXT: {{^[ +].*}}push 0
+// CHECK-NEXT: {{^[ +].*}}mstore
+bb15:
+  push0
+  push 1
+  dup 2
+  dup 1
+  push 0
+  mstore
+  stop

--- a/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.stdout
+++ b/tests/ui/codegen/evm-ir/peephole/patterns/cancellations.stdout
@@ -100,4 +100,59 @@
     push 0
     mstore
     stop
+  bb11:
+    push 1
+    push 2
+    push 3
+    push 4
+    push 5
+    swap 3
+    push 0
+    push 1
+-   swap 1
+-   swap 2
+-   swap 1
++   exchange 1, 2
+    pop
+    swap 1
+    pop
+    swap 4
+    push 0
+    mstore
+    stop
+  bb12:
+    calldatasize
+    push 0
+-   pop
+-   push 0
+    mstore
+    stop
+  bb13:
+    calldatasize
+    push_deferred 0
+    pop
+    push 0
+    mstore
+    stop
+  bb14:
+    push 0
+    push 1
+-   swap 1
+-   swap 2
+-   swap 1
++   exchange 1, 2
+    pop
+    swap 1
+    pop
+    stop
+  bb15:
+    push 0
+    push 1
+-   dup 2
+-   dup 1
++   push 0
++   push 0
+    push 0
+    mstore
+    stop
   


### PR DESCRIPTION
Remove redundant physical stack cleanup sequences after scheduling.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>