### PR TITLE
fix(sema): drop cached output allocations

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -215,7 +215,7 @@ fn ensure_contract_bytecode(
     // Valid code cannot have recursive creation dependencies; seed the entry
     // so an unexpected cycle terminates instead of recursing forever.
     bytecodes.insert(contract_id, codegen::lower::ContractBytecodes::default());
-    for dep in gcx.contract_bytecode_dependencies(contract_id) {
+    for dep in gcx.contract_bytecode_dependencies(contract_id).iter() {
         ensure_contract_bytecode(gcx, dep, bytecodes)?;
     }
     let mut module = codegen::lower::lower_contract(

--- a/crates/codegen/src/contract.rs
+++ b/crates/codegen/src/contract.rs
@@ -248,11 +248,11 @@ impl ContractGraph {
         }
 
         let dependencies = gcx.contract_bytecode_dependencies(contract_id);
-        for dependency in dependencies {
+        for dependency in dependencies.iter() {
             self.dependents[dependency].push(contract_id);
             self.discover_contract(gcx, dependency, visiting)?;
         }
-        for dependency in dependencies {
+        for dependency in dependencies.iter() {
             self.dependencies[contract_id].insert(dependency);
         }
         self.reachable.insert(contract_id);

--- a/crates/data-structures/src/drop_arena.rs
+++ b/crates/data-structures/src/drop_arena.rs
@@ -1,0 +1,148 @@
+use bumpalo::Bump;
+use std::{
+    cell::RefCell,
+    ptr::{self, NonNull},
+};
+
+/// A bump arena that runs destructors for allocated values.
+pub struct DropArena {
+    bump: Bump,
+    drops: RefCell<Vec<DropEntry>>,
+}
+
+// SAFETY: All values registered through the public allocation methods are `Send`.
+unsafe impl Send for DropArena {}
+
+struct DropEntry {
+    ptr: NonNull<()>,
+    len: usize,
+    drop: unsafe fn(NonNull<()>, usize),
+}
+
+struct DropEntries(*mut DropArena);
+
+impl Drop for DropEntries {
+    fn drop(&mut self) {
+        // SAFETY: The pointer comes from `DropArena::drop` and remains valid for this guard.
+        unsafe { (*self.0).drop_entries() };
+    }
+}
+
+impl DropArena {
+    /// Creates an empty arena.
+    #[inline]
+    pub fn new() -> Self {
+        Self { bump: Bump::new(), drops: RefCell::new(Vec::new()) }
+    }
+
+    /// Allocates a value in the arena.
+    #[inline]
+    pub fn alloc<T: Send>(&self, value: T) -> &mut T {
+        let value = self.bump.alloc(value);
+        self.register::<T>(NonNull::from(&mut *value).cast(), 1, drop_value::<T>);
+        value
+    }
+
+    /// Allocates an iterator's values in the arena.
+    #[inline]
+    pub fn alloc_slice_fill_iter<T: Send, I>(&self, iter: I) -> &mut [T]
+    where
+        I: IntoIterator<Item = T>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let values = self.bump.alloc_slice_fill_iter(iter);
+        if let Some(ptr) = NonNull::new(values.as_mut_ptr()) {
+            self.register::<T>(ptr.cast(), values.len(), drop_slice::<T>);
+        }
+        values
+    }
+
+    #[inline]
+    fn register<T>(&self, ptr: NonNull<()>, len: usize, drop: unsafe fn(NonNull<()>, usize)) {
+        if std::mem::needs_drop::<T>() && len != 0 {
+            self.drops.borrow_mut().push(DropEntry { ptr, len, drop });
+        }
+    }
+
+    unsafe fn drop_entries(&self) {
+        loop {
+            let Some(current) = self.drops.borrow_mut().pop() else { return };
+            // SAFETY: `current` records the allocation's pointer, length, and destructor.
+            unsafe { (current.drop)(current.ptr, current.len) };
+        }
+    }
+}
+
+impl Default for DropArena {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for DropArena {
+    fn drop(&mut self) {
+        let _guard = DropEntries(self);
+        // SAFETY: `drops` contains only entries added by `register`.
+        unsafe { self.drop_entries() };
+    }
+}
+
+unsafe fn drop_value<T>(ptr: NonNull<()>, _: usize) {
+    // SAFETY: `ptr` points to a `T` allocated by `DropArena::alloc`.
+    unsafe { ptr.cast::<T>().drop_in_place() };
+}
+
+unsafe fn drop_slice<T>(ptr: NonNull<()>, len: usize) {
+    // SAFETY: `ptr` points to `len` contiguous `T`s allocated by
+    // `DropArena::alloc_slice_fill_iter`.
+    unsafe { ptr::drop_in_place(ptr::slice_from_raw_parts_mut(ptr.cast::<T>().as_ptr(), len)) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{Arc, Mutex},
+    };
+
+    struct DropCounter(Arc<Mutex<Vec<usize>>>, usize);
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            self.0.lock().unwrap().push(self.1);
+        }
+    }
+
+    struct PanicOnDrop;
+
+    impl Drop for PanicOnDrop {
+        fn drop(&mut self) {
+            panic!("boom");
+        }
+    }
+
+    #[test]
+    fn drops_allocated_values() {
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        {
+            let arena = DropArena::new();
+            arena.alloc(DropCounter(dropped.clone(), 1));
+            arena.alloc_slice_fill_iter([2, 3].map(|i| DropCounter(dropped.clone(), i)));
+        }
+        assert_eq!(*dropped.lock().unwrap(), [2, 3, 1]);
+    }
+
+    #[test]
+    fn drops_remaining_values_after_panic() {
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let arena = DropArena::new();
+            arena.alloc(DropCounter(dropped.clone(), 1));
+            arena.alloc(PanicOnDrop);
+        }));
+        assert!(result.is_err());
+        assert_eq!(*dropped.lock().unwrap(), [1]);
+    }
+}

--- a/crates/data-structures/src/lib.rs
+++ b/crates/data-structures/src/lib.rs
@@ -32,6 +32,11 @@ pub use never::Never;
 mod drop_guard;
 pub use drop_guard::{DropGuard, defer};
 
+#[doc(hidden)]
+mod drop_arena;
+#[doc(hidden)]
+pub use drop_arena::DropArena;
+
 mod interned;
 pub use interned::Interned;
 

--- a/crates/sema/src/output/abi.rs
+++ b/crates/sema/src/output/abi.rs
@@ -32,10 +32,10 @@ impl<'gcx> Gcx<'gcx> {
         for f in self.interface_functions(id) {
             items.push(self.function_abi(f.id).into());
         }
-        for event in self.interface_events(id) {
+        for event in self.interface_events(id).iter() {
             items.push(self.event_abi(event).into());
         }
-        for error in self.interface_errors(id) {
+        for error in self.interface_errors(id).iter() {
             items.push(self.error_abi(error).into());
         }
 

--- a/crates/sema/src/ty/call_graph.rs
+++ b/crates/sema/src/ty/call_graph.rs
@@ -293,10 +293,10 @@ pub(super) fn interface_items(gcx: Gcx<'_>, id: hir::ContractId) -> InterfaceIte
     InterfaceItems { creation, deployed }
 }
 
-pub(super) fn all_bytecode_dependencies<'gcx>(
-    gcx: Gcx<'gcx>,
+pub(super) fn all_bytecode_dependencies(
+    gcx: Gcx<'_>,
     id: hir::ContractId,
-) -> &'gcx DenseBitSet<hir::ContractId> {
+) -> DenseBitSet<hir::ContractId> {
     let graph = CallGraphBuilder::build_all(gcx, id);
-    gcx.alloc(graph.bytecode_dependencies)
+    graph.bytecode_dependencies
 }

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1366,70 +1366,6 @@ impl<'gcx> Gcx<'gcx> {
     ) -> hir::FunctionId {
         self.super_function_target((contract, defining_contract, function))
     }
-
-    /// Returns all events included in the external interface of the given contract.
-    pub fn interface_events(self, id: hir::ContractId) -> &'gcx DenseBitSet<hir::EventId> {
-        let items = self.interface_items(id);
-        let mut events = DenseBitSet::new_empty(self.hir.event_ids().len());
-        for item in self.hir.contract_item_ids(id) {
-            if let hir::ItemId::Event(event) = item {
-                events.insert(event);
-            }
-        }
-        for event in items.creation.events.iter().chain(items.deployed.events.iter()) {
-            events.insert(event);
-        }
-        self.alloc(events)
-    }
-
-    /// Returns all errors included in the external interface of the given contract.
-    pub fn interface_errors(self, id: hir::ContractId) -> &'gcx DenseBitSet<hir::ErrorId> {
-        let items = self.interface_items(id);
-        let mut errors = DenseBitSet::new_empty(self.hir.error_ids().len());
-        for item in self.hir.contract_item_ids(id) {
-            if let hir::ItemId::Error(error) = item {
-                errors.insert(error);
-            }
-        }
-        for error in items.creation.errors.iter().chain(items.deployed.errors.iter()) {
-            errors.insert(error);
-        }
-        self.alloc(errors)
-    }
-
-    /// Returns the functions reachable during contract creation or at runtime.
-    pub fn contract_reachable_functions(
-        self,
-        id: hir::ContractId,
-    ) -> &'gcx DenseBitSet<hir::FunctionId> {
-        let items = self.interface_items(id);
-        let mut functions = DenseBitSet::new_empty(self.hir.function_ids().len());
-        for function in items.creation.functions.iter().chain(items.deployed.functions.iter()) {
-            functions.insert(function);
-        }
-        self.alloc(functions)
-    }
-
-    /// Returns the contracts whose bytecode is referenced by the given contract.
-    pub fn contract_bytecode_dependencies(
-        self,
-        id: hir::ContractId,
-    ) -> &'gcx DenseBitSet<hir::ContractId> {
-        if self.sess.opts.unstable.codegen_all_functions {
-            return self.all_contract_bytecode_dependencies(id);
-        }
-        let items = self.interface_items(id);
-        let mut dependencies = DenseBitSet::new_empty(self.hir.contract_ids().len());
-        for dependency in items
-            .creation
-            .bytecode_dependencies
-            .iter()
-            .chain(items.deployed.bytecode_dependencies.iter())
-        {
-            dependencies.insert(dependency);
-        }
-        self.alloc(dependencies)
-    }
 }
 
 fn using_directive_ty_matches(ty: Ty<'_>, using_ty: Ty<'_>) -> bool {
@@ -1590,7 +1526,7 @@ fn super_function_target(
 
 fn interface_items(gcx: _, id: hir::ContractId) -> &'gcx call_graph::InterfaceItems {
     assert!(gcx.has_typeck_results(), "interface items require type checking");
-    gcx.alloc(call_graph::interface_items(gcx, id))
+    gcx.cached_arena().alloc(call_graph::interface_items(gcx, id))
 }
 
 fn all_contract_bytecode_dependencies(
@@ -1598,7 +1534,65 @@ fn all_contract_bytecode_dependencies(
     id: hir::ContractId
 ) -> &'gcx DenseBitSet<hir::ContractId> {
     assert!(gcx.has_typeck_results(), "contract dependencies require type checking");
-    call_graph::all_bytecode_dependencies(gcx, id)
+    gcx.cached_arena().alloc(call_graph::all_bytecode_dependencies(gcx, id))
+}
+
+/// Returns all events included in the external interface of the given contract.
+pub fn interface_events(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::EventId> {
+    let items = gcx.interface_items(id);
+    let mut events = DenseBitSet::new_empty(gcx.hir.event_ids().len());
+    for item in gcx.hir.contract_item_ids(id) {
+        if let hir::ItemId::Event(event) = item {
+            events.insert(event);
+        }
+    }
+    for event in items.creation.events.iter().chain(items.deployed.events.iter()) {
+        events.insert(event);
+    }
+    gcx.cached_arena().alloc(events)
+}
+
+/// Returns all errors included in the external interface of the given contract.
+pub fn interface_errors(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::ErrorId> {
+    let items = gcx.interface_items(id);
+    let mut errors = DenseBitSet::new_empty(gcx.hir.error_ids().len());
+    for item in gcx.hir.contract_item_ids(id) {
+        if let hir::ItemId::Error(error) = item {
+            errors.insert(error);
+        }
+    }
+    for error in items.creation.errors.iter().chain(items.deployed.errors.iter()) {
+        errors.insert(error);
+    }
+    gcx.cached_arena().alloc(errors)
+}
+
+/// Returns the functions reachable during contract creation or at runtime.
+pub fn contract_reachable_functions(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::FunctionId> {
+    let items = gcx.interface_items(id);
+    let mut functions = DenseBitSet::new_empty(gcx.hir.function_ids().len());
+    for function in items.creation.functions.iter().chain(items.deployed.functions.iter()) {
+        functions.insert(function);
+    }
+    gcx.cached_arena().alloc(functions)
+}
+
+/// Returns the contracts whose bytecode is referenced by the given contract.
+pub fn contract_bytecode_dependencies(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::ContractId> {
+    if gcx.sess.opts.unstable.codegen_all_functions {
+        return gcx.all_contract_bytecode_dependencies(id);
+    }
+    let items = gcx.interface_items(id);
+    let mut dependencies = DenseBitSet::new_empty(gcx.hir.contract_ids().len());
+    for dependency in items
+        .creation
+        .bytecode_dependencies
+        .iter()
+        .chain(items.deployed.bytecode_dependencies.iter())
+    {
+        dependencies.insert(dependency);
+    }
+    gcx.cached_arena().alloc(dependencies)
 }
 
 /// Returns the [ERC-165] interface ID of the given contract.
@@ -1919,7 +1913,7 @@ fn internal_function_members_in_context(
 pub(crate) fn eval_const_value_result(gcx: _, expr: &hir::Expr<'_>)
     cached_by(hir::ExprId, expr.id) -> &'gcx crate::eval::EvalResult
 {
-    gcx.alloc(crate::eval::eval_const(gcx, expr))
+    gcx.cached_arena().alloc(crate::eval::eval_const(gcx, expr))
 }
 
 } // cached!

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -9,7 +9,7 @@ use alloy_primitives::{B256, Selector, U256, keccak256};
 use either::Either;
 use solar_ast::{DataLocation, StateMutability, TypeSize, UserDefinableOperator, Visibility};
 use solar_data_structures::{
-    BumpExt,
+    BumpExt, DropArena,
     bit_set::{DenseBitSet, GrowableBitSet},
     fmt::{from_fn, or_list},
     map::{FxBuildHasher, FxHashMap, FxHashSet},
@@ -349,6 +349,7 @@ pub struct GlobalCtxt<'gcx> {
 
     pub(crate) ast_arenas: ThreadLocal<ast::Arena>,
     pub(crate) hir_arenas: ThreadLocal<hir::Arena>,
+    cached_arenas: ThreadLocal<DropArena>,
     interner: Interner<'gcx>,
     cache: Cache<'gcx>,
     pub(crate) override_index: OnceLock<crate::typeck::override_checker::OverrideIndex<'gcx>>,
@@ -384,6 +385,7 @@ impl<'gcx> GlobalCtxt<'gcx> {
 
             ast_arenas: ThreadLocal::new(),
             hir_arenas,
+            cached_arenas: ThreadLocal::new(),
             interner,
             cache: Cache::default(),
             override_index: OnceLock::new(),
@@ -456,6 +458,10 @@ impl<'gcx> Gcx<'gcx> {
 
     pub fn bump(self) -> &'gcx bumpalo::Bump {
         self.arena().bump()
+    }
+
+    fn cached_arena(self) -> &'gcx DropArena {
+        self.cached_arenas.get_or_default()
     }
 
     pub fn alloc<T>(self, value: T) -> &'gcx T {
@@ -1521,17 +1527,17 @@ macro_rules! cached {
 cached! {
 /// Returns the ABI of the given contract.
 pub fn contract_abi(gcx: _, id: hir::ContractId) -> &'gcx [alloy_json_abi::AbiItem<'gcx>] {
-    gcx.bump().alloc_slice_fill_iter(gcx.build_contract_abi(id))
+    gcx.cached_arena().alloc_slice_fill_iter(gcx.build_contract_abi(id))
 }
 
 /// Returns the developer documentation for the given contract.
 pub fn dev_documentation(gcx: _, id: hir::ContractId) -> &'gcx crate::output::Documentation {
-    gcx.alloc(gcx.build_dev_documentation(id))
+    gcx.cached_arena().alloc(gcx.build_dev_documentation(id))
 }
 
 /// Returns the user documentation for the given contract.
 pub fn user_documentation(gcx: _, id: hir::ContractId) -> &'gcx crate::output::Documentation {
-    gcx.alloc(gcx.build_user_documentation(id))
+    gcx.cached_arena().alloc(gcx.build_user_documentation(id))
 }
 
 fn virtual_function_target(

--- a/crates/sema/src/ty/mod.rs
+++ b/crates/sema/src/ty/mod.rs
@@ -1366,6 +1366,67 @@ impl<'gcx> Gcx<'gcx> {
     ) -> hir::FunctionId {
         self.super_function_target((contract, defining_contract, function))
     }
+
+    /// Returns all events included in the external interface of the given contract.
+    pub fn interface_events(self, id: hir::ContractId) -> DenseBitSet<hir::EventId> {
+        let items = self.interface_items(id);
+        let mut events = DenseBitSet::new_empty(self.hir.event_ids().len());
+        for item in self.hir.contract_item_ids(id) {
+            if let hir::ItemId::Event(event) = item {
+                events.insert(event);
+            }
+        }
+        for event in items.creation.events.iter().chain(items.deployed.events.iter()) {
+            events.insert(event);
+        }
+        events
+    }
+
+    /// Returns all errors included in the external interface of the given contract.
+    pub fn interface_errors(self, id: hir::ContractId) -> DenseBitSet<hir::ErrorId> {
+        let items = self.interface_items(id);
+        let mut errors = DenseBitSet::new_empty(self.hir.error_ids().len());
+        for item in self.hir.contract_item_ids(id) {
+            if let hir::ItemId::Error(error) = item {
+                errors.insert(error);
+            }
+        }
+        for error in items.creation.errors.iter().chain(items.deployed.errors.iter()) {
+            errors.insert(error);
+        }
+        errors
+    }
+
+    /// Returns the functions reachable during contract creation or at runtime.
+    pub fn contract_reachable_functions(self, id: hir::ContractId) -> DenseBitSet<hir::FunctionId> {
+        let items = self.interface_items(id);
+        let mut functions = DenseBitSet::new_empty(self.hir.function_ids().len());
+        for function in items.creation.functions.iter().chain(items.deployed.functions.iter()) {
+            functions.insert(function);
+        }
+        functions
+    }
+
+    /// Returns the contracts whose bytecode is referenced by the given contract.
+    pub fn contract_bytecode_dependencies(
+        self,
+        id: hir::ContractId,
+    ) -> DenseBitSet<hir::ContractId> {
+        if self.sess.opts.unstable.codegen_all_functions {
+            return self.all_contract_bytecode_dependencies(id).clone();
+        }
+        let items = self.interface_items(id);
+        let mut dependencies = DenseBitSet::new_empty(self.hir.contract_ids().len());
+        for dependency in items
+            .creation
+            .bytecode_dependencies
+            .iter()
+            .chain(items.deployed.bytecode_dependencies.iter())
+        {
+            dependencies.insert(dependency);
+        }
+        dependencies
+    }
 }
 
 fn using_directive_ty_matches(ty: Ty<'_>, using_ty: Ty<'_>) -> bool {
@@ -1535,64 +1596,6 @@ fn all_contract_bytecode_dependencies(
 ) -> &'gcx DenseBitSet<hir::ContractId> {
     assert!(gcx.has_typeck_results(), "contract dependencies require type checking");
     gcx.cached_arena().alloc(call_graph::all_bytecode_dependencies(gcx, id))
-}
-
-/// Returns all events included in the external interface of the given contract.
-pub fn interface_events(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::EventId> {
-    let items = gcx.interface_items(id);
-    let mut events = DenseBitSet::new_empty(gcx.hir.event_ids().len());
-    for item in gcx.hir.contract_item_ids(id) {
-        if let hir::ItemId::Event(event) = item {
-            events.insert(event);
-        }
-    }
-    for event in items.creation.events.iter().chain(items.deployed.events.iter()) {
-        events.insert(event);
-    }
-    gcx.cached_arena().alloc(events)
-}
-
-/// Returns all errors included in the external interface of the given contract.
-pub fn interface_errors(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::ErrorId> {
-    let items = gcx.interface_items(id);
-    let mut errors = DenseBitSet::new_empty(gcx.hir.error_ids().len());
-    for item in gcx.hir.contract_item_ids(id) {
-        if let hir::ItemId::Error(error) = item {
-            errors.insert(error);
-        }
-    }
-    for error in items.creation.errors.iter().chain(items.deployed.errors.iter()) {
-        errors.insert(error);
-    }
-    gcx.cached_arena().alloc(errors)
-}
-
-/// Returns the functions reachable during contract creation or at runtime.
-pub fn contract_reachable_functions(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::FunctionId> {
-    let items = gcx.interface_items(id);
-    let mut functions = DenseBitSet::new_empty(gcx.hir.function_ids().len());
-    for function in items.creation.functions.iter().chain(items.deployed.functions.iter()) {
-        functions.insert(function);
-    }
-    gcx.cached_arena().alloc(functions)
-}
-
-/// Returns the contracts whose bytecode is referenced by the given contract.
-pub fn contract_bytecode_dependencies(gcx: _, id: hir::ContractId) -> &'gcx DenseBitSet<hir::ContractId> {
-    if gcx.sess.opts.unstable.codegen_all_functions {
-        return gcx.all_contract_bytecode_dependencies(id);
-    }
-    let items = gcx.interface_items(id);
-    let mut dependencies = DenseBitSet::new_empty(gcx.hir.contract_ids().len());
-    for dependency in items
-        .creation
-        .bytecode_dependencies
-        .iter()
-        .chain(items.deployed.bytecode_dependencies.iter())
-    {
-        dependencies.insert(dependency);
-    }
-    gcx.cached_arena().alloc(dependencies)
 }
 
 /// Returns the [ERC-165] interface ID of the given contract.


### PR DESCRIPTION
Track dropful cached ABI, NatSpec, call-graph, and constant-evaluation values in a bump arena that runs destructors when the global context drops. Transient interface bitsets now return owned values and free normally.