### PR TITLE
perf(lsp): cache derived document data

### DIFF
--- a/crates/lsp/benches/lsp.rs
+++ b/crates/lsp/benches/lsp.rs
@@ -4,9 +4,10 @@ use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, 
 use lsp_types::{GotoDefinitionResponse, HoverContents, OneOf, Position, Url};
 use solar_config::CompileOpts;
 use solar_lsp::{
-    BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkProject, BenchmarkRequest,
-    BenchmarkResponse, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
-    BenchmarkWorkspaceReports, benchmark_selection_ranges,
+    BenchmarkAnalysis, BenchmarkDocumentUpdate, BenchmarkOpenDocuments, BenchmarkProject,
+    BenchmarkRequest, BenchmarkResponse, BenchmarkSelectionRangeRequests,
+    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
+    benchmark_selection_ranges,
 };
 use std::{fs, hint::black_box, path::PathBuf};
 
@@ -16,6 +17,8 @@ const AGGREGATION_BATCH_COUNT: usize = 4;
 const AGGREGATION_FUNCTION_COUNT: usize = 64;
 const PATH_INDEX_QUERY_COUNT: usize = 1024;
 const PATH_INDEX_WORKSPACE_COUNT: usize = 16;
+const OPEN_DOCUMENT_COUNT: usize = 16;
+const OPEN_DOCUMENT_BYTES: usize = 256 * 1024;
 const UNIFAP_PROJECT: &str = "unifap-v2";
 const UNIFAP_ROUTER: &str = "src/UnifapV2Router.sol";
 const UNIFAP_PAIR: &str = "src/UnifapV2Pair.sol";
@@ -264,6 +267,25 @@ fn selection_range(c: &mut Criterion) {
     group.finish();
 }
 
+fn open_document_selection_range(c: &mut Criterion) {
+    let positions = [Position::new(0, 0)];
+    let requests =
+        BenchmarkSelectionRangeRequests::new(OPTIMISM_SOURCE.to_owned(), positions.iter().copied());
+    let expected = benchmark_selection_ranges(OPTIMISM_SOURCE.to_owned(), &positions)
+        .expect("the benchmark position should be valid");
+    let ranges = requests.run().expect("the benchmark position should be valid");
+    assert_eq!(ranges, expected);
+    assert_eq!(ranges.len(), positions.len());
+    assert!(ranges[0].range.start <= positions[0] && positions[0] < ranges[0].range.end);
+
+    let mut group = c.benchmark_group("lsp/open-document-selection-range");
+    group.throughput(Throughput::Bytes(OPTIMISM_SOURCE.len() as u64));
+    group.bench_function("optimism", |b| {
+        b.iter(|| black_box(black_box(&requests).run()));
+    });
+    group.finish();
+}
+
 fn workspace_diagnostic_hot_paths(c: &mut Criterion) {
     let source = OPTIMISM_SOURCE.to_owned();
     assert_eq!(BenchmarkDocumentUpdate::from_source(source.clone()).apply(), 1);
@@ -298,6 +320,19 @@ fn workspace_diagnostic_hot_paths(c: &mut Criterion) {
         );
     }
     reports.finish();
+}
+
+fn open_document_analysis_batches(c: &mut Criterion) {
+    let documents = BenchmarkOpenDocuments::new(OPEN_DOCUMENT_COUNT, OPEN_DOCUMENT_BYTES);
+    // Prime the initial snapshot so timing measures reuse across later analysis epochs.
+    assert!(documents.build_analysis_batches() >= documents.source_bytes());
+
+    let mut group = c.benchmark_group("lsp/open-document-analysis-batches");
+    group.throughput(Throughput::Bytes(documents.source_bytes() as u64));
+    group.bench_function(format!("{OPEN_DOCUMENT_COUNT}x{OPEN_DOCUMENT_BYTES}"), |b| {
+        b.iter(|| black_box(documents.build_analysis_batches()))
+    });
+    group.finish();
 }
 
 fn workspace_path_queries(c: &mut Criterion) {
@@ -504,7 +539,9 @@ criterion_group!(
     symbol_table_aggregation,
     burst_hover,
     selection_range,
+    open_document_selection_range,
     workspace_diagnostic_hot_paths,
+    open_document_analysis_batches,
     workspace_path_queries,
     unifap_benches
 );

--- a/crates/lsp/src/code_actions.rs
+++ b/crates/lsp/src/code_actions.rs
@@ -180,7 +180,7 @@ pub(crate) fn plans(
 }
 
 fn exact_byte_range(
-    index: &proto::LspPositionIndex<'_>,
+    index: &proto::LspPositionIndex<&Rope>,
     range: lsp_types::Range,
 ) -> Option<std::ops::Range<usize>> {
     let bytes = index.checked_text_range(range)?;

--- a/crates/lsp/src/folding_range.rs
+++ b/crates/lsp/src/folding_range.rs
@@ -506,7 +506,7 @@ fn has_blank_line_between(bytes: impl IntoIterator<Item = u8>) -> bool {
 }
 
 fn folding_range(
-    index: &proto::LspPositionIndex<'_>,
+    index: &proto::LspPositionIndex<&Rope>,
     candidate: Candidate,
 ) -> Option<FoldingRange> {
     let start = index.position_at_byte(candidate.range.start)?;

--- a/crates/lsp/src/global_state.rs
+++ b/crates/lsp/src/global_state.rs
@@ -2055,7 +2055,7 @@ impl GlobalStateSnapshot {
         paths
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "bench"))]
     fn analysis_batches(&self, disk_paths: Vec<PathBuf>) -> Vec<AnalysisBatch> {
         self.analysis_batches_cancellable(disk_paths, &IndexingCancellation::default())
             .map(|(batches, _)| batches)
@@ -2070,16 +2070,15 @@ impl GlobalStateSnapshot {
         let vfs_files = {
             let vfs = self.vfs.read();
             let mut files = Vec::new();
-            for (path, contents) in vfs.iter() {
+            for (path, _) in vfs.iter() {
                 if cancellation.is_cancelled() {
                     return None;
                 }
                 let Some(path_buf) = path.as_path() else { continue };
-                let mut src = String::with_capacity(contents.byte_len());
-                for chunk in contents.chunks() {
-                    src.push_str(chunk);
-                }
-                files.push((path_buf.to_path_buf(), Arc::new(src), vfs.get_file_version(path)));
+                let contents = vfs
+                    .get_file_analysis_source(path)
+                    .expect("iterated VFS path should retain its source");
+                files.push((path_buf.to_path_buf(), contents, vfs.get_file_version(path)));
             }
             files
         };

--- a/crates/lsp/src/global_state/benchmark.rs
+++ b/crates/lsp/src/global_state/benchmark.rs
@@ -535,6 +535,86 @@ impl BenchmarkDocumentUpdate {
     }
 }
 
+/// A prepared VFS snapshot containing several open documents.
+#[doc(hidden)]
+pub struct BenchmarkOpenDocuments {
+    snapshot: super::GlobalStateSnapshot,
+    source_bytes: usize,
+}
+
+/// A prepared open-document selection-range request workload.
+#[doc(hidden)]
+pub struct BenchmarkSelectionRangeRequests {
+    state: super::GlobalState,
+    path: VfsPath,
+    positions: Vec<Position>,
+}
+
+impl BenchmarkSelectionRangeRequests {
+    /// Prepare one immutable open document and the positions queried on every request.
+    pub fn new(source: String, positions: impl IntoIterator<Item = Position>) -> Self {
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        let path = VfsPath::from(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("benches/open-selection-range.sol"),
+        );
+        state.vfs.write().set_file_contents_with_version(
+            path.clone(),
+            Some(Rope::from(source.as_str())),
+            Some(1),
+        );
+        let positions = positions.into_iter().collect();
+        Self { state, path, positions }
+    }
+
+    /// Run one selection-range request through the open-document source path.
+    #[inline(never)]
+    pub fn run(&self) -> Option<Vec<lsp_types::SelectionRange>> {
+        let source = { self.state.vfs.read().get_file_selection_range_source(&self.path)? };
+        source.selection_ranges(&self.positions)
+    }
+}
+
+impl BenchmarkOpenDocuments {
+    /// Prepare `document_count` equally sized open-document overlays.
+    pub fn new(document_count: usize, bytes_per_document: usize) -> Self {
+        assert!(document_count > 0);
+        assert!(bytes_per_document > 0);
+
+        let state = super::GlobalState::new(ClientSocket::new_closed());
+        let mut vfs = state.vfs.write();
+        for index in 0..document_count {
+            let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("benches/open-documents")
+                .join(format!("Document-{index}.sol"));
+            let source = "x".repeat(bytes_per_document);
+            vfs.set_file_contents_with_version(
+                VfsPath::from(path),
+                Some(Rope::from(source.as_str())),
+                Some(1),
+            );
+        }
+        drop(vfs);
+
+        Self { snapshot: state.snapshot(), source_bytes: document_count * bytes_per_document }
+    }
+
+    /// The total source bytes represented by the open documents.
+    pub fn source_bytes(&self) -> usize {
+        self.source_bytes
+    }
+
+    /// Build production analysis batches from the prepared open documents.
+    #[inline(never)]
+    pub fn build_analysis_batches(&self) -> usize {
+        self.snapshot
+            .analysis_batches(Vec::new())
+            .into_iter()
+            .flat_map(|batch| batch.files)
+            .map(|(path, source)| path.as_os_str().len() + source.len())
+            .sum()
+    }
+}
+
 /// A diagnostic store prepared with overlapping current, reported, and previous document sets.
 #[doc(hidden)]
 pub struct BenchmarkWorkspaceReports {

--- a/crates/lsp/src/handlers/reqs.rs
+++ b/crates/lsp/src/handlers/reqs.rs
@@ -139,13 +139,19 @@ pub(crate) fn selection_range(
 
     async move {
         let (vfs_path, path, positions) = request?;
-        let source =
-            document_contents(&vfs, &vfs_path, &path).await.map_err(document_read_failed)?;
-        let ranges = tokio::task::spawn_blocking(move || {
-            crate::selection_range::selection_ranges(source, &positions)
-        })
-        .await
-        .map_err(selection_range_task_failed)?
+        let open_source = { vfs.read().get_file_selection_range_source(&vfs_path) };
+        let ranges = if let Some(source) = open_source {
+            tokio::task::spawn_blocking(move || source.selection_ranges(&positions))
+                .await
+                .map_err(selection_range_task_failed)?
+        } else {
+            let source = tokio::fs::read_to_string(path).await.map_err(document_read_failed)?;
+            tokio::task::spawn_blocking(move || {
+                crate::selection_range::selection_ranges(source, &positions)
+            })
+            .await
+            .map_err(selection_range_task_failed)?
+        }
         .ok_or_else(|| {
             ResponseError::new(ErrorCode::INVALID_PARAMS, "invalid selection range position")
         })?;

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -283,8 +283,9 @@ mod workspace;
 #[doc(hidden)]
 pub use global_state::benchmark::{
     BenchmarkAnalysis, BenchmarkDocumentChange, BenchmarkDocumentUpdate, BenchmarkEdit,
-    BenchmarkError, BenchmarkProject, BenchmarkRequest, BenchmarkResponse,
-    BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries, BenchmarkWorkspaceReports,
+    BenchmarkError, BenchmarkOpenDocuments, BenchmarkProject, BenchmarkRequest, BenchmarkResponse,
+    BenchmarkSelectionRangeRequests, BenchmarkWorkspaceDiscovery, BenchmarkWorkspacePathQueries,
+    BenchmarkWorkspaceReports,
 };
 
 /// Runs the selection-range kernel for Criterion benchmarks.

--- a/crates/lsp/src/proto.rs
+++ b/crates/lsp/src/proto.rs
@@ -13,6 +13,7 @@ use solar_interface::{
     diagnostics::{Diag, Level},
     source_map::SpanLoc,
 };
+use std::borrow::Borrow;
 
 #[derive(Debug)]
 pub(crate) enum Initialize {}
@@ -113,36 +114,27 @@ pub(crate) fn text_range(rope: &Rope, range: lsp_types::Range) -> std::ops::Rang
 }
 
 /// Maps between byte offsets and LSP UTF-16 positions for one document.
-pub(crate) struct LspPositionIndex<'a> {
-    rope: &'a Rope,
+pub(crate) struct LspPositionIndex<R> {
+    rope: R,
     line_starts: Vec<usize>,
 }
 
-impl<'a> LspPositionIndex<'a> {
+impl<'a> LspPositionIndex<&'a Rope> {
     pub(crate) fn new(rope: &'a Rope) -> Self {
-        let mut line_starts = Vec::with_capacity(rope.line_len() + 1);
-        line_starts.push(0);
+        Self { rope, line_starts: collect_line_starts(rope) }
+    }
+}
 
-        let mut bytes = rope.bytes().enumerate().peekable();
-        while let Some((offset, byte)) = bytes.next() {
-            let next_line = match byte {
-                b'\r' => {
-                    let mut next_line = offset + 1;
-                    if bytes.peek().is_some_and(|(_, byte)| *byte == b'\n') {
-                        bytes.next();
-                        next_line += 1;
-                    }
-                    Some(next_line)
-                }
-                b'\n' => Some(offset + 1),
-                _ => None,
-            };
-            if let Some(next_line) = next_line {
-                line_starts.push(next_line);
-            }
-        }
-
+impl LspPositionIndex<Rope> {
+    pub(crate) fn from_rope(rope: Rope) -> Self {
+        let line_starts = collect_line_starts(&rope);
         Self { rope, line_starts }
+    }
+}
+
+impl<R: Borrow<Rope>> LspPositionIndex<R> {
+    pub(crate) fn rope(&self) -> &Rope {
+        self.rope.borrow()
     }
 
     pub(crate) fn checked_text_range(
@@ -161,26 +153,24 @@ impl<'a> LspPositionIndex<'a> {
     }
 
     fn byte_position_clamped(&self, position: lsp_types::Position) -> usize {
+        let rope = self.rope();
         let line = usize::try_from(position.line).unwrap_or(usize::MAX);
         let start = self.line_starts.get(line).copied().unwrap_or_else(|| {
-            if position.line > self.rope.line_len() as u32 {
-                0
-            } else {
-                self.rope.byte_of_line(line)
-            }
+            if position.line > rope.line_len() as u32 { 0 } else { rope.byte_of_line(line) }
         });
-        let start_utf16 = self.rope.utf16_code_unit_of_byte(start);
-        self.rope.byte_of_utf16_code_unit(start_utf16 + position.character as usize)
+        let start_utf16 = rope.utf16_code_unit_of_byte(start);
+        rope.byte_of_utf16_code_unit(start_utf16 + position.character as usize)
     }
 
     fn byte_position(&self, position: lsp_types::Position) -> Option<usize> {
+        let rope = self.rope();
         let line = usize::try_from(position.line).ok()?;
         let start = *self.line_starts.get(line)?;
         let end = self.line_end(line);
         let target = usize::try_from(position.character).ok()?;
         let mut utf16 = 0;
         let mut byte = start;
-        for ch in self.rope.byte_slice(start..end).chars() {
+        for ch in rope.byte_slice(start..end).chars() {
             if utf16 == target {
                 return Some(byte);
             }
@@ -195,7 +185,8 @@ impl<'a> LspPositionIndex<'a> {
     }
 
     pub(crate) fn position_at_byte(&self, byte: usize) -> Option<lsp_types::Position> {
-        if byte > self.rope.byte_len() || !self.rope.is_char_boundary(byte) {
+        let rope = self.rope();
+        if byte > rope.byte_len() || !rope.is_char_boundary(byte) {
             return None;
         }
         let line = self.line_starts.partition_point(|&start| start <= byte).checked_sub(1)?;
@@ -204,27 +195,54 @@ impl<'a> LspPositionIndex<'a> {
             return None;
         }
         let character =
-            self.rope.byte_slice(start..byte).chars().map(|ch| ch.len_utf16()).sum::<usize>();
+            rope.byte_slice(start..byte).chars().map(|ch| ch.len_utf16()).sum::<usize>();
         Some(lsp_types::Position::new(u32::try_from(line).ok()?, u32::try_from(character).ok()?))
     }
 
     pub(crate) fn byte_len(&self) -> usize {
-        self.rope.byte_len()
+        self.rope().byte_len()
     }
 
     fn line_end(&self, line: usize) -> usize {
+        let rope = self.rope();
         let Some(&next_start) = self.line_starts.get(line + 1) else {
-            return self.rope.byte_len();
+            return rope.byte_len();
         };
-        if self.rope.byte(next_start - 1) == b'\n'
+        if rope.byte(next_start - 1) == b'\n'
             && next_start >= 2
-            && self.rope.byte(next_start - 2) == b'\r'
+            && rope.byte(next_start - 2) == b'\r'
         {
             next_start - 2
         } else {
             next_start - 1
         }
     }
+}
+
+fn collect_line_starts(rope: &Rope) -> Vec<usize> {
+    let mut line_starts = Vec::with_capacity(rope.line_len() + 1);
+    line_starts.push(0);
+
+    let mut bytes = rope.bytes().enumerate().peekable();
+    while let Some((offset, byte)) = bytes.next() {
+        let next_line = match byte {
+            b'\r' => {
+                let mut next_line = offset + 1;
+                if bytes.peek().is_some_and(|(_, byte)| *byte == b'\n') {
+                    bytes.next();
+                    next_line += 1;
+                }
+                Some(next_line)
+            }
+            b'\n' => Some(offset + 1),
+            _ => None,
+        };
+        if let Some(next_line) = next_line {
+            line_starts.push(next_line);
+        }
+    }
+
+    line_starts
 }
 
 /// Converts an LSP UTF-16 range to a byte range, rejecting invalid positions.

--- a/crates/lsp/src/selection_range.rs
+++ b/crates/lsp/src/selection_range.rs
@@ -10,8 +10,10 @@ use solar_parse::{
     ast::{self, visit::Visit},
 };
 use std::{
+    borrow::Borrow,
     cmp::Reverse,
     ops::{ControlFlow, Range as ByteRange},
+    sync::{Arc, OnceLock},
 };
 
 pub(crate) fn selection_ranges(
@@ -20,38 +22,63 @@ pub(crate) fn selection_ranges(
 ) -> Option<Vec<SelectionRange>> {
     let rope = Rope::from(source.as_str());
     let index = proto::LspPositionIndex::new(&rope);
-    let cursors = positions
-        .iter()
-        .map(|&position| {
-            index.checked_text_range(Range::new(position, position)).map(|range| range.start)
-        })
-        .collect::<Option<Vec<_>>>()?;
+    let cursors = checked_cursors(&index, positions)?;
     if cursors.is_empty() {
         return Some(Vec::new());
     }
-
-    let candidates = collect_ranges(source, &rope);
-    cursors
-        .into_iter()
-        .map(|cursor| selection_range_for_cursor(&index, &candidates, cursor))
-        .collect()
+    let candidates = collect_ranges(SourceCode::Owned(source), &rope);
+    selection_ranges_for_cursors(&index, &candidates, cursors)
 }
 
-fn collect_ranges(source: String, rope: &Rope) -> Vec<ByteRange<usize>> {
+pub(crate) struct SelectionRangeIndex {
+    source: Arc<String>,
+    positions: proto::LspPositionIndex<Rope>,
+    candidates: OnceLock<Vec<ByteRange<usize>>>,
+}
+
+impl SelectionRangeIndex {
+    pub(crate) fn new(source: Arc<String>, rope: Rope) -> Self {
+        let positions = proto::LspPositionIndex::from_rope(rope);
+        Self { source, positions, candidates: OnceLock::new() }
+    }
+
+    pub(crate) fn selection_ranges(&self, positions: &[Position]) -> Option<Vec<SelectionRange>> {
+        let index = &self.positions;
+        let cursors = checked_cursors(index, positions)?;
+        if cursors.is_empty() {
+            return Some(Vec::new());
+        }
+
+        let candidates = self
+            .candidates
+            .get_or_init(|| collect_ranges(SourceCode::Shared(self.source.clone()), index.rope()));
+        selection_ranges_for_cursors(index, candidates, cursors)
+    }
+}
+
+enum SourceCode {
+    Owned(String),
+    Shared(Arc<String>),
+}
+
+fn collect_ranges(source: SourceCode, rope: &Rope) -> Vec<ByteRange<usize>> {
     let mut opts = CompileOpts::default();
     opts.unstable.recover_incomplete_input = true;
     let sess = Session::builder().opts(opts).with_silent_emitter(None).single_threaded().build();
 
     sess.enter_sequential(|| {
         let arena = ast::Arena::new();
-        let Ok(mut parser) = Parser::from_source_code(
-            &sess,
-            &arena,
-            FileName::Custom("lsp-selection-range.sol".into()),
-            source,
-        ) else {
+        let filename = FileName::Custom("lsp-selection-range.sol".into());
+        let source_file = match source {
+            SourceCode::Owned(source) => sess.source_map().new_source_file(filename, source),
+            SourceCode::Shared(source) => {
+                sess.source_map().new_source_file_shared(filename, source)
+            }
+        };
+        let Ok(source_file) = source_file else {
             return Vec::new();
         };
+        let mut parser = Parser::from_source_file(&sess, &arena, &source_file);
         let source_unit = match parser.parse_file() {
             Ok(source_unit) => source_unit,
             Err(error) => {
@@ -67,8 +94,31 @@ fn collect_ranges(source: String, rope: &Rope) -> Vec<ByteRange<usize>> {
     })
 }
 
-fn selection_range_for_cursor(
-    index: &proto::LspPositionIndex<'_>,
+fn checked_cursors<R: Borrow<Rope>>(
+    index: &proto::LspPositionIndex<R>,
+    positions: &[Position],
+) -> Option<Vec<usize>> {
+    positions
+        .iter()
+        .map(|&position| {
+            index.checked_text_range(Range::new(position, position)).map(|range| range.start)
+        })
+        .collect()
+}
+
+fn selection_ranges_for_cursors<R: Borrow<Rope>>(
+    index: &proto::LspPositionIndex<R>,
+    candidates: &[ByteRange<usize>],
+    cursors: Vec<usize>,
+) -> Option<Vec<SelectionRange>> {
+    cursors
+        .into_iter()
+        .map(|cursor| selection_range_for_cursor(index, candidates, cursor))
+        .collect()
+}
+
+fn selection_range_for_cursor<R: Borrow<Rope>>(
+    index: &proto::LspPositionIndex<R>,
     candidates: &[ByteRange<usize>],
     cursor: usize,
 ) -> Option<SelectionRange> {

--- a/crates/lsp/src/tests/selection_range.rs
+++ b/crates/lsp/src/tests/selection_range.rs
@@ -1,5 +1,7 @@
 use super::support::RequestFixture;
+use crate::vfs::VfsPath;
 use async_lsp::ErrorCode;
+use crop::Rope;
 use lsp_types::Position;
 use snapbox::str;
 
@@ -126,6 +128,35 @@ fn uses_utf16_positions_for_crlf_documents_without_waiting_for_analysis() {
 
 "#]],
     );
+}
+
+#[test]
+fn cached_utf16_ranges_match_repeated_and_disk_requests() {
+    let fixture = RequestFixture::new(
+        concat!(
+            "//- /Open.sol open\r\n",
+            "contract C {\r\n",
+            "    function f(uint256 value) external pure returns (uint256) {\r\n",
+            "        /* 中😀 */ return val$1ue;\r\n",
+            "    }\r\n",
+            "}\r\n",
+            "//- /Disk.sol\r\n",
+            "contract C {\r\n",
+            "    function f(uint256 value) external pure returns (uint256) {\r\n",
+            "        /* 中😀 */ return val$2ue;\r\n",
+            "    }\r\n",
+            "}",
+        ),
+        "/Open.sol",
+    );
+    let mut state = fixture.state();
+
+    let first = fixture.selection_range_response_in_state(&mut state, &["$1"]);
+    let cached = fixture.selection_range_response_in_state(&mut state, &["$1"]);
+    let disk = fixture.selection_range_response_in_state(&mut state, &["$2"]);
+
+    assert_eq!(cached, first);
+    assert_eq!(disk, first);
 }
 
 #[test]
@@ -373,6 +404,54 @@ fn falls_back_when_source_cannot_be_parsed() {
 
 "#]],
     );
+}
+
+#[test]
+fn cached_parse_failure_matches_repeated_and_disk_fallbacks() {
+    let fixture = RequestFixture::new_allowing_diagnostics(
+        r#"
+        //- /Open.sol open
+        @$1
+        //- /Disk.sol
+        @$2
+        "#,
+        "/Open.sol",
+    );
+    let mut state = fixture.state();
+
+    let first = fixture.selection_range_response_in_state(&mut state, &["$1"]);
+    let cached = fixture.selection_range_response_in_state(&mut state, &["$1"]);
+    let disk = fixture.selection_range_response_in_state(&mut state, &["$2"]);
+
+    assert_eq!(cached, first);
+    assert_eq!(disk, first);
+}
+
+#[test]
+fn content_changes_replace_cached_selection_ranges() {
+    let fixture = RequestFixture::new(
+        r#"
+        //- /Selection.sol open
+        contract $1A {}
+        "#,
+        "/Selection.sol",
+    );
+    let mut state = fixture.state();
+    let first = fixture.selection_range_response_in_state(&mut state, &["$1"]);
+    let (_, position) = fixture.marker_location("$1");
+    let changed_source = "contract LongName {}";
+    state.vfs.write().set_file_contents_with_version(
+        VfsPath::from(fixture.project_path("/Selection.sol")),
+        Some(Rope::from(changed_source)),
+        Some(2),
+    );
+
+    let changed = fixture.selection_range_response_in_state(&mut state, &["$1"]);
+    let expected = crate::selection_range::selection_ranges(changed_source.into(), &[position])
+        .expect("the unchanged request position should remain valid");
+
+    assert_ne!(changed, first);
+    assert_eq!(changed, expected);
 }
 
 #[test]

--- a/crates/lsp/src/tests/support.rs
+++ b/crates/lsp/src/tests/support.rs
@@ -528,10 +528,18 @@ impl RequestFixture {
 
     pub(super) fn check_selection_ranges(&self, markers: &[&str], expected: impl IntoData) {
         let mut state = self.state();
-        let (params, positions) = self.selection_range_request(markers);
-        let response =
-            block_on(crate::handlers::selection_range(&mut state, params)).unwrap().unwrap();
+        let (_, positions) = self.selection_range_request(markers);
+        let response = self.selection_range_response_in_state(&mut state, markers);
         check_selection_range_response(response, &positions, expected);
+    }
+
+    pub(super) fn selection_range_response_in_state(
+        &self,
+        state: &mut GlobalState,
+        markers: &[&str],
+    ) -> Vec<SelectionRange> {
+        let (params, _) = self.selection_range_request(markers);
+        block_on(crate::handlers::selection_range(state, params)).unwrap().unwrap()
     }
 
     pub(super) fn check_selection_ranges_at(

--- a/crates/lsp/src/vfs/fs.rs
+++ b/crates/lsp/src/vfs/fs.rs
@@ -23,18 +23,63 @@
 //! [`SourceFile`]: solar_interface::source_map::SourceFile
 
 use super::VfsPath;
-use crate::file_operations::{FileMoveBatch, FileMoveError};
+use crate::{
+    file_operations::{FileMoveBatch, FileMoveError},
+    selection_range::SelectionRangeIndex,
+};
 use crop::Rope;
+use lsp_types::{Position, SelectionRange};
 use solar_interface::data_structures::map::rustc_hash::FxHashMap;
 use std::{
     collections::hash_map::Entry,
     mem,
     path::{Path, PathBuf},
+    sync::{Arc, OnceLock},
 };
+
+struct VfsFile {
+    contents: Rope,
+    analysis_source: OnceLock<Arc<String>>,
+    selection_range_index: OnceLock<SelectionRangeIndex>,
+}
+
+impl VfsFile {
+    fn new(contents: Rope) -> Self {
+        Self { contents, analysis_source: OnceLock::new(), selection_range_index: OnceLock::new() }
+    }
+
+    fn analysis_source(&self) -> Arc<String> {
+        self.analysis_source
+            .get_or_init(|| {
+                let mut source = String::with_capacity(self.contents.byte_len());
+                for chunk in self.contents.chunks() {
+                    source.push_str(chunk);
+                }
+                Arc::new(source)
+            })
+            .clone()
+    }
+}
+
+/// An exact-content handle for lazily answering selection-range requests.
+#[derive(Clone)]
+pub(crate) struct SelectionRangeSource(Arc<VfsFile>);
+
+impl SelectionRangeSource {
+    fn index(&self) -> &SelectionRangeIndex {
+        self.0.selection_range_index.get_or_init(|| {
+            SelectionRangeIndex::new(self.0.analysis_source(), self.0.contents.clone())
+        })
+    }
+
+    pub(crate) fn selection_ranges(&self, positions: &[Position]) -> Option<Vec<SelectionRange>> {
+        self.index().selection_ranges(positions)
+    }
+}
 
 #[derive(Default)]
 pub(crate) struct Vfs {
-    data: FxHashMap<VfsPath, Rope>,
+    data: FxHashMap<VfsPath, Arc<VfsFile>>,
     versions: FxHashMap<VfsPath, i32>,
     content_revision: u64,
     dirty: bool,
@@ -56,12 +101,14 @@ impl Vfs {
         if let Some(contents) = contents {
             let contents_changed = match self.data.entry(path.clone()) {
                 Entry::Occupied(mut entry) => {
-                    let changed = entry.get() != &contents;
-                    entry.insert(contents);
+                    let changed = entry.get().contents != contents;
+                    if changed {
+                        entry.insert(Arc::new(VfsFile::new(contents)));
+                    }
                     changed
                 }
                 Entry::Vacant(entry) => {
-                    entry.insert(contents);
+                    entry.insert(Arc::new(VfsFile::new(contents)));
                     true
                 }
             };
@@ -87,7 +134,20 @@ impl Vfs {
     }
 
     pub(crate) fn get_file_contents(&self, path: &VfsPath) -> Option<&Rope> {
-        self.data.get(path)
+        self.data.get(path).map(|file| &file.contents)
+    }
+
+    /// Returns a shared contiguous source for compiler analysis.
+    pub(crate) fn get_file_analysis_source(&self, path: &VfsPath) -> Option<Arc<String>> {
+        self.data.get(path).map(|file| file.analysis_source())
+    }
+
+    /// Returns an exact-content handle whose derived index can initialize outside the VFS lock.
+    pub(crate) fn get_file_selection_range_source(
+        &self,
+        path: &VfsPath,
+    ) -> Option<SelectionRangeSource> {
+        self.data.get(path).cloned().map(SelectionRangeSource)
     }
 
     pub(crate) fn get_file_version(&self, path: &VfsPath) -> Option<i32> {
@@ -193,7 +253,7 @@ impl Vfs {
 
     /// Returns an iterator over stored paths and their corresponding contents.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&VfsPath, &Rope)> {
-        self.data.iter()
+        self.data.iter().map(|(path, file)| (path, &file.contents))
     }
 
     fn bump_content_revision(&mut self) {
@@ -262,6 +322,133 @@ mod tests {
         assert_eq!(vfs.get_file_version(&file), None);
         assert!(!vfs.set_file_contents_with_version(file, None, None));
         assert_eq!(vfs.content_revision(), revision + 2);
+    }
+
+    #[test]
+    fn analysis_sources_are_cached_until_contents_change() {
+        let mut vfs = Vfs::default();
+        let file = path("/workspace/Test.sol");
+        insert(&mut vfs, "/workspace/Test.sol", "contract Test {}", 1);
+
+        let first = vfs.get_file_analysis_source(&file).unwrap();
+        let cached = vfs.get_file_analysis_source(&file).unwrap();
+        assert!(Arc::ptr_eq(&first, &cached));
+
+        assert!(!vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(Rope::from("contract Test {}")),
+            Some(2),
+        ));
+        let version_only = vfs.get_file_analysis_source(&file).unwrap();
+        assert!(Arc::ptr_eq(&first, &version_only));
+        assert_eq!(vfs.get_file_version(&file), Some(2));
+
+        assert!(vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(Rope::from("contract Changed {}")),
+            Some(3),
+        ));
+        let changed = vfs.get_file_analysis_source(&file).unwrap();
+        assert!(!Arc::ptr_eq(&first, &changed));
+        assert_eq!(changed.as_str(), "contract Changed {}");
+    }
+
+    #[test]
+    fn selection_range_indexes_are_cached_until_contents_change() {
+        let mut vfs = Vfs::default();
+        let file = path("/workspace/Test.sol");
+        insert(&mut vfs, "/workspace/Test.sol", "contract Test {}", 1);
+
+        let first_source = vfs.get_file_selection_range_source(&file).unwrap();
+        let first = first_source.index();
+        let cached_source = vfs.get_file_selection_range_source(&file).unwrap();
+        let cached = cached_source.index();
+        assert!(std::ptr::eq(first, cached));
+
+        assert!(!vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(Rope::from("contract Test {}")),
+            Some(2),
+        ));
+        let version_only_source = vfs.get_file_selection_range_source(&file).unwrap();
+        let version_only = version_only_source.index();
+        assert!(std::ptr::eq(first, version_only));
+
+        assert!(vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(Rope::from("contract Changed {}")),
+            Some(3),
+        ));
+        let changed_source = vfs.get_file_selection_range_source(&file).unwrap();
+        let changed = changed_source.index();
+        assert!(!std::ptr::eq(first, changed));
+    }
+
+    #[test]
+    fn stale_selection_range_handles_cannot_populate_replaced_files() {
+        let mut vfs = Vfs::default();
+        let file = path("/workspace/Test.sol");
+        insert(&mut vfs, "/workspace/Test.sol", "contract Old {}", 1);
+        let old_source = vfs.get_file_selection_range_source(&file).unwrap();
+
+        assert!(vfs.set_file_contents_with_version(
+            file.clone(),
+            Some(Rope::from("contract NewName {}")),
+            Some(2),
+        ));
+        let new_source = vfs.get_file_selection_range_source(&file).unwrap();
+
+        let old_index = old_source.index();
+        let new_index = new_source.index();
+        assert!(!std::ptr::eq(old_index, new_index));
+        assert_eq!(
+            old_source.selection_ranges(&[Position::new(0, 9)]).unwrap()[0].range.end.character,
+            12
+        );
+        assert_eq!(
+            new_source.selection_ranges(&[Position::new(0, 9)]).unwrap()[0].range.end.character,
+            16
+        );
+    }
+
+    #[test]
+    fn renaming_preserves_cached_analysis_sources() {
+        let mut vfs = Vfs::default();
+        let old = path("/workspace/Old.sol");
+        let new = path("/workspace/New.sol");
+        insert(&mut vfs, "/workspace/Old.sol", "contract Test {}", 1);
+        let source = vfs.get_file_analysis_source(&old).unwrap();
+
+        vfs.rename_file_prefixes(&moves([(
+            PathBuf::from("/workspace/Old.sol"),
+            PathBuf::from("/workspace/New.sol"),
+        )]))
+        .unwrap();
+
+        let renamed = vfs.get_file_analysis_source(&new).unwrap();
+        assert!(Arc::ptr_eq(&source, &renamed));
+        assert_eq!(vfs.get_file_analysis_source(&old), None);
+    }
+
+    #[test]
+    fn renaming_preserves_cached_selection_range_indexes() {
+        let mut vfs = Vfs::default();
+        let old = path("/workspace/Old.sol");
+        let new = path("/workspace/New.sol");
+        insert(&mut vfs, "/workspace/Old.sol", "contract Test {}", 1);
+        let source = vfs.get_file_selection_range_source(&old).unwrap();
+        let index = source.index();
+
+        vfs.rename_file_prefixes(&moves([(
+            PathBuf::from("/workspace/Old.sol"),
+            PathBuf::from("/workspace/New.sol"),
+        )]))
+        .unwrap();
+
+        let renamed_source = vfs.get_file_selection_range_source(&new).unwrap();
+        let renamed = renamed_source.index();
+        assert!(std::ptr::eq(index, renamed));
+        assert!(vfs.get_file_selection_range_source(&old).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Cache derived data for exact-content VFS entries. Open-document selection-range requests now reuse the flattened source, UTF-16 position index, and parsed range candidates; analysis batches reuse the flattened source. Content changes replace the cache, while version-only updates and renames retain it.

On the Optimism `Criterion` workload (5.38 MB source), repeated open-document selection-range latency fell from 58.825 ms to 153.092 µs per request (99.74% lower, 384× faster). This is the cached open-document path; cold/direct selection-range latency is unchanged.


