### PR TITLE
ci: remove website preview deployment

### DIFF
--- a/.github/workflows/web-pages.yml
+++ b/.github/workflows/web-pages.yml
@@ -92,7 +92,9 @@ jobs:
         if: steps.data.outcome == 'success' && steps.history.outcome == 'success'
         run: |
           mkdir -p source/web/public/data
-          cp published/data/index.json source/web/public/data/index.json
+          if [[ -f published/data/index.json ]]; then
+            cp published/data/index.json source/web/public/data/index.json
+          fi
 
       - name: Import benchmark run
         if: steps.data.outcome == 'success'

--- a/.github/workflows/web-pages.yml
+++ b/.github/workflows/web-pages.yml
@@ -4,7 +4,7 @@ permissions: {}
 
 on:
   push:
-    branches: [main, dani/perf-site]
+    branches: [main]
     paths:
       - web/**
       - .github/workflows/web-pages.yml
@@ -46,11 +46,10 @@ jobs:
 
   publish:
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dani/perf-site') ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_repository.full_name == github.repository &&
-       github.event.workflow_run.head_branch == 'main')
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == 'main'
     concurrency:
       group: web-pages
       cancel-in-progress: false
@@ -67,7 +66,7 @@ jobs:
       - name: Checkout trusted site source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'push' && github.sha || 'main' }}
+          ref: main
           path: source
 
       - name: Checkout published history
@@ -128,36 +127,34 @@ jobs:
           node scripts/import-run.mjs "${args[@]}"
 
       - uses: voidzero-dev/setup-vp@0cffb0a1ac50daa1541b57d1eb7c843f479522e1 # v1.18.0
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         with:
           cache: true
           node-version: '24'
           working-directory: source/web
 
       - name: Check website
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         working-directory: source/web
         run: vp check
 
       - name: Test website
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         working-directory: source/web
         run: vp test --run
 
       - name: Check website Worker
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         working-directory: source/web
         run: vp run worker:check
 
       - name: Build site
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         working-directory: source/web
         run: vp build
 
       - name: Prepare first publication
-        if: >-
-          (github.event_name == 'push' || steps.data.outcome == 'success') &&
-          steps.history.outcome != 'success'
+        if: steps.data.outcome == 'success' && steps.history.outcome != 'success'
         run: |
           mkdir -p published
           git -C published init
@@ -170,9 +167,9 @@ jobs:
           fi
 
       - name: Publish site
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           git -C published rm -r --ignore-unmatch assets index.html
           cp -R source/web/dist/. published/
@@ -188,16 +185,16 @@ jobs:
           git -C published push origin gh-pages
 
       - name: Configure GitHub Pages
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload GitHub Pages artifact
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: published
 
       - name: Deploy GitHub Pages
-        if: github.event_name == 'push' || steps.data.outcome == 'success'
+        if: steps.data.outcome == 'success'
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Remove the temporary dani/perf-site Pages publisher and restore the main-only deployment path after #1352.