### PR TITLE
chore(zed): link license files

### DIFF
--- a/editors/zed/LICENSE-APACHE
+++ b/editors/zed/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/editors/zed/LICENSE-MIT
+++ b/editors/zed/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
Link the Zed extension's Apache-2.0 and MIT license files to the repository copies so the extension package carries the declared license texts.