### PR TITLE
fix(web): use standard Pages deployment

### DIFF
--- a/.github/workflows/web-pages.yml
+++ b/.github/workflows/web-pages.yml
@@ -8,22 +8,18 @@ on:
     paths:
       - web/**
       - .github/workflows/web-pages.yml
-  pull_request:
-    branches: [main]
-    paths:
-      - web/**
-      - .github/workflows/web-pages.yml
-  workflow_run:
-    workflows: [Benchmark]
-    types: [completed]
 
 jobs:
-  check:
-    if: github.event_name != 'workflow_run'
+  deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: voidzero-dev/setup-vp@0cffb0a1ac50daa1541b57d1eb7c843f479522e1 # v1.18.0
@@ -43,160 +39,12 @@ jobs:
       - name: Build website
         working-directory: web
         run: vp build
-
-  publish:
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.head_branch == 'main'
-    concurrency:
-      group: web-pages
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-      pages: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Checkout trusted site source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: main
-          path: source
-
-      - name: Checkout published history
-        id: history
-        continue-on-error: true
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: gh-pages
-          path: published
-
-      - name: Download benchmark data
-        id: data
-        if: github.event_name == 'workflow_run'
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: codegen-runtime-results
-          path: incoming
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-
-      - name: Restore run index
-        if: steps.data.outcome == 'success' && steps.history.outcome == 'success'
-        run: |
-          mkdir -p source/web/public/data
-          if [[ -f published/data/index.json ]]; then
-            cp published/data/index.json source/web/public/data/index.json
-          fi
-
-      - name: Import benchmark run
-        if: steps.data.outcome == 'success'
-        working-directory: source/web
-        env:
-          BASE_COMMIT: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
-          BASE_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
-          HEAD_COMMIT: ${{ github.event.workflow_run.pull_requests[0].head.sha || github.event.workflow_run.head_sha }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.pull_requests[0].head.ref || github.event.workflow_run.head_branch }}
-          CREATED_AT: ${{ github.event.workflow_run.created_at }}
-          PR: ${{ github.event.workflow_run.pull_requests[0].number }}
-        run: |
-          if [[ -n "$BASE_COMMIT" && -f ../../incoming/baseline/results.json ]] && \
-            ! node -e 'const fs=require("fs"); const index=JSON.parse(fs.readFileSync(process.argv[1])); process.exit(index.runs.some(run => run.commit === process.argv[2]) ? 0 : 1)' public/data/index.json "$BASE_COMMIT"; then
-            node scripts/import-run.mjs \
-              --results ../../incoming/baseline/results.json \
-              --artifacts ../../incoming/baseline/artifacts \
-              --output public/data \
-              --commit "$BASE_COMMIT" \
-              --branch "$BASE_BRANCH" \
-              --timestamp "$CREATED_AT"
-          fi
-          args=(
-            --results ../../incoming/results.json
-            --artifacts ../../incoming/artifacts
-            --output public/data
-            --commit "$HEAD_COMMIT"
-            --branch "$HEAD_BRANCH"
-            --timestamp "$CREATED_AT"
-          )
-          if [[ -n "$PR" ]]; then args+=(--pr "$PR"); fi
-          node scripts/import-run.mjs "${args[@]}"
-
-      - uses: voidzero-dev/setup-vp@0cffb0a1ac50daa1541b57d1eb7c843f479522e1 # v1.18.0
-        if: steps.data.outcome == 'success'
-        with:
-          cache: true
-          node-version: '24'
-          working-directory: source/web
-
-      - name: Check website
-        if: steps.data.outcome == 'success'
-        working-directory: source/web
-        run: vp check
-
-      - name: Test website
-        if: steps.data.outcome == 'success'
-        working-directory: source/web
-        run: vp test --run
-
-      - name: Check website Worker
-        if: steps.data.outcome == 'success'
-        working-directory: source/web
-        run: vp run worker:check
-
-      - name: Build site
-        if: steps.data.outcome == 'success'
-        working-directory: source/web
-        run: vp build
-
-      - name: Prepare first publication
-        if: steps.data.outcome == 'success' && steps.history.outcome != 'success'
-        run: |
-          mkdir -p published
-          git -C published init
-          git -C published checkout -b gh-pages
-          remote="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
-          if git -C published remote get-url origin >/dev/null 2>&1; then
-            git -C published remote set-url origin "$remote"
-          else
-            git -C published remote add origin "$remote"
-          fi
-
-      - name: Publish site
-        if: steps.data.outcome == 'success'
-        env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          git -C published rm -r --ignore-unmatch assets index.html
-          cp -R source/web/dist/. published/
-          if [[ -f published/data/index.json ]]; then
-            node source/web/scripts/prune-runs.mjs published/data
-          fi
-          touch published/.nojekyll
-          git -C published config user.name github-actions[bot]
-          git -C published config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git -C published add .
-          if git -C published diff --cached --quiet; then exit 0; fi
-          git -C published commit -m "chore: publish ${HEAD_SHA::8}"
-          git -C published push origin gh-pages
-
       - name: Configure GitHub Pages
-        if: steps.data.outcome == 'success'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
       - name: Upload GitHub Pages artifact
-        if: steps.data.outcome == 'success'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: published
-
+          path: web/dist
       - name: Deploy GitHub Pages
-        if: steps.data.outcome == 'success'
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/web-pages.yml
+++ b/.github/workflows/web-pages.yml
@@ -47,9 +47,12 @@ jobs:
   publish:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.head_branch == 'main'
+      (
+        (github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main') ||
+        github.event.workflow_run.event == 'pull_request'
+      )
     concurrency:
       group: web-pages
       cancel-in-progress: false

--- a/.github/workflows/web-pages.yml
+++ b/.github/workflows/web-pages.yml
@@ -47,12 +47,9 @@ jobs:
   publish:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
-      (
-        (github.event.workflow_run.event == 'push' &&
-          github.event.workflow_run.head_branch == 'main') ||
-        github.event.workflow_run.event == 'pull_request'
-      )
+      github.event.workflow_run.head_branch == 'main'
     concurrency:
       group: web-pages
       cancel-in-progress: false

--- a/benches/runtime/report.py
+++ b/benches/runtime/report.py
@@ -360,7 +360,7 @@ def perf_link(
     head = os.environ.get("BENCHMARK_PR_HEAD_SHA")
     if not base or not head:
         return label
-    query = {"base": base, "head": head}
+    query = {"base": base[:8], "head": head[:8]}
     if benchmark is not None:
         query["benchmark"] = benchmark
         section = "artifacts"

--- a/benches/runtime/test_report.py
+++ b/benches/runtime/test_report.py
@@ -28,8 +28,8 @@ class ReportFormattingTests(unittest.TestCase):
         with patch.dict(
             os.environ,
             {
-                "BENCHMARK_BASE_SHA": "base",
-                "BENCHMARK_PR_HEAD_SHA": "head",
+                "BENCHMARK_BASE_SHA": "0123456789abcdef",
+                "BENCHMARK_PR_HEAD_SHA": "fedcba9876543210",
                 "BENCHMARK_SITE_URL": "https://example.test/",
             },
         ):
@@ -37,7 +37,7 @@ class ReportFormattingTests(unittest.TestCase):
 
         self.assertEqual(
             link,
-            "[factorial](https://example.test/?base=base&head=head&benchmark=factorial#artifacts)",
+            "[factorial](https://example.test/?base=01234567&head=fedcba98&benchmark=factorial#artifacts)",
         )
 
     def test_unchanged_report_has_note(self):

--- a/web/src/Compare.tsx
+++ b/web/src/Compare.tsx
@@ -54,6 +54,7 @@ export function Compare({ base, head }: Props) {
   const initial = new URLSearchParams(window.location.search)
   const initialMetric = initial.get('metric')
   const [runs, setRuns] = useState<[RunDocument, RunDocument] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
   const [metric, setMetric] = useState(
     initialMetric && initialMetric in metrics ? initialMetric : 'runtimeGas',
@@ -61,9 +62,11 @@ export function Compare({ base, head }: Props) {
   const [expanded, setExpanded] = useState(initial.get('benchmark') ?? '')
 
   useEffect(() => {
-    Promise.all([loadRun(base), loadRun(head)])
-      .then(setRuns)
-      .catch(() => setRuns(null))
+    setRuns(null)
+    setLoadError(null)
+    Promise.all([loadRun(base), loadRun(head)]).then(setRuns, () => {
+      setLoadError('These benchmark runs are not published yet.')
+    })
   }, [base, head])
 
   const rows = useMemo(() => {
@@ -87,6 +90,12 @@ export function Compare({ base, head }: Props) {
     history.replaceState(null, '', url)
   }
 
+  if (loadError)
+    return (
+      <main className="compare-page">
+        <p className="error">{loadError}</p>
+      </main>
+    )
   if (!runs)
     return (
       <main className="compare-page">

--- a/web/src/FileViewer.tsx
+++ b/web/src/FileViewer.tsx
@@ -46,6 +46,7 @@ function fileCounts(
 export function FileViewer({ base, head, benchmark, theme }: Props) {
   const params = new URLSearchParams(window.location.search)
   const [runs, setRuns] = useState<[RunDocument, RunDocument] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [activeBenchmark, setActiveBenchmark] = useState(benchmark)
   const [against, setAgainst] = useState<'base' | 'solc'>(
     params.get('against') === 'solc' ? 'solc' : 'base',
@@ -54,9 +55,11 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
   const [counts, setCounts] = useState<Record<string, Counts>>({})
 
   useEffect(() => {
-    Promise.all([loadRun(base), loadRun(head)])
-      .then(setRuns)
-      .catch(() => setRuns(null))
+    setRuns(null)
+    setLoadError(null)
+    Promise.all([loadRun(base), loadRun(head)]).then(setRuns, () => {
+      setLoadError('These benchmark runs are not published yet.')
+    })
   }, [base, head])
   useEffect(() => {
     setActiveBenchmark(benchmark)
@@ -169,7 +172,9 @@ export function FileViewer({ base, head, benchmark, theme }: Props) {
   }
   return (
     <main className="file-viewer">
-      {!runs ? (
+      {loadError ? (
+        <p className="error">{loadError}</p>
+      ) : !runs ? (
         <p className="empty">Loading files…</p>
       ) : !files.length ? (
         <p className="empty">No files were published for this benchmark run.</p>

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -12,14 +12,14 @@ const configuredRoot = configuredApi
   ? `${configuredApi.replace(/\/$/, '')}/api/data/`
   : configuredDataRoot
 const normalizeRoot = (root: string) => (root.endsWith('/') ? root : `${root}/`)
-let activeRoot = normalizeRoot(configuredRoot || (import.meta.env.DEV ? githubRoot : localRoot))
-let rootResolved = Boolean(configuredDataRoot) || !import.meta.env.DEV
+let activeRoot = normalizeRoot(configuredRoot || (import.meta.env.DEV ? localRoot : githubRoot))
+let rootResolved = Boolean(configuredRoot)
 let indexPromise: Promise<RunIndex> | null = null
 
 function fallbackRoots(root: string) {
   if (configuredDataRoot) return [root]
   if (configuredApi) return [...new Set([root, localRoot, githubRoot])]
-  return import.meta.env.DEV ? [localRoot, githubRoot] : [root]
+  return import.meta.env.DEV ? [root, githubRoot] : [root]
 }
 
 async function getJson<T>(root: string, path: string, fresh = false): Promise<T> {

--- a/web/src/data.ts
+++ b/web/src/data.ts
@@ -60,8 +60,16 @@ async function dataRoot() {
   return activeRoot
 }
 
+async function resolveCommit(commit: string) {
+  if (commit.length === 40) return commit
+  const prefix = commit.toLowerCase()
+  const matches = (await loadIndex()).runs.filter((run) => run.commit.startsWith(prefix))
+  return matches.length === 1 ? matches[0].commit : commit
+}
+
 export async function loadRun(commit: string) {
-  return getJson<RunDocument>(await dataRoot(), `runs/${encodeURIComponent(commit)}/run.json`)
+  const resolved = await resolveCommit(commit)
+  return getJson<RunDocument>(await dataRoot(), `runs/${encodeURIComponent(resolved)}/run.json`)
 }
 
 export async function loadArtifact(
@@ -70,7 +78,8 @@ export async function loadArtifact(
   compiler: string,
   storagePath: string,
 ): Promise<string | null> {
-  const parts = [commit, benchmark, compiler, ...storagePath.split('/')].map(encodeURIComponent)
+  const resolved = await resolveCommit(commit)
+  const parts = [resolved, benchmark, compiler, ...storagePath.split('/')].map(encodeURIComponent)
   const root = await dataRoot()
   const roots = fallbackRoots(root)
   for (const candidate of roots) {


### PR DESCRIPTION
Deploy the website through the standard GitHub Pages build, upload, and deploy flow on main website changes only. The static viewer reads published benchmark data directly from the public data branch, while benchmark comment links use short commit prefixes and unavailable data fails clearly.