### PR TITLE
perf(lsp): speed up benchmark reporting

### DIFF
--- a/benches/lsp/README.md
+++ b/benches/lsp/README.md
@@ -83,6 +83,9 @@ The displayed base and head values are means of those per-session percentiles;
 they are descriptive values, not percentiles from 100 pooled request samples.
 Within each order stratum, the renderer pairs base and head session summaries
 and computes an exact, deterministic paired-bootstrap 95% confidence interval.
+It represents each replacement count vector once with its multinomial weight, so
+the interval uses the same ordered-resample distribution without a random or
+asymptotic approximation.
 A metric is a regression only when the lower bounds for both absolute and
 percentage changes, for both p50 and p95, in both order strata, reach at least
 1.0 ms and 10 percent. An improvement requires the corresponding upper bounds

--- a/benches/lsp/benchmark.py
+++ b/benches/lsp/benchmark.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal, getcontext
 from enum import Enum
 from functools import cache
 from pathlib import Path
@@ -1441,13 +1441,76 @@ def _decimal_percentile(samples: Iterable[Decimal], percent: float) -> Decimal:
     return ordered[index]
 
 
+def _can_group_bootstrap(
+    base: Sequence[Decimal], head: Sequence[Decimal]
+) -> bool:
+    """Return whether grouped sums stay exact under the active Decimal context."""
+    values = tuple(itertools.chain(base, head))
+    if any(not value.is_finite() for value in values):
+        return False
+    nonzero_values = tuple(value for value in values if not value.is_zero())
+    if not nonzero_values:
+        return False
+
+    minimum_exponent = min(
+        value.as_tuple().exponent for value in nonzero_values
+    )
+    maximum_adjusted = max(value.adjusted() for value in nonzero_values)
+    carry_digits = len(str(len(base)))
+    context = getcontext()
+    return (
+        maximum_adjusted - minimum_exponent + 1 + carry_digits <= context.prec
+        and minimum_exponent >= context.Emin
+        and maximum_adjusted + carry_digits <= context.Emax
+    )
+
+
 @cache
-def _paired_bootstrap_interval(
+def _bootstrap_count_vectors(
+    sample_count: int,
+) -> tuple[tuple[tuple[int, ...], int], ...]:
+    """Return replacement count vectors and their ordered-resample weights."""
+    if sample_count <= 0:
+        raise ValueError("bootstrap requires a positive sample count")
+
+    factorial = math.factorial(sample_count)
+    vectors: list[tuple[tuple[int, ...], int]] = []
+    for selected in itertools.combinations_with_replacement(
+        range(sample_count), sample_count
+    ):
+        counts = [0] * sample_count
+        for index in selected:
+            counts[index] += 1
+        multiplicity = factorial // math.prod(
+            math.factorial(count) for count in counts
+        )
+        vectors.append((tuple(counts), multiplicity))
+    return tuple(vectors)
+
+
+def _weighted_decimal_percentile(
+    samples: Iterable[tuple[Decimal, int]], percent: float
+) -> Decimal:
+    ordered = sorted(samples, key=lambda sample: sample[0])
+    if not ordered:
+        raise ValueError("percentile requires at least one sample")
+    if not 0 < percent <= 100:
+        raise ValueError("percentile must be in (0, 100]")
+
+    total_weight = sum(weight for _, weight in ordered)
+    index = max(0, math.ceil(percent / 100 * total_weight) - 1)
+    cumulative_weight = 0
+    for value, weight in ordered:
+        cumulative_weight += weight
+        if cumulative_weight > index:
+            return value
+    raise ValueError("weighted percentile did not reach its requested rank")
+
+
+def _paired_bootstrap_interval_exhaustive(
     base: tuple[Decimal, ...], head: tuple[Decimal, ...]
 ) -> dict[str, tuple[Decimal, Decimal]]:
-    if len(base) != len(head) or not base:
-        raise ValueError("paired bootstrap requires equally sized samples")
-
+    """Preserve ordered Decimal arithmetic when grouped sums could round."""
     absolute_deltas: list[Decimal] = []
     percent_deltas: list[Decimal] = []
     for indices in itertools.product(range(len(base)), repeat=len(base)):
@@ -1466,6 +1529,45 @@ def _paired_bootstrap_interval(
         "delta_percent": (
             _decimal_percentile(percent_deltas, tail),
             _decimal_percentile(percent_deltas, 100 - tail),
+        ),
+    }
+
+
+@cache
+def _paired_bootstrap_interval(
+    base: tuple[Decimal, ...], head: tuple[Decimal, ...]
+) -> dict[str, tuple[Decimal, Decimal]]:
+    if len(base) != len(head) or not base:
+        raise ValueError("paired bootstrap requires equally sized samples")
+    if not _can_group_bootstrap(base, head):
+        return _paired_bootstrap_interval_exhaustive(base, head)
+
+    sample_count = len(base)
+    sample_count_decimal = Decimal(sample_count)
+    absolute_deltas: list[tuple[Decimal, int]] = []
+    percent_deltas: list[tuple[Decimal, int]] = []
+    for counts, multiplicity in _bootstrap_count_vectors(sample_count):
+        base_estimate = sum(
+            (value * count for value, count in zip(base, counts) if count), Decimal()
+        ) / sample_count_decimal
+        head_estimate = sum(
+            (value * count for value, count in zip(head, counts) if count), Decimal()
+        ) / sample_count_decimal
+        absolute_delta = head_estimate - base_estimate
+        absolute_deltas.append((absolute_delta, multiplicity))
+        percent_deltas.append(
+            (absolute_delta / base_estimate * Decimal(100), multiplicity)
+        )
+
+    tail = (1.0 - CONFIDENCE_LEVEL) * 50
+    return {
+        "delta_ms": (
+            _weighted_decimal_percentile(absolute_deltas, tail),
+            _weighted_decimal_percentile(absolute_deltas, 100 - tail),
+        ),
+        "delta_percent": (
+            _weighted_decimal_percentile(percent_deltas, tail),
+            _weighted_decimal_percentile(percent_deltas, 100 - tail),
         ),
     }
 

--- a/benches/lsp/test_benchmark.py
+++ b/benches/lsp/test_benchmark.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import copy
 import hashlib
 import importlib.util
+import itertools
 import json
 import os
 import sys
 import tempfile
 import unittest
+from decimal import Decimal, localcontext
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -1046,6 +1048,87 @@ class StatisticsTests(unittest.TestCase):
                 self.assertRaisesRegex(ValueError, "must be in"),
             ):
                 benchmark.percentile([1], percent)
+
+    def test_bootstrap_count_vectors_cover_ordered_resample_weights(self) -> None:
+        vectors = benchmark._bootstrap_count_vectors(5)
+
+        self.assertEqual(len(vectors), 126)
+        self.assertEqual(sum(weight for _, weight in vectors), 5**5)
+        weights = dict(vectors)
+        self.assertEqual(weights[(5, 0, 0, 0, 0)], 1)
+        self.assertEqual(weights[(2, 2, 1, 0, 0)], 30)
+
+    def test_paired_bootstrap_matches_ordered_resample_reference(self) -> None:
+        base = tuple(
+            Decimal(value) for value in ("1.1", "1.1", "2.2", "4.4", "4.4")
+        )
+        head = tuple(
+            Decimal(value) for value in ("1.4", "1.4", "2.0", "5.1", "5.1")
+        )
+        absolute_deltas = []
+        percent_deltas = []
+        for indices in itertools.product(range(len(base)), repeat=len(base)):
+            base_estimate = sum(
+                (base[index] for index in indices), Decimal()
+            ) / Decimal(len(base))
+            head_estimate = sum(
+                (head[index] for index in indices), Decimal()
+            ) / Decimal(len(head))
+            absolute_delta = head_estimate - base_estimate
+            absolute_deltas.append(absolute_delta)
+            percent_deltas.append(absolute_delta / base_estimate * Decimal(100))
+
+        tail = (1.0 - benchmark.CONFIDENCE_LEVEL) * 50
+        expected = {
+            "delta_ms": (
+                benchmark._decimal_percentile(absolute_deltas, tail),
+                benchmark._decimal_percentile(absolute_deltas, 100 - tail),
+            ),
+            "delta_percent": (
+                benchmark._decimal_percentile(percent_deltas, tail),
+                benchmark._decimal_percentile(percent_deltas, 100 - tail),
+            ),
+        }
+
+        benchmark._paired_bootstrap_interval.cache_clear()
+        actual = benchmark._paired_bootstrap_interval(base, head)
+
+        self.assertEqual(actual, expected)
+
+    def test_paired_bootstrap_falls_back_when_grouped_sums_could_round(
+        self,
+    ) -> None:
+        base = tuple(
+            Decimal(value) for value in ("1.1", "1.2", "1.3", "1.4", "1.5")
+        )
+        head = tuple(
+            Decimal(value) for value in ("1.2", "1.3", "1.4", "1.5", "1.6")
+        )
+        benchmark._paired_bootstrap_interval.cache_clear()
+        self.addCleanup(benchmark._paired_bootstrap_interval.cache_clear)
+
+        with localcontext() as context:
+            context.prec = 2
+            expected = benchmark._paired_bootstrap_interval_exhaustive(base, head)
+            with mock.patch.object(
+                benchmark,
+                "_paired_bootstrap_interval_exhaustive",
+                wraps=benchmark._paired_bootstrap_interval_exhaustive,
+            ) as exhaustive:
+                actual = benchmark._paired_bootstrap_interval(base, head)
+
+        exhaustive.assert_called_once_with(base, head)
+        self.assertEqual(actual, expected)
+
+    def test_weighted_decimal_percentile_uses_nearest_rank(self) -> None:
+        samples = ((Decimal("1"), 3), (Decimal("2"), 2))
+
+        self.assertEqual(
+            benchmark._weighted_decimal_percentile(samples, 50), Decimal("1")
+        )
+        self.assertEqual(
+            benchmark._weighted_decimal_percentile(samples, 95), Decimal("2")
+        )
 
     def test_method_verdict_requires_both_order_strata(self) -> None:
         cases = (


### PR DESCRIPTION
Towards OSS-738 , 

The LSP benchmark renderer currently walks every ordered five-session bootstrap resample, even when different orders produce the same estimate. This groups those resamples by replacement count and keeps their exact multinomial weights. If `Decimal` precision cannot preserve the grouped arithmetic, it uses the existing exhaustive path.

Here are the results from the same 10-session, same-binary control artifact:

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Bootstrap states per confidence interval | 3,125 | 126 | 95.97% fewer |
| Bootstrap states per full seven-metric report | 87,500 | 3,528 | 95.97% fewer |
| Renderer wall time, observed locally | 0.24 s (1 run) | 0.08–0.13 s (5 runs) | 46–67% lower |
| Generated Markdown and JSON | Baseline | Byte-for-byte identical | No change |

This only speeds up report generation. It does not change raw samples, measured LSP request times, confidence intervals, or verdicts. Benchmark collection itself took 49.58 seconds and does not run this code path.
