### PR TITLE
fix(sema): match solc library ABI and declaration checks

### DIFF
--- a/crates/sema/src/output/abi.rs
+++ b/crates/sema/src/output/abi.rs
@@ -31,7 +31,7 @@ impl<'gcx> Gcx<'gcx> {
         }
         let is_library = c.kind.is_library();
         for f in self.interface_functions(id) {
-            if is_library && stores_data_in_storage(f.ty) {
+            if is_library && omitted_from_library_abi(f.ty) {
                 continue;
             }
             items.push(self.function_abi(f.id).into());
@@ -124,15 +124,18 @@ impl<'gcx> Gcx<'gcx> {
     }
 }
 
-/// Returns `true` if any parameter or return of the given function type is stored in storage.
+/// Returns `true` if solc leaves the given library interface function out of the JSON ABI.
 ///
-/// Storage references have no ABI encoding, so solc drops the library functions that use them from
-/// the JSON ABI, while still listing them in the method identifiers.
+/// solc drops two kinds of library function. One is a function whose state mutability is above
+/// `view`: it can only run through `delegatecall`, so it is not callable through the ABI. The
+/// other is a function that holds a parameter or a return in storage, because a storage reference
+/// has no ABI encoding. Both kinds stay in the method identifiers.
 ///
 /// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/interface/ABI.cpp#L52-L56>
-fn stores_data_in_storage(ty: Ty<'_>) -> bool {
+fn omitted_from_library_abi(ty: Ty<'_>) -> bool {
     let TyKind::Fn(f) = ty.kind else { return false };
-    f.tys().any(|ty| ty.data_stored_in(hir::DataLocation::Storage))
+    !matches!(f.state_mutability, hir::StateMutability::Pure | hir::StateMutability::View)
+        || f.tys().any(|ty| ty.data_stored_in(hir::DataLocation::Storage))
 }
 
 fn json_state_mutability(s: hir::StateMutability) -> json::StateMutability {

--- a/crates/sema/src/output/abi.rs
+++ b/crates/sema/src/output/abi.rs
@@ -29,7 +29,11 @@ impl<'gcx> Gcx<'gcx> {
             let json::Function { state_mutability, .. } = self.function_abi(receive);
             items.push(json::Receive { state_mutability }.into());
         }
+        let is_library = c.kind.is_library();
         for f in self.interface_functions(id) {
+            if is_library && stores_data_in_storage(f.ty) {
+                continue;
+            }
             items.push(self.function_abi(f.id).into());
         }
         for event in self.interface_events(id).iter() {
@@ -118,6 +122,17 @@ impl<'gcx> Gcx<'gcx> {
         TySolcPrinter::new(self, &mut s).data_locations(false).print(ty).unwrap();
         s
     }
+}
+
+/// Returns `true` if any parameter or return of the given function type is stored in storage.
+///
+/// Storage references have no ABI encoding, so solc drops the library functions that use them from
+/// the JSON ABI, while still listing them in the method identifiers.
+///
+/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/interface/ABI.cpp#L52-L56>
+fn stores_data_in_storage(ty: Ty<'_>) -> bool {
+    let TyKind::Fn(f) = ty.kind else { return false };
+    f.tys().any(|ty| ty.data_stored_in(hir::DataLocation::Storage))
 }
 
 fn json_state_mutability(s: hir::StateMutability) -> json::StateMutability {

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -42,6 +42,9 @@ fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
     check_external_type_clashes(gcx, id);
     check_receive_function(gcx, id);
     check_library_functions(gcx, id);
+    for f_id in gcx.hir.contract(id).functions() {
+        check_payable_function(gcx, gcx.hir.function(f_id));
+    }
     for using in gcx.hir.contract(id).usings {
         check_using_directive(gcx, using);
     }
@@ -52,6 +55,9 @@ fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
 fn check_source(gcx: Gcx<'_>, id: hir::SourceId) {
     check_duplicate_definitions(gcx, &gcx.symbol_resolver.source_scopes[id]);
     check_break_continue(gcx, id);
+    for f_id in gcx.hir.source(id).items.iter().filter_map(ItemId::as_function) {
+        check_payable_function(gcx, gcx.hir.function(f_id));
+    }
     for using in gcx.hir.source(id).usings {
         check_using_directive(gcx, using);
     }
@@ -412,7 +418,10 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 
 /// Checks restrictions that only apply to functions declared in a library.
 ///
-/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L325-L333>
+/// References:
+/// - `virtual`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L306-L318>
+/// - constructor: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L444-L446>
+/// - `fallback`: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L2016-L2017>
 fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
     let contract = gcx.hir.contract(contract_id);
     if !contract.kind.is_library() {
@@ -421,14 +430,52 @@ fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
 
     for f_id in contract.functions() {
         let f = gcx.hir.function(f_id);
-        if f.state_mutability == StateMutability::Payable {
+
+        // A `private virtual` function is reported by `check_unimplemented_functions` instead.
+        if f.marked_virtual && f.visibility != Visibility::Private {
             gcx.dcx()
-                .err("library functions cannot be payable")
-                .code(error_code!(7708))
+                .err("library functions cannot be `virtual`")
+                .code(error_code!(7801))
+                .span(f.span)
+                .emit();
+        }
+
+        // A library `receive` gets its own error in `check_receive_function`.
+        if f.is_constructor() {
+            gcx.dcx()
+                .err("constructor cannot be defined in libraries")
+                .code(error_code!(7634))
+                .span(f.span)
+                .emit();
+        } else if f.kind.is_fallback() {
+            gcx.dcx()
+                .err("libraries cannot have fallback functions")
+                .code(error_code!(5982))
                 .span(f.span)
                 .emit();
         }
     }
+}
+
+/// Checks which functions are allowed to be `payable`.
+///
+/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L325-L333>
+fn check_payable_function(gcx: Gcx<'_>, f: &hir::Function<'_>) {
+    if f.state_mutability != StateMutability::Payable {
+        return;
+    }
+
+    let (msg, code) =
+        if f.contract.is_some_and(|contract| gcx.hir.contract(contract).kind.is_library()) {
+            ("library functions cannot be payable", error_code!(7708))
+        } else if f.is_free() {
+            ("free functions cannot be payable", error_code!(9559))
+        } else if f.is_ordinary() && !f.is_part_of_external_interface() {
+            ("`internal` and `private` functions cannot be payable", error_code!(5587))
+        } else {
+            return;
+        };
+    gcx.dcx().err(msg).code(code).span(f.span).emit();
 }
 
 /// Checks for violation of maximum storage size to ensure slot allocation algorithms works.

--- a/crates/sema/src/typeck/mod.rs
+++ b/crates/sema/src/typeck/mod.rs
@@ -41,6 +41,7 @@ fn check_contract(gcx: Gcx<'_>, id: hir::ContractId) {
     check_payable_fallback_without_receive(gcx, id);
     check_external_type_clashes(gcx, id);
     check_receive_function(gcx, id);
+    check_library_functions(gcx, id);
     for using in gcx.hir.contract(id).usings {
         check_using_directive(gcx, using);
     }
@@ -405,6 +406,27 @@ fn check_receive_function(gcx: Gcx<'_>, contract_id: hir::ContractId) {
         if !f.returns.is_empty() {
             gcx.dcx()
                 .emit_err(gcx.item_span(receive), "receive ether function cannot return values");
+        }
+    }
+}
+
+/// Checks restrictions that only apply to functions declared in a library.
+///
+/// Reference: <https://github.com/argotorg/solidity/blob/8a079791d9cca7a6c03fd6a8429b93aa3bddefed/libsolidity/analysis/TypeChecker.cpp#L325-L333>
+fn check_library_functions(gcx: Gcx<'_>, contract_id: hir::ContractId) {
+    let contract = gcx.hir.contract(contract_id);
+    if !contract.kind.is_library() {
+        return;
+    }
+
+    for f_id in contract.functions() {
+        let f = gcx.hir.function(f_id);
+        if f.state_mutability == StateMutability::Payable {
+            gcx.dcx()
+                .err("library functions cannot be payable")
+                .code(error_code!(7708))
+                .span(f.span)
+                .emit();
         }
     }
 }

--- a/tests/ui/abi/library_non_view.sol
+++ b/tests/ui/abi/library_non_view.sol
@@ -3,9 +3,8 @@
 // A library function that can modify state is only reachable through
 // `delegatecall`, so solc leaves every library function whose state
 // mutability is above `view` out of the JSON ABI. It still lists them in the
-// method identifiers. Only `nonpayable` appears below, because solc rejects a
-// `payable` library function outright; we do not yet, so the ABI filter covers
-// `payable` too.
+// method identifiers. Only `nonpayable` appears below, because a `payable`
+// library function is rejected outright.
 
 library L {
     function pureFn(uint256 x) external pure returns (uint256) {

--- a/tests/ui/abi/library_non_view.sol
+++ b/tests/ui/abi/library_non_view.sol
@@ -1,0 +1,54 @@
+//@ compile-flags: --emit=abi,hashes --pretty-json
+
+// A library function that can modify state is only reachable through
+// `delegatecall`, so solc leaves every library function whose state
+// mutability is above `view` out of the JSON ABI. It still lists them in the
+// method identifiers. `payable` is rejected for library functions, so
+// `nonpayable` is the only mutability this drops in practice.
+
+library L {
+    function pureFn(uint256 x) external pure returns (uint256) {
+        return x;
+    }
+
+    function viewFn() external view returns (uint256) {
+        return block.number;
+    }
+
+    function nonpayFn(uint256 x) external returns (uint256) {
+        assembly {
+            sstore(0, x)
+        }
+        return x;
+    }
+
+    function pubFn(uint256 x) public returns (uint256) {
+        assembly {
+            sstore(1, x)
+        }
+        return x;
+    }
+}
+
+// A contract keeps all of them: the rule only applies to libraries.
+contract C {
+    uint256 x;
+
+    function pureFn(uint256 y) external pure returns (uint256) {
+        return y;
+    }
+
+    function viewFn() external view returns (uint256) {
+        return x;
+    }
+
+    function nonpayFn(uint256 y) external returns (uint256) {
+        x = y;
+        return y;
+    }
+
+    function payFn(uint256 y) external payable returns (uint256) {
+        x = y;
+        return y;
+    }
+}

--- a/tests/ui/abi/library_non_view.sol
+++ b/tests/ui/abi/library_non_view.sol
@@ -3,8 +3,9 @@
 // A library function that can modify state is only reachable through
 // `delegatecall`, so solc leaves every library function whose state
 // mutability is above `view` out of the JSON ABI. It still lists them in the
-// method identifiers. `payable` is rejected for library functions, so
-// `nonpayable` is the only mutability this drops in practice.
+// method identifiers. Only `nonpayable` appears below, because solc rejects a
+// `payable` library function outright; we do not yet, so the ABI filter covers
+// `payable` too.
 
 library L {
     function pureFn(uint256 x) external pure returns (uint256) {

--- a/tests/ui/abi/library_non_view.stdout
+++ b/tests/ui/abi/library_non_view.stdout
@@ -1,0 +1,127 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/abi/library_non_view.sol:C": {
+      "abi": [
+        {
+          "type": "function",
+          "name": "nonpayFn",
+          "inputs": [
+            {
+              "name": "y",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "nonpayable"
+        },
+        {
+          "type": "function",
+          "name": "payFn",
+          "inputs": [
+            {
+              "name": "y",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "payable"
+        },
+        {
+          "type": "function",
+          "name": "pureFn",
+          "inputs": [
+            {
+              "name": "y",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "viewFn",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        }
+      ],
+      "hashes": {
+        "nonpayFn(uint256)": "780192ca",
+        "payFn(uint256)": "2bc2cb11",
+        "pureFn(uint256)": "a828eec5",
+        "viewFn()": "671ebb98"
+      }
+    },
+    "ROOT/tests/ui/abi/library_non_view.sol:L": {
+      "abi": [
+        {
+          "type": "function",
+          "name": "pureFn",
+          "inputs": [
+            {
+              "name": "x",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "viewFn",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "view"
+        }
+      ],
+      "hashes": {
+        "nonpayFn(uint256)": "780192ca",
+        "pubFn(uint256)": "11e04517",
+        "pureFn(uint256)": "a828eec5",
+        "viewFn()": "671ebb98"
+      }
+    }
+  },
+  "version": "VERSION"
+}

--- a/tests/ui/abi/library_storage_params.sol
+++ b/tests/ui/abi/library_storage_params.sol
@@ -1,7 +1,7 @@
 //@ compile-flags: --emit=abi,hashes --pretty-json
 
-// A `library` may expose `public`/`external` functions taking `storage`
-// reference parameters. Storage references have no ABI encoding, so solc
+// A `library` may expose `public`/`external` functions taking or returning
+// `storage` references. Storage references have no ABI encoding, so solc
 // omits those functions from the JSON ABI, but still lists them in the
 // method identifiers with a `storage` location suffix.
 
@@ -12,6 +12,11 @@ library L {
 
     struct Plain {
         uint256 a;
+    }
+
+    struct Nested {
+        Plain p;
+        Set s;
     }
 
     function withMapping(Set storage s) external view returns (uint256) {
@@ -28,6 +33,25 @@ library L {
 
     function arrParam(uint256[] storage a) external view returns (uint256) {
         return a.length;
+    }
+
+    function setArrParam(Set[] storage a) external view returns (uint256) {
+        return a.length;
+    }
+
+    function nestedParam(Nested storage n) external view returns (uint256) {
+        return n.p.a;
+    }
+
+    // `public`, not `external`.
+    function pubParam(Set storage s) public view returns (uint256) {
+        return s.idx[0];
+    }
+
+    // A `storage` return is omitted just like a `storage` parameter.
+    function storageReturn(uint256[] storage a) external view returns (uint256[] storage) {
+        require(a.length > 0);
+        return a;
     }
 
     function ext(uint256 x) external pure returns (uint256) {

--- a/tests/ui/abi/library_storage_params.sol
+++ b/tests/ui/abi/library_storage_params.sol
@@ -1,0 +1,40 @@
+//@ compile-flags: --emit=abi,hashes --pretty-json
+
+// A `library` may expose `public`/`external` functions taking `storage`
+// reference parameters. Storage references have no ABI encoding, so solc
+// omits those functions from the JSON ABI, but still lists them in the
+// method identifiers with a `storage` location suffix.
+
+library L {
+    struct Set {
+        mapping(uint256 => uint256) idx;
+    }
+
+    struct Plain {
+        uint256 a;
+    }
+
+    function withMapping(Set storage s) external view returns (uint256) {
+        return s.idx[0];
+    }
+
+    function plainStruct(Plain storage p) external view returns (uint256) {
+        return p.a;
+    }
+
+    function mappingParam(mapping(uint256 => uint256) storage m) external view returns (uint256) {
+        return m[0];
+    }
+
+    function arrParam(uint256[] storage a) external view returns (uint256) {
+        return a.length;
+    }
+
+    function ext(uint256 x) external pure returns (uint256) {
+        return x;
+    }
+
+    function memStruct(Plain memory p) external pure returns (uint256) {
+        return p.a;
+    }
+}

--- a/tests/ui/abi/library_storage_params.stdout
+++ b/tests/ui/abi/library_storage_params.stdout
@@ -53,7 +53,11 @@
         "ext(uint256)": "0be5edb6",
         "mappingParam(mapping(uint256 => uint256) storage)": "8aa88f55",
         "memStruct(L.Plain)": "e6d09e6b",
+        "nestedParam(L.Nested storage)": "5971f431",
         "plainStruct(L.Plain storage)": "2d886fae",
+        "pubParam(L.Set storage)": "35d8e2b3",
+        "setArrParam(L.Set[] storage)": "d1723c79",
+        "storageReturn(uint256[] storage)": "c37e2c8e",
         "withMapping(L.Set storage)": "6bd4ab76"
       }
     }

--- a/tests/ui/abi/library_storage_params.stdout
+++ b/tests/ui/abi/library_storage_params.stdout
@@ -1,0 +1,62 @@
+{
+  "contracts": {
+    "ROOT/tests/ui/abi/library_storage_params.sol:L": {
+      "abi": [
+        {
+          "type": "function",
+          "name": "ext",
+          "inputs": [
+            {
+              "name": "x",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        },
+        {
+          "type": "function",
+          "name": "memStruct",
+          "inputs": [
+            {
+              "name": "p",
+              "type": "tuple",
+              "internalType": "struct L.Plain",
+              "components": [
+                {
+                  "name": "a",
+                  "type": "uint256",
+                  "internalType": "uint256"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256"
+            }
+          ],
+          "stateMutability": "pure"
+        }
+      ],
+      "hashes": {
+        "arrParam(uint256[] storage)": "75803ad4",
+        "ext(uint256)": "0be5edb6",
+        "mappingParam(mapping(uint256 => uint256) storage)": "8aa88f55",
+        "memStruct(L.Plain)": "e6d09e6b",
+        "plainStruct(L.Plain storage)": "2d886fae",
+        "withMapping(L.Set storage)": "6bd4ab76"
+      }
+    }
+  },
+  "version": "VERSION"
+}

--- a/tests/ui/resolve/receive_func.sol
+++ b/tests/ui/resolve/receive_func.sol
@@ -1,5 +1,6 @@
 library L1 {
     receive() external payable {} //~ERROR: libraries cannot have receive ether functions
+    //~^ ERROR: library functions cannot be payable
 }
 
 contract C3 {

--- a/tests/ui/resolve/receive_func.stderr
+++ b/tests/ui/resolve/receive_func.stderr
@@ -4,6 +4,12 @@ error: libraries cannot have receive ether functions
 LL │     receive() external payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/resolve/receive_func.sol:LL:CC
+   │
+LL │     receive() external payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 error: receive ether function must be payable
    ╭▸ ROOT/tests/ui/resolve/receive_func.sol:LL:CC
    │
@@ -18,5 +24,5 @@ error: receive ether function cannot take parameters
 LL │     receive(bool _x) external payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/library_constructor.sol
+++ b/tests/ui/typeck/library_constructor.sol
@@ -1,0 +1,10 @@
+// ported-from: test/libsolidity/syntaxTests/constructor/library_constructor.sol
+
+library Lib {
+    constructor() {} //~ ERROR: constructor cannot be defined in libraries
+}
+
+// The restriction only applies to libraries.
+contract C {
+    constructor() {}
+}

--- a/tests/ui/typeck/library_constructor.stderr
+++ b/tests/ui/typeck/library_constructor.stderr
@@ -1,0 +1,8 @@
+error[7634]: constructor cannot be defined in libraries
+   ╭▸ ROOT/tests/ui/typeck/library_constructor.sol:LL:CC
+   │
+LL │     constructor() {}
+   ╰╴    ━━━━━━━━━━━━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/library_fallback_function.sol
+++ b/tests/ui/typeck/library_fallback_function.sol
@@ -1,0 +1,17 @@
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/076_fallback_function_in_library.sol
+
+library L {
+    fallback() external {} //~ ERROR: libraries cannot have fallback functions
+}
+
+// A library `receive` gets its own error instead.
+library L2 {
+    receive() external payable {}
+    //~^ ERROR: libraries cannot have receive ether functions
+    //~| ERROR: library functions cannot be payable
+}
+
+// The restriction only applies to libraries.
+contract C {
+    fallback() external {}
+}

--- a/tests/ui/typeck/library_fallback_function.stderr
+++ b/tests/ui/typeck/library_fallback_function.stderr
@@ -1,0 +1,20 @@
+error[5982]: libraries cannot have fallback functions
+   ╭▸ ROOT/tests/ui/typeck/library_fallback_function.sol:LL:CC
+   │
+LL │     fallback() external {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━
+
+error: libraries cannot have receive ether functions
+   ╭▸ ROOT/tests/ui/typeck/library_fallback_function.sol:LL:CC
+   │
+LL │     receive() external payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/library_fallback_function.sol:LL:CC
+   │
+LL │     receive() external payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/typeck/payable_free_function.sol
+++ b/tests/ui/typeck/payable_free_function.sol
@@ -1,0 +1,5 @@
+// ported-from: test/libsolidity/syntaxTests/freeFunctions/free_payable.sol
+
+function f() payable {} //~ ERROR: free functions cannot be payable
+
+function g() {}

--- a/tests/ui/typeck/payable_free_function.stderr
+++ b/tests/ui/typeck/payable_free_function.stderr
@@ -1,0 +1,8 @@
+error[9559]: free functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_free_function.sol:LL:CC
+   │
+LL │ function f() payable {}
+   ╰╴━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/typeck/payable_internal_function.sol
+++ b/tests/ui/typeck/payable_internal_function.sol
@@ -1,0 +1,16 @@
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/355_payable_external.sol
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/356_payable_internal.sol
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/357_payable_private.sol
+
+contract C {
+    function f() payable internal {} //~ ERROR: `internal` and `private` functions cannot be payable
+    function g() payable private {} //~ ERROR: `internal` and `private` functions cannot be payable
+
+    function h() payable external {}
+    function i() payable public {}
+
+    // Only ordinary functions are checked; these are always externally callable.
+    constructor() payable {}
+    fallback() external payable {}
+    receive() external payable {}
+}

--- a/tests/ui/typeck/payable_internal_function.stderr
+++ b/tests/ui/typeck/payable_internal_function.stderr
@@ -1,0 +1,14 @@
+error[5587]: `internal` and `private` functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_internal_function.sol:LL:CC
+   │
+LL │     function f() payable internal {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[5587]: `internal` and `private` functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_internal_function.sol:LL:CC
+   │
+LL │     function g() payable private {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/payable_library_function.sol
+++ b/tests/ui/typeck/payable_library_function.sol
@@ -1,0 +1,12 @@
+// ported-from: test/libsolidity/syntaxTests/nameAndTypeResolution/354_payable_in_library.sol
+
+library L {
+    function f() public payable {} //~ ERROR: library functions cannot be payable
+    function g() external payable {} //~ ERROR: library functions cannot be payable
+    function h() public {}
+}
+
+// The restriction only applies to libraries.
+contract C {
+    function f() public payable {}
+}

--- a/tests/ui/typeck/payable_library_function.sol
+++ b/tests/ui/typeck/payable_library_function.sol
@@ -4,6 +4,11 @@ library L {
     function f() public payable {} //~ ERROR: library functions cannot be payable
     function g() external payable {} //~ ERROR: library functions cannot be payable
     function h() public {}
+
+    // solc reports 7708 for these too, not 5587 ("`internal` and `private`
+    // functions cannot be payable"), because the library check comes first.
+    function i() internal payable {} //~ ERROR: library functions cannot be payable
+    function j() private payable {} //~ ERROR: library functions cannot be payable
 }
 
 // The restriction only applies to libraries.

--- a/tests/ui/typeck/payable_library_function.stderr
+++ b/tests/ui/typeck/payable_library_function.stderr
@@ -10,5 +10,17 @@ error[7708]: library functions cannot be payable
 LL │     function g() external payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 2 previous errors
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_library_function.sol:LL:CC
+   │
+LL │     function i() internal payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_library_function.sol:LL:CC
+   │
+LL │     function j() private payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/payable_library_function.stderr
+++ b/tests/ui/typeck/payable_library_function.stderr
@@ -1,0 +1,14 @@
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_library_function.sol:LL:CC
+   │
+LL │     function f() public payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/payable_library_function.sol:LL:CC
+   │
+LL │     function g() external payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/typeck/receive.sol
+++ b/tests/ui/typeck/receive.sol
@@ -1,6 +1,7 @@
 library L {
     receive() external payable {}
     //~^ ERROR: libraries cannot have receive ether functions
+    //~| ERROR: library functions cannot be payable
 }
 
 contract A {

--- a/tests/ui/typeck/receive.stderr
+++ b/tests/ui/typeck/receive.stderr
@@ -22,6 +22,12 @@ error: libraries cannot have receive ether functions
 LL │     receive() external payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+error[7708]: library functions cannot be payable
+   ╭▸ ROOT/tests/ui/typeck/receive.sol:LL:CC
+   │
+LL │     receive() external payable {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
 error: receive ether function must be payable
    ╭▸ ROOT/tests/ui/typeck/receive.sol:LL:CC
    │
@@ -36,5 +42,5 @@ error: receive ether function cannot take parameters
 LL │     receive(uint256 x) external payable {}
    ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/typeck/virtual_library_function.sol
+++ b/tests/ui/typeck/virtual_library_function.sol
@@ -1,0 +1,15 @@
+// ported-from: test/libsolidity/syntaxTests/inheritance/virtual/library_err.sol
+
+library L {
+    function f() internal pure virtual returns (uint) { return 0; } //~ ERROR: library functions cannot be `virtual`
+    function g() public virtual {} //~ ERROR: library functions cannot be `virtual`
+    function h() public {}
+
+    // `virtual` with `private` is reported on its own.
+    function i() private virtual {} //~ ERROR: `virtual` and `private` cannot be used together
+}
+
+// The restriction only applies to libraries.
+contract C {
+    function f() public virtual {}
+}

--- a/tests/ui/typeck/virtual_library_function.stderr
+++ b/tests/ui/typeck/virtual_library_function.stderr
@@ -1,0 +1,20 @@
+error[7801]: library functions cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/virtual_library_function.sol:LL:CC
+   │
+LL │     function f() internal pure virtual returns (uint) { return 0; }
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[7801]: library functions cannot be `virtual`
+   ╭▸ ROOT/tests/ui/typeck/virtual_library_function.sol:LL:CC
+   │
+LL │     function g() public virtual {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error[3942]: `virtual` and `private` cannot be used together
+   ╭▸ ROOT/tests/ui/typeck/virtual_library_function.sol:LL:CC
+   │
+LL │     function i() private virtual {}
+   ╰╴    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/using-for/operators/non_pure_definition.sol
+++ b/tests/ui/using-for/operators/non_pure_definition.sol
@@ -10,7 +10,7 @@ function sub(U a, U b) returns (U) {
     return a;
 }
 
-function mul(U a, U b) payable returns (U) {
+function mul(U a, U b) payable returns (U) { //~ ERROR: free functions cannot be payable
     return a;
 }
 

--- a/tests/ui/using-for/operators/non_pure_definition.stderr
+++ b/tests/ui/using-for/operators/non_pure_definition.stderr
@@ -1,3 +1,11 @@
+error[9559]: free functions cannot be payable
+   ╭▸ ROOT/tests/ui/using-for/operators/non_pure_definition.sol:LL:CC
+   │
+LL │ ┏ function mul(U a, U b) payable returns (U) {
+LL │ ┃     return a;
+LL │ ┃ }
+   ╰╴┗━┛
+
 error: only pure free functions can be used to define operators
    ╭▸ ROOT/tests/ui/using-for/operators/non_pure_definition.sol:LL:CC
    │
@@ -40,5 +48,5 @@ LL │ ┃     return a;
 LL │ ┃ }
    ╰╴┗━┛
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Part of the split of the solc-vs-solar differential audit branch (#1360) into independent PRs; this one is based on `main`. #1370 builds on it.

solc leaves every library function with a storage-reference parameter or return, and every library function above `view`, out of the JSON ABI while keeping them all in the selector list; we printed them, and asserted on a mapping in such a parameter type. solc also rejects `payable` library functions (7708) and five neighbouring declaration forms: constructors and `fallback` in libraries (7634, 5982), `virtual` library functions (7801), `internal`/`private` `payable` functions (5587), and `payable` free functions (9559). This adds those checks with solc's codes, fixes the ABI output, and teaches the typos check to ignore commit hashes and literal identifiers.
